### PR TITLE
refactor: reduce QueryResult clone with Arc sharing

### DIFF
--- a/src/app/action.rs
+++ b/src/app/action.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::app::connection_error::ConnectionErrorInfo;
 use crate::app::focused_pane::FocusedPane;
 use crate::app::sql_modal_context::CompletionCandidate;
@@ -178,7 +180,7 @@ pub enum Action {
         generation: u64,
     },
     ExecuteAdhoc(String),
-    QueryCompleted(Box<QueryResult>, u64),
+    QueryCompleted(Arc<QueryResult>, u64),
     QueryFailed(String, u64),
 
     // Result pane

--- a/src/app/effect_runner.rs
+++ b/src/app/effect_runner.rs
@@ -261,7 +261,7 @@ impl EffectRunner {
                     match executor.execute_preview(&dsn, &schema, &table, limit).await {
                         Ok(result) => {
                             let _ = tx
-                                .send(Action::QueryCompleted(Box::new(result), generation))
+                                .send(Action::QueryCompleted(Arc::new(result), generation))
                                 .await;
                         }
                         Err(e) => {
@@ -281,7 +281,7 @@ impl EffectRunner {
                 tokio::spawn(async move {
                     match executor.execute_adhoc(&dsn, &query).await {
                         Ok(result) => {
-                            let _ = tx.send(Action::QueryCompleted(Box::new(result), 0)).await;
+                            let _ = tx.send(Action::QueryCompleted(Arc::new(result), 0)).await;
                         }
                         Err(e) => {
                             let _ = tx.send(Action::QueryFailed(e.to_string(), 0)).await;

--- a/src/app/query_execution.rs
+++ b/src/app/query_execution.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Instant;
 
 use crate::app::result_history::ResultHistory;
@@ -14,7 +15,7 @@ pub enum QueryStatus {
 pub struct QueryExecution {
     pub status: QueryStatus,
     pub start_time: Option<Instant>,
-    pub current_result: Option<QueryResult>,
+    pub current_result: Option<Arc<QueryResult>>,
     pub result_history: ResultHistory,
     pub history_index: Option<usize>,
     pub result_highlight_until: Option<Instant>,

--- a/src/app/reducers/query.rs
+++ b/src/app/reducers/query.rs
@@ -1,5 +1,6 @@
 //! Query sub-reducer: query execution and command line.
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::app::action::Action;
@@ -33,10 +34,10 @@ pub fn reduce_query(state: &mut AppState, action: &Action, now: Instant) -> Opti
                 }
 
                 if result.source == QuerySource::Adhoc && !result.is_error() {
-                    state.query.result_history.push((**result).clone());
+                    state.query.result_history.push(Arc::clone(result));
                 }
 
-                state.query.current_result = Some((**result).clone());
+                state.query.current_result = Some(Arc::clone(result));
             }
             Some(vec![])
         }
@@ -47,12 +48,12 @@ pub fn reduce_query(state: &mut AppState, action: &Action, now: Instant) -> Opti
                 state.set_error(error.clone());
                 if state.ui.input_mode == InputMode::SqlModal {
                     state.sql_modal.status = SqlModalStatus::Error;
-                    let error_result = QueryResult::error(
+                    let error_result = Arc::new(QueryResult::error(
                         state.sql_modal.content.clone(),
                         error.clone(),
                         0,
                         QuerySource::Adhoc,
-                    );
+                    ));
                     state.query.current_result = Some(error_result);
                 }
             }

--- a/src/app/result_history.rs
+++ b/src/app/result_history.rs
@@ -1,10 +1,11 @@
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use crate::domain::QueryResult;
 
 #[derive(Debug, Clone)]
 pub struct ResultHistory {
-    entries: VecDeque<QueryResult>,
+    entries: VecDeque<Arc<QueryResult>>,
     capacity: usize,
 }
 
@@ -22,7 +23,7 @@ impl ResultHistory {
         }
     }
 
-    pub fn push(&mut self, result: QueryResult) {
+    pub fn push(&mut self, result: Arc<QueryResult>) {
         if self.entries.len() >= self.capacity {
             self.entries.pop_front();
         }
@@ -31,7 +32,7 @@ impl ResultHistory {
 
     /// Get a result by index (0 = oldest, len-1 = newest)
     pub fn get(&self, index: usize) -> Option<&QueryResult> {
-        self.entries.get(index)
+        self.entries.get(index).map(|arc| &**arc)
     }
 }
 
@@ -54,8 +55,8 @@ mod tests {
     fn push_and_get_returns_entries_in_order() {
         let mut history = ResultHistory::new(3);
 
-        history.push(make_result("SELECT 1"));
-        history.push(make_result("SELECT 2"));
+        history.push(Arc::new(make_result("SELECT 1")));
+        history.push(Arc::new(make_result("SELECT 2")));
 
         assert_eq!(history.get(0).unwrap().query, "SELECT 1");
         assert_eq!(history.get(1).unwrap().query, "SELECT 2");
@@ -66,9 +67,9 @@ mod tests {
     fn push_evicts_oldest_when_at_capacity() {
         let mut history = ResultHistory::new(2);
 
-        history.push(make_result("SELECT 1"));
-        history.push(make_result("SELECT 2"));
-        history.push(make_result("SELECT 3"));
+        history.push(Arc::new(make_result("SELECT 1")));
+        history.push(Arc::new(make_result("SELECT 2")));
+        history.push(Arc::new(make_result("SELECT 3")));
 
         // SELECT 1 should be evicted
         assert_eq!(history.get(0).unwrap().query, "SELECT 2");

--- a/src/ui/components/result.rs
+++ b/src/ui/components/result.rs
@@ -58,7 +58,7 @@ impl ResultPane {
 
     fn current_result(state: &AppState) -> Option<&QueryResult> {
         match state.query.history_index {
-            None => state.query.current_result.as_ref(),
+            None => state.query.current_result.as_deref(),
             Some(i) => state.query.result_history.get(i),
         }
     }

--- a/tests/render_snapshots.rs
+++ b/tests/render_snapshots.rs
@@ -3,6 +3,7 @@ mod harness;
 use harness::fixtures;
 use harness::{create_test_state, create_test_terminal, render_to_string, test_instant};
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use sabiql::app::action::Action;
@@ -45,7 +46,7 @@ fn table_selection_with_preview() {
     state.cache.state = MetadataState::Loaded;
     state.ui.set_explorer_selection(Some(0));
     state.cache.table_detail = Some(fixtures::sample_table_detail());
-    state.query.current_result = Some(fixtures::sample_query_result(now));
+    state.query.current_result = Some(Arc::new(fixtures::sample_query_result(now)));
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -61,7 +62,7 @@ fn focus_on_result_pane() {
     state.cache.metadata = Some(fixtures::sample_metadata(now));
     state.cache.state = MetadataState::Loaded;
     state.ui.set_explorer_selection(Some(0));
-    state.query.current_result = Some(fixtures::sample_query_result(now));
+    state.query.current_result = Some(Arc::new(fixtures::sample_query_result(now)));
     state.ui.focused_pane = FocusedPane::Result;
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -78,7 +79,7 @@ fn focus_mode_fullscreen_result() {
     state.cache.metadata = Some(fixtures::sample_metadata(now));
     state.cache.state = MetadataState::Loaded;
     state.ui.set_explorer_selection(Some(0));
-    state.query.current_result = Some(fixtures::sample_query_result(now));
+    state.query.current_result = Some(Arc::new(fixtures::sample_query_result(now)));
     state.ui.focus_mode = true;
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -187,7 +188,7 @@ fn empty_query_result() {
     state.cache.state = MetadataState::Loaded;
     state.ui.set_explorer_selection(Some(0));
     state.cache.table_detail = Some(fixtures::sample_table_detail());
-    state.query.current_result = Some(fixtures::empty_query_result(now));
+    state.query.current_result = Some(Arc::new(fixtures::empty_query_result(now)));
 
     let output = render_to_string(&mut terminal, &mut state);
 


### PR DESCRIPTION
## Scope

Refactor query result storage to use `Arc<QueryResult>` instead of owned values, eliminating deep clones when storing results in both history and current display.

## Changes

- `Action::QueryCompleted`: `Box` → `Arc`
- `ResultHistory`: `VecDeque<Arc<QueryResult>>`
- `QueryExecution::current_result`: `Option<Arc<QueryResult>>`

Closes #56