### PR TITLE
perf: reduce idle CPU usage with event-driven rendering

### DIFF
--- a/src/app/effect_runner.rs
+++ b/src/app/effect_runner.rs
@@ -31,6 +31,16 @@ use crate::app::state::AppState;
 use crate::domain::connection::ConnectionProfile;
 use crate::domain::{DatabaseMetadata, ErTableInfo};
 
+fn perf_enabled() -> bool {
+    std::env::var("SABIQL_PERF_LOG")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+fn perf_log(message: impl std::fmt::Display) {
+    eprintln!("[perf] {message}");
+}
+
 pub struct EffectRunner {
     metadata_provider: Arc<dyn MetadataProvider>,
     query_executor: Arc<dyn QueryExecutor>,
@@ -103,6 +113,7 @@ impl EffectRunner {
         state: &mut AppState,
         completion_engine: &RefCell<CompletionEngine>,
     ) -> Result<()> {
+        let perf_on = perf_enabled();
         match effect {
             Effect::Render => {
                 let output = tui.draw(state)?;
@@ -112,6 +123,45 @@ impl EffectRunner {
                 state.ui.result_viewport_plan = output.result_viewport_plan;
                 state.ui.inspector_pane_height = output.inspector_pane_height;
                 state.ui.result_pane_height = output.result_pane_height;
+
+                if state.query.perf_render_pending {
+                    if perf_on {
+                        let now = std::time::Instant::now();
+                        let total_ms = state
+                            .query
+                            .perf_started_at
+                            .map(|t| now.duration_since(t).as_millis());
+                        let render_delay_ms = state
+                            .query
+                            .perf_completed_at
+                            .map(|t| now.duration_since(t).as_millis());
+                        let (rows, cols, error, source, exec_ms) =
+                            if let Some(result) = state.query.current_result.as_ref() {
+                                (
+                                    result.row_count,
+                                    result.columns.len(),
+                                    result.is_error(),
+                                    format!("{:?}", result.source),
+                                    result.execution_time_ms,
+                                )
+                            } else {
+                                (0, 0, false, "-".to_string(), 0)
+                            };
+                        let total_ms = total_ms
+                            .map(|v| v.to_string())
+                            .unwrap_or_else(|| "-".to_string());
+                        let render_delay_ms = render_delay_ms
+                            .map(|v| v.to_string())
+                            .unwrap_or_else(|| "-".to_string());
+                        perf_log(format!(
+                            "render_done source={} total_ms={} render_delay_ms={} rows={} cols={} error={} exec_ms={}",
+                            source, total_ms, render_delay_ms, rows, cols, error, exec_ms
+                        ));
+                    }
+                    state.query.perf_render_pending = false;
+                    state.query.perf_started_at = None;
+                    state.query.perf_completed_at = None;
+                }
                 Ok(())
             }
 
@@ -257,17 +307,43 @@ impl EffectRunner {
                 let executor = Arc::clone(&self.query_executor);
                 let tx = self.action_tx.clone();
 
+                let perf_start = std::time::Instant::now();
+                state.query.perf_started_at = Some(perf_start);
+                state.query.perf_completed_at = None;
+                state.query.perf_render_pending = false;
+
+                if perf_on {
+                    perf_log(format!(
+                        "query_start source=Preview schema={} table={} gen={} limit={}",
+                        schema, table, generation, limit
+                    ));
+                }
+
                 tokio::spawn(async move {
                     match executor.execute_preview(&dsn, &schema, &table, limit).await {
                         Ok(result) => {
+                            if perf_on {
+                                perf_log(format!(
+                                    "query_complete source=Preview elapsed_ms={} rows={} cols={} error={}",
+                                    result.execution_time_ms,
+                                    result.row_count,
+                                    result.columns.len(),
+                                    result.is_error()
+                                ));
+                            }
                             let _ = tx
                                 .send(Action::QueryCompleted(Arc::new(result), generation))
                                 .await;
                         }
                         Err(e) => {
-                            let _ = tx
-                                .send(Action::QueryFailed(e.to_string(), generation))
-                                .await;
+                            let error_msg = e.to_string();
+                            if perf_on {
+                                perf_log(format!(
+                                    "query_failed source=Preview error_len={}",
+                                    error_msg.len()
+                                ));
+                            }
+                            let _ = tx.send(Action::QueryFailed(error_msg, generation)).await;
                         }
                     }
                 });
@@ -278,13 +354,41 @@ impl EffectRunner {
                 let executor = Arc::clone(&self.query_executor);
                 let tx = self.action_tx.clone();
 
+                let perf_start = std::time::Instant::now();
+                state.query.perf_started_at = Some(perf_start);
+                state.query.perf_completed_at = None;
+                state.query.perf_render_pending = false;
+
+                if perf_on {
+                    perf_log(format!(
+                        "query_start source=Adhoc query_len={}",
+                        query.len()
+                    ));
+                }
+
                 tokio::spawn(async move {
                     match executor.execute_adhoc(&dsn, &query).await {
                         Ok(result) => {
+                            if perf_on {
+                                perf_log(format!(
+                                    "query_complete source=Adhoc elapsed_ms={} rows={} cols={} error={}",
+                                    result.execution_time_ms,
+                                    result.row_count,
+                                    result.columns.len(),
+                                    result.is_error()
+                                ));
+                            }
                             let _ = tx.send(Action::QueryCompleted(Arc::new(result), 0)).await;
                         }
                         Err(e) => {
-                            let _ = tx.send(Action::QueryFailed(e.to_string(), 0)).await;
+                            let error_msg = e.to_string();
+                            if perf_on {
+                                perf_log(format!(
+                                    "query_failed source=Adhoc error_len={}",
+                                    error_msg.len()
+                                ));
+                            }
+                            let _ = tx.send(Action::QueryFailed(error_msg, 0)).await;
                         }
                     }
                 });

--- a/src/app/query_execution.rs
+++ b/src/app/query_execution.rs
@@ -19,6 +19,9 @@ pub struct QueryExecution {
     pub result_history: ResultHistory,
     pub history_index: Option<usize>,
     pub result_highlight_until: Option<Instant>,
+    pub perf_started_at: Option<Instant>,
+    pub perf_completed_at: Option<Instant>,
+    pub perf_render_pending: bool,
 }
 
 #[cfg(test)]

--- a/src/app/reducers/query.rs
+++ b/src/app/reducers/query.rs
@@ -20,6 +20,8 @@ pub fn reduce_query(state: &mut AppState, action: &Action, now: Instant) -> Opti
             if *generation == 0 || *generation == state.cache.selection_generation {
                 state.query.status = QueryStatus::Idle;
                 state.query.start_time = None;
+                state.query.perf_completed_at = Some(now);
+                state.query.perf_render_pending = true;
                 state.ui.result_scroll_offset = 0;
                 state.ui.result_horizontal_offset = 0;
                 state.query.result_highlight_until = Some(now + Duration::from_millis(500));
@@ -45,6 +47,8 @@ pub fn reduce_query(state: &mut AppState, action: &Action, now: Instant) -> Opti
             if *generation == 0 || *generation == state.cache.selection_generation {
                 state.query.status = QueryStatus::Idle;
                 state.query.start_time = None;
+                state.query.perf_completed_at = Some(now);
+                state.query.perf_render_pending = true;
                 state.set_error(error.clone());
                 if state.ui.input_mode == InputMode::SqlModal {
                     state.sql_modal.status = SqlModalStatus::Error;
@@ -99,6 +103,9 @@ pub fn reduce_query(state: &mut AppState, action: &Action, now: Instant) -> Opti
             if let Some(dsn) = &state.runtime.dsn {
                 state.query.status = QueryStatus::Running;
                 state.query.start_time = Some(now);
+                state.query.perf_started_at = Some(now);
+                state.query.perf_completed_at = None;
+                state.query.perf_render_pending = false;
 
                 let limit = state.cache.table_detail.as_ref().map_or(100, |detail| {
                     let col_count = detail.columns.len();
@@ -127,6 +134,9 @@ pub fn reduce_query(state: &mut AppState, action: &Action, now: Instant) -> Opti
             if let Some(dsn) = &state.runtime.dsn {
                 state.query.status = QueryStatus::Running;
                 state.query.start_time = Some(now);
+                state.query.perf_started_at = Some(now);
+                state.query.perf_completed_at = None;
+                state.query.perf_render_pending = false;
                 Some(vec![Effect::ExecuteAdhoc {
                     dsn: dsn.clone(),
                     query: query.clone(),


### PR DESCRIPTION
## Summary

Replaces fixed 30Hz render timer with event-driven rendering to reduce idle CPU usage from ~7% to ~0%.

### Key Changes
- Remove fixed render interval from TuiRunner (was 30Hz)
- Add `render_dirty` flag for batching state changes
- Add `next_animation_deadline()` pure function for deadline calculation
- Integrate deadline-based wake in main loop with `tokio::select!`

### Bug Fix: Busy Loop Prevention

During testing, discovered a critical bug causing 96% CPU usage:

**Root Cause:**
- `result_highlight_until` was set when query results arrived but never cleared when expired
- `next_animation_deadline()` returned this expired instant as the deadline
- `sleep_until(past_instant)` returned immediately (Duration::ZERO)
- This caused a busy loop: render → check deadline → instant return → render

**Evidence from macOS `sample` tool:**

Before fix (busy loop):
```
Call graph:
    822 Thread_14769314 (main-thread)
    +   819 sabiql::main::closure
    +     819 effect_runner::run  ← All samples in rendering!
    +       428 run_single → MainLayout::render
```

After fix (properly sleeping):
```
Call graph:
    881 Thread_14810045 (main-thread)
    +   881 tokio::runtime::park::CachedParkThread::park
    +     881 __psynch_cvwait  ← All samples in kernel wait!
```

**Fix:** Add `clear_expired_timers(now)` to clear `result_highlight_until` when expired.

## Test Plan

- [x] Verify idle CPU ~0% with Activity Monitor / `top`
- [x] Verify spinner animation smooth during query execution
- [x] Verify cursor blink works in SQL modal / Table picker
- [x] Verify message timeout auto-dismissal works
- [x] Run `mise run clippy` and `mise run test`

Closes #60