### PR TITLE
fix: remove duplicate hint text in SQL modal

### DIFF
--- a/src/ui/components/sql_modal.rs
+++ b/src/ui/components/sql_modal.rs
@@ -20,7 +20,7 @@ impl SqlModal {
             Constraint::Percentage(80),
             Constraint::Percentage(60),
             " SQL Editor ",
-            " Alt+Enter: Run │ Ctrl+L: Clear │ Esc: Close",
+            " Alt+Enter: Run │ Ctrl+L: Clear │ Esc: Close ",
         );
 
         // Split into editor area and status line
@@ -133,13 +133,7 @@ impl SqlModal {
             SqlModalStatus::Error => ("Error".to_string(), Style::default().fg(Color::Red)),
         };
 
-        let hints = " Alt+Enter: Run  Ctrl+L: Clear  Esc: Close";
-
-        let line = Line::from(vec![
-            Span::styled(status_text, status_style),
-            Span::raw(" │"),
-            Span::styled(hints, Style::default().fg(Theme::MODAL_HINT)),
-        ]);
+        let line = Line::from(vec![Span::styled(status_text, status_style)]);
 
         let paragraph = Paragraph::new(line).style(Style::default());
 

--- a/tests/snapshots/render_snapshots__sql_modal_with_completion.snap
+++ b/tests/snapshots/render_snapshots__sql_modal_with_completion.snap
@@ -19,8 +19,8 @@ test_project | - | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │                                                              │       │
 │       │                                                              │       │
-│       │Ready │ Alt+Enter: Run  Ctrl+L: Clear  Esc: Close             │       │
-│       ╰ Alt+Enter: Run │ Ctrl+L: Clear │ Esc: Close──────────────────╯       │
+│       │Ready                                                         │       │
+│       ╰ Alt+Enter: Run │ Ctrl+L: Clear │ Esc: Close ─────────────────╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘


### PR DESCRIPTION
Closes #88

## Scope

`src/ui/components/sql_modal.rs` — SQL modal rendering

## Summary

- Remove redundant hint from modal border (`title_bottom`), keeping only the status line hints which include contextual status info