### PR TITLE
fix: increase MAX_COL_WIDTH from 50 to 200

### DIFF
--- a/src/app/viewport.rs
+++ b/src/app/viewport.rs
@@ -1,5 +1,5 @@
 pub const MIN_COL_WIDTH: u16 = 4;
-pub const MAX_COL_WIDTH: u16 = 50;
+pub const MAX_COL_WIDTH: u16 = 200;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum SlackPolicy {

--- a/src/ui/components/result.rs
+++ b/src/ui/components/result.rs
@@ -374,14 +374,14 @@ mod tests {
         #[test]
         fn respects_max_width_constraint() {
             let headers = vec!["description".to_string()];
-            let long_text = "a".repeat(100);
+            let long_text = "a".repeat(300);
             let rows = vec![vec![long_text]];
 
             let result = calculate_ideal_widths(&headers, &rows);
 
             assert_eq!(result.len(), 1);
-            // Should be capped at MAX_COL_WIDTH (50)
-            assert_eq!(result[0], 50);
+            // Should be capped at MAX_COL_WIDTH (200)
+            assert_eq!(result[0], 200);
         }
 
         #[test]


### PR DESCRIPTION
## Summary
- Increase `MAX_COL_WIDTH` from `50` to `200` in `src/app/viewport.rs`
- Update related test to use a longer string (300 chars) so `MAX_COL_WIDTH` cap is still exercised

Closes #101