### PR TITLE
fix: prevent UTF-8 panic in completion semicolon check

### DIFF
--- a/src/app/completion.rs
+++ b/src/app/completion.rs
@@ -1237,7 +1237,8 @@ mod tests {
         fn typing_after_semicolon_returns_select_candidate() {
             let e = engine();
 
-            let candidates = e.get_candidates("SELECT * FROM users; S", 22, None, None, &[]);
+            let content = "SELECT * FROM users; S";
+            let candidates = e.get_candidates(content, content.chars().count(), None, None, &[]);
 
             assert!(!candidates.is_empty());
             assert!(candidates.iter().any(|c| c.text == "SELECT"));


### PR DESCRIPTION
Closes #159

## Scope

- `src/app/completion.rs` only

## Summary

- Convert char index to byte index before slicing `content` in semicolon suppression logic
- Add rstest-parametrized UTF-8 edge cases (multibyte literals, emoji, Japanese comments)
- Consolidate existing semicolon suppression tests into rstest