### PR TITLE
fix: clear stale Tier 2 cache on every ER diagram open (#162)

### DIFF
--- a/src/app/reducer.rs
+++ b/src/app/reducer.rs
@@ -762,7 +762,7 @@ mod tests {
         }
 
         #[test]
-        fn incomplete_prefetch_sets_waiting() {
+        fn always_clears_cache_even_with_pending_tables() {
             let mut state = create_test_state();
             state.runtime.dsn = Some("postgres://localhost/test".to_string());
             state.cache.metadata = Some(DatabaseMetadata {
@@ -781,11 +781,14 @@ mod tests {
             let effects = reduce(&mut state, Action::ErOpenDiagram, now);
 
             assert_eq!(state.er_preparation.status, ErStatus::Waiting);
-            assert!(effects.is_empty());
+            assert!(!state.sql_modal.prefetch_started);
+            assert_eq!(effects.len(), 2);
+            assert!(matches!(&effects[0], Effect::ClearCompletionEngineCache));
+            assert!(matches!(&effects[1], Effect::DispatchActions(_)));
         }
 
         #[test]
-        fn prefetch_complete_dispatches_generate() {
+        fn prefetch_started_true_clears_cache_and_restarts() {
             let mut state = create_test_state();
             state.runtime.dsn = Some("postgres://localhost/test".to_string());
             state.cache.metadata = Some(DatabaseMetadata {
@@ -799,11 +802,13 @@ mod tests {
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now);
 
-            assert_eq!(effects.len(), 1);
+            assert!(!state.sql_modal.prefetch_started);
+            assert_eq!(effects.len(), 2);
+            assert!(matches!(&effects[0], Effect::ClearCompletionEngineCache));
             assert!(matches!(
-                &effects[0],
+                &effects[1],
                 Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::ErGenerateFromCache))
+                    if actions.iter().any(|a| matches!(a, Action::StartPrefetchAll))
             ));
         }
 
@@ -822,8 +827,9 @@ mod tests {
             let effects = reduce(&mut state, Action::ErOpenDiagram, now);
 
             assert_eq!(state.er_preparation.status, ErStatus::Waiting);
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(&effects[0], Effect::DispatchActions(_)));
+            assert_eq!(effects.len(), 2);
+            assert!(matches!(&effects[0], Effect::ClearCompletionEngineCache));
+            assert!(matches!(&effects[1], Effect::DispatchActions(_)));
         }
 
         #[test]
@@ -1586,11 +1592,13 @@ mod tests {
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now);
 
-            assert_eq!(effects.len(), 1);
+            // Now always clears cache and re-prefetches (scoped since target_tables < total)
+            assert_eq!(effects.len(), 2);
+            assert!(matches!(&effects[0], Effect::ClearCompletionEngineCache));
             assert!(matches!(
-                &effects[0],
+                &effects[1],
                 Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::ErGenerateFromCache))
+                    if actions.iter().any(|a| matches!(a, Action::StartPrefetchScoped { .. }))
             ));
             assert_eq!(
                 state.er_preparation.target_tables,

--- a/src/app/reducers/er.rs
+++ b/src/app/reducers/er.rs
@@ -46,49 +46,27 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             let is_scoped = !state.er_preparation.target_tables.is_empty()
                 && state.er_preparation.target_tables.len() < total_table_count;
 
-            if !state.sql_modal.prefetch_started {
-                state.er_preparation.total_tables = total_table_count;
-                state.er_preparation.status = ErStatus::Waiting;
+            // Always start fresh: evict stale Tier 2 cache and re-prefetch
+            state.sql_modal.prefetch_started = false;
+            state.er_preparation.total_tables = total_table_count;
+            state.er_preparation.status = ErStatus::Waiting;
 
-                if is_scoped {
-                    let scoped_tables = state.er_preparation.target_tables.clone();
-                    state.set_success("Starting scoped prefetch for ER diagram...".to_string());
-                    return Some(vec![Effect::DispatchActions(vec![
-                        Action::StartPrefetchScoped {
-                            tables: scoped_tables,
-                        },
-                    ])]);
-                } else {
-                    state.set_success("Starting table prefetch for ER diagram...".to_string());
-                    return Some(vec![Effect::DispatchActions(vec![
-                        Action::StartPrefetchAll,
-                    ])]);
-                }
+            if is_scoped {
+                let scoped_tables = state.er_preparation.target_tables.clone();
+                state.set_success("Starting scoped prefetch for ER diagram...".to_string());
+                Some(vec![
+                    Effect::ClearCompletionEngineCache,
+                    Effect::DispatchActions(vec![Action::StartPrefetchScoped {
+                        tables: scoped_tables,
+                    }]),
+                ])
+            } else {
+                state.set_success("Starting table prefetch for ER diagram...".to_string());
+                Some(vec![
+                    Effect::ClearCompletionEngineCache,
+                    Effect::DispatchActions(vec![Action::StartPrefetchAll]),
+                ])
             }
-
-            if state.er_preparation.has_failures() {
-                let failed_tables: Vec<String> =
-                    state.er_preparation.failed_tables.keys().cloned().collect();
-                state.er_preparation.retry_failed();
-                state.sql_modal.failed_prefetch_tables.clear();
-
-                for qualified_name in failed_tables {
-                    state.sql_modal.prefetch_queue.push_back(qualified_name);
-                }
-
-                state.er_preparation.status = ErStatus::Waiting;
-                return Some(vec![Effect::ProcessPrefetchQueue]);
-            }
-
-            if !state.er_preparation.is_complete() {
-                state.er_preparation.status = ErStatus::Waiting;
-                return Some(vec![]);
-            }
-
-            // Prefetch already complete — delegate to ErGenerateFromCache
-            Some(vec![Effect::DispatchActions(vec![
-                Action::ErGenerateFromCache,
-            ])])
         }
 
         Action::ErGenerateFromCache => {
@@ -155,8 +133,9 @@ mod tests {
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
 
             assert_eq!(state.er_preparation.status, ErStatus::Waiting);
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(&effects[0], Effect::DispatchActions(_)));
+            assert_eq!(effects.len(), 2);
+            assert!(matches!(&effects[0], Effect::ClearCompletionEngineCache));
+            assert!(matches!(&effects[1], Effect::DispatchActions(_)));
         }
 
         #[test]
@@ -169,11 +148,13 @@ mod tests {
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
 
             assert_eq!(state.er_preparation.status, ErStatus::Waiting);
-            assert!(effects.iter().any(|e| matches!(
-                e,
+            assert_eq!(effects.len(), 2);
+            assert!(matches!(&effects[0], Effect::ClearCompletionEngineCache));
+            assert!(matches!(
+                &effects[1],
                 Effect::DispatchActions(actions)
                     if actions.iter().any(|a| matches!(a, Action::StartPrefetchScoped { .. }))
-            )));
+            ));
         }
 
         #[test]
@@ -184,15 +165,17 @@ mod tests {
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
 
-            assert!(effects.iter().any(|e| matches!(
-                e,
+            assert_eq!(effects.len(), 2);
+            assert!(matches!(&effects[0], Effect::ClearCompletionEngineCache));
+            assert!(matches!(
+                &effects[1],
                 Effect::DispatchActions(actions)
                     if actions.iter().any(|a| matches!(a, Action::StartPrefetchAll))
-            )));
+            ));
         }
 
         #[test]
-        fn prefetch_complete_dispatches_generate() {
+        fn prefetch_started_true_still_clears_cache_and_restarts() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.sql_modal.prefetch_started = true;
             state.cache.metadata = Some(DatabaseMetadata {
@@ -204,11 +187,15 @@ mod tests {
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
 
-            assert_eq!(effects.len(), 1);
+            // prefetch_started must be reset so stale fast-path is never taken
+            assert!(!state.sql_modal.prefetch_started);
+            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(effects.len(), 2);
+            assert!(matches!(&effects[0], Effect::ClearCompletionEngineCache));
             assert!(matches!(
-                &effects[0],
+                &effects[1],
                 Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::ErGenerateFromCache))
+                    if actions.iter().any(|a| matches!(a, Action::StartPrefetchAll))
             ));
         }
 


### PR DESCRIPTION
## Summary

- ER図を開くたびに Tier 2 キャッシュ（`completion_engine.table_detail_cache`）を全クリアし、再 prefetch を強制する
- ALTER TABLE 後に ER 図を再生成しても古いスキーマが表示される問題を修正

## Why

Tier 2 キャッシュに TTL がなく、`ErOpenDiagram` 時の無効化パスも存在しなかった。  
加えて `prefetch_started == true` の高速パスが DB 再取得をバイパスし、SQL Modal 経由で ER を開くと stale データがそのまま使われていた。

## Scope

- `ErOpenDiagram` reducer の簡素化（retry / incomplete / fast-path の3分岐 → 常にクリア＆再 prefetch の1パス）
- per-table evict による性能最適化は Phase 2（別 issue）で対応予定

## Test plan

- [x] `mise run build && mise run clippy && mise run test` all green
- [x] 手動: ALTER TABLE → ER 再生成で最新カラムが表示されること
- [x] 手動: SQL Modal open → close → ER 再生成で stale にならないこと

Closes #162