### PR TITLE
Refactor app_state tests into clearer responsibility groups

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -219,68 +219,15 @@ impl AppState {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Instant;
 
     use super::*;
     use crate::app::model::shared::focused_pane::FocusedPane;
     use crate::domain::DatabaseMetadata;
     use crate::domain::QuerySource;
     use rstest::rstest;
-    use std::time::Instant;
-
-    #[test]
-    fn default_result_pane_height_returns_zero_visible_rows() {
-        let state = AppState::new("test".to_string());
-
-        let visible = state.result_visible_rows();
-
-        assert_eq!(visible, 0);
-    }
-
-    #[rstest]
-    #[case(10, 5)]
-    #[case(15, 10)]
-    #[case(20, 15)]
-    #[case(30, 25)]
-    fn result_pane_height_calculates_correct_visible_rows(
-        #[case] pane_height: u16,
-        #[case] expected: usize,
-    ) {
-        let mut state = AppState::new("test".to_string());
-        state.ui.result_pane_height = pane_height;
-
-        let visible = state.result_visible_rows();
-
-        assert_eq!(visible, expected);
-    }
-
-    #[test]
-    fn small_result_pane_height_does_not_underflow() {
-        let mut state = AppState::new("test".to_string());
-        state.ui.result_pane_height = 2;
-
-        let visible = state.result_visible_rows();
-
-        assert_eq!(visible, 0);
-    }
-
-    #[test]
-    fn very_small_result_pane_returns_zero_rows() {
-        let mut state = AppState::new("test".to_string());
-        state.ui.result_pane_height = 1;
-
-        let visible = state.result_visible_rows();
-
-        assert_eq!(visible, 0);
-    }
-
-    #[test]
-    fn large_result_pane_height_returns_proportional_rows() {
-        let mut state = AppState::new("test".to_string());
-        state.ui.result_pane_height = 50;
-
-        let visible = state.result_visible_rows();
-
-        assert_eq!(visible, 45);
+    fn make_state() -> AppState {
+        AppState::new("test".to_string())
     }
 
     fn make_query_result(source: QuerySource) -> Arc<crate::domain::QueryResult> {
@@ -293,362 +240,82 @@ mod tests {
         ))
     }
 
-    #[test]
-    fn can_request_csv_export_returns_true_for_live_non_error_result() {
-        let mut state = AppState::new("test".to_string());
-        state
-            .query
-            .set_current_result(make_query_result(QuerySource::Preview));
-
-        assert!(state.can_request_csv_export());
-    }
-
-    #[test]
-    fn can_request_csv_export_returns_false_in_history_mode() {
-        let mut state = AppState::new("test".to_string());
-        state
-            .query
-            .push_history(make_query_result(QuerySource::Adhoc));
-        state.query.enter_history(0);
-
-        assert!(!state.can_request_csv_export());
-    }
-
-    #[test]
-    fn filtered_tables_with_empty_filter_returns_all() {
-        let mut state = AppState::new("test".to_string());
-        state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
+    fn make_metadata(table_summaries: Vec<TableSummary>) -> Arc<DatabaseMetadata> {
+        Arc::new(DatabaseMetadata {
             database_name: "test".to_string(),
             schemas: vec![],
-            table_summaries: vec![
-                TableSummary::new("public".to_string(), "users".to_string(), Some(100), false),
-                TableSummary::new("public".to_string(), "posts".to_string(), Some(50), false),
-            ],
+            table_summaries,
             fetched_at: Instant::now(),
-        })));
-        state
-            .ui
-            .table_picker
-            .filter_input
-            .set_content(String::new());
-
-        let filtered = state.filtered_tables();
-
-        assert_eq!(filtered.len(), 2);
+        })
     }
 
-    #[test]
-    fn filtered_tables_with_matching_filter_returns_subset() {
-        let mut state = AppState::new("test".to_string());
-        state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
-            database_name: "test".to_string(),
-            schemas: vec![],
-            table_summaries: vec![
-                TableSummary::new("public".to_string(), "users".to_string(), Some(100), false),
-                TableSummary::new("public".to_string(), "posts".to_string(), Some(50), false),
-            ],
-            fetched_at: Instant::now(),
-        })));
-        state
-            .ui
-            .table_picker
-            .filter_input
-            .set_content("user".to_string());
-
-        let filtered = state.filtered_tables();
-
-        assert_eq!(filtered.len(), 1);
-        assert_eq!(filtered[0].name, "users");
-    }
-
-    #[test]
-    fn filtered_tables_is_case_insensitive() {
-        let mut state = AppState::new("test".to_string());
-        state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
-            database_name: "test".to_string(),
-            schemas: vec![],
-            table_summaries: vec![TableSummary::new(
-                "public".to_string(),
-                "Users".to_string(),
-                Some(100),
-                false,
-            )],
-            fetched_at: Instant::now(),
-        })));
-        state
-            .ui
-            .table_picker
-            .filter_input
-            .set_content("user".to_string());
-
-        let filtered = state.filtered_tables();
-
-        assert_eq!(filtered.len(), 1);
-    }
-
-    #[test]
-    fn selection_generation_starts_at_zero() {
-        let state = AppState::new("test".to_string());
-
-        assert_eq!(state.session.selection_generation(), 0);
-    }
-
-    #[test]
-    fn selection_generation_increments_prevent_race_conditions() {
-        let mut state = AppState::new("test".to_string());
-
-        let gen1 = state.session.selection_generation();
-        let gen2 = state
-            .session
-            .select_table("public", "t1", &mut state.query.pagination);
-        let gen3 = state
-            .session
-            .select_table("public", "t2", &mut state.query.pagination);
-
-        assert_eq!(gen1, 0);
-        assert_eq!(gen2, 1);
-        assert_eq!(gen3, 2);
-    }
-
-    #[test]
-    fn selection_generation_can_detect_stale_responses() {
-        let mut state = AppState::new("test".to_string());
-
-        let initial_gen = state.session.selection_generation();
-        let current_gen =
-            state
-                .session
-                .select_table("public", "users", &mut state.query.pagination);
-
-        assert!(initial_gen < current_gen);
-    }
-
-    // Focus mode tests
-
-    #[test]
-    fn toggle_focus_enters_focus_mode() {
-        let mut state = AppState::new("test".to_string());
-        state.ui.focused_pane = FocusedPane::Explorer;
-
-        let result = state.toggle_focus();
-
-        assert!(result);
-        assert!(state.ui.is_focus_mode());
-        assert_eq!(state.ui.focused_pane, FocusedPane::Result);
-        assert_eq!(
-            state.ui.focus_mode.previous_pane(),
-            Some(FocusedPane::Explorer)
-        );
-    }
-
-    #[test]
-    fn toggle_focus_exits_focus_mode_and_restores_pane() {
-        let mut state = AppState::new("test".to_string());
-        state.ui.focused_pane = FocusedPane::Inspector;
-        state.toggle_focus();
-
-        let result = state.toggle_focus();
-
-        assert!(result);
-        assert!(!state.ui.is_focus_mode());
-        assert_eq!(state.ui.focused_pane, FocusedPane::Inspector);
-    }
-
-    // Prefetch state tests
-
-    #[test]
-    fn prefetch_queue_starts_empty() {
-        let state = AppState::new("test".to_string());
-
-        assert!(state.sql_modal.prefetch_queue.is_empty());
-        assert!(!state.sql_modal.is_prefetch_started());
-    }
-
-    #[test]
-    fn prefetch_queue_pop_returns_fifo_order() {
-        let mut state = AppState::new("test".to_string());
-        state
-            .sql_modal
-            .prefetch_queue
-            .push_back("public.users".to_string());
-        state
-            .sql_modal
-            .prefetch_queue
-            .push_back("public.orders".to_string());
-
-        let first = state.sql_modal.prefetch_queue.pop_front();
-        let second = state.sql_modal.prefetch_queue.pop_front();
-
-        assert_eq!(first, Some("public.users".to_string()));
-        assert_eq!(second, Some("public.orders".to_string()));
-    }
-
-    #[test]
-    fn prefetching_tables_tracks_in_flight() {
-        let mut state = AppState::new("test".to_string());
-
-        state
-            .sql_modal
-            .prefetching_tables
-            .insert("public.users".to_string());
-
-        assert!(state.sql_modal.prefetching_tables.contains("public.users"));
-        assert!(!state.sql_modal.prefetching_tables.contains("public.orders"));
-    }
-
-    #[test]
-    fn failed_prefetch_tables_tracks_failure_time_and_error() {
-        let mut state = AppState::new("test".to_string());
-        let now = Instant::now();
-
-        state.sql_modal.failed_prefetch_tables.insert(
-            "public.users".to_string(),
-            crate::app::model::sql_editor::modal::FailedPrefetchEntry {
-                failed_at: now,
-                error: "connection timeout".to_string(),
-                retry_count: 0,
-            },
-        );
-
-        assert!(
-            state
-                .sql_modal
-                .failed_prefetch_tables
-                .contains_key("public.users")
-        );
-        let entry = state
-            .sql_modal
-            .failed_prefetch_tables
-            .get("public.users")
-            .unwrap();
-        assert!(entry.failed_at.elapsed().as_secs() < 1);
-        assert_eq!(entry.error, "connection timeout");
-    }
-
-    mod er_preparation {
-        use super::*;
-        use crate::app::model::er_state::ErStatus;
-
-        #[test]
-        fn new_state_defaults_to_idle() {
-            let state = AppState::new("test".to_string());
-
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
-        }
-
-        #[test]
-        fn status_can_be_set_to_waiting() {
-            let mut state = AppState::new("test".to_string());
-
-            state.er_preparation.status = ErStatus::Waiting;
-
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
-        }
-
-        #[test]
-        fn status_can_be_set_to_rendering() {
-            let mut state = AppState::new("test".to_string());
-
-            state.er_preparation.status = ErStatus::Rendering;
-
-            assert_eq!(state.er_preparation.status, ErStatus::Rendering);
-        }
-    }
-
-    mod reload_metadata_reset {
+    mod pane_geometry {
         use super::*;
 
         #[test]
-        fn clears_prefetch_state() {
-            let mut state = AppState::new("test".to_string());
-            state.sql_modal.begin_prefetch();
-            state
-                .sql_modal
-                .prefetch_queue
-                .push_back("public.users".to_string());
-            state
-                .sql_modal
-                .prefetching_tables
-                .insert("public.orders".to_string());
-            state.sql_modal.failed_prefetch_tables.insert(
-                "public.failed".to_string(),
-                crate::app::model::sql_editor::modal::FailedPrefetchEntry {
-                    failed_at: Instant::now(),
-                    error: "timeout".to_string(),
-                    retry_count: 0,
-                },
-            );
+        fn default_result_pane_height_returns_zero_visible_rows() {
+            let state = make_state();
 
-            // Simulate ReloadMetadata reset using reset_prefetch()
-            state.sql_modal.reset_prefetch();
+            let visible = state.result_visible_rows();
 
-            assert!(!state.sql_modal.is_prefetch_started());
-            assert!(state.sql_modal.prefetch_queue.is_empty());
-            assert!(state.sql_modal.prefetching_tables.is_empty());
-            assert!(state.sql_modal.failed_prefetch_tables.is_empty());
+            assert_eq!(visible, 0);
+        }
+
+        #[rstest]
+        #[case(10, 5)]
+        #[case(15, 10)]
+        #[case(20, 15)]
+        #[case(30, 25)]
+        fn result_pane_height_calculates_correct_visible_rows(
+            #[case] pane_height: u16,
+            #[case] expected: usize,
+        ) {
+            let mut state = make_state();
+            state.ui.result_pane_height = pane_height;
+
+            let visible = state.result_visible_rows();
+
+            assert_eq!(visible, expected);
         }
 
         #[test]
-        fn resets_er_preparation() {
-            use crate::app::model::er_state::ErStatus;
+        fn small_result_pane_height_does_not_underflow() {
+            let mut state = make_state();
+            state.ui.result_pane_height = 2;
 
-            let mut state = AppState::new("test".to_string());
-            state.er_preparation.status = ErStatus::Waiting;
+            let visible = state.result_visible_rows();
 
-            state.er_preparation.reset();
-
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(visible, 0);
         }
 
         #[test]
-        fn clears_stale_messages() {
-            let mut state = AppState::new("test".to_string());
-            state.set_error("Old error".to_string());
+        fn very_small_result_pane_returns_zero_rows() {
+            let mut state = make_state();
+            state.ui.result_pane_height = 1;
 
-            // Simulate ReloadMetadata reset
-            state.messages.clear();
+            let visible = state.result_visible_rows();
 
-            assert!(state.messages.last_error.is_none());
-            assert!(state.messages.last_success.is_none());
-            assert!(state.messages.expires_at.is_none());
-        }
-    }
-
-    mod inspector_scroll_reset {
-        use super::*;
-
-        #[test]
-        fn scroll_offset_resets_to_zero_on_table_switch() {
-            let mut state = AppState::new("test".to_string());
-            state.ui.inspector_scroll_offset = 42;
-
-            // Simulate table switch (TableDetailLoaded action)
-            state.ui.inspector_scroll_offset = 0;
-
-            assert_eq!(state.ui.inspector_scroll_offset, 0);
+            assert_eq!(visible, 0);
         }
 
         #[test]
-        fn scroll_offset_stays_zero_when_no_table_detail() {
-            let state = AppState::new("test".to_string());
+        fn large_result_pane_height_returns_proportional_rows() {
+            let mut state = make_state();
+            state.ui.result_pane_height = 50;
 
-            assert_eq!(state.ui.inspector_scroll_offset, 0);
-            assert!(state.session.table_detail().is_none());
+            let visible = state.result_visible_rows();
+
+            assert_eq!(visible, 45);
         }
-    }
-
-    mod inspector_visible_rows {
-        use super::*;
 
         #[test]
         fn ddl_visible_rows_is_greater_than_standard() {
-            let mut state = AppState::new("test".to_string());
+            let mut state = make_state();
             state.ui.inspector_pane_height = 20;
 
             let standard = state.inspector_visible_rows();
             let ddl = state.inspector_ddl_visible_rows();
 
-            // DDL has no header row, so it should have 2 more visible rows
             assert_eq!(ddl - standard, 2);
         }
 
@@ -660,7 +327,7 @@ mod tests {
             #[case] pane_height: u16,
             #[case] expected: usize,
         ) {
-            let mut state = AppState::new("test".to_string());
+            let mut state = make_state();
             state.ui.inspector_pane_height = pane_height;
 
             let visible = state.inspector_ddl_visible_rows();
@@ -670,7 +337,7 @@ mod tests {
 
         #[test]
         fn small_pane_height_does_not_underflow() {
-            let mut state = AppState::new("test".to_string());
+            let mut state = make_state();
             state.ui.inspector_pane_height = 2;
 
             let visible = state.inspector_ddl_visible_rows();
@@ -679,7 +346,335 @@ mod tests {
         }
     }
 
-    mod connection_setters {
+    mod table_selection {
+        use super::*;
+
+        #[test]
+        fn filtered_tables_with_empty_filter_returns_all() {
+            let mut state = make_state();
+            state.session.set_metadata(Some(make_metadata(vec![
+                TableSummary::new("public".to_string(), "users".to_string(), Some(100), false),
+                TableSummary::new("public".to_string(), "posts".to_string(), Some(50), false),
+            ])));
+            state
+                .ui
+                .table_picker
+                .filter_input
+                .set_content(String::new());
+
+            let filtered = state.filtered_tables();
+
+            assert_eq!(filtered.len(), 2);
+        }
+
+        #[test]
+        fn filtered_tables_with_matching_filter_returns_subset() {
+            let mut state = make_state();
+            state.session.set_metadata(Some(make_metadata(vec![
+                TableSummary::new("public".to_string(), "users".to_string(), Some(100), false),
+                TableSummary::new("public".to_string(), "posts".to_string(), Some(50), false),
+            ])));
+            state
+                .ui
+                .table_picker
+                .filter_input
+                .set_content("user".to_string());
+
+            let filtered = state.filtered_tables();
+
+            assert_eq!(filtered.len(), 1);
+            assert_eq!(filtered[0].name, "users");
+        }
+
+        #[test]
+        fn filtered_tables_is_case_insensitive() {
+            let mut state = make_state();
+            state
+                .session
+                .set_metadata(Some(make_metadata(vec![TableSummary::new(
+                    "public".to_string(),
+                    "Users".to_string(),
+                    Some(100),
+                    false,
+                )])));
+            state
+                .ui
+                .table_picker
+                .filter_input
+                .set_content("user".to_string());
+
+            let filtered = state.filtered_tables();
+
+            assert_eq!(filtered.len(), 1);
+        }
+
+        #[test]
+        fn selection_generation_starts_at_zero() {
+            let state = make_state();
+
+            assert_eq!(state.session.selection_generation(), 0);
+        }
+
+        #[test]
+        fn selection_generation_increments_prevent_race_conditions() {
+            let mut state = make_state();
+
+            let gen1 = state.session.selection_generation();
+            let gen2 = state
+                .session
+                .select_table("public", "t1", &mut state.query.pagination);
+            let gen3 = state
+                .session
+                .select_table("public", "t2", &mut state.query.pagination);
+
+            assert_eq!(gen1, 0);
+            assert_eq!(gen2, 1);
+            assert_eq!(gen3, 2);
+        }
+
+        #[test]
+        fn selection_generation_can_detect_stale_responses() {
+            let mut state = make_state();
+
+            let initial_gen = state.session.selection_generation();
+            let current_gen =
+                state
+                    .session
+                    .select_table("public", "users", &mut state.query.pagination);
+
+            assert!(initial_gen < current_gen);
+        }
+    }
+
+    mod sql_modal_lifecycle {
+        use super::*;
+
+        #[test]
+        fn prefetch_queue_starts_empty() {
+            let state = make_state();
+
+            assert!(state.sql_modal.prefetch_queue.is_empty());
+            assert!(!state.sql_modal.is_prefetch_started());
+        }
+
+        #[test]
+        fn prefetch_queue_pop_returns_fifo_order() {
+            let mut state = make_state();
+            state
+                .sql_modal
+                .prefetch_queue
+                .push_back("public.users".to_string());
+            state
+                .sql_modal
+                .prefetch_queue
+                .push_back("public.orders".to_string());
+
+            let first = state.sql_modal.prefetch_queue.pop_front();
+            let second = state.sql_modal.prefetch_queue.pop_front();
+
+            assert_eq!(first, Some("public.users".to_string()));
+            assert_eq!(second, Some("public.orders".to_string()));
+        }
+
+        #[test]
+        fn prefetching_tables_tracks_in_flight() {
+            let mut state = make_state();
+
+            state
+                .sql_modal
+                .prefetching_tables
+                .insert("public.users".to_string());
+
+            assert!(state.sql_modal.prefetching_tables.contains("public.users"));
+            assert!(!state.sql_modal.prefetching_tables.contains("public.orders"));
+        }
+
+        #[test]
+        fn failed_prefetch_tables_tracks_failure_time_and_error() {
+            let mut state = make_state();
+            let now = Instant::now();
+
+            state.sql_modal.failed_prefetch_tables.insert(
+                "public.users".to_string(),
+                crate::app::model::sql_editor::modal::FailedPrefetchEntry {
+                    failed_at: now,
+                    error: "connection timeout".to_string(),
+                    retry_count: 0,
+                },
+            );
+
+            assert!(
+                state
+                    .sql_modal
+                    .failed_prefetch_tables
+                    .contains_key("public.users")
+            );
+            let entry = state
+                .sql_modal
+                .failed_prefetch_tables
+                .get("public.users")
+                .unwrap();
+            assert!(entry.failed_at.elapsed().as_secs() < 1);
+            assert_eq!(entry.error, "connection timeout");
+        }
+
+        mod reload_metadata_reset {
+            use super::*;
+
+            #[test]
+            fn clears_prefetch_state() {
+                let mut state = make_state();
+                state.sql_modal.begin_prefetch();
+                state
+                    .sql_modal
+                    .prefetch_queue
+                    .push_back("public.users".to_string());
+                state
+                    .sql_modal
+                    .prefetching_tables
+                    .insert("public.orders".to_string());
+                state.sql_modal.failed_prefetch_tables.insert(
+                    "public.failed".to_string(),
+                    crate::app::model::sql_editor::modal::FailedPrefetchEntry {
+                        failed_at: Instant::now(),
+                        error: "timeout".to_string(),
+                        retry_count: 0,
+                    },
+                );
+
+                state.sql_modal.reset_prefetch();
+
+                assert!(!state.sql_modal.is_prefetch_started());
+                assert!(state.sql_modal.prefetch_queue.is_empty());
+                assert!(state.sql_modal.prefetching_tables.is_empty());
+                assert!(state.sql_modal.failed_prefetch_tables.is_empty());
+            }
+
+            #[test]
+            fn clears_stale_messages() {
+                let mut state = make_state();
+                state.set_error("Old error".to_string());
+
+                state.messages.clear();
+
+                assert!(state.messages.last_error.is_none());
+                assert!(state.messages.last_success.is_none());
+                assert!(state.messages.expires_at.is_none());
+            }
+        }
+    }
+
+    mod ui_facade {
+        use super::*;
+
+        #[test]
+        fn toggle_focus_enters_focus_mode() {
+            let mut state = make_state();
+            state.ui.focused_pane = FocusedPane::Explorer;
+
+            let result = state.toggle_focus();
+
+            assert!(result);
+            assert!(state.ui.is_focus_mode());
+            assert_eq!(state.ui.focused_pane, FocusedPane::Result);
+            assert_eq!(
+                state.ui.focus_mode.previous_pane(),
+                Some(FocusedPane::Explorer)
+            );
+        }
+
+        #[test]
+        fn toggle_focus_exits_focus_mode_and_restores_pane() {
+            let mut state = make_state();
+            state.ui.focused_pane = FocusedPane::Inspector;
+            state.toggle_focus();
+
+            let result = state.toggle_focus();
+
+            assert!(result);
+            assert!(!state.ui.is_focus_mode());
+            assert_eq!(state.ui.focused_pane, FocusedPane::Inspector);
+        }
+
+        #[test]
+        fn can_request_csv_export_returns_true_for_live_non_error_result() {
+            let mut state = make_state();
+            state
+                .query
+                .set_current_result(make_query_result(QuerySource::Preview));
+
+            assert!(state.can_request_csv_export());
+        }
+
+        #[test]
+        fn can_request_csv_export_returns_false_in_history_mode() {
+            let mut state = make_state();
+            state
+                .query
+                .push_history(make_query_result(QuerySource::Adhoc));
+            state.query.enter_history(0);
+
+            assert!(!state.can_request_csv_export());
+        }
+    }
+
+    mod local_state_regressions {
+        use super::*;
+        use crate::app::model::er_state::ErStatus;
+
+        mod er_preparation {
+            use super::*;
+
+            #[test]
+            fn new_state_defaults_to_idle() {
+                let state = make_state();
+
+                assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            }
+
+            #[test]
+            fn status_can_be_set_to_waiting() {
+                let mut state = make_state();
+
+                state.er_preparation.status = ErStatus::Waiting;
+
+                assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            }
+
+            #[test]
+            fn status_can_be_set_to_rendering() {
+                let mut state = make_state();
+
+                state.er_preparation.status = ErStatus::Rendering;
+
+                assert_eq!(state.er_preparation.status, ErStatus::Rendering);
+            }
+        }
+
+        mod inspector_scroll_reset {
+            use super::*;
+
+            #[test]
+            fn scroll_offset_resets_to_zero_on_table_switch() {
+                let mut state = make_state();
+                state.ui.inspector_scroll_offset = 42;
+
+                state.ui.inspector_scroll_offset = 0;
+
+                assert_eq!(state.ui.inspector_scroll_offset, 0);
+            }
+
+            #[test]
+            fn scroll_offset_stays_zero_when_no_table_detail() {
+                let state = make_state();
+
+                assert_eq!(state.ui.inspector_scroll_offset, 0);
+                assert!(state.session.table_detail().is_none());
+            }
+        }
+    }
+
+    mod connection_catalog {
         use super::*;
         use crate::app::model::connection::list::ConnectionListItem;
         use crate::domain::connection::{ConnectionId, ConnectionName, ConnectionProfile, SslMode};
@@ -709,7 +704,7 @@ mod tests {
 
         #[test]
         fn set_connections_rebuilds_list() {
-            let mut state = AppState::new("test".to_string());
+            let mut state = make_state();
 
             state.set_connections(vec![make_profile("a"), make_profile("b")]);
 
@@ -725,7 +720,7 @@ mod tests {
 
         #[test]
         fn set_service_entries_rebuilds_list() {
-            let mut state = AppState::new("test".to_string());
+            let mut state = make_state();
 
             state.set_service_entries(vec![make_service("s1"), make_service("s2")]);
 
@@ -741,7 +736,7 @@ mod tests {
 
         #[test]
         fn set_connections_and_services_rebuilds_combined_list() {
-            let mut state = AppState::new("test".to_string());
+            let mut state = make_state();
 
             state.set_connections_and_services(
                 vec![make_profile("p1")],
@@ -763,7 +758,7 @@ mod tests {
 
         #[test]
         fn retain_connections_filters_and_rebuilds() {
-            let mut state = AppState::new("test".to_string());
+            let mut state = make_state();
             let keep = make_profile("keep");
             let drop = make_profile("drop");
             let keep_id = keep.id.clone();
@@ -783,7 +778,7 @@ mod tests {
 
         #[test]
         fn set_connections_with_empty_vec_clears_list() {
-            let mut state = AppState::new("test".to_string());
+            let mut state = make_state();
             state.set_connections(vec![make_profile("a")]);
             assert_eq!(state.connections().len(), 1);
 
@@ -795,7 +790,7 @@ mod tests {
 
         #[test]
         fn set_service_entries_with_empty_vec_clears_list() {
-            let mut state = AppState::new("test".to_string());
+            let mut state = make_state();
             state.set_service_entries(vec![make_service("s1")]);
             assert_eq!(state.service_entries().len(), 1);
 

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -662,22 +662,15 @@ mod tests {
                 assert_eq!(state.er_preparation.status, ErStatus::Idle);
             }
 
-            #[test]
-            fn accepts_waiting() {
+            #[rstest]
+            #[case(ErStatus::Waiting)]
+            #[case(ErStatus::Rendering)]
+            fn accepts_status(#[case] status: ErStatus) {
                 let mut state = make_state();
 
-                state.er_preparation.status = ErStatus::Waiting;
+                state.er_preparation.status = status;
 
-                assert_eq!(state.er_preparation.status, ErStatus::Waiting);
-            }
-
-            #[test]
-            fn accepts_rendering() {
-                let mut state = make_state();
-
-                state.er_preparation.status = ErStatus::Rendering;
-
-                assert_eq!(state.er_preparation.status, ErStatus::Rendering);
+                assert_eq!(state.er_preparation.status, status);
             }
         }
 
@@ -741,7 +734,7 @@ mod tests {
         }
 
         #[test]
-        fn set_rebuilds_list() {
+        fn set_connections_rebuilds_list() {
             let mut state = make_state();
 
             state.set_connections(vec![make_profile("a"), make_profile("b")]);

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -585,7 +585,13 @@ mod tests {
         #[test]
         fn clears_stale_messages() {
             let mut state = prepare_state_for_reload();
-            state.set_error("Old error".to_string());
+            state.messages.last_error = Some("Old error".to_string());
+            state.messages.last_success = Some("Old success".to_string());
+            state.messages.expires_at = Some(Instant::now());
+
+            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_success.is_some());
+            assert!(state.messages.expires_at.is_some());
 
             reduce_metadata(&mut state, &Action::ReloadMetadata, Instant::now());
 

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -620,14 +620,14 @@ mod tests {
             use super::*;
 
             #[test]
-            fn er_preparation_defaults_to_idle() {
+            fn defaults_to_idle() {
                 let state = make_state();
 
                 assert_eq!(state.er_preparation.status, ErStatus::Idle);
             }
 
             #[test]
-            fn er_preparation_accepts_waiting() {
+            fn accepts_waiting() {
                 let mut state = make_state();
 
                 state.er_preparation.status = ErStatus::Waiting;
@@ -636,7 +636,7 @@ mod tests {
             }
 
             #[test]
-            fn er_preparation_accepts_rendering() {
+            fn accepts_rendering() {
                 let mut state = make_state();
 
                 state.er_preparation.status = ErStatus::Rendering;
@@ -649,7 +649,7 @@ mod tests {
             use super::*;
 
             #[test]
-            fn inspector_scroll_reset_is_zero_on_switch() {
+            fn is_zero_on_switch() {
                 let mut state = make_state();
                 state.ui.inspector_scroll_offset = 42;
 

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -222,9 +222,13 @@ mod tests {
     use std::time::Instant;
 
     use super::*;
+    use crate::app::model::er_state::ErStatus;
     use crate::app::model::shared::focused_pane::FocusedPane;
+    use crate::app::update::action::Action;
+    use crate::app::update::reduce_metadata;
     use crate::domain::DatabaseMetadata;
     use crate::domain::QuerySource;
+    use crate::domain::Table;
     use rstest::rstest;
     fn make_state() -> AppState {
         AppState::new("test".to_string())
@@ -247,6 +251,22 @@ mod tests {
             table_summaries,
             fetched_at: Instant::now(),
         })
+    }
+
+    fn make_table_detail() -> Table {
+        Table {
+            schema: "public".to_string(),
+            name: "users".to_string(),
+            owner: None,
+            columns: Vec::new(),
+            primary_key: None,
+            foreign_keys: Vec::new(),
+            indexes: Vec::new(),
+            rls: None,
+            triggers: Vec::new(),
+            row_count_estimate: None,
+            comment: None,
+        }
     }
 
     mod pane_geometry {
@@ -313,6 +333,7 @@ mod tests {
             let standard = state.inspector_visible_rows();
             let ddl = state.inspector_ddl_visible_rows();
 
+            // DDL omits the standard header rows, so it exposes two more rows.
             assert_eq!(ddl - standard, 2);
         }
 
@@ -344,7 +365,7 @@ mod tests {
         use super::*;
 
         #[test]
-        fn filtered_tables_return_all_for_empty_filter() {
+        fn empty_filter_returns_all() {
             let mut state = make_state();
             state.session.set_metadata(Some(make_metadata(vec![
                 TableSummary::new("public".to_string(), "users".to_string(), Some(100), false),
@@ -362,7 +383,7 @@ mod tests {
         }
 
         #[test]
-        fn filtered_tables_match_substring() {
+        fn substring_filter_matches() {
             let mut state = make_state();
             state.session.set_metadata(Some(make_metadata(vec![
                 TableSummary::new("public".to_string(), "users".to_string(), Some(100), false),
@@ -381,7 +402,7 @@ mod tests {
         }
 
         #[test]
-        fn filtered_tables_ignore_case() {
+        fn filter_ignores_case() {
             let mut state = make_state();
             state
                 .session
@@ -511,50 +532,66 @@ mod tests {
             assert!(entry.failed_at.elapsed().as_secs() < 1);
             assert_eq!(entry.error, "connection timeout");
         }
+    }
 
-        mod reload_metadata_reset {
-            use super::*;
+    mod reload_metadata_reset {
+        use super::*;
 
-            #[test]
-            fn reset_prefetch_clears_state() {
-                let mut state = make_state();
-                state.sql_modal.begin_prefetch();
-                state
-                    .sql_modal
-                    .prefetch_queue
-                    .push_back("public.users".to_string());
-                state
-                    .sql_modal
-                    .prefetching_tables
-                    .insert("public.orders".to_string());
-                state.sql_modal.failed_prefetch_tables.insert(
-                    "public.failed".to_string(),
-                    crate::app::model::sql_editor::modal::FailedPrefetchEntry {
-                        failed_at: Instant::now(),
-                        error: "timeout".to_string(),
-                        retry_count: 0,
-                    },
-                );
+        fn prepare_state_for_reload() -> AppState {
+            let mut state = make_state();
+            state.session.begin_connecting("postgres://localhost/test");
+            state.sql_modal.begin_prefetch();
+            state
+                .sql_modal
+                .prefetch_queue
+                .push_back("public.users".to_string());
+            state
+                .sql_modal
+                .prefetching_tables
+                .insert("public.orders".to_string());
+            state.sql_modal.failed_prefetch_tables.insert(
+                "public.failed".to_string(),
+                crate::app::model::sql_editor::modal::FailedPrefetchEntry {
+                    failed_at: Instant::now(),
+                    error: "timeout".to_string(),
+                    retry_count: 0,
+                },
+            );
+            state
+        }
 
-                state.sql_modal.reset_prefetch();
+        #[test]
+        fn resets_prefetch_state() {
+            let mut state = prepare_state_for_reload();
 
-                assert!(!state.sql_modal.is_prefetch_started());
-                assert!(state.sql_modal.prefetch_queue.is_empty());
-                assert!(state.sql_modal.prefetching_tables.is_empty());
-                assert!(state.sql_modal.failed_prefetch_tables.is_empty());
-            }
+            reduce_metadata(&mut state, &Action::ReloadMetadata, Instant::now());
 
-            #[test]
-            fn reset_messages_clears_stale_errors() {
-                let mut state = make_state();
-                state.set_error("Old error".to_string());
+            assert!(!state.sql_modal.is_prefetch_started());
+            assert!(state.sql_modal.prefetch_queue.is_empty());
+            assert!(state.sql_modal.prefetching_tables.is_empty());
+            assert!(state.sql_modal.failed_prefetch_tables.is_empty());
+        }
 
-                state.messages.clear();
+        #[test]
+        fn resets_er_preparation() {
+            let mut state = prepare_state_for_reload();
+            state.er_preparation.status = ErStatus::Waiting;
 
-                assert!(state.messages.last_error.is_none());
-                assert!(state.messages.last_success.is_none());
-                assert!(state.messages.expires_at.is_none());
-            }
+            reduce_metadata(&mut state, &Action::ReloadMetadata, Instant::now());
+
+            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+        }
+
+        #[test]
+        fn clears_stale_messages() {
+            let mut state = prepare_state_for_reload();
+            state.set_error("Old error".to_string());
+
+            reduce_metadata(&mut state, &Action::ReloadMetadata, Instant::now());
+
+            assert!(state.messages.last_error.is_none());
+            assert!(state.messages.last_success.is_none());
+            assert!(state.messages.expires_at.is_none());
         }
     }
 
@@ -614,7 +651,6 @@ mod tests {
 
     mod local_state_regressions {
         use super::*;
-        use crate::app::model::er_state::ErStatus;
 
         mod er_preparation {
             use super::*;
@@ -649,17 +685,25 @@ mod tests {
             use super::*;
 
             #[test]
-            fn is_zero_on_switch() {
+            fn resets_to_zero_on_table_detail_loaded() {
                 let mut state = make_state();
+                let _ = state
+                    .session
+                    .select_table("public", "users", &mut state.query.pagination);
+                let generation = state.session.selection_generation();
                 state.ui.inspector_scroll_offset = 42;
 
-                state.ui.inspector_scroll_offset = 0;
+                reduce_metadata(
+                    &mut state,
+                    &Action::TableDetailLoaded(Box::new(make_table_detail()), generation),
+                    Instant::now(),
+                );
 
                 assert_eq!(state.ui.inspector_scroll_offset, 0);
             }
 
             #[test]
-            fn inspector_scroll_offset_defaults_to_zero() {
+            fn offset_defaults_to_zero() {
                 let state = make_state();
 
                 assert_eq!(state.ui.inspector_scroll_offset, 0);
@@ -697,7 +741,7 @@ mod tests {
         }
 
         #[test]
-        fn connections_rebuild_list() {
+        fn set_rebuilds_list() {
             let mut state = make_state();
 
             state.set_connections(vec![make_profile("a"), make_profile("b")]);
@@ -713,7 +757,7 @@ mod tests {
         }
 
         #[test]
-        fn service_entries_rebuild_list() {
+        fn set_service_entries_rebuilds_list() {
             let mut state = make_state();
 
             state.set_service_entries(vec![make_service("s1"), make_service("s2")]);
@@ -729,7 +773,7 @@ mod tests {
         }
 
         #[test]
-        fn connections_and_services_rebuild_combined_list() {
+        fn set_connections_and_services_rebuilds_combined_list() {
             let mut state = make_state();
 
             state.set_connections_and_services(
@@ -751,7 +795,7 @@ mod tests {
         }
 
         #[test]
-        fn retain_connections_rebuilds_list() {
+        fn retain_rebuilds_list() {
             let mut state = make_state();
             let keep = make_profile("keep");
             let drop = make_profile("drop");
@@ -771,7 +815,7 @@ mod tests {
         }
 
         #[test]
-        fn clearing_connections_clears_list() {
+        fn clear_connections_empties_list() {
             let mut state = make_state();
             state.set_connections(vec![make_profile("a")]);
             assert_eq!(state.connections().len(), 1);
@@ -783,7 +827,7 @@ mod tests {
         }
 
         #[test]
-        fn clearing_service_entries_clears_list() {
+        fn clear_service_entries_empties_list() {
             let mut state = make_state();
             state.set_service_entries(vec![make_service("s1")]);
             assert_eq!(state.service_entries().len(), 1);

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -253,7 +253,7 @@ mod tests {
         use super::*;
 
         #[test]
-        fn default_result_pane_height_returns_zero_visible_rows() {
+        fn result_rows_default_to_zero() {
             let state = make_state();
 
             let visible = state.result_visible_rows();
@@ -266,10 +266,7 @@ mod tests {
         #[case(15, 10)]
         #[case(20, 15)]
         #[case(30, 25)]
-        fn result_pane_height_calculates_correct_visible_rows(
-            #[case] pane_height: u16,
-            #[case] expected: usize,
-        ) {
+        fn result_rows_follow_pane_height(#[case] pane_height: u16, #[case] expected: usize) {
             let mut state = make_state();
             state.ui.result_pane_height = pane_height;
 
@@ -279,7 +276,7 @@ mod tests {
         }
 
         #[test]
-        fn small_result_pane_height_does_not_underflow() {
+        fn result_rows_clamp_small_heights() {
             let mut state = make_state();
             state.ui.result_pane_height = 2;
 
@@ -289,7 +286,7 @@ mod tests {
         }
 
         #[test]
-        fn very_small_result_pane_returns_zero_rows() {
+        fn result_rows_stay_zero_at_minimum() {
             let mut state = make_state();
             state.ui.result_pane_height = 1;
 
@@ -299,7 +296,7 @@ mod tests {
         }
 
         #[test]
-        fn large_result_pane_height_returns_proportional_rows() {
+        fn result_rows_scale_with_height() {
             let mut state = make_state();
             state.ui.result_pane_height = 50;
 
@@ -309,7 +306,7 @@ mod tests {
         }
 
         #[test]
-        fn ddl_visible_rows_is_greater_than_standard() {
+        fn inspector_ddl_rows_exceed_standard_rows() {
             let mut state = make_state();
             state.ui.inspector_pane_height = 20;
 
@@ -323,10 +320,7 @@ mod tests {
         #[case(10, 7)]
         #[case(15, 12)]
         #[case(20, 17)]
-        fn ddl_visible_rows_equals_height_minus_three(
-            #[case] pane_height: u16,
-            #[case] expected: usize,
-        ) {
+        fn inspector_ddl_rows_subtract_three(#[case] pane_height: u16, #[case] expected: usize) {
             let mut state = make_state();
             state.ui.inspector_pane_height = pane_height;
 
@@ -336,7 +330,7 @@ mod tests {
         }
 
         #[test]
-        fn small_pane_height_does_not_underflow() {
+        fn inspector_ddl_rows_clamp_small_heights() {
             let mut state = make_state();
             state.ui.inspector_pane_height = 2;
 
@@ -350,7 +344,7 @@ mod tests {
         use super::*;
 
         #[test]
-        fn filtered_tables_with_empty_filter_returns_all() {
+        fn filtered_tables_return_all_for_empty_filter() {
             let mut state = make_state();
             state.session.set_metadata(Some(make_metadata(vec![
                 TableSummary::new("public".to_string(), "users".to_string(), Some(100), false),
@@ -368,7 +362,7 @@ mod tests {
         }
 
         #[test]
-        fn filtered_tables_with_matching_filter_returns_subset() {
+        fn filtered_tables_match_substring() {
             let mut state = make_state();
             state.session.set_metadata(Some(make_metadata(vec![
                 TableSummary::new("public".to_string(), "users".to_string(), Some(100), false),
@@ -387,7 +381,7 @@ mod tests {
         }
 
         #[test]
-        fn filtered_tables_is_case_insensitive() {
+        fn filtered_tables_ignore_case() {
             let mut state = make_state();
             state
                 .session
@@ -416,7 +410,7 @@ mod tests {
         }
 
         #[test]
-        fn selection_generation_increments_prevent_race_conditions() {
+        fn selection_generation_increments_on_selection() {
             let mut state = make_state();
 
             let gen1 = state.session.selection_generation();
@@ -433,7 +427,7 @@ mod tests {
         }
 
         #[test]
-        fn selection_generation_can_detect_stale_responses() {
+        fn selection_generation_advances_after_reselection() {
             let mut state = make_state();
 
             let initial_gen = state.session.selection_generation();
@@ -458,7 +452,7 @@ mod tests {
         }
 
         #[test]
-        fn prefetch_queue_pop_returns_fifo_order() {
+        fn prefetch_queue_is_fifo() {
             let mut state = make_state();
             state
                 .sql_modal
@@ -477,7 +471,7 @@ mod tests {
         }
 
         #[test]
-        fn prefetching_tables_tracks_in_flight() {
+        fn prefetching_tables_track_in_flight() {
             let mut state = make_state();
 
             state
@@ -490,7 +484,7 @@ mod tests {
         }
 
         #[test]
-        fn failed_prefetch_tables_tracks_failure_time_and_error() {
+        fn failed_prefetch_tables_store_error_and_time() {
             let mut state = make_state();
             let now = Instant::now();
 
@@ -522,7 +516,7 @@ mod tests {
             use super::*;
 
             #[test]
-            fn clears_prefetch_state() {
+            fn reset_prefetch_clears_state() {
                 let mut state = make_state();
                 state.sql_modal.begin_prefetch();
                 state
@@ -551,7 +545,7 @@ mod tests {
             }
 
             #[test]
-            fn clears_stale_messages() {
+            fn reset_messages_clears_stale_errors() {
                 let mut state = make_state();
                 state.set_error("Old error".to_string());
 
@@ -584,7 +578,7 @@ mod tests {
         }
 
         #[test]
-        fn toggle_focus_exits_focus_mode_and_restores_pane() {
+        fn toggle_focus_restores_previous_pane() {
             let mut state = make_state();
             state.ui.focused_pane = FocusedPane::Inspector;
             state.toggle_focus();
@@ -597,7 +591,7 @@ mod tests {
         }
 
         #[test]
-        fn can_request_csv_export_returns_true_for_live_non_error_result() {
+        fn csv_export_allowed_for_live_result() {
             let mut state = make_state();
             state
                 .query
@@ -607,7 +601,7 @@ mod tests {
         }
 
         #[test]
-        fn can_request_csv_export_returns_false_in_history_mode() {
+        fn csv_export_blocked_in_history_mode() {
             let mut state = make_state();
             state
                 .query
@@ -626,14 +620,14 @@ mod tests {
             use super::*;
 
             #[test]
-            fn new_state_defaults_to_idle() {
+            fn er_preparation_defaults_to_idle() {
                 let state = make_state();
 
                 assert_eq!(state.er_preparation.status, ErStatus::Idle);
             }
 
             #[test]
-            fn status_can_be_set_to_waiting() {
+            fn er_preparation_accepts_waiting() {
                 let mut state = make_state();
 
                 state.er_preparation.status = ErStatus::Waiting;
@@ -642,7 +636,7 @@ mod tests {
             }
 
             #[test]
-            fn status_can_be_set_to_rendering() {
+            fn er_preparation_accepts_rendering() {
                 let mut state = make_state();
 
                 state.er_preparation.status = ErStatus::Rendering;
@@ -655,7 +649,7 @@ mod tests {
             use super::*;
 
             #[test]
-            fn scroll_offset_resets_to_zero_on_table_switch() {
+            fn inspector_scroll_reset_is_zero_on_switch() {
                 let mut state = make_state();
                 state.ui.inspector_scroll_offset = 42;
 
@@ -665,7 +659,7 @@ mod tests {
             }
 
             #[test]
-            fn scroll_offset_stays_zero_when_no_table_detail() {
+            fn inspector_scroll_offset_defaults_to_zero() {
                 let state = make_state();
 
                 assert_eq!(state.ui.inspector_scroll_offset, 0);
@@ -703,7 +697,7 @@ mod tests {
         }
 
         #[test]
-        fn set_connections_rebuilds_list() {
+        fn connections_rebuild_list() {
             let mut state = make_state();
 
             state.set_connections(vec![make_profile("a"), make_profile("b")]);
@@ -719,7 +713,7 @@ mod tests {
         }
 
         #[test]
-        fn set_service_entries_rebuilds_list() {
+        fn service_entries_rebuild_list() {
             let mut state = make_state();
 
             state.set_service_entries(vec![make_service("s1"), make_service("s2")]);
@@ -735,7 +729,7 @@ mod tests {
         }
 
         #[test]
-        fn set_connections_and_services_rebuilds_combined_list() {
+        fn connections_and_services_rebuild_combined_list() {
             let mut state = make_state();
 
             state.set_connections_and_services(
@@ -757,7 +751,7 @@ mod tests {
         }
 
         #[test]
-        fn retain_connections_filters_and_rebuilds() {
+        fn retain_connections_rebuilds_list() {
             let mut state = make_state();
             let keep = make_profile("keep");
             let drop = make_profile("drop");
@@ -777,7 +771,7 @@ mod tests {
         }
 
         #[test]
-        fn set_connections_with_empty_vec_clears_list() {
+        fn clearing_connections_clears_list() {
             let mut state = make_state();
             state.set_connections(vec![make_profile("a")]);
             assert_eq!(state.connections().len(), 1);
@@ -789,7 +783,7 @@ mod tests {
         }
 
         #[test]
-        fn set_service_entries_with_empty_vec_clears_list() {
+        fn clearing_service_entries_clears_list() {
             let mut state = make_state();
             state.set_service_entries(vec![make_service("s1")]);
             assert_eq!(state.service_entries().len(), 1);

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -529,7 +529,7 @@ mod tests {
                 .failed_prefetch_tables
                 .get("public.users")
                 .unwrap();
-            assert!(entry.failed_at.elapsed().as_secs() < 1);
+            assert_eq!(entry.failed_at, now);
             assert_eq!(entry.error, "connection timeout");
         }
     }


### PR DESCRIPTION
## Problem
The app_state test module mixed several concerns at the same level, which made the test intent harder to read and the failure surface harder to understand.

## Background
AppState is a central facade and is expected to keep growing, so its tests need a stable structure that reflects responsibility boundaries instead of the current ad hoc mix of concerns.

## Approach
Group the tests by responsibility domain, keep sibling modules at a similar semantic granularity, and normalize test names toward concise, observation-based wording.

## Screenshots
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストには、エンドユーザーに対する目に見える変更はありません。内部のテストコードの改善のみが含まれています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->