### PR TITLE
Refactor test grouping by responsibility boundaries

### DIFF
--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -288,91 +288,77 @@ mod tests {
     mod page_scroll {
         use super::*;
 
-        #[test]
-        fn half_page_down_from_top() {
-            let mut state = state_with_result_rows(100, 25);
-            // visible = 25 - 5 = 20, half = 10
-            let effects = reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::HalfPage,
-                },
-            );
+        mod scroll_mode {
+            use super::*;
 
-            assert!(effects.is_some());
-            assert_eq!(state.result_interaction.scroll_offset, 10);
-        }
+            #[test]
+            fn half_page_down_from_top() {
+                let mut state = state_with_result_rows(100, 25);
+                // visible = 25 - 5 = 20, half = 10
+                let effects = reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::HalfPage,
+                    },
+                );
 
-        #[test]
-        fn half_page_up_from_middle() {
-            let mut state = state_with_result_rows(100, 25);
-            state.result_interaction.scroll_offset = 50;
+                assert!(effects.is_some());
+                assert_eq!(state.result_interaction.scroll_offset, 10);
+            }
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Up,
-                    amount: ScrollAmount::HalfPage,
-                },
-            );
+            #[test]
+            fn half_page_up_from_middle() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.scroll_offset = 50;
 
-            assert_eq!(state.result_interaction.scroll_offset, 40);
-        }
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Up,
+                        amount: ScrollAmount::HalfPage,
+                    },
+                );
 
-        #[test]
-        fn full_page_down_clamped_at_max() {
-            let mut state = state_with_result_rows(30, 25);
-            // visible = 20, max_scroll = 30-20 = 10
-            state.result_interaction.scroll_offset = 5;
+                assert_eq!(state.result_interaction.scroll_offset, 40);
+            }
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::FullPage,
-                },
-            );
+            #[test]
+            fn full_page_down_clamped_at_max() {
+                let mut state = state_with_result_rows(30, 25);
+                // visible = 20, max_scroll = 30-20 = 10
+                state.result_interaction.scroll_offset = 5;
 
-            // delta=20, 5+20=25, clamped to 10
-            assert_eq!(state.result_interaction.scroll_offset, 10);
-        }
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::FullPage,
+                    },
+                );
 
-        #[test]
-        fn full_page_up_clamped_at_zero() {
-            let mut state = state_with_result_rows(100, 25);
-            state.result_interaction.scroll_offset = 5;
+                assert_eq!(state.result_interaction.scroll_offset, 10);
+            }
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Up,
-                    amount: ScrollAmount::FullPage,
-                },
-            );
+            #[test]
+            fn full_page_up_clamped_at_zero() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.scroll_offset = 5;
 
-            // delta=20, saturating_sub(5,20) = 0
-            assert_eq!(state.result_interaction.scroll_offset, 0);
-        }
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Up,
+                        amount: ScrollAmount::FullPage,
+                    },
+                );
 
-        #[test]
-        fn zero_height_pane_scroll_mode_is_noop() {
-            let mut state = state_with_result_rows(100, 0);
-            // visible = 0 → no-op for all modes
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::HalfPage,
-                },
-            );
-
-            assert_eq!(state.result_interaction.scroll_offset, 0);
+                assert_eq!(state.result_interaction.scroll_offset, 0);
+            }
         }
 
         mod viewport_position {
@@ -413,276 +399,280 @@ mod tests {
             }
         }
 
-        #[test]
-        fn half_page_down_cell_active_moves_both_cursor_and_viewport() {
-            let mut state = state_with_result_rows(100, 25);
-            // visible=20, half=10
-            state.result_interaction.activate_cell(10, 0);
-            state.result_interaction.scroll_offset = 5;
+        mod cell_active {
+            use super::*;
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::HalfPage,
-                },
-            );
+            #[test]
+            fn half_page_down_moves_both_cursor_and_viewport() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.activate_cell(10, 0);
+                state.result_interaction.scroll_offset = 5;
 
-            assert_eq!(state.result_interaction.selection().row(), Some(20));
-            assert_eq!(state.result_interaction.scroll_offset, 15);
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::HalfPage,
+                    },
+                );
+
+                assert_eq!(state.result_interaction.selection().row(), Some(20));
+                assert_eq!(state.result_interaction.scroll_offset, 15);
+            }
+
+            #[test]
+            fn half_page_up_moves_both_cursor_and_viewport() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.activate_cell(30, 0);
+                state.result_interaction.scroll_offset = 25;
+
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Up,
+                        amount: ScrollAmount::HalfPage,
+                    },
+                );
+
+                assert_eq!(state.result_interaction.selection().row(), Some(20));
+                assert_eq!(state.result_interaction.scroll_offset, 15);
+            }
+
+            #[test]
+            fn half_page_down_preserves_relative_position() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.activate_cell(15, 3);
+                state.result_interaction.scroll_offset = 10;
+
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::HalfPage,
+                    },
+                );
+
+                assert_eq!(state.result_interaction.selection().row(), Some(25));
+                assert_eq!(state.result_interaction.selection().cell(), Some(3));
+                assert_eq!(state.result_interaction.scroll_offset, 20);
+                let relative = state.result_interaction.selection().row().unwrap()
+                    - state.result_interaction.scroll_offset;
+                assert_eq!(relative, 5);
+            }
+
+            #[test]
+            fn half_page_down_preserves_column() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.activate_cell(10, 3);
+                state.result_interaction.scroll_offset = 5;
+
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::HalfPage,
+                    },
+                );
+
+                assert_eq!(state.result_interaction.selection().row(), Some(20));
+                assert_eq!(state.result_interaction.selection().cell(), Some(3));
+                assert_eq!(state.result_interaction.scroll_offset, 15);
+            }
+
+            #[test]
+            fn full_page_down_moves_both() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.activate_cell(10, 0);
+                state.result_interaction.scroll_offset = 5;
+
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::FullPage,
+                    },
+                );
+
+                assert_eq!(state.result_interaction.selection().row(), Some(30));
+                assert_eq!(state.result_interaction.scroll_offset, 25);
+            }
+
+            #[test]
+            fn full_page_up_moves_both() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.activate_cell(40, 0);
+                state.result_interaction.scroll_offset = 30;
+
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Up,
+                        amount: ScrollAmount::FullPage,
+                    },
+                );
+
+                assert_eq!(state.result_interaction.selection().row(), Some(20));
+                assert_eq!(state.result_interaction.scroll_offset, 10);
+            }
         }
 
-        #[test]
-        fn half_page_up_cell_active_moves_both_cursor_and_viewport() {
-            let mut state = state_with_result_rows(100, 25);
-            // visible=20, half=10
-            state.result_interaction.activate_cell(30, 0);
-            state.result_interaction.scroll_offset = 25;
+        mod boundary_conditions {
+            use super::*;
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Up,
-                    amount: ScrollAmount::HalfPage,
-                },
-            );
+            #[test]
+            fn zero_height_scroll_mode_is_noop() {
+                let mut state = state_with_result_rows(100, 0);
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::HalfPage,
+                    },
+                );
 
-            assert_eq!(state.result_interaction.selection().row(), Some(20));
-            assert_eq!(state.result_interaction.scroll_offset, 15);
-        }
+                assert_eq!(state.result_interaction.scroll_offset, 0);
+            }
 
-        #[test]
-        fn half_page_down_cell_active_preserves_relative_position() {
-            let mut state = state_with_result_rows(100, 25);
-            // visible=20, half=10
-            state.result_interaction.activate_cell(15, 3);
-            state.result_interaction.scroll_offset = 10;
-            // cursor is at relative position 5 within viewport
+            #[test]
+            fn half_page_down_clamps_near_bottom() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.activate_cell(95, 0);
+                state.result_interaction.scroll_offset = 75;
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::HalfPage,
-                },
-            );
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::HalfPage,
+                    },
+                );
 
-            // both move by 10: cursor=25, offset=20 → relative position still 5
-            assert_eq!(state.result_interaction.selection().row(), Some(25));
-            assert_eq!(state.result_interaction.selection().cell(), Some(3));
-            assert_eq!(state.result_interaction.scroll_offset, 20);
-            let relative = state.result_interaction.selection().row().unwrap()
-                - state.result_interaction.scroll_offset;
-            assert_eq!(relative, 5);
-        }
+                assert_eq!(state.result_interaction.selection().row(), Some(99));
+                assert_eq!(state.result_interaction.scroll_offset, 80);
+            }
 
-        #[test]
-        fn half_page_down_cell_active_clamps_near_bottom() {
-            let mut state = state_with_result_rows(100, 25);
-            // visible=20, half=10, max_row=99, max_scroll=80
-            state.result_interaction.activate_cell(95, 0);
-            state.result_interaction.scroll_offset = 75;
+            #[test]
+            fn half_page_up_clamps_near_top() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.activate_cell(5, 0);
+                state.result_interaction.scroll_offset = 3;
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::HalfPage,
-                },
-            );
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Up,
+                        amount: ScrollAmount::HalfPage,
+                    },
+                );
 
-            // cursor: 95+10=105 → clamped to 99
-            // scroll: 75+10=85 → clamped to 80
-            assert_eq!(state.result_interaction.selection().row(), Some(99));
-            assert_eq!(state.result_interaction.scroll_offset, 80);
-        }
+                assert_eq!(state.result_interaction.selection().row(), Some(0));
+                assert_eq!(state.result_interaction.scroll_offset, 0);
+            }
 
-        #[test]
-        fn half_page_up_cell_active_clamps_near_top() {
-            let mut state = state_with_result_rows(100, 25);
-            // visible=20, half=10
-            state.result_interaction.activate_cell(5, 0);
-            state.result_interaction.scroll_offset = 3;
+            #[test]
+            fn visible_zero_cell_active_is_noop() {
+                let mut state = state_with_result_rows(100, 0);
+                state.result_interaction.activate_cell(5, 1);
+                state.result_interaction.scroll_offset = 3;
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Up,
-                    amount: ScrollAmount::HalfPage,
-                },
-            );
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::HalfPage,
+                    },
+                );
 
-            // cursor: 5-10 → 0
-            // scroll: 3-10 → 0
-            assert_eq!(state.result_interaction.selection().row(), Some(0));
-            assert_eq!(state.result_interaction.scroll_offset, 0);
-        }
+                assert_eq!(state.result_interaction.selection().row(), Some(5));
+                assert_eq!(state.result_interaction.selection().cell(), Some(1));
+                assert_eq!(state.result_interaction.scroll_offset, 3);
+            }
 
-        #[test]
-        fn cell_active_half_page_down_preserves_column() {
-            let mut state = state_with_result_rows(100, 25);
-            state.result_interaction.activate_cell(10, 3);
-            state.result_interaction.scroll_offset = 5;
+            #[test]
+            fn data_fewer_than_viewport_scroll_stays_zero() {
+                let mut state = state_with_result_rows(10, 25);
+                state.result_interaction.activate_cell(3, 0);
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::HalfPage,
-                },
-            );
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::HalfPage,
+                    },
+                );
 
-            assert_eq!(state.result_interaction.selection().row(), Some(20));
-            assert_eq!(state.result_interaction.selection().cell(), Some(3));
-            assert_eq!(state.result_interaction.scroll_offset, 15);
-        }
+                assert_eq!(state.result_interaction.selection().row(), Some(9));
+                assert_eq!(state.result_interaction.scroll_offset, 0);
+            }
 
-        #[test]
-        fn visible_zero_cell_active_is_noop() {
-            let mut state = state_with_result_rows(100, 0);
-            // visible=0
-            state.result_interaction.activate_cell(5, 1);
-            state.result_interaction.scroll_offset = 3;
+            #[test]
+            fn full_page_down_clamps_near_bottom() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.activate_cell(90, 0);
+                state.result_interaction.scroll_offset = 75;
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::HalfPage,
-                },
-            );
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::FullPage,
+                    },
+                );
 
-            assert_eq!(state.result_interaction.selection().row(), Some(5));
-            assert_eq!(state.result_interaction.selection().cell(), Some(1));
-            assert_eq!(state.result_interaction.scroll_offset, 3);
-        }
+                assert_eq!(state.result_interaction.selection().row(), Some(99));
+                assert_eq!(state.result_interaction.scroll_offset, 80);
+            }
 
-        #[test]
-        fn data_fewer_than_viewport_scroll_stays_zero() {
-            let mut state = state_with_result_rows(10, 25);
-            // visible=20, 10 rows < 20 visible → max_scroll=0
-            state.result_interaction.activate_cell(3, 0);
+            #[test]
+            fn full_page_up_clamps_near_top() {
+                let mut state = state_with_result_rows(100, 25);
+                state.result_interaction.activate_cell(10, 0);
+                state.result_interaction.scroll_offset = 5;
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::HalfPage,
-                },
-            );
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Up,
+                        amount: ScrollAmount::FullPage,
+                    },
+                );
 
-            // cursor: 3+10=13 → clamped to 9
-            // scroll: 0+10=10 → clamped to max_scroll=0
-            assert_eq!(state.result_interaction.selection().row(), Some(9));
-            assert_eq!(state.result_interaction.scroll_offset, 0);
-        }
+                assert_eq!(state.result_interaction.selection().row(), Some(0));
+                assert_eq!(state.result_interaction.scroll_offset, 0);
+            }
 
-        #[test]
-        fn full_page_down_cell_active_moves_both() {
-            let mut state = state_with_result_rows(100, 25);
-            // visible=20, delta=20
-            state.result_interaction.activate_cell(10, 0);
-            state.result_interaction.scroll_offset = 5;
+            #[test]
+            fn visible_zero_cell_active_full_page_is_noop() {
+                let mut state = state_with_result_rows(100, 0);
+                state.result_interaction.activate_cell(5, 1);
+                state.result_interaction.scroll_offset = 3;
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::FullPage,
-                },
-            );
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::FullPage,
+                    },
+                );
 
-            assert_eq!(state.result_interaction.selection().row(), Some(30));
-            assert_eq!(state.result_interaction.scroll_offset, 25);
-        }
-
-        #[test]
-        fn full_page_up_cell_active_moves_both() {
-            let mut state = state_with_result_rows(100, 25);
-            // visible=20, delta=20
-            state.result_interaction.activate_cell(40, 0);
-            state.result_interaction.scroll_offset = 30;
-
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Up,
-                    amount: ScrollAmount::FullPage,
-                },
-            );
-
-            assert_eq!(state.result_interaction.selection().row(), Some(20));
-            assert_eq!(state.result_interaction.scroll_offset, 10);
-        }
-
-        #[test]
-        fn full_page_down_cell_active_clamps_near_bottom() {
-            let mut state = state_with_result_rows(100, 25);
-            // visible=20, delta=20, max_row=99, max_scroll=80
-            state.result_interaction.activate_cell(90, 0);
-            state.result_interaction.scroll_offset = 75;
-
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::FullPage,
-                },
-            );
-
-            assert_eq!(state.result_interaction.selection().row(), Some(99));
-            assert_eq!(state.result_interaction.scroll_offset, 80);
-        }
-
-        #[test]
-        fn full_page_up_cell_active_clamps_near_top() {
-            let mut state = state_with_result_rows(100, 25);
-            // visible=20, delta=20
-            state.result_interaction.activate_cell(10, 0);
-            state.result_interaction.scroll_offset = 5;
-
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Up,
-                    amount: ScrollAmount::FullPage,
-                },
-            );
-
-            assert_eq!(state.result_interaction.selection().row(), Some(0));
-            assert_eq!(state.result_interaction.scroll_offset, 0);
-        }
-
-        #[test]
-        fn visible_zero_cell_active_full_page_is_noop() {
-            let mut state = state_with_result_rows(100, 0);
-            state.result_interaction.activate_cell(5, 1);
-            state.result_interaction.scroll_offset = 3;
-
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::FullPage,
-                },
-            );
-
-            assert_eq!(state.result_interaction.selection().row(), Some(5));
-            assert_eq!(state.result_interaction.selection().cell(), Some(1));
-            assert_eq!(state.result_interaction.scroll_offset, 3);
+                assert_eq!(state.result_interaction.selection().row(), Some(5));
+                assert_eq!(state.result_interaction.selection().cell(), Some(1));
+                assert_eq!(state.result_interaction.scroll_offset, 3);
+            }
         }
     }
 

--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -285,7 +285,7 @@ mod tests {
         state
     }
 
-    mod result_page_scroll {
+    mod page_scroll {
         use super::*;
 
         #[test]
@@ -375,38 +375,42 @@ mod tests {
             assert_eq!(state.result_interaction.scroll_offset, 0);
         }
 
-        #[test]
-        fn scroll_middle_is_noop_in_scroll_mode() {
-            let mut state = state_with_result_rows(100, 25);
+        mod viewport_position {
+            use super::*;
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Up,
-                    amount: ScrollAmount::ViewportMiddle,
-                },
-            );
+            #[test]
+            fn scroll_middle_moves_row_to_viewport_center_in_cell_active() {
+                let mut state = state_with_result_rows(100, 25);
+                // visible = 20, mid_viewport = 10, target = 0 + 10 = 10
+                state.result_interaction.activate_cell(0, 0);
 
-            assert_eq!(state.result_interaction.scroll_offset, 0);
-        }
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Up,
+                        amount: ScrollAmount::ViewportMiddle,
+                    },
+                );
 
-        #[test]
-        fn scroll_middle_moves_row_to_viewport_center_in_cell_active() {
-            let mut state = state_with_result_rows(100, 25);
-            // visible = 20, mid_viewport = 10, target = 0 + 10 = 10
-            state.result_interaction.activate_cell(0, 0);
+                assert_eq!(state.result_interaction.selection().row(), Some(10));
+            }
 
-            reduce(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Result,
-                    direction: ScrollDirection::Up,
-                    amount: ScrollAmount::ViewportMiddle,
-                },
-            );
+            #[test]
+            fn scroll_middle_is_noop_in_scroll_mode() {
+                let mut state = state_with_result_rows(100, 25);
 
-            assert_eq!(state.result_interaction.selection().row(), Some(10));
+                reduce(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::Result,
+                        direction: ScrollDirection::Up,
+                        amount: ScrollAmount::ViewportMiddle,
+                    },
+                );
+
+                assert_eq!(state.result_interaction.scroll_offset, 0);
+            }
         }
 
         #[test]

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -666,7 +666,10 @@ mod tests {
     mod catalog_semantics {
         use super::*;
         use crate::app::update::input::keymap;
-        use rstest::rstest;
+
+        mod action_mapping {
+            use super::*;
+            use rstest::rstest;
 
         // ------------------------------------------------------------------ //
         // 1. idx-to-Action correctness
@@ -767,6 +770,11 @@ mod tests {
             );
         }
 
+        }
+
+        mod binding_shape {
+            use super::*;
+
         // ------------------------------------------------------------------ //
         // 2. Non-None bindings have at least one combo (KeyBinding arrays)
         // ------------------------------------------------------------------ //
@@ -824,6 +832,11 @@ mod tests {
                 check_mode_rows_exec_valid(mb.rows, name);
             }
         }
+
+        }
+
+        mod conflict_safety {
+            use super::*;
 
         // ------------------------------------------------------------------ //
         // 3. No duplicate combos within simple (non-context-dependent) modes
@@ -1059,6 +1072,11 @@ mod tests {
             check_none_action_entries_have_no_combos(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
         }
 
+        }
+
+        mod catalog_coverage {
+            use super::*;
+
         // ------------------------------------------------------------------ //
         // 7. ALL_MODE_BINDINGS exhaustiveness
         // ------------------------------------------------------------------ //
@@ -1067,6 +1085,8 @@ mod tests {
         #[test]
         fn all_mode_bindings_count() {
             assert_eq!(ALL_MODE_BINDINGS.len(), 9);
+        }
+
         }
     }
 }

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -671,422 +671,406 @@ mod tests {
             use super::*;
             use rstest::rstest;
 
-        // ------------------------------------------------------------------ //
-        // 1. idx-to-Action correctness
-        // ------------------------------------------------------------------ //
+            #[rstest]
+            #[case(idx::global::QUIT, Action::Quit)]
+            #[case(idx::global::HELP, Action::OpenHelp)]
+            #[case(idx::global::TABLE_PICKER, Action::OpenTablePicker)]
+            #[case(idx::global::PALETTE, Action::OpenCommandPalette)]
+            #[case(idx::global::COMMAND_LINE, Action::EnterCommandLine)]
+            #[case(idx::global::RELOAD, Action::ReloadMetadata)]
+            #[case(idx::global::SQL, Action::OpenSqlModal)]
+            #[case(idx::global::ER_DIAGRAM, Action::OpenErTablePicker)]
+            #[case(idx::global::CONNECTIONS, Action::OpenConnectionSelector)]
+            #[case(idx::global::CSV_EXPORT, Action::RequestCsvExport)]
+            #[case(idx::global::READ_ONLY, Action::ToggleReadOnly)]
+            #[case(idx::global::EXIT_READ_ONLY, Action::ToggleReadOnly)]
+            #[case(idx::global::QUERY_HISTORY, Action::OpenQueryHistoryPicker)]
+            fn global_key_action_matches(#[case] i: usize, #[case] expected: Action) {
+                assert!(
+                    std::mem::discriminant(&GLOBAL_KEYS[i].action)
+                        == std::mem::discriminant(&expected),
+                    "GLOBAL_KEYS[{i}] has action {:?}, expected {expected:?}",
+                    GLOBAL_KEYS[i].action
+                );
+            }
 
-        #[rstest]
-        #[case(idx::global::QUIT, Action::Quit)]
-        #[case(idx::global::HELP, Action::OpenHelp)]
-        #[case(idx::global::TABLE_PICKER, Action::OpenTablePicker)]
-        #[case(idx::global::PALETTE, Action::OpenCommandPalette)]
-        #[case(idx::global::COMMAND_LINE, Action::EnterCommandLine)]
-        #[case(idx::global::RELOAD, Action::ReloadMetadata)]
-        #[case(idx::global::SQL, Action::OpenSqlModal)]
-        #[case(idx::global::ER_DIAGRAM, Action::OpenErTablePicker)]
-        #[case(idx::global::CONNECTIONS, Action::OpenConnectionSelector)]
-        #[case(idx::global::CSV_EXPORT, Action::RequestCsvExport)]
-        #[case(idx::global::READ_ONLY, Action::ToggleReadOnly)]
-        #[case(idx::global::EXIT_READ_ONLY, Action::ToggleReadOnly)]
-        #[case(idx::global::QUERY_HISTORY, Action::OpenQueryHistoryPicker)]
-        fn global_key_action_matches(#[case] i: usize, #[case] expected: Action) {
-            assert!(
-                std::mem::discriminant(&GLOBAL_KEYS[i].action) == std::mem::discriminant(&expected),
-                "GLOBAL_KEYS[{i}] has action {:?}, expected {expected:?}",
-                GLOBAL_KEYS[i].action
-            );
-        }
+            #[test]
+            fn confirm_yes_action_matches() {
+                assert!(matches!(
+                    CONFIRM_DIALOG_KEYS[idx::confirm::YES].action,
+                    Action::ConfirmDialogConfirm
+                ));
+            }
 
-        #[test]
-        fn confirm_yes_action_matches() {
-            assert!(matches!(
-                CONFIRM_DIALOG_KEYS[idx::confirm::YES].action,
-                Action::ConfirmDialogConfirm
-            ));
-        }
+            #[test]
+            fn confirm_scroll_down_action_matches() {
+                assert!(matches!(
+                    CONFIRM_DIALOG_KEYS[idx::confirm::SCROLL_DOWN].action,
+                    Action::Scroll {
+                        target: ScrollTarget::ConfirmDialog,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::Line,
+                    }
+                ));
+            }
 
-        #[test]
-        fn confirm_scroll_down_action_matches() {
-            assert!(matches!(
-                CONFIRM_DIALOG_KEYS[idx::confirm::SCROLL_DOWN].action,
-                Action::Scroll {
-                    target: ScrollTarget::ConfirmDialog,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::Line,
-                }
-            ));
-        }
+            #[test]
+            fn confirm_scroll_up_action_matches() {
+                assert!(matches!(
+                    CONFIRM_DIALOG_KEYS[idx::confirm::SCROLL_UP].action,
+                    Action::Scroll {
+                        target: ScrollTarget::ConfirmDialog,
+                        direction: ScrollDirection::Up,
+                        amount: ScrollAmount::Line,
+                    }
+                ));
+            }
 
-        #[test]
-        fn confirm_scroll_up_action_matches() {
-            assert!(matches!(
-                CONFIRM_DIALOG_KEYS[idx::confirm::SCROLL_UP].action,
-                Action::Scroll {
-                    target: ScrollTarget::ConfirmDialog,
-                    direction: ScrollDirection::Up,
-                    amount: ScrollAmount::Line,
-                }
-            ));
-        }
+            #[test]
+            fn confirm_no_action_matches() {
+                assert!(matches!(
+                    CONFIRM_DIALOG_KEYS[idx::confirm::NO].action,
+                    Action::ConfirmDialogCancel
+                ));
+            }
 
-        #[test]
-        fn confirm_no_action_matches() {
-            assert!(matches!(
-                CONFIRM_DIALOG_KEYS[idx::confirm::NO].action,
-                Action::ConfirmDialogCancel
-            ));
-        }
+            #[rstest]
+            #[case(idx::sql_modal_plan::EXPLAIN, Action::ExplainRequest)]
+            #[case(idx::sql_modal_plan::ANALYZE, Action::ExplainAnalyzeRequest)]
+            #[case(idx::sql_modal_plan::YANK, Action::SqlModalYank)]
+            #[case(idx::sql_modal_plan::TAB, Action::SqlModalNextTab)]
+            #[case(idx::sql_modal_plan::BACKTAB, Action::SqlModalPrevTab)]
+            #[case(idx::sql_modal_plan::CLOSE, Action::CloseSqlModal)]
+            fn plan_key_action_matches(#[case] i: usize, #[case] expected: Action) {
+                assert!(
+                    std::mem::discriminant(&SQL_MODAL_PLAN_KEYS[i].action)
+                        == std::mem::discriminant(&expected),
+                    "SQL_MODAL_PLAN_KEYS[{i}] has action {:?}, expected {expected:?}",
+                    SQL_MODAL_PLAN_KEYS[i].action
+                );
+            }
 
-        #[rstest]
-        #[case(idx::sql_modal_plan::EXPLAIN, Action::ExplainRequest)]
-        #[case(idx::sql_modal_plan::ANALYZE, Action::ExplainAnalyzeRequest)]
-        #[case(idx::sql_modal_plan::YANK, Action::SqlModalYank)]
-        #[case(idx::sql_modal_plan::TAB, Action::SqlModalNextTab)]
-        #[case(idx::sql_modal_plan::BACKTAB, Action::SqlModalPrevTab)]
-        #[case(idx::sql_modal_plan::CLOSE, Action::CloseSqlModal)]
-        fn plan_key_action_matches(#[case] i: usize, #[case] expected: Action) {
-            assert!(
-                std::mem::discriminant(&SQL_MODAL_PLAN_KEYS[i].action)
-                    == std::mem::discriminant(&expected),
-                "SQL_MODAL_PLAN_KEYS[{i}] has action {:?}, expected {expected:?}",
-                SQL_MODAL_PLAN_KEYS[i].action
-            );
-        }
-
-        #[rstest]
-        #[case(idx::sql_modal_compare::EXPLAIN, Action::ExplainRequest)]
-        #[case(idx::sql_modal_compare::ANALYZE, Action::ExplainAnalyzeRequest)]
-        #[case(idx::sql_modal_compare::EDIT_QUERY, Action::CompareEditQuery)]
-        #[case(idx::sql_modal_compare::YANK, Action::SqlModalYank)]
-        #[case(idx::sql_modal_compare::TAB, Action::SqlModalNextTab)]
-        #[case(idx::sql_modal_compare::BACKTAB, Action::SqlModalPrevTab)]
-        #[case(idx::sql_modal_compare::CLOSE, Action::CloseSqlModal)]
-        fn compare_key_action_matches(#[case] i: usize, #[case] expected: Action) {
-            assert!(
-                std::mem::discriminant(&SQL_MODAL_COMPARE_KEYS[i].action)
-                    == std::mem::discriminant(&expected),
-                "SQL_MODAL_COMPARE_KEYS[{i}] has action {:?}, expected {expected:?}",
-                SQL_MODAL_COMPARE_KEYS[i].action
-            );
-        }
-
+            #[rstest]
+            #[case(idx::sql_modal_compare::EXPLAIN, Action::ExplainRequest)]
+            #[case(idx::sql_modal_compare::ANALYZE, Action::ExplainAnalyzeRequest)]
+            #[case(idx::sql_modal_compare::EDIT_QUERY, Action::CompareEditQuery)]
+            #[case(idx::sql_modal_compare::YANK, Action::SqlModalYank)]
+            #[case(idx::sql_modal_compare::TAB, Action::SqlModalNextTab)]
+            #[case(idx::sql_modal_compare::BACKTAB, Action::SqlModalPrevTab)]
+            #[case(idx::sql_modal_compare::CLOSE, Action::CloseSqlModal)]
+            fn compare_key_action_matches(#[case] i: usize, #[case] expected: Action) {
+                assert!(
+                    std::mem::discriminant(&SQL_MODAL_COMPARE_KEYS[i].action)
+                        == std::mem::discriminant(&expected),
+                    "SQL_MODAL_COMPARE_KEYS[{i}] has action {:?}, expected {expected:?}",
+                    SQL_MODAL_COMPARE_KEYS[i].action
+                );
+            }
         }
 
         mod binding_shape {
             use super::*;
 
-        // ------------------------------------------------------------------ //
-        // 2. Non-None bindings have at least one combo (KeyBinding arrays)
-        // ------------------------------------------------------------------ //
+            fn check_non_none_have_combos(bindings: &[KeyBinding], name: &str) {
+                for (i, kb) in bindings.iter().enumerate() {
+                    if !matches!(kb.action, Action::None) && kb.combos.is_empty() {
+                        if kb.key.starts_with(':') {
+                            continue;
+                        }
+                        if kb.key_short == ":w" || kb.desc_short == "Write" {
+                            continue;
+                        }
+                        panic!(
+                            "{name}[{i}] has action {:?} but no combos (key={:?})",
+                            kb.action, kb.key
+                        );
+                    }
+                }
+            }
 
-        fn check_non_none_have_combos(bindings: &[KeyBinding], name: &str) {
-            for (i, kb) in bindings.iter().enumerate() {
-                if !matches!(kb.action, Action::None) && kb.combos.is_empty() {
-                    if kb.key.starts_with(':') {
-                        continue;
+            #[test]
+            fn all_non_none_bindings_have_combos() {
+                check_non_none_have_combos(GLOBAL_KEYS, "GLOBAL_KEYS");
+                check_non_none_have_combos(CONFIRM_DIALOG_KEYS, "CONFIRM_DIALOG_KEYS");
+                check_non_none_have_combos(COMMAND_LINE_KEYS, "COMMAND_LINE_KEYS");
+                check_non_none_have_combos(CELL_EDIT_KEYS, "CELL_EDIT_KEYS");
+                check_non_none_have_combos(HISTORY_KEYS, "HISTORY_KEYS");
+                check_non_none_have_combos(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
+            }
+
+            // ------------------------------------------------------------------ //
+            // 2b. ModeRow exec entries have non-empty combos
+            // ------------------------------------------------------------------ //
+
+            fn check_mode_rows_exec_valid(rows: &[ModeRow], name: &str) {
+                for (i, row) in rows.iter().enumerate() {
+                    for (j, eb) in row.bindings.iter().enumerate() {
+                        assert!(
+                            !eb.combos.is_empty(),
+                            "{name}[{i}].bindings[{j}] has action {:?} but no combos",
+                            eb.action
+                        );
+                        assert!(
+                            !matches!(eb.action, Action::None),
+                            "{name}[{i}].bindings[{j}] has Action::None in exec binding",
+                        );
                     }
-                    if kb.key_short == ":w" || kb.desc_short == "Write" {
-                        continue;
-                    }
-                    panic!(
-                        "{name}[{i}] has action {:?} but no combos (key={:?})",
-                        kb.action, kb.key
+                }
+            }
+
+            #[test]
+            fn all_mode_row_exec_entries_are_valid() {
+                for (name, mb) in ALL_MODE_BINDINGS {
+                    check_mode_rows_exec_valid(mb.rows, name);
+                }
+            }
+
+            fn check_none_action_entries_have_no_combos(bindings: &[KeyBinding], name: &str) {
+                for (i, kb) in bindings.iter().enumerate() {
+                    assert!(
+                        !matches!(kb.action, Action::None) || kb.combos.is_empty(),
+                        "{name}[{i}] has action Action::None but non-empty combos: {:?}",
+                        kb.combos
                     );
                 }
             }
-        }
 
-        #[test]
-        fn all_non_none_bindings_have_combos() {
-            check_non_none_have_combos(GLOBAL_KEYS, "GLOBAL_KEYS");
-            check_non_none_have_combos(CONFIRM_DIALOG_KEYS, "CONFIRM_DIALOG_KEYS");
-            check_non_none_have_combos(COMMAND_LINE_KEYS, "COMMAND_LINE_KEYS");
-            check_non_none_have_combos(CELL_EDIT_KEYS, "CELL_EDIT_KEYS");
-            check_non_none_have_combos(HISTORY_KEYS, "HISTORY_KEYS");
-            check_non_none_have_combos(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
-        }
-
-        // ------------------------------------------------------------------ //
-        // 2b. ModeRow exec entries have non-empty combos
-        // ------------------------------------------------------------------ //
-
-        fn check_mode_rows_exec_valid(rows: &[ModeRow], name: &str) {
-            for (i, row) in rows.iter().enumerate() {
-                for (j, eb) in row.bindings.iter().enumerate() {
-                    assert!(
-                        !eb.combos.is_empty(),
-                        "{name}[{i}].bindings[{j}] has action {:?} but no combos",
-                        eb.action
-                    );
-                    assert!(
-                        !matches!(eb.action, Action::None),
-                        "{name}[{i}].bindings[{j}] has Action::None in exec binding",
-                    );
-                }
+            #[test]
+            fn none_action_entries_have_no_combos() {
+                check_none_action_entries_have_no_combos(GLOBAL_KEYS, "GLOBAL_KEYS");
+                check_none_action_entries_have_no_combos(NAVIGATION_KEYS, "NAVIGATION_KEYS");
+                check_none_action_entries_have_no_combos(FOOTER_NAV_KEYS, "FOOTER_NAV_KEYS");
+                check_none_action_entries_have_no_combos(
+                    SQL_MODAL_NORMAL_KEYS,
+                    "SQL_MODAL_NORMAL_KEYS",
+                );
+                check_none_action_entries_have_no_combos(SQL_MODAL_KEYS, "SQL_MODAL_KEYS");
+                check_none_action_entries_have_no_combos(
+                    SQL_MODAL_PLAN_KEYS,
+                    "SQL_MODAL_PLAN_KEYS",
+                );
+                check_none_action_entries_have_no_combos(
+                    SQL_MODAL_COMPARE_KEYS,
+                    "SQL_MODAL_COMPARE_KEYS",
+                );
+                check_none_action_entries_have_no_combos(
+                    SQL_MODAL_CONFIRMING_KEYS,
+                    "SQL_MODAL_CONFIRMING_KEYS",
+                );
+                check_none_action_entries_have_no_combos(OVERLAY_KEYS, "OVERLAY_KEYS");
+                check_none_action_entries_have_no_combos(
+                    CONNECTION_SETUP_KEYS,
+                    "CONNECTION_SETUP_KEYS",
+                );
+                check_none_action_entries_have_no_combos(RESULT_ACTIVE_KEYS, "RESULT_ACTIVE_KEYS");
+                check_none_action_entries_have_no_combos(HISTORY_KEYS, "HISTORY_KEYS");
+                check_none_action_entries_have_no_combos(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
             }
         }
 
-        #[test]
-        fn all_mode_row_exec_entries_are_valid() {
-            for (name, mb) in ALL_MODE_BINDINGS {
-                check_mode_rows_exec_valid(mb.rows, name);
-            }
-        }
-
-        }
-
-        mod conflict_safety {
+        mod uniqueness {
             use super::*;
 
-        // ------------------------------------------------------------------ //
-        // 3. No duplicate combos within simple (non-context-dependent) modes
-        // ------------------------------------------------------------------ //
-
-        fn check_no_duplicate_combos(bindings: &[KeyBinding], name: &str) {
-            let mut seen: Vec<KeyCombo> = Vec::new();
-            for kb in bindings
-                .iter()
-                .filter(|kb| !matches!(kb.action, Action::None))
-            {
-                for combo in kb.combos {
-                    assert!(
-                        !seen.contains(combo),
-                        "{name}: duplicate combo {combo:?} in binding {:?}",
-                        kb.action
-                    );
-                    seen.push(*combo);
-                }
-            }
-        }
-
-        fn check_no_duplicate_combos_rows(rows: &[ModeRow], name: &str) {
-            let mut seen: Vec<KeyCombo> = Vec::new();
-            for row in rows {
-                for eb in row.bindings {
-                    for combo in eb.combos {
+            fn check_no_duplicate_combos(bindings: &[KeyBinding], name: &str) {
+                let mut seen: Vec<KeyCombo> = Vec::new();
+                for kb in bindings
+                    .iter()
+                    .filter(|kb| !matches!(kb.action, Action::None))
+                {
+                    for combo in kb.combos {
                         assert!(
                             !seen.contains(combo),
                             "{name}: duplicate combo {combo:?} in binding {:?}",
-                            eb.action
+                            kb.action
                         );
                         seen.push(*combo);
                     }
                 }
             }
-        }
 
-        // GLOBAL_KEYS excluded: FOCUS/EXIT_FOCUS share a combo for footer label switching.
-        #[test]
-        fn no_duplicate_combos_in_simple_modes() {
-            check_no_duplicate_combos(CONFIRM_DIALOG_KEYS, "CONFIRM_DIALOG_KEYS");
-            check_no_duplicate_combos(COMMAND_LINE_KEYS, "COMMAND_LINE_KEYS");
-            check_no_duplicate_combos(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
-            for (name, mb) in ALL_MODE_BINDINGS {
-                check_no_duplicate_combos_rows(mb.rows, name);
-            }
-        }
-
-        // ------------------------------------------------------------------ //
-        // 4. keymap::resolve() round-trip
-        // ------------------------------------------------------------------ //
-
-        fn check_keymap_roundtrip(bindings: &[KeyBinding], name: &str) {
-            for kb in bindings
-                .iter()
-                .filter(|kb| !matches!(kb.action, Action::None))
-            {
-                for combo in kb.combos {
-                    let resolved = keymap::resolve(combo, bindings);
-                    match resolved {
-                        Some(ref action)
-                            if std::mem::discriminant(action)
-                                == std::mem::discriminant(&kb.action) => {}
-                        other => panic!(
-                            "{name}: combo {combo:?} resolved to {other:?}, expected {:?}",
-                            kb.action
-                        ),
+            fn check_no_duplicate_combos_rows(rows: &[ModeRow], name: &str) {
+                let mut seen: Vec<KeyCombo> = Vec::new();
+                for row in rows {
+                    for eb in row.bindings {
+                        for combo in eb.combos {
+                            assert!(
+                                !seen.contains(combo),
+                                "{name}: duplicate combo {combo:?} in binding {:?}",
+                                eb.action
+                            );
+                            seen.push(*combo);
+                        }
                     }
+                }
+            }
+
+            // GLOBAL_KEYS excluded: FOCUS/EXIT_FOCUS share a combo for footer label switching.
+            #[test]
+            fn no_duplicate_combos_in_simple_modes() {
+                check_no_duplicate_combos(CONFIRM_DIALOG_KEYS, "CONFIRM_DIALOG_KEYS");
+                check_no_duplicate_combos(COMMAND_LINE_KEYS, "COMMAND_LINE_KEYS");
+                check_no_duplicate_combos(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
+                for (name, mb) in ALL_MODE_BINDINGS {
+                    check_no_duplicate_combos_rows(mb.rows, name);
                 }
             }
         }
 
-        fn check_resolve_mode_roundtrip(rows: &[ModeRow], name: &str) {
-            for row in rows {
-                for eb in row.bindings {
-                    for combo in eb.combos {
-                        let resolved = keymap::resolve_mode(combo, rows);
+        mod resolver_contract {
+            use super::*;
+
+            fn check_keymap_roundtrip(bindings: &[KeyBinding], name: &str) {
+                for kb in bindings
+                    .iter()
+                    .filter(|kb| !matches!(kb.action, Action::None))
+                {
+                    for combo in kb.combos {
+                        let resolved = keymap::resolve(combo, bindings);
                         match resolved {
                             Some(ref action)
                                 if std::mem::discriminant(action)
-                                    == std::mem::discriminant(&eb.action) => {}
+                                    == std::mem::discriminant(&kb.action) => {}
                             other => panic!(
                                 "{name}: combo {combo:?} resolved to {other:?}, expected {:?}",
-                                eb.action
+                                kb.action
                             ),
                         }
                     }
                 }
             }
-        }
 
-        #[test]
-        fn keymap_resolve_roundtrip_for_simple_modes() {
-            check_keymap_roundtrip(CONFIRM_DIALOG_KEYS, "CONFIRM_DIALOG_KEYS");
-            check_keymap_roundtrip(COMMAND_LINE_KEYS, "COMMAND_LINE_KEYS");
-            check_keymap_roundtrip(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
-            for (name, mb) in ALL_MODE_BINDINGS {
-                check_resolve_mode_roundtrip(mb.rows, name);
-            }
-        }
-
-        // ------------------------------------------------------------------ //
-        // 5. Char fallback safety
-        // ------------------------------------------------------------------ //
-
-        fn check_no_plain_char_in_filter_mode(
-            bindings: &[KeyBinding],
-            name: &str,
-            allowed_chars: &[char],
-        ) {
-            let no_mods = Modifiers {
-                ctrl: false,
-                alt: false,
-                shift: false,
-            };
-            for kb in bindings
-                .iter()
-                .filter(|kb| !matches!(kb.action, Action::None))
-            {
-                for combo in kb.combos {
-                    if combo.modifiers == no_mods
-                        && let Key::Char(c) = combo.key
-                    {
-                        assert!(
-                            allowed_chars.contains(&c),
-                            "{name}: executable entry {:?} has plain Char({c:?}) combo \
-                             which would shadow filter input",
-                            kb.action
-                        );
+            fn check_resolve_mode_roundtrip(rows: &[ModeRow], name: &str) {
+                for row in rows {
+                    for eb in row.bindings {
+                        for combo in eb.combos {
+                            let resolved = keymap::resolve_mode(combo, rows);
+                            match resolved {
+                                Some(ref action)
+                                    if std::mem::discriminant(action)
+                                        == std::mem::discriminant(&eb.action) => {}
+                                other => panic!(
+                                    "{name}: combo {combo:?} resolved to {other:?}, expected {:?}",
+                                    eb.action
+                                ),
+                            }
+                        }
                     }
+                }
+            }
+
+            #[test]
+            fn keymap_resolve_roundtrip_for_simple_modes() {
+                check_keymap_roundtrip(CONFIRM_DIALOG_KEYS, "CONFIRM_DIALOG_KEYS");
+                check_keymap_roundtrip(COMMAND_LINE_KEYS, "COMMAND_LINE_KEYS");
+                check_keymap_roundtrip(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
+                for (name, mb) in ALL_MODE_BINDINGS {
+                    check_resolve_mode_roundtrip(mb.rows, name);
                 }
             }
         }
 
-        fn check_no_plain_char_in_filter_mode_rows(
-            rows: &[ModeRow],
-            name: &str,
-            allowed_chars: &[char],
-        ) {
-            let no_mods = Modifiers {
-                ctrl: false,
-                alt: false,
-                shift: false,
-            };
-            for row in rows {
-                for eb in row.bindings {
-                    for combo in eb.combos {
+        mod conflict_safety {
+            use super::*;
+
+            fn check_no_plain_char_in_filter_mode(
+                bindings: &[KeyBinding],
+                name: &str,
+                allowed_chars: &[char],
+            ) {
+                let no_mods = Modifiers {
+                    ctrl: false,
+                    alt: false,
+                    shift: false,
+                };
+                for kb in bindings
+                    .iter()
+                    .filter(|kb| !matches!(kb.action, Action::None))
+                {
+                    for combo in kb.combos {
                         if combo.modifiers == no_mods
                             && let Key::Char(c) = combo.key
                         {
                             assert!(
                                 allowed_chars.contains(&c),
                                 "{name}: executable entry {:?} has plain Char({c:?}) combo \
-                                 which would shadow filter input",
-                                eb.action
+                             which would shadow filter input",
+                                kb.action
                             );
                         }
                     }
                 }
             }
-        }
 
-        #[test]
-        fn table_picker_has_no_plain_char_combos() {
-            check_no_plain_char_in_filter_mode_rows(TABLE_PICKER_ROWS, "TABLE_PICKER_ROWS", &[]);
-        }
+            fn check_no_plain_char_in_filter_mode_rows(
+                rows: &[ModeRow],
+                name: &str,
+                allowed_chars: &[char],
+            ) {
+                let no_mods = Modifiers {
+                    ctrl: false,
+                    alt: false,
+                    shift: false,
+                };
+                for row in rows {
+                    for eb in row.bindings {
+                        for combo in eb.combos {
+                            if combo.modifiers == no_mods
+                                && let Key::Char(c) = combo.key
+                            {
+                                assert!(
+                                    allowed_chars.contains(&c),
+                                    "{name}: executable entry {:?} has plain Char({c:?}) combo \
+                                 which would shadow filter input",
+                                    eb.action
+                                );
+                            }
+                        }
+                    }
+                }
+            }
 
-        #[test]
-        fn er_picker_has_no_plain_char_combos() {
-            check_no_plain_char_in_filter_mode_rows(ER_PICKER_ROWS, "ER_PICKER_ROWS", &[' ']);
-        }
-
-        #[test]
-        fn query_history_picker_has_no_plain_char_combos() {
-            check_no_plain_char_in_filter_mode_rows(
-                QUERY_HISTORY_PICKER_ROWS,
-                "QUERY_HISTORY_PICKER_ROWS",
-                &[],
-            );
-        }
-
-        #[test]
-        fn command_line_has_no_problematic_plain_char_combos() {
-            check_no_plain_char_in_filter_mode(COMMAND_LINE_KEYS, "COMMAND_LINE_KEYS", &[]);
-        }
-
-        #[test]
-        fn cell_edit_plain_char_combos_are_intentional() {
-            check_no_plain_char_in_filter_mode(CELL_EDIT_KEYS, "CELL_EDIT_KEYS", &[':']);
-        }
-
-        // ------------------------------------------------------------------ //
-        // 6. Action::None entries must have combos: &[] (KeyBinding arrays only)
-        // ------------------------------------------------------------------ //
-
-        fn check_none_action_entries_have_no_combos(bindings: &[KeyBinding], name: &str) {
-            for (i, kb) in bindings.iter().enumerate() {
-                assert!(
-                    !matches!(kb.action, Action::None) || kb.combos.is_empty(),
-                    "{name}[{i}] has action Action::None but non-empty combos: {:?}",
-                    kb.combos
+            #[test]
+            fn table_picker_has_no_plain_char_combos() {
+                check_no_plain_char_in_filter_mode_rows(
+                    TABLE_PICKER_ROWS,
+                    "TABLE_PICKER_ROWS",
+                    &[],
                 );
             }
-        }
 
-        #[test]
-        fn none_action_entries_have_no_combos() {
-            check_none_action_entries_have_no_combos(GLOBAL_KEYS, "GLOBAL_KEYS");
-            check_none_action_entries_have_no_combos(NAVIGATION_KEYS, "NAVIGATION_KEYS");
-            check_none_action_entries_have_no_combos(FOOTER_NAV_KEYS, "FOOTER_NAV_KEYS");
-            check_none_action_entries_have_no_combos(
-                SQL_MODAL_NORMAL_KEYS,
-                "SQL_MODAL_NORMAL_KEYS",
-            );
-            check_none_action_entries_have_no_combos(SQL_MODAL_KEYS, "SQL_MODAL_KEYS");
-            check_none_action_entries_have_no_combos(SQL_MODAL_PLAN_KEYS, "SQL_MODAL_PLAN_KEYS");
-            check_none_action_entries_have_no_combos(
-                SQL_MODAL_COMPARE_KEYS,
-                "SQL_MODAL_COMPARE_KEYS",
-            );
-            check_none_action_entries_have_no_combos(
-                SQL_MODAL_CONFIRMING_KEYS,
-                "SQL_MODAL_CONFIRMING_KEYS",
-            );
-            check_none_action_entries_have_no_combos(OVERLAY_KEYS, "OVERLAY_KEYS");
-            check_none_action_entries_have_no_combos(
-                CONNECTION_SETUP_KEYS,
-                "CONNECTION_SETUP_KEYS",
-            );
-            check_none_action_entries_have_no_combos(RESULT_ACTIVE_KEYS, "RESULT_ACTIVE_KEYS");
-            check_none_action_entries_have_no_combos(HISTORY_KEYS, "HISTORY_KEYS");
-            check_none_action_entries_have_no_combos(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
-        }
+            #[test]
+            fn er_picker_has_no_plain_char_combos() {
+                check_no_plain_char_in_filter_mode_rows(ER_PICKER_ROWS, "ER_PICKER_ROWS", &[' ']);
+            }
 
+            #[test]
+            fn query_history_picker_has_no_plain_char_combos() {
+                check_no_plain_char_in_filter_mode_rows(
+                    QUERY_HISTORY_PICKER_ROWS,
+                    "QUERY_HISTORY_PICKER_ROWS",
+                    &[],
+                );
+            }
+
+            #[test]
+            fn command_line_has_no_problematic_plain_char_combos() {
+                check_no_plain_char_in_filter_mode(COMMAND_LINE_KEYS, "COMMAND_LINE_KEYS", &[]);
+            }
+
+            #[test]
+            fn cell_edit_plain_char_combos_are_intentional() {
+                check_no_plain_char_in_filter_mode(CELL_EDIT_KEYS, "CELL_EDIT_KEYS", &[':']);
+            }
         }
 
         mod catalog_coverage {
             use super::*;
 
-        // ------------------------------------------------------------------ //
-        // 7. ALL_MODE_BINDINGS exhaustiveness
-        // ------------------------------------------------------------------ //
-
-        // HELP, CONNECTION_ERROR, TABLE_PICKER, ER_PICKER, COMMAND_PALETTE, CONNECTION_SELECTOR
-        #[test]
-        fn all_mode_bindings_count() {
-            assert_eq!(ALL_MODE_BINDINGS.len(), 9);
-        }
-
+            // HELP, CONNECTION_ERROR, TABLE_PICKER, ER_PICKER, COMMAND_PALETTE, CONNECTION_SELECTOR
+            #[test]
+            fn all_mode_bindings_count() {
+                assert_eq!(ALL_MODE_BINDINGS.len(), 9);
+            }
         }
     }
 }

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -429,237 +429,241 @@ mod tests {
     use super::*;
     use crate::app::update::action::{ScrollAmount, ScrollDirection, ScrollTarget};
 
-    #[test]
-    fn idx_constants_are_within_bounds() {
-        // GLOBAL_KEYS
-        assert!(idx::global::QUIT < GLOBAL_KEYS.len());
-        assert!(idx::global::HELP < GLOBAL_KEYS.len());
-        assert!(idx::global::TABLE_PICKER < GLOBAL_KEYS.len());
-        assert!(idx::global::PALETTE < GLOBAL_KEYS.len());
-        assert!(idx::global::COMMAND_LINE < GLOBAL_KEYS.len());
-        assert!(idx::global::FOCUS < GLOBAL_KEYS.len());
-        assert!(idx::global::EXIT_FOCUS < GLOBAL_KEYS.len());
-        assert!(idx::global::PANE_SWITCH < GLOBAL_KEYS.len());
-        assert!(idx::global::INSPECTOR_TABS < GLOBAL_KEYS.len());
-        assert!(idx::global::RELOAD < GLOBAL_KEYS.len());
-        assert!(idx::global::SQL < GLOBAL_KEYS.len());
-        assert!(idx::global::ER_DIAGRAM < GLOBAL_KEYS.len());
-        assert!(idx::global::CONNECTIONS < GLOBAL_KEYS.len());
-        assert!(idx::global::CSV_EXPORT < GLOBAL_KEYS.len());
-        assert!(idx::global::READ_ONLY < GLOBAL_KEYS.len());
-        assert!(idx::global::EXIT_READ_ONLY < GLOBAL_KEYS.len());
-        assert!(idx::global::QUERY_HISTORY < GLOBAL_KEYS.len());
+    mod structure {
+        use super::*;
 
-        // FOOTER_NAV_KEYS
-        assert!(idx::footer_nav::SCROLL < FOOTER_NAV_KEYS.len());
-        assert!(idx::footer_nav::SCROLL_SHORT < FOOTER_NAV_KEYS.len());
-        assert!(idx::footer_nav::TOP_BOTTOM < FOOTER_NAV_KEYS.len());
-        assert!(idx::footer_nav::H_SCROLL < FOOTER_NAV_KEYS.len());
-        assert!(idx::footer_nav::PAGE_NAV < FOOTER_NAV_KEYS.len());
+        #[test]
+        fn idx_constants_are_within_bounds() {
+            // GLOBAL_KEYS
+            assert!(idx::global::QUIT < GLOBAL_KEYS.len());
+            assert!(idx::global::HELP < GLOBAL_KEYS.len());
+            assert!(idx::global::TABLE_PICKER < GLOBAL_KEYS.len());
+            assert!(idx::global::PALETTE < GLOBAL_KEYS.len());
+            assert!(idx::global::COMMAND_LINE < GLOBAL_KEYS.len());
+            assert!(idx::global::FOCUS < GLOBAL_KEYS.len());
+            assert!(idx::global::EXIT_FOCUS < GLOBAL_KEYS.len());
+            assert!(idx::global::PANE_SWITCH < GLOBAL_KEYS.len());
+            assert!(idx::global::INSPECTOR_TABS < GLOBAL_KEYS.len());
+            assert!(idx::global::RELOAD < GLOBAL_KEYS.len());
+            assert!(idx::global::SQL < GLOBAL_KEYS.len());
+            assert!(idx::global::ER_DIAGRAM < GLOBAL_KEYS.len());
+            assert!(idx::global::CONNECTIONS < GLOBAL_KEYS.len());
+            assert!(idx::global::CSV_EXPORT < GLOBAL_KEYS.len());
+            assert!(idx::global::READ_ONLY < GLOBAL_KEYS.len());
+            assert!(idx::global::EXIT_READ_ONLY < GLOBAL_KEYS.len());
+            assert!(idx::global::QUERY_HISTORY < GLOBAL_KEYS.len());
 
-        // SQL_MODAL_NORMAL_KEYS
-        assert!(idx::sql_modal_normal::RUN < SQL_MODAL_NORMAL_KEYS.len());
-        assert!(idx::sql_modal_normal::YANK < SQL_MODAL_NORMAL_KEYS.len());
-        assert!(idx::sql_modal_normal::ENTER_INSERT < SQL_MODAL_NORMAL_KEYS.len());
-        assert!(idx::sql_modal_normal::APPEND < SQL_MODAL_NORMAL_KEYS.len());
-        assert!(idx::sql_modal_normal::MOVE < SQL_MODAL_NORMAL_KEYS.len());
-        assert!(idx::sql_modal_normal::HOME_END < SQL_MODAL_NORMAL_KEYS.len());
-        assert!(idx::sql_modal_normal::VIEWPORT < SQL_MODAL_NORMAL_KEYS.len());
-        assert!(idx::sql_modal_normal::CLOSE < SQL_MODAL_NORMAL_KEYS.len());
-        assert!(idx::sql_modal_normal::CLEAR < SQL_MODAL_NORMAL_KEYS.len());
-        assert!(idx::sql_modal_normal::QUERY_HISTORY < SQL_MODAL_NORMAL_KEYS.len());
+            // FOOTER_NAV_KEYS
+            assert!(idx::footer_nav::SCROLL < FOOTER_NAV_KEYS.len());
+            assert!(idx::footer_nav::SCROLL_SHORT < FOOTER_NAV_KEYS.len());
+            assert!(idx::footer_nav::TOP_BOTTOM < FOOTER_NAV_KEYS.len());
+            assert!(idx::footer_nav::H_SCROLL < FOOTER_NAV_KEYS.len());
+            assert!(idx::footer_nav::PAGE_NAV < FOOTER_NAV_KEYS.len());
 
-        // SQL_MODAL_KEYS
-        assert!(idx::sql_modal::RUN < SQL_MODAL_KEYS.len());
-        assert!(idx::sql_modal::ESC_NORMAL < SQL_MODAL_KEYS.len());
-        assert!(idx::sql_modal::MOVE < SQL_MODAL_KEYS.len());
-        assert!(idx::sql_modal::HOME_END < SQL_MODAL_KEYS.len());
-        assert!(idx::sql_modal::TAB < SQL_MODAL_KEYS.len());
-        assert!(idx::sql_modal::COMPLETION_TRIGGER < SQL_MODAL_KEYS.len());
-        assert!(idx::sql_modal::CLEAR < SQL_MODAL_KEYS.len());
-        assert!(idx::sql_modal::QUERY_HISTORY < SQL_MODAL_KEYS.len());
+            // SQL_MODAL_NORMAL_KEYS
+            assert!(idx::sql_modal_normal::RUN < SQL_MODAL_NORMAL_KEYS.len());
+            assert!(idx::sql_modal_normal::YANK < SQL_MODAL_NORMAL_KEYS.len());
+            assert!(idx::sql_modal_normal::ENTER_INSERT < SQL_MODAL_NORMAL_KEYS.len());
+            assert!(idx::sql_modal_normal::APPEND < SQL_MODAL_NORMAL_KEYS.len());
+            assert!(idx::sql_modal_normal::MOVE < SQL_MODAL_NORMAL_KEYS.len());
+            assert!(idx::sql_modal_normal::HOME_END < SQL_MODAL_NORMAL_KEYS.len());
+            assert!(idx::sql_modal_normal::VIEWPORT < SQL_MODAL_NORMAL_KEYS.len());
+            assert!(idx::sql_modal_normal::CLOSE < SQL_MODAL_NORMAL_KEYS.len());
+            assert!(idx::sql_modal_normal::CLEAR < SQL_MODAL_NORMAL_KEYS.len());
+            assert!(idx::sql_modal_normal::QUERY_HISTORY < SQL_MODAL_NORMAL_KEYS.len());
 
-        // SQL_MODAL_PLAN_KEYS
-        assert!(idx::sql_modal_plan::EXPLAIN < SQL_MODAL_PLAN_KEYS.len());
-        assert!(idx::sql_modal_plan::ANALYZE < SQL_MODAL_PLAN_KEYS.len());
-        assert!(idx::sql_modal_plan::YANK < SQL_MODAL_PLAN_KEYS.len());
-        assert!(idx::sql_modal_plan::SCROLL < SQL_MODAL_PLAN_KEYS.len());
-        assert!(idx::sql_modal_plan::TAB < SQL_MODAL_PLAN_KEYS.len());
-        assert!(idx::sql_modal_plan::BACKTAB < SQL_MODAL_PLAN_KEYS.len());
-        assert!(idx::sql_modal_plan::CLOSE < SQL_MODAL_PLAN_KEYS.len());
+            // SQL_MODAL_KEYS
+            assert!(idx::sql_modal::RUN < SQL_MODAL_KEYS.len());
+            assert!(idx::sql_modal::ESC_NORMAL < SQL_MODAL_KEYS.len());
+            assert!(idx::sql_modal::MOVE < SQL_MODAL_KEYS.len());
+            assert!(idx::sql_modal::HOME_END < SQL_MODAL_KEYS.len());
+            assert!(idx::sql_modal::TAB < SQL_MODAL_KEYS.len());
+            assert!(idx::sql_modal::COMPLETION_TRIGGER < SQL_MODAL_KEYS.len());
+            assert!(idx::sql_modal::CLEAR < SQL_MODAL_KEYS.len());
+            assert!(idx::sql_modal::QUERY_HISTORY < SQL_MODAL_KEYS.len());
 
-        // SQL_MODAL_COMPARE_KEYS
-        assert!(idx::sql_modal_compare::EXPLAIN < SQL_MODAL_COMPARE_KEYS.len());
-        assert!(idx::sql_modal_compare::ANALYZE < SQL_MODAL_COMPARE_KEYS.len());
-        assert!(idx::sql_modal_compare::EDIT_QUERY < SQL_MODAL_COMPARE_KEYS.len());
-        assert!(idx::sql_modal_compare::YANK < SQL_MODAL_COMPARE_KEYS.len());
-        assert!(idx::sql_modal_compare::SCROLL < SQL_MODAL_COMPARE_KEYS.len());
-        assert!(idx::sql_modal_compare::TAB < SQL_MODAL_COMPARE_KEYS.len());
-        assert!(idx::sql_modal_compare::BACKTAB < SQL_MODAL_COMPARE_KEYS.len());
-        assert!(idx::sql_modal_compare::CLOSE < SQL_MODAL_COMPARE_KEYS.len());
+            // SQL_MODAL_PLAN_KEYS
+            assert!(idx::sql_modal_plan::EXPLAIN < SQL_MODAL_PLAN_KEYS.len());
+            assert!(idx::sql_modal_plan::ANALYZE < SQL_MODAL_PLAN_KEYS.len());
+            assert!(idx::sql_modal_plan::YANK < SQL_MODAL_PLAN_KEYS.len());
+            assert!(idx::sql_modal_plan::SCROLL < SQL_MODAL_PLAN_KEYS.len());
+            assert!(idx::sql_modal_plan::TAB < SQL_MODAL_PLAN_KEYS.len());
+            assert!(idx::sql_modal_plan::BACKTAB < SQL_MODAL_PLAN_KEYS.len());
+            assert!(idx::sql_modal_plan::CLOSE < SQL_MODAL_PLAN_KEYS.len());
 
-        // SQL_MODAL_CONFIRMING_KEYS
-        assert!(idx::sql_modal_confirming::CANCEL_CONFIRM < SQL_MODAL_CONFIRMING_KEYS.len());
+            // SQL_MODAL_COMPARE_KEYS
+            assert!(idx::sql_modal_compare::EXPLAIN < SQL_MODAL_COMPARE_KEYS.len());
+            assert!(idx::sql_modal_compare::ANALYZE < SQL_MODAL_COMPARE_KEYS.len());
+            assert!(idx::sql_modal_compare::EDIT_QUERY < SQL_MODAL_COMPARE_KEYS.len());
+            assert!(idx::sql_modal_compare::YANK < SQL_MODAL_COMPARE_KEYS.len());
+            assert!(idx::sql_modal_compare::SCROLL < SQL_MODAL_COMPARE_KEYS.len());
+            assert!(idx::sql_modal_compare::TAB < SQL_MODAL_COMPARE_KEYS.len());
+            assert!(idx::sql_modal_compare::BACKTAB < SQL_MODAL_COMPARE_KEYS.len());
+            assert!(idx::sql_modal_compare::CLOSE < SQL_MODAL_COMPARE_KEYS.len());
 
-        // OVERLAY_KEYS
-        assert!(idx::overlay::ESC_CANCEL < OVERLAY_KEYS.len());
-        assert!(idx::overlay::ESC_CLOSE < OVERLAY_KEYS.len());
-        assert!(idx::overlay::ENTER_EXECUTE < OVERLAY_KEYS.len());
-        assert!(idx::overlay::ENTER_SELECT < OVERLAY_KEYS.len());
-        assert!(idx::overlay::NAVIGATE_JK < OVERLAY_KEYS.len());
-        assert!(idx::overlay::TYPE_FILTER < OVERLAY_KEYS.len());
-        assert!(idx::overlay::ERROR_OPEN < OVERLAY_KEYS.len());
+            // SQL_MODAL_CONFIRMING_KEYS
+            assert!(idx::sql_modal_confirming::CANCEL_CONFIRM < SQL_MODAL_CONFIRMING_KEYS.len());
 
-        // CONNECTION_SETUP_KEYS
-        assert!(idx::conn_setup::TAB_NAV < CONNECTION_SETUP_KEYS.len());
-        assert!(idx::conn_setup::TAB_NEXT < CONNECTION_SETUP_KEYS.len());
-        assert!(idx::conn_setup::TAB_PREV < CONNECTION_SETUP_KEYS.len());
-        assert!(idx::conn_setup::SAVE < CONNECTION_SETUP_KEYS.len());
-        assert!(idx::conn_setup::ESC_CANCEL < CONNECTION_SETUP_KEYS.len());
-        assert!(idx::conn_setup::ENTER_DROPDOWN < CONNECTION_SETUP_KEYS.len());
-        assert!(idx::conn_setup::DROPDOWN_NAV < CONNECTION_SETUP_KEYS.len());
+            // OVERLAY_KEYS
+            assert!(idx::overlay::ESC_CANCEL < OVERLAY_KEYS.len());
+            assert!(idx::overlay::ESC_CLOSE < OVERLAY_KEYS.len());
+            assert!(idx::overlay::ENTER_EXECUTE < OVERLAY_KEYS.len());
+            assert!(idx::overlay::ENTER_SELECT < OVERLAY_KEYS.len());
+            assert!(idx::overlay::NAVIGATE_JK < OVERLAY_KEYS.len());
+            assert!(idx::overlay::TYPE_FILTER < OVERLAY_KEYS.len());
+            assert!(idx::overlay::ERROR_OPEN < OVERLAY_KEYS.len());
 
-        // CONNECTION_ERROR_ROWS
-        assert!(idx::conn_error::EDIT < CONNECTION_ERROR_ROWS.len());
-        assert!(idx::conn_error::SWITCH < CONNECTION_ERROR_ROWS.len());
-        assert!(idx::conn_error::DETAILS < CONNECTION_ERROR_ROWS.len());
-        assert!(idx::conn_error::COPY < CONNECTION_ERROR_ROWS.len());
-        assert!(idx::conn_error::SCROLL < CONNECTION_ERROR_ROWS.len());
-        assert!(idx::conn_error::ESC_CLOSE < CONNECTION_ERROR_ROWS.len());
+            // CONNECTION_SETUP_KEYS
+            assert!(idx::conn_setup::TAB_NAV < CONNECTION_SETUP_KEYS.len());
+            assert!(idx::conn_setup::TAB_NEXT < CONNECTION_SETUP_KEYS.len());
+            assert!(idx::conn_setup::TAB_PREV < CONNECTION_SETUP_KEYS.len());
+            assert!(idx::conn_setup::SAVE < CONNECTION_SETUP_KEYS.len());
+            assert!(idx::conn_setup::ESC_CANCEL < CONNECTION_SETUP_KEYS.len());
+            assert!(idx::conn_setup::ENTER_DROPDOWN < CONNECTION_SETUP_KEYS.len());
+            assert!(idx::conn_setup::DROPDOWN_NAV < CONNECTION_SETUP_KEYS.len());
 
-        // CONFIRM_DIALOG_KEYS
-        assert!(idx::confirm::YES < CONFIRM_DIALOG_KEYS.len());
-        assert!(idx::confirm::SCROLL_DOWN < CONFIRM_DIALOG_KEYS.len());
-        assert!(idx::confirm::SCROLL_UP < CONFIRM_DIALOG_KEYS.len());
-        assert!(idx::confirm::NO < CONFIRM_DIALOG_KEYS.len());
+            // CONNECTION_ERROR_ROWS
+            assert!(idx::conn_error::EDIT < CONNECTION_ERROR_ROWS.len());
+            assert!(idx::conn_error::SWITCH < CONNECTION_ERROR_ROWS.len());
+            assert!(idx::conn_error::DETAILS < CONNECTION_ERROR_ROWS.len());
+            assert!(idx::conn_error::COPY < CONNECTION_ERROR_ROWS.len());
+            assert!(idx::conn_error::SCROLL < CONNECTION_ERROR_ROWS.len());
+            assert!(idx::conn_error::ESC_CLOSE < CONNECTION_ERROR_ROWS.len());
 
-        // TABLE_PICKER_ROWS
-        assert!(idx::table_picker::ENTER_SELECT < TABLE_PICKER_ROWS.len());
-        assert!(idx::table_picker::NAVIGATE < TABLE_PICKER_ROWS.len());
-        assert!(idx::table_picker::TYPE_FILTER < TABLE_PICKER_ROWS.len());
-        assert!(idx::table_picker::ESC_CLOSE < TABLE_PICKER_ROWS.len());
+            // CONFIRM_DIALOG_KEYS
+            assert!(idx::confirm::YES < CONFIRM_DIALOG_KEYS.len());
+            assert!(idx::confirm::SCROLL_DOWN < CONFIRM_DIALOG_KEYS.len());
+            assert!(idx::confirm::SCROLL_UP < CONFIRM_DIALOG_KEYS.len());
+            assert!(idx::confirm::NO < CONFIRM_DIALOG_KEYS.len());
 
-        // ER_PICKER_ROWS
-        assert!(idx::er_picker::ENTER_GENERATE < ER_PICKER_ROWS.len());
-        assert!(idx::er_picker::SELECT < ER_PICKER_ROWS.len());
-        assert!(idx::er_picker::SELECT_ALL < ER_PICKER_ROWS.len());
-        assert!(idx::er_picker::NAVIGATE < ER_PICKER_ROWS.len());
-        assert!(idx::er_picker::TYPE_FILTER < ER_PICKER_ROWS.len());
-        assert!(idx::er_picker::ESC_CLOSE < ER_PICKER_ROWS.len());
+            // TABLE_PICKER_ROWS
+            assert!(idx::table_picker::ENTER_SELECT < TABLE_PICKER_ROWS.len());
+            assert!(idx::table_picker::NAVIGATE < TABLE_PICKER_ROWS.len());
+            assert!(idx::table_picker::TYPE_FILTER < TABLE_PICKER_ROWS.len());
+            assert!(idx::table_picker::ESC_CLOSE < TABLE_PICKER_ROWS.len());
 
-        // QUERY_HISTORY_PICKER_ROWS
-        assert!(idx::qh_picker::ENTER_SELECT < QUERY_HISTORY_PICKER_ROWS.len());
-        assert!(idx::qh_picker::NAVIGATE < QUERY_HISTORY_PICKER_ROWS.len());
-        assert!(idx::qh_picker::TYPE_FILTER < QUERY_HISTORY_PICKER_ROWS.len());
-        assert!(idx::qh_picker::ESC_CLOSE < QUERY_HISTORY_PICKER_ROWS.len());
+            // ER_PICKER_ROWS
+            assert!(idx::er_picker::ENTER_GENERATE < ER_PICKER_ROWS.len());
+            assert!(idx::er_picker::SELECT < ER_PICKER_ROWS.len());
+            assert!(idx::er_picker::SELECT_ALL < ER_PICKER_ROWS.len());
+            assert!(idx::er_picker::NAVIGATE < ER_PICKER_ROWS.len());
+            assert!(idx::er_picker::TYPE_FILTER < ER_PICKER_ROWS.len());
+            assert!(idx::er_picker::ESC_CLOSE < ER_PICKER_ROWS.len());
 
-        // COMMAND_PALETTE_ROWS
-        assert!(idx::cmd_palette::ENTER_EXECUTE < COMMAND_PALETTE_ROWS.len());
-        assert!(idx::cmd_palette::NAVIGATE_JK < COMMAND_PALETTE_ROWS.len());
-        assert!(idx::cmd_palette::ESC_CLOSE < COMMAND_PALETTE_ROWS.len());
+            // QUERY_HISTORY_PICKER_ROWS
+            assert!(idx::qh_picker::ENTER_SELECT < QUERY_HISTORY_PICKER_ROWS.len());
+            assert!(idx::qh_picker::NAVIGATE < QUERY_HISTORY_PICKER_ROWS.len());
+            assert!(idx::qh_picker::TYPE_FILTER < QUERY_HISTORY_PICKER_ROWS.len());
+            assert!(idx::qh_picker::ESC_CLOSE < QUERY_HISTORY_PICKER_ROWS.len());
 
-        // HELP_ROWS
-        assert!(idx::help::SCROLL < HELP_ROWS.len());
-        assert!(idx::help::TOP_BOTTOM < HELP_ROWS.len());
-        assert!(idx::help::HALF_PAGE < HELP_ROWS.len());
-        assert!(idx::help::FULL_PAGE < HELP_ROWS.len());
-        assert!(idx::help::CLOSE < HELP_ROWS.len());
+            // COMMAND_PALETTE_ROWS
+            assert!(idx::cmd_palette::ENTER_EXECUTE < COMMAND_PALETTE_ROWS.len());
+            assert!(idx::cmd_palette::NAVIGATE_JK < COMMAND_PALETTE_ROWS.len());
+            assert!(idx::cmd_palette::ESC_CLOSE < COMMAND_PALETTE_ROWS.len());
 
-        // RESULT_ACTIVE_KEYS
-        assert!(idx::result_active::ENTER_DEEPEN < RESULT_ACTIVE_KEYS.len());
-        assert!(idx::result_active::YANK < RESULT_ACTIVE_KEYS.len());
-        assert!(idx::result_active::STAGE_DELETE < RESULT_ACTIVE_KEYS.len());
-        assert!(idx::result_active::UNSTAGE_DELETE < RESULT_ACTIVE_KEYS.len());
-        assert!(idx::result_active::CELL_NAV < RESULT_ACTIVE_KEYS.len());
-        assert!(idx::result_active::ROW_NAV < RESULT_ACTIVE_KEYS.len());
-        assert!(idx::result_active::TOP_BOTTOM < RESULT_ACTIVE_KEYS.len());
-        assert!(idx::result_active::ESC_BACK < RESULT_ACTIVE_KEYS.len());
-        assert!(idx::result_active::EDIT < RESULT_ACTIVE_KEYS.len());
-        assert!(idx::result_active::DRAFT_DISCARD < RESULT_ACTIVE_KEYS.len());
-        assert!(idx::result_active::ROW_YANK < RESULT_ACTIVE_KEYS.len());
+            // HELP_ROWS
+            assert!(idx::help::SCROLL < HELP_ROWS.len());
+            assert!(idx::help::TOP_BOTTOM < HELP_ROWS.len());
+            assert!(idx::help::HALF_PAGE < HELP_ROWS.len());
+            assert!(idx::help::FULL_PAGE < HELP_ROWS.len());
+            assert!(idx::help::CLOSE < HELP_ROWS.len());
 
-        // HISTORY_KEYS
-        assert!(idx::history::OPEN < HISTORY_KEYS.len());
-        assert!(idx::history::NAV < HISTORY_KEYS.len());
-        assert!(idx::history::EXIT < HISTORY_KEYS.len());
+            // RESULT_ACTIVE_KEYS
+            assert!(idx::result_active::ENTER_DEEPEN < RESULT_ACTIVE_KEYS.len());
+            assert!(idx::result_active::YANK < RESULT_ACTIVE_KEYS.len());
+            assert!(idx::result_active::STAGE_DELETE < RESULT_ACTIVE_KEYS.len());
+            assert!(idx::result_active::UNSTAGE_DELETE < RESULT_ACTIVE_KEYS.len());
+            assert!(idx::result_active::CELL_NAV < RESULT_ACTIVE_KEYS.len());
+            assert!(idx::result_active::ROW_NAV < RESULT_ACTIVE_KEYS.len());
+            assert!(idx::result_active::TOP_BOTTOM < RESULT_ACTIVE_KEYS.len());
+            assert!(idx::result_active::ESC_BACK < RESULT_ACTIVE_KEYS.len());
+            assert!(idx::result_active::EDIT < RESULT_ACTIVE_KEYS.len());
+            assert!(idx::result_active::DRAFT_DISCARD < RESULT_ACTIVE_KEYS.len());
+            assert!(idx::result_active::ROW_YANK < RESULT_ACTIVE_KEYS.len());
 
-        // INSPECTOR_DDL_KEYS
-        assert!(idx::inspector_ddl::YANK < INSPECTOR_DDL_KEYS.len());
+            // HISTORY_KEYS
+            assert!(idx::history::OPEN < HISTORY_KEYS.len());
+            assert!(idx::history::NAV < HISTORY_KEYS.len());
+            assert!(idx::history::EXIT < HISTORY_KEYS.len());
 
-        // CELL_EDIT_KEYS
-        assert!(idx::cell_edit::WRITE < CELL_EDIT_KEYS.len());
-        assert!(idx::cell_edit::TYPE < CELL_EDIT_KEYS.len());
-        assert!(idx::cell_edit::MOVE < CELL_EDIT_KEYS.len());
-        assert!(idx::cell_edit::HOME_END < CELL_EDIT_KEYS.len());
-        assert!(idx::cell_edit::COMMAND < CELL_EDIT_KEYS.len());
-        assert!(idx::cell_edit::ESC_CANCEL < CELL_EDIT_KEYS.len());
+            // INSPECTOR_DDL_KEYS
+            assert!(idx::inspector_ddl::YANK < INSPECTOR_DDL_KEYS.len());
 
-        // CONNECTION_SELECTOR_ROWS
-        assert!(idx::connection_selector::CONFIRM < CONNECTION_SELECTOR_ROWS.len());
-        assert!(idx::connection_selector::SELECT < CONNECTION_SELECTOR_ROWS.len());
-        assert!(idx::connection_selector::NEW < CONNECTION_SELECTOR_ROWS.len());
-        assert!(idx::connection_selector::EDIT < CONNECTION_SELECTOR_ROWS.len());
-        assert!(idx::connection_selector::DELETE < CONNECTION_SELECTOR_ROWS.len());
-        assert!(idx::connection_selector::CLOSE < CONNECTION_SELECTOR_ROWS.len());
+            // CELL_EDIT_KEYS
+            assert!(idx::cell_edit::WRITE < CELL_EDIT_KEYS.len());
+            assert!(idx::cell_edit::TYPE < CELL_EDIT_KEYS.len());
+            assert!(idx::cell_edit::MOVE < CELL_EDIT_KEYS.len());
+            assert!(idx::cell_edit::HOME_END < CELL_EDIT_KEYS.len());
+            assert!(idx::cell_edit::COMMAND < CELL_EDIT_KEYS.len());
+            assert!(idx::cell_edit::ESC_CANCEL < CELL_EDIT_KEYS.len());
 
-        // JSONB_DETAIL_ROWS
-        assert!(idx::jsonb_detail::YANK < JSONB_DETAIL_ROWS.len());
-        assert!(idx::jsonb_detail::INSERT < JSONB_DETAIL_ROWS.len());
-        assert!(idx::jsonb_detail::SEARCH < JSONB_DETAIL_ROWS.len());
-        assert!(idx::jsonb_detail::NEXT_PREV < JSONB_DETAIL_ROWS.len());
-        assert!(idx::jsonb_detail::MOVE < JSONB_DETAIL_ROWS.len());
-        assert!(idx::jsonb_detail::HOME_END < JSONB_DETAIL_ROWS.len());
-        assert!(idx::jsonb_detail::CLOSE < JSONB_DETAIL_ROWS.len());
+            // CONNECTION_SELECTOR_ROWS
+            assert!(idx::connection_selector::CONFIRM < CONNECTION_SELECTOR_ROWS.len());
+            assert!(idx::connection_selector::SELECT < CONNECTION_SELECTOR_ROWS.len());
+            assert!(idx::connection_selector::NEW < CONNECTION_SELECTOR_ROWS.len());
+            assert!(idx::connection_selector::EDIT < CONNECTION_SELECTOR_ROWS.len());
+            assert!(idx::connection_selector::DELETE < CONNECTION_SELECTOR_ROWS.len());
+            assert!(idx::connection_selector::CLOSE < CONNECTION_SELECTOR_ROWS.len());
 
-        // JSONB_SEARCH_KEYS
-        assert!(idx::jsonb_search::TYPE_SEARCH < JSONB_SEARCH_KEYS.len());
-        assert!(idx::jsonb_search::CONFIRM < JSONB_SEARCH_KEYS.len());
-        assert!(idx::jsonb_search::CANCEL < JSONB_SEARCH_KEYS.len());
+            // JSONB_DETAIL_ROWS
+            assert!(idx::jsonb_detail::YANK < JSONB_DETAIL_ROWS.len());
+            assert!(idx::jsonb_detail::INSERT < JSONB_DETAIL_ROWS.len());
+            assert!(idx::jsonb_detail::SEARCH < JSONB_DETAIL_ROWS.len());
+            assert!(idx::jsonb_detail::NEXT_PREV < JSONB_DETAIL_ROWS.len());
+            assert!(idx::jsonb_detail::MOVE < JSONB_DETAIL_ROWS.len());
+            assert!(idx::jsonb_detail::HOME_END < JSONB_DETAIL_ROWS.len());
+            assert!(idx::jsonb_detail::CLOSE < JSONB_DETAIL_ROWS.len());
 
-        // JSONB_EDIT_ROWS
-        assert!(idx::jsonb_edit::ESC_NORMAL < JSONB_EDIT_ROWS.len());
-        assert!(idx::jsonb_edit::MOVE < JSONB_EDIT_ROWS.len());
-        assert!(idx::jsonb_edit::HOME_END < JSONB_EDIT_ROWS.len());
+            // JSONB_SEARCH_KEYS
+            assert!(idx::jsonb_search::TYPE_SEARCH < JSONB_SEARCH_KEYS.len());
+            assert!(idx::jsonb_search::CONFIRM < JSONB_SEARCH_KEYS.len());
+            assert!(idx::jsonb_search::CANCEL < JSONB_SEARCH_KEYS.len());
+
+            // JSONB_EDIT_ROWS
+            assert!(idx::jsonb_edit::ESC_NORMAL < JSONB_EDIT_ROWS.len());
+            assert!(idx::jsonb_edit::MOVE < JSONB_EDIT_ROWS.len());
+            assert!(idx::jsonb_edit::HOME_END < JSONB_EDIT_ROWS.len());
+        }
+
+        #[test]
+        fn help_content_line_count_matches_section_structure() {
+            let sections: &[usize] = &[
+                GLOBAL_KEYS.len(),
+                NAVIGATION_KEYS.len(),
+                HISTORY_KEYS.len(),
+                RESULT_ACTIVE_KEYS.len(),
+                INSPECTOR_DDL_KEYS.len(),
+                CELL_EDIT_KEYS.len(),
+                SQL_MODAL_NORMAL_KEYS.len(),
+                SQL_MODAL_KEYS.len(),
+                SQL_MODAL_PLAN_KEYS.len(),
+                SQL_MODAL_COMPARE_KEYS.len(),
+                SQL_MODAL_CONFIRMING_KEYS.len(),
+                OVERLAY_KEYS.len(),
+                COMMAND_LINE_KEYS.len(),
+                CONNECTION_SETUP_KEYS.len(),
+                CONNECTION_ERROR_ROWS.len(),
+                CONNECTION_SELECTOR_ROWS.len(),
+                ER_PICKER_ROWS.len(),
+                QUERY_HISTORY_PICKER_ROWS.len(),
+                TABLE_PICKER_ROWS.len(),
+                COMMAND_PALETTE_ROWS.len(),
+                HELP_ROWS.len(),
+                CONFIRM_DIALOG_KEYS.len(),
+                JSONB_DETAIL_ROWS.len(),
+                JSONB_EDIT_ROWS.len(),
+                JSONB_SEARCH_KEYS.len(),
+            ];
+            let section_count = sections.len();
+            let dedup_pairs = 3; // Focus, ReadOnly, History
+            let expected: usize =
+                section_count + sections.iter().sum::<usize>() + (section_count - 1) - dedup_pairs;
+
+            assert_eq!(help_content_line_count(), expected);
+        }
     }
 
-    #[test]
-    fn help_content_line_count_matches_section_structure() {
-        let sections: &[usize] = &[
-            GLOBAL_KEYS.len(),
-            NAVIGATION_KEYS.len(),
-            HISTORY_KEYS.len(),
-            RESULT_ACTIVE_KEYS.len(),
-            INSPECTOR_DDL_KEYS.len(),
-            CELL_EDIT_KEYS.len(),
-            SQL_MODAL_NORMAL_KEYS.len(),
-            SQL_MODAL_KEYS.len(),
-            SQL_MODAL_PLAN_KEYS.len(),
-            SQL_MODAL_COMPARE_KEYS.len(),
-            SQL_MODAL_CONFIRMING_KEYS.len(),
-            OVERLAY_KEYS.len(),
-            COMMAND_LINE_KEYS.len(),
-            CONNECTION_SETUP_KEYS.len(),
-            CONNECTION_ERROR_ROWS.len(),
-            CONNECTION_SELECTOR_ROWS.len(),
-            ER_PICKER_ROWS.len(),
-            QUERY_HISTORY_PICKER_ROWS.len(),
-            TABLE_PICKER_ROWS.len(),
-            COMMAND_PALETTE_ROWS.len(),
-            HELP_ROWS.len(),
-            CONFIRM_DIALOG_KEYS.len(),
-            JSONB_DETAIL_ROWS.len(),
-            JSONB_EDIT_ROWS.len(),
-            JSONB_SEARCH_KEYS.len(),
-        ];
-        let section_count = sections.len();
-        let dedup_pairs = 3; // Focus, ReadOnly, History
-        let expected: usize =
-            section_count + sections.iter().sum::<usize>() + (section_count - 1) - dedup_pairs;
-
-        assert_eq!(help_content_line_count(), expected);
-    }
-
-    mod semantic {
+    mod catalog_semantics {
         use super::*;
         use crate::app::update::input::keymap;
         use rstest::rstest;

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -11,10 +11,6 @@ pub use normal::*;
 pub use overlays::*;
 pub use types::{Key, KeyCombo, Modifiers};
 
-// =============================================================================
-// KeyBinding
-// =============================================================================
-
 #[derive(Clone)]
 pub struct KeyBinding {
     pub key_short: &'static str,
@@ -101,10 +97,6 @@ pub const ALL_MODE_BINDINGS: &[(&str, &ModeBindings)] = &[
     ("JSONB_DETAIL", &JSONB_DETAIL),
     ("JSONB_EDIT", &JSONB_EDIT),
 ];
-
-// =============================================================================
-// Index Constants for Footer Lookup
-// =============================================================================
 
 pub mod idx {
     pub mod global {
@@ -365,10 +357,6 @@ pub const fn help_content_line_count() -> usize {
         + JSONB_EDIT_ROWS.len()
         + JSONB_SEARCH_KEYS.len()
 }
-
-// =============================================================================
-// Predicate functions for Normal mode routing
-// =============================================================================
 
 pub fn is_quit(combo: &KeyCombo) -> bool {
     GLOBAL_KEYS[idx::global::QUIT].combos.contains(combo)
@@ -798,10 +786,6 @@ mod tests {
                 check_non_none_have_combos(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
             }
 
-            // ------------------------------------------------------------------ //
-            // 2b. ModeRow exec entries have non-empty combos
-            // ------------------------------------------------------------------ //
-
             fn check_mode_rows_exec_valid(rows: &[ModeRow], name: &str) {
                 for (i, row) in rows.iter().enumerate() {
                     for (j, eb) in row.bindings.iter().enumerate() {
@@ -1066,7 +1050,6 @@ mod tests {
         mod catalog_coverage {
             use super::*;
 
-            // HELP, CONNECTION_ERROR, TABLE_PICKER, ER_PICKER, COMMAND_PALETTE, CONNECTION_SELECTOR
             #[test]
             fn all_mode_bindings_count() {
                 assert_eq!(ALL_MODE_BINDINGS.len(), 9);

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -631,7 +631,7 @@ mod tests {
             }
 
             #[test]
-            fn scroll_down_increments_offset() {
+            fn down_increments_offset() {
                 let mut state = state_with_scrollable_preview();
 
                 reduce_modal(
@@ -648,7 +648,7 @@ mod tests {
             }
 
             #[test]
-            fn scroll_up_decrements_offset() {
+            fn up_decrements_offset() {
                 let mut state = state_with_scrollable_preview();
                 state.confirm_dialog.preview_scroll = 5;
 
@@ -666,7 +666,7 @@ mod tests {
             }
 
             #[test]
-            fn scroll_up_clamps_at_zero() {
+            fn up_clamps_at_zero() {
                 let mut state = state_with_scrollable_preview();
                 state.confirm_dialog.preview_scroll = 0;
 
@@ -684,7 +684,7 @@ mod tests {
             }
 
             #[test]
-            fn scroll_down_clamps_at_max() {
+            fn down_clamps_at_max() {
                 let mut state = state_with_scrollable_preview();
                 state.confirm_dialog.preview_scroll = 15;
 

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -624,348 +624,384 @@ mod tests {
             state
         }
 
-        #[test]
-        fn open_when_not_connected_is_noop() {
-            let mut state = create_test_state();
-            state.session.active_connection_id = None;
-
-            let effects =
-                reduce_modal(&mut state, &Action::OpenQueryHistoryPicker, Instant::now()).unwrap();
-
-            assert_eq!(state.input_mode(), InputMode::Normal);
-            assert!(effects.is_empty());
-        }
-
-        #[test]
-        fn open_when_running_is_noop() {
-            let mut state = connected_state();
-            state.query.begin_running(Instant::now());
-
-            let effects =
-                reduce_modal(&mut state, &Action::OpenQueryHistoryPicker, Instant::now()).unwrap();
-
-            assert_eq!(state.input_mode(), InputMode::Normal);
-            assert!(effects.is_empty());
-        }
-
-        #[test]
-        fn open_from_normal_sets_mode_and_emits_load_effect() {
-            let mut state = connected_state();
-
-            let effects =
-                reduce_modal(&mut state, &Action::OpenQueryHistoryPicker, Instant::now()).unwrap();
-
-            assert_eq!(state.input_mode(), InputMode::QueryHistoryPicker);
-            assert_eq!(state.modal.return_destination(), InputMode::Normal);
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(&effects[0], Effect::LoadQueryHistory { .. }));
-        }
-
-        #[test]
-        fn close_restores_origin_mode() {
-            let mut state = connected_state();
-            state.modal.set_mode(InputMode::SqlModal);
-            state.modal.push_mode(InputMode::QueryHistoryPicker);
-
-            let effects =
-                reduce_modal(&mut state, &Action::CloseQueryHistoryPicker, Instant::now()).unwrap();
-
-            assert_eq!(state.input_mode(), InputMode::SqlModal);
-            assert!(effects.is_empty());
-        }
-
-        #[test]
-        fn loaded_stores_entries() {
-            let mut state = connected_state();
-            state.modal.set_mode(InputMode::QueryHistoryPicker);
-            let conn_id = ConnectionId::from_string("test-conn");
-            let entries = vec![make_entry("SELECT 1", &conn_id)];
-
-            let effects = reduce_modal(
-                &mut state,
-                &Action::QueryHistoryLoaded(conn_id, entries),
-                Instant::now(),
-            )
-            .unwrap();
-
-            assert_eq!(state.query_history_picker.entries.len(), 1);
-            assert!(effects.is_empty());
-        }
-
-        #[test]
-        fn loaded_ignores_stale_connection() {
-            let mut state = connected_state();
-            state.modal.set_mode(InputMode::QueryHistoryPicker);
-            let stale_conn = ConnectionId::from_string("old-conn");
-            let entries = vec![make_entry("SELECT 1", &stale_conn)];
-
-            reduce_modal(
-                &mut state,
-                &Action::QueryHistoryLoaded(stale_conn, entries),
-                Instant::now(),
-            )
-            .unwrap();
-
-            assert!(state.query_history_picker.entries.is_empty());
-        }
-
-        #[test]
-        fn loaded_ignores_when_picker_closed() {
-            let mut state = connected_state();
-            let conn_id = ConnectionId::from_string("test-conn");
-            let entries = vec![make_entry("SELECT 1", &conn_id)];
-
-            reduce_modal(
-                &mut state,
-                &Action::QueryHistoryLoaded(conn_id, entries),
-                Instant::now(),
-            )
-            .unwrap();
-
-            assert!(state.query_history_picker.entries.is_empty());
-        }
-
-        #[test]
-        fn load_failed_sets_error_with_expiry() {
-            let mut state = connected_state();
-            state.modal.set_mode(InputMode::QueryHistoryPicker);
-            let now = Instant::now();
-
-            reduce_modal(
-                &mut state,
-                &Action::QueryHistoryLoadFailed(QueryHistoryError::IoError(
-                    "disk error".to_string(),
-                )),
-                now,
-            )
-            .unwrap();
-
-            assert_eq!(
-                state.messages.last_error.as_deref(),
-                Some("IO error: disk error")
-            );
-            assert!(state.messages.expires_at.is_some());
-        }
-
-        #[test]
-        fn load_failed_ignored_when_picker_not_active() {
-            let mut state = connected_state();
-            let now = Instant::now();
-
-            reduce_modal(
-                &mut state,
-                &Action::QueryHistoryLoadFailed(QueryHistoryError::IoError(
-                    "stale error".to_string(),
-                )),
-                now,
-            )
-            .unwrap();
-
-            assert!(state.messages.last_error.is_none());
-        }
-
-        #[test]
-        fn append_failed_does_not_set_error() {
-            let mut state = connected_state();
-            let now = Instant::now();
-
-            let effects = reduce_modal(
-                &mut state,
-                &Action::QueryHistoryAppendFailed(QueryHistoryError::IoError(
-                    "write error".to_string(),
-                )),
-                now,
-            )
-            .unwrap();
-
-            assert!(state.messages.last_error.is_none());
-            assert!(effects.is_empty());
-        }
-
-        #[test]
-        fn filter_input_resets_selection() {
-            let mut state = connected_state();
-            state.query_history_picker.selected = 5;
-
-            let effects = reduce_modal(
-                &mut state,
-                &Action::TextInput {
-                    target: InputTarget::QueryHistoryFilter,
-                    ch: 'a',
-                },
-                Instant::now(),
-            )
-            .unwrap();
-
-            assert_eq!(state.query_history_picker.selected, 0);
-            assert_eq!(state.query_history_picker.filter_input.content(), "a");
-            assert!(effects.is_empty());
-        }
-
         fn enter_query_history(state: &mut AppState, origin: InputMode) {
             state.modal.set_mode(origin);
             state.modal.push_mode(InputMode::QueryHistoryPicker);
         }
 
-        #[test]
-        fn confirm_sets_cursor_to_char_count_not_byte_len() {
-            let mut state = connected_state();
-            enter_query_history(&mut state, InputMode::Normal);
-            // 「SELECT 'あいう'」: 13 chars but 19 bytes
-            let query = "SELECT '\u{3042}\u{3044}\u{3046}'".to_string();
-            let expected_chars = query.chars().count(); // 13
-            assert_ne!(query.len(), expected_chars); // sanity: bytes != chars
-            let test_conn = ConnectionId::from_string("test-conn");
-            state.query_history_picker.entries = vec![make_entry(&query, &test_conn)];
+        mod open_guards {
+            use super::*;
 
-            reduce_modal(
-                &mut state,
-                &Action::QueryHistoryConfirmSelection,
-                Instant::now(),
-            )
-            .unwrap();
+            #[test]
+            fn open_when_not_connected_is_noop() {
+                let mut state = create_test_state();
+                state.session.active_connection_id = None;
 
-            assert_eq!(state.sql_modal.editor.cursor(), expected_chars);
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::OpenQueryHistoryPicker,
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.input_mode(), InputMode::Normal);
+                assert!(effects.is_empty());
+            }
+
+            #[test]
+            fn open_when_running_is_noop() {
+                let mut state = connected_state();
+                state.query.begin_running(Instant::now());
+
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::OpenQueryHistoryPicker,
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.input_mode(), InputMode::Normal);
+                assert!(effects.is_empty());
+            }
+
+            #[test]
+            fn open_from_normal_sets_mode_and_emits_load_effect() {
+                let mut state = connected_state();
+
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::OpenQueryHistoryPicker,
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.input_mode(), InputMode::QueryHistoryPicker);
+                assert_eq!(state.modal.return_destination(), InputMode::Normal);
+                assert_eq!(effects.len(), 1);
+                assert!(matches!(&effects[0], Effect::LoadQueryHistory { .. }));
+            }
         }
 
-        #[test]
-        fn confirm_from_normal_opens_sql_modal_with_query() {
-            let mut state = connected_state();
-            enter_query_history(&mut state, InputMode::Normal);
-            let test_conn = ConnectionId::from_string("test-conn");
-            state.query_history_picker.entries =
-                vec![make_entry("SELECT * FROM users", &test_conn)];
-            state.query_history_picker.selected = 0;
+        mod lifecycle {
+            use super::*;
 
-            let effects = reduce_modal(
-                &mut state,
-                &Action::QueryHistoryConfirmSelection,
-                Instant::now(),
-            )
-            .unwrap();
+            #[test]
+            fn close_restores_origin_mode() {
+                let mut state = connected_state();
+                state.modal.set_mode(InputMode::SqlModal);
+                state.modal.push_mode(InputMode::QueryHistoryPicker);
 
-            assert_eq!(state.input_mode(), InputMode::SqlModal);
-            assert_eq!(state.sql_modal.editor.content(), "SELECT * FROM users");
-            assert!(matches!(
-                state.sql_modal.status(),
-                crate::app::model::sql_editor::modal::SqlModalStatus::Normal
-            ));
-            assert!(effects.is_empty());
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::CloseQueryHistoryPicker,
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.input_mode(), InputMode::SqlModal);
+                assert!(effects.is_empty());
+            }
         }
 
-        #[test]
-        fn confirm_from_sql_modal_overwrites_editor_content() {
-            let mut state = connected_state();
-            enter_query_history(&mut state, InputMode::SqlModal);
-            state.sql_modal.editor.set_content("old query".to_string());
-            state
-                .sql_modal
-                .set_status(crate::app::model::sql_editor::modal::SqlModalStatus::Editing);
-            state.sql_modal.completion.visible = true;
-            state.sql_modal.completion.candidates = vec![
-                crate::app::model::sql_editor::completion::CompletionCandidate {
-                    text: "stale".to_string(),
-                    kind: crate::app::model::sql_editor::completion::CompletionKind::Keyword,
-                    score: 1,
-                },
-            ];
-            state.sql_modal.completion.selected_index = 3;
-            let test_conn = ConnectionId::from_string("test-conn");
-            state.query_history_picker.entries = vec![make_entry("new query", &test_conn)];
-            state.query_history_picker.selected = 0;
+        mod loading {
+            use super::*;
 
-            reduce_modal(
-                &mut state,
-                &Action::QueryHistoryConfirmSelection,
-                Instant::now(),
-            )
-            .unwrap();
+            #[test]
+            fn loaded_stores_entries() {
+                let mut state = connected_state();
+                state.modal.set_mode(InputMode::QueryHistoryPicker);
+                let conn_id = ConnectionId::from_string("test-conn");
+                let entries = vec![make_entry("SELECT 1", &conn_id)];
 
-            assert_eq!(state.input_mode(), InputMode::SqlModal);
-            assert_eq!(state.sql_modal.editor.content(), "new query");
-            assert!(matches!(
-                state.sql_modal.status(),
-                crate::app::model::sql_editor::modal::SqlModalStatus::Normal
-            ));
-            assert!(!state.sql_modal.completion.visible);
-            assert!(state.sql_modal.completion.candidates.is_empty());
-            assert_eq!(state.sql_modal.completion.selected_index, 0);
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::QueryHistoryLoaded(conn_id, entries),
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.query_history_picker.entries.len(), 1);
+                assert!(effects.is_empty());
+            }
+
+            #[test]
+            fn loaded_ignores_stale_connection() {
+                let mut state = connected_state();
+                state.modal.set_mode(InputMode::QueryHistoryPicker);
+                let stale_conn = ConnectionId::from_string("old-conn");
+                let entries = vec![make_entry("SELECT 1", &stale_conn)];
+
+                reduce_modal(
+                    &mut state,
+                    &Action::QueryHistoryLoaded(stale_conn, entries),
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert!(state.query_history_picker.entries.is_empty());
+            }
+
+            #[test]
+            fn loaded_ignores_when_picker_closed() {
+                let mut state = connected_state();
+                let conn_id = ConnectionId::from_string("test-conn");
+                let entries = vec![make_entry("SELECT 1", &conn_id)];
+
+                reduce_modal(
+                    &mut state,
+                    &Action::QueryHistoryLoaded(conn_id, entries),
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert!(state.query_history_picker.entries.is_empty());
+            }
+
+            #[test]
+            fn load_failed_sets_error_with_expiry() {
+                let mut state = connected_state();
+                state.modal.set_mode(InputMode::QueryHistoryPicker);
+                let now = Instant::now();
+
+                reduce_modal(
+                    &mut state,
+                    &Action::QueryHistoryLoadFailed(QueryHistoryError::IoError(
+                        "disk error".to_string(),
+                    )),
+                    now,
+                )
+                .unwrap();
+
+                assert_eq!(
+                    state.messages.last_error.as_deref(),
+                    Some("IO error: disk error")
+                );
+                assert!(state.messages.expires_at.is_some());
+            }
+
+            #[test]
+            fn load_failed_ignored_when_picker_not_active() {
+                let mut state = connected_state();
+                let now = Instant::now();
+
+                reduce_modal(
+                    &mut state,
+                    &Action::QueryHistoryLoadFailed(QueryHistoryError::IoError(
+                        "stale error".to_string(),
+                    )),
+                    now,
+                )
+                .unwrap();
+
+                assert!(state.messages.last_error.is_none());
+            }
+
+            #[test]
+            fn append_failed_does_not_set_error() {
+                let mut state = connected_state();
+                let now = Instant::now();
+
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::QueryHistoryAppendFailed(QueryHistoryError::IoError(
+                        "write error".to_string(),
+                    )),
+                    now,
+                )
+                .unwrap();
+
+                assert!(state.messages.last_error.is_none());
+                assert!(effects.is_empty());
+            }
         }
 
-        #[test]
-        fn confirm_with_empty_entries_is_noop() {
-            let mut state = connected_state();
-            enter_query_history(&mut state, InputMode::Normal);
+        mod filter_and_selection {
+            use super::*;
 
-            reduce_modal(
-                &mut state,
-                &Action::QueryHistoryConfirmSelection,
-                Instant::now(),
-            )
-            .unwrap();
+            #[test]
+            fn filter_input_resets_selection() {
+                let mut state = connected_state();
+                state.query_history_picker.selected = 5;
 
-            assert_eq!(state.input_mode(), InputMode::Normal);
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::TextInput {
+                        target: InputTarget::QueryHistoryFilter,
+                        ch: 'a',
+                    },
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.query_history_picker.selected, 0);
+                assert_eq!(state.query_history_picker.filter_input.content(), "a");
+                assert!(effects.is_empty());
+            }
+
+            #[test]
+            fn select_next_increments() {
+                let mut state = connected_state();
+                let test_conn = ConnectionId::from_string("test-conn");
+                state.query_history_picker.entries = vec![
+                    make_entry("SELECT 1", &test_conn),
+                    make_entry("SELECT 2", &test_conn),
+                ];
+                state.query_history_picker.selected = 0;
+
+                reduce_modal(
+                    &mut state,
+                    &Action::ListSelect {
+                        target: ListTarget::QueryHistory,
+                        motion: ListMotion::Next,
+                    },
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.query_history_picker.selected, 1);
+            }
+
+            #[test]
+            fn select_next_clamps_at_end() {
+                let mut state = connected_state();
+                let test_conn = ConnectionId::from_string("test-conn");
+                state.query_history_picker.entries = vec![make_entry("SELECT 1", &test_conn)];
+                state.query_history_picker.selected = 0;
+
+                reduce_modal(
+                    &mut state,
+                    &Action::ListSelect {
+                        target: ListTarget::QueryHistory,
+                        motion: ListMotion::Next,
+                    },
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.query_history_picker.selected, 0);
+            }
+
+            #[test]
+            fn select_previous_decrements() {
+                let mut state = connected_state();
+                state.query_history_picker.selected = 1;
+
+                reduce_modal(
+                    &mut state,
+                    &Action::ListSelect {
+                        target: ListTarget::QueryHistory,
+                        motion: ListMotion::Previous,
+                    },
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.query_history_picker.selected, 0);
+            }
         }
 
-        #[test]
-        fn select_next_increments() {
-            let mut state = connected_state();
-            let test_conn = ConnectionId::from_string("test-conn");
-            state.query_history_picker.entries = vec![
-                make_entry("SELECT 1", &test_conn),
-                make_entry("SELECT 2", &test_conn),
-            ];
-            state.query_history_picker.selected = 0;
+        mod confirm_selection {
+            use super::*;
 
-            reduce_modal(
-                &mut state,
-                &Action::ListSelect {
-                    target: ListTarget::QueryHistory,
-                    motion: ListMotion::Next,
-                },
-                Instant::now(),
-            )
-            .unwrap();
+            #[test]
+            fn confirm_sets_cursor_to_char_count_not_byte_len() {
+                let mut state = connected_state();
+                enter_query_history(&mut state, InputMode::Normal);
+                // 「SELECT 'あいう'」: 13 chars but 19 bytes
+                let query = "SELECT '\u{3042}\u{3044}\u{3046}'".to_string();
+                let expected_chars = query.chars().count(); // 13
+                assert_ne!(query.len(), expected_chars); // sanity: bytes != chars
+                let test_conn = ConnectionId::from_string("test-conn");
+                state.query_history_picker.entries = vec![make_entry(&query, &test_conn)];
 
-            assert_eq!(state.query_history_picker.selected, 1);
-        }
+                reduce_modal(
+                    &mut state,
+                    &Action::QueryHistoryConfirmSelection,
+                    Instant::now(),
+                )
+                .unwrap();
 
-        #[test]
-        fn select_next_clamps_at_end() {
-            let mut state = connected_state();
-            let test_conn = ConnectionId::from_string("test-conn");
-            state.query_history_picker.entries = vec![make_entry("SELECT 1", &test_conn)];
-            state.query_history_picker.selected = 0;
+                assert_eq!(state.sql_modal.editor.cursor(), expected_chars);
+            }
 
-            reduce_modal(
-                &mut state,
-                &Action::ListSelect {
-                    target: ListTarget::QueryHistory,
-                    motion: ListMotion::Next,
-                },
-                Instant::now(),
-            )
-            .unwrap();
+            #[test]
+            fn confirm_from_normal_opens_sql_modal_with_query() {
+                let mut state = connected_state();
+                enter_query_history(&mut state, InputMode::Normal);
+                let test_conn = ConnectionId::from_string("test-conn");
+                state.query_history_picker.entries =
+                    vec![make_entry("SELECT * FROM users", &test_conn)];
+                state.query_history_picker.selected = 0;
 
-            assert_eq!(state.query_history_picker.selected, 0);
-        }
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::QueryHistoryConfirmSelection,
+                    Instant::now(),
+                )
+                .unwrap();
 
-        #[test]
-        fn select_previous_decrements() {
-            let mut state = connected_state();
-            state.query_history_picker.selected = 1;
+                assert_eq!(state.input_mode(), InputMode::SqlModal);
+                assert_eq!(state.sql_modal.editor.content(), "SELECT * FROM users");
+                assert!(matches!(
+                    state.sql_modal.status(),
+                    crate::app::model::sql_editor::modal::SqlModalStatus::Normal
+                ));
+                assert!(effects.is_empty());
+            }
 
-            reduce_modal(
-                &mut state,
-                &Action::ListSelect {
-                    target: ListTarget::QueryHistory,
-                    motion: ListMotion::Previous,
-                },
-                Instant::now(),
-            )
-            .unwrap();
+            #[test]
+            fn confirm_from_sql_modal_overwrites_editor_content() {
+                let mut state = connected_state();
+                enter_query_history(&mut state, InputMode::SqlModal);
+                state.sql_modal.editor.set_content("old query".to_string());
+                state
+                    .sql_modal
+                    .set_status(crate::app::model::sql_editor::modal::SqlModalStatus::Editing);
+                state.sql_modal.completion.visible = true;
+                state.sql_modal.completion.candidates = vec![
+                    crate::app::model::sql_editor::completion::CompletionCandidate {
+                        text: "stale".to_string(),
+                        kind: crate::app::model::sql_editor::completion::CompletionKind::Keyword,
+                        score: 1,
+                    },
+                ];
+                state.sql_modal.completion.selected_index = 3;
+                let test_conn = ConnectionId::from_string("test-conn");
+                state.query_history_picker.entries = vec![make_entry("new query", &test_conn)];
+                state.query_history_picker.selected = 0;
 
-            assert_eq!(state.query_history_picker.selected, 0);
+                reduce_modal(
+                    &mut state,
+                    &Action::QueryHistoryConfirmSelection,
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.input_mode(), InputMode::SqlModal);
+                assert_eq!(state.sql_modal.editor.content(), "new query");
+                assert!(matches!(
+                    state.sql_modal.status(),
+                    crate::app::model::sql_editor::modal::SqlModalStatus::Normal
+                ));
+                assert!(!state.sql_modal.completion.visible);
+                assert!(state.sql_modal.completion.candidates.is_empty());
+                assert_eq!(state.sql_modal.completion.selected_index, 0);
+            }
+
+            #[test]
+            fn confirm_with_empty_entries_is_noop() {
+                let mut state = connected_state();
+                enter_query_history(&mut state, InputMode::Normal);
+
+                reduce_modal(
+                    &mut state,
+                    &Action::QueryHistoryConfirmSelection,
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(state.input_mode(), InputMode::Normal);
+            }
         }
     }
 

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -184,7 +184,6 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             state.ui.er_selected_tables.clear();
             Some(vec![Effect::DispatchActions(vec![Action::ErOpenDiagram])])
         }
-        // Query History Picker
         Action::OpenQueryHistoryPicker => {
             if state.session.active_connection_id.is_none() {
                 return Some(vec![]);
@@ -307,7 +306,6 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             Some(vec![])
         }
 
-        // Confirm Dialog
         Action::ConfirmDialogConfirm => {
             let intent = state.confirm_dialog.take_intent();
             state.modal.pop_mode();

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -402,7 +402,7 @@ mod tests {
         AppState::new("test".to_string())
     }
 
-    mod confirm_dialog_confirm {
+    mod confirm_dialog {
         use super::*;
 
         pub(super) fn enter_confirm_dialog(state: &mut AppState, return_mode: InputMode) {
@@ -410,193 +410,368 @@ mod tests {
             state.modal.push_mode(InputMode::ConfirmDialog);
         }
 
-        #[test]
-        fn quit_no_connection_sets_should_quit() {
-            let mut state = create_test_state();
-            enter_confirm_dialog(&mut state, InputMode::Normal);
-            state
-                .confirm_dialog
-                .open("", "", ConfirmIntent::QuitNoConnection);
+        mod confirm {
+            use super::*;
 
-            let effects =
-                reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now()).unwrap();
+            #[test]
+            fn quit_no_connection_sets_should_quit() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                state
+                    .confirm_dialog
+                    .open("", "", ConfirmIntent::QuitNoConnection);
 
-            assert!(state.should_quit);
-            assert!(state.confirm_dialog.intent().is_none());
-            assert!(effects.is_empty());
-        }
+                let effects =
+                    reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now())
+                        .unwrap();
 
-        #[test]
-        fn delete_connection_returns_delete_effect() {
-            let mut state = create_test_state();
-            enter_confirm_dialog(&mut state, InputMode::ConnectionSelector);
-            let id = crate::domain::ConnectionId::new();
-            state
-                .confirm_dialog
-                .open("", "", ConfirmIntent::DeleteConnection(id));
+                assert!(state.should_quit);
+                assert!(state.confirm_dialog.intent().is_none());
+                assert!(effects.is_empty());
+            }
 
-            let effects =
-                reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now()).unwrap();
+            #[test]
+            fn delete_connection_returns_delete_effect() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::ConnectionSelector);
+                let id = crate::domain::ConnectionId::new();
+                state
+                    .confirm_dialog
+                    .open("", "", ConfirmIntent::DeleteConnection(id));
 
-            assert_eq!(state.input_mode(), InputMode::ConnectionSelector);
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(&effects[0], Effect::DeleteConnection { .. }));
-        }
+                let effects =
+                    reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now())
+                        .unwrap();
 
-        #[test]
-        fn execute_write_sets_running_state_and_returns_effect() {
-            let mut state = create_test_state();
-            enter_confirm_dialog(&mut state, InputMode::CellEdit);
-            state.session.dsn = Some("postgres://localhost/test".to_string());
-            state.confirm_dialog.open(
-                "",
-                "",
-                ConfirmIntent::ExecuteWrite {
-                    sql: "UPDATE t SET x=1".to_string(),
-                    blocked: false,
-                },
-            );
+                assert_eq!(state.input_mode(), InputMode::ConnectionSelector);
+                assert_eq!(effects.len(), 1);
+                assert!(matches!(&effects[0], Effect::DeleteConnection { .. }));
+            }
 
-            let now = Instant::now();
-            let effects = reduce_modal(&mut state, &Action::ConfirmDialogConfirm, now).unwrap();
-
-            assert_eq!(state.input_mode(), InputMode::CellEdit);
-            assert!(state.query.is_running());
-            assert!(state.query.start_time().is_some());
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(&effects[0], Effect::ExecuteWrite { .. }));
-        }
-
-        #[test]
-        fn execute_write_no_dsn_sets_error() {
-            let mut state = create_test_state();
-            enter_confirm_dialog(&mut state, InputMode::Normal);
-            state.session.dsn = None;
-            state.confirm_dialog.open(
-                "",
-                "",
-                ConfirmIntent::ExecuteWrite {
-                    sql: "UPDATE t SET x=1".to_string(),
-                    blocked: false,
-                },
-            );
-
-            let effects =
-                reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now()).unwrap();
-
-            assert!(effects.is_empty());
-            assert_eq!(
-                state.messages.last_error.as_deref(),
-                Some("No active connection")
-            );
-        }
-
-        #[test]
-        fn execute_write_blocked_returns_to_mode_with_no_effects() {
-            let mut state = create_test_state();
-            enter_confirm_dialog(&mut state, InputMode::Normal);
-            state.confirm_dialog.open(
-                "",
-                "",
-                ConfirmIntent::ExecuteWrite {
-                    sql: "UPDATE t SET x=1".to_string(),
-                    blocked: true,
-                },
-            );
-
-            let effects =
-                reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now()).unwrap();
-
-            assert_eq!(state.input_mode(), InputMode::Normal);
-            assert!(effects.is_empty());
-        }
-
-        #[test]
-        fn execute_write_blocked_confirm_clears_preview_state() {
-            let mut state = create_test_state();
-            enter_confirm_dialog(&mut state, InputMode::Normal);
-            state.result_interaction.set_write_preview(
-                crate::app::policy::write::write_guardrails::WritePreview {
-                    operation: crate::app::policy::write::write_guardrails::WriteOperation::Update,
-                    sql: "UPDATE t SET x=1".to_string(),
-                    target_summary: crate::app::policy::write::write_guardrails::TargetSummary {
-                        schema: "public".to_string(),
-                        table: "t".to_string(),
-                        key_values: vec![],
+            #[test]
+            fn execute_write_sets_running_state_and_returns_effect() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::CellEdit);
+                state.session.dsn = Some("postgres://localhost/test".to_string());
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::ExecuteWrite {
+                        sql: "UPDATE t SET x=1".to_string(),
+                        blocked: false,
                     },
-                    diff: vec![],
-                    guardrail: crate::app::policy::write::write_guardrails::GuardrailDecision {
-                        risk_level: crate::app::policy::write::write_guardrails::RiskLevel::High,
+                );
+
+                let now = Instant::now();
+                let effects = reduce_modal(&mut state, &Action::ConfirmDialogConfirm, now).unwrap();
+
+                assert_eq!(state.input_mode(), InputMode::CellEdit);
+                assert!(state.query.is_running());
+                assert!(state.query.start_time().is_some());
+                assert_eq!(effects.len(), 1);
+                assert!(matches!(&effects[0], Effect::ExecuteWrite { .. }));
+            }
+
+            #[test]
+            fn execute_write_no_dsn_sets_error() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                state.session.dsn = None;
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::ExecuteWrite {
+                        sql: "UPDATE t SET x=1".to_string(),
+                        blocked: false,
+                    },
+                );
+
+                let effects =
+                    reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now())
+                        .unwrap();
+
+                assert!(effects.is_empty());
+                assert_eq!(
+                    state.messages.last_error.as_deref(),
+                    Some("No active connection")
+                );
+            }
+
+            #[test]
+            fn execute_write_blocked_returns_to_mode_with_no_effects() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::ExecuteWrite {
+                        sql: "UPDATE t SET x=1".to_string(),
                         blocked: true,
-                        reason: Some("too risky".to_string()),
-                        target_summary: None,
                     },
-                },
-            );
-            state.query.set_delete_refresh_target(0, None, 1);
-            state.confirm_dialog.open(
-                "",
-                "",
-                ConfirmIntent::ExecuteWrite {
-                    sql: "UPDATE t SET x=1".to_string(),
-                    blocked: true,
-                },
-            );
+                );
 
-            reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now()).unwrap();
+                let effects =
+                    reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now())
+                        .unwrap();
 
-            assert!(state.result_interaction.pending_write_preview().is_none());
-            assert!(state.query.pending_delete_refresh_target().is_none());
-        }
+                assert_eq!(state.input_mode(), InputMode::Normal);
+                assert!(effects.is_empty());
+            }
 
-        #[test]
-        fn csv_export_returns_export_effect() {
-            let mut state = create_test_state();
-            enter_confirm_dialog(&mut state, InputMode::Normal);
-            state.session.dsn = Some("postgres://localhost/test".to_string());
-            state.confirm_dialog.open(
-                "",
-                "",
-                ConfirmIntent::CsvExport {
-                    export_query: "SELECT 1".to_string(),
-                    file_name: "test.csv".to_string(),
-                    row_count: Some(200_000),
-                },
-            );
+            #[test]
+            fn execute_write_blocked_confirm_clears_preview_state() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                state.result_interaction.set_write_preview(
+                    crate::app::policy::write::write_guardrails::WritePreview {
+                        operation:
+                            crate::app::policy::write::write_guardrails::WriteOperation::Update,
+                        sql: "UPDATE t SET x=1".to_string(),
+                        target_summary:
+                            crate::app::policy::write::write_guardrails::TargetSummary {
+                                schema: "public".to_string(),
+                                table: "t".to_string(),
+                                key_values: vec![],
+                            },
+                        diff: vec![],
+                        guardrail: crate::app::policy::write::write_guardrails::GuardrailDecision {
+                            risk_level:
+                                crate::app::policy::write::write_guardrails::RiskLevel::High,
+                            blocked: true,
+                            reason: Some("too risky".to_string()),
+                            target_summary: None,
+                        },
+                    },
+                );
+                state.query.set_delete_refresh_target(0, None, 1);
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::ExecuteWrite {
+                        sql: "UPDATE t SET x=1".to_string(),
+                        blocked: true,
+                    },
+                );
 
-            let effects =
                 reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now()).unwrap();
 
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(&effects[0], Effect::ExportCsv { .. }));
+                assert!(state.result_interaction.pending_write_preview().is_none());
+                assert!(state.query.pending_delete_refresh_target().is_none());
+            }
+
+            #[test]
+            fn csv_export_returns_export_effect() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                state.session.dsn = Some("postgres://localhost/test".to_string());
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::CsvExport {
+                        export_query: "SELECT 1".to_string(),
+                        file_name: "test.csv".to_string(),
+                        row_count: Some(200_000),
+                    },
+                );
+
+                let effects =
+                    reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now())
+                        .unwrap();
+
+                assert_eq!(effects.len(), 1);
+                assert!(matches!(&effects[0], Effect::ExportCsv { .. }));
+            }
+
+            #[test]
+            fn disable_read_only_confirm_sets_read_only_false() {
+                let mut state = create_test_state();
+                state.session.read_only = true;
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                state
+                    .confirm_dialog
+                    .open("", "", ConfirmIntent::DisableReadOnly);
+
+                let effects =
+                    reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now())
+                        .unwrap();
+
+                assert!(!state.session.read_only);
+                assert_eq!(state.input_mode(), InputMode::Normal);
+                assert!(effects.is_empty());
+            }
+
+            #[test]
+            fn none_intent_confirm_does_not_panic() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+
+                let effects =
+                    reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now())
+                        .unwrap();
+
+                assert!(effects.is_empty());
+            }
         }
 
-        #[test]
-        fn disable_read_only_confirm_sets_read_only_false() {
-            let mut state = create_test_state();
-            state.session.read_only = true;
-            enter_confirm_dialog(&mut state, InputMode::Normal);
-            state
-                .confirm_dialog
-                .open("", "", ConfirmIntent::DisableReadOnly);
+        mod scroll {
+            use super::*;
 
-            let effects =
-                reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now()).unwrap();
+            fn state_with_scrollable_preview() -> AppState {
+                let mut state = create_test_state();
+                state.modal.set_mode(InputMode::ConfirmDialog);
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::ExecuteWrite {
+                        sql: "UPDATE t SET x=1".to_string(),
+                        blocked: false,
+                    },
+                );
+                state.confirm_dialog.preview_viewport_height = Some(10);
+                state.confirm_dialog.preview_content_height = Some(25);
+                state
+            }
 
-            assert!(!state.session.read_only);
-            assert_eq!(state.input_mode(), InputMode::Normal);
-            assert!(effects.is_empty());
+            #[test]
+            fn scroll_down_increments_offset() {
+                let mut state = state_with_scrollable_preview();
+
+                reduce_modal(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::ConfirmDialog,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::Line,
+                    },
+                    Instant::now(),
+                );
+
+                assert_eq!(state.confirm_dialog.preview_scroll, 1);
+            }
+
+            #[test]
+            fn scroll_up_decrements_offset() {
+                let mut state = state_with_scrollable_preview();
+                state.confirm_dialog.preview_scroll = 5;
+
+                reduce_modal(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::ConfirmDialog,
+                        direction: ScrollDirection::Up,
+                        amount: ScrollAmount::Line,
+                    },
+                    Instant::now(),
+                );
+
+                assert_eq!(state.confirm_dialog.preview_scroll, 4);
+            }
+
+            #[test]
+            fn scroll_up_clamps_at_zero() {
+                let mut state = state_with_scrollable_preview();
+                state.confirm_dialog.preview_scroll = 0;
+
+                reduce_modal(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::ConfirmDialog,
+                        direction: ScrollDirection::Up,
+                        amount: ScrollAmount::Line,
+                    },
+                    Instant::now(),
+                );
+
+                assert_eq!(state.confirm_dialog.preview_scroll, 0);
+            }
+
+            #[test]
+            fn scroll_down_clamps_at_max() {
+                let mut state = state_with_scrollable_preview();
+                state.confirm_dialog.preview_scroll = 15;
+
+                reduce_modal(
+                    &mut state,
+                    &Action::Scroll {
+                        target: ScrollTarget::ConfirmDialog,
+                        direction: ScrollDirection::Down,
+                        amount: ScrollAmount::Line,
+                    },
+                    Instant::now(),
+                );
+
+                assert_eq!(state.confirm_dialog.preview_scroll, 15);
+            }
+
+            #[test]
+            fn open_resets_scroll_to_zero() {
+                let mut state = create_test_state();
+                state.confirm_dialog.preview_scroll = 10;
+
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::ExecuteWrite {
+                        sql: "test".to_string(),
+                        blocked: false,
+                    },
+                );
+
+                assert_eq!(state.confirm_dialog.preview_scroll, 0);
+                assert!(state.confirm_dialog.preview_viewport_height.is_none());
+                assert!(state.confirm_dialog.preview_content_height.is_none());
+            }
         }
 
-        #[test]
-        fn none_intent_confirm_does_not_panic() {
-            let mut state = create_test_state();
-            enter_confirm_dialog(&mut state, InputMode::Normal);
+        mod cancel {
+            use super::*;
 
-            let effects =
-                reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now()).unwrap();
+            #[test]
+            fn quit_no_connection_restores_connection_setup_synchronously() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                state
+                    .confirm_dialog
+                    .open("", "", ConfirmIntent::QuitNoConnection);
 
-            assert!(effects.is_empty());
+                let effects =
+                    reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now()).unwrap();
+
+                assert_eq!(state.input_mode(), InputMode::ConnectionSetup);
+                assert!(effects.is_empty());
+            }
+
+            #[test]
+            fn other_intents_cancel_returns_empty_effects() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::CellEdit);
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::ExecuteWrite {
+                        sql: "UPDATE t SET x=1".to_string(),
+                        blocked: false,
+                    },
+                );
+
+                let effects =
+                    reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now()).unwrap();
+
+                assert_eq!(state.input_mode(), InputMode::CellEdit);
+                assert!(effects.is_empty());
+                assert!(state.result_interaction.pending_write_preview().is_none());
+            }
+
+            #[test]
+            fn none_intent_cancel_does_not_panic() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+
+                let effects =
+                    reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now()).unwrap();
+
+                assert!(effects.is_empty());
+            }
         }
     }
 
@@ -637,12 +812,9 @@ mod tests {
                 let mut state = create_test_state();
                 state.session.active_connection_id = None;
 
-                let effects = reduce_modal(
-                    &mut state,
-                    &Action::OpenQueryHistoryPicker,
-                    Instant::now(),
-                )
-                .unwrap();
+                let effects =
+                    reduce_modal(&mut state, &Action::OpenQueryHistoryPicker, Instant::now())
+                        .unwrap();
 
                 assert_eq!(state.input_mode(), InputMode::Normal);
                 assert!(effects.is_empty());
@@ -653,32 +825,12 @@ mod tests {
                 let mut state = connected_state();
                 state.query.begin_running(Instant::now());
 
-                let effects = reduce_modal(
-                    &mut state,
-                    &Action::OpenQueryHistoryPicker,
-                    Instant::now(),
-                )
-                .unwrap();
+                let effects =
+                    reduce_modal(&mut state, &Action::OpenQueryHistoryPicker, Instant::now())
+                        .unwrap();
 
                 assert_eq!(state.input_mode(), InputMode::Normal);
                 assert!(effects.is_empty());
-            }
-
-            #[test]
-            fn open_from_normal_sets_mode_and_emits_load_effect() {
-                let mut state = connected_state();
-
-                let effects = reduce_modal(
-                    &mut state,
-                    &Action::OpenQueryHistoryPicker,
-                    Instant::now(),
-                )
-                .unwrap();
-
-                assert_eq!(state.input_mode(), InputMode::QueryHistoryPicker);
-                assert_eq!(state.modal.return_destination(), InputMode::Normal);
-                assert_eq!(effects.len(), 1);
-                assert!(matches!(&effects[0], Effect::LoadQueryHistory { .. }));
             }
         }
 
@@ -686,17 +838,28 @@ mod tests {
             use super::*;
 
             #[test]
+            fn open_from_normal_sets_mode_and_emits_load_effect() {
+                let mut state = connected_state();
+
+                let effects =
+                    reduce_modal(&mut state, &Action::OpenQueryHistoryPicker, Instant::now())
+                        .unwrap();
+
+                assert_eq!(state.input_mode(), InputMode::QueryHistoryPicker);
+                assert_eq!(state.modal.return_destination(), InputMode::Normal);
+                assert_eq!(effects.len(), 1);
+                assert!(matches!(&effects[0], Effect::LoadQueryHistory { .. }));
+            }
+
+            #[test]
             fn close_restores_origin_mode() {
                 let mut state = connected_state();
                 state.modal.set_mode(InputMode::SqlModal);
                 state.modal.push_mode(InputMode::QueryHistoryPicker);
 
-                let effects = reduce_modal(
-                    &mut state,
-                    &Action::CloseQueryHistoryPicker,
-                    Instant::now(),
-                )
-                .unwrap();
+                let effects =
+                    reduce_modal(&mut state, &Action::CloseQueryHistoryPicker, Instant::now())
+                        .unwrap();
 
                 assert_eq!(state.input_mode(), InputMode::SqlModal);
                 assert!(effects.is_empty());
@@ -1002,170 +1165,6 @@ mod tests {
 
                 assert_eq!(state.input_mode(), InputMode::Normal);
             }
-        }
-    }
-
-    mod confirm_dialog_scroll {
-        use super::*;
-
-        fn state_with_scrollable_preview() -> AppState {
-            let mut state = create_test_state();
-            state.modal.set_mode(InputMode::ConfirmDialog);
-            state.confirm_dialog.open(
-                "",
-                "",
-                ConfirmIntent::ExecuteWrite {
-                    sql: "UPDATE t SET x=1".to_string(),
-                    blocked: false,
-                },
-            );
-            // Simulate render having recorded viewport < content
-            state.confirm_dialog.preview_viewport_height = Some(10);
-            state.confirm_dialog.preview_content_height = Some(25);
-            state
-        }
-
-        #[test]
-        fn scroll_down_increments_offset() {
-            let mut state = state_with_scrollable_preview();
-
-            reduce_modal(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::ConfirmDialog,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::Line,
-                },
-                Instant::now(),
-            );
-
-            assert_eq!(state.confirm_dialog.preview_scroll, 1);
-        }
-
-        #[test]
-        fn scroll_up_decrements_offset() {
-            let mut state = state_with_scrollable_preview();
-            state.confirm_dialog.preview_scroll = 5;
-
-            reduce_modal(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::ConfirmDialog,
-                    direction: ScrollDirection::Up,
-                    amount: ScrollAmount::Line,
-                },
-                Instant::now(),
-            );
-
-            assert_eq!(state.confirm_dialog.preview_scroll, 4);
-        }
-
-        #[test]
-        fn scroll_up_clamps_at_zero() {
-            let mut state = state_with_scrollable_preview();
-            state.confirm_dialog.preview_scroll = 0;
-
-            reduce_modal(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::ConfirmDialog,
-                    direction: ScrollDirection::Up,
-                    amount: ScrollAmount::Line,
-                },
-                Instant::now(),
-            );
-
-            assert_eq!(state.confirm_dialog.preview_scroll, 0);
-        }
-
-        #[test]
-        fn scroll_down_clamps_at_max() {
-            let mut state = state_with_scrollable_preview();
-            // max_scroll = 25 - 10 = 15
-            state.confirm_dialog.preview_scroll = 15;
-
-            reduce_modal(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::ConfirmDialog,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::Line,
-                },
-                Instant::now(),
-            );
-
-            assert_eq!(state.confirm_dialog.preview_scroll, 15);
-        }
-
-        #[test]
-        fn open_resets_scroll_to_zero() {
-            let mut state = create_test_state();
-            state.confirm_dialog.preview_scroll = 10;
-
-            state.confirm_dialog.open(
-                "",
-                "",
-                ConfirmIntent::ExecuteWrite {
-                    sql: "test".to_string(),
-                    blocked: false,
-                },
-            );
-
-            assert_eq!(state.confirm_dialog.preview_scroll, 0);
-            assert!(state.confirm_dialog.preview_viewport_height.is_none());
-            assert!(state.confirm_dialog.preview_content_height.is_none());
-        }
-    }
-
-    mod confirm_dialog_cancel {
-        use super::confirm_dialog_confirm::enter_confirm_dialog;
-        use super::*;
-
-        #[test]
-        fn quit_no_connection_restores_connection_setup_synchronously() {
-            let mut state = create_test_state();
-            enter_confirm_dialog(&mut state, InputMode::Normal);
-            state
-                .confirm_dialog
-                .open("", "", ConfirmIntent::QuitNoConnection);
-
-            let effects =
-                reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now()).unwrap();
-
-            assert_eq!(state.input_mode(), InputMode::ConnectionSetup);
-            assert!(effects.is_empty());
-        }
-
-        #[test]
-        fn other_intents_cancel_returns_empty_effects() {
-            let mut state = create_test_state();
-            enter_confirm_dialog(&mut state, InputMode::CellEdit);
-            state.confirm_dialog.open(
-                "",
-                "",
-                ConfirmIntent::ExecuteWrite {
-                    sql: "UPDATE t SET x=1".to_string(),
-                    blocked: false,
-                },
-            );
-
-            let effects =
-                reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now()).unwrap();
-
-            assert_eq!(state.input_mode(), InputMode::CellEdit);
-            assert!(effects.is_empty());
-            assert!(state.result_interaction.pending_write_preview().is_none());
-        }
-
-        #[test]
-        fn none_intent_cancel_does_not_panic() {
-            let mut state = create_test_state();
-            enter_confirm_dialog(&mut state, InputMode::Normal);
-
-            let effects =
-                reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now()).unwrap();
-
-            assert!(effects.is_empty());
         }
     }
 }


### PR DESCRIPTION
## Problem
Test modules had grown into uneven buckets, so a failing test name did not always tell which guarantee or responsibility broke.

## Background
These areas are expected to keep growing, especially keybindings, so the grouping needs to reflect stable semantic boundaries instead of the current file-local shape.

## Approach
Scope: a test-only refactor across keybindings, result scroll, and the query history picker modal flow.
Re-group tests by responsibility boundary rather than by historical layout, so sibling modules stay at the same abstraction level and test names stay short enough to read as behavior documentation.
Separate structure checks from semantic checks in keybindings, split result scroll between page behavior and viewport positioning, and divide query history picker tests into guards, lifecycle, loading, selection, and confirmation.

## Screenshots
