### PR TITLE
refactor: group theme palette tokens

### DIFF
--- a/src/ui/features/browse/explorer.rs
+++ b/src/ui/features/browse/explorer.rs
@@ -80,10 +80,10 @@ impl Explorer {
         };
 
         let list = List::new(items)
-            .style(Style::default().fg(theme.text_primary))
+            .style(Style::default().fg(theme.semantic.text.primary))
             .highlight_style(
                 Style::default()
-                    .fg(theme.text_accent)
+                    .fg(theme.semantic.text.accent)
                     .add_modifier(Modifier::BOLD),
             )
             .highlight_symbol("> ");

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -48,10 +48,10 @@ impl Inspector {
                 let is_selected = *tab == state.ui.inspector_tab;
                 let style = if is_selected {
                     Style::default()
-                        .fg(theme.tab_active)
+                        .fg(theme.component.navigation.tab_active)
                         .add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(theme.tab_inactive)
+                    Style::default().fg(theme.component.navigation.tab_inactive)
                 };
 
                 let mut spans = vec![];
@@ -148,7 +148,7 @@ impl Inspector {
         } else {
             let content = Paragraph::new("(select a table)")
                 .block(block)
-                .style(Style::default().fg(theme.placeholder_text));
+                .style(Style::default().fg(theme.semantic.text.placeholder));
             frame.render_widget(content, area);
             ViewportPlan::default()
         }
@@ -162,7 +162,7 @@ impl Inspector {
         theme: &ThemePalette,
     ) {
         let label_style = Style::default().add_modifier(Modifier::BOLD);
-        let none_style = Style::default().fg(theme.placeholder_text);
+        let none_style = Style::default().fg(theme.semantic.text.placeholder);
 
         let owner_value = table.owner.as_deref().unwrap_or("(none)");
         let comment_value = table.comment.as_deref().unwrap_or("(none)");
@@ -216,7 +216,7 @@ impl Inspector {
         let clamped_scroll_offset = clamp_scroll_offset(scroll_offset, visible_lines, total_lines);
 
         let paragraph = Paragraph::new(lines)
-            .style(Style::default().fg(theme.text_primary))
+            .style(Style::default().fg(theme.semantic.text.primary))
             .wrap(Wrap { trim: false })
             .scroll((clamped_scroll_offset as u16, 0));
         frame.render_widget(paragraph, area);
@@ -319,7 +319,7 @@ impl Inspector {
             Style::default()
                 .add_modifier(Modifier::UNDERLINED)
                 .add_modifier(Modifier::BOLD)
-                .fg(theme.text_primary),
+                .fg(theme.semantic.text.primary),
         )
         .height(1);
 
@@ -339,7 +339,7 @@ impl Inspector {
             .take(data_rows_visible)
             .map(|(row_idx, row)| {
                 let base_style = if (row_idx - clamped_scroll_offset) % 2 == 1 {
-                    Style::default().bg(theme.striped_row_bg)
+                    Style::default().bg(theme.component.table.striped_row_bg)
                 } else {
                     Style::default()
                 };
@@ -351,9 +351,9 @@ impl Inspector {
 
                         // Special styling for PK and Comment columns
                         let cell_style = if col_idx == 3 && !text.is_empty() {
-                            Style::default().fg(theme.text_accent)
+                            Style::default().fg(theme.semantic.text.accent)
                         } else if col_idx == 5 {
-                            Style::default().fg(theme.text_muted)
+                            Style::default().fg(theme.semantic.text.muted)
                         } else {
                             Style::default()
                         };
@@ -366,7 +366,7 @@ impl Inspector {
 
         let table_widget = RatatuiTable::new(rows, widths)
             .header(header)
-            .style(Style::default().fg(theme.text_primary));
+            .style(Style::default().fg(theme.semantic.text.primary));
         frame.render_widget(table_widget, area);
 
         use crate::ui::primitives::atoms::scroll_indicator::{
@@ -519,7 +519,7 @@ impl Inspector {
         match &table.rls {
             None => {
                 let msg = Paragraph::new("RLS not enabled")
-                    .style(Style::default().fg(theme.placeholder_text));
+                    .style(Style::default().fg(theme.semantic.text.placeholder));
                 frame.render_widget(msg, area);
             }
             Some(rls) => {
@@ -538,9 +538,9 @@ impl Inspector {
                     Span::styled(
                         status,
                         Style::default().fg(if rls.enabled {
-                            theme.status_success
+                            theme.semantic.status.success
                         } else {
-                            theme.status_error
+                            theme.semantic.status.error
                         }),
                     ),
                 ])];
@@ -583,7 +583,7 @@ impl Inspector {
                     clamp_scroll_offset(scroll_offset, visible_lines, total_lines);
 
                 let paragraph = Paragraph::new(lines)
-                    .style(Style::default().fg(theme.text_primary))
+                    .style(Style::default().fg(theme.semantic.text.primary))
                     .wrap(Wrap { trim: false })
                     .scroll((clamped_scroll_offset as u16, 0));
                 frame.render_widget(paragraph, area);
@@ -679,7 +679,9 @@ impl Inspector {
 
         let mut lines: Vec<Line> = ddl
             .lines()
-            .map(|l| Line::from(l.to_string()).style(Style::default().fg(theme.text_primary)))
+            .map(|l| {
+                Line::from(l.to_string()).style(Style::default().fg(theme.semantic.text.primary))
+            })
             .collect();
 
         crate::ui::primitives::atoms::apply_yank_flash(&mut lines, flash_active, theme);

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -110,8 +110,8 @@ impl JsonbDetail {
             } else {
                 " Press Enter or i to edit..."
             },
-            base_style: Style::default().fg(theme.text_primary),
-            current_line_style: Style::default().bg(theme.editor_current_line_bg),
+            base_style: Style::default().fg(theme.semantic.text.primary),
+            current_line_style: Style::default().bg(theme.component.editor.current_line_bg),
         };
 
         let line_spans: Vec<Vec<Span<'static>>> = content
@@ -135,19 +135,19 @@ impl JsonbDetail {
         if state.jsonb_detail.has_pending_changes() {
             spans.push(Span::styled(
                 "\u{25cf} Modified  ",
-                Style::default().fg(theme.cell_draft_pending_fg),
+                Style::default().fg(theme.component.table.cell_draft_pending_fg),
             ));
         }
 
         if let Some(err) = state.jsonb_detail.validation_error() {
             spans.push(Span::styled(
                 format!("\u{2717} {err}"),
-                Style::default().fg(theme.status_error),
+                Style::default().fg(theme.semantic.status.error),
             ));
         } else {
             spans.push(Span::styled(
                 "\u{2713} Valid JSON",
-                Style::default().fg(theme.status_success),
+                Style::default().fg(theme.semantic.status.success),
             ));
         }
 
@@ -172,7 +172,10 @@ impl JsonbDetail {
         let visible_input = slice_chars_fitting_width(input, viewport_offset, visible_width);
         let relative_cursor = cursor.saturating_sub(viewport_offset);
 
-        let mut spans = vec![Span::styled("/", Style::default().fg(theme.text_accent))];
+        let mut spans = vec![Span::styled(
+            "/",
+            Style::default().fg(theme.semantic.text.accent),
+        )];
         spans.extend(text_cursor_spans_with_kind(
             &visible_input,
             relative_cursor,
@@ -181,7 +184,10 @@ impl JsonbDetail {
             CursorKind::Insert,
             theme,
         ));
-        spans.push(Span::styled(suffix, Style::default().fg(theme.text_muted)));
+        spans.push(Span::styled(
+            suffix,
+            Style::default().fg(theme.semantic.text.muted),
+        ));
 
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
         set_terminal_cursor(frame, area, &visible_input, 0, relative_cursor, 0, 1);

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -135,7 +135,7 @@ impl JsonbDetail {
         if state.jsonb_detail.has_pending_changes() {
             spans.push(Span::styled(
                 "\u{25cf} Modified  ",
-                Style::default().fg(theme.component.table.cell_draft_pending_fg),
+                Style::default().fg(theme.semantic.status.pending),
             ));
         }
 

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -322,7 +322,7 @@ impl ResultPane {
                                 cell = Cell::from(display).style(
                                     Style::default()
                                         .bg(theme.component.table.result_cell_active_bg)
-                                        .fg(theme.component.table.cell_draft_pending_fg),
+                                        .fg(theme.semantic.status.pending),
                                 );
                             }
                         } else {

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -124,14 +124,14 @@ impl ResultPane {
     fn render_placeholder(frame: &mut Frame, area: Rect, block: Block, theme: &ThemePalette) {
         let content = Paragraph::new("(select a table to preview)")
             .block(block)
-            .style(Style::default().fg(theme.placeholder_text));
+            .style(Style::default().fg(theme.semantic.text.placeholder));
         frame.render_widget(content, area);
     }
 
     fn render_empty(frame: &mut Frame, area: Rect, block: Block, theme: &ThemePalette) {
         let content = Paragraph::new("No rows returned")
             .block(block)
-            .style(Style::default().fg(theme.placeholder_text));
+            .style(Style::default().fg(theme.semantic.text.placeholder));
         frame.render_widget(content, area);
     }
 
@@ -144,12 +144,12 @@ impl ResultPane {
     ) {
         let error_msg = result.error.as_deref().unwrap_or("Unknown error");
 
-        let block = block.style(Style::default().fg(theme.status_error));
+        let block = block.style(Style::default().fg(theme.semantic.status.error));
 
         let content = Paragraph::new(error_msg)
             .block(block)
             .wrap(Wrap { trim: false })
-            .style(Style::default().fg(theme.status_error));
+            .style(Style::default().fg(theme.semantic.status.error));
 
         frame.render_widget(content, area);
     }
@@ -257,7 +257,7 @@ impl ResultPane {
             Style::default()
                 .add_modifier(Modifier::UNDERLINED)
                 .add_modifier(Modifier::BOLD)
-                .fg(theme.text_primary),
+                .fg(theme.semantic.text.primary),
         )
         .height(1);
 
@@ -283,13 +283,13 @@ impl ResultPane {
                     .map(|f| f.col);
                 let is_row_flash = flash_scope == Some(None);
                 let row_bg = if is_row_flash {
-                    Some(theme.yank_flash_bg)
+                    Some(theme.component.feedback.yank_flash_bg)
                 } else if is_staged_for_delete {
-                    Some(theme.staged_delete_bg)
+                    Some(theme.component.table.staged_delete_bg)
                 } else if is_active_row {
-                    Some(theme.result_row_active_bg)
+                    Some(theme.component.table.result_row_active_bg)
                 } else if (abs_row_idx - scroll_offset) % 2 == 1 {
-                    Some(theme.striped_row_bg)
+                    Some(theme.component.table.striped_row_bg)
                 } else {
                     None
                 };
@@ -314,15 +314,15 @@ impl ResultPane {
                                 );
                                 cell = Cell::from(line).style(
                                     Style::default()
-                                        .bg(theme.result_cell_active_bg)
-                                        .fg(theme.cell_edit_fg),
+                                        .bg(theme.component.table.result_cell_active_bg)
+                                        .fg(theme.component.table.cell_edit_fg),
                                 );
                             } else {
                                 let display = truncate_cell(draft, col_width as usize);
                                 cell = Cell::from(display).style(
                                     Style::default()
-                                        .bg(theme.result_cell_active_bg)
-                                        .fg(theme.cell_draft_pending_fg),
+                                        .bg(theme.component.table.result_cell_active_bg)
+                                        .fg(theme.component.table.cell_draft_pending_fg),
                                 );
                             }
                         } else {
@@ -333,13 +333,18 @@ impl ResultPane {
                             if is_row_flash || flash_scope == Some(Some(orig_idx)) {
                                 cell = cell.style(
                                     Style::default()
-                                        .fg(theme.yank_flash_fg)
-                                        .bg(theme.yank_flash_bg),
+                                        .fg(theme.component.feedback.yank_flash_fg)
+                                        .bg(theme.component.feedback.yank_flash_bg),
                                 );
                             } else if is_staged_for_delete {
-                                cell = cell.style(Style::default().fg(theme.staged_delete_fg));
+                                cell = cell.style(
+                                    Style::default().fg(theme.component.table.staged_delete_fg),
+                                );
                             } else if is_active_row && active_cell == Some(orig_idx) {
-                                cell = cell.style(Style::default().bg(theme.result_cell_active_bg));
+                                cell = cell.style(
+                                    Style::default()
+                                        .bg(theme.component.table.result_cell_active_bg),
+                                );
                             }
                         }
                         cell
@@ -356,7 +361,7 @@ impl ResultPane {
 
         let table = Table::new(rows, widths)
             .header(header)
-            .style(Style::default().fg(theme.text_primary));
+            .style(Style::default().fg(theme.semantic.text.primary));
 
         frame.render_widget(table, inner);
 
@@ -388,7 +393,7 @@ impl ResultPane {
             frame.render_widget(
                 Paragraph::new(Line::from(vec![ratatui::text::Span::styled(
                     text,
-                    Style::default().fg(theme.text_secondary),
+                    Style::default().fg(theme.semantic.text.secondary),
                 )])),
                 Rect::new(inner.x, bottom_row, render_width, 1),
             );

--- a/src/ui/features/connections/error.rs
+++ b/src/ui/features/connections/error.rs
@@ -80,11 +80,11 @@ impl ConnectionError {
 
     fn render_summary(frame: &mut Frame, area: Rect, summary: &str, theme: &ThemePalette) {
         let line = Line::from(vec![
-            Span::styled("✗ ", Style::default().fg(theme.status_error)),
+            Span::styled("✗ ", Style::default().fg(theme.semantic.status.error)),
             Span::styled(
                 summary,
                 Style::default()
-                    .fg(theme.status_error)
+                    .fg(theme.semantic.status.error)
                     .add_modifier(Modifier::BOLD),
             ),
         ]);
@@ -98,15 +98,18 @@ impl ConnectionError {
             .as_ref()
             .map_or("", |e| e.kind.hint());
         let mut spans = vec![
-            Span::styled("Hint: ", Style::default().fg(theme.text_accent)),
-            Span::styled(hint.to_string(), Style::default().fg(theme.text_secondary)),
+            Span::styled("Hint: ", Style::default().fg(theme.semantic.text.accent)),
+            Span::styled(
+                hint.to_string(),
+                Style::default().fg(theme.semantic.text.secondary),
+            ),
         ];
         if state.session.is_service_connection()
             && let Some(ref path) = state.runtime.service_file_path
         {
             spans.push(Span::styled(
                 format!("  (edit {})", path.display()),
-                Style::default().fg(theme.text_muted),
+                Style::default().fg(theme.semantic.text.muted),
             ));
         }
         let line = Line::from(spans);
@@ -126,7 +129,7 @@ impl ConnectionError {
             let toggle_line = Line::from(vec![Span::styled(
                 "▼ Details",
                 Style::default()
-                    .fg(theme.section_header)
+                    .fg(theme.component.navigation.section_header)
                     .add_modifier(Modifier::BOLD),
             )]);
             frame.render_widget(Paragraph::new(toggle_line), chunks[0]);
@@ -140,14 +143,23 @@ impl ConnectionError {
                 let para = Paragraph::new(lines)
                     .scroll((scroll as u16, 0))
                     .wrap(Wrap { trim: false })
-                    .style(Style::default().fg(theme.text_muted));
+                    .style(Style::default().fg(theme.semantic.text.muted));
                 frame.render_widget(para, chunks[1]);
             }
         } else {
             let toggle_line = Line::from(vec![
-                Span::styled("▶ ", Style::default().fg(theme.section_header)),
-                Span::styled("Details ", Style::default().fg(theme.section_header)),
-                Span::styled("(press d to expand)", Style::default().fg(theme.text_muted)),
+                Span::styled(
+                    "▶ ",
+                    Style::default().fg(theme.component.navigation.section_header),
+                ),
+                Span::styled(
+                    "Details ",
+                    Style::default().fg(theme.component.navigation.section_header),
+                ),
+                Span::styled(
+                    "(press d to expand)",
+                    Style::default().fg(theme.semantic.text.muted),
+                ),
             ]);
             frame.render_widget(Paragraph::new(toggle_line), area);
         }
@@ -163,7 +175,7 @@ impl ConnectionError {
         let error_state = &state.connection_error;
         let mut spans = vec![Span::styled(
             "Actions: ",
-            Style::default().fg(theme.text_muted),
+            Style::default().fg(theme.semantic.text.muted),
         )];
 
         if state.session.is_service_connection() {
@@ -188,7 +200,7 @@ impl ConnectionError {
             spans.push(Span::styled(
                 "Copied!",
                 Style::default()
-                    .fg(theme.status_success)
+                    .fg(theme.semantic.status.success)
                     .add_modifier(Modifier::BOLD),
             ));
         }

--- a/src/ui/features/connections/selector.rs
+++ b/src/ui/features/connections/selector.rs
@@ -72,9 +72,9 @@ fn render_profile_item(
     let prefix = active_prefix(is_active);
     let text = format!("{prefix}{display_name}");
     let style = if is_active {
-        Style::default().fg(theme.active_indicator)
+        Style::default().fg(theme.component.navigation.active_indicator)
     } else {
-        Style::default().fg(theme.text_secondary)
+        Style::default().fg(theme.semantic.text.secondary)
     };
     ListItem::new(text).style(style)
 }
@@ -109,16 +109,16 @@ fn render_service_item(
     let name_part = format!("{prefix}{name}");
 
     let name_style = if is_active {
-        Style::default().fg(theme.active_indicator)
+        Style::default().fg(theme.component.navigation.active_indicator)
     } else {
-        Style::default().fg(theme.text_secondary)
+        Style::default().fg(theme.semantic.text.secondary)
     };
     let line = Line::from(vec![
         Span::styled(name_part, name_style),
         Span::raw(" ".repeat(gap)),
         Span::styled(
             source_label.to_owned(),
-            Style::default().fg(theme.text_muted),
+            Style::default().fg(theme.semantic.text.muted),
         ),
     ]);
     ListItem::new(line)
@@ -165,7 +165,7 @@ pub fn render_connection_list(
     let list = List::new(items)
         .highlight_style(
             Style::default()
-                .fg(theme.text_accent)
+                .fg(theme.semantic.text.accent)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("> ");

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -291,7 +291,7 @@ impl ConnectionSetup {
 
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(theme.semantic.surface.modal_border))
+            .border_style(Style::default().fg(theme.component.modal.border))
             .style(Style::default());
         frame.render_widget(block, dropdown_area);
 

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -22,7 +22,7 @@ fn bracketed_input(content: &str, border_style: Style, theme: &ThemePalette) -> 
         Span::styled("[", border_style),
         Span::styled(
             format!(" {content} "),
-            Style::default().fg(theme.text_primary),
+            Style::default().fg(theme.semantic.text.primary),
         ),
         Span::styled("]", border_style),
     ])
@@ -128,7 +128,8 @@ impl ConnectionSetup {
         );
 
         let notice = "Note: Connection info is stored locally in plain text";
-        let notice_para = Paragraph::new(notice).style(Style::default().fg(theme.note_text));
+        let notice_para =
+            Paragraph::new(notice).style(Style::default().fg(theme.component.feedback.note_text));
         frame.render_widget(notice_para, chunks[8]);
 
         if form_state.ssl_dropdown.is_open {
@@ -161,9 +162,9 @@ impl ConnectionSetup {
         .split(area);
 
         let label_style = if is_focused {
-            Style::default().fg(theme.text_secondary).bold()
+            Style::default().fg(theme.semantic.text.secondary).bold()
         } else {
-            Style::default().fg(theme.text_secondary)
+            Style::default().fg(theme.semantic.text.secondary)
         };
         let label_para = Paragraph::new(field.label()).style(label_style);
         frame.render_widget(label_para, chunks[0]);
@@ -200,13 +201,16 @@ impl ConnectionSetup {
 
             let mut spans = vec![
                 Span::styled("[", border_style),
-                Span::styled(" ", Style::default().fg(theme.text_primary)),
+                Span::styled(" ", Style::default().fg(theme.semantic.text.primary)),
             ];
             spans.extend(cursor_spans);
             if padding > 0 {
                 spans.push(Span::raw(" ".repeat(padding)));
             }
-            spans.push(Span::styled(" ", Style::default().fg(theme.text_primary)));
+            spans.push(Span::styled(
+                " ",
+                Style::default().fg(theme.semantic.text.primary),
+            ));
             spans.push(Span::styled("]", border_style));
             Line::from(spans)
         } else {
@@ -223,8 +227,8 @@ impl ConnectionSetup {
         frame.render_widget(input_para, chunks[1]);
 
         if let Some(err) = error {
-            let err_para =
-                Paragraph::new(format!(" {err}")).style(Style::default().fg(theme.status_error));
+            let err_para = Paragraph::new(format!(" {err}"))
+                .style(Style::default().fg(theme.semantic.status.error));
             frame.render_widget(err_para, chunks[2]);
         }
     }
@@ -245,9 +249,9 @@ impl ConnectionSetup {
 
         // Label: gray (like Explorer content), bold when focused
         let label_style = if is_focused {
-            Style::default().fg(theme.text_secondary).bold()
+            Style::default().fg(theme.semantic.text.secondary).bold()
         } else {
-            Style::default().fg(theme.text_secondary)
+            Style::default().fg(theme.semantic.text.secondary)
         };
         let label_para = Paragraph::new("SSL Mode:").style(label_style);
         frame.render_widget(label_para, chunks[0]);
@@ -287,7 +291,7 @@ impl ConnectionSetup {
 
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(theme.modal_border))
+            .border_style(Style::default().fg(theme.semantic.surface.modal_border))
             .style(Style::default());
         frame.render_widget(block, dropdown_area);
 
@@ -309,7 +313,7 @@ impl ConnectionSetup {
             let item_style = if is_selected {
                 theme.picker_selected_style()
             } else {
-                Style::default().fg(theme.text_secondary)
+                Style::default().fg(theme.semantic.text.secondary)
             };
 
             let item_para = Paragraph::new(variant.to_string()).style(item_style);

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -177,7 +177,7 @@ impl ConnectionSetup {
 
         let content_width = CONNECTION_INPUT_VISIBLE_WIDTH;
 
-        let border_style = theme.input_border_style(is_focused, error.is_some());
+        let border_style = theme.modal_input_border_style(is_focused, error.is_some());
 
         let input_line = if is_focused {
             let input = state.focused_input().unwrap();
@@ -261,7 +261,7 @@ impl ConnectionSetup {
         let ssl_mode_str = ssl_mode.to_string();
         let display_content = format!("{:<1$} ▼", ssl_mode_str, content_width - 2);
 
-        let border_style = theme.input_border_style(is_focused, false);
+        let border_style = theme.modal_input_border_style(is_focused, false);
 
         let input_para = Paragraph::new(bracketed_input(&display_content, border_style, theme));
         frame.render_widget(input_para, chunks[1]);

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -291,7 +291,7 @@ impl ConnectionSetup {
 
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(theme.component.modal.border))
+            .border_style(theme.modal_border_style())
             .style(Style::default());
         frame.render_widget(block, dropdown_area);
 

--- a/src/ui/features/overlays/confirm_dialog.rs
+++ b/src/ui/features/overlays/confirm_dialog.rs
@@ -35,8 +35,8 @@ impl ConfirmDialog {
 
     fn intent_border_color(intent: Option<&ConfirmIntent>, theme: &ThemePalette) -> Option<Color> {
         match intent {
-            Some(ConfirmIntent::DisableReadOnly) => Some(theme.status_warning),
-            Some(ConfirmIntent::DeleteConnection(_)) => Some(theme.status_error),
+            Some(ConfirmIntent::DisableReadOnly) => Some(theme.semantic.status.warning),
+            Some(ConfirmIntent::DeleteConnection(_)) => Some(theme.semantic.status.error),
             _ => None,
         }
     }
@@ -93,7 +93,7 @@ impl ConfirmDialog {
 
         let inner = modal_inner.inner(Margin::new(1, 0));
         let message_para = Paragraph::new(dialog.message().to_owned())
-            .style(Style::default().fg(theme.text_primary))
+            .style(Style::default().fg(theme.semantic.text.primary))
             .alignment(Alignment::Left)
             .wrap(Wrap { trim: false });
         frame.render_widget(message_para, inner);
@@ -142,12 +142,12 @@ impl ConfirmDialog {
             WriteOperation::Update => {
                 content_lines.push(Line::from(vec![Span::styled(
                     "Diff",
-                    Style::default().fg(theme.text_secondary),
+                    Style::default().fg(theme.semantic.text.secondary),
                 )]));
                 for (i, diff) in preview.diff.iter().enumerate() {
                     content_lines.push(Line::from(Span::styled(
                         format!("  {}:", diff.column),
-                        Style::default().fg(theme.text_secondary),
+                        Style::default().fg(theme.semantic.text.secondary),
                     )));
                     if let Some(json_lines) = &diff.json_diff {
                         Self::render_json_diff_lines(json_lines, &mut content_lines, theme);
@@ -156,11 +156,11 @@ impl ConfirmDialog {
                         let after = format!("\"{}\"", escape_preview_value(&diff.after));
                         content_lines.push(Line::from(Span::styled(
                             format!("    - {before}"),
-                            Style::default().fg(theme.status_error),
+                            Style::default().fg(theme.semantic.status.error),
                         )));
                         content_lines.push(Line::from(Span::styled(
                             format!("    + {after}"),
-                            Style::default().fg(theme.status_success),
+                            Style::default().fg(theme.semantic.status.success),
                         )));
                     }
                     if i + 1 < preview.diff.len() {
@@ -171,17 +171,17 @@ impl ConfirmDialog {
             WriteOperation::Delete => {
                 content_lines.push(Line::from(vec![Span::styled(
                     "Target",
-                    Style::default().fg(theme.text_secondary),
+                    Style::default().fg(theme.semantic.text.secondary),
                 )]));
                 for (key, value) in &preview.target_summary.key_values {
                     content_lines.push(Line::from(vec![
                         Span::styled(
                             format!("  {key}: "),
-                            Style::default().fg(theme.text_secondary),
+                            Style::default().fg(theme.semantic.text.secondary),
                         ),
                         Span::styled(
                             format!("\"{}\"", escape_preview_value(value)),
-                            Style::default().fg(theme.text_primary),
+                            Style::default().fg(theme.semantic.text.primary),
                         ),
                     ]));
                 }
@@ -192,7 +192,7 @@ impl ConfirmDialog {
 
         content_lines.push(Line::from(vec![Span::styled(
             "SQL Preview",
-            Style::default().fg(theme.text_secondary),
+            Style::default().fg(theme.semantic.text.secondary),
         )]));
         for sql_line in preview.sql.lines() {
             let indented = format!("  {sql_line}");
@@ -284,25 +284,25 @@ impl ConfirmDialog {
                 JsonDiffLine::Context(s) => {
                     output.push(Line::from(Span::styled(
                         format!("    {s}"),
-                        Style::default().fg(theme.text_dim),
+                        Style::default().fg(theme.semantic.text.dim),
                     )));
                 }
                 JsonDiffLine::Added(s) => {
                     output.push(Line::from(Span::styled(
                         format!("  + {s}"),
-                        Style::default().fg(theme.status_success),
+                        Style::default().fg(theme.semantic.status.success),
                     )));
                 }
                 JsonDiffLine::Removed(s) => {
                     output.push(Line::from(Span::styled(
                         format!("  - {s}"),
-                        Style::default().fg(theme.status_error),
+                        Style::default().fg(theme.semantic.status.error),
                     )));
                 }
                 JsonDiffLine::Ellipsis => {
                     output.push(Line::from(Span::styled(
                         "    ...".to_string(),
-                        Style::default().fg(theme.text_dim),
+                        Style::default().fg(theme.semantic.text.dim),
                     )));
                 }
             }

--- a/src/ui/features/overlays/help.rs
+++ b/src/ui/features/overlays/help.rs
@@ -207,11 +207,14 @@ impl HelpOverlay {
 
     fn section(title: &str, theme: &ThemePalette) -> Line<'static> {
         Line::from(vec![
-            Span::styled("▸ ", Style::default().fg(theme.section_header)),
+            Span::styled(
+                "▸ ",
+                Style::default().fg(theme.component.navigation.section_header),
+            ),
             Span::styled(
                 title.to_string(),
                 Style::default()
-                    .fg(theme.section_header)
+                    .fg(theme.component.navigation.section_header)
                     .add_modifier(Modifier::BOLD),
             ),
         ])
@@ -240,10 +243,13 @@ impl HelpOverlay {
             Span::styled(
                 format!("  {key:<20}"),
                 Style::default()
-                    .fg(theme.text_accent)
+                    .fg(theme.semantic.text.accent)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(desc.to_string(), Style::default().fg(theme.text_secondary)),
+            Span::styled(
+                desc.to_string(),
+                Style::default().fg(theme.semantic.text.secondary),
+            ),
         ])
     }
 }

--- a/src/ui/features/pickers/command_palette.rs
+++ b/src/ui/features/pickers/command_palette.rs
@@ -28,7 +28,7 @@ impl CommandPalette {
                 let style = if i == state.ui.table_picker.selected() {
                     theme.picker_selected_style()
                 } else {
-                    Style::default().fg(theme.text_secondary)
+                    Style::default().fg(theme.semantic.text.secondary)
                 };
                 let content = format!("  {:<18} {}", kb.key, kb.description);
                 ListItem::new(content).style(style)

--- a/src/ui/features/pickers/er_table_picker.rs
+++ b/src/ui/features/pickers/er_table_picker.rs
@@ -29,21 +29,29 @@ impl ErTablePicker {
         let filtered_count = state.er_filtered_tables().len();
 
         let (mode_label, targets_label, preview_color) = if selected_count == 0 {
-            ("Invalid".to_string(), "—".to_string(), theme.status_error)
+            (
+                "Invalid".to_string(),
+                "—".to_string(),
+                theme.semantic.status.error,
+            )
         } else if selected_count == total_count {
             (
                 "Full ER".to_string(),
                 format!("all {total_count} tables"),
-                theme.text_muted,
+                theme.semantic.text.muted,
             )
         } else if selected_count == 1 {
             let name = state.ui.er_selected_tables.iter().next().unwrap().clone();
-            ("Partial ER".to_string(), name, theme.section_header)
+            (
+                "Partial ER".to_string(),
+                name,
+                theme.component.navigation.section_header,
+            )
         } else {
             (
                 "Partial ER".to_string(),
                 format!("{selected_count} tables"),
-                theme.section_header,
+                theme.component.navigation.section_header,
             )
         };
 
@@ -88,22 +96,34 @@ impl ErTablePicker {
             visible_width,
             theme,
         );
-        let mut spans = vec![Span::styled("  > ", Style::default().fg(theme.modal_title))];
+        let mut spans = vec![Span::styled(
+            "  > ",
+            Style::default().fg(theme.component.modal.title),
+        )];
         spans.extend(cursor_spans);
         frame.render_widget(Paragraph::new(Line::from(spans)), filter_area);
 
         // 3-line execution preview
         let preview_lines = vec![
             Line::from(vec![
-                Span::styled("  Mode:    ", Style::default().fg(theme.text_muted)),
+                Span::styled(
+                    "  Mode:    ",
+                    Style::default().fg(theme.semantic.text.muted),
+                ),
                 Span::styled(mode_label, Style::default().fg(preview_color)),
             ]),
             Line::from(vec![
-                Span::styled("  Targets: ", Style::default().fg(theme.text_muted)),
+                Span::styled(
+                    "  Targets: ",
+                    Style::default().fg(theme.semantic.text.muted),
+                ),
                 Span::styled(targets_label, Style::default().fg(preview_color)),
             ]),
             Line::from(vec![
-                Span::styled("  Output:  ", Style::default().fg(theme.text_muted)),
+                Span::styled(
+                    "  Output:  ",
+                    Style::default().fg(theme.semantic.text.muted),
+                ),
                 Span::styled(output_label, Style::default().fg(preview_color)),
             ]),
         ];
@@ -118,9 +138,9 @@ impl ErTablePicker {
                 let is_selected = state.ui.er_selected_tables.contains(&qn);
                 let mark = if is_selected { "✔ " } else { "  " };
                 let style = if is_selected {
-                    Style::default().fg(theme.focus_border)
+                    Style::default().fg(theme.semantic.surface.focus_border)
                 } else {
-                    Style::default().fg(theme.text_secondary)
+                    Style::default().fg(theme.semantic.text.secondary)
                 };
                 ListItem::new(format!("  {mark}{qn}")).style(style)
             })

--- a/src/ui/features/pickers/query_history_picker.rs
+++ b/src/ui/features/pickers/query_history_picker.rs
@@ -291,7 +291,7 @@ fn render_preview(
 ) {
     let block = Block::default()
         .borders(Borders::TOP)
-        .border_style(Style::default().fg(theme.semantic.surface.modal_border))
+        .border_style(Style::default().fg(theme.component.modal.border))
         .title(Span::styled(
             " Preview ",
             Style::default().fg(theme.component.modal.title),
@@ -338,7 +338,7 @@ fn render_preview(
 fn render_empty_preview(frame: &mut Frame, area: ratatui::layout::Rect, theme: &ThemePalette) {
     let block = Block::default()
         .borders(Borders::TOP)
-        .border_style(Style::default().fg(theme.semantic.surface.modal_border))
+        .border_style(Style::default().fg(theme.component.modal.border))
         .title(Span::styled(
             " Preview ",
             Style::default().fg(theme.component.modal.title),

--- a/src/ui/features/pickers/query_history_picker.rs
+++ b/src/ui/features/pickers/query_history_picker.rs
@@ -133,16 +133,19 @@ impl QueryHistoryPicker {
         let filter_line = if filter_content.is_empty() {
             Line::from(Span::styled(
                 "  type to filter",
-                Style::default().fg(theme.placeholder_text),
+                Style::default().fg(theme.semantic.text.placeholder),
             ))
         } else {
             Line::from(vec![
-                Span::styled("  > ", Style::default().fg(theme.modal_title)),
-                Span::styled(filter_content, Style::default().fg(theme.text_primary)),
+                Span::styled("  > ", Style::default().fg(theme.component.modal.title)),
+                Span::styled(
+                    filter_content,
+                    Style::default().fg(theme.semantic.text.primary),
+                ),
                 Span::styled(
                     "\u{2588}",
                     Style::default()
-                        .fg(theme.cursor_fg)
+                        .fg(theme.semantic.cursor.fg)
                         .add_modifier(Modifier::SLOW_BLINK),
                 ),
             ])
@@ -158,7 +161,7 @@ impl QueryHistoryPicker {
             };
             let empty_line = Line::from(Span::styled(
                 format!("  {msg}"),
-                Style::default().fg(theme.text_secondary),
+                Style::default().fg(theme.semantic.text.secondary),
             ));
             frame.render_widget(Paragraph::new(empty_line), list_area);
             if let Some(pa) = preview_area {
@@ -228,9 +231,9 @@ fn build_list_item(
         spans.push(Span::styled(
             truncated.clone(),
             Style::default().fg(if i == selected_idx {
-                theme.text_primary
+                theme.semantic.text.primary
             } else {
-                theme.text_secondary
+                theme.semantic.text.secondary
             }),
         ));
     } else {
@@ -238,11 +241,11 @@ fn build_list_item(
         for (ci, ch) in chars.iter().enumerate() {
             let is_match = ge.match_indices.contains(&(ci as u32));
             let color = if is_match {
-                theme.text_accent
+                theme.semantic.text.accent
             } else if i == selected_idx {
-                theme.text_primary
+                theme.semantic.text.primary
             } else {
-                theme.text_secondary
+                theme.semantic.text.secondary
             };
             let mut style = Style::default().fg(color);
             if is_match {
@@ -265,13 +268,16 @@ fn build_list_item(
     let pad = query_max.saturating_sub(used);
 
     if !badge.is_empty() {
-        spans.push(Span::styled(badge, Style::default().fg(theme.text_dim)));
+        spans.push(Span::styled(
+            badge,
+            Style::default().fg(theme.semantic.text.dim),
+        ));
     }
 
     spans.push(Span::raw(" ".repeat(pad)));
     spans.push(Span::styled(
         format!("  {ts_short}"),
-        Style::default().fg(theme.text_dim),
+        Style::default().fg(theme.semantic.text.dim),
     ));
 
     ListItem::new(Line::from(spans))
@@ -285,10 +291,10 @@ fn render_preview(
 ) {
     let block = Block::default()
         .borders(Borders::TOP)
-        .border_style(Style::default().fg(theme.modal_border))
+        .border_style(Style::default().fg(theme.semantic.surface.modal_border))
         .title(Span::styled(
             " Preview ",
-            Style::default().fg(theme.modal_title),
+            Style::default().fg(theme.component.modal.title),
         ));
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -308,12 +314,12 @@ fn render_preview(
     if let Some(rows) = pd.affected_rows {
         meta_spans.push(Span::styled(
             format!("  \u{2502} {rows} rows affected"),
-            Style::default().fg(theme.text_secondary),
+            Style::default().fg(theme.semantic.text.secondary),
         ));
     }
     meta_spans.push(Span::styled(
         format!("  \u{2502} {}", format_short_timestamp(&pd.executed_at)),
-        Style::default().fg(theme.text_dim),
+        Style::default().fg(theme.semantic.text.dim),
     ));
     lines.push(Line::from(meta_spans));
     lines.push(Line::raw(""));
@@ -321,7 +327,7 @@ fn render_preview(
     for sql_line in pd.query.lines() {
         lines.push(Line::styled(
             sql_line.to_string(),
-            Style::default().fg(theme.text_primary),
+            Style::default().fg(theme.semantic.text.primary),
         ));
     }
 
@@ -332,17 +338,17 @@ fn render_preview(
 fn render_empty_preview(frame: &mut Frame, area: ratatui::layout::Rect, theme: &ThemePalette) {
     let block = Block::default()
         .borders(Borders::TOP)
-        .border_style(Style::default().fg(theme.modal_border))
+        .border_style(Style::default().fg(theme.semantic.surface.modal_border))
         .title(Span::styled(
             " Preview ",
-            Style::default().fg(theme.modal_title),
+            Style::default().fg(theme.component.modal.title),
         ));
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
     let msg = Paragraph::new(Line::styled(
         "No selection",
-        Style::default().fg(theme.text_muted),
+        Style::default().fg(theme.semantic.text.muted),
     ));
     frame.render_widget(msg, inner);
 }

--- a/src/ui/features/pickers/query_history_picker.rs
+++ b/src/ui/features/pickers/query_history_picker.rs
@@ -291,7 +291,7 @@ fn render_preview(
 ) {
     let block = Block::default()
         .borders(Borders::TOP)
-        .border_style(Style::default().fg(theme.component.modal.border))
+        .border_style(theme.modal_border_style())
         .title(Span::styled(
             " Preview ",
             Style::default().fg(theme.component.modal.title),
@@ -338,7 +338,7 @@ fn render_preview(
 fn render_empty_preview(frame: &mut Frame, area: ratatui::layout::Rect, theme: &ThemePalette) {
     let block = Block::default()
         .borders(Borders::TOP)
-        .border_style(Style::default().fg(theme.component.modal.border))
+        .border_style(theme.modal_border_style())
         .title(Span::styled(
             " Preview ",
             Style::default().fg(theme.component.modal.title),

--- a/src/ui/features/pickers/table_picker.rs
+++ b/src/ui/features/pickers/table_picker.rs
@@ -50,7 +50,10 @@ impl TablePicker {
             visible_width,
             theme,
         );
-        let mut spans = vec![Span::styled("  > ", Style::default().fg(theme.modal_title))];
+        let mut spans = vec![Span::styled(
+            "  > ",
+            Style::default().fg(theme.component.modal.title),
+        )];
         spans.extend(cursor_spans);
         let filter_line = Line::from(spans);
 
@@ -61,7 +64,7 @@ impl TablePicker {
             .iter()
             .map(|t| {
                 let content = format!("  {}", t.qualified_name());
-                ListItem::new(content).style(Style::default().fg(theme.text_secondary))
+                ListItem::new(content).style(Style::default().fg(theme.semantic.text.secondary))
             })
             .collect();
 

--- a/src/ui/features/sql_modal/compare.rs
+++ b/src/ui/features/sql_modal/compare.rs
@@ -158,10 +158,7 @@ fn render_verdict_section(
     push_chrome(
         lines,
         flash_mask,
-        Line::styled(
-            format!(" {sep}"),
-            Style::default().fg(theme.component.modal.border),
-        ),
+        Line::styled(format!(" {sep}"), theme.modal_border_style()),
     );
     push_empty(lines, flash_mask);
 }
@@ -177,10 +174,7 @@ fn render_slot_columns(
     theme: &ThemePalette,
 ) {
     let half = (total_width.saturating_sub(3) / 2) as usize;
-    let sep = Span::styled(
-        " \u{2502} ",
-        Style::default().fg(theme.component.modal.border),
-    );
+    let sep = Span::styled(" \u{2502} ", theme.modal_border_style());
 
     let active_header = Style::default()
         .fg(theme.semantic.text.accent)

--- a/src/ui/features/sql_modal/compare.rs
+++ b/src/ui/features/sql_modal/compare.rs
@@ -39,7 +39,7 @@ pub fn render(
     if lines.is_empty() {
         lines.push(Line::from(Span::styled(
             " Run EXPLAIN (Ctrl+E) to start comparing.",
-            Style::default().fg(theme.placeholder_text),
+            Style::default().fg(theme.semantic.text.placeholder),
         )));
         flash_mask.push(false);
     }
@@ -63,7 +63,7 @@ pub fn render(
 
     frame.render_widget(
         Paragraph::new(visible)
-            .style(Style::default().fg(theme.text_primary))
+            .style(Style::default().fg(theme.semantic.text.primary))
             .wrap(Wrap { trim: false }),
         area,
     );
@@ -103,25 +103,25 @@ fn render_verdict_section(
         ComparisonVerdict::Improved => (
             "\u{2193} Improved",
             Style::default()
-                .fg(theme.status_success)
+                .fg(theme.semantic.status.success)
                 .add_modifier(Modifier::BOLD),
         ),
         ComparisonVerdict::Worsened => (
             "\u{2191} Worsened",
             Style::default()
-                .fg(theme.status_error)
+                .fg(theme.semantic.status.error)
                 .add_modifier(Modifier::BOLD),
         ),
         ComparisonVerdict::Similar => (
             "\u{2248} Similar",
             Style::default()
-                .fg(theme.text_accent)
+                .fg(theme.semantic.text.accent)
                 .add_modifier(Modifier::BOLD),
         ),
         ComparisonVerdict::Unavailable => (
             "Comparison unavailable",
             Style::default()
-                .fg(theme.text_muted)
+                .fg(theme.semantic.text.muted)
                 .add_modifier(Modifier::BOLD),
         ),
     };
@@ -139,8 +139,14 @@ fn render_verdict_section(
             lines,
             flash_mask,
             Line::from(vec![
-                Span::styled("  \u{2022} ", Style::default().fg(theme.text_muted)),
-                Span::styled(reason.clone(), Style::default().fg(theme.text_primary)),
+                Span::styled(
+                    "  \u{2022} ",
+                    Style::default().fg(theme.semantic.text.muted),
+                ),
+                Span::styled(
+                    reason.clone(),
+                    Style::default().fg(theme.semantic.text.primary),
+                ),
             ]),
         );
     }
@@ -152,7 +158,10 @@ fn render_verdict_section(
     push_chrome(
         lines,
         flash_mask,
-        Line::styled(format!(" {sep}"), Style::default().fg(theme.modal_border)),
+        Line::styled(
+            format!(" {sep}"),
+            Style::default().fg(theme.semantic.surface.modal_border),
+        ),
     );
     push_empty(lines, flash_mask);
 }
@@ -168,13 +177,16 @@ fn render_slot_columns(
     theme: &ThemePalette,
 ) {
     let half = (total_width.saturating_sub(3) / 2) as usize;
-    let sep = Span::styled(" \u{2502} ", Style::default().fg(theme.modal_border));
+    let sep = Span::styled(
+        " \u{2502} ",
+        Style::default().fg(theme.semantic.surface.modal_border),
+    );
 
     let active_header = Style::default()
-        .fg(theme.text_accent)
+        .fg(theme.semantic.text.accent)
         .add_modifier(Modifier::BOLD);
     let empty_header = Style::default()
-        .fg(theme.text_dim)
+        .fg(theme.semantic.text.dim)
         .add_modifier(Modifier::BOLD);
 
     let left_label = match left {
@@ -210,8 +222,8 @@ fn render_slot_columns(
         ]),
     );
 
-    let detail_style = Style::default().fg(theme.text_muted);
-    let placeholder_style = Style::default().fg(theme.placeholder_text);
+    let detail_style = Style::default().fg(theme.semantic.text.muted);
+    let placeholder_style = Style::default().fg(theme.semantic.text.placeholder);
 
     let left_detail = slot_detail_text(left);
     let right_detail = slot_detail_text(right);
@@ -245,13 +257,19 @@ fn render_slot_columns(
         lines,
         flash_mask,
         Line::from(vec![
-            Span::styled(format!(" {thin_sep}"), Style::default().fg(theme.text_dim)),
+            Span::styled(
+                format!(" {thin_sep}"),
+                Style::default().fg(theme.semantic.text.dim),
+            ),
             sep.clone(),
-            Span::styled(format!(" {thin_sep}"), Style::default().fg(theme.text_dim)),
+            Span::styled(
+                format!(" {thin_sep}"),
+                Style::default().fg(theme.semantic.text.dim),
+            ),
         ]),
     );
 
-    let dim_style = Style::default().fg(theme.text_dim);
+    let dim_style = Style::default().fg(theme.semantic.text.dim);
 
     let l_plan: Vec<&str> = left
         .map(|s| s.plan.raw_text.lines().collect())
@@ -292,9 +310,9 @@ fn render_slot_stacked(
     theme: &ThemePalette,
 ) {
     let header_style = Style::default()
-        .fg(theme.text_accent)
+        .fg(theme.semantic.text.accent)
         .add_modifier(Modifier::BOLD);
-    let badge_style = Style::default().fg(theme.text_muted);
+    let badge_style = Style::default().fg(theme.semantic.text.muted);
 
     render_stacked_slot(
         lines,
@@ -355,7 +373,7 @@ fn render_stacked_slot(
             Line::from(Span::styled(
                 empty_label.to_string(),
                 Style::default()
-                    .fg(theme.text_dim)
+                    .fg(theme.semantic.text.dim)
                     .add_modifier(Modifier::BOLD),
             )),
         );
@@ -364,7 +382,7 @@ fn render_stacked_slot(
             flash_mask,
             Line::from(Span::styled(
                 "  Run EXPLAIN again to compare",
-                Style::default().fg(theme.placeholder_text),
+                Style::default().fg(theme.semantic.text.placeholder),
             )),
         );
     }

--- a/src/ui/features/sql_modal/compare.rs
+++ b/src/ui/features/sql_modal/compare.rs
@@ -160,7 +160,7 @@ fn render_verdict_section(
         flash_mask,
         Line::styled(
             format!(" {sep}"),
-            Style::default().fg(theme.semantic.surface.modal_border),
+            Style::default().fg(theme.component.modal.border),
         ),
     );
     push_empty(lines, flash_mask);
@@ -179,7 +179,7 @@ fn render_slot_columns(
     let half = (total_width.saturating_sub(3) / 2) as usize;
     let sep = Span::styled(
         " \u{2502} ",
-        Style::default().fg(theme.semantic.surface.modal_border),
+        Style::default().fg(theme.component.modal.border),
     );
 
     let active_header = Style::default()

--- a/src/ui/features/sql_modal/completion.rs
+++ b/src/ui/features/sql_modal/completion.rs
@@ -95,7 +95,7 @@ pub(super) fn render_completion_popup(
             let style = if is_selected {
                 theme.picker_selected_style()
             } else {
-                Style::default().fg(theme.text_secondary)
+                Style::default().fg(theme.semantic.text.secondary)
             };
 
             ListItem::new(text).style(style)
@@ -105,7 +105,7 @@ pub(super) fn render_completion_popup(
     let list = List::new(items).block(
         Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(theme.modal_border))
+            .border_style(Style::default().fg(theme.semantic.surface.modal_border))
             .style(Style::default()),
     );
 

--- a/src/ui/features/sql_modal/completion.rs
+++ b/src/ui/features/sql_modal/completion.rs
@@ -105,7 +105,7 @@ pub(super) fn render_completion_popup(
     let list = List::new(items).block(
         Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(theme.semantic.surface.modal_border))
+            .border_style(Style::default().fg(theme.component.modal.border))
             .style(Style::default()),
     );
 

--- a/src/ui/features/sql_modal/completion.rs
+++ b/src/ui/features/sql_modal/completion.rs
@@ -105,7 +105,7 @@ pub(super) fn render_completion_popup(
     let list = List::new(items).block(
         Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(theme.component.modal.border))
+            .border_style(theme.modal_border_style())
             .style(Style::default()),
     );
 

--- a/src/ui/features/sql_modal/editor.rs
+++ b/src/ui/features/sql_modal/editor.rs
@@ -34,7 +34,7 @@ pub(super) fn render_editor(
             .map(|line| {
                 Line::from(Span::styled(
                     line.to_string(),
-                    Style::default().fg(theme.text_muted),
+                    Style::default().fg(theme.semantic.text.muted),
                 ))
             })
             .collect();
@@ -71,7 +71,7 @@ pub(super) fn render_editor(
             " Enter SQL query..."
         },
         base_style: Style::default(),
-        current_line_style: Style::default().bg(theme.editor_current_line_bg),
+        current_line_style: Style::default().bg(theme.component.editor.current_line_bg),
     };
     let line_spans = highlight_sql_spans(content, theme);
     let mut lines = build_modal_text_surface_lines(surface, line_spans, theme);

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -136,10 +136,7 @@ fn build_analyze_confirm_lines<'a>(
     lines.push(Line::raw(""));
 
     let sep = "\u{2500}".repeat(area.width.saturating_sub(2) as usize);
-    lines.push(Line::styled(
-        format!(" {sep}"),
-        Style::default().fg(theme.component.modal.border),
-    ));
+    lines.push(Line::styled(format!(" {sep}"), theme.modal_border_style()));
     lines.push(Line::raw(""));
 
     lines.push(Line::from(Span::styled(

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -36,7 +36,7 @@ pub fn render(
             .map(|line| {
                 Line::from(Span::styled(
                     line.to_string(),
-                    Style::default().fg(theme.status_error),
+                    Style::default().fg(theme.semantic.status.error),
                 ))
             })
             .collect();
@@ -47,14 +47,14 @@ pub fn render(
             (
                 "EXPLAIN ANALYZE",
                 Style::default()
-                    .fg(theme.text_accent)
+                    .fg(theme.semantic.text.accent)
                     .add_modifier(Modifier::BOLD),
             )
         } else {
             (
                 "EXPLAIN",
                 Style::default()
-                    .fg(theme.text_accent)
+                    .fg(theme.semantic.text.accent)
                     .add_modifier(Modifier::BOLD),
             )
         };
@@ -63,7 +63,7 @@ pub fn render(
             Span::styled(format!("{label} "), label_style),
             Span::styled(
                 format!("({time_secs:.2}s)"),
-                Style::default().fg(theme.text_muted),
+                Style::default().fg(theme.semantic.text.muted),
             ),
         ]);
 
@@ -72,7 +72,7 @@ pub fn render(
             Span::styled("  ", Style::default()),
             Span::styled(
                 query_snippet.to_string(),
-                Style::default().fg(theme.text_muted),
+                Style::default().fg(theme.semantic.text.muted),
             ),
         ]);
 
@@ -101,7 +101,7 @@ pub fn render(
     } else {
         let placeholder = Line::from(Span::styled(
             " Press Ctrl+E to run EXPLAIN",
-            Style::default().fg(theme.placeholder_text),
+            Style::default().fg(theme.semantic.text.placeholder),
         ));
         frame.render_widget(Paragraph::new(vec![placeholder]), area);
         area.height
@@ -125,7 +125,7 @@ fn build_analyze_confirm_lines<'a>(
     let mut lines = Vec::new();
 
     let header_style = Style::default()
-        .fg(theme.status_error)
+        .fg(theme.semantic.status.error)
         .add_modifier(Modifier::BOLD);
 
     lines.push(Line::raw(""));
@@ -138,7 +138,7 @@ fn build_analyze_confirm_lines<'a>(
     let sep = "\u{2500}".repeat(area.width.saturating_sub(2) as usize);
     lines.push(Line::styled(
         format!(" {sep}"),
-        Style::default().fg(theme.modal_border),
+        Style::default().fg(theme.semantic.surface.modal_border),
     ));
     lines.push(Line::raw(""));
 
@@ -156,7 +156,7 @@ fn build_analyze_confirm_lines<'a>(
     for line in full_query.lines() {
         lines.push(Line::from(Span::styled(
             format!("  {line}"),
-            Style::default().fg(theme.text_dim),
+            Style::default().fg(theme.semantic.text.dim),
         )));
     }
     lines.push(Line::raw(""));
@@ -167,7 +167,7 @@ fn build_analyze_confirm_lines<'a>(
             let prompt = format!(" Type \"{name}\" to confirm: > ");
             let mut prompt_spans = vec![Span::styled(
                 prompt,
-                Style::default().fg(theme.text_secondary),
+                Style::default().fg(theme.semantic.text.secondary),
             )];
             prompt_spans.extend(text_cursor_spans(
                 input.content(),
@@ -179,7 +179,7 @@ fn build_analyze_confirm_lines<'a>(
             if is_match {
                 prompt_spans.push(Span::styled(
                     " \u{2713}",
-                    Style::default().fg(theme.status_success),
+                    Style::default().fg(theme.semantic.status.success),
                 ));
             }
             lines.push(Line::from(prompt_spans));
@@ -187,7 +187,7 @@ fn build_analyze_confirm_lines<'a>(
         None => {
             lines.push(Line::from(Span::styled(
                 " Cannot identify target object name.  Esc: Back",
-                Style::default().fg(theme.text_muted),
+                Style::default().fg(theme.semantic.text.muted),
             )));
         }
     }

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -138,7 +138,7 @@ fn build_analyze_confirm_lines<'a>(
     let sep = "\u{2500}".repeat(area.width.saturating_sub(2) as usize);
     lines.push(Line::styled(
         format!(" {sep}"),
-        Style::default().fg(theme.semantic.surface.modal_border),
+        Style::default().fg(theme.component.modal.border),
     ));
     lines.push(Line::raw(""));
 

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -123,7 +123,7 @@ impl SqlModal {
         frame.render_widget(
             Paragraph::new(Line::styled(
                 sep_line,
-                Style::default().fg(theme.semantic.surface.modal_border),
+                Style::default().fg(theme.component.modal.border),
             )),
             separator_area,
         );
@@ -171,7 +171,7 @@ impl SqlModal {
             .title_bottom(Line::styled(hint.to_string(), theme.modal_hint_style()))
             .borders(Borders::ALL)
             .border_set(border::ROUNDED)
-            .border_style(Style::default().fg(theme.semantic.surface.modal_border))
+            .border_style(Style::default().fg(theme.component.modal.border))
             .style(Style::default().fg(theme.semantic.text.primary));
         let inner = block.inner(area);
         frame.render_widget(block, area);
@@ -198,7 +198,7 @@ impl SqlModal {
             Span::styled(" SQL Editor ", title_style),
             Span::styled(
                 "\u{2500}\u{2500} ",
-                Style::default().fg(theme.semantic.surface.modal_border),
+                Style::default().fg(theme.component.modal.border),
             ),
             Span::styled("[SQL]", style_for(SqlModalTab::Sql)),
             Span::raw(" "),

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -64,7 +64,7 @@ impl SqlModal {
                         Constraint::Percentage(SQL_MODAL_HEIGHT_PERCENT),
                         &title,
                         footer,
-                        theme.status_error,
+                        theme.semantic.status.error,
                         theme,
                     )
                 }
@@ -123,7 +123,7 @@ impl SqlModal {
         frame.render_widget(
             Paragraph::new(Line::styled(
                 sep_line,
-                Style::default().fg(theme.modal_border),
+                Style::default().fg(theme.semantic.surface.modal_border),
             )),
             separator_area,
         );
@@ -171,8 +171,8 @@ impl SqlModal {
             .title_bottom(Line::styled(hint.to_string(), theme.modal_hint_style()))
             .borders(Borders::ALL)
             .border_set(border::ROUNDED)
-            .border_style(Style::default().fg(theme.modal_border))
-            .style(Style::default().fg(theme.text_primary));
+            .border_style(Style::default().fg(theme.semantic.surface.modal_border))
+            .style(Style::default().fg(theme.semantic.text.primary));
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
@@ -182,9 +182,9 @@ impl SqlModal {
     fn build_title_with_tabs(active_tab: SqlModalTab, theme: &ThemePalette) -> Line<'static> {
         let title_style = theme.modal_title_style();
         let active_style = Style::default()
-            .fg(theme.tab_active)
+            .fg(theme.component.navigation.tab_active)
             .add_modifier(Modifier::BOLD);
-        let inactive_style = Style::default().fg(theme.tab_inactive);
+        let inactive_style = Style::default().fg(theme.component.navigation.tab_inactive);
 
         let style_for = |tab: SqlModalTab| {
             if tab == active_tab {
@@ -196,7 +196,10 @@ impl SqlModal {
 
         Line::from(vec![
             Span::styled(" SQL Editor ", title_style),
-            Span::styled("\u{2500}\u{2500} ", Style::default().fg(theme.modal_border)),
+            Span::styled(
+                "\u{2500}\u{2500} ",
+                Style::default().fg(theme.semantic.surface.modal_border),
+            ),
             Span::styled("[SQL]", style_for(SqlModalTab::Sql)),
             Span::raw(" "),
             Span::styled("[Plan]", style_for(SqlModalTab::Plan)),

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -121,10 +121,7 @@ impl SqlModal {
         // Draw horizontal separator between editor and status bar
         let sep_line = "\u{2500}".repeat(separator_area.width as usize);
         frame.render_widget(
-            Paragraph::new(Line::styled(
-                sep_line,
-                Style::default().fg(theme.component.modal.border),
-            )),
+            Paragraph::new(Line::styled(sep_line, theme.modal_border_style())),
             separator_area,
         );
 
@@ -171,7 +168,7 @@ impl SqlModal {
             .title_bottom(Line::styled(hint.to_string(), theme.modal_hint_style()))
             .borders(Borders::ALL)
             .border_set(border::ROUNDED)
-            .border_style(Style::default().fg(theme.component.modal.border))
+            .border_style(theme.modal_border_style())
             .style(Style::default().fg(theme.semantic.text.primary));
         let inner = block.inner(area);
         frame.render_widget(block, area);
@@ -196,10 +193,7 @@ impl SqlModal {
 
         Line::from(vec![
             Span::styled(" SQL Editor ", title_style),
-            Span::styled(
-                "\u{2500}\u{2500} ",
-                Style::default().fg(theme.component.modal.border),
-            ),
+            Span::styled("\u{2500}\u{2500} ", theme.modal_border_style()),
             Span::styled("[SQL]", style_for(SqlModalTab::Sql)),
             Span::raw(" "),
             Span::styled("[Plan]", style_for(SqlModalTab::Plan)),

--- a/src/ui/features/sql_modal/plan_highlight.rs
+++ b/src/ui/features/sql_modal/plan_highlight.rs
@@ -63,9 +63,9 @@ pub fn highlight_plan_line(raw: &str, theme: &ThemePalette) -> Line<'static> {
         let cost_part = &content[cost_paren..];
 
         let node_style = Style::default()
-            .fg(theme.section_header)
+            .fg(theme.component.navigation.section_header)
             .add_modifier(Modifier::BOLD);
-        let cost_style = Style::default().fg(theme.text_dim);
+        let cost_style = Style::default().fg(theme.semantic.text.dim);
 
         if let Some(node_name) = find_node_type(before_cost) {
             let after_node = &before_cost[node_name.len()..];
@@ -78,7 +78,7 @@ pub fn highlight_plan_line(raw: &str, theme: &ThemePalette) -> Line<'static> {
         spans.push(Span::styled(cost_part.to_string(), cost_style));
     } else if let Some(node_name) = find_node_type(content) {
         let node_style = Style::default()
-            .fg(theme.section_header)
+            .fg(theme.component.navigation.section_header)
             .add_modifier(Modifier::BOLD);
         let after_node = &content[node_name.len()..];
         spans.push(Span::styled(node_name.to_string(), node_style));
@@ -100,9 +100,9 @@ pub(super) fn highlight_truncated(
     let content = trimmed.trim_start_matches("->").trim_start();
 
     let node_style = Style::default()
-        .fg(theme.section_header)
+        .fg(theme.component.navigation.section_header)
         .add_modifier(Modifier::BOLD);
-    let cost_style = Style::default().fg(theme.text_dim);
+    let cost_style = Style::default().fg(theme.semantic.text.dim);
 
     let prefix_len = truncated.len() - content.len();
     let prefix = &truncated[..prefix_len];

--- a/src/ui/features/sql_modal/status.rs
+++ b/src/ui/features/sql_modal/status.rs
@@ -25,26 +25,26 @@ pub(super) fn render_status(frame: &mut Frame, area: Rect, state: &AppState, the
             if let Some(ref msg) = state.messages.last_success {
                 (
                     "[NORMAL]",
-                    Style::default().fg(theme.text_dim),
+                    Style::default().fg(theme.semantic.text.dim),
                     format!("\u{2713} {msg}"),
-                    Style::default().fg(theme.status_success),
+                    Style::default().fg(theme.semantic.status.success),
                 )
             } else {
                 (
                     "[NORMAL]",
-                    Style::default().fg(theme.text_dim),
+                    Style::default().fg(theme.semantic.text.dim),
                     "Ready".to_string(),
-                    Style::default().fg(theme.text_dim),
+                    Style::default().fg(theme.semantic.text.dim),
                 )
             }
         }
         SqlModalStatus::Editing => (
             "[INSERT]",
             Style::default()
-                .fg(theme.text_accent)
+                .fg(theme.semantic.text.accent)
                 .add_modifier(Modifier::BOLD),
             "Ready".to_string(),
-            Style::default().fg(theme.text_dim),
+            Style::default().fg(theme.semantic.text.dim),
         ),
         SqlModalStatus::Running => {
             let elapsed = state
@@ -57,19 +57,19 @@ pub(super) fn render_status(frame: &mut Frame, area: Rect, state: &AppState, the
             let status = format!("{spinner} Running {elapsed_secs:.1}s");
             (
                 "[RUNNING]",
-                Style::default().fg(theme.text_accent),
+                Style::default().fg(theme.semantic.text.accent),
                 status,
-                Style::default().fg(theme.text_accent),
+                Style::default().fg(theme.semantic.text.accent),
             )
         }
         SqlModalStatus::Success => {
             let msg = success_status_message(state);
             (
                 "[NORMAL]",
-                Style::default().fg(theme.status_success),
+                Style::default().fg(theme.semantic.status.success),
                 msg,
                 Style::default()
-                    .fg(theme.status_success)
+                    .fg(theme.semantic.status.success)
                     .add_modifier(Modifier::BOLD),
             )
         }
@@ -77,21 +77,21 @@ pub(super) fn render_status(frame: &mut Frame, area: Rect, state: &AppState, the
             let msg = error_status_message(state);
             (
                 "[NORMAL]",
-                Style::default().fg(theme.status_error),
+                Style::default().fg(theme.semantic.status.error),
                 msg,
                 Style::default()
-                    .fg(theme.status_error)
+                    .fg(theme.semantic.status.error)
                     .add_modifier(Modifier::BOLD),
             )
         }
         SqlModalStatus::ConfirmingAnalyzeHigh { .. } => (
             "[CONFIRM]",
             Style::default()
-                .fg(theme.status_error)
+                .fg(theme.semantic.status.error)
                 .add_modifier(Modifier::BOLD),
             "Confirm ANALYZE".to_string(),
             Style::default()
-                .fg(theme.status_error)
+                .fg(theme.semantic.status.error)
                 .add_modifier(Modifier::BOLD),
         ),
         SqlModalStatus::ConfirmingHigh { .. } => unreachable!(),
@@ -133,7 +133,7 @@ fn render_confirming_high_status(
     target_name: Option<&String>,
     theme: &ThemePalette,
 ) {
-    let error_style = Style::default().fg(theme.status_error);
+    let error_style = Style::default().fg(theme.semantic.status.error);
 
     if let Some(name) = target_name {
         let is_match = input.content() == name;
@@ -146,7 +146,7 @@ fn render_confirming_high_status(
             line1_spans.push(Span::raw(" ".repeat(padding as usize)));
             line1_spans.push(Span::styled(
                 blocked_label,
-                Style::default().fg(theme.text_muted),
+                Style::default().fg(theme.semantic.text.muted),
             ));
         }
         let line1 = Line::from(line1_spans);
@@ -166,13 +166,13 @@ fn render_confirming_high_status(
         );
         let mut line2_spans = vec![Span::styled(
             prompt,
-            Style::default().fg(theme.text_secondary),
+            Style::default().fg(theme.semantic.text.secondary),
         )];
         line2_spans.extend(cursor_spans);
         if is_match {
             line2_spans.push(Span::styled(
                 " \u{2713}",
-                Style::default().fg(theme.status_success),
+                Style::default().fg(theme.semantic.status.success),
             ));
         }
         let line2 = Line::from(line2_spans);
@@ -186,7 +186,7 @@ fn render_confirming_high_status(
         ));
         let line2 = Line::from(Span::styled(
             "Cannot identify target object name.  Esc: Back",
-            Style::default().fg(theme.text_muted),
+            Style::default().fg(theme.semantic.text.muted),
         ));
         let paragraph = Paragraph::new(vec![line1, line2]);
         frame.render_widget(paragraph, area);

--- a/src/ui/primitives/atoms/key_chip.rs
+++ b/src/ui/primitives/atoms/key_chip.rs
@@ -7,12 +7,15 @@ pub fn key_chip(key: &str, theme: &ThemePalette) -> Span<'static> {
     Span::styled(
         format!(" {key} "),
         Style::default()
-            .bg(theme.key_chip_bg)
-            .fg(theme.key_chip_fg)
+            .bg(theme.component.navigation.key_chip_bg)
+            .fg(theme.component.navigation.key_chip_fg)
             .add_modifier(Modifier::BOLD),
     )
 }
 
 pub fn key_text(key: &str, theme: &ThemePalette) -> Span<'static> {
-    Span::styled(key.to_string(), Style::default().fg(theme.text_accent))
+    Span::styled(
+        key.to_string(),
+        Style::default().fg(theme.semantic.text.accent),
+    )
 }

--- a/src/ui/primitives/atoms/scroll_indicator.rs
+++ b/src/ui/primitives/atoms/scroll_indicator.rs
@@ -47,7 +47,7 @@ pub fn render_horizontal_scroll_indicator(
     let fixed_parts_len = position_text.len() + 1 + 1;
     let scrollbar_width = available_width.saturating_sub(fixed_parts_len).max(5);
 
-    let text_style = Style::default().fg(theme.scrollbar_active);
+    let text_style = Style::default().fg(theme.component.navigation.scrollbar_active);
 
     let position_span = Span::styled(format!("{position_text} "), text_style);
 
@@ -68,16 +68,16 @@ pub fn render_horizontal_scroll_indicator(
         height: 1,
     };
 
-    let arrow_active = Style::default().fg(theme.scrollbar_active);
-    let arrow_inactive = Style::default().fg(theme.scrollbar_inactive);
+    let arrow_active = Style::default().fg(theme.component.navigation.scrollbar_active);
+    let arrow_inactive = Style::default().fg(theme.component.navigation.scrollbar_inactive);
 
     let scrollbar = Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
         .thumb_symbol("═")
         .track_symbol(Some("─"))
         .begin_symbol(Some("◀︎"))
         .end_symbol(Some("▶︎"))
-        .thumb_style(Style::default().fg(theme.scrollbar_active))
-        .track_style(Style::default().fg(theme.scrollbar_inactive))
+        .thumb_style(Style::default().fg(theme.component.navigation.scrollbar_active))
+        .track_style(Style::default().fg(theme.component.navigation.scrollbar_inactive))
         .begin_style(if can_scroll_left {
             arrow_active
         } else {
@@ -142,16 +142,16 @@ pub fn render_vertical_scroll_indicator_bar(
         height,
     };
 
-    let arrow_active = Style::default().fg(theme.scrollbar_active);
-    let arrow_inactive = Style::default().fg(theme.scrollbar_inactive);
+    let arrow_active = Style::default().fg(theme.component.navigation.scrollbar_active);
+    let arrow_inactive = Style::default().fg(theme.component.navigation.scrollbar_inactive);
 
     let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
         .thumb_symbol("┃")
         .track_symbol(Some("│"))
         .begin_symbol(Some("▲"))
         .end_symbol(Some("▼"))
-        .thumb_style(Style::default().fg(theme.scrollbar_active))
-        .track_style(Style::default().fg(theme.scrollbar_inactive))
+        .thumb_style(Style::default().fg(theme.component.navigation.scrollbar_active))
+        .track_style(Style::default().fg(theme.component.navigation.scrollbar_inactive))
         .begin_style(if can_scroll_up {
             arrow_active
         } else {

--- a/src/ui/primitives/atoms/sql_highlight.rs
+++ b/src/ui/primitives/atoms/sql_highlight.rs
@@ -58,16 +58,16 @@ pub fn highlight_sql_spans(text: &str, theme: &ThemePalette) -> Vec<Vec<Span<'st
 fn token_style(kind: &TokenKind, theme: &ThemePalette) -> Style {
     match kind {
         TokenKind::Keyword(_) => Style::default()
-            .fg(theme.sql_keyword)
+            .fg(theme.component.syntax.sql_keyword)
             .add_modifier(Modifier::BOLD),
-        TokenKind::StringLiteral => Style::default().fg(theme.sql_string),
-        TokenKind::Number => Style::default().fg(theme.sql_number),
-        TokenKind::Comment => Style::default().fg(theme.sql_comment),
-        TokenKind::Operator(_) => Style::default().fg(theme.sql_operator),
+        TokenKind::StringLiteral => Style::default().fg(theme.component.syntax.sql_string),
+        TokenKind::Number => Style::default().fg(theme.component.syntax.sql_number),
+        TokenKind::Comment => Style::default().fg(theme.component.syntax.sql_comment),
+        TokenKind::Operator(_) => Style::default().fg(theme.component.syntax.sql_operator),
         TokenKind::Identifier(_)
         | TokenKind::Punctuation(_)
         | TokenKind::Whitespace
-        | TokenKind::Unknown => Style::default().fg(theme.sql_text),
+        | TokenKind::Unknown => Style::default().fg(theme.component.syntax.sql_text),
     }
 }
 
@@ -109,13 +109,13 @@ mod tests {
             lines[0]
                 .spans
                 .iter()
-                .any(|span| span.style.fg == Some(DEFAULT_THEME.sql_comment))
+                .any(|span| span.style.fg == Some(DEFAULT_THEME.component.syntax.sql_comment))
         );
         assert!(
             lines[1]
                 .spans
                 .iter()
-                .any(|span| span.style.fg == Some(DEFAULT_THEME.sql_comment))
+                .any(|span| span.style.fg == Some(DEFAULT_THEME.component.syntax.sql_comment))
         );
     }
 
@@ -124,22 +124,46 @@ mod tests {
         let lines = highlight_sql("SELECT 'x', 42 -- note", &DEFAULT_THEME);
         let spans = &lines[0].spans;
 
-        assert_eq!(spans[0].style.fg, Some(DEFAULT_THEME.sql_keyword));
+        assert_eq!(
+            spans[0].style.fg,
+            Some(DEFAULT_THEME.component.syntax.sql_keyword)
+        );
         assert!(spans[0].style.add_modifier.contains(Modifier::BOLD));
-        assert_eq!(spans[2].style.fg, Some(DEFAULT_THEME.sql_string));
-        assert_eq!(spans[5].style.fg, Some(DEFAULT_THEME.sql_number));
-        assert_eq!(spans[7].style.fg, Some(DEFAULT_THEME.sql_comment));
+        assert_eq!(
+            spans[2].style.fg,
+            Some(DEFAULT_THEME.component.syntax.sql_string)
+        );
+        assert_eq!(
+            spans[5].style.fg,
+            Some(DEFAULT_THEME.component.syntax.sql_number)
+        );
+        assert_eq!(
+            spans[7].style.fg,
+            Some(DEFAULT_THEME.component.syntax.sql_comment)
+        );
     }
 
     #[test]
     fn highlight_sql_with_cursor_preserves_neighbor_styles() {
         let spans = line_spans_with_cursor("SELECT 'x'", 0, 8, CursorKind::Block);
 
-        assert_eq!(spans[0].style.fg, Some(DEFAULT_THEME.sql_keyword));
-        assert_eq!(spans[2].style.fg, Some(DEFAULT_THEME.sql_string));
-        assert_eq!(spans[3].style.bg, Some(DEFAULT_THEME.cursor_bg));
-        assert_eq!(spans[3].style.fg, Some(DEFAULT_THEME.cursor_text_fg));
-        assert_eq!(spans[4].style.fg, Some(DEFAULT_THEME.sql_string));
+        assert_eq!(
+            spans[0].style.fg,
+            Some(DEFAULT_THEME.component.syntax.sql_keyword)
+        );
+        assert_eq!(
+            spans[2].style.fg,
+            Some(DEFAULT_THEME.component.syntax.sql_string)
+        );
+        assert_eq!(spans[3].style.bg, Some(DEFAULT_THEME.semantic.cursor.bg));
+        assert_eq!(
+            spans[3].style.fg,
+            Some(DEFAULT_THEME.semantic.cursor.text_fg)
+        );
+        assert_eq!(
+            spans[4].style.fg,
+            Some(DEFAULT_THEME.component.syntax.sql_string)
+        );
     }
 
     #[test]
@@ -173,7 +197,7 @@ mod tests {
                 .collect::<String>(),
             " "
         );
-        assert_eq!(spans[0].style.bg, Some(DEFAULT_THEME.cursor_bg));
+        assert_eq!(spans[0].style.bg, Some(DEFAULT_THEME.semantic.cursor.bg));
     }
 
     #[test]
@@ -189,9 +213,12 @@ mod tests {
         );
         assert_eq!(
             spans.last().unwrap().style.bg,
-            Some(DEFAULT_THEME.cursor_bg)
+            Some(DEFAULT_THEME.semantic.cursor.bg)
         );
-        assert_eq!(spans[0].style.fg, Some(DEFAULT_THEME.sql_keyword));
+        assert_eq!(
+            spans[0].style.fg,
+            Some(DEFAULT_THEME.component.syntax.sql_keyword)
+        );
     }
 
     #[test]
@@ -206,7 +233,7 @@ mod tests {
             r#"SET "email" = 0"#
         );
         assert_eq!(spans[2].content.as_ref(), "\"");
-        assert_eq!(spans[2].style.bg, Some(DEFAULT_THEME.cursor_bg));
+        assert_eq!(spans[2].style.bg, Some(DEFAULT_THEME.semantic.cursor.bg));
         assert_eq!(spans[3].content.as_ref(), "email\"");
     }
 
@@ -225,13 +252,19 @@ mod tests {
             .iter()
             .find(|span| span.content.as_ref() == "0")
             .expect("number token should be present");
-        assert_eq!(number_span.style.bg, Some(DEFAULT_THEME.cursor_bg));
+        assert_eq!(number_span.style.bg, Some(DEFAULT_THEME.semantic.cursor.bg));
     }
 
     #[test]
     fn highlight_sql_honors_injected_theme_colors() {
         let custom_theme = ThemePalette {
-            sql_keyword: ratatui::style::Color::Rgb(0x12, 0x34, 0x56),
+            component: crate::ui::theme::ComponentTokens {
+                syntax: crate::ui::theme::SyntaxTokens {
+                    sql_keyword: ratatui::style::Color::Rgb(0x12, 0x34, 0x56),
+                    ..DEFAULT_THEME.component.syntax
+                },
+                ..DEFAULT_THEME.component
+            },
             ..DEFAULT_THEME
         };
 
@@ -239,14 +272,20 @@ mod tests {
 
         assert_eq!(
             highlighted[0].spans[0].style.fg,
-            Some(custom_theme.sql_keyword)
+            Some(custom_theme.component.syntax.sql_keyword)
         );
     }
 
     #[test]
     fn highlight_sql_with_insert_cursor_preserves_injected_token_style() {
         let custom_theme = ThemePalette {
-            cursor_fg: ratatui::style::Color::Rgb(0xfe, 0xdc, 0xba),
+            semantic: crate::ui::theme::SemanticTokens {
+                cursor: crate::ui::theme::CursorTokens {
+                    fg: ratatui::style::Color::Rgb(0xfe, 0xdc, 0xba),
+                    ..DEFAULT_THEME.semantic.cursor
+                },
+                ..DEFAULT_THEME.semantic
+            },
             ..DEFAULT_THEME
         };
 
@@ -261,7 +300,7 @@ mod tests {
 
         assert_eq!(
             highlighted_with_cursor[0].style.fg,
-            Some(custom_theme.sql_keyword)
+            Some(custom_theme.component.syntax.sql_keyword)
         );
     }
 }

--- a/src/ui/primitives/atoms/text_cursor.rs
+++ b/src/ui/primitives/atoms/text_cursor.rs
@@ -244,7 +244,7 @@ pub fn build_modal_text_surface_lines(
                 placeholder_span.clone(),
                 Span::styled(
                     surface.empty_placeholder.to_string(),
-                    Style::default().fg(theme.placeholder_text),
+                    Style::default().fg(theme.semantic.text.placeholder),
                 ),
             ])
             .style(surface.current_line_style),
@@ -550,15 +550,15 @@ mod tests {
             let spans = vec![
                 Span::styled(
                     "ab".to_string(),
-                    Style::default().fg(DEFAULT_THEME.sql_keyword),
+                    Style::default().fg(DEFAULT_THEME.component.syntax.sql_keyword),
                 ),
                 Span::styled(
                     "cd".to_string(),
-                    Style::default().fg(DEFAULT_THEME.sql_string),
+                    Style::default().fg(DEFAULT_THEME.component.syntax.sql_string),
                 ),
                 Span::styled(
                     "ef".to_string(),
-                    Style::default().fg(DEFAULT_THEME.sql_comment),
+                    Style::default().fg(DEFAULT_THEME.component.syntax.sql_comment),
                 ),
             ];
 
@@ -566,13 +566,22 @@ mod tests {
 
             let texts: Vec<String> = inserted.iter().map(|s| s.content.to_string()).collect();
             assert_eq!(texts, vec!["ab", "c", "d", "ef"]);
-            assert_eq!(inserted[0].style.fg, Some(DEFAULT_THEME.sql_keyword));
+            assert_eq!(
+                inserted[0].style.fg,
+                Some(DEFAULT_THEME.component.syntax.sql_keyword)
+            );
             assert_eq!(
                 inserted[1].style,
                 cursor_style_for(CursorKind::Block, &DEFAULT_THEME)
             );
-            assert_eq!(inserted[2].style.fg, Some(DEFAULT_THEME.sql_string));
-            assert_eq!(inserted[3].style.fg, Some(DEFAULT_THEME.sql_comment));
+            assert_eq!(
+                inserted[2].style.fg,
+                Some(DEFAULT_THEME.component.syntax.sql_string)
+            );
+            assert_eq!(
+                inserted[3].style.fg,
+                Some(DEFAULT_THEME.component.syntax.sql_comment)
+            );
         }
 
         #[test]
@@ -580,11 +589,11 @@ mod tests {
             let spans = vec![
                 Span::styled(
                     "ab".to_string(),
-                    Style::default().fg(DEFAULT_THEME.sql_keyword),
+                    Style::default().fg(DEFAULT_THEME.component.syntax.sql_keyword),
                 ),
                 Span::styled(
                     "cd".to_string(),
-                    Style::default().fg(DEFAULT_THEME.sql_string),
+                    Style::default().fg(DEFAULT_THEME.component.syntax.sql_string),
                 ),
             ];
 
@@ -592,12 +601,18 @@ mod tests {
 
             let texts: Vec<String> = inserted.iter().map(|s| s.content.to_string()).collect();
             assert_eq!(texts, vec!["ab", "c", "d"]);
-            assert_eq!(inserted[0].style.fg, Some(DEFAULT_THEME.sql_keyword));
+            assert_eq!(
+                inserted[0].style.fg,
+                Some(DEFAULT_THEME.component.syntax.sql_keyword)
+            );
             assert_eq!(
                 inserted[1].style,
                 cursor_style_for(CursorKind::Block, &DEFAULT_THEME)
             );
-            assert_eq!(inserted[2].style.fg, Some(DEFAULT_THEME.sql_string));
+            assert_eq!(
+                inserted[2].style.fg,
+                Some(DEFAULT_THEME.component.syntax.sql_string)
+            );
         }
 
         #[test]
@@ -605,15 +620,18 @@ mod tests {
             let spans = vec![Span::styled(
                 "ab".to_string(),
                 Style::default()
-                    .fg(DEFAULT_THEME.sql_keyword)
+                    .fg(DEFAULT_THEME.component.syntax.sql_keyword)
                     .add_modifier(Modifier::BOLD),
             )];
 
             let inserted = insert_cursor_span(spans, 0, &DEFAULT_THEME);
 
             assert_eq!(inserted[0].content.as_ref(), "a");
-            assert_eq!(inserted[0].style.bg, Some(DEFAULT_THEME.cursor_bg));
-            assert_eq!(inserted[0].style.fg, Some(DEFAULT_THEME.cursor_text_fg));
+            assert_eq!(inserted[0].style.bg, Some(DEFAULT_THEME.semantic.cursor.bg));
+            assert_eq!(
+                inserted[0].style.fg,
+                Some(DEFAULT_THEME.semantic.cursor.text_fg)
+            );
             assert!(inserted[0].style.add_modifier.contains(Modifier::BOLD));
         }
 
@@ -622,11 +640,11 @@ mod tests {
             let spans = vec![
                 Span::styled(
                     "ab".to_string(),
-                    Style::default().fg(DEFAULT_THEME.sql_keyword),
+                    Style::default().fg(DEFAULT_THEME.component.syntax.sql_keyword),
                 ),
                 Span::styled(
                     "cd".to_string(),
-                    Style::default().fg(DEFAULT_THEME.sql_string),
+                    Style::default().fg(DEFAULT_THEME.component.syntax.sql_string),
                 ),
             ];
 
@@ -644,7 +662,7 @@ mod tests {
         fn with_insert_kind_preserves_text_without_glyph() {
             let spans = vec![Span::styled(
                 "abcd".to_string(),
-                Style::default().fg(DEFAULT_THEME.sql_keyword),
+                Style::default().fg(DEFAULT_THEME.component.syntax.sql_keyword),
             )];
 
             let inserted =
@@ -652,8 +670,14 @@ mod tests {
 
             let texts: Vec<String> = inserted.iter().map(|s| s.content.to_string()).collect();
             assert_eq!(texts, vec!["ab", "cd"]);
-            assert_eq!(inserted[0].style.fg, Some(DEFAULT_THEME.sql_keyword));
-            assert_eq!(inserted[1].style.fg, Some(DEFAULT_THEME.sql_keyword));
+            assert_eq!(
+                inserted[0].style.fg,
+                Some(DEFAULT_THEME.component.syntax.sql_keyword)
+            );
+            assert_eq!(
+                inserted[1].style.fg,
+                Some(DEFAULT_THEME.component.syntax.sql_keyword)
+            );
         }
     }
 }

--- a/src/ui/primitives/atoms/yank_flash.rs
+++ b/src/ui/primitives/atoms/yank_flash.rs
@@ -8,8 +8,8 @@ pub fn apply_yank_flash(lines: &mut [Line], active: bool, theme: &ThemePalette) 
         return;
     }
     let flash_style = Style::default()
-        .fg(theme.yank_flash_fg)
-        .bg(theme.yank_flash_bg);
+        .fg(theme.component.feedback.yank_flash_fg)
+        .bg(theme.component.feedback.yank_flash_bg);
     for line in lines {
         *line = std::mem::take(line).style(flash_style);
     }
@@ -30,8 +30,8 @@ pub fn apply_yank_flash_masked(
         return;
     }
     let flash_style = Style::default()
-        .fg(theme.yank_flash_fg)
-        .bg(theme.yank_flash_bg);
+        .fg(theme.component.feedback.yank_flash_fg)
+        .bg(theme.component.feedback.yank_flash_bg);
     for (line, &should_flash) in lines.iter_mut().zip(mask.iter()) {
         if should_flash {
             *line = std::mem::take(line).style(flash_style);

--- a/src/ui/primitives/molecules/data_table.rs
+++ b/src/ui/primitives/molecules/data_table.rs
@@ -33,7 +33,7 @@ pub fn render_striped_table<'a>(
             Style::default()
                 .add_modifier(Modifier::BOLD)
                 .add_modifier(Modifier::UNDERLINED)
-                .fg(theme.text_primary),
+                .fg(theme.semantic.text.primary),
         )
         .height(1);
 
@@ -47,7 +47,7 @@ pub fn render_striped_table<'a>(
         .enumerate()
         .map(|(visual_idx, item_idx)| {
             let style = if visual_idx % 2 == 1 {
-                Style::default().bg(theme.striped_row_bg)
+                Style::default().bg(theme.component.table.striped_row_bg)
             } else {
                 Style::default()
             };
@@ -57,7 +57,7 @@ pub fn render_striped_table<'a>(
 
     let table_widget = Table::new(rows, config.widths)
         .header(header)
-        .style(Style::default().fg(theme.text_primary));
+        .style(Style::default().fg(theme.semantic.text.primary));
     frame.render_widget(table_widget, area);
 
     render_vertical_scroll_indicator_bar(

--- a/src/ui/primitives/molecules/hint_bar.rs
+++ b/src/ui/primitives/molecules/hint_bar.rs
@@ -26,6 +26,9 @@ pub fn chip_hint_line(key: &str, desc: &str, theme: &ThemePalette) -> Line<'stat
         Span::raw("  "),
         chip,
         Span::raw(" ".repeat(padding_len)),
-        Span::styled(desc.to_string(), Style::default().fg(theme.text_secondary)),
+        Span::styled(
+            desc.to_string(),
+            Style::default().fg(theme.semantic.text.secondary),
+        ),
     ])
 }

--- a/src/ui/primitives/molecules/overlay.rs
+++ b/src/ui/primitives/molecules/overlay.rs
@@ -21,13 +21,13 @@ pub fn render_scrim(frame: &mut Frame, theme: &ThemePalette) {
     buf.set_style(
         area,
         Style::default()
-            .fg(theme.text_muted)
+            .fg(theme.semantic.text.muted)
             .add_modifier(Modifier::DIM),
     );
 }
 
 pub fn modal_block_with_hint(title: String, hint: String, theme: &ThemePalette) -> Block<'static> {
-    modal_block_with_hint_color(title, hint, theme.modal_border, theme)
+    modal_block_with_hint_color(title, hint, theme.semantic.surface.modal_border, theme)
 }
 
 pub fn modal_block_with_hint_color(

--- a/src/ui/primitives/molecules/overlay.rs
+++ b/src/ui/primitives/molecules/overlay.rs
@@ -27,7 +27,7 @@ pub fn render_scrim(frame: &mut Frame, theme: &ThemePalette) {
 }
 
 pub fn modal_block_with_hint(title: String, hint: String, theme: &ThemePalette) -> Block<'static> {
-    modal_block_with_hint_color(title, hint, theme.semantic.surface.modal_border, theme)
+    modal_block_with_hint_color(title, hint, theme.component.modal.border, theme)
 }
 
 pub fn modal_block_with_hint_color(

--- a/src/ui/shell/command_line.rs
+++ b/src/ui/shell/command_line.rs
@@ -29,7 +29,10 @@ impl CommandLine {
                 visible_width,
                 theme,
             );
-            let mut spans = vec![Span::styled(":", Style::default().fg(theme.text_accent))];
+            let mut spans = vec![Span::styled(
+                ":",
+                Style::default().fg(theme.semantic.text.accent),
+            )];
             spans.extend(cursor_spans);
             Line::from(spans)
         } else {

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -31,7 +31,7 @@ impl Footer {
         time_ms: Option<u128>,
         theme: &ThemePalette,
     ) {
-        let base_style = Style::default().fg(theme.text_primary);
+        let base_style = Style::default().fg(theme.semantic.text.primary);
         if state.er_preparation.status == ErStatus::Waiting {
             let line = Self::build_er_waiting_line(state, time_ms, theme);
             frame.render_widget(Paragraph::new(line).style(base_style), area);
@@ -70,7 +70,10 @@ impl Footer {
         let cached = total.saturating_sub(remaining + failed_count);
 
         let text = format!("{spinner} Preparing ER... ({cached}/{total})");
-        Line::from(Span::styled(text, Style::default().fg(theme.text_accent)))
+        Line::from(Span::styled(
+            text,
+            Style::default().fg(theme.semantic.text.accent),
+        ))
     }
 
     // Hint ordering: Actions → Navigation → Help → Close/Cancel → Quit
@@ -322,7 +325,7 @@ impl Footer {
         if let Some(msg) = success_msg {
             spans.push(Span::styled(
                 format!("✓ {msg}  "),
-                Style::default().fg(theme.status_success),
+                Style::default().fg(theme.semantic.status.success),
             ));
         }
 

--- a/src/ui/shell/header.rs
+++ b/src/ui/shell/header.rs
@@ -15,17 +15,17 @@ impl Header {
         let db_name = state.session.database_name().unwrap_or("-");
         let table = state.session.selected_table_key().unwrap_or("-");
 
-        let sep_style = Style::default().fg(theme.text_muted);
-        let item_style = Style::default().fg(theme.text_secondary);
+        let sep_style = Style::default().fg(theme.semantic.text.muted);
+        let item_style = Style::default().fg(theme.semantic.text.secondary);
 
         let (status_text, status_color) = if state.session.dsn.is_none() {
-            ("no dsn", theme.status_error)
+            ("no dsn", theme.semantic.status.error)
         } else {
             match &state.session.metadata_state() {
-                MetadataState::Loaded => ("connected", theme.status_success),
-                MetadataState::Loading => ("loading...", theme.status_warning),
-                MetadataState::Error(_) => ("error", theme.status_error),
-                MetadataState::NotLoaded => ("not loaded", theme.text_muted),
+                MetadataState::Loaded => ("connected", theme.semantic.status.success),
+                MetadataState::Loading => ("loading...", theme.semantic.status.warning),
+                MetadataState::Error(_) => ("error", theme.semantic.status.error),
+                MetadataState::NotLoaded => ("not loaded", theme.semantic.text.muted),
             }
         };
 
@@ -40,7 +40,7 @@ impl Header {
             Span::styled(" | ", sep_style),
             Span::styled(db_name, item_style),
             Span::styled(" | ", sep_style),
-            Span::styled(table, Style::default().fg(theme.text_primary)),
+            Span::styled(table, Style::default().fg(theme.semantic.text.primary)),
             Span::styled(" | ", sep_style),
             Span::styled(status_text, Style::default().fg(status_color)),
             Span::styled(" | ", sep_style),
@@ -50,7 +50,7 @@ impl Header {
             line.push_span(Span::styled(" | ", sep_style));
             line.push_span(Span::styled(
                 "READ-ONLY",
-                Style::default().fg(theme.status_warning),
+                Style::default().fg(theme.semantic.status.warning),
             ));
         }
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -12,217 +12,327 @@ pub enum StatusTone {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ThemePalette {
+    pub semantic: SemanticTokens,
+    pub component: ComponentTokens,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SemanticTokens {
+    pub surface: SurfaceTokens,
+    pub text: TextTokens,
+    pub status: StatusTokens,
+    pub cursor: CursorTokens,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SurfaceTokens {
     pub modal_border: Color,
     pub modal_border_highlight: Color,
-    pub modal_title: Color,
-    pub modal_hint: Color,
-    pub key_chip_bg: Color,
-    pub key_chip_fg: Color,
-    pub editor_current_line_bg: Color,
-    pub completion_selected_bg: Color,
-    pub note_text: Color,
     pub focus_border: Color,
     pub unfocus_border: Color,
     pub highlight_border: Color,
-    pub text_primary: Color,
-    pub text_secondary: Color,
-    pub text_muted: Color,
-    pub text_dim: Color,
-    pub text_accent: Color,
-    pub status_success: Color,
-    pub status_error: Color,
-    pub status_warning: Color,
-    pub status_medium_risk: Color,
-    pub cursor_fg: Color,
-    pub cursor_bg: Color,
-    pub cursor_text_fg: Color,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextTokens {
+    pub primary: Color,
+    pub secondary: Color,
+    pub muted: Color,
+    pub dim: Color,
+    pub accent: Color,
+    pub placeholder: Color,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatusTokens {
+    pub success: Color,
+    pub error: Color,
+    pub warning: Color,
+    pub medium_risk: Color,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CursorTokens {
+    pub fg: Color,
+    pub bg: Color,
+    pub text_fg: Color,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComponentTokens {
+    pub modal: ModalTokens,
+    pub navigation: NavigationTokens,
+    pub editor: EditorTokens,
+    pub table: TableTokens,
+    pub feedback: FeedbackTokens,
+    pub syntax: SyntaxTokens,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModalTokens {
+    pub title: Color,
+    pub hint: Color,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NavigationTokens {
+    pub key_chip_bg: Color,
+    pub key_chip_fg: Color,
     pub section_header: Color,
     pub scrollbar_active: Color,
     pub scrollbar_inactive: Color,
+    pub tab_active: Color,
+    pub tab_inactive: Color,
+    pub active_indicator: Color,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EditorTokens {
+    pub current_line_bg: Color,
+    pub completion_selected_bg: Color,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TableTokens {
     pub result_row_active_bg: Color,
     pub result_cell_active_bg: Color,
     pub cell_edit_fg: Color,
     pub cell_draft_pending_fg: Color,
     pub staged_delete_bg: Color,
     pub staged_delete_fg: Color,
+    pub striped_row_bg: Color,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FeedbackTokens {
     pub yank_flash_bg: Color,
     pub yank_flash_fg: Color,
+    pub note_text: Color,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SyntaxTokens {
     pub sql_keyword: Color,
     pub sql_string: Color,
     pub sql_number: Color,
     pub sql_comment: Color,
     pub sql_operator: Color,
     pub sql_text: Color,
-    pub striped_row_bg: Color,
-    pub tab_active: Color,
-    pub tab_inactive: Color,
-    pub active_indicator: Color,
-    pub placeholder_text: Color,
 }
 
 impl ThemePalette {
     pub fn risk_color(&self, level: RiskLevel) -> Color {
         match level {
-            RiskLevel::Low => self.status_warning,
-            RiskLevel::Medium => self.status_medium_risk,
-            RiskLevel::High => self.status_error,
+            RiskLevel::Low => self.semantic.status.warning,
+            RiskLevel::Medium => self.semantic.status.medium_risk,
+            RiskLevel::High => self.semantic.status.error,
         }
     }
 
     pub fn modal_title_style(&self) -> Style {
         Style::default()
-            .fg(self.modal_title)
+            .fg(self.component.modal.title)
             .add_modifier(Modifier::BOLD)
     }
 
     pub fn modal_hint_style(&self) -> Style {
-        Style::default().fg(self.modal_hint)
+        Style::default().fg(self.component.modal.hint)
     }
 
     pub fn panel_border_style(&self, focused: bool, highlight: bool) -> Style {
         let color = if focused {
-            self.focus_border
+            self.semantic.surface.focus_border
         } else if highlight {
-            self.highlight_border
+            self.semantic.surface.highlight_border
         } else {
-            self.unfocus_border
+            self.semantic.surface.unfocus_border
         };
         Style::default().fg(color)
     }
 
     pub fn picker_selected_style(&self) -> Style {
         Style::default()
-            .bg(self.completion_selected_bg)
-            .fg(self.text_primary)
+            .bg(self.component.editor.completion_selected_bg)
+            .fg(self.semantic.text.primary)
             .add_modifier(Modifier::BOLD)
     }
 
     pub fn input_border_style(&self, focused: bool, has_error: bool) -> Style {
         let color = if has_error {
-            self.status_error
+            self.semantic.status.error
         } else if focused {
-            self.modal_border_highlight
+            self.semantic.surface.modal_border_highlight
         } else {
-            self.modal_border
+            self.semantic.surface.modal_border
         };
         Style::default().fg(color)
     }
 
     pub fn status_style(&self, tone: StatusTone) -> Style {
         let color = match tone {
-            StatusTone::Success => self.status_success,
-            StatusTone::Error => self.status_error,
-            StatusTone::Warning => self.status_warning,
+            StatusTone::Success => self.semantic.status.success,
+            StatusTone::Error => self.semantic.status.error,
+            StatusTone::Warning => self.semantic.status.warning,
         };
         Style::default().fg(color)
     }
 
     pub fn block_cursor_style(&self) -> Style {
-        Style::default().bg(self.cursor_bg).fg(self.cursor_text_fg)
+        Style::default()
+            .bg(self.semantic.cursor.bg)
+            .fg(self.semantic.cursor.text_fg)
     }
 
     pub fn insert_cursor_style(&self) -> Style {
-        Style::default().fg(self.cursor_fg)
+        Style::default().fg(self.semantic.cursor.fg)
     }
 }
 
 pub const DEFAULT_THEME: ThemePalette = ThemePalette {
-    modal_border: Color::Rgb(0x70, 0x68, 0x60),
-    modal_border_highlight: Color::Rgb(0xc0, 0xb8, 0xb8),
-    modal_title: Color::Rgb(0xe9, 0xdb, 0xdb),
-    modal_hint: Color::Rgb(0xc0, 0xb8, 0xb0),
-    key_chip_bg: Color::Rgb(0x3a, 0x3a, 0x4a),
-    key_chip_fg: Color::Rgb(0xd4, 0xa4, 0x85),
-    editor_current_line_bg: Color::Rgb(0x22, 0x26, 0x33),
-    completion_selected_bg: Color::Rgb(0x45, 0x47, 0x5a),
-    note_text: Color::Rgb(0x66, 0x66, 0x77),
-    focus_border: Color::Rgb(0x97, 0xc9, 0xc3),
-    unfocus_border: Color::Rgb(0x45, 0x47, 0x55),
-    highlight_border: Color::Rgb(0xb0, 0xdd, 0xd8),
-    text_primary: Color::Rgb(0xe9, 0xdb, 0xdb),
-    text_secondary: Color::Rgb(0xc0, 0xb8, 0xb8),
-    text_muted: Color::Rgb(0x5c, 0x63, 0x70),
-    text_dim: Color::Rgb(0x6a, 0x6e, 0x7a),
-    text_accent: Color::Rgb(0xd4, 0xa4, 0x85),
-    status_success: Color::Rgb(0x97, 0xc9, 0xc3),
-    status_error: Color::Rgb(0xc4, 0x74, 0x6e),
-    status_warning: Color::Rgb(0xe0, 0xaf, 0x68),
-    status_medium_risk: Color::Rgb(0xd4, 0x70, 0x50),
-    cursor_fg: Color::White,
-    cursor_bg: Color::White,
-    cursor_text_fg: Color::Black,
-    section_header: Color::Rgb(0x6a, 0xb8, 0x9a),
-    scrollbar_active: Color::Rgb(0xc0, 0xb8, 0xb0),
-    scrollbar_inactive: Color::Rgb(0x50, 0x52, 0x5e),
-    result_row_active_bg: Color::Rgb(0x2e, 0x2e, 0x44),
-    result_cell_active_bg: Color::Rgb(0x3a, 0x3a, 0x5a),
-    cell_edit_fg: Color::Rgb(0xa8, 0xb8, 0xb5),
-    cell_draft_pending_fg: Color::Rgb(0xd4, 0xa0, 0x60),
-    staged_delete_bg: Color::Rgb(0x3d, 0x22, 0x22),
-    staged_delete_fg: Color::Rgb(0xee, 0x77, 0x77),
-    yank_flash_bg: Color::Rgb(0xF4, 0x9E, 0x4C),
-    yank_flash_fg: Color::Rgb(0x11, 0x14, 0x19),
-    sql_keyword: Color::Rgb(0x80, 0x90, 0xa8),
-    sql_string: Color::Rgb(0xcd, 0xc8, 0xdb),
-    sql_number: Color::Rgb(0xd4, 0xa4, 0x85),
-    sql_comment: Color::Rgb(0x62, 0x72, 0xa4),
-    sql_operator: Color::Rgb(0x8a, 0x91, 0xa5),
-    sql_text: Color::Rgb(0xe9, 0xdb, 0xdb),
-    striped_row_bg: Color::Rgb(0x1e, 0x1e, 0x23),
-    tab_active: Color::Rgb(0xd0, 0xc0, 0xa0),
-    tab_inactive: Color::Rgb(0x5b, 0x5f, 0x6e),
-    active_indicator: Color::Rgb(0xff, 0xff, 0xff),
-    placeholder_text: Color::Rgb(0x5b, 0x5f, 0x6e),
+    semantic: SemanticTokens {
+        surface: SurfaceTokens {
+            modal_border: Color::Rgb(0x70, 0x68, 0x60),
+            modal_border_highlight: Color::Rgb(0xc0, 0xb8, 0xb8),
+            focus_border: Color::Rgb(0x97, 0xc9, 0xc3),
+            unfocus_border: Color::Rgb(0x45, 0x47, 0x55),
+            highlight_border: Color::Rgb(0xb0, 0xdd, 0xd8),
+        },
+        text: TextTokens {
+            primary: Color::Rgb(0xe9, 0xdb, 0xdb),
+            secondary: Color::Rgb(0xc0, 0xb8, 0xb8),
+            muted: Color::Rgb(0x5c, 0x63, 0x70),
+            dim: Color::Rgb(0x6a, 0x6e, 0x7a),
+            accent: Color::Rgb(0xd4, 0xa4, 0x85),
+            placeholder: Color::Rgb(0x5b, 0x5f, 0x6e),
+        },
+        status: StatusTokens {
+            success: Color::Rgb(0x97, 0xc9, 0xc3),
+            error: Color::Rgb(0xc4, 0x74, 0x6e),
+            warning: Color::Rgb(0xe0, 0xaf, 0x68),
+            medium_risk: Color::Rgb(0xd4, 0x70, 0x50),
+        },
+        cursor: CursorTokens {
+            fg: Color::White,
+            bg: Color::White,
+            text_fg: Color::Black,
+        },
+    },
+    component: ComponentTokens {
+        modal: ModalTokens {
+            title: Color::Rgb(0xe9, 0xdb, 0xdb),
+            hint: Color::Rgb(0xc0, 0xb8, 0xb0),
+        },
+        navigation: NavigationTokens {
+            key_chip_bg: Color::Rgb(0x3a, 0x3a, 0x4a),
+            key_chip_fg: Color::Rgb(0xd4, 0xa4, 0x85),
+            section_header: Color::Rgb(0x6a, 0xb8, 0x9a),
+            scrollbar_active: Color::Rgb(0xc0, 0xb8, 0xb0),
+            scrollbar_inactive: Color::Rgb(0x50, 0x52, 0x5e),
+            tab_active: Color::Rgb(0xd0, 0xc0, 0xa0),
+            tab_inactive: Color::Rgb(0x5b, 0x5f, 0x6e),
+            active_indicator: Color::Rgb(0xff, 0xff, 0xff),
+        },
+        editor: EditorTokens {
+            current_line_bg: Color::Rgb(0x22, 0x26, 0x33),
+            completion_selected_bg: Color::Rgb(0x45, 0x47, 0x5a),
+        },
+        table: TableTokens {
+            result_row_active_bg: Color::Rgb(0x2e, 0x2e, 0x44),
+            result_cell_active_bg: Color::Rgb(0x3a, 0x3a, 0x5a),
+            cell_edit_fg: Color::Rgb(0xa8, 0xb8, 0xb5),
+            cell_draft_pending_fg: Color::Rgb(0xd4, 0xa0, 0x60),
+            staged_delete_bg: Color::Rgb(0x3d, 0x22, 0x22),
+            staged_delete_fg: Color::Rgb(0xee, 0x77, 0x77),
+            striped_row_bg: Color::Rgb(0x1e, 0x1e, 0x23),
+        },
+        feedback: FeedbackTokens {
+            yank_flash_bg: Color::Rgb(0xF4, 0x9E, 0x4C),
+            yank_flash_fg: Color::Rgb(0x11, 0x14, 0x19),
+            note_text: Color::Rgb(0x66, 0x66, 0x77),
+        },
+        syntax: SyntaxTokens {
+            sql_keyword: Color::Rgb(0x80, 0x90, 0xa8),
+            sql_string: Color::Rgb(0xcd, 0xc8, 0xdb),
+            sql_number: Color::Rgb(0xd4, 0xa4, 0x85),
+            sql_comment: Color::Rgb(0x62, 0x72, 0xa4),
+            sql_operator: Color::Rgb(0x8a, 0x91, 0xa5),
+            sql_text: Color::Rgb(0xe9, 0xdb, 0xdb),
+        },
+    },
 };
 
 #[cfg(any(test, feature = "test-support"))]
 pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
-    modal_border: Color::Rgb(0xd8, 0x2a, 0x1f),
-    modal_border_highlight: Color::Rgb(0xff, 0xe0, 0x66),
-    modal_title: Color::Rgb(0xf6, 0xf0, 0xe8),
-    modal_hint: Color::Rgb(0x7b, 0xe0, 0x73),
-    key_chip_bg: Color::Rgb(0x1a, 0x45, 0x5e),
-    key_chip_fg: Color::Rgb(0xff, 0xe0, 0x66),
-    editor_current_line_bg: Color::Rgb(0x1d, 0x2d, 0x3f),
-    completion_selected_bg: Color::Rgb(0x2d, 0x5d, 0x46),
-    note_text: Color::Rgb(0x92, 0xb3, 0xc2),
-    focus_border: Color::Rgb(0x2f, 0xc4, 0xb2),
-    unfocus_border: Color::Rgb(0x5d, 0x62, 0x74),
-    highlight_border: Color::Rgb(0xff, 0xc8, 0x57),
-    text_primary: Color::Rgb(0xf6, 0xf0, 0xe8),
-    text_secondary: Color::Rgb(0xc9, 0xd6, 0xdf),
-    text_muted: Color::Rgb(0x92, 0xb3, 0xc2),
-    text_dim: Color::Rgb(0x6a, 0x85, 0x95),
-    text_accent: Color::Rgb(0xff, 0xc8, 0x57),
-    status_success: Color::Rgb(0x7b, 0xe0, 0x73),
-    status_error: Color::Rgb(0xff, 0x7a, 0x59),
-    status_warning: Color::Rgb(0xff, 0xc8, 0x57),
-    status_medium_risk: Color::Rgb(0xff, 0x9f, 0x1c),
-    cursor_fg: Color::Rgb(0xff, 0xf4, 0xe0),
-    cursor_bg: Color::Rgb(0xff, 0xf4, 0xe0),
-    cursor_text_fg: Color::Rgb(0x0d, 0x11, 0x18),
-    section_header: Color::Rgb(0x2f, 0xc4, 0xb2),
-    scrollbar_active: Color::Rgb(0x2f, 0xc4, 0xb2),
-    scrollbar_inactive: Color::Rgb(0x5d, 0x62, 0x74),
-    result_row_active_bg: Color::Rgb(0x2b, 0x32, 0x54),
-    result_cell_active_bg: Color::Rgb(0x3a, 0x44, 0x6e),
-    cell_edit_fg: Color::Rgb(0xff, 0xe0, 0x66),
-    cell_draft_pending_fg: Color::Rgb(0xff, 0x9f, 0x1c),
-    staged_delete_bg: Color::Rgb(0x4a, 0x1f, 0x1f),
-    staged_delete_fg: Color::Rgb(0xff, 0x7a, 0x59),
-    yank_flash_bg: Color::Rgb(0xff, 0xc8, 0x57),
-    yank_flash_fg: Color::Rgb(0x14, 0x17, 0x21),
-    sql_keyword: Color::Rgb(0x7d, 0xc4, 0xff),
-    sql_string: Color::Rgb(0x9b, 0xf0, 0x8f),
-    sql_number: Color::Rgb(0xff, 0xb8, 0x6b),
-    sql_comment: Color::Rgb(0x7c, 0x8a, 0xa5),
-    sql_operator: Color::Rgb(0x5e, 0xe0, 0xd5),
-    sql_text: Color::Rgb(0xf6, 0xf0, 0xe8),
-    striped_row_bg: Color::Rgb(0x1d, 0x21, 0x2b),
-    tab_active: Color::Rgb(0x2f, 0xc4, 0xb2),
-    tab_inactive: Color::Rgb(0x92, 0xb3, 0xc2),
-    active_indicator: Color::Rgb(0x2f, 0xc4, 0xb2),
-    placeholder_text: Color::Rgb(0x92, 0xb3, 0xc2),
+    semantic: SemanticTokens {
+        surface: SurfaceTokens {
+            modal_border: Color::Rgb(0xd8, 0x2a, 0x1f),
+            modal_border_highlight: Color::Rgb(0xff, 0xe0, 0x66),
+            focus_border: Color::Rgb(0x2f, 0xc4, 0xb2),
+            unfocus_border: Color::Rgb(0x5d, 0x62, 0x74),
+            highlight_border: Color::Rgb(0xff, 0xc8, 0x57),
+        },
+        text: TextTokens {
+            primary: Color::Rgb(0xf6, 0xf0, 0xe8),
+            secondary: Color::Rgb(0xc9, 0xd6, 0xdf),
+            muted: Color::Rgb(0x92, 0xb3, 0xc2),
+            dim: Color::Rgb(0x6a, 0x85, 0x95),
+            accent: Color::Rgb(0xff, 0xc8, 0x57),
+            placeholder: Color::Rgb(0x92, 0xb3, 0xc2),
+        },
+        status: StatusTokens {
+            success: Color::Rgb(0x7b, 0xe0, 0x73),
+            error: Color::Rgb(0xff, 0x7a, 0x59),
+            warning: Color::Rgb(0xff, 0xc8, 0x57),
+            medium_risk: Color::Rgb(0xff, 0x9f, 0x1c),
+        },
+        cursor: CursorTokens {
+            fg: Color::Rgb(0xff, 0xf4, 0xe0),
+            bg: Color::Rgb(0xff, 0xf4, 0xe0),
+            text_fg: Color::Rgb(0x0d, 0x11, 0x18),
+        },
+    },
+    component: ComponentTokens {
+        modal: ModalTokens {
+            title: Color::Rgb(0xf6, 0xf0, 0xe8),
+            hint: Color::Rgb(0x7b, 0xe0, 0x73),
+        },
+        navigation: NavigationTokens {
+            key_chip_bg: Color::Rgb(0x1a, 0x45, 0x5e),
+            key_chip_fg: Color::Rgb(0xff, 0xe0, 0x66),
+            section_header: Color::Rgb(0x2f, 0xc4, 0xb2),
+            scrollbar_active: Color::Rgb(0x2f, 0xc4, 0xb2),
+            scrollbar_inactive: Color::Rgb(0x5d, 0x62, 0x74),
+            tab_active: Color::Rgb(0x2f, 0xc4, 0xb2),
+            tab_inactive: Color::Rgb(0x92, 0xb3, 0xc2),
+            active_indicator: Color::Rgb(0x2f, 0xc4, 0xb2),
+        },
+        editor: EditorTokens {
+            current_line_bg: Color::Rgb(0x1d, 0x2d, 0x3f),
+            completion_selected_bg: Color::Rgb(0x2d, 0x5d, 0x46),
+        },
+        table: TableTokens {
+            result_row_active_bg: Color::Rgb(0x2b, 0x32, 0x54),
+            result_cell_active_bg: Color::Rgb(0x3a, 0x44, 0x6e),
+            cell_edit_fg: Color::Rgb(0xff, 0xe0, 0x66),
+            cell_draft_pending_fg: Color::Rgb(0xff, 0x9f, 0x1c),
+            staged_delete_bg: Color::Rgb(0x4a, 0x1f, 0x1f),
+            staged_delete_fg: Color::Rgb(0xff, 0x7a, 0x59),
+            striped_row_bg: Color::Rgb(0x1d, 0x21, 0x2b),
+        },
+        feedback: FeedbackTokens {
+            yank_flash_bg: Color::Rgb(0xff, 0xc8, 0x57),
+            yank_flash_fg: Color::Rgb(0x14, 0x17, 0x21),
+            note_text: Color::Rgb(0x92, 0xb3, 0xc2),
+        },
+        syntax: SyntaxTokens {
+            sql_keyword: Color::Rgb(0x7d, 0xc4, 0xff),
+            sql_string: Color::Rgb(0x9b, 0xf0, 0x8f),
+            sql_number: Color::Rgb(0xff, 0xb8, 0x6b),
+            sql_comment: Color::Rgb(0x7c, 0x8a, 0xa5),
+            sql_operator: Color::Rgb(0x5e, 0xe0, 0xd5),
+            sql_text: Color::Rgb(0xf6, 0xf0, 0xe8),
+        },
+    },
 };
 
 pub fn palette_for(theme_id: ThemeId) -> &'static ThemePalette {
@@ -251,15 +361,18 @@ mod tests {
     fn panel_border_style_prefers_focus_over_highlight() {
         let style = DEFAULT_THEME.panel_border_style(true, true);
 
-        assert_eq!(style.fg, Some(DEFAULT_THEME.focus_border));
+        assert_eq!(style.fg, Some(DEFAULT_THEME.semantic.surface.focus_border));
     }
 
     #[test]
     fn picker_selected_style_uses_selected_colors() {
         let style = DEFAULT_THEME.picker_selected_style();
 
-        assert_eq!(style.bg, Some(DEFAULT_THEME.completion_selected_bg));
-        assert_eq!(style.fg, Some(DEFAULT_THEME.text_primary));
+        assert_eq!(
+            style.bg,
+            Some(DEFAULT_THEME.component.editor.completion_selected_bg)
+        );
+        assert_eq!(style.fg, Some(DEFAULT_THEME.semantic.text.primary));
         assert!(style.add_modifier.contains(Modifier::BOLD));
     }
 
@@ -267,21 +380,21 @@ mod tests {
     fn input_border_style_prefers_error_over_focus() {
         let style = DEFAULT_THEME.input_border_style(true, true);
 
-        assert_eq!(style.fg, Some(DEFAULT_THEME.status_error));
+        assert_eq!(style.fg, Some(DEFAULT_THEME.semantic.status.error));
     }
 
     #[test]
     fn status_style_uses_requested_tone() {
         let style = DEFAULT_THEME.status_style(StatusTone::Warning);
 
-        assert_eq!(style.fg, Some(DEFAULT_THEME.status_warning));
+        assert_eq!(style.fg, Some(DEFAULT_THEME.semantic.status.warning));
     }
 
     #[test]
     fn modal_hint_style_uses_hint_token_without_bold() {
         let style = DEFAULT_THEME.modal_hint_style();
 
-        assert_eq!(style.fg, Some(DEFAULT_THEME.modal_hint));
+        assert_eq!(style.fg, Some(DEFAULT_THEME.component.modal.hint));
         assert!(!style.add_modifier.contains(Modifier::BOLD));
     }
 
@@ -289,7 +402,7 @@ mod tests {
     fn block_cursor_style_inverts_cursor_and_selection_colors() {
         let style = DEFAULT_THEME.block_cursor_style();
 
-        assert_eq!(style.bg, Some(DEFAULT_THEME.cursor_bg));
-        assert_eq!(style.fg, Some(DEFAULT_THEME.cursor_text_fg));
+        assert_eq!(style.bg, Some(DEFAULT_THEME.semantic.cursor.bg));
+        assert_eq!(style.fg, Some(DEFAULT_THEME.semantic.cursor.text_fg));
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -168,6 +168,10 @@ impl ThemePalette {
         Style::default().fg(color)
     }
 
+    pub fn modal_border_style(&self) -> Style {
+        Style::default().fg(self.component.modal.border)
+    }
+
     pub fn status_style(&self, tone: StatusTone) -> Style {
         let color = match tone {
             StatusTone::Success => self.semantic.status.success,
@@ -396,6 +400,13 @@ mod tests {
 
         assert_eq!(style.fg, Some(DEFAULT_THEME.component.modal.hint));
         assert!(!style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn modal_border_style_uses_component_modal_border() {
+        let style = DEFAULT_THEME.modal_border_style();
+
+        assert_eq!(style.fg, Some(DEFAULT_THEME.component.modal.border));
     }
 
     #[test]

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -157,7 +157,7 @@ impl ThemePalette {
             .add_modifier(Modifier::BOLD)
     }
 
-    pub fn input_border_style(&self, focused: bool, has_error: bool) -> Style {
+    pub fn modal_input_border_style(&self, focused: bool, has_error: bool) -> Style {
         let color = if has_error {
             self.semantic.status.error
         } else if focused {
@@ -381,8 +381,8 @@ mod tests {
     }
 
     #[test]
-    fn input_border_style_prefers_error_over_focus() {
-        let style = DEFAULT_THEME.input_border_style(true, true);
+    fn modal_input_border_style_prefers_error_over_focus() {
+        let style = DEFAULT_THEME.modal_input_border_style(true, true);
 
         assert_eq!(style.fg, Some(DEFAULT_THEME.semantic.status.error));
     }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -26,8 +26,6 @@ pub struct SemanticTokens {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SurfaceTokens {
-    pub modal_border: Color,
-    pub modal_border_highlight: Color,
     pub focus_border: Color,
     pub unfocus_border: Color,
     pub highlight_border: Color,
@@ -48,6 +46,7 @@ pub struct StatusTokens {
     pub success: Color,
     pub error: Color,
     pub warning: Color,
+    pub pending: Color,
     pub medium_risk: Color,
 }
 
@@ -72,6 +71,8 @@ pub struct ComponentTokens {
 pub struct ModalTokens {
     pub title: Color,
     pub hint: Color,
+    pub border: Color,
+    pub border_highlight: Color,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,7 +98,6 @@ pub struct TableTokens {
     pub result_row_active_bg: Color,
     pub result_cell_active_bg: Color,
     pub cell_edit_fg: Color,
-    pub cell_draft_pending_fg: Color,
     pub staged_delete_bg: Color,
     pub staged_delete_fg: Color,
     pub striped_row_bg: Color,
@@ -161,9 +161,9 @@ impl ThemePalette {
         let color = if has_error {
             self.semantic.status.error
         } else if focused {
-            self.semantic.surface.modal_border_highlight
+            self.component.modal.border_highlight
         } else {
-            self.semantic.surface.modal_border
+            self.component.modal.border
         };
         Style::default().fg(color)
     }
@@ -191,8 +191,6 @@ impl ThemePalette {
 pub const DEFAULT_THEME: ThemePalette = ThemePalette {
     semantic: SemanticTokens {
         surface: SurfaceTokens {
-            modal_border: Color::Rgb(0x70, 0x68, 0x60),
-            modal_border_highlight: Color::Rgb(0xc0, 0xb8, 0xb8),
             focus_border: Color::Rgb(0x97, 0xc9, 0xc3),
             unfocus_border: Color::Rgb(0x45, 0x47, 0x55),
             highlight_border: Color::Rgb(0xb0, 0xdd, 0xd8),
@@ -209,6 +207,7 @@ pub const DEFAULT_THEME: ThemePalette = ThemePalette {
             success: Color::Rgb(0x97, 0xc9, 0xc3),
             error: Color::Rgb(0xc4, 0x74, 0x6e),
             warning: Color::Rgb(0xe0, 0xaf, 0x68),
+            pending: Color::Rgb(0xd4, 0xa0, 0x60),
             medium_risk: Color::Rgb(0xd4, 0x70, 0x50),
         },
         cursor: CursorTokens {
@@ -221,6 +220,8 @@ pub const DEFAULT_THEME: ThemePalette = ThemePalette {
         modal: ModalTokens {
             title: Color::Rgb(0xe9, 0xdb, 0xdb),
             hint: Color::Rgb(0xc0, 0xb8, 0xb0),
+            border: Color::Rgb(0x70, 0x68, 0x60),
+            border_highlight: Color::Rgb(0xc0, 0xb8, 0xb8),
         },
         navigation: NavigationTokens {
             key_chip_bg: Color::Rgb(0x3a, 0x3a, 0x4a),
@@ -240,7 +241,6 @@ pub const DEFAULT_THEME: ThemePalette = ThemePalette {
             result_row_active_bg: Color::Rgb(0x2e, 0x2e, 0x44),
             result_cell_active_bg: Color::Rgb(0x3a, 0x3a, 0x5a),
             cell_edit_fg: Color::Rgb(0xa8, 0xb8, 0xb5),
-            cell_draft_pending_fg: Color::Rgb(0xd4, 0xa0, 0x60),
             staged_delete_bg: Color::Rgb(0x3d, 0x22, 0x22),
             staged_delete_fg: Color::Rgb(0xee, 0x77, 0x77),
             striped_row_bg: Color::Rgb(0x1e, 0x1e, 0x23),
@@ -265,8 +265,6 @@ pub const DEFAULT_THEME: ThemePalette = ThemePalette {
 pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
     semantic: SemanticTokens {
         surface: SurfaceTokens {
-            modal_border: Color::Rgb(0xd8, 0x2a, 0x1f),
-            modal_border_highlight: Color::Rgb(0xff, 0xe0, 0x66),
             focus_border: Color::Rgb(0x2f, 0xc4, 0xb2),
             unfocus_border: Color::Rgb(0x5d, 0x62, 0x74),
             highlight_border: Color::Rgb(0xff, 0xc8, 0x57),
@@ -283,6 +281,7 @@ pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
             success: Color::Rgb(0x7b, 0xe0, 0x73),
             error: Color::Rgb(0xff, 0x7a, 0x59),
             warning: Color::Rgb(0xff, 0xc8, 0x57),
+            pending: Color::Rgb(0xff, 0x9f, 0x1c),
             medium_risk: Color::Rgb(0xff, 0x9f, 0x1c),
         },
         cursor: CursorTokens {
@@ -295,6 +294,8 @@ pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
         modal: ModalTokens {
             title: Color::Rgb(0xf6, 0xf0, 0xe8),
             hint: Color::Rgb(0x7b, 0xe0, 0x73),
+            border: Color::Rgb(0xd8, 0x2a, 0x1f),
+            border_highlight: Color::Rgb(0xff, 0xe0, 0x66),
         },
         navigation: NavigationTokens {
             key_chip_bg: Color::Rgb(0x1a, 0x45, 0x5e),
@@ -314,7 +315,6 @@ pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
             result_row_active_bg: Color::Rgb(0x2b, 0x32, 0x54),
             result_cell_active_bg: Color::Rgb(0x3a, 0x44, 0x6e),
             cell_edit_fg: Color::Rgb(0xff, 0xe0, 0x66),
-            cell_draft_pending_fg: Color::Rgb(0xff, 0x9f, 0x1c),
             staged_delete_bg: Color::Rgb(0x4a, 0x1f, 0x1f),
             staged_delete_fg: Color::Rgb(0xff, 0x7a, 0x59),
             striped_row_bg: Color::Rgb(0x1d, 0x21, 0x2b),
@@ -399,7 +399,7 @@ mod tests {
     }
 
     #[test]
-    fn block_cursor_style_inverts_cursor_and_selection_colors() {
+    fn block_cursor_style_uses_semantic_cursor_colors() {
         let style = DEFAULT_THEME.block_cursor_style();
 
         assert_eq!(style.bg, Some(DEFAULT_THEME.semantic.cursor.bg));

--- a/tests/render_snapshots/style_assertions.rs
+++ b/tests/render_snapshots/style_assertions.rs
@@ -111,7 +111,7 @@ fn pending_draft_cell_uses_orange_fg() {
         .find(|&(x, y)| {
             buffer
                 .cell((x, y))
-                .is_some_and(|c| c.fg == DEFAULT_THEME.component.table.cell_draft_pending_fg)
+                .is_some_and(|c| c.fg == DEFAULT_THEME.semantic.status.pending)
         });
     assert!(
         draft_cell.is_some(),
@@ -256,7 +256,7 @@ fn modal_border_uses_theme_color() {
         cell.symbol()
     );
     assert_eq!(
-        cell.fg, DEFAULT_THEME.semantic.surface.modal_border,
+        cell.fg, DEFAULT_THEME.component.modal.border,
         "Expected MODAL_BORDER fg on modal border at ({}, {}), got {:?}",
         mx, my, cell.fg
     );
@@ -857,7 +857,6 @@ fn injected_palette_changes_shell_modal_and_picker_styles() {
         semantic: sabiql::ui::theme::SemanticTokens {
             surface: sabiql::ui::theme::SurfaceTokens {
                 focus_border: Color::Rgb(0x11, 0x88, 0xdd),
-                modal_border: Color::Rgb(0xdd, 0x44, 0x11),
                 ..DEFAULT_THEME.semantic.surface
             },
             ..DEFAULT_THEME.semantic
@@ -865,6 +864,7 @@ fn injected_palette_changes_shell_modal_and_picker_styles() {
         component: sabiql::ui::theme::ComponentTokens {
             modal: sabiql::ui::theme::ModalTokens {
                 hint: Color::Rgb(0xaa, 0xee, 0x22),
+                border: Color::Rgb(0xdd, 0x44, 0x11),
                 ..DEFAULT_THEME.component.modal
             },
             editor: sabiql::ui::theme::EditorTokens {
@@ -893,7 +893,7 @@ fn injected_palette_changes_shell_modal_and_picker_styles() {
     let help_buffer = render_and_get_buffer_at_with_theme(&mut terminal, &mut state, now, &theme);
     let (mx, my) = help_modal_origin();
     let modal_corner = help_buffer.cell((mx, my)).unwrap();
-    assert_eq!(modal_corner.fg, theme.semantic.surface.modal_border);
+    assert_eq!(modal_corner.fg, theme.component.modal.border);
     let has_custom_help_hint = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
@@ -1008,9 +1008,9 @@ fn test_contrast_theme_applies_result_pane_table_colors() {
     let has_pending_draft_fg = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
-            draft_buffer.cell((x, y)).is_some_and(|cell| {
-                cell.fg == TEST_CONTRAST_THEME.component.table.cell_draft_pending_fg
-            })
+            draft_buffer
+                .cell((x, y))
+                .is_some_and(|cell| cell.fg == TEST_CONTRAST_THEME.semantic.status.pending)
         });
 
     assert!(
@@ -1024,20 +1024,18 @@ fn sql_completion_popup_uses_injected_theme_styles() {
     let (mut state, now) = connected_state();
     let mut terminal = create_test_terminal();
     let theme = ThemePalette {
-        semantic: sabiql::ui::theme::SemanticTokens {
-            surface: sabiql::ui::theme::SurfaceTokens {
-                modal_border: Color::Rgb(0xdd, 0x44, 0x11),
-                ..DEFAULT_THEME.semantic.surface
-            },
-            ..DEFAULT_THEME.semantic
-        },
         component: sabiql::ui::theme::ComponentTokens {
+            modal: sabiql::ui::theme::ModalTokens {
+                border: Color::Rgb(0xdd, 0x44, 0x11),
+                ..DEFAULT_THEME.component.modal
+            },
             editor: sabiql::ui::theme::EditorTokens {
                 completion_selected_bg: Color::Rgb(0x22, 0x66, 0x33),
                 ..DEFAULT_THEME.component.editor
             },
             ..DEFAULT_THEME.component
         },
+        ..DEFAULT_THEME
     };
 
     state.modal.set_mode(InputMode::SqlModal);
@@ -1114,9 +1112,9 @@ fn sql_completion_popup_uses_injected_theme_styles() {
     let top_left = buffer.cell((popup_x, popup_y)).unwrap();
     let top_right = buffer.cell((popup_x + popup_width - 1, popup_y)).unwrap();
     let has_completion_border = top_left.symbol() == "┌"
-        && top_left.fg == theme.semantic.surface.modal_border
+        && top_left.fg == theme.component.modal.border
         && top_right.symbol() == "┐"
-        && top_right.fg == theme.semantic.surface.modal_border;
+        && top_right.fg == theme.component.modal.border;
 
     assert!(
         has_completion_border,

--- a/tests/render_snapshots/style_assertions.rs
+++ b/tests/render_snapshots/style_assertions.rs
@@ -111,7 +111,7 @@ fn pending_draft_cell_uses_orange_fg() {
         .find(|&(x, y)| {
             buffer
                 .cell((x, y))
-                .is_some_and(|c| c.fg == DEFAULT_THEME.cell_draft_pending_fg)
+                .is_some_and(|c| c.fg == DEFAULT_THEME.component.table.cell_draft_pending_fg)
         });
     assert!(
         draft_cell.is_some(),
@@ -143,7 +143,7 @@ fn active_cell_edit_uses_yellow_fg() {
         .find(|&(x, y)| {
             buffer
                 .cell((x, y))
-                .is_some_and(|c| c.fg == DEFAULT_THEME.cell_edit_fg)
+                .is_some_and(|c| c.fg == DEFAULT_THEME.component.table.cell_edit_fg)
         });
     assert!(
         edit_cell.is_some(),
@@ -168,7 +168,7 @@ fn staged_delete_row_uses_dark_red_bg() {
         .find(|&(x, y)| {
             buffer
                 .cell((x, y))
-                .is_some_and(|c| c.bg == DEFAULT_THEME.staged_delete_bg)
+                .is_some_and(|c| c.bg == DEFAULT_THEME.component.table.staged_delete_bg)
         });
     assert!(
         staged_cell.is_some(),
@@ -213,7 +213,7 @@ fn result_highlight_respects_injected_now() {
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
             let cell = buf_before.cell((x, y)).unwrap();
-            cell.fg == DEFAULT_THEME.highlight_border && cell.symbol() == "─"
+            cell.fg == DEFAULT_THEME.semantic.surface.highlight_border && cell.symbol() == "─"
         });
     assert!(
         has_green_border,
@@ -228,7 +228,7 @@ fn result_highlight_respects_injected_now() {
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
             let cell = buf_after.cell((x, y)).unwrap();
-            cell.fg == DEFAULT_THEME.highlight_border && cell.symbol() == "─"
+            cell.fg == DEFAULT_THEME.semantic.surface.highlight_border && cell.symbol() == "─"
         });
     assert!(
         !has_green_border_after,
@@ -256,7 +256,7 @@ fn modal_border_uses_theme_color() {
         cell.symbol()
     );
     assert_eq!(
-        cell.fg, DEFAULT_THEME.modal_border,
+        cell.fg, DEFAULT_THEME.semantic.surface.modal_border,
         "Expected MODAL_BORDER fg on modal border at ({}, {}), got {:?}",
         mx, my, cell.fg
     );
@@ -278,7 +278,7 @@ fn header_status_uses_success_warning_and_error_colors() {
     let has_success = (0..TEST_WIDTH).any(|x| {
         connected_buffer
             .cell((x, 0))
-            .is_some_and(|cell| cell.fg == DEFAULT_THEME.status_success)
+            .is_some_and(|cell| cell.fg == DEFAULT_THEME.semantic.status.success)
     });
     assert!(
         has_success,
@@ -293,7 +293,7 @@ fn header_status_uses_success_warning_and_error_colors() {
     let has_warning = (0..TEST_WIDTH).any(|x| {
         loading_buffer
             .cell((x, 0))
-            .is_some_and(|cell| cell.fg == DEFAULT_THEME.status_warning)
+            .is_some_and(|cell| cell.fg == DEFAULT_THEME.semantic.status.warning)
     });
     assert!(
         has_warning,
@@ -305,7 +305,7 @@ fn header_status_uses_success_warning_and_error_colors() {
     let has_error = (0..TEST_WIDTH).any(|x| {
         no_dsn_buffer
             .cell((x, 0))
-            .is_some_and(|cell| cell.fg == DEFAULT_THEME.status_error)
+            .is_some_and(|cell| cell.fg == DEFAULT_THEME.semantic.status.error)
     });
     assert!(
         has_error,
@@ -326,9 +326,9 @@ fn help_overlay_uses_section_header_and_scrollbar_colors() {
     let has_section_header = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
-            buffer
-                .cell((x, y))
-                .is_some_and(|cell| cell.symbol() == "▸" && cell.fg == DEFAULT_THEME.section_header)
+            buffer.cell((x, y)).is_some_and(|cell| {
+                cell.symbol() == "▸" && cell.fg == DEFAULT_THEME.component.navigation.section_header
+            })
         });
     assert!(
         has_section_header,
@@ -340,7 +340,7 @@ fn help_overlay_uses_section_header_and_scrollbar_colors() {
         .any(|(x, y)| {
             buffer.cell((x, y)).is_some_and(|cell| {
                 matches!(cell.symbol(), "▲" | "▼" | "┃")
-                    && cell.fg == DEFAULT_THEME.scrollbar_active
+                    && cell.fg == DEFAULT_THEME.component.navigation.scrollbar_active
             })
         });
     assert!(
@@ -352,7 +352,8 @@ fn help_overlay_uses_section_header_and_scrollbar_colors() {
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
             buffer.cell((x, y)).is_some_and(|cell| {
-                cell.symbol() == "│" && cell.fg == DEFAULT_THEME.scrollbar_inactive
+                cell.symbol() == "│"
+                    && cell.fg == DEFAULT_THEME.component.navigation.scrollbar_inactive
             })
         });
     assert!(
@@ -376,7 +377,8 @@ fn test_contrast_theme_applies_help_overlay_navigation_colors() {
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
             buffer.cell((x, y)).is_some_and(|cell| {
-                cell.symbol() == "▸" && cell.fg == TEST_CONTRAST_THEME.section_header
+                cell.symbol() == "▸"
+                    && cell.fg == TEST_CONTRAST_THEME.component.navigation.section_header
             })
         });
     assert!(
@@ -389,7 +391,7 @@ fn test_contrast_theme_applies_help_overlay_navigation_colors() {
         .any(|(x, y)| {
             buffer.cell((x, y)).is_some_and(|cell| {
                 matches!(cell.symbol(), "▲" | "▼" | "┃")
-                    && cell.fg == TEST_CONTRAST_THEME.scrollbar_active
+                    && cell.fg == TEST_CONTRAST_THEME.component.navigation.scrollbar_active
             })
         });
     assert!(
@@ -413,14 +415,16 @@ fn sql_modal_keyword_and_number_use_syntax_colors() {
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .find_map(|(x, y)| {
             buffer.cell((x, y)).and_then(|cell| {
-                (cell.symbol() == "S" && cell.fg == DEFAULT_THEME.sql_keyword).then_some(cell)
+                (cell.symbol() == "S" && cell.fg == DEFAULT_THEME.component.syntax.sql_keyword)
+                    .then_some(cell)
             })
         });
     let number_cell = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .find_map(|(x, y)| {
             buffer.cell((x, y)).and_then(|cell| {
-                (cell.symbol() == "4" && cell.fg == DEFAULT_THEME.sql_number).then_some(cell)
+                (cell.symbol() == "4" && cell.fg == DEFAULT_THEME.component.syntax.sql_number)
+                    .then_some(cell)
             })
         });
 
@@ -451,23 +455,23 @@ fn sql_modal_string_comment_and_operator_use_syntax_colors() {
     let has_string = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
-            buffer
-                .cell((x, y))
-                .is_some_and(|cell| cell.symbol() == "'" && cell.fg == DEFAULT_THEME.sql_string)
+            buffer.cell((x, y)).is_some_and(|cell| {
+                cell.symbol() == "'" && cell.fg == DEFAULT_THEME.component.syntax.sql_string
+            })
         });
     let has_operator = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
-            buffer
-                .cell((x, y))
-                .is_some_and(|cell| cell.symbol() == ":" && cell.fg == DEFAULT_THEME.sql_operator)
+            buffer.cell((x, y)).is_some_and(|cell| {
+                cell.symbol() == ":" && cell.fg == DEFAULT_THEME.component.syntax.sql_operator
+            })
         });
     let has_comment = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
-            buffer
-                .cell((x, y))
-                .is_some_and(|cell| cell.symbol() == "-" && cell.fg == DEFAULT_THEME.sql_comment)
+            buffer.cell((x, y)).is_some_and(|cell| {
+                cell.symbol() == "-" && cell.fg == DEFAULT_THEME.component.syntax.sql_comment
+            })
         });
 
     assert!(has_string, "Expected a green SQL string cell");
@@ -494,21 +498,21 @@ fn test_contrast_theme_applies_sql_syntax_colors() {
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
             buffer.cell((x, y)).is_some_and(|cell| {
-                cell.symbol() == "S" && cell.fg == TEST_CONTRAST_THEME.sql_keyword
+                cell.symbol() == "S" && cell.fg == TEST_CONTRAST_THEME.component.syntax.sql_keyword
             })
         });
     let has_string = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
             buffer.cell((x, y)).is_some_and(|cell| {
-                cell.symbol() == "'" && cell.fg == TEST_CONTRAST_THEME.sql_string
+                cell.symbol() == "'" && cell.fg == TEST_CONTRAST_THEME.component.syntax.sql_string
             })
         });
     let has_comment = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
             buffer.cell((x, y)).is_some_and(|cell| {
-                cell.symbol() == "-" && cell.fg == TEST_CONTRAST_THEME.sql_comment
+                cell.symbol() == "-" && cell.fg == TEST_CONTRAST_THEME.component.syntax.sql_comment
             })
         });
 
@@ -540,7 +544,8 @@ fn sql_modal_normal_and_insert_use_distinct_cursor_styles() {
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
             normal_buffer.cell((x, y)).is_some_and(|cell| {
-                cell.bg == DEFAULT_THEME.cursor_bg && cell.fg == DEFAULT_THEME.cursor_text_fg
+                cell.bg == DEFAULT_THEME.semantic.cursor.bg
+                    && cell.fg == DEFAULT_THEME.semantic.cursor.text_fg
             })
         });
 
@@ -570,7 +575,8 @@ fn sql_modal_block_cursor_position(buffer: &ratatui::buffer::Buffer) -> Option<(
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .find(|&(x, y)| {
             buffer.cell((x, y)).is_some_and(|cell| {
-                cell.bg == DEFAULT_THEME.cursor_bg && cell.fg == DEFAULT_THEME.cursor_text_fg
+                cell.bg == DEFAULT_THEME.semantic.cursor.bg
+                    && cell.fg == DEFAULT_THEME.semantic.cursor.text_fg
             })
         })
 }
@@ -804,7 +810,7 @@ fn sql_modal_unterminated_string_keeps_string_highlight() {
         .any(|(x, y)| {
             buffer.cell((x, y)).is_some_and(|cell| {
                 (cell.symbol() == "'" || cell.symbol() == "u")
-                    && cell.fg == DEFAULT_THEME.sql_string
+                    && cell.fg == DEFAULT_THEME.component.syntax.sql_string
             })
         });
 
@@ -833,7 +839,7 @@ fn sql_modal_unterminated_block_comment_keeps_comment_highlight() {
         .any(|(x, y)| {
             buffer.cell((x, y)).is_some_and(|cell| {
                 (cell.symbol() == "/" || cell.symbol() == "*")
-                    && cell.fg == DEFAULT_THEME.sql_comment
+                    && cell.fg == DEFAULT_THEME.component.syntax.sql_comment
             })
         });
 
@@ -848,11 +854,25 @@ fn injected_palette_changes_shell_modal_and_picker_styles() {
     let (mut state, now) = connected_state();
     let mut terminal = create_test_terminal();
     let theme = ThemePalette {
-        focus_border: Color::Rgb(0x11, 0x88, 0xdd),
-        modal_border: Color::Rgb(0xdd, 0x44, 0x11),
-        completion_selected_bg: Color::Rgb(0x22, 0x66, 0x33),
-        modal_hint: Color::Rgb(0xaa, 0xee, 0x22),
-        ..DEFAULT_THEME
+        semantic: sabiql::ui::theme::SemanticTokens {
+            surface: sabiql::ui::theme::SurfaceTokens {
+                focus_border: Color::Rgb(0x11, 0x88, 0xdd),
+                modal_border: Color::Rgb(0xdd, 0x44, 0x11),
+                ..DEFAULT_THEME.semantic.surface
+            },
+            ..DEFAULT_THEME.semantic
+        },
+        component: sabiql::ui::theme::ComponentTokens {
+            modal: sabiql::ui::theme::ModalTokens {
+                hint: Color::Rgb(0xaa, 0xee, 0x22),
+                ..DEFAULT_THEME.component.modal
+            },
+            editor: sabiql::ui::theme::EditorTokens {
+                completion_selected_bg: Color::Rgb(0x22, 0x66, 0x33),
+                ..DEFAULT_THEME.component.editor
+            },
+            ..DEFAULT_THEME.component
+        },
     };
 
     state.ui.focused_pane = FocusedPane::Explorer;
@@ -860,9 +880,9 @@ fn injected_palette_changes_shell_modal_and_picker_styles() {
     let has_custom_focus_border = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
-            shell_buffer
-                .cell((x, y))
-                .is_some_and(|cell| cell.symbol() == "─" && cell.fg == theme.focus_border)
+            shell_buffer.cell((x, y)).is_some_and(|cell| {
+                cell.symbol() == "─" && cell.fg == theme.semantic.surface.focus_border
+            })
         });
     assert!(
         has_custom_focus_border,
@@ -873,13 +893,13 @@ fn injected_palette_changes_shell_modal_and_picker_styles() {
     let help_buffer = render_and_get_buffer_at_with_theme(&mut terminal, &mut state, now, &theme);
     let (mx, my) = help_modal_origin();
     let modal_corner = help_buffer.cell((mx, my)).unwrap();
-    assert_eq!(modal_corner.fg, theme.modal_border);
+    assert_eq!(modal_corner.fg, theme.semantic.surface.modal_border);
     let has_custom_help_hint = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
             help_buffer
                 .cell((x, y))
-                .is_some_and(|cell| cell.fg == theme.modal_hint)
+                .is_some_and(|cell| cell.fg == theme.component.modal.hint)
         });
     assert!(
         has_custom_help_hint,
@@ -893,7 +913,7 @@ fn injected_palette_changes_shell_modal_and_picker_styles() {
         .any(|(x, y)| {
             picker_buffer
                 .cell((x, y))
-                .is_some_and(|cell| cell.bg == theme.completion_selected_bg)
+                .is_some_and(|cell| cell.bg == theme.component.editor.completion_selected_bg)
         });
     assert!(
         has_custom_picker_selection,
@@ -908,7 +928,7 @@ fn injected_palette_changes_shell_modal_and_picker_styles() {
         .any(|(x, y)| {
             sql_buffer
                 .cell((x, y))
-                .is_some_and(|cell| cell.fg == theme.modal_hint)
+                .is_some_and(|cell| cell.fg == theme.component.modal.hint)
         });
     assert!(
         has_custom_sql_hint,
@@ -930,7 +950,7 @@ fn state_theme_id_drives_render_palette_resolution() {
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
             buffer.cell((x, y)).is_some_and(|cell| {
-                cell.symbol() == "─" && cell.fg == TEST_CONTRAST_THEME.focus_border
+                cell.symbol() == "─" && cell.fg == TEST_CONTRAST_THEME.semantic.surface.focus_border
             })
         });
 
@@ -957,14 +977,14 @@ fn test_contrast_theme_applies_result_pane_table_colors() {
         .any(|(x, y)| {
             staged_buffer
                 .cell((x, y))
-                .is_some_and(|cell| cell.bg == TEST_CONTRAST_THEME.staged_delete_bg)
+                .is_some_and(|cell| cell.bg == TEST_CONTRAST_THEME.component.table.staged_delete_bg)
         });
     let has_active_cell_bg = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
-            staged_buffer
-                .cell((x, y))
-                .is_some_and(|cell| cell.bg == TEST_CONTRAST_THEME.result_cell_active_bg)
+            staged_buffer.cell((x, y)).is_some_and(|cell| {
+                cell.bg == TEST_CONTRAST_THEME.component.table.result_cell_active_bg
+            })
         });
 
     assert!(
@@ -988,9 +1008,9 @@ fn test_contrast_theme_applies_result_pane_table_colors() {
     let has_pending_draft_fg = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
         .any(|(x, y)| {
-            draft_buffer
-                .cell((x, y))
-                .is_some_and(|cell| cell.fg == TEST_CONTRAST_THEME.cell_draft_pending_fg)
+            draft_buffer.cell((x, y)).is_some_and(|cell| {
+                cell.fg == TEST_CONTRAST_THEME.component.table.cell_draft_pending_fg
+            })
         });
 
     assert!(
@@ -1004,9 +1024,20 @@ fn sql_completion_popup_uses_injected_theme_styles() {
     let (mut state, now) = connected_state();
     let mut terminal = create_test_terminal();
     let theme = ThemePalette {
-        modal_border: Color::Rgb(0xdd, 0x44, 0x11),
-        completion_selected_bg: Color::Rgb(0x22, 0x66, 0x33),
-        ..DEFAULT_THEME
+        semantic: sabiql::ui::theme::SemanticTokens {
+            surface: sabiql::ui::theme::SurfaceTokens {
+                modal_border: Color::Rgb(0xdd, 0x44, 0x11),
+                ..DEFAULT_THEME.semantic.surface
+            },
+            ..DEFAULT_THEME.semantic
+        },
+        component: sabiql::ui::theme::ComponentTokens {
+            editor: sabiql::ui::theme::EditorTokens {
+                completion_selected_bg: Color::Rgb(0x22, 0x66, 0x33),
+                ..DEFAULT_THEME.component.editor
+            },
+            ..DEFAULT_THEME.component
+        },
     };
 
     state.modal.set_mode(InputMode::SqlModal);
@@ -1078,14 +1109,14 @@ fn sql_completion_popup_uses_injected_theme_styles() {
         .any(|(x, y)| {
             buffer
                 .cell((x, y))
-                .is_some_and(|cell| cell.bg == theme.completion_selected_bg)
+                .is_some_and(|cell| cell.bg == theme.component.editor.completion_selected_bg)
         });
     let top_left = buffer.cell((popup_x, popup_y)).unwrap();
     let top_right = buffer.cell((popup_x + popup_width - 1, popup_y)).unwrap();
     let has_completion_border = top_left.symbol() == "┌"
-        && top_left.fg == theme.modal_border
+        && top_left.fg == theme.semantic.surface.modal_border
         && top_right.symbol() == "┐"
-        && top_right.fg == theme.modal_border;
+        && top_right.fg == theme.semantic.surface.modal_border;
 
     assert!(
         has_completion_border,


### PR DESCRIPTION
## Problem
The UI theme palette is a flat token bag, so semantic tokens and component-specific tokens live at the same level and are hard to evolve safely.

## Background
This branch follows the dead-token cleanup and keeps the new color safety-net tests in the parent branch as a guard before structural theme changes.

## Approach
Restructure the palette into semantic and component token groups, align mis-placed tokens with their intended purpose, and extract a shared helper for the repeating modal-border style. Renderers and render assertions are updated to consume the grouped tokens so the refactor stays behavior-preserving under the current test coverage.

- **Grouping**: replace the flat `ThemePalette` with `semantic` (surface / text / status / cursor) and `component` (modal / navigation / editor / table / feedback / syntax) groups.
- **Alignment**: move `modal_border` / `modal_border_highlight` from `semantic.surface` into `component.modal` (they carry component-specific vocabulary). Unify the "pending / unsaved" state across table cells and the JSONB modal behind a cross-cutting `semantic.status.pending`, removing the indirect coupling through `component.table.cell_draft_pending_fg`.
- **DRY**: add `ThemePalette::modal_border_style()` and collapse 10 direct `Style::default().fg(theme.component.modal.border)` call sites.
- **Test hygiene**: rename the block-cursor test so its name matches what it actually asserts.

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## テーマシステムの内部構造改善

* **リファクタリング**
  * テーマカラーを平坦な定義からセマンティック／コンポーネント階層へ移行しました。アプリ内の全UIで新しいトークンを参照するようになり、保守性と拡張性が向上しています。見た目や動作のユーザー体験には変更はありません。

* **テスト**
  * 既存のレンダリング／スタイル検証テストを新しいテーマ構造に合わせて更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->