### PR TITLE
chore: remove unused dev-dependency pretty_assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,12 +621,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,16 +2083,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
-dependencies = [
- "diff",
- "yansi",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,7 +2576,6 @@ dependencies = [
  "lru",
  "mockall",
  "nucleo-matcher",
- "pretty_assertions",
  "ratatui",
  "rstest",
  "self_update",
@@ -4048,12 +4031,6 @@ dependencies = [
  "libc",
  "rustix",
 ]
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ self-update = ["dep:self_update"]
 test-support = []
 
 [dev-dependencies]
-pretty_assertions = "1"
 rstest = "0.19"
 tempfile = "3"
 insta = "1"


### PR DESCRIPTION
## Scope

Dev-dependency hygiene only. No runtime or test behavior change.

## Summary

- `pretty_assertions` was declared in `[dev-dependencies]` but never imported or used anywhere in the codebase
- Detected via `cargo +nightly udeps --all-targets`, then confirmed with ripgrep that no source file references the crate

```bash
# 1. nightly toolchain
rustup toolchain install nightly

# 2. udeps install
cargo install cargo-udeps --locked

# 3. execute
cargo +nightly udeps --all-targets

# 4. Double-checking the reported crate with rg, just in case
rg 'crate_name' --type rust

# 5. remove
cargo check && cargo test --all && cargo clippy --all-targets -- -D warnings
```

## Verification

- `cargo check` — pass
- `cargo test --all` — pass
- `cargo clippy --all-targets -- -D warnings` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * 開発環境の依存パッケージを削除し、プロジェクトを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->