### PR TITLE
feat: JSONB detail Vim parity

### DIFF
--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -530,6 +530,7 @@ pub enum Action {
     CloseJsonbDetail,
     JsonbYankAll,
     JsonbEnterEdit,
+    JsonbAppendInsert,
     JsonbExitEdit,
     JsonbEnterSearch,
     JsonbExitSearch,

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -4,10 +4,12 @@ use unicode_casefold::UnicodeCaseFold;
 use crate::app::cmd::effect::Effect;
 use crate::app::model::app_state::AppState;
 use crate::app::model::browse::jsonb_detail::JsonbDetailState;
+use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::shared::input_mode::InputMode;
 use crate::app::model::shared::key_sequence::KeySequenceState;
 use crate::app::model::shared::text_input::TextInputLike;
 use crate::app::model::shared::ui_state::DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS;
+use crate::app::ports::ClipboardError;
 use crate::app::update::action::{Action, CursorMove, InputTarget};
 use crate::domain::QuerySource;
 
@@ -82,14 +84,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
 
         Action::JsonbYankAll => {
             let json = state.jsonb_detail.current_json_for_yank();
-            state.flash_timers.set(
-                crate::app::model::shared::flash_timer::FlashId::JsonbDetail,
-                now,
-            );
+            state.flash_timers.set(FlashId::JsonbDetail, now);
             Some(vec![Effect::CopyToClipboard {
                 content: json,
                 on_success: Some(Action::CellCopied),
-                on_failure: Some(Action::CopyFailed(crate::app::ports::ClipboardError {
+                on_failure: Some(Action::CopyFailed(ClipboardError {
                     message: "Clipboard unavailable".into(),
                 })),
             }])
@@ -565,6 +564,7 @@ mod tests {
         use super::*;
         use crate::app::model::browse::jsonb_detail::JsonbDetailMode;
         use crate::app::model::shared::key_sequence::{KeySequenceState, Prefix};
+        use crate::app::update::action::CursorMove;
         use rstest::rstest;
 
         #[test]
@@ -586,7 +586,7 @@ mod tests {
                 &mut state,
                 &Action::TextMoveCursor {
                     target: InputTarget::JsonbEdit,
-                    direction: crate::app::update::action::CursorMove::Down,
+                    direction: CursorMove::Down,
                 },
                 Instant::now(),
             );
@@ -594,7 +594,7 @@ mod tests {
                 &mut state,
                 &Action::TextMoveCursor {
                     target: InputTarget::JsonbEdit,
-                    direction: crate::app::update::action::CursorMove::Right,
+                    direction: CursorMove::Right,
                 },
                 Instant::now(),
             );
@@ -631,7 +631,7 @@ mod tests {
                 &mut state,
                 &Action::TextMoveCursor {
                     target: InputTarget::JsonbEdit,
-                    direction: crate::app::update::action::CursorMove::Down,
+                    direction: CursorMove::Down,
                 },
                 Instant::now(),
             );
@@ -639,7 +639,7 @@ mod tests {
                 &mut state,
                 &Action::TextMoveCursor {
                     target: InputTarget::JsonbEdit,
-                    direction: crate::app::update::action::CursorMove::Down,
+                    direction: CursorMove::Down,
                 },
                 Instant::now(),
             );
@@ -648,11 +648,11 @@ mod tests {
         }
 
         #[rstest]
-        #[case(crate::app::update::action::CursorMove::ViewportTop, 0)]
-        #[case(crate::app::update::action::CursorMove::ViewportMiddle, 1)]
-        #[case(crate::app::update::action::CursorMove::ViewportBottom, 2)]
+        #[case(CursorMove::ViewportTop, 0)]
+        #[case(CursorMove::ViewportMiddle, 1)]
+        #[case(CursorMove::ViewportBottom, 2)]
         fn viewport_cursor_moves_follow_visible_rows(
-            #[case] movement: crate::app::update::action::CursorMove,
+            #[case] movement: CursorMove,
             #[case] expected_row: usize,
         ) {
             let mut state =
@@ -693,7 +693,7 @@ mod tests {
                 &mut state,
                 &Action::TextMoveCursor {
                     target: InputTarget::JsonbEdit,
-                    direction: crate::app::update::action::CursorMove::Right,
+                    direction: CursorMove::Right,
                 },
                 Instant::now(),
             );

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -5,6 +5,7 @@ use crate::app::cmd::effect::Effect;
 use crate::app::model::app_state::AppState;
 use crate::app::model::browse::jsonb_detail::JsonbDetailState;
 use crate::app::model::shared::input_mode::InputMode;
+use crate::app::model::shared::key_sequence::KeySequenceState;
 use crate::app::model::shared::text_input::TextInputLike;
 use crate::app::model::shared::ui_state::DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS;
 use crate::app::update::action::{Action, InputTarget};
@@ -106,6 +107,23 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             Some(vec![])
         }
 
+        Action::JsonbAppendInsert => {
+            if state.session.read_only {
+                state
+                    .messages
+                    .set_error_at("Read-only mode: editing is disabled".to_string(), now);
+                return Some(vec![]);
+            }
+            state
+                .jsonb_detail
+                .editor_mut()
+                .move_cursor(crate::app::update::action::CursorMove::LineEnd);
+            update_editor_scroll(state);
+            state.jsonb_detail.enter_edit();
+            state.modal.replace_mode(InputMode::JsonbEdit);
+            Some(vec![])
+        }
+
         Action::JsonbExitEdit => {
             state.jsonb_detail.exit_edit();
             state.modal.replace_mode(InputMode::JsonbDetail);
@@ -150,8 +168,23 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             target: InputTarget::JsonbEdit,
             direction,
         } => {
-            state.jsonb_detail.editor_mut().move_cursor(*direction);
+            match direction {
+                crate::app::update::action::CursorMove::ViewportTop
+                | crate::app::update::action::CursorMove::ViewportMiddle
+                | crate::app::update::action::CursorMove::ViewportBottom => {
+                    let visible_rows = match state.jsonb_detail_editor_visible_rows() {
+                        0 => DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS,
+                        rows => rows,
+                    };
+                    state
+                        .jsonb_detail
+                        .editor_mut()
+                        .move_cursor_to_viewport_position(*direction, visible_rows);
+                }
+                _ => state.jsonb_detail.editor_mut().move_cursor(*direction),
+            }
             update_editor_scroll(state);
+            state.ui.key_sequence = KeySequenceState::Idle;
             Some(vec![])
         }
 
@@ -530,6 +563,8 @@ mod tests {
     mod edit_lifecycle {
         use super::*;
         use crate::app::model::browse::jsonb_detail::JsonbDetailMode;
+        use crate::app::model::shared::key_sequence::{KeySequenceState, Prefix};
+        use rstest::rstest;
 
         #[test]
         fn enter_edit_switches_to_jsonb_edit_mode() {
@@ -570,6 +605,22 @@ mod tests {
         }
 
         #[test]
+        fn append_insert_moves_to_current_line_end_before_editing() {
+            let mut state = state_with_jsonb_value(r#"{"items":["admin","writer"]}"#);
+            open_detail(&mut state);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content_with_cursor("abc\ndef".to_string(), 1);
+
+            reduce(&mut state, &Action::JsonbAppendInsert, Instant::now());
+
+            assert_eq!(state.input_mode(), InputMode::JsonbEdit);
+            assert_eq!(state.jsonb_detail.editor().cursor_to_position(), (0, 3));
+            assert_eq!(state.jsonb_detail.mode(), JsonbDetailMode::Editing);
+        }
+
+        #[test]
         fn movement_updates_scroll_with_current_editor_viewport_height() {
             let mut state = state_with_jsonb_value(r#"{"items":["admin","writer","reader"]}"#);
             state.ui.jsonb_detail_editor_visible_rows = 2;
@@ -593,6 +644,60 @@ mod tests {
             );
 
             assert_eq!(state.jsonb_detail.editor().scroll_row(), 1);
+        }
+
+        #[rstest]
+        #[case(crate::app::update::action::CursorMove::ViewportTop, 0)]
+        #[case(crate::app::update::action::CursorMove::ViewportMiddle, 1)]
+        #[case(crate::app::update::action::CursorMove::ViewportBottom, 2)]
+        fn viewport_cursor_moves_follow_visible_rows(
+            #[case] movement: crate::app::update::action::CursorMove,
+            #[case] expected_row: usize,
+        ) {
+            let mut state =
+                state_with_jsonb_value("{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3,\n  \"d\": 4\n}");
+            state.ui.jsonb_detail_editor_visible_rows = 3;
+            open_detail(&mut state);
+            state.modal.replace_mode(InputMode::JsonbEdit);
+            state.jsonb_detail.set_mode(JsonbDetailMode::Editing);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content_with_cursor("line1\nline2\nline3\nline4".to_string(), 0);
+
+            reduce(
+                &mut state,
+                &Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: movement,
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(
+                state.jsonb_detail.editor().cursor_to_position().0,
+                expected_row
+            );
+        }
+
+        #[test]
+        fn cursor_movement_clears_pending_key_sequence() {
+            let mut state = state_with_jsonb_cell();
+            open_detail(&mut state);
+            state.modal.replace_mode(InputMode::JsonbEdit);
+            state.jsonb_detail.set_mode(JsonbDetailMode::Editing);
+            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::G);
+
+            reduce(
+                &mut state,
+                &Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: crate::app::update::action::CursorMove::Right,
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(state.ui.key_sequence.pending_prefix(), None);
         }
 
         #[test]

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -8,7 +8,7 @@ use crate::app::model::shared::input_mode::InputMode;
 use crate::app::model::shared::key_sequence::KeySequenceState;
 use crate::app::model::shared::text_input::TextInputLike;
 use crate::app::model::shared::ui_state::DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS;
-use crate::app::update::action::{Action, InputTarget};
+use crate::app::update::action::{Action, CursorMove, InputTarget};
 use crate::domain::QuerySource;
 
 pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
@@ -117,7 +117,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             state
                 .jsonb_detail
                 .editor_mut()
-                .move_cursor(crate::app::update::action::CursorMove::LineEnd);
+                .move_cursor(CursorMove::LineEnd);
             update_editor_scroll(state);
             state.jsonb_detail.enter_edit();
             state.modal.replace_mode(InputMode::JsonbEdit);
@@ -169,13 +169,10 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             direction,
         } => {
             match direction {
-                crate::app::update::action::CursorMove::ViewportTop
-                | crate::app::update::action::CursorMove::ViewportMiddle
-                | crate::app::update::action::CursorMove::ViewportBottom => {
-                    let visible_rows = match state.jsonb_detail_editor_visible_rows() {
-                        0 => DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS,
-                        rows => rows,
-                    };
+                CursorMove::ViewportTop
+                | CursorMove::ViewportMiddle
+                | CursorMove::ViewportBottom => {
+                    let visible_rows = effective_visible_rows(state);
                     state
                         .jsonb_detail
                         .editor_mut()
@@ -306,11 +303,15 @@ fn jump_to_current_match(state: &mut AppState) {
 }
 
 fn update_editor_scroll(state: &mut AppState) {
-    let visible_rows = match state.jsonb_detail_editor_visible_rows() {
+    let visible_rows = effective_visible_rows(state);
+    state.jsonb_detail.editor_mut().update_scroll(visible_rows);
+}
+
+fn effective_visible_rows(state: &AppState) -> usize {
+    match state.jsonb_detail_editor_visible_rows() {
         0 => DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS,
         rows => rows,
-    };
-    state.jsonb_detail.editor_mut().update_scroll(visible_rows);
+    }
 }
 
 fn find_text_matches(content: &str, query: &str) -> Vec<usize> {
@@ -709,6 +710,20 @@ mod tests {
             reduce(&mut state, &Action::JsonbEnterEdit, Instant::now());
 
             assert_eq!(state.input_mode(), InputMode::JsonbDetail);
+            assert!(state.messages.last_error.is_some());
+        }
+
+        #[test]
+        fn append_insert_blocked_in_read_only_mode() {
+            let mut state = state_with_jsonb_cell();
+            open_detail(&mut state);
+            state.session.read_only = true;
+            let cursor_before = state.jsonb_detail.editor().cursor();
+
+            reduce(&mut state, &Action::JsonbAppendInsert, Instant::now());
+
+            assert_eq!(state.input_mode(), InputMode::JsonbDetail);
+            assert_eq!(state.jsonb_detail.editor().cursor(), cursor_before);
             assert!(state.messages.last_error.is_some());
         }
 

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -2,6 +2,7 @@ use std::time::{Duration, Instant};
 
 use crate::app::cmd::effect::Effect;
 use crate::app::model::app_state::AppState;
+use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::shared::inspector_tab::InspectorTab;
 use crate::app::model::shared::ui_state::YankFlash;
 use crate::app::ports::ClipboardError;
@@ -56,13 +57,11 @@ pub fn reduce(
                 && let Some(table) = state.session.table_detail().as_ref()
             {
                 let ddl = services.ddl_generator.generate_ddl(table);
-                state
-                    .flash_timers
-                    .set(crate::app::model::shared::flash_timer::FlashId::Ddl, now);
+                state.flash_timers.set(FlashId::Ddl, now);
                 return Some(vec![Effect::CopyToClipboard {
                     content: ddl,
                     on_success: Some(Action::CellCopied),
-                    on_failure: Some(Action::CopyFailed(crate::app::ports::ClipboardError {
+                    on_failure: Some(Action::CopyFailed(ClipboardError {
                         message: "Clipboard unavailable".into(),
                     })),
                 }]);
@@ -496,11 +495,7 @@ mod tests {
 
             reduce(&mut state, &Action::DdlYank, &fake_services(), now);
 
-            assert!(
-                state
-                    .flash_timers
-                    .is_active(crate::app::model::shared::flash_timer::FlashId::Ddl, now)
-            );
+            assert!(state.flash_timers.is_active(FlashId::Ddl, now));
         }
 
         #[test]

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -292,8 +292,9 @@ pub mod idx {
         pub const SEARCH: usize = 2;
         pub const NEXT_PREV: usize = 3;
         pub const MOVE: usize = 4;
-        pub const HOME_END: usize = 5;
-        pub const CLOSE: usize = 6;
+        pub const JUMP: usize = 5;
+        pub const VIEW: usize = 6;
+        pub const CLOSE: usize = 7;
     }
 
     pub mod jsonb_search {
@@ -599,7 +600,8 @@ mod tests {
             assert!(idx::jsonb_detail::SEARCH < JSONB_DETAIL_ROWS.len());
             assert!(idx::jsonb_detail::NEXT_PREV < JSONB_DETAIL_ROWS.len());
             assert!(idx::jsonb_detail::MOVE < JSONB_DETAIL_ROWS.len());
-            assert!(idx::jsonb_detail::HOME_END < JSONB_DETAIL_ROWS.len());
+            assert!(idx::jsonb_detail::JUMP < JSONB_DETAIL_ROWS.len());
+            assert!(idx::jsonb_detail::VIEW < JSONB_DETAIL_ROWS.len());
             assert!(idx::jsonb_detail::CLOSE < JSONB_DETAIL_ROWS.len());
 
             // JSONB_SEARCH_KEYS

--- a/src/app/update/input/keybindings/overlays.rs
+++ b/src/app/update/input/keybindings/overlays.rs
@@ -613,14 +613,14 @@ pub const JSONB_DETAIL_ROWS: &[ModeRow] = &[
         }],
     },
     ModeRow {
-        key_short: "Enter/i/A",
-        key: "Enter / i / A",
-        desc_short: "Insert",
+        key_short: "i/A",
+        key: "i / A",
+        desc_short: "Insert/Append",
         description: "Enter Insert mode / append at line end",
         bindings: &[
             ExecBinding {
                 action: Action::JsonbEnterEdit,
-                combos: &[KeyCombo::plain(Key::Enter), KeyCombo::plain(Key::Char('i'))],
+                combos: &[KeyCombo::plain(Key::Char('i'))],
             },
             ExecBinding {
                 action: Action::JsonbAppendInsert,

--- a/src/app/update/input/keybindings/overlays.rs
+++ b/src/app/update/input/keybindings/overlays.rs
@@ -613,9 +613,9 @@ pub const JSONB_DETAIL_ROWS: &[ModeRow] = &[
         }],
     },
     ModeRow {
-        key_short: "i/A",
+        key_short: "i",
         key: "i / A",
-        desc_short: "Insert/Append",
+        desc_short: "Insert",
         description: "Enter Insert mode / append at line end",
         bindings: &[
             ExecBinding {

--- a/src/app/update/input/keybindings/overlays.rs
+++ b/src/app/update/input/keybindings/overlays.rs
@@ -709,14 +709,14 @@ pub const JSONB_DETAIL_ROWS: &[ModeRow] = &[
                     target: InputTarget::JsonbEdit,
                     direction: CursorMove::LineStart,
                 },
-                combos: &[KeyCombo::plain(Key::Char('0')), KeyCombo::plain(Key::Home)],
+                combos: &[KeyCombo::plain(Key::Char('0'))],
             },
             ExecBinding {
                 action: Action::TextMoveCursor {
                     target: InputTarget::JsonbEdit,
                     direction: CursorMove::LineEnd,
                 },
-                combos: &[KeyCombo::plain(Key::Char('$')), KeyCombo::plain(Key::End)],
+                combos: &[KeyCombo::plain(Key::Char('$'))],
             },
             ExecBinding {
                 action: Action::TextMoveCursor {
@@ -739,7 +739,36 @@ pub const JSONB_DETAIL_ROWS: &[ModeRow] = &[
         key: "gg / G / H / M / L",
         desc_short: "View",
         description: "Jump by buffer or viewport",
-        bindings: &[],
+        bindings: &[
+            ExecBinding {
+                action: Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: CursorMove::LastLine,
+                },
+                combos: &[KeyCombo::plain(Key::Char('G'))],
+            },
+            ExecBinding {
+                action: Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: CursorMove::ViewportTop,
+                },
+                combos: &[KeyCombo::plain(Key::Char('H'))],
+            },
+            ExecBinding {
+                action: Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: CursorMove::ViewportMiddle,
+                },
+                combos: &[KeyCombo::plain(Key::Char('M'))],
+            },
+            ExecBinding {
+                action: Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: CursorMove::ViewportBottom,
+                },
+                combos: &[KeyCombo::plain(Key::Char('L'))],
+            },
+        ],
     },
     ModeRow {
         key_short: "Esc",

--- a/src/app/update/input/keybindings/overlays.rs
+++ b/src/app/update/input/keybindings/overlays.rs
@@ -613,14 +613,20 @@ pub const JSONB_DETAIL_ROWS: &[ModeRow] = &[
         }],
     },
     ModeRow {
-        key_short: "Enter/i",
-        key: "Enter / i",
+        key_short: "Enter/i/A",
+        key: "Enter / i / A",
         desc_short: "Insert",
-        description: "Enter Insert mode",
-        bindings: &[ExecBinding {
-            action: Action::JsonbEnterEdit,
-            combos: &[KeyCombo::plain(Key::Enter), KeyCombo::plain(Key::Char('i'))],
-        }],
+        description: "Enter Insert mode / append at line end",
+        bindings: &[
+            ExecBinding {
+                action: Action::JsonbEnterEdit,
+                combos: &[KeyCombo::plain(Key::Enter), KeyCombo::plain(Key::Char('i'))],
+            },
+            ExecBinding {
+                action: Action::JsonbAppendInsert,
+                combos: &[KeyCombo::plain(Key::Char('A'))],
+            },
+        ],
     },
     ModeRow {
         key_short: "/",
@@ -693,26 +699,47 @@ pub const JSONB_DETAIL_ROWS: &[ModeRow] = &[
         ],
     },
     ModeRow {
-        key_short: "Home/End",
-        key: "Home / End",
-        desc_short: "Line",
-        description: "Line start/end",
+        key_short: "0$wb",
+        key: "0 / $ / w / b / Home / End",
+        desc_short: "Jump",
+        description: "Move by word or line boundary",
         bindings: &[
             ExecBinding {
                 action: Action::TextMoveCursor {
                     target: InputTarget::JsonbEdit,
-                    direction: CursorMove::Home,
+                    direction: CursorMove::LineStart,
                 },
-                combos: &[KeyCombo::plain(Key::Home)],
+                combos: &[KeyCombo::plain(Key::Char('0')), KeyCombo::plain(Key::Home)],
             },
             ExecBinding {
                 action: Action::TextMoveCursor {
                     target: InputTarget::JsonbEdit,
-                    direction: CursorMove::End,
+                    direction: CursorMove::LineEnd,
                 },
-                combos: &[KeyCombo::plain(Key::End)],
+                combos: &[KeyCombo::plain(Key::Char('$')), KeyCombo::plain(Key::End)],
+            },
+            ExecBinding {
+                action: Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: CursorMove::WordForward,
+                },
+                combos: &[KeyCombo::plain(Key::Char('w'))],
+            },
+            ExecBinding {
+                action: Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: CursorMove::WordBackward,
+                },
+                combos: &[KeyCombo::plain(Key::Char('b'))],
             },
         ],
+    },
+    ModeRow {
+        key_short: "ggGHML",
+        key: "gg / G / H / M / L",
+        desc_short: "View",
+        description: "Jump by buffer or viewport",
+        bindings: &[],
     },
     ModeRow {
         key_short: "Esc",

--- a/src/app/update/input/vim/actions/jsonb.rs
+++ b/src/app/update/input/vim/actions/jsonb.rs
@@ -25,7 +25,7 @@ pub(in crate::app::update::input::vim) fn command(
                 Some(Action::JsonbSearchPrev)
             }
             VimCommand::Operator(VimOperator::Yank) => Some(Action::JsonbYankAll),
-            VimCommand::Operator(VimOperator::Delete) => Some(Action::None),
+            VimCommand::Operator(VimOperator::Delete) => None,
         },
         JsonbDetailVimContext::Editing => match command {
             VimCommand::ModeTransition(VimModeTransition::Escape) => Some(Action::JsonbExitEdit),

--- a/src/app/update/input/vim/actions/jsonb.rs
+++ b/src/app/update/input/vim/actions/jsonb.rs
@@ -13,11 +13,13 @@ pub(in crate::app::update::input::vim) fn command(
         JsonbDetailVimContext::Viewing => match command {
             VimCommand::Navigation(navigation) => navigation_action(navigation),
             VimCommand::ModeTransition(VimModeTransition::Escape) => Some(Action::CloseJsonbDetail),
-            VimCommand::ModeTransition(
-                VimModeTransition::Insert
-                | VimModeTransition::Append
-                | VimModeTransition::ConfirmOrEnter,
-            ) => Some(Action::JsonbEnterEdit),
+            VimCommand::ModeTransition(VimModeTransition::Insert)
+            | VimCommand::ModeTransition(VimModeTransition::ConfirmOrEnter) => {
+                Some(Action::JsonbEnterEdit)
+            }
+            VimCommand::ModeTransition(VimModeTransition::Append) => {
+                Some(Action::JsonbAppendInsert)
+            }
             VimCommand::SearchContinuation(SearchContinuation::Next) => {
                 Some(Action::JsonbSearchNext)
             }
@@ -41,8 +43,15 @@ fn navigation_action(navigation: VimNavigation) -> Option<Action> {
         VimNavigation::MoveRight => CursorMove::Right,
         VimNavigation::MoveUp => CursorMove::Up,
         VimNavigation::MoveDown => CursorMove::Down,
-        VimNavigation::MoveToFirst => CursorMove::Home,
-        VimNavigation::MoveToLast => CursorMove::End,
+        VimNavigation::MoveToFirst => CursorMove::FirstLine,
+        VimNavigation::MoveToLast => CursorMove::LastLine,
+        VimNavigation::MoveLineStart => CursorMove::LineStart,
+        VimNavigation::MoveLineEnd => CursorMove::LineEnd,
+        VimNavigation::MoveWordForward => CursorMove::WordForward,
+        VimNavigation::MoveWordBackward => CursorMove::WordBackward,
+        VimNavigation::ViewportTop => CursorMove::ViewportTop,
+        VimNavigation::ViewportMiddle => CursorMove::ViewportMiddle,
+        VimNavigation::ViewportBottom => CursorMove::ViewportBottom,
         _ => return None,
     };
 
@@ -57,6 +66,7 @@ mod tests {
     use super::*;
     use crate::app::update::input::keybindings::{Key, KeyCombo};
     use crate::app::update::input::vim::{VimSurfaceContext, action_for_key};
+    use rstest::rstest;
 
     fn combo(key: Key) -> KeyCombo {
         KeyCombo::plain(key)
@@ -77,7 +87,47 @@ mod tests {
 
         let action = action_for_key(&combo(Key::Char('A')), ctx);
 
-        assert!(matches!(action, Some(Action::JsonbEnterEdit)));
+        assert!(matches!(action, Some(Action::JsonbAppendInsert)));
+    }
+
+    #[rstest]
+    #[case(Key::Char('0'), CursorMove::LineStart)]
+    #[case(Key::Char('$'), CursorMove::LineEnd)]
+    #[case(Key::Char('w'), CursorMove::WordForward)]
+    #[case(Key::Char('b'), CursorMove::WordBackward)]
+    #[case(Key::Char('G'), CursorMove::LastLine)]
+    #[case(Key::Char('H'), CursorMove::ViewportTop)]
+    #[case(Key::Char('M'), CursorMove::ViewportMiddle)]
+    #[case(Key::Char('L'), CursorMove::ViewportBottom)]
+    fn extended_navigation_maps_to_cursor_moves(#[case] key: Key, #[case] expected: CursorMove) {
+        let ctx = VimSurfaceContext::JsonbDetail(JsonbDetailVimContext::Viewing);
+
+        let action = action_for_key(&combo(key), ctx);
+
+        assert!(matches!(
+            action,
+            Some(Action::TextMoveCursor {
+                target: InputTarget::JsonbEdit,
+                direction,
+            }) if direction == expected
+        ));
+    }
+
+    #[test]
+    fn gg_moves_to_first_line() {
+        let action = crate::app::update::input::vim::action_for_input(
+            &combo(Key::Char('g')),
+            Some(crate::app::model::shared::key_sequence::Prefix::G),
+            VimSurfaceContext::JsonbDetail(JsonbDetailVimContext::Viewing),
+        );
+
+        assert!(matches!(
+            action,
+            Some(Action::TextMoveCursor {
+                target: InputTarget::JsonbEdit,
+                direction: CursorMove::FirstLine,
+            })
+        ));
     }
 
     #[test]

--- a/src/app/update/input/vim/actions/jsonb.rs
+++ b/src/app/update/input/vim/actions/jsonb.rs
@@ -14,7 +14,6 @@ pub(in crate::app::update::input::vim) fn command(
             VimCommand::Navigation(navigation) => navigation_action(navigation),
             VimCommand::ModeTransition(VimModeTransition::Escape) => Some(Action::CloseJsonbDetail),
             VimCommand::ModeTransition(VimModeTransition::Insert) => Some(Action::JsonbEnterEdit),
-            VimCommand::ModeTransition(VimModeTransition::ConfirmOrEnter) => None,
             VimCommand::ModeTransition(VimModeTransition::Append) => {
                 Some(Action::JsonbAppendInsert)
             }
@@ -25,7 +24,8 @@ pub(in crate::app::update::input::vim) fn command(
                 Some(Action::JsonbSearchPrev)
             }
             VimCommand::Operator(VimOperator::Yank) => Some(Action::JsonbYankAll),
-            VimCommand::Operator(VimOperator::Delete) => None,
+            VimCommand::ModeTransition(VimModeTransition::ConfirmOrEnter)
+            | VimCommand::Operator(VimOperator::Delete) => None,
         },
         JsonbDetailVimContext::Editing => match command {
             VimCommand::ModeTransition(VimModeTransition::Escape) => Some(Action::JsonbExitEdit),

--- a/src/app/update/input/vim/actions/jsonb.rs
+++ b/src/app/update/input/vim/actions/jsonb.rs
@@ -13,10 +13,8 @@ pub(in crate::app::update::input::vim) fn command(
         JsonbDetailVimContext::Viewing => match command {
             VimCommand::Navigation(navigation) => navigation_action(navigation),
             VimCommand::ModeTransition(VimModeTransition::Escape) => Some(Action::CloseJsonbDetail),
-            VimCommand::ModeTransition(VimModeTransition::Insert)
-            | VimCommand::ModeTransition(VimModeTransition::ConfirmOrEnter) => {
-                Some(Action::JsonbEnterEdit)
-            }
+            VimCommand::ModeTransition(VimModeTransition::Insert) => Some(Action::JsonbEnterEdit),
+            VimCommand::ModeTransition(VimModeTransition::ConfirmOrEnter) => None,
             VimCommand::ModeTransition(VimModeTransition::Append) => {
                 Some(Action::JsonbAppendInsert)
             }
@@ -27,7 +25,7 @@ pub(in crate::app::update::input::vim) fn command(
                 Some(Action::JsonbSearchPrev)
             }
             VimCommand::Operator(VimOperator::Yank) => Some(Action::JsonbYankAll),
-            VimCommand::Operator(VimOperator::Delete) => None,
+            VimCommand::Operator(VimOperator::Delete) => Some(Action::None),
         },
         JsonbDetailVimContext::Editing => match command {
             VimCommand::ModeTransition(VimModeTransition::Escape) => Some(Action::JsonbExitEdit),
@@ -73,12 +71,12 @@ mod tests {
     }
 
     #[test]
-    fn enter_opens_edit_mode() {
+    fn enter_is_ignored_in_viewing_mode() {
         let ctx = VimSurfaceContext::JsonbDetail(JsonbDetailVimContext::Viewing);
 
         let action = action_for_key(&combo(Key::Enter), ctx);
 
-        assert!(matches!(action, Some(Action::JsonbEnterEdit)));
+        assert!(action.is_none());
     }
 
     #[test]

--- a/src/app/update/input/vim/actions/jsonb.rs
+++ b/src/app/update/input/vim/actions/jsonb.rs
@@ -62,6 +62,7 @@ fn navigation_action(navigation: VimNavigation) -> Option<Action> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::model::shared::key_sequence::Prefix;
     use crate::app::update::input::keybindings::{Key, KeyCombo};
     use crate::app::update::input::vim::{VimSurfaceContext, action_for_key};
     use rstest::rstest;
@@ -115,7 +116,7 @@ mod tests {
     fn gg_moves_to_first_line() {
         let action = crate::app::update::input::vim::action_for_input(
             &combo(Key::Char('g')),
-            Some(crate::app::model::shared::key_sequence::Prefix::G),
+            Some(Prefix::G),
             VimSurfaceContext::JsonbDetail(JsonbDetailVimContext::Viewing),
         );
 

--- a/src/app/update/input/vim/actions/sql.rs
+++ b/src/app/update/input/vim/actions/sql.rs
@@ -1,3 +1,4 @@
+use crate::app::model::shared::key_sequence::Prefix;
 use crate::app::update::action::{
     Action, CursorMove, InputTarget, ScrollAmount, ScrollDirection, ScrollTarget,
 };
@@ -144,7 +145,7 @@ mod tests {
     fn gg_moves_to_first_line() {
         let action = crate::app::update::input::vim::action_for_input(
             &combo(Key::Char('g')),
-            Some(crate::app::model::shared::key_sequence::Prefix::G),
+            Some(Prefix::G),
             VimSurfaceContext::SqlModal(SqlModalVimContext::QueryNormal),
         );
 

--- a/src/app/update/input/vim/actions/sql.rs
+++ b/src/app/update/input/vim/actions/sql.rs
@@ -1,4 +1,3 @@
-use crate::app::model::shared::key_sequence::Prefix;
 use crate::app::update::action::{
     Action, CursorMove, InputTarget, ScrollAmount, ScrollDirection, ScrollTarget,
 };
@@ -77,6 +76,7 @@ fn viewer(command: VimCommand, target: ScrollTarget) -> Option<Action> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::model::shared::key_sequence::Prefix;
     use crate::app::update::input::keybindings::{Key, KeyCombo};
     use crate::app::update::input::vim::{VimSurfaceContext, action_for_key};
     use rstest::rstest;

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use crate::app::cmd::effect::Effect;
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::confirm_dialog::ConfirmIntent;
+use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::shared::input_mode::InputMode;
 use crate::app::update::action::{
     Action, InputTarget, ListMotion, ListTarget, ScrollAmount, ScrollDirection, ScrollTarget,
@@ -81,9 +82,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             state.modal.set_mode(InputMode::Normal);
             state.sql_modal.completion.visible = false;
             state.sql_modal.completion_debounce = None;
-            state
-                .flash_timers
-                .clear(crate::app::model::shared::flash_timer::FlashId::SqlModal);
+            state.flash_timers.clear(FlashId::SqlModal);
             Some(vec![])
         }
         Action::OpenErTablePicker => {

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 
 use crate::app::cmd::effect::Effect;
 use crate::app::model::app_state::AppState;
+use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::shared::input_mode::InputMode;
 use crate::app::model::shared::key_sequence::KeySequenceState;
 use crate::app::model::shared::text_input::{TextInputLike, TextInputState};
@@ -17,6 +18,7 @@ use crate::app::policy::write::sql_risk::{
 use crate::app::policy::write::write_guardrails::{
     AdhocRiskDecision, RiskLevel, evaluate_sql_risk,
 };
+use crate::app::ports::ClipboardError;
 use crate::app::update::action::{Action, CursorMove, InputTarget};
 use crate::domain::explain_plan::{ComparisonVerdict, compare_plans};
 
@@ -171,9 +173,7 @@ pub fn reduce_sql_modal(
             state.sql_modal.completion.candidates.clear();
             state.sql_modal.completion.selected_index = 0;
             state.sql_modal.completion_debounce = None;
-            state
-                .flash_timers
-                .clear(crate::app::model::shared::flash_timer::FlashId::SqlModal);
+            state.flash_timers.clear(FlashId::SqlModal);
             if !state.sql_modal.is_prefetch_started() && state.session.metadata().is_some() {
                 Some(vec![Effect::DispatchActions(vec![
                     Action::StartPrefetchAll,
@@ -419,7 +419,7 @@ pub fn reduce_sql_modal(
                 Some(c) if !c.is_empty() => Some(vec![Effect::CopyToClipboard {
                     content: c,
                     on_success: Some(Action::SqlModalYankSuccess),
-                    on_failure: Some(Action::CopyFailed(crate::app::ports::ClipboardError {
+                    on_failure: Some(Action::CopyFailed(ClipboardError {
                         message: "Clipboard unavailable".into(),
                     })),
                 }]),
@@ -427,10 +427,7 @@ pub fn reduce_sql_modal(
             }
         }
         Action::SqlModalYankSuccess => {
-            state.flash_timers.set(
-                crate::app::model::shared::flash_timer::FlashId::SqlModal,
-                now,
-            );
+            state.flash_timers.set(FlashId::SqlModal, now);
             Some(vec![])
         }
 
@@ -1250,10 +1247,7 @@ mod tests {
 
             reduce_sql_modal(&mut state, &Action::SqlModalYankSuccess, now);
 
-            assert!(state.flash_timers.is_active(
-                crate::app::model::shared::flash_timer::FlashId::SqlModal,
-                now
-            ));
+            assert!(state.flash_timers.is_active(FlashId::SqlModal, now));
         }
 
         #[test]

--- a/src/ui/event/handlers/jsonb.rs
+++ b/src/ui/event/handlers/jsonb.rs
@@ -253,6 +253,7 @@ mod tests {
 
     mod jsonb_search {
         use super::*;
+        use crate::app::model::shared::key_sequence::Prefix;
 
         #[test]
         fn ctrl_n_still_falls_through_to_search_input() {
@@ -276,6 +277,19 @@ mod tests {
                 Action::TextInput {
                     target: InputTarget::JsonbSearch,
                     ch: 'p',
+                }
+            ));
+        }
+
+        #[test]
+        fn pending_prefix_is_ignored_while_search_is_active() {
+            let result = handle_jsonb_detail_keys(combo(Key::Char('g')), true, Some(Prefix::G));
+
+            assert!(matches!(
+                result,
+                Action::TextInput {
+                    target: InputTarget::JsonbSearch,
+                    ch: 'g',
                 }
             ));
         }

--- a/src/ui/event/handlers/jsonb.rs
+++ b/src/ui/event/handlers/jsonb.rs
@@ -35,6 +35,24 @@ pub fn handle_jsonb_detail_keys(
         return Action::BeginKeySequence(Prefix::G);
     }
 
+    if !combo.modifiers.ctrl && !combo.modifiers.alt {
+        match combo.key {
+            Key::Home => {
+                return Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: CursorMove::LineStart,
+                };
+            }
+            Key::End => {
+                return Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: CursorMove::LineEnd,
+                };
+            }
+            _ => {}
+        }
+    }
+
     if let Some(action) = action_for_key(
         &combo,
         VimSurfaceContext::JsonbDetail(JsonbDetailVimContext::Viewing),
@@ -205,6 +223,32 @@ mod tests {
                 Action::TextMoveCursor {
                     target: InputTarget::JsonbEdit,
                     direction: CursorMove::Left,
+                }
+            ));
+        }
+
+        #[test]
+        fn home_moves_cursor_to_line_start_in_normal_mode() {
+            let result = handle_jsonb_detail_keys(combo(Key::Home), false, None);
+
+            assert!(matches!(
+                result,
+                Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: CursorMove::LineStart,
+                }
+            ));
+        }
+
+        #[test]
+        fn end_moves_cursor_to_line_end_in_normal_mode() {
+            let result = handle_jsonb_detail_keys(combo(Key::End), false, None);
+
+            assert!(matches!(
+                result,
+                Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: CursorMove::LineEnd,
                 }
             ));
         }

--- a/src/ui/event/handlers/jsonb.rs
+++ b/src/ui/event/handlers/jsonb.rs
@@ -1,13 +1,38 @@
+use crate::app::model::shared::key_sequence::Prefix;
 use crate::app::update::action::{Action, CursorMove, InputTarget};
 use crate::app::update::input::keybindings::{
     JSONB_DETAIL, JSONB_EDIT, JSONB_SEARCH_KEYS, Key, KeyCombo,
 };
 use crate::app::update::input::keymap;
-use crate::app::update::input::vim::{JsonbDetailVimContext, VimSurfaceContext, action_for_key};
+use crate::app::update::input::vim::{
+    JsonbDetailVimContext, VimSurfaceContext, action_for_input, action_for_key,
+};
 
-pub fn handle_jsonb_detail_keys(combo: KeyCombo, is_searching: bool) -> Action {
+pub fn handle_jsonb_detail_keys(
+    combo: KeyCombo,
+    is_searching: bool,
+    pending_prefix: Option<Prefix>,
+) -> Action {
     if is_searching {
         return handle_search_input(combo);
+    }
+
+    if let Some(prefix) = pending_prefix {
+        if combo.modifiers.ctrl || combo.modifiers.alt {
+            return Action::CancelKeySequence;
+        }
+        return match action_for_input(
+            &combo,
+            Some(prefix),
+            VimSurfaceContext::JsonbDetail(JsonbDetailVimContext::Viewing),
+        ) {
+            Some(Action::None) | None => Action::CancelKeySequence,
+            Some(action) => action,
+        };
+    }
+
+    if !combo.modifiers.ctrl && !combo.modifiers.alt && combo.key == Key::Char('g') {
+        return Action::BeginKeySequence(Prefix::G);
     }
 
     if let Some(action) = action_for_key(
@@ -136,10 +161,11 @@ mod tests {
 
     mod jsonb_detail {
         use super::*;
+        use crate::app::model::shared::key_sequence::Prefix;
 
         #[test]
         fn ctrl_n_moves_cursor_down_in_normal_mode() {
-            let result = handle_jsonb_detail_keys(combo_ctrl(Key::Char('n')), false);
+            let result = handle_jsonb_detail_keys(combo_ctrl(Key::Char('n')), false, None);
 
             assert!(matches!(
                 result,
@@ -152,7 +178,7 @@ mod tests {
 
         #[test]
         fn ctrl_p_moves_cursor_up_in_normal_mode() {
-            let result = handle_jsonb_detail_keys(combo_ctrl(Key::Char('p')), false);
+            let result = handle_jsonb_detail_keys(combo_ctrl(Key::Char('p')), false, None);
 
             assert!(matches!(
                 result,
@@ -165,14 +191,14 @@ mod tests {
 
         #[test]
         fn enter_enters_insert_mode() {
-            let result = handle_jsonb_detail_keys(combo(Key::Enter), false);
+            let result = handle_jsonb_detail_keys(combo(Key::Enter), false, None);
 
             assert!(matches!(result, Action::JsonbEnterEdit));
         }
 
         #[test]
         fn h_moves_cursor_left_in_normal_mode() {
-            let result = handle_jsonb_detail_keys(combo(Key::Char('h')), false);
+            let result = handle_jsonb_detail_keys(combo(Key::Char('h')), false, None);
 
             assert!(matches!(
                 result,
@@ -185,16 +211,43 @@ mod tests {
 
         #[test]
         fn n_moves_to_next_search_match() {
-            let result = handle_jsonb_detail_keys(combo(Key::Char('n')), false);
+            let result = handle_jsonb_detail_keys(combo(Key::Char('n')), false, None);
 
             assert!(matches!(result, Action::JsonbSearchNext));
         }
 
         #[test]
         fn upper_n_moves_to_previous_search_match() {
-            let result = handle_jsonb_detail_keys(combo(Key::Char('N')), false);
+            let result = handle_jsonb_detail_keys(combo(Key::Char('N')), false, None);
 
             assert!(matches!(result, Action::JsonbSearchPrev));
+        }
+
+        #[test]
+        fn g_begins_key_sequence() {
+            let result = handle_jsonb_detail_keys(combo(Key::Char('g')), false, None);
+
+            assert!(matches!(result, Action::BeginKeySequence(Prefix::G)));
+        }
+
+        #[test]
+        fn gg_moves_to_first_line() {
+            let result = handle_jsonb_detail_keys(combo(Key::Char('g')), false, Some(Prefix::G));
+
+            assert!(matches!(
+                result,
+                Action::TextMoveCursor {
+                    target: InputTarget::JsonbEdit,
+                    direction: CursorMove::FirstLine,
+                }
+            ));
+        }
+
+        #[test]
+        fn unknown_prefixed_key_cancels_sequence() {
+            let result = handle_jsonb_detail_keys(combo(Key::Char('x')), false, Some(Prefix::G));
+
+            assert!(matches!(result, Action::CancelKeySequence));
         }
     }
 
@@ -203,7 +256,7 @@ mod tests {
 
         #[test]
         fn ctrl_n_still_falls_through_to_search_input() {
-            let result = handle_jsonb_detail_keys(combo_ctrl(Key::Char('n')), true);
+            let result = handle_jsonb_detail_keys(combo_ctrl(Key::Char('n')), true, None);
 
             assert!(matches!(
                 result,
@@ -216,7 +269,7 @@ mod tests {
 
         #[test]
         fn ctrl_p_still_falls_through_to_search_input() {
-            let result = handle_jsonb_detail_keys(combo_ctrl(Key::Char('p')), true);
+            let result = handle_jsonb_detail_keys(combo_ctrl(Key::Char('p')), true, None);
 
             assert!(matches!(
                 result,

--- a/src/ui/event/handlers/jsonb.rs
+++ b/src/ui/event/handlers/jsonb.rs
@@ -190,10 +190,10 @@ mod tests {
         }
 
         #[test]
-        fn enter_enters_insert_mode() {
+        fn enter_is_ignored_in_viewing_mode() {
             let result = handle_jsonb_detail_keys(combo(Key::Enter), false, None);
 
-            assert!(matches!(result, Action::JsonbEnterEdit));
+            assert!(matches!(result, Action::None));
         }
 
         #[test]

--- a/src/ui/event/handlers/mod.rs
+++ b/src/ui/event/handlers/mod.rs
@@ -64,7 +64,11 @@ fn handle_key_event(combo: KeyCombo, state: &AppState) -> Action {
         InputMode::QueryHistoryPicker => pickers::handle_query_history_picker_keys(combo),
         InputMode::JsonbDetail => {
             let is_searching = state.jsonb_detail.search().active;
-            jsonb::handle_jsonb_detail_keys(combo, is_searching)
+            jsonb::handle_jsonb_detail_keys(
+                combo,
+                is_searching,
+                state.ui.key_sequence.pending_prefix(),
+            )
         }
         InputMode::JsonbEdit => jsonb::handle_jsonb_edit_keys(combo),
     }

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -7,6 +7,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Cell, Paragraph, Row, Table as RatatuiTable, Wrap};
 
 use crate::app::model::app_state::AppState;
+use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::shared::focused_pane::FocusedPane;
 use crate::app::model::shared::inspector_tab::InspectorTab;
 use crate::app::model::shared::viewport::{
@@ -674,8 +675,7 @@ impl Inspector {
         };
         let clamped_scroll_offset = clamp_scroll_offset(scroll_offset, visible_lines, total_lines);
 
-        let flash_active =
-            flash_timers.is_active(crate::app::model::shared::flash_timer::FlashId::Ddl, now);
+        let flash_active = flash_timers.is_active(FlashId::Ddl, now);
 
         let mut lines: Vec<Line> = ddl
             .lines()

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -46,7 +46,7 @@ impl JsonbDetail {
         let hint = if is_editing {
             " Esc:Normal "
         } else {
-            " y:Copy  /:Search  i/A:Insert/Append  Esc:Close "
+            " y:Copy  /:Search  i:Insert  Esc:Close "
         };
 
         let (_area, inner) = render_modal(

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -109,7 +109,7 @@ impl JsonbDetail {
             empty_placeholder: if is_editing {
                 " Enter JSON..."
             } else {
-                " Press i or A to edit..."
+                " Press i to edit..."
             },
             base_style: Style::default().fg(theme.semantic.text.primary),
             current_line_style: Style::default().bg(theme.component.editor.current_line_bg),

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -46,7 +46,7 @@ impl JsonbDetail {
         let hint = if is_editing {
             " Esc:Normal "
         } else {
-            " y:Copy  /:Search  Enter/i:Insert  Esc:Close "
+            " y:Copy  /:Search  Enter/i/A:Insert  Esc:Close "
         };
 
         let (_area, inner) = render_modal(

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -7,6 +7,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::browse::jsonb_detail::JsonbDetailMode;
+use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::shared::text_input::TextInputLike;
 use crate::ui::primitives::atoms::{
     CursorKind, ModalTextSurface, build_modal_text_surface_lines, render_modal_text_surface,
@@ -120,10 +121,7 @@ impl JsonbDetail {
             .collect();
         let mut lines = build_modal_text_surface_lines(surface, line_spans, theme);
 
-        let flash_active = state.flash_timers.is_active(
-            crate::app::model::shared::flash_timer::FlashId::JsonbDetail,
-            now,
-        );
+        let flash_active = state.flash_timers.is_active(FlashId::JsonbDetail, now);
         crate::ui::primitives::atoms::apply_yank_flash(&mut lines, flash_active, theme);
 
         render_modal_text_surface(frame, area, surface, lines);

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -46,7 +46,7 @@ impl JsonbDetail {
         let hint = if is_editing {
             " Esc:Normal "
         } else {
-            " y:Copy  /:Search  Enter/i/A:Insert  Esc:Close "
+            " y:Copy  /:Search  i/A:Insert/Append  Esc:Close "
         };
 
         let (_area, inner) = render_modal(
@@ -108,7 +108,7 @@ impl JsonbDetail {
             empty_placeholder: if is_editing {
                 " Enter JSON..."
             } else {
-                " Press Enter or i to edit..."
+                " Press i or A to edit..."
             },
             base_style: Style::default().fg(theme.semantic.text.primary),
             current_line_style: Style::default().bg(theme.component.editor.current_line_bg),

--- a/src/ui/features/sql_modal/compare.rs
+++ b/src/ui/features/sql_modal/compare.rs
@@ -8,6 +8,7 @@ use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::explain_context::CompareSlot;
+use crate::app::model::shared::flash_timer::FlashId;
 use crate::domain::explain_plan::{self, ComparisonVerdict};
 use crate::ui::theme::ThemePalette;
 
@@ -49,11 +50,7 @@ pub fn render(
     let mut visible: Vec<Line> = lines.into_iter().skip(clamped).collect();
     let visible_mask: Vec<bool> = flash_mask.into_iter().skip(clamped).collect();
 
-    let flash_active = can_yank
-        && state.flash_timers.is_active(
-            crate::app::model::shared::flash_timer::FlashId::SqlModal,
-            now,
-        );
+    let flash_active = can_yank && state.flash_timers.is_active(FlashId::SqlModal, now);
     crate::ui::primitives::atoms::apply_yank_flash_masked(
         &mut visible,
         flash_active,

--- a/src/ui/features/sql_modal/editor.rs
+++ b/src/ui/features/sql_modal/editor.rs
@@ -7,6 +7,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::model::app_state::AppState;
+use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::shared::text_input::TextInputLike;
 use crate::app::model::sql_editor::modal::SqlModalStatus;
 use crate::ui::primitives::atoms::{
@@ -76,10 +77,7 @@ pub(super) fn render_editor(
     let line_spans = highlight_sql_spans(content, theme);
     let mut lines = build_modal_text_surface_lines(surface, line_spans, theme);
 
-    let flash_active = state.flash_timers.is_active(
-        crate::app::model::shared::flash_timer::FlashId::SqlModal,
-        now,
-    );
+    let flash_active = state.flash_timers.is_active(FlashId::SqlModal, now);
     crate::ui::primitives::atoms::apply_yank_flash(&mut lines, flash_active, theme);
 
     render_modal_text_surface(frame, area, surface, lines);

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -7,6 +7,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::model::app_state::AppState;
+use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::sql_editor::modal::{HIGH_RISK_INPUT_VISIBLE_WIDTH, SqlModalStatus};
 use crate::ui::primitives::atoms::text_cursor_spans;
 use crate::ui::theme::ThemePalette;
@@ -85,10 +86,7 @@ pub fn render(
                 .map(|line| super::plan_highlight::highlight_plan_line(line, theme)),
         );
 
-        let flash_active = state.flash_timers.is_active(
-            crate::app::model::shared::flash_timer::FlashId::SqlModal,
-            now,
-        );
+        let flash_active = state.flash_timers.is_active(FlashId::SqlModal, now);
         let content_start = 3; // skip header, query snippet, empty line
         crate::ui::primitives::atoms::apply_yank_flash(
             &mut lines[content_start..],

--- a/tests/render_snapshots/snapshots/render_snapshots__result_pane__result_pane_jsonb_detail_mode.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__result_pane__result_pane_jsonb_detail_mode.snap
@@ -21,7 +21,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │                                                              │       │
 │       │✓ Valid JSON                                                  │       │
-│       ╰ y:Copy  /:Search  i/A:Insert/Append  Esc:Close ──────────────╯       │
+│       ╰ y:Copy  /:Search  i:Insert  Esc:Close ───────────────────────╯       │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-y:Copy  i/A:Insert/Append  /:Search  n/N:Next/Prev  hjkl/↑↓←→:Move  Esc:Close
+y:Copy  i:Insert  /:Search  n/N:Next/Prev  hjkl/↑↓←→:Move  Esc:Close

--- a/tests/render_snapshots/snapshots/render_snapshots__result_pane__result_pane_jsonb_detail_mode.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__result_pane__result_pane_jsonb_detail_mode.snap
@@ -21,7 +21,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │                                                              │       │
 │       │✓ Valid JSON                                                  │       │
-│       ╰ y:Copy  /:Search  Enter/i/A:Insert  Esc:Close ───────────────╯       │
+│       ╰ y:Copy  /:Search  i/A:Insert/Append  Esc:Close ──────────────╯       │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-y:Copy  Enter/i/A:Insert  /:Search  n/N:Next/Prev  hjkl/↑↓←→:Move  Esc:Close
+y:Copy  i/A:Insert/Append  /:Search  n/N:Next/Prev  hjkl/↑↓←→:Move  Esc:Close

--- a/tests/render_snapshots/snapshots/render_snapshots__result_pane__result_pane_jsonb_detail_mode.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__result_pane__result_pane_jsonb_detail_mode.snap
@@ -21,7 +21,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │                                                              │       │
 │       │✓ Valid JSON                                                  │       │
-│       ╰ y:Copy  /:Search  Enter/i:Insert  Esc:Close ─────────────────╯       │
+│       ╰ y:Copy  /:Search  Enter/i/A:Insert  Esc:Close ───────────────╯       │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-y:Copy  Enter/i:Insert  /:Search  n/N:Next/Prev  hjkl/↑↓←→:Move  Esc:Close
+y:Copy  Enter/i/A:Insert  /:Search  n/N:Next/Prev  hjkl/↑↓←→:Move  Esc:Close


### PR DESCRIPTION
## Problem
JSONB detail needed a more usable navigation and edit contract: Vim-style movement and append insert were missing, and the modal still exposed an Enter-based edit shortcut that we no longer want.

## Background
This is a feature addition for the JSONB detail modal, not a correction for a broken mode. The goal is to make the viewer easier to inspect and edit with a smaller, explicit shortcut set.

## Approach
Scope: JSONB detail modal input handling, reducer behavior, and the user-facing hints. Add Vim-style navigation and append insert, keep search/editing behavior intact, remove the Enter shortcut, and align the hint text and tests with the resulting contract.
