### PR TITLE
feat: restore Ctrl+P as Table Picker trigger on main screen

### DIFF
--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -367,16 +367,6 @@ pub fn is_help(combo: &KeyCombo) -> bool {
     GLOBAL_KEYS[idx::global::HELP].combos.contains(combo)
 }
 
-pub fn is_table_picker(combo: &KeyCombo) -> bool {
-    GLOBAL_KEYS[idx::global::TABLE_PICKER]
-        .combos
-        .contains(combo)
-}
-
-pub fn is_command_palette(combo: &KeyCombo) -> bool {
-    GLOBAL_KEYS[idx::global::PALETTE].combos.contains(combo)
-}
-
 pub fn is_command_line(combo: &KeyCombo) -> bool {
     GLOBAL_KEYS[idx::global::COMMAND_LINE]
         .combos
@@ -397,20 +387,6 @@ pub fn is_open_sql(combo: &KeyCombo) -> bool {
 
 pub fn is_open_er(combo: &KeyCombo) -> bool {
     GLOBAL_KEYS[idx::global::ER_DIAGRAM].combos.contains(combo)
-}
-
-pub fn is_csv_export(combo: &KeyCombo) -> bool {
-    GLOBAL_KEYS[idx::global::CSV_EXPORT].combos.contains(combo)
-}
-
-pub fn is_read_only_toggle(combo: &KeyCombo) -> bool {
-    GLOBAL_KEYS[idx::global::READ_ONLY].combos.contains(combo)
-}
-
-pub fn is_query_history(combo: &KeyCombo) -> bool {
-    GLOBAL_KEYS[idx::global::QUERY_HISTORY]
-        .combos
-        .contains(combo)
 }
 
 #[cfg(test)]

--- a/src/app/update/input/keybindings/normal.rs
+++ b/src/app/update/input/keybindings/normal.rs
@@ -24,12 +24,12 @@ pub const GLOBAL_KEYS: &[KeyBinding] = &[
         combos: &[KeyCombo::plain(Key::Char('?'))],
     },
     KeyBinding {
-        key_short: "p",
-        key: "p",
+        key_short: "^P",
+        key: "Ctrl+P",
         desc_short: "Tables",
         description: "Open Table Picker",
         action: Action::OpenTablePicker,
-        combos: &[KeyCombo::plain(Key::Char('p'))],
+        combos: &[KeyCombo::ctrl(Key::Char('p'))],
     },
     KeyBinding {
         key_short: "^K",
@@ -151,16 +151,16 @@ pub const GLOBAL_KEYS: &[KeyBinding] = &[
 
 pub const NAVIGATION_KEYS: &[KeyBinding] = &[
     KeyBinding {
-        key_short: "^N/j/↓",
-        key: "Ctrl+N / j / ↓",
+        key_short: "j/↓",
+        key: "j / ↓",
         desc_short: "Down",
         description: "Move down / scroll",
         action: Action::None,
         combos: &[],
     },
     KeyBinding {
-        key_short: "^P/k/↑",
-        key: "Ctrl+P / k / ↑",
+        key_short: "k/↑",
+        key: "k / ↑",
         desc_short: "Up",
         description: "Move up / scroll",
         action: Action::None,
@@ -258,16 +258,16 @@ pub const NAVIGATION_KEYS: &[KeyBinding] = &[
 
 pub const FOOTER_NAV_KEYS: &[KeyBinding] = &[
     KeyBinding {
-        key_short: "^N/j/↓",
-        key: "Ctrl+N / j / ↓",
+        key_short: "j/↓",
+        key: "j / ↓",
         desc_short: "Scroll",
         description: "Move down/up",
         action: Action::None,
         combos: &[],
     },
     KeyBinding {
-        key_short: "^P/k/↑",
-        key: "Ctrl+P / k / ↑",
+        key_short: "k/↑",
+        key: "k / ↑",
         desc_short: "Scroll",
         description: "Move down/up",
         action: Action::None,

--- a/src/app/update/input/vim/classify.rs
+++ b/src/app/update/input/vim/classify.rs
@@ -57,6 +57,9 @@ fn navigation(combo: &KeyCombo) -> Option<VimNavigation> {
 
     if combo.modifiers.ctrl {
         return match combo.key {
+            // NOTE: Ctrl+N/P are intercepted on the main screen (handlers/normal.rs)
+            // and mapped to OpenTablePicker / None. These entries are only reached
+            // from modal contexts (SQL Modal Plan/Compare, JSONB Detail via vim dispatch).
             Key::Char('n') => Some(VimNavigation::MoveDown),
             Key::Char('p') => Some(VimNavigation::MoveUp),
             Key::Char('d') => Some(VimNavigation::HalfPageDown),

--- a/src/ui/event/handlers/normal.rs
+++ b/src/ui/event/handlers/normal.rs
@@ -40,6 +40,14 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
             Key::Char('e') if state.can_request_csv_export() => {
                 return Action::RequestCsvExport;
             }
+            Key::Char('p') if !state.query.is_history_mode() => {
+                return Action::OpenTablePicker;
+            }
+            // Ctrl+N/P navigation disabled on main screen; use j/k or arrows.
+            // Modals/pickers handle Ctrl+N/P independently via their own bindings.
+            Key::Char('n' | 'p') => {
+                return Action::None;
+            }
             _ => {
                 if let Some(action) = action_for_key(&combo, VimSurfaceContext::Browse(browse_ctx))
                 {
@@ -151,7 +159,6 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
         {
             Action::ResultCellYank
         }
-        Key::Char('p') => Action::OpenTablePicker,
         Key::Char('s') => Action::OpenSqlModal,
         Key::Char('e') => Action::OpenErTablePicker,
         Key::Char('c') if state.ui.focused_pane == FocusedPane::Explorer => {
@@ -214,12 +221,21 @@ mod tests {
             use super::*;
 
             #[test]
-            fn p_opens_table_picker() {
+            fn ctrl_p_opens_table_picker() {
+                let state = browse_state();
+
+                let result = handle_normal_mode(combo_ctrl(Key::Char('p')), &state);
+
+                assert!(matches!(result, Action::OpenTablePicker));
+            }
+
+            #[test]
+            fn plain_p_is_noop() {
                 let state = browse_state();
 
                 let result = handle_normal_mode(combo(Key::Char('p')), &state);
 
-                assert!(matches!(result, Action::OpenTablePicker));
+                assert!(matches!(result, Action::None));
             }
 
             #[test]
@@ -321,21 +337,12 @@ mod tests {
             }
 
             #[test]
-            fn ctrl_n_selects_next_when_explorer_focused() {
+            fn ctrl_n_is_noop_on_main_screen() {
                 let state = browse_state();
 
                 let result = handle_normal_mode(combo_ctrl(Key::Char('n')), &state);
 
-                assert!(matches!(result, Action::Select(SelectMotion::Next)));
-            }
-
-            #[test]
-            fn ctrl_p_selects_previous_when_explorer_focused() {
-                let state = browse_state();
-
-                let result = handle_normal_mode(combo_ctrl(Key::Char('p')), &state);
-
-                assert!(matches!(result, Action::Select(SelectMotion::Previous)));
+                assert!(matches!(result, Action::None));
             }
 
             #[rstest]
@@ -583,19 +590,12 @@ mod tests {
             }
 
             #[test]
-            fn ctrl_p_scrolls_up() {
+            fn ctrl_p_opens_table_picker_from_inspector() {
                 let state = inspector_focused_state();
 
                 let result = handle_normal_mode(combo_ctrl(Key::Char('p')), &state);
 
-                assert!(matches!(
-                    result,
-                    Action::Scroll {
-                        target: ScrollTarget::Inspector,
-                        direction: ScrollDirection::Up,
-                        amount: ScrollAmount::Line
-                    }
-                ));
+                assert!(matches!(result, Action::OpenTablePicker));
             }
 
             #[rstest]
@@ -1247,7 +1247,7 @@ mod tests {
                 }
 
                 #[test]
-                fn ctrl_p_and_ctrl_n_scroll() {
+                fn ctrl_p_and_ctrl_n_are_noop_in_history() {
                     let mut state = state_with_history(3);
                     state.query.enter_history(1);
                     state.ui.focus_mode = FocusMode::focused(FocusedPane::Explorer);
@@ -1255,22 +1255,8 @@ mod tests {
                     let prev = handle_normal_mode(combo_ctrl(Key::Char('p')), &state);
                     let next = handle_normal_mode(combo_ctrl(Key::Char('n')), &state);
 
-                    assert!(matches!(
-                        prev,
-                        Action::Scroll {
-                            target: ScrollTarget::Result,
-                            direction: ScrollDirection::Up,
-                            amount: ScrollAmount::Line
-                        }
-                    ));
-                    assert!(matches!(
-                        next,
-                        Action::Scroll {
-                            target: ScrollTarget::Result,
-                            direction: ScrollDirection::Down,
-                            amount: ScrollAmount::Line
-                        }
-                    ));
+                    assert!(matches!(prev, Action::None));
+                    assert!(matches!(next, Action::None));
                 }
 
                 #[test]

--- a/src/ui/event/handlers/normal.rs
+++ b/src/ui/event/handlers/normal.rs
@@ -44,7 +44,10 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
                 return Action::OpenTablePicker;
             }
             // Ctrl+N/P navigation disabled on main screen; use j/k or arrows.
-            // Modals/pickers handle Ctrl+N/P independently via their own bindings.
+            // Modals/pickers handle Ctrl+N/P via their own bindings.
+            // NOTE: vim/classify.rs still maps Ctrl+N/P → MoveDown/MoveUp for
+            // modal contexts (SQL Modal Plan/Compare). This catch-all prevents
+            // that mapping from reaching the main screen.
             Key::Char('n' | 'p') => {
                 return Action::None;
             }

--- a/tests/render_snapshots/snapshots/render_snapshots__connection_flow__footer_shows_success_message.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__connection_flow__footer_shows_success_message.snap
@@ -24,4 +24,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-✓ Reconnected!  r:Reload  s:SQL  e:ER Diagram  c:Connections  p:Tables  ^O:Histo
+✓ Reconnected!  r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:Hist

--- a/tests/render_snapshots/snapshots/render_snapshots__initial_state__explorer_shows_not_connected_when_no_active_connection.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__initial_state__explorer_shows_not_connected_when_no_active_connection.snap
@@ -24,4 +24,4 @@ test_project | - | - | no dsn | -
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  p:Tables  ^O:History  ^R:Read-Only
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Onl

--- a/tests/render_snapshots/snapshots/render_snapshots__initial_state__initial_state_no_metadata.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__initial_state__initial_state_no_metadata.snap
@@ -24,4 +24,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  p:Tables  ^O:History  ^R:Read-Only
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Onl

--- a/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
@@ -24,4 +24,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  p:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab

--- a/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_indexes_tab_with_data.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_indexes_tab_with_data.snap
@@ -24,4 +24,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  p:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab

--- a/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_info_tab_shows_owner_and_comment.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_info_tab_shows_owner_and_comment.snap
@@ -24,4 +24,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  p:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab

--- a/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_info_tab_with_no_metadata.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_info_tab_with_no_metadata.snap
@@ -24,4 +24,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  p:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab

--- a/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_triggers_tab_empty.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_triggers_tab_empty.snap
@@ -24,4 +24,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  p:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab

--- a/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_triggers_tab_with_data.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__inspector__inspector_triggers_tab_with_data.snap
@@ -24,4 +24,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  p:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab

--- a/tests/render_snapshots/snapshots/render_snapshots__overlays__command_palette_overlay.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__overlays__command_palette_overlay.snap
@@ -11,7 +11,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  │╭ Command Palette ─────────────────────╮                   │
 │                  ││  q                  Quit application │                   │
 │                  ││  ?                  Toggle help      │                   │
-│                  ││  p                  Open Table Picker│                   │
+│                  ││  Ctrl+P             Open Table Picker│                   │
 │                  ││  f                  Toggle Focus mode│                   │
 │                  ││  r                  Reload metadata  │───────────────────┘
 │                  ││  s                  Open SQL Editor  │───────────────────┐

--- a/tests/render_snapshots/snapshots/render_snapshots__overlays__help_overlay.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__overlays__help_overlay.snap
@@ -8,7 +8,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │  public.po│▸ Global Keys                                        ▲│           │
 │  public.co│  q                   Quit application               ┃│           │
 │           │  ?                   Toggle help                    ││           │
-│           │  p                   Open Table Picker              ││           │
+│           │  Ctrl+P              Open Table Picker              ││           │
 │           │  Ctrl+K              Open Command Palette           ││           │
 │           │  :                   Enter command line             ││           │
 │           │  f                   Toggle Focus                   ││           │

--- a/tests/render_snapshots/snapshots/render_snapshots__result_history__preview_with_history_hint.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__result_history__preview_with_history_hint.snap
@@ -24,4 +24,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  p:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:E
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:

--- a/tests/render_snapshots/snapshots/render_snapshots__result_history__result_query_with_history_hint.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__result_history__result_query_with_history_hint.snap
@@ -24,4 +24,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  p:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:E
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:

--- a/tests/render_snapshots/snapshots/render_snapshots__table_explorer__empty_query_result.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__table_explorer__empty_query_result.snap
@@ -24,4 +24,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  p:Tables  ^O:History  ^R:Read-Only
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Onl

--- a/tests/render_snapshots/snapshots/render_snapshots__table_explorer__focus_on_result_pane.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__table_explorer__focus_on_result_pane.snap
@@ -24,4 +24,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  p:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:E
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:

--- a/tests/render_snapshots/snapshots/render_snapshots__table_explorer__table_selection_with_preview.snap
+++ b/tests/render_snapshots/snapshots/render_snapshots__table_explorer__table_selection_with_preview.snap
@@ -24,4 +24,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  p:Tables  ^O:History  ^R:Read-Only
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Onl


### PR DESCRIPTION
## Problem

`Ctrl+P` is a well-established convention across major editors (VS Code, Sublime Text, JetBrains) for "find and open something." Users instinctively reach for `Ctrl+P` when searching for a table — but it didn't work, because it had been reassigned to a navigation alias.

## Background

In #303, I over-eagerly extended Vim-like Ctrl+N/P navigation to the entire app, including the main screen where `j/k/↑/↓` already covered the same motion. To avoid collision, Table Picker was moved from `Ctrl+P` to plain `p`. Sorry about that — I didn't think through the UX trade-off carefully enough. 🙏

Restoring `Ctrl+P` for Table Picker aligns with the convention established by VS Code (`Ctrl+P` = Quick Open), Sublime Text, and JetBrains IDEs, where `Ctrl+P` universally means "find and open a resource."

## Scope

- **Main screen**: Restore `Ctrl+P` → Table Picker. Disable Ctrl+N/P navigation (j/k/arrows remain).
- **Modals/pickers**: No change. Ctrl+N/P navigation stays (needed where j/k are consumed by filter input).
- **Dead code**: Remove unused keybinding predicate functions (`is_table_picker`, `is_command_palette`, etc.).
- **Out of scope**: Broader keybinding consistency audit tracked in SAB-202.

## Approach

Intercept Ctrl+N/P in the main screen handler before they reach the vim navigation layer, which still classifies them as movement for modal contexts (SQL Plan/Compare tabs). This avoids touching the shared vim dispatch while cleanly separating main screen and modal behavior.

**Breaking change**: Users relying on Ctrl+N/P for main screen navigation must use `j/k` or arrow keys instead.