### PR TITLE
refactor: migrate layer-boundary type conversions to From/TryFrom

### DIFF
--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -188,7 +188,7 @@ pub(crate) async fn run(
         Effect::SwitchToService { service_index } => {
             if let Some(entry) = state.service_entries().get(service_index) {
                 let id = entry.connection_id();
-                let dsn = entry.to_dsn();
+                let dsn = String::from(entry);
                 let name = entry.display_name().to_owned();
                 action_tx
                     .send(Action::SwitchConnection(ConnectionTarget { id, dsn, name }))

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -188,7 +188,7 @@ pub(crate) async fn run(
         Effect::SwitchToService { service_index } => {
             if let Some(entry) = state.service_entries().get(service_index) {
                 let id = entry.connection_id();
-                let dsn = String::from(entry);
+                let dsn = entry.to_string();
                 let name = entry.display_name().to_owned();
                 action_tx
                     .send(Action::SwitchConnection(ConnectionTarget { id, dsn, name }))

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -175,7 +175,13 @@ impl ConnectionSetupState {
         !self.validation_errors.is_empty()
     }
 
-    pub fn from_profile(profile: &ConnectionProfile) -> Self {
+    pub fn is_edit_mode(&self) -> bool {
+        self.editing_id.is_some()
+    }
+}
+
+impl From<&ConnectionProfile> for ConnectionSetupState {
+    fn from(profile: &ConnectionProfile) -> Self {
         let name_len = profile.name.as_str().chars().count();
         let host_len = profile.host.chars().count();
         let port_str = profile.port.to_string();
@@ -197,10 +203,6 @@ impl ConnectionSetupState {
             is_first_run: false,
             editing_id: Some(profile.id.clone()),
         }
-    }
-
-    pub fn is_edit_mode(&self) -> bool {
-        self.editing_id.is_some()
     }
 }
 
@@ -338,7 +340,7 @@ mod tests {
             )
             .unwrap();
 
-            let state = ConnectionSetupState::from_profile(&profile);
+            let state = ConnectionSetupState::from(&profile);
 
             assert_eq!(state.name.content(), "Test DB");
             assert_eq!(state.host.content(), "db.example.com");
@@ -369,7 +371,7 @@ mod tests {
                 SslMode::Prefer,
             )
             .unwrap();
-            let state = ConnectionSetupState::from_profile(&profile);
+            let state = ConnectionSetupState::from(&profile);
             assert!(state.is_edit_mode());
         }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -23,7 +23,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         }
         Action::ConnectionEditLoaded(profile) => {
             state.connection_setup =
-                crate::app::model::connection::setup::ConnectionSetupState::from_profile(profile);
+                crate::app::model::connection::setup::ConnectionSetupState::from(&**profile);
             state.modal.set_mode(InputMode::ConnectionSetup);
             Some(vec![])
         }

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -2,7 +2,9 @@ use std::time::Instant;
 
 use crate::app::cmd::effect::Effect;
 use crate::app::model::app_state::AppState;
-use crate::app::model::connection::setup::{CONNECTION_INPUT_VISIBLE_WIDTH, ConnectionField};
+use crate::app::model::connection::setup::{
+    CONNECTION_INPUT_VISIBLE_WIDTH, ConnectionField, ConnectionSetupState,
+};
 use crate::app::model::shared::input_mode::InputMode;
 use crate::app::update::action::{Action, ConnectionTarget, InputTarget};
 use crate::app::update::helpers::{validate_all, validate_field};
@@ -22,8 +24,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             Some(vec![Effect::LoadConnectionForEdit { id: id.clone() }])
         }
         Action::ConnectionEditLoaded(profile) => {
-            state.connection_setup =
-                crate::app::model::connection::setup::ConnectionSetupState::from(&**profile);
+            state.connection_setup = ConnectionSetupState::from(&**profile);
             state.modal.set_mode(InputMode::ConnectionSetup);
             Some(vec![])
         }

--- a/src/app/update/input/vim/types.rs
+++ b/src/app/update/input/vim/types.rs
@@ -84,7 +84,17 @@ pub struct ResultVimContext {
 }
 
 impl BrowseVimContext {
-    pub fn from_state(state: &AppState) -> Self {
+    pub fn is_result(self) -> bool {
+        matches!(self, Self::Result(_))
+    }
+
+    pub fn is_inspector(self) -> bool {
+        matches!(self, Self::Inspector(_))
+    }
+}
+
+impl From<&AppState> for BrowseVimContext {
+    fn from(state: &AppState) -> Self {
         let result_nav = state.ui.is_focus_mode() || state.ui.focused_pane == FocusedPane::Result;
 
         if result_nav {
@@ -106,14 +116,6 @@ impl BrowseVimContext {
         } else {
             Self::Explorer
         }
-    }
-
-    pub fn is_result(self) -> bool {
-        matches!(self, Self::Result(_))
-    }
-
-    pub fn is_inspector(self) -> bool {
-        matches!(self, Self::Inspector(_))
     }
 }
 
@@ -145,7 +147,7 @@ mod tests {
         state.result_interaction.yank_op_pending = true;
         state.result_interaction.delete_op_pending = true;
 
-        let BrowseVimContext::Result(result_ctx) = BrowseVimContext::from_state(&state) else {
+        let BrowseVimContext::Result(result_ctx) = BrowseVimContext::from(&state) else {
             panic!("expected result context");
         };
 

--- a/src/domain/connection/service_entry.rs
+++ b/src/domain/connection/service_entry.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use super::ConnectionId;
 
 const SERVICE_ID_PREFIX: &str = "service:";
@@ -21,9 +23,9 @@ impl ServiceEntry {
     }
 }
 
-impl From<&ServiceEntry> for String {
-    fn from(entry: &ServiceEntry) -> Self {
-        format!("service={}", entry.service_name)
+impl fmt::Display for ServiceEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "service={}", self.service_name)
     }
 }
 
@@ -42,8 +44,8 @@ mod tests {
     }
 
     #[test]
-    fn to_dsn_formats_correctly() {
-        assert_eq!(String::from(&sample()), "service=mydb");
+    fn formats_service_dsn_correctly() {
+        assert_eq!(sample().to_string(), "service=mydb");
     }
 
     #[test]

--- a/src/domain/connection/service_entry.rs
+++ b/src/domain/connection/service_entry.rs
@@ -12,16 +12,18 @@ pub struct ServiceEntry {
 }
 
 impl ServiceEntry {
-    pub fn to_dsn(&self) -> String {
-        format!("service={}", self.service_name)
-    }
-
     pub fn connection_id(&self) -> ConnectionId {
         ConnectionId::from_string(format!("{}{}", SERVICE_ID_PREFIX, self.service_name))
     }
 
     pub fn display_name(&self) -> &str {
         &self.service_name
+    }
+}
+
+impl From<&ServiceEntry> for String {
+    fn from(entry: &ServiceEntry) -> Self {
+        format!("service={}", entry.service_name)
     }
 }
 
@@ -41,7 +43,7 @@ mod tests {
 
     #[test]
     fn to_dsn_formats_correctly() {
-        assert_eq!(sample().to_dsn(), "service=mydb");
+        assert_eq!(String::from(&sample()), "service=mydb");
     }
 
     #[test]

--- a/src/infra/adapters/connection_store.rs
+++ b/src/infra/adapters/connection_store.rs
@@ -36,7 +36,7 @@ impl TomlConnectionStore {
                 .map_err(|e| ConnectionStoreError::IoError(e.to_string()))?;
         }
 
-        let config = ConnectionConfigFile::from_profiles(profiles);
+        let config = ConnectionConfigFile::from(profiles);
         let content = toml::to_string_pretty(&config)
             .map_err(|e| ConnectionStoreError::WriteError(e.to_string()))?;
 

--- a/src/infra/adapters/connection_store.rs
+++ b/src/infra/adapters/connection_store.rs
@@ -101,8 +101,7 @@ impl ConnectionStore for TomlConnectionStore {
         let config: ConnectionConfigFile = toml::from_str(&content)
             .map_err(|e| ConnectionStoreError::InvalidFormat(e.to_string()))?;
 
-        config
-            .to_profiles()
+        Vec::<ConnectionProfile>::try_from(&config)
             .map_err(|e| ConnectionStoreError::InvalidFormat(e.to_string()))
     }
 

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -29,8 +29,8 @@ pub struct ConnectionConfigEntry {
     pub ssl_mode: SslMode,
 }
 
-impl ConnectionConfigFile {
-    pub fn from_profiles(profiles: &[ConnectionProfile]) -> Self {
+impl From<&[ConnectionProfile]> for ConnectionConfigFile {
+    fn from(profiles: &[ConnectionProfile]) -> Self {
         Self {
             version: CURRENT_VERSION,
             connections: profiles
@@ -48,7 +48,9 @@ impl ConnectionConfigFile {
                 .collect(),
         }
     }
+}
 
+impl ConnectionConfigFile {
     pub fn to_profiles(&self) -> Result<Vec<ConnectionProfile>, ConnectionNameError> {
         self.connections
             .iter()

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -50,9 +50,12 @@ impl From<&[ConnectionProfile]> for ConnectionConfigFile {
     }
 }
 
-impl ConnectionConfigFile {
-    pub fn to_profiles(&self) -> Result<Vec<ConnectionProfile>, ConnectionNameError> {
-        self.connections
+impl TryFrom<&ConnectionConfigFile> for Vec<ConnectionProfile> {
+    type Error = ConnectionNameError;
+
+    fn try_from(config: &ConnectionConfigFile) -> Result<Self, Self::Error> {
+        config
+            .connections
             .iter()
             .map(|entry| {
                 Ok(ConnectionProfile {

--- a/src/ui/event/handlers/normal.rs
+++ b/src/ui/event/handlers/normal.rs
@@ -14,7 +14,7 @@ use crate::app::model::connection::error::ConnectionErrorInfo;
 use crate::app::model::shared::ui_state::FocusMode;
 
 pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
-    let browse_ctx = BrowseVimContext::from_state(state);
+    let browse_ctx = BrowseVimContext::from(state);
     let result_navigation = browse_ctx.is_result();
     let inspector_navigation = browse_ctx.is_inspector();
 


### PR DESCRIPTION
## Problem

Layer-boundary type conversions were implemented as hand-written `from_xxx` / `to_xxx` inherent methods rather than standard Rust trait contracts, leaving call sites verbose and conversion intent implicit.

## Scope

All single-argument, pure, side-effect-free conversions across `src/`. Conversions requiring multiple arguments or external context are construction — not conversion — and are left as-is. `ConnectionId::from_string` and `FocusedPane::from_browse_key` were also excluded: the former cannot be expressed as a `From` impl due to the `impl Into<String>` bound; the latter would force a meaningless `Error = ()` on `TryFrom`.

## Approach

Replaced eligible conversions with `From`/`TryFrom` impls and deleted the originals. `ServiceEntry`'s DSN representation uses `Display` rather than `From<&Self> for String`, since `Display` is the Rust idiom for text representation and preserves room for alternative formats.