### PR TITLE
refactor: unify infra adapter error conversion with #[from]

### DIFF
--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -332,9 +332,10 @@ mod tests {
         async fn error_returns_empty_connections_list() {
             let mut mock_store = MockConnectionStore::new();
             mock_store.expect_load_all().once().returning(|| {
-                Err(ConnectionStoreError::Io(std::sync::Arc::new(
-                    std::io::Error::new(std::io::ErrorKind::NotFound, "file not found"),
-                )))
+                Err(ConnectionStoreError::Io(Arc::new(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "file not found",
+                ))))
             });
 
             let cache = TtlCache::new(300);

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -332,9 +332,9 @@ mod tests {
         async fn error_returns_empty_connections_list() {
             let mut mock_store = MockConnectionStore::new();
             mock_store.expect_load_all().once().returning(|| {
-                Err(ConnectionStoreError::ReadError(
-                    "file not found".to_string(),
-                ))
+                Err(ConnectionStoreError::Io(std::sync::Arc::new(
+                    std::io::Error::new(std::io::ErrorKind::NotFound, "file not found"),
+                )))
             });
 
             let cache = TtlCache::new(300);

--- a/src/app/cmd/utility.rs
+++ b/src/app/cmd/utility.rs
@@ -81,9 +81,9 @@ mod tests {
         fn failing(error: &str) -> Self {
             Self {
                 opened: Mutex::new(vec![]),
-                result: Err(FolderOpenError {
-                    message: error.to_string(),
-                }),
+                result: Err(FolderOpenError::Spawn(Arc::new(std::io::Error::other(
+                    error,
+                )))),
             }
         }
     }
@@ -128,9 +128,7 @@ mod tests {
         async fn on_failure_dispatched_when_copy_fails() {
             let (tx, mut rx) = mpsc::channel(8);
             let clipboard: Arc<dyn ClipboardWriter> = Arc::new(MockClipboard {
-                result: Err(ClipboardError {
-                    message: "clipboard error".to_string(),
-                }),
+                result: Err(ClipboardError::Unavailable("clipboard error".to_string())),
             });
             let folder_opener: Arc<dyn FolderOpener> = Arc::new(MockFolderOpener::new());
 
@@ -158,9 +156,7 @@ mod tests {
         async fn copy_failed_dispatched_when_no_on_failure() {
             let (tx, mut rx) = mpsc::channel(8);
             let clipboard: Arc<dyn ClipboardWriter> = Arc::new(MockClipboard {
-                result: Err(ClipboardError {
-                    message: "clipboard error".to_string(),
-                }),
+                result: Err(ClipboardError::Unavailable("clipboard error".to_string())),
             });
             let folder_opener: Arc<dyn FolderOpener> = Arc::new(MockFolderOpener::new());
 
@@ -182,7 +178,7 @@ mod tests {
                 .expect("action timeout")
                 .expect("channel closed");
             match action {
-                Action::CopyFailed(e) => assert_eq!(e.message, "clipboard error"),
+                Action::CopyFailed(e) => assert_eq!(e.to_string(), "clipboard error"),
                 other => panic!("expected CopyFailed, got {other:?}"),
             }
         }
@@ -238,7 +234,7 @@ mod tests {
                 .expect("channel closed");
             match action {
                 Action::OpenFolderFailed(e) => {
-                    assert_eq!(e.message, "No such file or directory");
+                    assert_eq!(e.to_string(), "No such file or directory");
                 }
                 other => panic!("expected OpenFolderFailed, got {other:?}"),
             }

--- a/src/app/ports/clipboard.rs
+++ b/src/app/ports/clipboard.rs
@@ -1,7 +1,17 @@
+use std::sync::Arc;
+
 #[derive(Debug, Clone, thiserror::Error)]
-#[error("{message}")]
-pub struct ClipboardError {
-    pub message: String,
+pub enum ClipboardError {
+    #[error("{0}")]
+    Backend(Arc<arboard::Error>),
+    #[error("{0}")]
+    Unavailable(String),
+}
+
+impl From<arboard::Error> for ClipboardError {
+    fn from(e: arboard::Error) -> Self {
+        Self::Backend(Arc::new(e))
+    }
 }
 
 pub trait ClipboardWriter: Send + Sync {

--- a/src/app/ports/clipboard.rs
+++ b/src/app/ports/clipboard.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ClipboardError {
     #[error("{0}")]
-    Backend(Arc<arboard::Error>),
+    Backend(#[source] Arc<arboard::Error>),
     #[error("{0}")]
     Unavailable(String),
 }

--- a/src/app/ports/connection_store.rs
+++ b/src/app/ports/connection_store.rs
@@ -8,13 +8,13 @@ pub enum ConnectionStoreError {
     #[error("Config version mismatch: found {found}, expected {expected}")]
     VersionMismatch { found: u32, expected: u32 },
     #[error("IO error: {0}")]
-    Io(Arc<std::io::Error>),
+    Io(#[source] Arc<std::io::Error>),
     #[error("TOML serialize error: {0}")]
-    TomlSerialize(Arc<toml::ser::Error>),
+    TomlSerialize(#[source] Arc<toml::ser::Error>),
     #[error("TOML deserialize error: {0}")]
-    TomlDeserialize(Arc<toml::de::Error>),
+    TomlDeserialize(#[source] Arc<toml::de::Error>),
     #[error("Invalid profile: {0}")]
-    InvalidProfile(ConnectionNameError),
+    InvalidProfile(#[source] ConnectionNameError),
     #[error("Connection name already exists: {0}")]
     DuplicateName(String),
     #[error("Connection not found: {0}")]

--- a/src/app/ports/connection_store.rs
+++ b/src/app/ports/connection_store.rs
@@ -1,23 +1,42 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
-use crate::domain::connection::{ConnectionId, ConnectionProfile};
+use crate::domain::connection::{ConnectionId, ConnectionNameError, ConnectionProfile};
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ConnectionStoreError {
     #[error("Config version mismatch: found {found}, expected {expected}")]
     VersionMismatch { found: u32, expected: u32 },
-    #[error("Read error: {0}")]
-    ReadError(String),
-    #[error("Write error: {0}")]
-    WriteError(String),
-    #[error("Invalid format: {0}")]
-    InvalidFormat(String),
     #[error("IO error: {0}")]
-    IoError(String),
+    Io(Arc<std::io::Error>),
+    #[error("TOML serialize error: {0}")]
+    TomlSerialize(Arc<toml::ser::Error>),
+    #[error("TOML deserialize error: {0}")]
+    TomlDeserialize(Arc<toml::de::Error>),
+    #[error("Invalid profile: {0}")]
+    InvalidProfile(ConnectionNameError),
     #[error("Connection name already exists: {0}")]
     DuplicateName(String),
     #[error("Connection not found: {0}")]
     NotFound(String),
+}
+
+impl From<std::io::Error> for ConnectionStoreError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(Arc::new(e))
+    }
+}
+
+impl From<toml::ser::Error> for ConnectionStoreError {
+    fn from(e: toml::ser::Error) -> Self {
+        Self::TomlSerialize(Arc::new(e))
+    }
+}
+
+impl From<toml::de::Error> for ConnectionStoreError {
+    fn from(e: toml::de::Error) -> Self {
+        Self::TomlDeserialize(Arc::new(e))
+    }
 }
 
 #[cfg_attr(test, mockall::automock)]

--- a/src/app/ports/db_operation_error.rs
+++ b/src/app/ports/db_operation_error.rs
@@ -7,11 +7,11 @@ pub enum DbOperationError {
     #[error("Query failed: {0}")]
     QueryFailed(String),
     #[error("Invalid JSON: {0}")]
-    InvalidJson(Arc<serde_json::Error>),
+    InvalidJson(#[source] Arc<serde_json::Error>),
     #[error("Empty response: {0}")]
     EmptyResponse(String),
     #[error("CSV parse error: {0}")]
-    CsvParse(Arc<csv::Error>),
+    CsvParse(#[source] Arc<csv::Error>),
     #[error("Command not found: {0}")]
     CommandNotFound(String),
     #[error("Operation timed out: {0}")]

--- a/src/app/ports/db_operation_error.rs
+++ b/src/app/ports/db_operation_error.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum DbOperationError {
     #[error("Connection failed: {0}")]
@@ -5,9 +7,25 @@ pub enum DbOperationError {
     #[error("Query failed: {0}")]
     QueryFailed(String),
     #[error("Invalid JSON: {0}")]
-    InvalidJson(String),
+    InvalidJson(Arc<serde_json::Error>),
+    #[error("Empty response: {0}")]
+    EmptyResponse(String),
+    #[error("CSV parse error: {0}")]
+    CsvParse(Arc<csv::Error>),
     #[error("Command not found: {0}")]
     CommandNotFound(String),
     #[error("Operation timed out: {0}")]
     Timeout(String),
+}
+
+impl From<serde_json::Error> for DbOperationError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::InvalidJson(Arc::new(e))
+    }
+}
+
+impl From<csv::Error> for DbOperationError {
+    fn from(e: csv::Error) -> Self {
+        Self::CsvParse(Arc::new(e))
+    }
 }

--- a/src/app/ports/folder_opener.rs
+++ b/src/app/ports/folder_opener.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum FolderOpenError {
     #[error("{0}")]
-    Spawn(Arc<std::io::Error>),
+    Spawn(#[source] Arc<std::io::Error>),
 }
 
 impl From<std::io::Error> for FolderOpenError {

--- a/src/app/ports/folder_opener.rs
+++ b/src/app/ports/folder_opener.rs
@@ -1,9 +1,16 @@
 use std::path::Path;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, thiserror::Error)]
-#[error("{message}")]
-pub struct FolderOpenError {
-    pub message: String,
+pub enum FolderOpenError {
+    #[error("{0}")]
+    Spawn(Arc<std::io::Error>),
+}
+
+impl From<std::io::Error> for FolderOpenError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Spawn(Arc::new(e))
+    }
 }
 
 pub trait FolderOpener: Send + Sync {

--- a/src/app/ports/graphviz.rs
+++ b/src/app/ports/graphviz.rs
@@ -15,7 +15,7 @@ pub enum GraphvizError {
 #[derive(Debug, thiserror::Error)]
 pub enum ViewerError {
     #[error("Failed to open viewer: {0}")]
-    LaunchFailed(#[source] std::io::Error),
+    LaunchFailed(#[from] std::io::Error),
 }
 
 pub trait GraphvizRunner: Send + Sync {

--- a/src/app/ports/mod.rs
+++ b/src/app/ports/mod.rs
@@ -1,3 +1,7 @@
+//! Error variants here carry source types (`std::io::Error`, `arboard::Error`, etc.)
+//! via `#[source]` to preserve `Error::source()` chains. Method signatures stay free
+//! of adapter-specific types; only error sources are exposed.
+
 pub mod clipboard;
 pub mod config_writer;
 pub mod connection_store;

--- a/src/app/ports/mod.rs
+++ b/src/app/ports/mod.rs
@@ -1,6 +1,8 @@
-//! Error variants here carry source types (`std::io::Error`, `arboard::Error`, etc.)
-//! via `#[source]` to preserve `Error::source()` chains. Method signatures stay free
-//! of adapter-specific types; only error sources are exposed.
+//! Port traits and their error types.
+//!
+//! Error variants carry source types (`std::io::Error`, `arboard::Error`, etc.)
+//! via `#[source]` to preserve `Error::source()` chains. Method signatures stay
+//! free of adapter-specific types; only error sources are exposed.
 
 pub mod clipboard;
 pub mod config_writer;

--- a/src/app/ports/query_history.rs
+++ b/src/app/ports/query_history.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 use crate::domain::connection::ConnectionId;
@@ -6,11 +8,29 @@ use crate::domain::query_history::QueryHistoryEntry;
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum QueryHistoryError {
     #[error("IO error: {0}")]
-    IoError(String),
+    IoError(Arc<std::io::Error>),
     #[error("Serialization error: {0}")]
-    SerializationError(String),
+    SerializationError(Arc<serde_json::Error>),
     #[error("Task join error: {0}")]
-    JoinError(String),
+    JoinError(Arc<tokio::task::JoinError>),
+}
+
+impl From<std::io::Error> for QueryHistoryError {
+    fn from(e: std::io::Error) -> Self {
+        Self::IoError(Arc::new(e))
+    }
+}
+
+impl From<serde_json::Error> for QueryHistoryError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::SerializationError(Arc::new(e))
+    }
+}
+
+impl From<tokio::task::JoinError> for QueryHistoryError {
+    fn from(e: tokio::task::JoinError) -> Self {
+        Self::JoinError(Arc::new(e))
+    }
 }
 
 #[async_trait]

--- a/src/app/ports/query_history.rs
+++ b/src/app/ports/query_history.rs
@@ -8,28 +8,28 @@ use crate::domain::query_history::QueryHistoryEntry;
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum QueryHistoryError {
     #[error("IO error: {0}")]
-    IoError(Arc<std::io::Error>),
+    Io(#[source] Arc<std::io::Error>),
     #[error("Serialization error: {0}")]
-    SerializationError(Arc<serde_json::Error>),
+    Serialization(#[source] Arc<serde_json::Error>),
     #[error("Task join error: {0}")]
-    JoinError(Arc<tokio::task::JoinError>),
+    Join(#[source] Arc<tokio::task::JoinError>),
 }
 
 impl From<std::io::Error> for QueryHistoryError {
     fn from(e: std::io::Error) -> Self {
-        Self::IoError(Arc::new(e))
+        Self::Io(Arc::new(e))
     }
 }
 
 impl From<serde_json::Error> for QueryHistoryError {
     fn from(e: serde_json::Error) -> Self {
-        Self::SerializationError(Arc::new(e))
+        Self::Serialization(Arc::new(e))
     }
 }
 
 impl From<tokio::task::JoinError> for QueryHistoryError {
     fn from(e: tokio::task::JoinError) -> Self {
-        Self::JoinError(Arc::new(e))
+        Self::Join(Arc::new(e))
     }
 }
 
@@ -47,4 +47,16 @@ pub trait QueryHistoryStore: Send + Sync {
         project_name: &str,
         connection_id: &ConnectionId,
     ) -> Result<Vec<QueryHistoryEntry>, QueryHistoryError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn io_variant_preserves_source_chain() {
+        let err: QueryHistoryError = std::io::Error::other("disk full").into();
+        assert!(err.source().is_some());
+    }
 }

--- a/src/app/ports/service_file.rs
+++ b/src/app/ports/service_file.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::domain::connection::ServiceEntry;
 
@@ -6,8 +7,12 @@ use crate::domain::connection::ServiceEntry;
 pub enum ServiceFileError {
     #[error("Service file not found: {0}")]
     NotFound(String),
-    #[error("Read error: {0}")]
-    ReadError(String),
+    #[error("Failed to read {path}: {source}", path = path.display())]
+    ReadAt {
+        path: PathBuf,
+        #[source]
+        source: Arc<std::io::Error>,
+    },
     #[error("Parse error: {0}")]
     ParseError(String),
 }

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -88,9 +88,9 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             Some(vec![Effect::CopyToClipboard {
                 content: json,
                 on_success: Some(Action::CellCopied),
-                on_failure: Some(Action::CopyFailed(ClipboardError {
-                    message: "Clipboard unavailable".into(),
-                })),
+                on_failure: Some(Action::CopyFailed(ClipboardError::Unavailable(
+                    "Clipboard unavailable".into(),
+                ))),
             }])
         }
 

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -115,9 +115,7 @@ pub fn reduce(
 }
 
 fn clipboard_unavailable() -> Action {
-    Action::CopyFailed(ClipboardError::Unavailable(
-        "Clipboard unavailable".into(),
-    ))
+    Action::CopyFailed(ClipboardError::Unavailable("Clipboard unavailable".into()))
 }
 
 #[cfg(test)]

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -61,9 +61,9 @@ pub fn reduce(
                 return Some(vec![Effect::CopyToClipboard {
                     content: ddl,
                     on_success: Some(Action::CellCopied),
-                    on_failure: Some(Action::CopyFailed(ClipboardError {
-                        message: "Clipboard unavailable".into(),
-                    })),
+                    on_failure: Some(Action::CopyFailed(ClipboardError::Unavailable(
+                        "Clipboard unavailable".into(),
+                    ))),
                 }]);
             }
             Some(vec![])
@@ -115,9 +115,9 @@ pub fn reduce(
 }
 
 fn clipboard_unavailable() -> Action {
-    Action::CopyFailed(ClipboardError {
-        message: "Clipboard unavailable".into(),
-    })
+    Action::CopyFailed(ClipboardError::Unavailable(
+        "Clipboard unavailable".into(),
+    ))
 }
 
 #[cfg(test)]

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -61,9 +61,7 @@ pub fn reduce(
                 return Some(vec![Effect::CopyToClipboard {
                     content: ddl,
                     on_success: Some(Action::CellCopied),
-                    on_failure: Some(Action::CopyFailed(ClipboardError::Unavailable(
-                        "Clipboard unavailable".into(),
-                    ))),
+                    on_failure: Some(clipboard_unavailable()),
                 }]);
             }
             Some(vec![])

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -381,6 +381,8 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::app::model::shared::confirm_dialog::ConfirmIntent;
 
@@ -916,9 +918,9 @@ mod tests {
 
                 reduce_modal(
                     &mut state,
-                    &Action::QueryHistoryLoadFailed(QueryHistoryError::IoError(
-                        "disk error".to_string(),
-                    )),
+                    &Action::QueryHistoryLoadFailed(QueryHistoryError::IoError(Arc::new(
+                        std::io::Error::other("disk error"),
+                    ))),
                     now,
                 )
                 .unwrap();
@@ -937,9 +939,9 @@ mod tests {
 
                 reduce_modal(
                     &mut state,
-                    &Action::QueryHistoryLoadFailed(QueryHistoryError::IoError(
-                        "stale error".to_string(),
-                    )),
+                    &Action::QueryHistoryLoadFailed(QueryHistoryError::IoError(Arc::new(
+                        std::io::Error::other("stale error"),
+                    ))),
                     now,
                 )
                 .unwrap();
@@ -954,9 +956,9 @@ mod tests {
 
                 let effects = reduce_modal(
                     &mut state,
-                    &Action::QueryHistoryAppendFailed(QueryHistoryError::IoError(
-                        "write error".to_string(),
-                    )),
+                    &Action::QueryHistoryAppendFailed(QueryHistoryError::IoError(Arc::new(
+                        std::io::Error::other("write error"),
+                    ))),
                     now,
                 )
                 .unwrap();

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -918,7 +918,7 @@ mod tests {
 
                 reduce_modal(
                     &mut state,
-                    &Action::QueryHistoryLoadFailed(QueryHistoryError::IoError(Arc::new(
+                    &Action::QueryHistoryLoadFailed(QueryHistoryError::Io(Arc::new(
                         std::io::Error::other("disk error"),
                     ))),
                     now,
@@ -939,7 +939,7 @@ mod tests {
 
                 reduce_modal(
                     &mut state,
-                    &Action::QueryHistoryLoadFailed(QueryHistoryError::IoError(Arc::new(
+                    &Action::QueryHistoryLoadFailed(QueryHistoryError::Io(Arc::new(
                         std::io::Error::other("stale error"),
                     ))),
                     now,
@@ -956,7 +956,7 @@ mod tests {
 
                 let effects = reduce_modal(
                     &mut state,
-                    &Action::QueryHistoryAppendFailed(QueryHistoryError::IoError(Arc::new(
+                    &Action::QueryHistoryAppendFailed(QueryHistoryError::Io(Arc::new(
                         std::io::Error::other("write error"),
                     ))),
                     now,

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1503,7 +1503,9 @@ mod tests {
             let effects = reduce(
                 &mut state,
                 Action::ConnectionSaveFailed(ConnectionSaveError::Store(
-                    ConnectionStoreError::IoError("Write error".to_string()),
+                    ConnectionStoreError::Io(std::sync::Arc::new(std::io::Error::other(
+                        "Write error",
+                    ))),
                 )),
                 now,
                 &AppServices::stub(),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1502,9 +1502,9 @@ mod tests {
 
             let effects = reduce(
                 &mut state,
-                Action::ConnectionSaveFailed(ConnectionSaveError::Store(
-                    ConnectionStoreError::Io(Arc::new(std::io::Error::other("Write error"))),
-                )),
+                Action::ConnectionSaveFailed(ConnectionSaveError::Store(ConnectionStoreError::Io(
+                    Arc::new(std::io::Error::other("Write error")),
+                ))),
                 now,
                 &AppServices::stub(),
             );

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1503,9 +1503,7 @@ mod tests {
             let effects = reduce(
                 &mut state,
                 Action::ConnectionSaveFailed(ConnectionSaveError::Store(
-                    ConnectionStoreError::Io(std::sync::Arc::new(std::io::Error::other(
-                        "Write error",
-                    ))),
+                    ConnectionStoreError::Io(Arc::new(std::io::Error::other("Write error"))),
                 )),
                 now,
                 &AppServices::stub(),

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -419,9 +419,9 @@ pub fn reduce_sql_modal(
                 Some(c) if !c.is_empty() => Some(vec![Effect::CopyToClipboard {
                     content: c,
                     on_success: Some(Action::SqlModalYankSuccess),
-                    on_failure: Some(Action::CopyFailed(ClipboardError {
-                        message: "Clipboard unavailable".into(),
-                    })),
+                    on_failure: Some(Action::CopyFailed(ClipboardError::Unavailable(
+                        "Clipboard unavailable".into(),
+                    ))),
                 }]),
                 _ => Some(vec![]),
             }

--- a/src/infra/adapters/clipboard.rs
+++ b/src/infra/adapters/clipboard.rs
@@ -4,10 +4,7 @@ pub struct ArboardClipboard;
 
 impl ClipboardWriter for ArboardClipboard {
     fn copy_text(&self, content: &str) -> Result<(), ClipboardError> {
-        arboard::Clipboard::new()
-            .and_then(|mut cb| cb.set_text(content))
-            .map_err(|e| ClipboardError {
-                message: e.to_string(),
-            })
+        arboard::Clipboard::new().and_then(|mut cb| cb.set_text(content))?;
+        Ok(())
     }
 }

--- a/src/infra/adapters/connection_store.rs
+++ b/src/infra/adapters/connection_store.rs
@@ -32,13 +32,11 @@ impl TomlConnectionStore {
 
     fn write_all(&self, profiles: &[ConnectionProfile]) -> Result<(), ConnectionStoreError> {
         if !self.config_dir.exists() {
-            fs::create_dir_all(&self.config_dir)
-                .map_err(|e| ConnectionStoreError::IoError(e.to_string()))?;
+            fs::create_dir_all(&self.config_dir)?;
         }
 
         let config = ConnectionConfigFile::from_profiles(profiles);
-        let content = toml::to_string_pretty(&config)
-            .map_err(|e| ConnectionStoreError::WriteError(e.to_string()))?;
+        let content = toml::to_string_pretty(&config)?;
 
         let content_with_header = format!(
             "# sabiql connection configuration\n# WARNING: Passwords are stored in plain text\n\n{content}"
@@ -54,7 +52,7 @@ impl TomlConnectionStore {
 
         if let Err(e) = fs::write(&tmp_path, &content_with_header) {
             let _ = fs::remove_file(&tmp_path);
-            return Err(ConnectionStoreError::WriteError(e.to_string()));
+            return Err(e.into());
         }
 
         if let Err(e) = set_file_permissions(&tmp_path) {
@@ -64,7 +62,7 @@ impl TomlConnectionStore {
 
         if let Err(e) = fs::rename(&tmp_path, &path) {
             let _ = fs::remove_file(&tmp_path);
-            return Err(ConnectionStoreError::WriteError(e.to_string()));
+            return Err(e.into());
         }
 
         Ok(())
@@ -84,12 +82,10 @@ impl ConnectionStore for TomlConnectionStore {
             return Ok(vec![]);
         }
 
-        let content = fs::read_to_string(&path)
-            .map_err(|e| ConnectionStoreError::ReadError(e.to_string()))?;
+        let content = fs::read_to_string(&path)?;
 
         // Check version first to detect v1 format before full parse fails
-        let version_check: ConfigVersionCheck = toml::from_str(&content)
-            .map_err(|e| ConnectionStoreError::InvalidFormat(e.to_string()))?;
+        let version_check: ConfigVersionCheck = toml::from_str(&content)?;
 
         if version_check.version != CURRENT_VERSION {
             return Err(ConnectionStoreError::VersionMismatch {
@@ -98,12 +94,11 @@ impl ConnectionStore for TomlConnectionStore {
             });
         }
 
-        let config: ConnectionConfigFile = toml::from_str(&content)
-            .map_err(|e| ConnectionStoreError::InvalidFormat(e.to_string()))?;
+        let config: ConnectionConfigFile = toml::from_str(&content)?;
 
         config
             .to_profiles()
-            .map_err(|e| ConnectionStoreError::InvalidFormat(e.to_string()))
+            .map_err(ConnectionStoreError::InvalidProfile)
     }
 
     fn save(&self, profile: &ConnectionProfile) -> Result<(), ConnectionStoreError> {
@@ -154,8 +149,12 @@ impl ConnectionStore for TomlConnectionStore {
 }
 
 fn get_config_dir() -> Result<PathBuf, ConnectionStoreError> {
-    let config_base = dirs::config_dir()
-        .ok_or_else(|| ConnectionStoreError::IoError("Could not find config directory".into()))?;
+    let config_base = dirs::config_dir().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Could not find config directory",
+        )
+    })?;
     Ok(config_base.join("sabiql"))
 }
 
@@ -163,7 +162,7 @@ fn get_config_dir() -> Result<PathBuf, ConnectionStoreError> {
 fn set_file_permissions(path: &Path) -> Result<(), ConnectionStoreError> {
     use std::os::unix::fs::PermissionsExt;
     let perms = fs::Permissions::from_mode(0o600);
-    fs::set_permissions(path, perms).map_err(|e| ConnectionStoreError::IoError(e.to_string()))?;
+    fs::set_permissions(path, perms)?;
     Ok(())
 }
 
@@ -247,7 +246,7 @@ ssl_mode = "prefer"
 
             assert!(matches!(
                 result,
-                Err(ConnectionStoreError::InvalidFormat(_))
+                Err(ConnectionStoreError::TomlDeserialize(_))
             ));
         }
     }

--- a/src/infra/adapters/folder_opener.rs
+++ b/src/infra/adapters/folder_opener.rs
@@ -20,8 +20,7 @@ impl FolderOpener for NativeFolderOpener {
         )))]
         compile_error!("FolderOpener: unsupported target OS");
 
-        result.map(|_| ()).map_err(|e| FolderOpenError {
-            message: e.to_string(),
-        })
+        result?;
+        Ok(())
     }
 }

--- a/src/infra/adapters/pg_service.rs
+++ b/src/infra/adapters/pg_service.rs
@@ -15,8 +15,11 @@ impl PgServiceFileReader {
 impl ServiceFileReader for PgServiceFileReader {
     fn read_services(&self) -> Result<(Vec<ServiceEntry>, PathBuf), ServiceFileError> {
         let path = find_service_file()?;
-        let content = std::fs::read_to_string(&path)
-            .map_err(|e| ServiceFileError::ReadError(format!("{}: {}", path.display(), e)))?;
+        let content =
+            std::fs::read_to_string(&path).map_err(|source| ServiceFileError::ReadAt {
+                path: path.clone(),
+                source: std::sync::Arc::new(source),
+            })?;
         let entries = parse(&content);
         Ok((entries, path))
     }

--- a/src/infra/adapters/pg_service.rs
+++ b/src/infra/adapters/pg_service.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::app::ports::service_file::{ServiceFileError, ServiceFileReader};
 use crate::domain::connection::ServiceEntry;
@@ -18,7 +19,7 @@ impl ServiceFileReader for PgServiceFileReader {
         let content =
             std::fs::read_to_string(&path).map_err(|source| ServiceFileError::ReadAt {
                 path: path.clone(),
-                source: std::sync::Arc::new(source),
+                source: Arc::new(source),
             })?;
         let entries = parse(&content);
         Ok((entries, path))

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -269,17 +269,11 @@ impl PostgresAdapter {
             .has_headers(true)
             .from_reader(csv_block.as_bytes());
 
-        let columns: Vec<String> = reader
-            .headers()
-            .map_err(|e| DbOperationError::QueryFailed(format!("CSV parse error: {e}")))?
-            .iter()
-            .map(ToString::to_string)
-            .collect();
+        let columns: Vec<String> = reader.headers()?.iter().map(ToString::to_string).collect();
 
         let mut rows = Vec::new();
         for result in reader.records() {
-            let record = result
-                .map_err(|e| DbOperationError::QueryFailed(format!("CSV parse error: {e}")))?;
+            let record = result?;
             let row: Vec<String> = record.iter().map(ToString::to_string).collect();
             rows.push(row);
         }
@@ -430,7 +424,7 @@ impl PostgresAdapter {
             return Ok(vec![]);
         }
 
-        serde_json::from_str(trimmed).map_err(|e| DbOperationError::InvalidJson(e.to_string()))
+        serde_json::from_str(trimmed).map_err(Into::into)
     }
 
     pub(in crate::infra::adapters::postgres) fn parse_affected_rows(stdout: &str) -> Option<usize> {

--- a/src/infra/adapters/postgres/psql/parser/metadata.rs
+++ b/src/infra/adapters/postgres/psql/parser/metadata.rs
@@ -49,8 +49,7 @@ impl PostgresAdapter {
             row_count_estimate: Option<i64>,
         }
 
-        let raw: RawTableInfo = serde_json::from_str(trimmed)
-            .map_err(|e| DbOperationError::InvalidJson(e.to_string()))?;
+        let raw: RawTableInfo = serde_json::from_str(trimmed)?;
 
         // PostgreSQL returns reltuples = -1 when VACUUM/ANALYZE has never run
         let row_count = raw.row_count_estimate.filter(|&n| n >= 0);
@@ -77,8 +76,7 @@ impl PostgresAdapter {
             has_rls: bool,
         }
 
-        let raw: Vec<RawTable> = serde_json::from_str(trimmed)
-            .map_err(|e| DbOperationError::InvalidJson(e.to_string()))?;
+        let raw: Vec<RawTable> = serde_json::from_str(trimmed)?;
 
         Ok(raw
             .into_iter()
@@ -100,8 +98,7 @@ impl PostgresAdapter {
             signature: String,
         }
 
-        let raw: Vec<RawTableSignature> = serde_json::from_str(trimmed)
-            .map_err(|e| DbOperationError::InvalidJson(e.to_string()))?;
+        let raw: Vec<RawTableSignature> = serde_json::from_str(trimmed)?;
 
         Ok(raw
             .into_iter()
@@ -125,8 +122,7 @@ impl PostgresAdapter {
             name: String,
         }
 
-        let raw: Vec<RawSchema> = serde_json::from_str(trimmed)
-            .map_err(|e| DbOperationError::InvalidJson(e.to_string()))?;
+        let raw: Vec<RawSchema> = serde_json::from_str(trimmed)?;
 
         Ok(raw.into_iter().map(|s| Schema::new(s.name)).collect())
     }
@@ -150,8 +146,7 @@ impl PostgresAdapter {
             ordinal_position: i32,
         }
 
-        let raw: Vec<RawColumn> = serde_json::from_str(trimmed)
-            .map_err(|e| DbOperationError::InvalidJson(e.to_string()))?;
+        let raw: Vec<RawColumn> = serde_json::from_str(trimmed)?;
 
         Ok(raw
             .into_iter()
@@ -185,8 +180,7 @@ impl PostgresAdapter {
             definition: Option<String>,
         }
 
-        let raw: Vec<RawIndex> = serde_json::from_str(trimmed)
-            .map_err(|e| DbOperationError::InvalidJson(e.to_string()))?;
+        let raw: Vec<RawIndex> = serde_json::from_str(trimmed)?;
 
         Ok(raw
             .into_iter()
@@ -238,8 +232,7 @@ impl PostgresAdapter {
             }
         }
 
-        let raw: Vec<RawForeignKey> = serde_json::from_str(trimmed)
-            .map_err(|e| DbOperationError::InvalidJson(e.to_string()))?;
+        let raw: Vec<RawForeignKey> = serde_json::from_str(trimmed)?;
 
         Ok(raw
             .into_iter()
@@ -281,8 +274,7 @@ impl PostgresAdapter {
             with_check: Option<String>,
         }
 
-        let raw: RawRls = serde_json::from_str(trimmed)
-            .map_err(|e| DbOperationError::InvalidJson(e.to_string()))?;
+        let raw: RawRls = serde_json::from_str(trimmed)?;
 
         let policies = raw
             .policies
@@ -326,8 +318,7 @@ impl PostgresAdapter {
             security_definer: bool,
         }
 
-        let raw: Vec<RawTrigger> = serde_json::from_str(trimmed)
-            .map_err(|e| DbOperationError::InvalidJson(e.to_string()))?;
+        let raw: Vec<RawTrigger> = serde_json::from_str(trimmed)?;
 
         Ok(raw
             .into_iter()
@@ -359,8 +350,8 @@ impl PostgresAdapter {
         json: &str,
     ) -> Result<TableDetailCombined, DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
-            return Err(DbOperationError::InvalidJson(
-                "table_detail_combined: empty response".to_string(),
+            return Err(DbOperationError::EmptyResponse(
+                "table_detail_combined".to_string(),
             ));
         };
 
@@ -375,8 +366,7 @@ impl PostgresAdapter {
             table_info: serde_json::Value,
         }
 
-        let combined: CombinedDetail = serde_json::from_str(trimmed)
-            .map_err(|e| DbOperationError::InvalidJson(e.to_string()))?;
+        let combined: CombinedDetail = serde_json::from_str(trimmed)?;
 
         let columns = Self::parse_columns(&combined.columns.to_string())?;
         let indexes = Self::parse_indexes(&combined.indexes.to_string())?;
@@ -392,8 +382,8 @@ impl PostgresAdapter {
         json: &str,
     ) -> Result<(Vec<Column>, Vec<ForeignKey>), DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
-            return Err(DbOperationError::InvalidJson(
-                "table_columns_and_fks: empty response".to_string(),
+            return Err(DbOperationError::EmptyResponse(
+                "table_columns_and_fks".to_string(),
             ));
         };
 
@@ -404,8 +394,7 @@ impl PostgresAdapter {
             foreign_keys: serde_json::Value,
         }
 
-        let light: LightDetail = serde_json::from_str(trimmed)
-            .map_err(|e| DbOperationError::InvalidJson(e.to_string()))?;
+        let light: LightDetail = serde_json::from_str(trimmed)?;
 
         let columns = Self::parse_columns(&light.columns.to_string())?;
         let foreign_keys = Self::parse_foreign_keys(&light.foreign_keys.to_string())?;
@@ -1126,13 +1115,13 @@ mod tests {
         #[test]
         fn empty_input_returns_error_for_combined_detail() {
             let result = PostgresAdapter::parse_table_detail_combined("");
-            assert!(matches!(result, Err(DbOperationError::InvalidJson(_))));
+            assert!(matches!(result, Err(DbOperationError::EmptyResponse(_))));
         }
 
         #[test]
         fn null_input_returns_error_for_combined_detail() {
             let result = PostgresAdapter::parse_table_detail_combined("null");
-            assert!(matches!(result, Err(DbOperationError::InvalidJson(_))));
+            assert!(matches!(result, Err(DbOperationError::EmptyResponse(_))));
         }
     }
 
@@ -1185,13 +1174,13 @@ mod tests {
         #[test]
         fn empty_input_returns_error_for_columns_and_fks() {
             let result = PostgresAdapter::parse_table_columns_and_fks("");
-            assert!(matches!(result, Err(DbOperationError::InvalidJson(_))));
+            assert!(matches!(result, Err(DbOperationError::EmptyResponse(_))));
         }
 
         #[test]
         fn null_input_returns_error_for_columns_and_fks() {
             let result = PostgresAdapter::parse_table_columns_and_fks("null");
-            assert!(matches!(result, Err(DbOperationError::InvalidJson(_))));
+            assert!(matches!(result, Err(DbOperationError::EmptyResponse(_))));
         }
     }
 }

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -60,8 +60,7 @@ impl FileQueryHistoryStore {
         if let Some(base) = &self.base_dir {
             Ok(base.join("history"))
         } else {
-            let cache_dir =
-                get_cache_dir(project_name).map_err(|e| std::io::Error::other(e.to_string()))?;
+            let cache_dir = get_cache_dir(project_name).map_err(std::io::Error::other)?;
             Ok(cache_dir.join("history"))
         }
     }

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -14,27 +14,22 @@ fn append_entry(path: &Path, dir: &Path, line: &str) -> Result<(), QueryHistoryE
     use std::io::Write;
 
     if !dir.exists() {
-        std::fs::create_dir_all(dir).map_err(|e| QueryHistoryError::IoError(e.to_string()))?;
+        std::fs::create_dir_all(dir)?;
     }
 
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .map_err(|e| QueryHistoryError::IoError(e.to_string()))?;
-    writeln!(file, "{line}").map_err(|e| QueryHistoryError::IoError(e.to_string()))
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    writeln!(file, "{line}")?;
+    Ok(())
 }
 
 fn trim_if_exceeded(path: &Path, max: usize) -> Result<(), QueryHistoryError> {
-    let content =
-        std::fs::read_to_string(path).map_err(|e| QueryHistoryError::IoError(e.to_string()))?;
+    let content = std::fs::read_to_string(path)?;
     let lines: Vec<&str> = content.lines().collect();
     if lines.len() > max {
         let trimmed = &lines[lines.len() - max..];
         let tmp_path = path.with_extension("jsonl.tmp");
-        std::fs::write(&tmp_path, trimmed.join("\n") + "\n")
-            .map_err(|e| QueryHistoryError::IoError(e.to_string()))?;
-        std::fs::rename(&tmp_path, path).map_err(|e| QueryHistoryError::IoError(e.to_string()))?;
+        std::fs::write(&tmp_path, trimmed.join("\n") + "\n")?;
+        std::fs::rename(&tmp_path, path)?;
     }
     Ok(())
 }
@@ -65,8 +60,8 @@ impl FileQueryHistoryStore {
         if let Some(base) = &self.base_dir {
             Ok(base.join("history"))
         } else {
-            let cache_dir = get_cache_dir(project_name)
-                .map_err(|e| QueryHistoryError::IoError(e.to_string()))?;
+            let cache_dir =
+                get_cache_dir(project_name).map_err(|e| std::io::Error::other(e.to_string()))?;
             Ok(cache_dir.join("history"))
         }
     }
@@ -82,8 +77,7 @@ impl QueryHistoryStore for FileQueryHistoryStore {
     ) -> Result<(), QueryHistoryError> {
         let history_dir = self.resolve_history_dir(project_name)?;
         let path = history_dir.join(format!("{connection_id}.jsonl"));
-        let line = serde_json::to_string(entry)
-            .map_err(|e| QueryHistoryError::SerializationError(e.to_string()))?;
+        let line = serde_json::to_string(entry)?;
 
         tokio::task::spawn_blocking(move || {
             append_entry(&path, &history_dir, &line)?;
@@ -91,8 +85,7 @@ impl QueryHistoryStore for FileQueryHistoryStore {
             if let Err(_err) = trim_if_exceeded(&path, MAX_HISTORY_ENTRIES) {}
             Ok(())
         })
-        .await
-        .map_err(|e| QueryHistoryError::JoinError(e.to_string()))?
+        .await?
     }
 
     async fn load(
@@ -108,8 +101,7 @@ impl QueryHistoryStore for FileQueryHistoryStore {
                 return Ok(Vec::new());
             }
 
-            let content = std::fs::read_to_string(&path)
-                .map_err(|e| QueryHistoryError::IoError(e.to_string()))?;
+            let content = std::fs::read_to_string(&path)?;
             let entries: Vec<QueryHistoryEntry> = content
                 .lines()
                 .filter(|line| !line.trim().is_empty())
@@ -118,8 +110,7 @@ impl QueryHistoryStore for FileQueryHistoryStore {
 
             Ok(entries)
         })
-        .await
-        .map_err(|e| QueryHistoryError::JoinError(e.to_string()))?
+        .await?
     }
 }
 

--- a/src/infra/export/dot.rs
+++ b/src/infra/export/dot.rs
@@ -62,7 +62,10 @@ impl ViewerLauncher for SystemViewerLauncher {
         }
         #[cfg(target_os = "windows")]
         {
-            Command::new("cmd").args(["/C", "start"]).arg(path).spawn()?;
+            Command::new("cmd")
+                .args(["/C", "start"])
+                .arg(path)
+                .spawn()?;
         }
         Ok(())
     }

--- a/src/infra/export/dot.rs
+++ b/src/infra/export/dot.rs
@@ -43,40 +43,26 @@ impl ViewerLauncher for SystemViewerLauncher {
                     .arg("-a")
                     .arg(&browser)
                     .arg(path)
-                    .spawn()
-                    .map_err(ViewerError::LaunchFailed)?;
+                    .spawn()?;
             }
             #[cfg(not(target_os = "macos"))]
             {
-                Command::new(&browser)
-                    .arg(path)
-                    .spawn()
-                    .map_err(ViewerError::LaunchFailed)?;
+                Command::new(&browser).arg(path).spawn()?;
             }
             return Ok(());
         }
 
         #[cfg(target_os = "macos")]
         {
-            Command::new("open")
-                .arg(path)
-                .spawn()
-                .map_err(ViewerError::LaunchFailed)?;
+            Command::new("open").arg(path).spawn()?;
         }
         #[cfg(any(target_os = "freebsd", target_os = "linux"))]
         {
-            Command::new("xdg-open")
-                .arg(path)
-                .spawn()
-                .map_err(ViewerError::LaunchFailed)?;
+            Command::new("xdg-open").arg(path).spawn()?;
         }
         #[cfg(target_os = "windows")]
         {
-            Command::new("cmd")
-                .args(["/C", "start"])
-                .arg(path)
-                .spawn()
-                .map_err(ViewerError::LaunchFailed)?;
+            Command::new("cmd").args(["/C", "start"]).arg(path).spawn()?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Problem

The infra/adapters layer was littered with `map_err(|e| SomeError::Variant(e.to_string()))` that collapsed structured source errors into opaque strings. The source chain was severed at every boundary, making debugging harder, and the boilerplate was repeated across every I/O call.

## Background

The rest of the codebase (`ports::GraphvizError`, `ports::ErExportError`) already demonstrated the target idiom: `thiserror` with `#[from]` so that `?` alone is enough to propagate errors while preserving `source()` chains. The adapter layer simply hadn't been brought in line, and newer adapters were inheriting the older pattern by example.

## Scope

- **In scope**:
  - Redesign error enums in `app/ports/` so each source type maps cleanly to a dedicated variant — `QueryHistoryError`, `ConnectionStoreError`, `ServiceFileError`, `ClipboardError`, `FolderOpenError`, `DbOperationError`, `ViewerError`.
  - Convert the struct-shaped `ClipboardError` / `FolderOpenError` into enums so source errors can be carried structurally instead of flattened into `message: String`.
  - Rework adapter implementations (`query_history`, `connection_store`, `pg_service`, `clipboard`, `folder_opener`, `postgres/psql/executor`, `postgres/psql/parser/metadata`) to propagate via `?` and drop the manual string conversions.
  - Preserve path context where it was a deliberate affordance (`ServiceFileError::ReadAt { path, source }`).
- **Out of scope**:
  - Migration to `anyhow` / `snafu` or any error framework swap.
  - Expansion of `color-eyre`'s footprint beyond `main.rs`.
  - Reclassification of `DbOperationError` variants whose meaning is a user-facing category rather than a source type (`CommandNotFound`, `QueryFailed`, `Timeout`, `ConnectionFailed`).
  - Cross-layer error-type unification.

## Approach

The core constraint is that several error types flow through `Action`, which derives `Clone`; most underlying source errors (`std::io::Error`, `serde_json::Error`, `toml::Error`, `arboard::Error`, `csv::Error`) are not `Clone`. Rather than strip `Clone` from `Action` (wide blast radius) or fall back to stringification (defeats the refactor), source errors are wrapped in `Arc` and paired with a hand-written `From` impl. This keeps `?` ergonomic, restores the `source()` chain, and leaves `Clone` intact at the Action boundary.

For enums whose variants previously conflated multiple source types behind a single `String` (notably `ConnectionStoreError`'s read/write paths, and `DbOperationError`'s JSON path), variants are split so each source has a structural home — with a separate semantic variant (`EmptyResponse`) for the cases that were never really "invalid JSON" in the first place.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (2911 + 3 passed, 0 failed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * エラーハンドリング構造を改善し、型付けされたエラーソースを活用してエラー情報の追跡可能性を向上させました。エラーチェーンの保持とエラー情報の構造化により、より詳細なエラー診断が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->