### PR TITLE
perf: Improve modal text rendering performance

### DIFF
--- a/src/ui/features/overlays/confirm_dialog.rs
+++ b/src/ui/features/overlays/confirm_dialog.rs
@@ -1,9 +1,12 @@
+use std::cell::RefCell;
+
 use ratatui::prelude::*;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::confirm_dialog::ConfirmIntent;
+use crate::app::model::shared::theme_id::ThemeId;
 use crate::app::policy::json::json_diff::JsonDiffLine;
 use crate::app::policy::write::write_guardrails::{RiskLevel, WriteOperation};
 use crate::app::policy::write::write_update::escape_preview_value;
@@ -18,6 +21,18 @@ pub struct ConfirmPreviewMetrics {
     pub viewport_height: Option<u16>,
     pub content_height: Option<u16>,
     pub scroll: u16,
+}
+
+#[derive(Debug, Clone)]
+struct SqlPreviewLinesCache {
+    theme_id: ThemeId,
+    sql: String,
+    lines: Vec<Line<'static>>,
+}
+
+thread_local! {
+    static SQL_PREVIEW_LINES_CACHE: RefCell<Option<SqlPreviewLinesCache>> =
+        const { RefCell::new(None) };
 }
 
 impl ConfirmDialog {
@@ -194,10 +209,7 @@ impl ConfirmDialog {
             "SQL Preview",
             Style::default().fg(theme.semantic.text.secondary),
         )]));
-        for sql_line in preview.sql.lines() {
-            let indented = format!("  {sql_line}");
-            content_lines.push(Self::highlight_sql_line(&indented, theme));
-        }
+        content_lines.extend(Self::highlight_sql_lines(&preview.sql, theme, state.ui.theme_id()));
 
         content_lines.push(Line::from(""));
 
@@ -314,5 +326,34 @@ impl ConfirmDialog {
             .into_iter()
             .next()
             .unwrap_or_else(|| Line::from(""))
+    }
+
+    fn highlight_sql_lines(
+        sql: &str,
+        theme: &ThemePalette,
+        theme_id: ThemeId,
+    ) -> Vec<Line<'static>> {
+        SQL_PREVIEW_LINES_CACHE.with(|cache| {
+            if let Some(cached) = cache.borrow().as_ref()
+                && cached.theme_id == theme_id
+                && cached.sql == sql
+            {
+                return cached.lines.clone();
+            }
+
+            let mut lines = Vec::new();
+            for sql_line in sql.lines() {
+                let indented = format!("  {sql_line}");
+                lines.push(Self::highlight_sql_line(&indented, theme));
+            }
+
+            *cache.borrow_mut() = Some(SqlPreviewLinesCache {
+                theme_id,
+                sql: sql.to_string(),
+                lines: lines.clone(),
+            });
+
+            lines
+        })
     }
 }

--- a/src/ui/primitives/atoms/sql_highlight.rs
+++ b/src/ui/primitives/atoms/sql_highlight.rs
@@ -22,27 +22,18 @@ pub fn highlight_sql_spans(text: &str, theme: &ThemePalette) -> Vec<Vec<Span<'st
 
     for token in tokens {
         let style = token_style(&token.kind, theme);
-        let mut segment = String::new();
+        let mut segments = token.text.split('\n').peekable();
 
-        for ch in token.text.chars() {
-            if ch == '\n' {
-                if !segment.is_empty() {
-                    lines
-                        .last_mut()
-                        .expect("sql highlight should always keep one line")
-                        .push(Span::styled(std::mem::take(&mut segment), style));
-                }
-                lines.push(Vec::new());
-            } else {
-                segment.push(ch);
+        while let Some(segment) = segments.next() {
+            if !segment.is_empty() {
+                lines
+                    .last_mut()
+                    .expect("sql highlight should always keep one line")
+                    .push(Span::styled(segment.to_string(), style));
             }
-        }
-
-        if !segment.is_empty() {
-            lines
-                .last_mut()
-                .expect("sql highlight should always keep one line")
-                .push(Span::styled(segment, style));
+            if segments.peek().is_some() {
+                lines.push(Vec::new());
+            }
         }
     }
 

--- a/src/ui/primitives/atoms/text_cursor.rs
+++ b/src/ui/primitives/atoms/text_cursor.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::cmp::Ordering;
 
 use ratatui::Frame;
@@ -318,6 +319,20 @@ fn placeholder_span(kind: CursorKind, theme: &ThemePalette) -> Span<'static> {
     }
 }
 
+#[derive(Debug, Clone)]
+struct VisualCursorCache {
+    content: String,
+    available_width: usize,
+    line_starts: Vec<usize>,
+    lines: Vec<String>,
+    ends_with_newline: bool,
+}
+
+thread_local! {
+    static VISUAL_CURSOR_POSITION_CACHE: RefCell<Option<VisualCursorCache>> =
+        const { RefCell::new(None) };
+}
+
 fn visual_cursor_position(
     content: &str,
     cursor_row: usize,
@@ -329,31 +344,92 @@ fn visual_cursor_position(
         return None;
     }
 
-    let mut wrapped_rows_before_cursor = 0;
-    let mut current_line = "";
-
-    for (row, line) in content.split('\n').enumerate() {
-        if row < scroll_row {
-            continue;
-        }
-
-        match row.cmp(&cursor_row) {
-            Ordering::Less => {
-                wrapped_rows_before_cursor += wrapped_visual_rows(line, available_width);
+    if let Some(result) = VISUAL_CURSOR_POSITION_CACHE.with(|cache| {
+        let cache = cache.borrow();
+        match cache.as_ref() {
+            Some(current)
+                if current.available_width == available_width && current.content == content =>
+            {
+                resolve_visual_cursor_position(current, cursor_row, cursor_col, scroll_row)
             }
-            Ordering::Equal => {
-                current_line = line;
-                break;
-            }
-            Ordering::Greater => return None,
+            _ => None,
         }
+    }) {
+        return Some(result);
     }
+
+    let mut line_starts = Vec::new();
+    let mut lines = Vec::new();
+    let mut wrapped_row_count = 0usize;
+
+    line_starts.push(0);
+    for line in content.split('\n') {
+        lines.push(line.to_string());
+        wrapped_row_count += wrapped_visual_rows(line, available_width);
+        line_starts.push(wrapped_row_count);
+    }
+
+    let cache_entry = VisualCursorCache {
+        content: content.to_string(),
+        available_width,
+        line_starts,
+        lines,
+        ends_with_newline: content.ends_with('\n'),
+    };
+
+    let computed = resolve_visual_cursor_position(&cache_entry, cursor_row, cursor_col, scroll_row);
+
+    if computed.is_some() {
+        VISUAL_CURSOR_POSITION_CACHE.with(|cache| {
+            *cache.borrow_mut() = Some(cache_entry);
+        });
+    }
+
+    computed
+}
+
+fn visual_cursor_position_for_cache(
+    cache: &VisualCursorCache,
+    cursor_row: usize,
+) -> Option<(usize, &str)> {
+    if cursor_row > cache.lines.len() {
+        return None;
+    }
+
+    if cursor_row < cache.lines.len() {
+        Some((
+            cache.line_starts.get(cursor_row).copied().unwrap_or_default(),
+            cache.lines.get(cursor_row).map_or("", |line| line.as_str()),
+        ))
+    } else if cache.ends_with_newline {
+        Some((*cache.line_starts.last().unwrap_or(&0), ""))
+    } else {
+        None
+    }
+}
+
+fn resolve_visual_cursor_position(
+    cache: &VisualCursorCache,
+    cursor_row: usize,
+    cursor_col: usize,
+    scroll_row: usize,
+) -> Option<(usize, usize)> {
+    let (wrapped_rows_before_cursor, current_line) =
+        visual_cursor_position_for_cache(cache, cursor_row)?;
+
+    let scroll_wrapped_row = cache
+        .line_starts
+        .get(scroll_row)
+        .copied()
+        .unwrap_or_else(|| *cache.line_starts.last().unwrap_or(&0));
 
     let cursor_display_width = display_width_up_to_char(current_line, cursor_col) as usize;
 
     Some((
-        wrapped_rows_before_cursor + cursor_display_width / available_width,
-        cursor_display_width % available_width,
+        wrapped_rows_before_cursor
+            .saturating_sub(scroll_wrapped_row)
+            + cursor_display_width / cache.available_width,
+        cursor_display_width % cache.available_width,
     ))
 }
 


### PR DESCRIPTION
## Problem
SAB-207 targets render-time overhead in text-heavy UI paths. SQL preview highlighting and visual cursor layout were recomputed on repeated renders even when the inputs had not changed.

## Background
Scope: UI performance only for modal text rendering and SQL preview rendering. No behavior or workflow changes are intended.

These paths sit in hot render loops, so repeated full recomputation adds avoidable cost as content grows.

## Approach
Reuse render-derived data only where the existing inputs already define correctness, so unchanged content can skip repeated highlight and wrapping work without introducing new cross-layer state.

This keeps the change focused on hot-path efficiency while preserving the current rendering contract. Validated with targeted unit tests for text cursor and SQL highlighting.

## Screenshots
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * SQLプレビューレンダリングのパフォーマンスを最適化しました。
  * SQLハイライト処理のロジックを改善しました。
  * テキストカーソル位置の計算パフォーマンスを向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->