### PR TITLE
perf: cache shared input derived state

### DIFF
--- a/src/app/model/shared/multi_line_input.rs
+++ b/src/app/model/shared/multi_line_input.rs
@@ -8,7 +8,7 @@ struct LineSpan {
     len: usize,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct MultiLineDerivedState {
     line_spans: Vec<LineSpan>,
     cursor_row: usize,
@@ -289,6 +289,14 @@ impl TextInputLike for MultiLineInputState {
 }
 
 impl MultiLineDerivedState {
+    fn default_empty_line() -> Self {
+        Self {
+            line_spans: vec![LineSpan::default()],
+            cursor_row: 0,
+            cursor_col: 0,
+        }
+    }
+
     fn new(content: &str, cursor: usize) -> Self {
         let line_spans = build_line_spans(content);
         let (cursor_row, cursor_col) = find_cursor_position(&line_spans, cursor);
@@ -297,6 +305,12 @@ impl MultiLineDerivedState {
             cursor_row,
             cursor_col,
         }
+    }
+}
+
+impl Default for MultiLineDerivedState {
+    fn default() -> Self {
+        Self::default_empty_line()
     }
 }
 
@@ -900,6 +914,16 @@ mod tests {
 
     mod content_management {
         use super::*;
+
+        #[test]
+        fn default_preserves_single_empty_line_invariant() {
+            let mut s = MultiLineInputState::default();
+
+            s.move_cursor(CursorMove::LineEnd);
+
+            assert_eq!(s.cursor(), 0);
+            assert_eq!(s.cursor_to_position(), (0, 0));
+        }
 
         #[test]
         fn set_content_resets_scroll_and_sets_cursor_to_end() {

--- a/src/app/model/shared/multi_line_input.rs
+++ b/src/app/model/shared/multi_line_input.rs
@@ -39,12 +39,41 @@ impl MultiLineInputState {
         self.scroll_row
     }
 
+    pub fn set_cursor(&mut self, pos: usize) {
+        self.set_cursor_and_sync(pos);
+        self.preferred_col = None;
+    }
+
     pub fn insert_newline(&mut self) {
         self.insert_char('\n');
     }
 
     pub fn insert_tab(&mut self) {
         self.insert_str("    ");
+    }
+
+    pub fn insert_char(&mut self, c: char) {
+        self.inner.insert_char(c);
+        self.preferred_col = None;
+        self.rebuild_derived();
+    }
+
+    pub fn insert_str(&mut self, text: &str) {
+        self.inner.insert_str(text);
+        self.preferred_col = None;
+        self.rebuild_derived();
+    }
+
+    pub fn backspace(&mut self) {
+        self.inner.backspace();
+        self.preferred_col = None;
+        self.rebuild_derived();
+    }
+
+    pub fn delete(&mut self) {
+        self.inner.delete();
+        self.preferred_col = None;
+        self.rebuild_derived();
     }
 
     pub fn set_content(&mut self, s: String) {
@@ -56,6 +85,7 @@ impl MultiLineInputState {
 
     pub fn set_content_with_cursor(&mut self, s: String, cursor: usize) {
         self.inner.set_content(s);
+        // set_content resets the cursor to the end, so restore the requested position here.
         self.inner.set_cursor(cursor);
         self.scroll_row = 0;
         self.preferred_col = None;
@@ -197,6 +227,7 @@ impl MultiLineInputState {
     }
 
     fn line_spans(&self) -> &[LineSpan] {
+        debug_assert!(!self.derived.line_spans.is_empty());
         &self.derived.line_spans
     }
 
@@ -255,34 +286,6 @@ impl TextInputLike for MultiLineInputState {
     fn text_input(&self) -> &TextInputState {
         &self.inner
     }
-
-    fn text_input_mut(&mut self) -> &mut TextInputState {
-        &mut self.inner
-    }
-
-    fn insert_char(&mut self, c: char) {
-        self.inner.insert_char(c);
-        self.preferred_col = None;
-        self.rebuild_derived();
-    }
-
-    fn insert_str(&mut self, text: &str) {
-        self.inner.insert_str(text);
-        self.preferred_col = None;
-        self.rebuild_derived();
-    }
-
-    fn backspace(&mut self) {
-        self.inner.backspace();
-        self.preferred_col = None;
-        self.rebuild_derived();
-    }
-
-    fn delete(&mut self) {
-        self.inner.delete();
-        self.preferred_col = None;
-        self.rebuild_derived();
-    }
 }
 
 impl MultiLineDerivedState {
@@ -323,176 +326,15 @@ fn char_to_byte_index_impl(s: &str, char_idx: usize) -> usize {
 }
 
 #[cfg(test)]
+mod perf_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use rstest::rstest;
 
     fn ml(content: &str, cursor: usize) -> MultiLineInputState {
         MultiLineInputState::new(content, cursor)
-    }
-
-    #[derive(Clone)]
-    struct BaselineMultiLineInputState {
-        inner: TextInputState,
-        scroll_row: usize,
-        preferred_col: Option<usize>,
-    }
-
-    impl BaselineMultiLineInputState {
-        fn new(content: impl Into<String>, cursor: usize) -> Self {
-            Self {
-                inner: TextInputState::new(content, cursor),
-                scroll_row: 0,
-                preferred_col: None,
-            }
-        }
-
-        fn content(&self) -> &str {
-            self.inner.content()
-        }
-
-        fn cursor(&self) -> usize {
-            self.inner.cursor()
-        }
-
-        fn line_spans(&self) -> Vec<(usize, usize)> {
-            let mut result = Vec::new();
-            let mut start = 0;
-            for line in self.content().split('\n') {
-                let len = line.chars().count();
-                result.push((start, len));
-                start += len + 1;
-            }
-            result
-        }
-
-        fn current_line_col(&self) -> (usize, usize) {
-            let cursor = self.cursor();
-            let lines = self.line_spans();
-            for (i, (start, len)) in lines.iter().enumerate() {
-                if cursor >= *start && cursor <= start + len {
-                    return (i, cursor - start);
-                }
-            }
-            (0, cursor)
-        }
-
-        fn set_cursor_raw(&mut self, pos: usize) {
-            self.inner.set_cursor(pos.min(self.inner.char_count()));
-        }
-
-        fn move_cursor(&mut self, movement: CursorMove) {
-            match movement {
-                CursorMove::Left | CursorMove::Right => {
-                    self.inner.move_cursor(movement);
-                    self.preferred_col = None;
-                }
-                CursorMove::Up => {
-                    let (current_line, current_col) = self.current_line_col();
-                    let preferred_col = self.preferred_col.unwrap_or(current_col);
-                    if current_line > 0 {
-                        let lines = self.line_spans();
-                        let (prev_start, prev_len) = lines[current_line - 1];
-                        self.set_cursor_raw(prev_start + preferred_col.min(prev_len));
-                    }
-                    self.preferred_col = Some(preferred_col);
-                }
-                CursorMove::Down => {
-                    let (current_line, current_col) = self.current_line_col();
-                    let preferred_col = self.preferred_col.unwrap_or(current_col);
-                    let lines = self.line_spans();
-                    if current_line + 1 < lines.len() {
-                        let (next_start, next_len) = lines[current_line + 1];
-                        self.set_cursor_raw(next_start + preferred_col.min(next_len));
-                    }
-                    self.preferred_col = Some(preferred_col);
-                }
-                CursorMove::Home | CursorMove::LineStart => {
-                    let (current_line, _) = self.current_line_col();
-                    let lines = self.line_spans();
-                    if let Some((start, _)) = lines.get(current_line) {
-                        self.set_cursor_raw(*start);
-                    }
-                    self.preferred_col = None;
-                }
-                CursorMove::End | CursorMove::LineEnd => {
-                    let (current_line, _) = self.current_line_col();
-                    let lines = self.line_spans();
-                    if let Some((start, len)) = lines.get(current_line) {
-                        self.set_cursor_raw(start + len);
-                    }
-                    self.preferred_col = None;
-                }
-                CursorMove::WordForward => {
-                    self.set_cursor_raw(next_word_start(self.content(), self.cursor()));
-                    self.preferred_col = None;
-                }
-                CursorMove::WordBackward => {
-                    self.set_cursor_raw(previous_word_start(self.content(), self.cursor()));
-                    self.preferred_col = None;
-                }
-                CursorMove::BufferStart => {
-                    self.set_cursor_raw(0);
-                    self.preferred_col = None;
-                }
-                CursorMove::BufferEnd => {
-                    self.set_cursor_raw(self.inner.char_count());
-                    self.preferred_col = None;
-                }
-                CursorMove::FirstLine => {
-                    let (_, current_col) = self.current_line_col();
-                    let preferred_col = self.preferred_col.unwrap_or(current_col);
-                    let lines = self.line_spans();
-                    if let Some((start, len)) = lines.first() {
-                        self.set_cursor_raw(start + preferred_col.min(*len));
-                    }
-                    self.preferred_col = Some(preferred_col);
-                }
-                CursorMove::LastLine => {
-                    let (_, current_col) = self.current_line_col();
-                    let preferred_col = self.preferred_col.unwrap_or(current_col);
-                    let lines = self.line_spans();
-                    if let Some((start, len)) = lines.last() {
-                        self.set_cursor_raw(start + preferred_col.min(*len));
-                    }
-                    self.preferred_col = Some(preferred_col);
-                }
-                CursorMove::ViewportTop
-                | CursorMove::ViewportMiddle
-                | CursorMove::ViewportBottom => {}
-            }
-        }
-
-        fn cursor_to_position(&self) -> (usize, usize) {
-            let mut row = 0;
-            let mut col = 0;
-
-            for (current_pos, ch) in self.content().chars().enumerate() {
-                if current_pos >= self.cursor() {
-                    break;
-                }
-                if ch == '\n' {
-                    row += 1;
-                    col = 0;
-                } else {
-                    col += 1;
-                }
-            }
-
-            (row, col)
-        }
-
-        fn update_scroll(&mut self, visible_rows: usize) {
-            if visible_rows == 0 {
-                return;
-            }
-            let (row, _) = self.cursor_to_position();
-            if row < self.scroll_row {
-                self.scroll_row = row;
-            } else if row >= self.scroll_row + visible_rows {
-                self.scroll_row = row - visible_rows + 1;
-            }
-        }
     }
 
     mod cursor_to_position {
@@ -1094,6 +936,16 @@ mod tests {
         }
 
         #[test]
+        fn set_cursor_syncs_cached_position() {
+            let mut s = ml("aa\nbb\ncc", 0);
+
+            s.set_cursor(4);
+
+            assert_eq!(s.cursor(), 4);
+            assert_eq!(s.cursor_to_position(), (1, 1));
+        }
+
+        #[test]
         fn clear_resets_all_fields() {
             let mut s = ml("multi\nline", 8);
             s.scroll_row = 3;
@@ -1130,55 +982,4 @@ mod tests {
         }
     }
 
-    #[test]
-    #[ignore = "local-only dev benchmark, not tied to a CI issue"]
-    #[allow(clippy::print_stderr, reason = "benchmark result output")]
-    fn bench_multiline_cache_speedup() {
-        use std::time::Instant;
-
-        let content = (0..400)
-            .map(|i| format!("line_{i:04}_{}", "x".repeat((i % 17) + 8)))
-            .collect::<Vec<_>>()
-            .join("\n");
-        let iterations = 5_000;
-
-        let mut baseline = BaselineMultiLineInputState::new(content.clone(), 0);
-        let start = Instant::now();
-        for _ in 0..iterations {
-            baseline.move_cursor(CursorMove::LastLine);
-            baseline.update_scroll(12);
-            std::hint::black_box(baseline.cursor_to_position());
-            baseline.move_cursor(CursorMove::FirstLine);
-            baseline.update_scroll(12);
-            std::hint::black_box(baseline.cursor_to_position());
-            baseline.move_cursor(CursorMove::Down);
-            baseline.move_cursor(CursorMove::Down);
-            baseline.move_cursor(CursorMove::Up);
-        }
-        let baseline_elapsed = start.elapsed();
-
-        let mut cached = MultiLineInputState::new(content, 0);
-        let start = Instant::now();
-        for _ in 0..iterations {
-            cached.move_cursor(CursorMove::LastLine);
-            cached.update_scroll(12);
-            std::hint::black_box(cached.cursor_to_position());
-            cached.move_cursor(CursorMove::FirstLine);
-            cached.update_scroll(12);
-            std::hint::black_box(cached.cursor_to_position());
-            cached.move_cursor(CursorMove::Down);
-            cached.move_cursor(CursorMove::Down);
-            cached.move_cursor(CursorMove::Up);
-        }
-        let cached_elapsed = start.elapsed();
-
-        eprintln!(
-            "Baseline: {:?} ({:.1} µs/iter), Cached: {:?} ({:.1} µs/iter), Speedup: {:.2}x",
-            baseline_elapsed,
-            baseline_elapsed.as_micros() as f64 / iterations as f64,
-            cached_elapsed,
-            cached_elapsed.as_micros() as f64 / iterations as f64,
-            baseline_elapsed.as_secs_f64() / cached_elapsed.as_secs_f64(),
-        );
-    }
 }

--- a/src/app/model/shared/multi_line_input.rs
+++ b/src/app/model/shared/multi_line_input.rs
@@ -65,13 +65,21 @@ impl MultiLineInputState {
     }
 
     pub fn backspace(&mut self) {
+        let previous_char_count = self.inner.char_count();
         self.inner.backspace();
+        if self.inner.char_count() == previous_char_count {
+            return;
+        }
         self.preferred_col = None;
         self.rebuild_derived();
     }
 
     pub fn delete(&mut self) {
+        let previous_char_count = self.inner.char_count();
         self.inner.delete();
+        if self.inner.char_count() == previous_char_count {
+            return;
+        }
         self.preferred_col = None;
         self.rebuild_derived();
     }
@@ -816,6 +824,16 @@ mod tests {
         }
 
         #[test]
+        fn backspace_at_buffer_start_is_noop() {
+            let mut s = ml("abc", 0);
+
+            s.backspace();
+
+            assert_eq!(s.content(), "abc");
+            assert_eq!(s.cursor_to_position(), (0, 0));
+        }
+
+        #[test]
         fn delete_at_newline_joins_adjacent_lines() {
             // "abc\ndef" → cursor at 3 (end of "abc", on \n)
             // delete removes \n → "abcdef", cursor=3
@@ -823,6 +841,16 @@ mod tests {
             s.delete();
             assert_eq!(s.content(), "abcdef");
             assert_eq!(s.cursor(), 3);
+        }
+
+        #[test]
+        fn delete_at_buffer_end_is_noop() {
+            let mut s = ml("abc", 3);
+
+            s.delete();
+
+            assert_eq!(s.content(), "abc");
+            assert_eq!(s.cursor_to_position(), (0, 3));
         }
 
         #[test]

--- a/src/app/model/shared/multi_line_input.rs
+++ b/src/app/model/shared/multi_line_input.rs
@@ -2,19 +2,36 @@ use crate::app::update::action::CursorMove;
 
 use super::text_input::{TextInputLike, TextInputState, next_word_start, previous_word_start};
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct LineSpan {
+    start: usize,
+    len: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct MultiLineDerivedState {
+    line_spans: Vec<LineSpan>,
+    cursor_row: usize,
+    cursor_col: usize,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MultiLineInputState {
     inner: TextInputState,
     scroll_row: usize,
     preferred_col: Option<usize>,
+    derived: MultiLineDerivedState,
 }
 
 impl MultiLineInputState {
     pub fn new(content: impl Into<String>, cursor: usize) -> Self {
+        let inner = TextInputState::new(content, cursor);
+        let derived = MultiLineDerivedState::new(inner.content(), inner.cursor());
         Self {
-            inner: TextInputState::new(content, cursor),
+            inner,
             scroll_row: 0,
             preferred_col: None,
+            derived,
         }
     }
 
@@ -34,98 +51,98 @@ impl MultiLineInputState {
         self.inner.set_content(s);
         self.scroll_row = 0;
         self.preferred_col = None;
+        self.rebuild_derived();
     }
 
     pub fn set_content_with_cursor(&mut self, s: String, cursor: usize) {
-        let len = s.chars().count();
         self.inner.set_content(s);
-        self.inner.set_cursor(cursor.min(len));
+        self.inner.set_cursor(cursor);
         self.scroll_row = 0;
         self.preferred_col = None;
+        self.rebuild_derived();
     }
 
     pub fn clear(&mut self) {
         self.inner.clear();
         self.scroll_row = 0;
         self.preferred_col = None;
+        self.rebuild_derived();
     }
 
     pub fn move_cursor(&mut self, movement: CursorMove) {
         match movement {
             CursorMove::Left | CursorMove::Right => {
-                self.inner.move_cursor(movement);
+                self.move_cursor_horizontally(movement);
                 self.preferred_col = None;
             }
             CursorMove::Up => {
                 let (current_line, current_col) = self.current_line_col();
                 let preferred_col = self.preferred_col.unwrap_or(current_col);
                 if current_line > 0 {
-                    let lines = self.line_spans();
-                    let (prev_start, prev_len) = lines[current_line - 1];
-                    self.set_cursor_raw(prev_start + preferred_col.min(prev_len));
+                    let previous = self.line_spans()[current_line - 1];
+                    self.set_cursor_from_line(
+                        current_line - 1,
+                        preferred_col.min(previous.len),
+                    );
                 }
                 self.preferred_col = Some(preferred_col);
             }
             CursorMove::Down => {
                 let (current_line, current_col) = self.current_line_col();
                 let preferred_col = self.preferred_col.unwrap_or(current_col);
-                let lines = self.line_spans();
-                if current_line + 1 < lines.len() {
-                    let (next_start, next_len) = lines[current_line + 1];
-                    self.set_cursor_raw(next_start + preferred_col.min(next_len));
+                if current_line + 1 < self.line_spans().len() {
+                    let next = self.line_spans()[current_line + 1];
+                    self.set_cursor_from_line(
+                        current_line + 1,
+                        preferred_col.min(next.len),
+                    );
                 }
                 self.preferred_col = Some(preferred_col);
             }
             CursorMove::Home | CursorMove::LineStart => {
                 let (current_line, _) = self.current_line_col();
-                let lines = self.line_spans();
-                if let Some((start, _)) = lines.get(current_line) {
-                    self.set_cursor_raw(*start);
-                }
+                self.set_cursor_from_line(current_line, 0);
                 self.preferred_col = None;
             }
             CursorMove::End | CursorMove::LineEnd => {
                 let (current_line, _) = self.current_line_col();
-                let lines = self.line_spans();
-                if let Some((start, len)) = lines.get(current_line) {
-                    self.set_cursor_raw(start + len);
-                }
+                let current = self.line_spans()[current_line];
+                self.set_cursor_from_line(current_line, current.len);
                 self.preferred_col = None;
             }
             CursorMove::WordForward => {
                 let next = next_word_start(self.content(), self.cursor());
-                self.set_cursor_raw(next);
+                self.set_cursor_and_sync(next);
                 self.preferred_col = None;
             }
             CursorMove::WordBackward => {
                 let previous = previous_word_start(self.content(), self.cursor());
-                self.set_cursor_raw(previous);
+                self.set_cursor_and_sync(previous);
                 self.preferred_col = None;
             }
             CursorMove::BufferStart => {
-                self.set_cursor_raw(0);
+                self.set_cursor_from_line(0, 0);
                 self.preferred_col = None;
             }
             CursorMove::BufferEnd => {
-                self.set_cursor_raw(self.char_count());
+                let last_row = self.line_spans().len().saturating_sub(1);
+                let last = self.line_spans()[last_row];
+                self.set_cursor_from_line(last_row, last.len);
                 self.preferred_col = None;
             }
             CursorMove::FirstLine => {
                 let (_, current_col) = self.current_line_col();
                 let preferred_col = self.preferred_col.unwrap_or(current_col);
-                let lines = self.line_spans();
-                if let Some((start, len)) = lines.first() {
-                    self.set_cursor_raw(start + preferred_col.min(*len));
-                }
+                let first = self.line_spans()[0];
+                self.set_cursor_from_line(0, preferred_col.min(first.len));
                 self.preferred_col = Some(preferred_col);
             }
             CursorMove::LastLine => {
                 let (_, current_col) = self.current_line_col();
                 let preferred_col = self.preferred_col.unwrap_or(current_col);
-                let lines = self.line_spans();
-                if let Some((start, len)) = lines.last() {
-                    self.set_cursor_raw(start + preferred_col.min(*len));
-                }
+                let last_row = self.line_spans().len().saturating_sub(1);
+                let last = self.line_spans()[last_row];
+                self.set_cursor_from_line(last_row, preferred_col.min(last.len));
                 self.preferred_col = Some(preferred_col);
             }
             CursorMove::ViewportTop | CursorMove::ViewportMiddle | CursorMove::ViewportBottom => {}
@@ -137,11 +154,6 @@ impl MultiLineInputState {
             return;
         }
 
-        let lines = self.line_spans();
-        if lines.is_empty() {
-            return;
-        }
-
         let (_, current_col) = self.current_line_col();
         let preferred_col = self.preferred_col.unwrap_or(current_col);
         let target_row = match movement {
@@ -150,26 +162,25 @@ impl MultiLineInputState {
             CursorMove::ViewportBottom => self.scroll_row + visible_rows.saturating_sub(1),
             _ => return,
         }
-        .min(lines.len().saturating_sub(1));
+        .min(self.line_spans().len().saturating_sub(1));
 
-        let (start, len) = lines[target_row];
-        self.set_cursor_raw(start + preferred_col.min(len));
+        let target = self.line_spans()[target_row];
+        self.set_cursor_from_line(target_row, preferred_col.min(target.len));
         self.preferred_col = Some(preferred_col);
     }
 
     pub fn cursor_to_position(&self) -> (usize, usize) {
-        cursor_to_position_impl(self.content(), self.cursor())
+        (self.derived.cursor_row, self.derived.cursor_col)
     }
 
     pub fn update_scroll(&mut self, visible_rows: usize) {
         if visible_rows == 0 {
             return;
         }
-        let (row, _) = self.cursor_to_position();
-        if row < self.scroll_row {
-            self.scroll_row = row;
-        } else if row >= self.scroll_row + visible_rows {
-            self.scroll_row = row - visible_rows + 1;
+        if self.derived.cursor_row < self.scroll_row {
+            self.scroll_row = self.derived.cursor_row;
+        } else if self.derived.cursor_row >= self.scroll_row + visible_rows {
+            self.scroll_row = self.derived.cursor_row - visible_rows + 1;
         }
     }
 
@@ -177,33 +188,66 @@ impl MultiLineInputState {
         char_to_byte_index_impl(self.content(), char_idx)
     }
 
-    fn line_spans(&self) -> Vec<(usize, usize)> {
-        let content = self.content();
-        let mut result = Vec::new();
-        let mut start = 0;
-        for line in content.split('\n') {
-            let len = line.chars().count();
-            result.push((start, len));
-            start += len + 1; // +1 for '\n'
-        }
-        result
+    fn rebuild_derived(&mut self) {
+        self.derived = MultiLineDerivedState::new(self.content(), self.cursor());
     }
 
     fn current_line_col(&self) -> (usize, usize) {
-        let cursor = self.cursor();
-        let lines = self.line_spans();
-        for (i, (start, len)) in lines.iter().enumerate() {
-            if cursor >= *start && cursor <= start + len {
-                return (i, cursor - start);
-            }
+        (self.derived.cursor_row, self.derived.cursor_col)
+    }
+
+    fn line_spans(&self) -> &[LineSpan] {
+        &self.derived.line_spans
+    }
+
+    fn move_cursor_horizontally(&mut self, movement: CursorMove) {
+        let previous_cursor = self.cursor();
+        self.inner.move_cursor(movement);
+        if self.cursor() == previous_cursor {
+            return;
         }
-        (0, cursor)
+
+        match movement {
+            CursorMove::Left => {
+                if self.derived.cursor_col > 0 {
+                    self.derived.cursor_col -= 1;
+                } else if self.derived.cursor_row > 0 {
+                    self.derived.cursor_row -= 1;
+                    self.derived.cursor_col = self.line_spans()[self.derived.cursor_row].len;
+                }
+            }
+            CursorMove::Right => {
+                let current = self.line_spans()[self.derived.cursor_row];
+                if self.derived.cursor_col < current.len {
+                    self.derived.cursor_col += 1;
+                } else if self.derived.cursor_row + 1 < self.line_spans().len() {
+                    self.derived.cursor_row += 1;
+                    self.derived.cursor_col = 0;
+                }
+            }
+            _ => unreachable!("horizontal helper only supports left/right"),
+        }
     }
 
     fn set_cursor_raw(&mut self, pos: usize) {
         let clamped = pos.min(self.char_count());
         // viewport reset by set_cursor is acceptable: MultiLineInputState doesn't use inner's viewport
         self.inner.set_cursor(clamped);
+    }
+
+    fn set_cursor_from_line(&mut self, row: usize, col: usize) {
+        let span = self.line_spans()[row];
+        let clamped_col = col.min(span.len);
+        self.set_cursor_raw(span.start + clamped_col);
+        self.derived.cursor_row = row;
+        self.derived.cursor_col = clamped_col;
+    }
+
+    fn set_cursor_and_sync(&mut self, pos: usize) {
+        self.set_cursor_raw(pos);
+        let (row, col) = find_cursor_position(self.line_spans(), self.cursor());
+        self.derived.cursor_row = row;
+        self.derived.cursor_col = col;
     }
 }
 
@@ -219,41 +263,57 @@ impl TextInputLike for MultiLineInputState {
     fn insert_char(&mut self, c: char) {
         self.inner.insert_char(c);
         self.preferred_col = None;
+        self.rebuild_derived();
     }
 
     fn insert_str(&mut self, text: &str) {
         self.inner.insert_str(text);
         self.preferred_col = None;
+        self.rebuild_derived();
     }
 
     fn backspace(&mut self) {
         self.inner.backspace();
         self.preferred_col = None;
+        self.rebuild_derived();
     }
 
     fn delete(&mut self) {
         self.inner.delete();
         self.preferred_col = None;
+        self.rebuild_derived();
     }
 }
 
-fn cursor_to_position_impl(content: &str, cursor_pos: usize) -> (usize, usize) {
-    let mut row = 0;
-    let mut col = 0;
-
-    for (current_pos, ch) in content.chars().enumerate() {
-        if current_pos >= cursor_pos {
-            break;
-        }
-        if ch == '\n' {
-            row += 1;
-            col = 0;
-        } else {
-            col += 1;
+impl MultiLineDerivedState {
+    fn new(content: &str, cursor: usize) -> Self {
+        let line_spans = build_line_spans(content);
+        let (cursor_row, cursor_col) = find_cursor_position(&line_spans, cursor);
+        Self {
+            line_spans,
+            cursor_row,
+            cursor_col,
         }
     }
+}
 
-    (row, col)
+fn build_line_spans(content: &str) -> Vec<LineSpan> {
+    let mut line_spans = Vec::new();
+    let mut start = 0;
+    for line in content.split('\n') {
+        let len = line.chars().count();
+        line_spans.push(LineSpan { start, len });
+        start += len + 1;
+    }
+    line_spans
+}
+
+fn find_cursor_position(line_spans: &[LineSpan], cursor: usize) -> (usize, usize) {
+    let row = line_spans
+        .partition_point(|span| span.start <= cursor)
+        .saturating_sub(1);
+    let span = line_spans.get(row).copied().unwrap_or_default();
+    (row, cursor.saturating_sub(span.start).min(span.len))
 }
 
 fn char_to_byte_index_impl(s: &str, char_idx: usize) -> usize {
@@ -269,6 +329,170 @@ mod tests {
 
     fn ml(content: &str, cursor: usize) -> MultiLineInputState {
         MultiLineInputState::new(content, cursor)
+    }
+
+    #[derive(Clone)]
+    struct BaselineMultiLineInputState {
+        inner: TextInputState,
+        scroll_row: usize,
+        preferred_col: Option<usize>,
+    }
+
+    impl BaselineMultiLineInputState {
+        fn new(content: impl Into<String>, cursor: usize) -> Self {
+            Self {
+                inner: TextInputState::new(content, cursor),
+                scroll_row: 0,
+                preferred_col: None,
+            }
+        }
+
+        fn content(&self) -> &str {
+            self.inner.content()
+        }
+
+        fn cursor(&self) -> usize {
+            self.inner.cursor()
+        }
+
+        fn line_spans(&self) -> Vec<(usize, usize)> {
+            let mut result = Vec::new();
+            let mut start = 0;
+            for line in self.content().split('\n') {
+                let len = line.chars().count();
+                result.push((start, len));
+                start += len + 1;
+            }
+            result
+        }
+
+        fn current_line_col(&self) -> (usize, usize) {
+            let cursor = self.cursor();
+            let lines = self.line_spans();
+            for (i, (start, len)) in lines.iter().enumerate() {
+                if cursor >= *start && cursor <= start + len {
+                    return (i, cursor - start);
+                }
+            }
+            (0, cursor)
+        }
+
+        fn set_cursor_raw(&mut self, pos: usize) {
+            self.inner.set_cursor(pos.min(self.inner.char_count()));
+        }
+
+        fn move_cursor(&mut self, movement: CursorMove) {
+            match movement {
+                CursorMove::Left | CursorMove::Right => {
+                    self.inner.move_cursor(movement);
+                    self.preferred_col = None;
+                }
+                CursorMove::Up => {
+                    let (current_line, current_col) = self.current_line_col();
+                    let preferred_col = self.preferred_col.unwrap_or(current_col);
+                    if current_line > 0 {
+                        let lines = self.line_spans();
+                        let (prev_start, prev_len) = lines[current_line - 1];
+                        self.set_cursor_raw(prev_start + preferred_col.min(prev_len));
+                    }
+                    self.preferred_col = Some(preferred_col);
+                }
+                CursorMove::Down => {
+                    let (current_line, current_col) = self.current_line_col();
+                    let preferred_col = self.preferred_col.unwrap_or(current_col);
+                    let lines = self.line_spans();
+                    if current_line + 1 < lines.len() {
+                        let (next_start, next_len) = lines[current_line + 1];
+                        self.set_cursor_raw(next_start + preferred_col.min(next_len));
+                    }
+                    self.preferred_col = Some(preferred_col);
+                }
+                CursorMove::Home | CursorMove::LineStart => {
+                    let (current_line, _) = self.current_line_col();
+                    let lines = self.line_spans();
+                    if let Some((start, _)) = lines.get(current_line) {
+                        self.set_cursor_raw(*start);
+                    }
+                    self.preferred_col = None;
+                }
+                CursorMove::End | CursorMove::LineEnd => {
+                    let (current_line, _) = self.current_line_col();
+                    let lines = self.line_spans();
+                    if let Some((start, len)) = lines.get(current_line) {
+                        self.set_cursor_raw(start + len);
+                    }
+                    self.preferred_col = None;
+                }
+                CursorMove::WordForward => {
+                    self.set_cursor_raw(next_word_start(self.content(), self.cursor()));
+                    self.preferred_col = None;
+                }
+                CursorMove::WordBackward => {
+                    self.set_cursor_raw(previous_word_start(self.content(), self.cursor()));
+                    self.preferred_col = None;
+                }
+                CursorMove::BufferStart => {
+                    self.set_cursor_raw(0);
+                    self.preferred_col = None;
+                }
+                CursorMove::BufferEnd => {
+                    self.set_cursor_raw(self.inner.char_count());
+                    self.preferred_col = None;
+                }
+                CursorMove::FirstLine => {
+                    let (_, current_col) = self.current_line_col();
+                    let preferred_col = self.preferred_col.unwrap_or(current_col);
+                    let lines = self.line_spans();
+                    if let Some((start, len)) = lines.first() {
+                        self.set_cursor_raw(start + preferred_col.min(*len));
+                    }
+                    self.preferred_col = Some(preferred_col);
+                }
+                CursorMove::LastLine => {
+                    let (_, current_col) = self.current_line_col();
+                    let preferred_col = self.preferred_col.unwrap_or(current_col);
+                    let lines = self.line_spans();
+                    if let Some((start, len)) = lines.last() {
+                        self.set_cursor_raw(start + preferred_col.min(*len));
+                    }
+                    self.preferred_col = Some(preferred_col);
+                }
+                CursorMove::ViewportTop
+                | CursorMove::ViewportMiddle
+                | CursorMove::ViewportBottom => {}
+            }
+        }
+
+        fn cursor_to_position(&self) -> (usize, usize) {
+            let mut row = 0;
+            let mut col = 0;
+
+            for (current_pos, ch) in self.content().chars().enumerate() {
+                if current_pos >= self.cursor() {
+                    break;
+                }
+                if ch == '\n' {
+                    row += 1;
+                    col = 0;
+                } else {
+                    col += 1;
+                }
+            }
+
+            (row, col)
+        }
+
+        fn update_scroll(&mut self, visible_rows: usize) {
+            if visible_rows == 0 {
+                return;
+            }
+            let (row, _) = self.cursor_to_position();
+            if row < self.scroll_row {
+                self.scroll_row = row;
+            } else if row >= self.scroll_row + visible_rows {
+                self.scroll_row = row - visible_rows + 1;
+            }
+        }
     }
 
     mod cursor_to_position {
@@ -714,6 +938,7 @@ mod tests {
             s.insert_newline();
             assert_eq!(s.content(), "abc\ndef");
             assert_eq!(s.cursor(), 4);
+            assert_eq!(s.cursor_to_position(), (1, 0));
         }
 
         #[test]
@@ -755,6 +980,16 @@ mod tests {
             s.move_cursor(CursorMove::Down);
 
             assert_eq!(s.cursor_to_position(), (2, 3));
+        }
+
+        #[test]
+        fn backspace_rebuilds_cached_cursor_position() {
+            let mut s = ml("abc\ndef", 4);
+
+            s.backspace();
+
+            assert_eq!(s.content(), "abcdef");
+            assert_eq!(s.cursor_to_position(), (0, 3));
         }
     }
 
@@ -846,6 +1081,7 @@ mod tests {
             assert_eq!(s.content(), "new\nvalue");
             assert_eq!(s.cursor(), 4);
             assert_eq!(s.scroll_row(), 0);
+            assert_eq!(s.cursor_to_position(), (1, 0));
         }
 
         #[test]
@@ -892,5 +1128,57 @@ mod tests {
             let s = ml("abc", 0);
             assert_eq!(s.char_to_byte_index(100), 3);
         }
+    }
+
+    #[test]
+    #[ignore = "local-only dev benchmark, not tied to a CI issue"]
+    #[allow(clippy::print_stderr, reason = "benchmark result output")]
+    fn bench_multiline_cache_speedup() {
+        use std::time::Instant;
+
+        let content = (0..400)
+            .map(|i| format!("line_{i:04}_{}", "x".repeat((i % 17) + 8)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let iterations = 5_000;
+
+        let mut baseline = BaselineMultiLineInputState::new(content.clone(), 0);
+        let start = Instant::now();
+        for _ in 0..iterations {
+            baseline.move_cursor(CursorMove::LastLine);
+            baseline.update_scroll(12);
+            std::hint::black_box(baseline.cursor_to_position());
+            baseline.move_cursor(CursorMove::FirstLine);
+            baseline.update_scroll(12);
+            std::hint::black_box(baseline.cursor_to_position());
+            baseline.move_cursor(CursorMove::Down);
+            baseline.move_cursor(CursorMove::Down);
+            baseline.move_cursor(CursorMove::Up);
+        }
+        let baseline_elapsed = start.elapsed();
+
+        let mut cached = MultiLineInputState::new(content, 0);
+        let start = Instant::now();
+        for _ in 0..iterations {
+            cached.move_cursor(CursorMove::LastLine);
+            cached.update_scroll(12);
+            std::hint::black_box(cached.cursor_to_position());
+            cached.move_cursor(CursorMove::FirstLine);
+            cached.update_scroll(12);
+            std::hint::black_box(cached.cursor_to_position());
+            cached.move_cursor(CursorMove::Down);
+            cached.move_cursor(CursorMove::Down);
+            cached.move_cursor(CursorMove::Up);
+        }
+        let cached_elapsed = start.elapsed();
+
+        eprintln!(
+            "Baseline: {:?} ({:.1} µs/iter), Cached: {:?} ({:.1} µs/iter), Speedup: {:.2}x",
+            baseline_elapsed,
+            baseline_elapsed.as_micros() as f64 / iterations as f64,
+            cached_elapsed,
+            cached_elapsed.as_micros() as f64 / iterations as f64,
+            baseline_elapsed.as_secs_f64() / cached_elapsed.as_secs_f64(),
+        );
     }
 }

--- a/src/app/model/shared/multi_line_input/perf_tests.rs
+++ b/src/app/model/shared/multi_line_input/perf_tests.rs
@@ -1,0 +1,219 @@
+use std::time::Instant;
+
+use super::{MultiLineInputState, TextInputState, next_word_start, previous_word_start};
+use crate::app::update::action::CursorMove;
+
+// Snapshot of the pre-cache implementation, kept only for local perf comparison.
+#[derive(Clone)]
+struct BaselineMultiLineInputState {
+    inner: TextInputState,
+    scroll_row: usize,
+    preferred_col: Option<usize>,
+}
+
+impl BaselineMultiLineInputState {
+    fn new(content: impl Into<String>, cursor: usize) -> Self {
+        Self {
+            inner: TextInputState::new(content, cursor),
+            scroll_row: 0,
+            preferred_col: None,
+        }
+    }
+
+    fn content(&self) -> &str {
+        self.inner.content()
+    }
+
+    fn cursor(&self) -> usize {
+        self.inner.cursor()
+    }
+
+    fn line_spans(&self) -> Vec<(usize, usize)> {
+        let mut result = Vec::new();
+        let mut start = 0;
+        for line in self.content().split('\n') {
+            let len = line.chars().count();
+            result.push((start, len));
+            start += len + 1;
+        }
+        result
+    }
+
+    fn current_line_col(&self) -> (usize, usize) {
+        let cursor = self.cursor();
+        let lines = self.line_spans();
+        for (i, (start, len)) in lines.iter().enumerate() {
+            if cursor >= *start && cursor <= start + len {
+                return (i, cursor - start);
+            }
+        }
+        (0, cursor)
+    }
+
+    fn set_cursor_raw(&mut self, pos: usize) {
+        self.inner.set_cursor(pos.min(self.inner.char_count()));
+    }
+
+    fn move_cursor(&mut self, movement: CursorMove) {
+        match movement {
+            CursorMove::Left | CursorMove::Right => {
+                self.inner.move_cursor(movement);
+                self.preferred_col = None;
+            }
+            CursorMove::Up => {
+                let (current_line, current_col) = self.current_line_col();
+                let preferred_col = self.preferred_col.unwrap_or(current_col);
+                if current_line > 0 {
+                    let lines = self.line_spans();
+                    let (prev_start, prev_len) = lines[current_line - 1];
+                    self.set_cursor_raw(prev_start + preferred_col.min(prev_len));
+                }
+                self.preferred_col = Some(preferred_col);
+            }
+            CursorMove::Down => {
+                let (current_line, current_col) = self.current_line_col();
+                let preferred_col = self.preferred_col.unwrap_or(current_col);
+                let lines = self.line_spans();
+                if current_line + 1 < lines.len() {
+                    let (next_start, next_len) = lines[current_line + 1];
+                    self.set_cursor_raw(next_start + preferred_col.min(next_len));
+                }
+                self.preferred_col = Some(preferred_col);
+            }
+            CursorMove::Home | CursorMove::LineStart => {
+                let (current_line, _) = self.current_line_col();
+                let lines = self.line_spans();
+                if let Some((start, _)) = lines.get(current_line) {
+                    self.set_cursor_raw(*start);
+                }
+                self.preferred_col = None;
+            }
+            CursorMove::End | CursorMove::LineEnd => {
+                let (current_line, _) = self.current_line_col();
+                let lines = self.line_spans();
+                if let Some((start, len)) = lines.get(current_line) {
+                    self.set_cursor_raw(start + len);
+                }
+                self.preferred_col = None;
+            }
+            CursorMove::WordForward => {
+                self.set_cursor_raw(next_word_start(self.content(), self.cursor()));
+                self.preferred_col = None;
+            }
+            CursorMove::WordBackward => {
+                self.set_cursor_raw(previous_word_start(self.content(), self.cursor()));
+                self.preferred_col = None;
+            }
+            CursorMove::BufferStart => {
+                self.set_cursor_raw(0);
+                self.preferred_col = None;
+            }
+            CursorMove::BufferEnd => {
+                self.set_cursor_raw(self.inner.char_count());
+                self.preferred_col = None;
+            }
+            CursorMove::FirstLine => {
+                let (_, current_col) = self.current_line_col();
+                let preferred_col = self.preferred_col.unwrap_or(current_col);
+                let lines = self.line_spans();
+                if let Some((start, len)) = lines.first() {
+                    self.set_cursor_raw(start + preferred_col.min(*len));
+                }
+                self.preferred_col = Some(preferred_col);
+            }
+            CursorMove::LastLine => {
+                let (_, current_col) = self.current_line_col();
+                let preferred_col = self.preferred_col.unwrap_or(current_col);
+                let lines = self.line_spans();
+                if let Some((start, len)) = lines.last() {
+                    self.set_cursor_raw(start + preferred_col.min(*len));
+                }
+                self.preferred_col = Some(preferred_col);
+            }
+            CursorMove::ViewportTop
+            | CursorMove::ViewportMiddle
+            | CursorMove::ViewportBottom => {}
+        }
+    }
+
+    fn cursor_to_position(&self) -> (usize, usize) {
+        let mut row = 0;
+        let mut col = 0;
+
+        for (current_pos, ch) in self.content().chars().enumerate() {
+            if current_pos >= self.cursor() {
+                break;
+            }
+            if ch == '\n' {
+                row += 1;
+                col = 0;
+            } else {
+                col += 1;
+            }
+        }
+
+        (row, col)
+    }
+
+    fn update_scroll(&mut self, visible_rows: usize) {
+        if visible_rows == 0 {
+            return;
+        }
+        let (row, _) = self.cursor_to_position();
+        if row < self.scroll_row {
+            self.scroll_row = row;
+        } else if row >= self.scroll_row + visible_rows {
+            self.scroll_row = row - visible_rows + 1;
+        }
+    }
+}
+
+#[test]
+#[ignore = "local-only dev benchmark, not tied to a CI issue"]
+#[allow(clippy::print_stderr, reason = "benchmark result output")]
+fn bench_multiline_cache_speedup() {
+    let content = (0..400)
+        .map(|i| format!("line_{i:04}_{}", "x".repeat((i % 17) + 8)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let iterations = 5_000;
+
+    let mut baseline = BaselineMultiLineInputState::new(content.clone(), 0);
+    let start = Instant::now();
+    for _ in 0..iterations {
+        baseline.move_cursor(CursorMove::LastLine);
+        baseline.update_scroll(12);
+        std::hint::black_box(baseline.cursor_to_position());
+        baseline.move_cursor(CursorMove::FirstLine);
+        baseline.update_scroll(12);
+        std::hint::black_box(baseline.cursor_to_position());
+        baseline.move_cursor(CursorMove::Down);
+        baseline.move_cursor(CursorMove::Down);
+        baseline.move_cursor(CursorMove::Up);
+    }
+    let baseline_elapsed = start.elapsed();
+
+    let mut cached = MultiLineInputState::new(content, 0);
+    let start = Instant::now();
+    for _ in 0..iterations {
+        cached.move_cursor(CursorMove::LastLine);
+        cached.update_scroll(12);
+        std::hint::black_box(cached.cursor_to_position());
+        cached.move_cursor(CursorMove::FirstLine);
+        cached.update_scroll(12);
+        std::hint::black_box(cached.cursor_to_position());
+        cached.move_cursor(CursorMove::Down);
+        cached.move_cursor(CursorMove::Down);
+        cached.move_cursor(CursorMove::Up);
+    }
+    let cached_elapsed = start.elapsed();
+
+    eprintln!(
+        "Baseline: {:?} ({:.1} µs/iter), Cached: {:?} ({:.1} µs/iter), Speedup: {:.2}x",
+        baseline_elapsed,
+        baseline_elapsed.as_micros() as f64 / iterations as f64,
+        cached_elapsed,
+        cached_elapsed.as_micros() as f64 / iterations as f64,
+        baseline_elapsed.as_secs_f64() / cached_elapsed.as_secs_f64(),
+    );
+}

--- a/src/app/model/shared/multi_line_input/perf_tests.rs
+++ b/src/app/model/shared/multi_line_input/perf_tests.rs
@@ -1,12 +1,82 @@
 use std::time::Instant;
 
-use super::{MultiLineInputState, TextInputState, next_word_start, previous_word_start};
+use super::{MultiLineInputState, next_word_start, previous_word_start};
 use crate::app::update::action::CursorMove;
 
 // Snapshot of the pre-cache implementation, kept only for local perf comparison.
 #[derive(Clone)]
+struct BaselineTextInputState {
+    content: String,
+    cursor: usize,
+}
+
+impl BaselineTextInputState {
+    fn new(content: impl Into<String>, cursor: usize) -> Self {
+        let content = content.into();
+        let char_count = content.chars().count();
+        Self {
+            content,
+            cursor: cursor.min(char_count),
+        }
+    }
+
+    fn content(&self) -> &str {
+        &self.content
+    }
+
+    fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    fn char_count(&self) -> usize {
+        self.content.chars().count()
+    }
+
+    fn set_cursor(&mut self, pos: usize) {
+        self.cursor = pos.min(self.char_count());
+    }
+
+    fn move_cursor(&mut self, movement: CursorMove) {
+        match movement {
+            CursorMove::Left => {
+                self.cursor = self.cursor.saturating_sub(1);
+            }
+            CursorMove::Right => {
+                if self.cursor < self.char_count() {
+                    self.cursor += 1;
+                }
+            }
+            CursorMove::Home
+            | CursorMove::LineStart
+            | CursorMove::BufferStart
+            | CursorMove::FirstLine => {
+                self.cursor = 0;
+            }
+            CursorMove::End
+            | CursorMove::LineEnd
+            | CursorMove::BufferEnd
+            | CursorMove::LastLine => {
+                self.cursor = self.char_count();
+            }
+            CursorMove::WordForward => {
+                self.cursor = next_word_start(&self.content, self.cursor);
+            }
+            CursorMove::WordBackward => {
+                self.cursor = previous_word_start(&self.content, self.cursor);
+            }
+            CursorMove::Up
+            | CursorMove::Down
+            | CursorMove::ViewportTop
+            | CursorMove::ViewportMiddle
+            | CursorMove::ViewportBottom => {}
+        }
+    }
+}
+
+// Snapshot of the pre-cache multi-line implementation, including its uncached inner text input.
+#[derive(Clone)]
 struct BaselineMultiLineInputState {
-    inner: TextInputState,
+    inner: BaselineTextInputState,
     scroll_row: usize,
     preferred_col: Option<usize>,
 }
@@ -14,7 +84,7 @@ struct BaselineMultiLineInputState {
 impl BaselineMultiLineInputState {
     fn new(content: impl Into<String>, cursor: usize) -> Self {
         Self {
-            inner: TextInputState::new(content, cursor),
+            inner: BaselineTextInputState::new(content, cursor),
             scroll_row: 0,
             preferred_col: None,
         }

--- a/src/app/model/shared/text_input.rs
+++ b/src/app/model/shared/text_input.rs
@@ -10,7 +10,6 @@ pub struct TextInputState {
 
 pub trait TextInputLike {
     fn text_input(&self) -> &TextInputState;
-    fn text_input_mut(&mut self) -> &mut TextInputState;
 
     fn content(&self) -> &str {
         self.text_input().content()
@@ -22,22 +21,6 @@ pub trait TextInputLike {
 
     fn char_count(&self) -> usize {
         self.text_input().char_count()
-    }
-
-    fn insert_char(&mut self, c: char) {
-        self.text_input_mut().insert_char(c);
-    }
-
-    fn insert_str(&mut self, text: &str) {
-        self.text_input_mut().insert_str(text);
-    }
-
-    fn backspace(&mut self) {
-        self.text_input_mut().backspace();
-    }
-
-    fn delete(&mut self) {
-        self.text_input_mut().delete();
     }
 }
 
@@ -207,10 +190,6 @@ impl TextInputLike for TextInputState {
     fn text_input(&self) -> &TextInputState {
         self
     }
-
-    fn text_input_mut(&mut self) -> &mut TextInputState {
-        self
-    }
 }
 
 fn char_to_byte_index(s: &str, char_idx: usize) -> usize {
@@ -218,6 +197,9 @@ fn char_to_byte_index(s: &str, char_idx: usize) -> usize {
         .nth(char_idx)
         .map_or(s.len(), |(byte_idx, _)| byte_idx)
 }
+
+#[cfg(test)]
+mod perf_tests;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum WordKind {
@@ -851,128 +833,4 @@ mod tests {
         }
     }
 
-    #[derive(Clone)]
-    struct BaselineTextInputState {
-        content: String,
-        cursor: usize,
-        viewport_offset: usize,
-    }
-
-    impl BaselineTextInputState {
-        fn new(content: impl Into<String>, cursor: usize) -> Self {
-            let content = content.into();
-            let char_count = content.chars().count();
-            Self {
-                content,
-                cursor: cursor.min(char_count),
-                viewport_offset: 0,
-            }
-        }
-
-        fn move_cursor(&mut self, movement: CursorMove) {
-            match movement {
-                CursorMove::Left => {
-                    self.cursor = self.cursor.saturating_sub(1);
-                }
-                CursorMove::Right => {
-                    let len = self.content.chars().count();
-                    if self.cursor < len {
-                        self.cursor += 1;
-                    }
-                }
-                CursorMove::Home
-                | CursorMove::LineStart
-                | CursorMove::BufferStart
-                | CursorMove::FirstLine => {
-                    self.cursor = 0;
-                }
-                CursorMove::End
-                | CursorMove::LineEnd
-                | CursorMove::BufferEnd
-                | CursorMove::LastLine => {
-                    self.cursor = self.content.chars().count();
-                }
-                CursorMove::WordForward => {
-                    self.cursor = next_word_start(&self.content, self.cursor);
-                }
-                CursorMove::WordBackward => {
-                    self.cursor = previous_word_start(&self.content, self.cursor);
-                }
-                CursorMove::Up
-                | CursorMove::Down
-                | CursorMove::ViewportTop
-                | CursorMove::ViewportMiddle
-                | CursorMove::ViewportBottom => {}
-            }
-        }
-
-        fn update_viewport(&mut self, visible_width: usize) {
-            if visible_width == 0 {
-                self.viewport_offset = 0;
-                return;
-            }
-
-            let effective_width = if self.cursor == self.content.chars().count() {
-                visible_width.saturating_sub(1)
-            } else {
-                visible_width
-            };
-
-            if effective_width == 0 {
-                self.viewport_offset = self.cursor;
-                return;
-            }
-
-            if self.cursor < self.viewport_offset {
-                self.viewport_offset = self.cursor;
-            } else if self.cursor >= self.viewport_offset + effective_width {
-                self.viewport_offset = self.cursor - effective_width + 1;
-            }
-        }
-    }
-
-    #[test]
-    #[ignore = "local-only dev benchmark, not tied to a CI issue"]
-    #[allow(clippy::print_stderr, reason = "benchmark result output")]
-    fn bench_cached_char_count_speedup() {
-        use std::time::Instant;
-
-        let content = "x".repeat(4096);
-        let iterations = 20_000;
-
-        let mut baseline = BaselineTextInputState::new(content.clone(), 2048);
-        let start = Instant::now();
-        for _ in 0..iterations {
-            baseline.move_cursor(CursorMove::End);
-            baseline.update_viewport(80);
-            baseline.move_cursor(CursorMove::Home);
-            baseline.move_cursor(CursorMove::Right);
-            baseline.update_viewport(80);
-            std::hint::black_box(baseline.cursor);
-            std::hint::black_box(baseline.viewport_offset);
-        }
-        let baseline_elapsed = start.elapsed();
-
-        let mut cached = TextInputState::new(content, 2048);
-        let start = Instant::now();
-        for _ in 0..iterations {
-            cached.move_cursor(CursorMove::End);
-            cached.update_viewport(80);
-            cached.move_cursor(CursorMove::Home);
-            cached.move_cursor(CursorMove::Right);
-            cached.update_viewport(80);
-            std::hint::black_box(cached.cursor());
-            std::hint::black_box(cached.viewport_offset());
-        }
-        let cached_elapsed = start.elapsed();
-
-        eprintln!(
-            "Baseline: {:?} ({:.1} µs/iter), Cached: {:?} ({:.1} µs/iter), Speedup: {:.2}x",
-            baseline_elapsed,
-            baseline_elapsed.as_micros() as f64 / iterations as f64,
-            cached_elapsed,
-            cached_elapsed.as_micros() as f64 / iterations as f64,
-            baseline_elapsed.as_secs_f64() / cached_elapsed.as_secs_f64(),
-        );
-    }
 }

--- a/src/app/model/shared/text_input.rs
+++ b/src/app/model/shared/text_input.rs
@@ -3,6 +3,7 @@ use crate::app::update::action::CursorMove;
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TextInputState {
     content: String,
+    char_count: usize,
     cursor: usize,
     viewport_offset: usize,
 }
@@ -43,10 +44,11 @@ pub trait TextInputLike {
 impl TextInputState {
     pub fn new(content: impl Into<String>, cursor: usize) -> Self {
         let content = content.into();
-        let len = content.chars().count();
+        let char_count = content.chars().count();
         Self {
             content,
-            cursor: cursor.min(len),
+            char_count,
+            cursor: cursor.min(char_count),
             viewport_offset: 0,
         }
     }
@@ -57,10 +59,11 @@ impl TextInputState {
         viewport_offset: usize,
     ) -> Self {
         let content = content.into();
-        let len = content.chars().count();
+        let char_count = content.chars().count();
         Self {
             content,
-            cursor: cursor.min(len),
+            char_count,
+            cursor: cursor.min(char_count),
             viewport_offset,
         }
     }
@@ -78,7 +81,7 @@ impl TextInputState {
     }
 
     pub fn set_cursor(&mut self, pos: usize) {
-        self.cursor = pos.min(self.char_count());
+        self.cursor = pos.min(self.char_count);
         self.viewport_offset = 0;
     }
 
@@ -86,12 +89,15 @@ impl TextInputState {
         let byte_idx = char_to_byte_index(&self.content, self.cursor);
         self.content.insert(byte_idx, c);
         self.cursor += 1;
+        self.char_count += 1;
     }
 
     pub fn insert_str(&mut self, text: &str) {
         let byte_idx = char_to_byte_index(&self.content, self.cursor);
+        let inserted_chars = text.chars().count();
         self.content.insert_str(byte_idx, text);
-        self.cursor += text.chars().count();
+        self.cursor += inserted_chars;
+        self.char_count += inserted_chars;
     }
 
     pub fn backspace(&mut self) {
@@ -103,16 +109,17 @@ impl TextInputState {
         let end = char_to_byte_index(&self.content, self.cursor);
         self.content.drain(start..end);
         self.cursor = prev;
+        self.char_count -= 1;
     }
 
     pub fn delete(&mut self) {
-        let len = self.char_count();
-        if self.cursor >= len {
+        if self.cursor >= self.char_count {
             return;
         }
         let start = char_to_byte_index(&self.content, self.cursor);
         let end = char_to_byte_index(&self.content, self.cursor + 1);
         self.content.drain(start..end);
+        self.char_count -= 1;
     }
 
     pub fn move_cursor(&mut self, movement: CursorMove) {
@@ -121,8 +128,7 @@ impl TextInputState {
                 self.cursor = self.cursor.saturating_sub(1);
             }
             CursorMove::Right => {
-                let len = self.char_count();
-                if self.cursor < len {
+                if self.cursor < self.char_count {
                     self.cursor += 1;
                 }
             }
@@ -136,7 +142,7 @@ impl TextInputState {
             | CursorMove::LineEnd
             | CursorMove::BufferEnd
             | CursorMove::LastLine => {
-                self.cursor = self.char_count();
+                self.cursor = self.char_count;
             }
             CursorMove::WordForward => {
                 self.cursor = next_word_start(&self.content, self.cursor);
@@ -159,7 +165,7 @@ impl TextInputState {
         }
 
         // █ occupies one terminal cell at end-of-input; shrink effective width to keep it visible
-        let effective_width = if self.cursor == self.char_count() {
+        let effective_width = if self.cursor == self.char_count {
             visible_width.saturating_sub(1)
         } else {
             visible_width
@@ -178,20 +184,22 @@ impl TextInputState {
     }
 
     pub fn set_content(&mut self, s: String) {
-        let len = s.chars().count();
+        let char_count = s.chars().count();
         self.content = s;
-        self.cursor = len;
+        self.char_count = char_count;
+        self.cursor = char_count;
         self.viewport_offset = 0;
     }
 
     pub fn clear(&mut self) {
         self.content.clear();
+        self.char_count = 0;
         self.cursor = 0;
         self.viewport_offset = 0;
     }
 
     pub fn char_count(&self) -> usize {
-        self.content.chars().count()
+        self.char_count
     }
 }
 
@@ -769,6 +777,30 @@ mod tests {
 
             assert_eq!(s.char_count(), 5);
         }
+
+        #[test]
+        fn mutations_keep_cached_char_count_in_sync() {
+            let mut s = state_with("ab", 2);
+
+            s.insert_char('日');
+            assert_eq!(s.char_count(), 3);
+
+            s.insert_str("本語");
+            assert_eq!(s.char_count(), 5);
+
+            s.backspace();
+            assert_eq!(s.char_count(), 4);
+
+            s.set_cursor(1);
+            s.delete();
+            assert_eq!(s.char_count(), 3);
+
+            s.set_content("xyz".to_string());
+            assert_eq!(s.char_count(), 3);
+
+            s.clear();
+            assert_eq!(s.char_count(), 0);
+        }
     }
 
     mod constructor_tests {
@@ -817,5 +849,130 @@ mod tests {
             assert_eq!(s.cursor(), 1);
             assert_eq!(s.viewport_offset(), 0);
         }
+    }
+
+    #[derive(Clone)]
+    struct BaselineTextInputState {
+        content: String,
+        cursor: usize,
+        viewport_offset: usize,
+    }
+
+    impl BaselineTextInputState {
+        fn new(content: impl Into<String>, cursor: usize) -> Self {
+            let content = content.into();
+            let char_count = content.chars().count();
+            Self {
+                content,
+                cursor: cursor.min(char_count),
+                viewport_offset: 0,
+            }
+        }
+
+        fn move_cursor(&mut self, movement: CursorMove) {
+            match movement {
+                CursorMove::Left => {
+                    self.cursor = self.cursor.saturating_sub(1);
+                }
+                CursorMove::Right => {
+                    let len = self.content.chars().count();
+                    if self.cursor < len {
+                        self.cursor += 1;
+                    }
+                }
+                CursorMove::Home
+                | CursorMove::LineStart
+                | CursorMove::BufferStart
+                | CursorMove::FirstLine => {
+                    self.cursor = 0;
+                }
+                CursorMove::End
+                | CursorMove::LineEnd
+                | CursorMove::BufferEnd
+                | CursorMove::LastLine => {
+                    self.cursor = self.content.chars().count();
+                }
+                CursorMove::WordForward => {
+                    self.cursor = next_word_start(&self.content, self.cursor);
+                }
+                CursorMove::WordBackward => {
+                    self.cursor = previous_word_start(&self.content, self.cursor);
+                }
+                CursorMove::Up
+                | CursorMove::Down
+                | CursorMove::ViewportTop
+                | CursorMove::ViewportMiddle
+                | CursorMove::ViewportBottom => {}
+            }
+        }
+
+        fn update_viewport(&mut self, visible_width: usize) {
+            if visible_width == 0 {
+                self.viewport_offset = 0;
+                return;
+            }
+
+            let effective_width = if self.cursor == self.content.chars().count() {
+                visible_width.saturating_sub(1)
+            } else {
+                visible_width
+            };
+
+            if effective_width == 0 {
+                self.viewport_offset = self.cursor;
+                return;
+            }
+
+            if self.cursor < self.viewport_offset {
+                self.viewport_offset = self.cursor;
+            } else if self.cursor >= self.viewport_offset + effective_width {
+                self.viewport_offset = self.cursor - effective_width + 1;
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "local-only dev benchmark, not tied to a CI issue"]
+    #[allow(clippy::print_stderr, reason = "benchmark result output")]
+    fn bench_cached_char_count_speedup() {
+        use std::time::Instant;
+
+        let content = "x".repeat(4096);
+        let iterations = 20_000;
+
+        let mut baseline = BaselineTextInputState::new(content.clone(), 2048);
+        let start = Instant::now();
+        for _ in 0..iterations {
+            baseline.move_cursor(CursorMove::End);
+            baseline.update_viewport(80);
+            baseline.move_cursor(CursorMove::Home);
+            baseline.move_cursor(CursorMove::Right);
+            baseline.update_viewport(80);
+            std::hint::black_box(baseline.cursor);
+            std::hint::black_box(baseline.viewport_offset);
+        }
+        let baseline_elapsed = start.elapsed();
+
+        let mut cached = TextInputState::new(content, 2048);
+        let start = Instant::now();
+        for _ in 0..iterations {
+            cached.move_cursor(CursorMove::End);
+            cached.update_viewport(80);
+            cached.move_cursor(CursorMove::Home);
+            cached.move_cursor(CursorMove::Right);
+            cached.update_viewport(80);
+            std::hint::black_box(cached.cursor());
+            std::hint::black_box(cached.viewport_offset());
+        }
+        let cached_elapsed = start.elapsed();
+
+        eprintln!(
+            "Baseline: {:?} ({:.1} µs/iter), Cached: {:?} ({:.1} µs/iter), Speedup: {:.2}x",
+            baseline_elapsed,
+            baseline_elapsed.as_micros() as f64 / iterations as f64,
+            cached_elapsed,
+            cached_elapsed.as_micros() as f64 / iterations as f64,
+            baseline_elapsed.as_secs_f64() / cached_elapsed.as_secs_f64(),
+        );
     }
 }

--- a/src/app/model/shared/text_input/perf_tests.rs
+++ b/src/app/model/shared/text_input/perf_tests.rs
@@ -1,0 +1,128 @@
+use std::time::Instant;
+
+use super::{TextInputState, next_word_start, previous_word_start};
+use crate::app::update::action::CursorMove;
+
+// Snapshot of the pre-cache implementation, kept only for local perf comparison.
+#[derive(Clone)]
+struct BaselineTextInputState {
+    content: String,
+    cursor: usize,
+    viewport_offset: usize,
+}
+
+impl BaselineTextInputState {
+    fn new(content: impl Into<String>, cursor: usize) -> Self {
+        let content = content.into();
+        let char_count = content.chars().count();
+        Self {
+            content,
+            cursor: cursor.min(char_count),
+            viewport_offset: 0,
+        }
+    }
+
+    fn move_cursor(&mut self, movement: CursorMove) {
+        match movement {
+            CursorMove::Left => {
+                self.cursor = self.cursor.saturating_sub(1);
+            }
+            CursorMove::Right => {
+                let len = self.content.chars().count();
+                if self.cursor < len {
+                    self.cursor += 1;
+                }
+            }
+            CursorMove::Home
+            | CursorMove::LineStart
+            | CursorMove::BufferStart
+            | CursorMove::FirstLine => {
+                self.cursor = 0;
+            }
+            CursorMove::End
+            | CursorMove::LineEnd
+            | CursorMove::BufferEnd
+            | CursorMove::LastLine => {
+                self.cursor = self.content.chars().count();
+            }
+            CursorMove::WordForward => {
+                self.cursor = next_word_start(&self.content, self.cursor);
+            }
+            CursorMove::WordBackward => {
+                self.cursor = previous_word_start(&self.content, self.cursor);
+            }
+            CursorMove::Up
+            | CursorMove::Down
+            | CursorMove::ViewportTop
+            | CursorMove::ViewportMiddle
+            | CursorMove::ViewportBottom => {}
+        }
+    }
+
+    fn update_viewport(&mut self, visible_width: usize) {
+        if visible_width == 0 {
+            self.viewport_offset = 0;
+            return;
+        }
+
+        let effective_width = if self.cursor == self.content.chars().count() {
+            visible_width.saturating_sub(1)
+        } else {
+            visible_width
+        };
+
+        if effective_width == 0 {
+            self.viewport_offset = self.cursor;
+            return;
+        }
+
+        if self.cursor < self.viewport_offset {
+            self.viewport_offset = self.cursor;
+        } else if self.cursor >= self.viewport_offset + effective_width {
+            self.viewport_offset = self.cursor - effective_width + 1;
+        }
+    }
+}
+
+#[test]
+#[ignore = "local-only dev benchmark, not tied to a CI issue"]
+#[allow(clippy::print_stderr, reason = "benchmark result output")]
+fn bench_cached_char_count_speedup() {
+    let content = "x".repeat(4096);
+    let iterations = 20_000;
+
+    let mut baseline = BaselineTextInputState::new(content.clone(), 2048);
+    let start = Instant::now();
+    for _ in 0..iterations {
+        baseline.move_cursor(CursorMove::End);
+        baseline.update_viewport(80);
+        baseline.move_cursor(CursorMove::Home);
+        baseline.move_cursor(CursorMove::Right);
+        baseline.update_viewport(80);
+        std::hint::black_box(baseline.cursor);
+        std::hint::black_box(baseline.viewport_offset);
+    }
+    let baseline_elapsed = start.elapsed();
+
+    let mut cached = TextInputState::new(content, 2048);
+    let start = Instant::now();
+    for _ in 0..iterations {
+        cached.move_cursor(CursorMove::End);
+        cached.update_viewport(80);
+        cached.move_cursor(CursorMove::Home);
+        cached.move_cursor(CursorMove::Right);
+        cached.update_viewport(80);
+        std::hint::black_box(cached.cursor());
+        std::hint::black_box(cached.viewport_offset());
+    }
+    let cached_elapsed = start.elapsed();
+
+    eprintln!(
+        "Baseline: {:?} ({:.1} µs/iter), Cached: {:?} ({:.1} µs/iter), Speedup: {:.2}x",
+        baseline_elapsed,
+        baseline_elapsed.as_micros() as f64 / iterations as f64,
+        cached_elapsed,
+        cached_elapsed.as_micros() as f64 / iterations as f64,
+        baseline_elapsed.as_secs_f64() / cached_elapsed.as_secs_f64(),
+    );
+}

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -292,11 +292,7 @@ fn update_search_matches(state: &mut AppState) {
 fn jump_to_current_match(state: &mut AppState) {
     let search = state.jsonb_detail.search();
     if let Some(&match_pos) = search.matches.get(search.current_match) {
-        state
-            .jsonb_detail
-            .editor_mut()
-            .text_input_mut()
-            .set_cursor(match_pos);
+        state.jsonb_detail.editor_mut().set_cursor(match_pos);
         update_editor_scroll(state);
     }
 }
@@ -467,6 +463,25 @@ mod tests {
 
     fn open_detail(state: &mut AppState) {
         reduce(state, &Action::OpenJsonbDetail, Instant::now());
+    }
+
+    fn cursor_position(content: &str, cursor: usize) -> (usize, usize) {
+        let mut row = 0;
+        let mut col = 0;
+
+        for (idx, ch) in content.chars().enumerate() {
+            if idx >= cursor {
+                break;
+            }
+            if ch == '\n' {
+                row += 1;
+                col = 0;
+            } else {
+                col += 1;
+            }
+        }
+
+        (row, col)
     }
 
     mod entry_guards {
@@ -856,9 +871,11 @@ mod tests {
             reduce(&mut state, &Action::JsonbSearchSubmit, Instant::now());
 
             assert!(!state.jsonb_detail.search().active);
+            let expected_cursor = state.jsonb_detail.search().matches[0];
+            assert_eq!(state.jsonb_detail.editor().cursor(), expected_cursor);
             assert_eq!(
-                state.jsonb_detail.editor().cursor(),
-                state.jsonb_detail.search().matches[0]
+                state.jsonb_detail.editor().cursor_to_position(),
+                cursor_position(state.jsonb_detail.editor().content(), expected_cursor)
             );
         }
 
@@ -913,9 +930,11 @@ mod tests {
             reduce(&mut state, &Action::JsonbSearchNext, Instant::now());
 
             assert_eq!(state.jsonb_detail.search().current_match, 1);
+            let expected_cursor = state.jsonb_detail.search().matches[1];
+            assert_eq!(state.jsonb_detail.editor().cursor(), expected_cursor);
             assert_eq!(
-                state.jsonb_detail.editor().cursor(),
-                state.jsonb_detail.search().matches[1]
+                state.jsonb_detail.editor().cursor_to_position(),
+                cursor_position(state.jsonb_detail.editor().content(), expected_cursor)
             );
         }
 
@@ -943,9 +962,11 @@ mod tests {
             reduce(&mut state, &Action::JsonbSearchPrev, Instant::now());
 
             assert_eq!(state.jsonb_detail.search().current_match, match_count - 1);
+            let expected_cursor = state.jsonb_detail.search().matches[match_count - 1];
+            assert_eq!(state.jsonb_detail.editor().cursor(), expected_cursor);
             assert_eq!(
-                state.jsonb_detail.editor().cursor(),
-                state.jsonb_detail.search().matches[match_count - 1]
+                state.jsonb_detail.editor().cursor_to_position(),
+                cursor_position(state.jsonb_detail.editor().content(), expected_cursor)
             );
         }
     }


### PR DESCRIPTION
## Problem
Shared input state recomputes text-derived data on read-heavy paths, especially during cursor movement and viewport updates in multi-line editors.

## Background
SAB-207 is scoped to state-owned performance work. Scope: shared input state and its local-only performance coverage only, with no UI render-layer caching.

## Approach
Move the hot-path caching into the shared input models and keep derived state synchronized through their mutation APIs, so repeated reads can reuse stable cursor and line geometry without weakening state invariants.

Local-only benchmarks were added for the targeted hotspots. In the measured cases, single-line input improved from 12.775ms to 449.792us over 20k iterations (~28.4x), and multi-line input improved from 2.148s to 479.792us over 5k iterations (~4477.6x).

## Screenshots
N/A
