### PR TITLE
Refactor port error boundaries away from color_eyre

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -200,11 +200,10 @@ mod tests {
     use crate::app::ports::connection_store::MockConnectionStore;
     use crate::app::ports::metadata::MockMetadataProvider;
     use crate::app::ports::query_executor::MockQueryExecutor;
-    use crate::app::ports::{DbOperationError, RenderOutput, Renderer};
+    use crate::app::ports::{DbOperationError, RenderOutput, RenderResult, Renderer};
     use crate::app::services::AppServices;
     use crate::app::update::action::Action;
     use crate::domain::DatabaseMetadata;
-    use color_eyre::eyre::Result;
 
     struct NoopRenderer;
     impl Renderer for NoopRenderer {
@@ -213,7 +212,7 @@ mod tests {
             _state: &AppState,
             _services: &AppServices,
             _now: Instant,
-        ) -> Result<RenderOutput> {
+        ) -> RenderResult<RenderOutput> {
             Ok(RenderOutput::default())
         }
     }

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -433,10 +433,9 @@ mod tests {
         use crate::app::ports::connection_store::MockConnectionStore;
         use crate::app::ports::metadata::MockMetadataProvider;
         use crate::app::ports::query_executor::MockQueryExecutor;
-        use crate::app::ports::{DbOperationError, RenderOutput, Renderer};
+        use crate::app::ports::{DbOperationError, RenderOutput, RenderResult, Renderer};
         use crate::app::services::AppServices;
         use crate::app::update::action::Action;
-        use color_eyre::eyre::Result;
 
         struct NoopRenderer;
         impl Renderer for NoopRenderer {
@@ -445,7 +444,7 @@ mod tests {
                 _state: &AppState,
                 _services: &AppServices,
                 _now: Instant,
-            ) -> Result<RenderOutput> {
+            ) -> RenderResult<RenderOutput> {
                 Ok(RenderOutput::default())
             }
         }

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -218,11 +218,12 @@ mod tests {
     use crate::app::ports::connection_store::MockConnectionStore;
     use crate::app::ports::metadata::MockMetadataProvider;
     use crate::app::ports::query_executor::MockQueryExecutor;
-    use crate::app::ports::{ConnectionStoreError, DsnBuilder, RenderOutput, Renderer};
+    use crate::app::ports::{
+        ConnectionStoreError, DsnBuilder, RenderOutput, RenderResult, Renderer,
+    };
     use crate::app::services::AppServices;
     use crate::app::update::action::{Action, ConnectionTarget, ConnectionsLoadedPayload};
     use crate::domain::connection::{ConnectionId, ConnectionProfile, SslMode};
-    use color_eyre::eyre::Result;
 
     struct NoopRenderer;
     impl Renderer for NoopRenderer {
@@ -231,7 +232,7 @@ mod tests {
             _state: &AppState,
             _services: &AppServices,
             _now: Instant,
-        ) -> Result<RenderOutput> {
+        ) -> RenderResult<RenderOutput> {
             Ok(RenderOutput::default())
         }
     }

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -19,7 +19,11 @@ use crate::app::cmd::sql_editor::query_history as cmd_query_history;
 use crate::app::cmd::utility as cmd_utility;
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::ui_state::scroll_max_offset;
-use crate::app::ports::{ClipboardWriter, ConfigWriter, ConnectionStore, DsnBuilder, ErDiagramExporter, ErLogWriter, FolderOpener, MetadataProvider, PgServiceEntryReader, QueryExecutor, QueryHistoryStore, Renderer};
+use crate::app::ports::{
+    ClipboardWriter, ConfigWriter, ConnectionStore, DsnBuilder, ErDiagramExporter, ErLogWriter,
+    FolderOpener, MetadataProvider, PgServiceEntryReader, QueryExecutor, QueryHistoryStore,
+    Renderer,
+};
 use crate::app::services::AppServices;
 use crate::app::update::action::Action;
 use crate::domain::DatabaseMetadata;

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -20,8 +20,17 @@ use crate::app::cmd::utility as cmd_utility;
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::ui_state::scroll_max_offset;
 use crate::app::ports::{
-    ClipboardWriter, ConfigWriter, ConnectionStore, DsnBuilder, ErDiagramExporter, ErLogWriter,
-    FolderOpener, MetadataProvider, PgServiceEntryReader, QueryExecutor, QueryHistoryStore,
+    ClipboardWriter,
+    ConfigWriter,
+    ConnectionStore,
+    DsnBuilder,
+    ErDiagramExporter,
+    ErLogWriter,
+    FolderOpener,
+    MetadataProvider,
+    PgServiceEntryReader,
+    QueryExecutor,
+    QueryHistoryStore,
     Renderer,
 };
 use crate::app::services::AppServices;
@@ -403,13 +412,12 @@ impl EffectRunner {
 mod tests {
     use super::*;
     use crate::app::cmd::test_support::*;
-    use crate::app::ports::RenderOutput;
+    use crate::app::ports::{RenderOutput, RenderResult};
     use crate::app::ports::connection_store::MockConnectionStore;
     use crate::app::ports::metadata::MockMetadataProvider;
     use crate::app::ports::query_executor::MockQueryExecutor;
     use crate::app::services::AppServices;
     use crate::domain::{DatabaseMetadata, TableSummary};
-    use color_eyre::eyre::Result;
     use tokio::sync::mpsc;
 
     struct NoopRenderer;
@@ -419,7 +427,7 @@ mod tests {
             _state: &AppState,
             _services: &AppServices,
             _now: Instant,
-        ) -> Result<RenderOutput> {
+        ) -> RenderResult<RenderOutput> {
             Ok(RenderOutput::default())
         }
     }
@@ -442,7 +450,7 @@ mod tests {
                 _state: &AppState,
                 _services: &AppServices,
                 _now: Instant,
-            ) -> Result<RenderOutput> {
+            ) -> RenderResult<RenderOutput> {
                 Ok(RenderOutput {
                     explorer_content_width: self.explorer_content_width,
                     ..RenderOutput::default()
@@ -456,7 +464,7 @@ mod tests {
                 _state: &AppState,
                 _services: &AppServices,
                 _now: Instant,
-            ) -> Result<RenderOutput> {
+            ) -> RenderResult<RenderOutput> {
                 Ok(RenderOutput {
                     jsonb_detail_editor_visible_rows: Some(self.visible_rows),
                     ..RenderOutput::default()

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -19,20 +19,7 @@ use crate::app::cmd::sql_editor::query_history as cmd_query_history;
 use crate::app::cmd::utility as cmd_utility;
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::ui_state::scroll_max_offset;
-use crate::app::ports::{
-    ClipboardWriter,
-    ConfigWriter,
-    ConnectionStore,
-    DsnBuilder,
-    ErDiagramExporter,
-    ErLogWriter,
-    FolderOpener,
-    MetadataProvider,
-    PgServiceEntryReader,
-    QueryExecutor,
-    QueryHistoryStore,
-    Renderer,
-};
+use crate::app::ports::{ClipboardWriter, ConfigWriter, ConnectionStore, DsnBuilder, ErDiagramExporter, ErLogWriter, FolderOpener, MetadataProvider, PgServiceEntryReader, QueryExecutor, QueryHistoryStore, Renderer};
 use crate::app::services::AppServices;
 use crate::app::update::action::Action;
 use crate::domain::DatabaseMetadata;

--- a/src/app/cmd/test_support.rs
+++ b/src/app/cmd/test_support.rs
@@ -7,8 +7,8 @@ use tokio::sync::mpsc;
 use crate::app::cmd::cache::TtlCache;
 use crate::app::cmd::runner::{EffectRunner, EffectRunnerBuilder};
 use crate::app::ports::{
-    ClipboardError, ClipboardWriter, ConfigWriter, ConnectionStore, DsnBuilder, ErDiagramExporter,
-    ErExportResult, ErLogWriter, FolderOpenError, FolderOpener, MetadataProvider,
+    ClipboardError, ClipboardWriter, ConfigWriter, ConfigWriterError, ConnectionStore, DsnBuilder,
+    ErDiagramExporter, ErExportResult, ErLogWriter, FolderOpenError, FolderOpener, MetadataProvider,
     PgServiceEntryReader, QueryExecutor, QueryHistoryError, QueryHistoryStore, ServiceFileError,
 };
 use crate::app::update::action::Action;
@@ -18,7 +18,10 @@ use crate::domain::{ConnectionId, DatabaseMetadata, ErTableInfo, QueryResult, Qu
 
 pub struct NoopConfigWriter;
 impl ConfigWriter for NoopConfigWriter {
-    fn get_cache_dir(&self, _project_name: &str) -> color_eyre::eyre::Result<PathBuf> {
+    fn get_cache_dir(
+        &self,
+        _project_name: &str,
+    ) -> Result<PathBuf, ConfigWriterError> {
         Ok(PathBuf::from("/tmp"))
     }
 }

--- a/src/app/ports/config_writer.rs
+++ b/src/app/ports/config_writer.rs
@@ -1,7 +1,20 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
-use color_eyre::eyre::Result;
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ConfigWriterError {
+    #[error("cache directory is unavailable")]
+    MissingCacheDir,
+    #[error("i/o error: {0}")]
+    Io(#[source] Arc<std::io::Error>),
+}
+
+impl From<std::io::Error> for ConfigWriterError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(Arc::new(error))
+    }
+}
 
 pub trait ConfigWriter: Send + Sync {
-    fn get_cache_dir(&self, project_name: &str) -> Result<PathBuf>;
+    fn get_cache_dir(&self, project_name: &str) -> Result<PathBuf, ConfigWriterError>;
 }

--- a/src/app/ports/config_writer.rs
+++ b/src/app/ports/config_writer.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 pub enum ConfigWriterError {
     #[error("cache directory is unavailable")]
     MissingCacheDir,
-    #[error("i/o error: {0}")]
+    #[error("I/O error: {0}")]
     Io(#[source] Arc<std::io::Error>),
 }
 

--- a/src/app/ports/mod.rs
+++ b/src/app/ports/mod.rs
@@ -23,7 +23,7 @@ pub mod service_file;
 pub mod sql_dialect;
 
 pub use clipboard::{ClipboardError, ClipboardWriter};
-pub use config_writer::ConfigWriter;
+pub use config_writer::{ConfigWriter, ConfigWriterError};
 pub use connection_store::{ConnectionStore, ConnectionStoreError};
 pub use db_capabilities::{DatabaseCapabilities, DatabaseCapabilityProvider, InspectorFeature};
 pub use db_operation_error::DbOperationError;
@@ -36,6 +36,6 @@ pub use graphviz::{GraphvizError, GraphvizRunner, ViewerError, ViewerLauncher};
 pub use metadata::MetadataProvider;
 pub use query_executor::QueryExecutor;
 pub use query_history::{QueryHistoryError, QueryHistoryStore};
-pub use renderer::{RenderOutput, Renderer};
+pub use renderer::{RenderError, RenderOutput, RenderResult, Renderer};
 pub use service_file::{PgServiceEntryReader, ServiceFileError};
 pub use sql_dialect::SqlDialect;

--- a/src/app/ports/query_history.rs
+++ b/src/app/ports/query_history.rs
@@ -7,6 +7,8 @@ use crate::domain::query_history::QueryHistoryEntry;
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum QueryHistoryError {
+    #[error("cache directory is unavailable")]
+    MissingCacheDir,
     #[error("IO error: {0}")]
     Io(#[source] Arc<std::io::Error>),
     #[error("Serialization error: {0}")]
@@ -53,6 +55,14 @@ pub trait QueryHistoryStore: Send + Sync {
 mod tests {
     use super::*;
     use std::error::Error;
+
+    #[test]
+    fn missing_cache_dir_has_clear_display() {
+        assert_eq!(
+            QueryHistoryError::MissingCacheDir.to_string(),
+            "cache directory is unavailable"
+        );
+    }
 
     #[test]
     fn io_variant_preserves_source_chain() {

--- a/src/app/ports/renderer.rs
+++ b/src/app/ports/renderer.rs
@@ -1,5 +1,9 @@
-use std::time::Instant;
 use std::sync::Arc;
+use std::time::Instant;
+
+use crate::app::model::app_state::AppState;
+use crate::app::model::shared::viewport::{ColumnWidthsCache, ViewportPlan};
+use crate::app::services::AppServices;
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum RenderError {
@@ -14,10 +18,6 @@ impl From<std::io::Error> for RenderError {
 }
 
 pub type RenderResult<T> = Result<T, RenderError>;
-
-use crate::app::model::app_state::AppState;
-use crate::app::model::shared::viewport::{ColumnWidthsCache, ViewportPlan};
-use crate::app::services::AppServices;
 
 #[derive(Default)]
 pub struct RenderOutput {

--- a/src/app/ports/renderer.rs
+++ b/src/app/ports/renderer.rs
@@ -1,6 +1,19 @@
 use std::time::Instant;
+use std::sync::Arc;
 
-use color_eyre::eyre::Result;
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum RenderError {
+    #[error("I/O error: {0}")]
+    Io(#[source] Arc<std::io::Error>),
+}
+
+impl From<std::io::Error> for RenderError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(Arc::new(error))
+    }
+}
+
+pub type RenderResult<T> = Result<T, RenderError>;
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::viewport::{ColumnWidthsCache, ViewportPlan};
@@ -35,5 +48,5 @@ pub trait Renderer {
         state: &AppState,
         services: &AppServices,
         now: Instant,
-    ) -> Result<RenderOutput>;
+    ) -> RenderResult<RenderOutput>;
 }

--- a/src/infra/adapters/config_writer.rs
+++ b/src/infra/adapters/config_writer.rs
@@ -17,10 +17,12 @@ impl Default for FileConfigWriter {
     }
 }
 
-fn map_cache_dir_error(error: CacheDirError) -> ConfigWriterError {
-    match error {
-        CacheDirError::BaseDirUnavailable => ConfigWriterError::MissingCacheDir,
-        CacheDirError::Io(error) => error.into(),
+impl From<CacheDirError> for ConfigWriterError {
+    fn from(error: CacheDirError) -> Self {
+        match error {
+            CacheDirError::BaseDirUnavailable => Self::MissingCacheDir,
+            CacheDirError::Io(error) => error.into(),
+        }
     }
 }
 
@@ -29,7 +31,7 @@ impl ConfigWriter for FileConfigWriter {
         &self,
         project_name: &str,
     ) -> Result<PathBuf, ConfigWriterError> {
-        get_cache_dir(project_name).map_err(map_cache_dir_error)
+        Ok(get_cache_dir(project_name)?)
     }
 }
 
@@ -41,17 +43,18 @@ mod tests {
 
     #[test]
     fn unavailable_cache_base_maps_to_missing_cache_dir() {
-        let error = map_cache_dir_error(CacheDirError::BaseDirUnavailable);
+        let error: ConfigWriterError = CacheDirError::BaseDirUnavailable.into();
 
         assert!(matches!(error, ConfigWriterError::MissingCacheDir));
     }
 
     #[test]
     fn io_not_found_remains_io_error() {
-        let error = map_cache_dir_error(CacheDirError::Io(io::Error::new(
+        let error: ConfigWriterError = CacheDirError::Io(io::Error::new(
             io::ErrorKind::NotFound,
             "missing parent",
-        )));
+        ))
+        .into();
 
         match error {
             ConfigWriterError::Io(source) => {

--- a/src/infra/adapters/config_writer.rs
+++ b/src/infra/adapters/config_writer.rs
@@ -1,8 +1,7 @@
-use std::io;
 use std::path::PathBuf;
 
 use crate::app::ports::{ConfigWriter, ConfigWriterError};
-use crate::infra::config::cache::get_cache_dir;
+use crate::infra::config::cache::{CacheDirError, get_cache_dir};
 
 pub struct FileConfigWriter;
 
@@ -18,17 +17,18 @@ impl Default for FileConfigWriter {
     }
 }
 
+fn map_cache_dir_error(error: CacheDirError) -> ConfigWriterError {
+    match error {
+        CacheDirError::BaseDirUnavailable => ConfigWriterError::MissingCacheDir,
+        CacheDirError::Io(error) => error.into(),
+    }
+}
+
 impl ConfigWriter for FileConfigWriter {
     fn get_cache_dir(
         &self,
         project_name: &str,
     ) -> Result<PathBuf, ConfigWriterError> {
-        get_cache_dir(project_name).map_err(|error| {
-            if error.kind() == io::ErrorKind::NotFound {
-                ConfigWriterError::MissingCacheDir
-            } else {
-                error.into()
-            }
-        })
+        get_cache_dir(project_name).map_err(map_cache_dir_error)
     }
 }

--- a/src/infra/adapters/config_writer.rs
+++ b/src/infra/adapters/config_writer.rs
@@ -32,3 +32,32 @@ impl ConfigWriter for FileConfigWriter {
         get_cache_dir(project_name).map_err(map_cache_dir_error)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::*;
+
+    #[test]
+    fn unavailable_cache_base_maps_to_missing_cache_dir() {
+        let error = map_cache_dir_error(CacheDirError::BaseDirUnavailable);
+
+        assert!(matches!(error, ConfigWriterError::MissingCacheDir));
+    }
+
+    #[test]
+    fn io_not_found_remains_io_error() {
+        let error = map_cache_dir_error(CacheDirError::Io(io::Error::new(
+            io::ErrorKind::NotFound,
+            "missing parent",
+        )));
+
+        match error {
+            ConfigWriterError::Io(source) => {
+                assert_eq!(source.kind(), io::ErrorKind::NotFound);
+            }
+            ConfigWriterError::MissingCacheDir => panic!("expected io error"),
+        }
+    }
+}

--- a/src/infra/adapters/config_writer.rs
+++ b/src/infra/adapters/config_writer.rs
@@ -1,8 +1,8 @@
+use std::io;
 use std::path::PathBuf;
 
-use color_eyre::eyre::Result;
-
 use crate::app::ports::ConfigWriter;
+use crate::app::ports::ConfigWriterError;
 use crate::infra::config::cache::get_cache_dir;
 
 pub struct FileConfigWriter;
@@ -20,7 +20,16 @@ impl Default for FileConfigWriter {
 }
 
 impl ConfigWriter for FileConfigWriter {
-    fn get_cache_dir(&self, project_name: &str) -> Result<PathBuf> {
-        get_cache_dir(project_name)
+    fn get_cache_dir(
+        &self,
+        project_name: &str,
+    ) -> Result<PathBuf, ConfigWriterError> {
+        get_cache_dir(project_name).map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                ConfigWriterError::MissingCacheDir
+            } else {
+                error.into()
+            }
+        })
     }
 }

--- a/src/infra/adapters/config_writer.rs
+++ b/src/infra/adapters/config_writer.rs
@@ -1,8 +1,7 @@
 use std::io;
 use std::path::PathBuf;
 
-use crate::app::ports::ConfigWriter;
-use crate::app::ports::ConfigWriterError;
+use crate::app::ports::{ConfigWriter, ConfigWriterError};
 use crate::infra::config::cache::get_cache_dir;
 
 pub struct FileConfigWriter;

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
@@ -5,9 +6,18 @@ use async_trait::async_trait;
 use crate::app::ports::{QueryHistoryError, QueryHistoryStore};
 use crate::domain::connection::ConnectionId;
 use crate::domain::query_history::QueryHistoryEntry;
-use crate::infra::config::cache::get_cache_dir;
+use crate::infra::config::cache::{CacheDirError, get_cache_dir};
 
 const MAX_HISTORY_ENTRIES: usize = 1000;
+
+fn map_cache_dir_error(error: CacheDirError) -> QueryHistoryError {
+    match error {
+        CacheDirError::BaseDirUnavailable => {
+            io::Error::new(io::ErrorKind::NotFound, "Could not find cache directory").into()
+        }
+        CacheDirError::Io(error) => error.into(),
+    }
+}
 
 fn append_entry(path: &Path, dir: &Path, line: &str) -> Result<(), QueryHistoryError> {
     use std::fs::OpenOptions;
@@ -60,7 +70,7 @@ impl FileQueryHistoryStore {
         if let Some(base) = &self.base_dir {
             Ok(base.join("history"))
         } else {
-            let cache_dir = get_cache_dir(project_name)?;
+            let cache_dir = get_cache_dir(project_name).map_err(map_cache_dir_error)?;
             Ok(cache_dir.join("history"))
         }
     }

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -13,9 +13,7 @@ const MAX_HISTORY_ENTRIES: usize = 1000;
 impl From<CacheDirError> for QueryHistoryError {
     fn from(error: CacheDirError) -> Self {
         match error {
-            CacheDirError::BaseDirUnavailable => {
-                io::Error::new(io::ErrorKind::NotFound, "cache directory is unavailable").into()
-            }
+            CacheDirError::BaseDirUnavailable => Self::MissingCacheDir,
             CacheDirError::Io(error) => error.into(),
         }
     }

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -10,12 +10,14 @@ use crate::infra::config::cache::{CacheDirError, get_cache_dir};
 
 const MAX_HISTORY_ENTRIES: usize = 1000;
 
-fn map_cache_dir_error(error: CacheDirError) -> QueryHistoryError {
-    match error {
-        CacheDirError::BaseDirUnavailable => {
-            io::Error::new(io::ErrorKind::NotFound, "cache directory is unavailable").into()
+impl From<CacheDirError> for QueryHistoryError {
+    fn from(error: CacheDirError) -> Self {
+        match error {
+            CacheDirError::BaseDirUnavailable => {
+                io::Error::new(io::ErrorKind::NotFound, "cache directory is unavailable").into()
+            }
+            CacheDirError::Io(error) => error.into(),
         }
-        CacheDirError::Io(error) => error.into(),
     }
 }
 
@@ -70,7 +72,7 @@ impl FileQueryHistoryStore {
         if let Some(base) = &self.base_dir {
             Ok(base.join("history"))
         } else {
-            let cache_dir = get_cache_dir(project_name).map_err(map_cache_dir_error)?;
+            let cache_dir = get_cache_dir(project_name)?;
             Ok(cache_dir.join("history"))
         }
     }

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -13,7 +13,7 @@ const MAX_HISTORY_ENTRIES: usize = 1000;
 fn map_cache_dir_error(error: CacheDirError) -> QueryHistoryError {
     match error {
         CacheDirError::BaseDirUnavailable => {
-            io::Error::new(io::ErrorKind::NotFound, "Could not find cache directory").into()
+            io::Error::new(io::ErrorKind::NotFound, "cache directory is unavailable").into()
         }
         CacheDirError::Io(error) => error.into(),
     }

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -60,7 +60,7 @@ impl FileQueryHistoryStore {
         if let Some(base) = &self.base_dir {
             Ok(base.join("history"))
         } else {
-            let cache_dir = get_cache_dir(project_name).map_err(std::io::Error::other)?;
+            let cache_dir = get_cache_dir(project_name)?;
             Ok(cache_dir.join("history"))
         }
     }

--- a/src/infra/config/cache.rs
+++ b/src/infra/config/cache.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 pub enum CacheDirError {
     #[error("cache directory is unavailable")]
     BaseDirUnavailable,
-    #[error("i/o error: {0}")]
+    #[error("I/O error: {0}")]
     Io(#[source] io::Error),
 }
 

--- a/src/infra/config/cache.rs
+++ b/src/infra/config/cache.rs
@@ -1,10 +1,10 @@
 use std::fs;
+use std::io;
 use std::path::PathBuf;
 
-use color_eyre::eyre::{Result, eyre};
-
-pub fn get_cache_dir(project_name: &str) -> Result<PathBuf> {
-    let cache_base = dirs::cache_dir().ok_or_else(|| eyre!("Could not find cache directory"))?;
+pub fn get_cache_dir(project_name: &str) -> io::Result<PathBuf> {
+    let cache_base = dirs::cache_dir()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Could not find cache directory"))?;
     let cache_dir = cache_base.join("sabiql").join(project_name);
 
     if !cache_dir.exists() {

--- a/src/infra/config/cache.rs
+++ b/src/infra/config/cache.rs
@@ -17,8 +17,7 @@ impl From<io::Error> for CacheDirError {
 }
 
 pub fn get_cache_dir(project_name: &str) -> Result<PathBuf, CacheDirError> {
-    let cache_base = dirs::cache_dir()
-        .ok_or(CacheDirError::BaseDirUnavailable)?;
+    let cache_base = dirs::cache_dir().ok_or(CacheDirError::BaseDirUnavailable)?;
     let cache_dir = cache_base.join("sabiql").join(project_name);
 
     if !cache_dir.exists() {

--- a/src/infra/config/cache.rs
+++ b/src/infra/config/cache.rs
@@ -2,9 +2,23 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 
-pub fn get_cache_dir(project_name: &str) -> io::Result<PathBuf> {
+#[derive(Debug, thiserror::Error)]
+pub enum CacheDirError {
+    #[error("cache directory is unavailable")]
+    BaseDirUnavailable,
+    #[error("i/o error: {0}")]
+    Io(#[source] io::Error),
+}
+
+impl From<io::Error> for CacheDirError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+pub fn get_cache_dir(project_name: &str) -> Result<PathBuf, CacheDirError> {
     let cache_base = dirs::cache_dir()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Could not find cache directory"))?;
+        .ok_or(CacheDirError::BaseDirUnavailable)?;
     let cache_dir = cache_base.join("sabiql").join(project_name);
 
     if !cache_dir.exists() {

--- a/src/infra/config/project_root.rs
+++ b/src/infra/config/project_root.rs
@@ -1,9 +1,8 @@
 use std::env;
+use std::io;
 use std::path::{Path, PathBuf};
 
-use color_eyre::eyre::Result;
-
-pub fn find_project_root() -> Result<PathBuf> {
+pub fn find_project_root() -> io::Result<PathBuf> {
     let cwd = env::current_dir()?;
 
     if let Some(root) = find_dir_upward(&cwd, ".git") {

--- a/src/ui/adapters/tui_adapter.rs
+++ b/src/ui/adapters/tui_adapter.rs
@@ -1,12 +1,11 @@
 use std::time::Instant;
 
-use color_eyre::eyre::Result;
 use crossterm::cursor::SetCursorStyle;
 use crossterm::execute;
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::input_mode::InputMode;
-use crate::app::ports::renderer::{RenderOutput, Renderer};
+use crate::app::ports::renderer::{RenderOutput, RenderResult, Renderer};
 use crate::app::services::AppServices;
 use crate::ui::shell::layout::MainLayout;
 use crate::ui::tui::TuiRunner;
@@ -31,7 +30,7 @@ impl Renderer for TuiAdapter<'_> {
         state: &AppState,
         services: &AppServices,
         now: Instant,
-    ) -> Result<RenderOutput> {
+    ) -> RenderResult<RenderOutput> {
         let mut output = RenderOutput::default();
         self.tui.terminal().draw(|frame| {
             output = MainLayout::render(frame, state, None, services, now);

--- a/src/ui/adapters/tui_adapter.rs
+++ b/src/ui/adapters/tui_adapter.rs
@@ -37,14 +37,14 @@ impl Renderer for TuiAdapter<'_> {
         })?;
         let uses_insert = uses_insert_cursor(state);
         if self.last_cursor_insert != Some(uses_insert) {
-            let _ = execute!(
+            execute!(
                 std::io::stdout(),
                 if uses_insert {
                     SetCursorStyle::SteadyBar
                 } else {
                     SetCursorStyle::SteadyBlock
                 }
-            );
+            )?;
             self.last_cursor_insert = Some(uses_insert);
         }
         Ok(output)


### PR DESCRIPTION
## Problem
Scope: replace `color_eyre` at app port boundaries and adjacent infra helpers with typed errors, while preserving existing behavior at the application layer.

Port and infra code still exposed generic reports, which blurred error contracts and leaked composition-root concerns below the intended boundary.

## Background
These ports act as stable app-layer contracts, so generic error reports make branching behavior, testing, and follow-up evolution harder than explicit domain errors.

## Approach
Introduce typed errors for config writing and rendering, separate cache base-directory unavailability from generic filesystem failures, and keep adapter mappings explicit so callers receive semantically meaningful failures without depending on `color_eyre`.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * レンダリングと設定周りのエラーハンドリングを型安全な専用エラー型へ移行し、結果型を統一しました（レンダリング／キャッシュ取得など）。
* **Bug Fixes**
  * キャッシュディレクトリ関連のエラー変換を明確化し、誤ったエラーマッピングを修正しました。
* **Tests**
  * 新しいエラー型に合わせた単体テストと表示メッセージ検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->