### PR TITLE
Refactor metadata enum parsing through FromStr

### DIFF
--- a/src/app/ports/db_operation_error.rs
+++ b/src/app/ports/db_operation_error.rs
@@ -6,6 +6,8 @@ pub enum DbOperationError {
     ConnectionFailed(String),
     #[error("Query failed: {0}")]
     QueryFailed(String),
+    #[error("Metadata parse failed: {0}")]
+    MetadataParseFailed(String),
     #[error("Invalid JSON: {0}")]
     InvalidJson(#[source] Arc<serde_json::Error>),
     #[error("Empty response: {0}")]

--- a/src/domain/foreign_key.rs
+++ b/src/domain/foreign_key.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForeignKey {
     pub name: String,
@@ -39,9 +41,38 @@ impl std::fmt::Display for FkAction {
     }
 }
 
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum ParseFkActionError {
+    #[error("invalid foreign key action: {input}")]
+    Invalid { input: String },
+}
+
+impl FromStr for FkAction {
+    type Err = ParseFkActionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "a" => Ok(Self::NoAction),
+            "r" => Ok(Self::Restrict),
+            "c" => Ok(Self::Cascade),
+            "n" => Ok(Self::SetNull),
+            "d" => Ok(Self::SetDefault),
+            input if input.eq_ignore_ascii_case("NO ACTION") => Ok(Self::NoAction),
+            input if input.eq_ignore_ascii_case("RESTRICT") => Ok(Self::Restrict),
+            input if input.eq_ignore_ascii_case("CASCADE") => Ok(Self::Cascade),
+            input if input.eq_ignore_ascii_case("SET NULL") => Ok(Self::SetNull),
+            input if input.eq_ignore_ascii_case("SET DEFAULT") => Ok(Self::SetDefault),
+            _ => Err(ParseFkActionError::Invalid {
+                input: s.to_string(),
+            }),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn referenced_table_returns_schema_dot_table() {
@@ -58,5 +89,38 @@ mod tests {
         };
 
         assert_eq!(fk.referenced_table(), "public.users");
+    }
+
+    #[rstest]
+    #[case(FkAction::NoAction)]
+    #[case(FkAction::Restrict)]
+    #[case(FkAction::Cascade)]
+    #[case(FkAction::SetNull)]
+    #[case(FkAction::SetDefault)]
+    fn display_round_trips(#[case] action: FkAction) {
+        assert_eq!(action.to_string().parse::<FkAction>().unwrap(), action);
+    }
+
+    #[rstest]
+    #[case("a", FkAction::NoAction)]
+    #[case("r", FkAction::Restrict)]
+    #[case("c", FkAction::Cascade)]
+    #[case("n", FkAction::SetNull)]
+    #[case("d", FkAction::SetDefault)]
+    #[case("no action", FkAction::NoAction)]
+    #[case("restrict", FkAction::Restrict)]
+    #[case("cascade", FkAction::Cascade)]
+    #[case("set null", FkAction::SetNull)]
+    #[case("set default", FkAction::SetDefault)]
+    fn from_str_accepts_codes_and_labels(#[case] input: &str, #[case] expected: FkAction) {
+        assert_eq!(input.parse::<FkAction>().unwrap(), expected);
+    }
+
+    #[test]
+    fn from_str_rejects_unknown_action() {
+        assert!(matches!(
+            "x".parse::<FkAction>(),
+            Err(ParseFkActionError::Invalid { .. })
+        ));
     }
 }

--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 #[derive(Debug, Clone)]
 pub struct Index {
     pub name: String,
@@ -29,5 +31,49 @@ impl std::fmt::Display for IndexType {
             Self::Brin => write!(f, "brin"),
             Self::Other(s) => write!(f, "{s}"),
         }
+    }
+}
+
+impl FromStr for IndexType {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.to_ascii_lowercase().as_str() {
+            "btree" => Self::BTree,
+            "hash" => Self::Hash,
+            "gist" => Self::Gist,
+            "gin" => Self::Gin,
+            "brin" => Self::Brin,
+            _ => Self::Other(s.to_string()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(IndexType::BTree)]
+    #[case(IndexType::Hash)]
+    #[case(IndexType::Gist)]
+    #[case(IndexType::Gin)]
+    #[case(IndexType::Brin)]
+    #[case(IndexType::Other("custom_am".to_string()))]
+    fn display_round_trips(#[case] index_type: IndexType) {
+        assert_eq!(
+            index_type.to_string().parse::<IndexType>().unwrap(),
+            index_type
+        );
+    }
+
+    #[rstest]
+    #[case("btree", IndexType::BTree)]
+    #[case("HASH", IndexType::Hash)]
+    #[case("gist", IndexType::Gist)]
+    #[case("custom_am", IndexType::Other("custom_am".to_string()))]
+    fn from_str_parses_known_and_unknown_types(#[case] input: &str, #[case] expected: IndexType) {
+        assert_eq!(input.parse::<IndexType>().unwrap(), expected);
     }
 }

--- a/src/domain/rls.rs
+++ b/src/domain/rls.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 #[derive(Debug, Clone)]
 pub struct RlsInfo {
     pub enabled: bool,
@@ -44,5 +46,68 @@ impl std::fmt::Display for RlsCommand {
             Self::Update => write!(f, "UPDATE"),
             Self::Delete => write!(f, "DELETE"),
         }
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum ParseRlsCommandError {
+    #[error("invalid RLS command: {input}")]
+    Invalid { input: String },
+}
+
+impl FromStr for RlsCommand {
+    type Err = ParseRlsCommandError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "*" => Ok(Self::All),
+            "r" => Ok(Self::Select),
+            "a" => Ok(Self::Insert),
+            "w" => Ok(Self::Update),
+            "d" => Ok(Self::Delete),
+            input if input.eq_ignore_ascii_case("ALL") => Ok(Self::All),
+            input if input.eq_ignore_ascii_case("SELECT") => Ok(Self::Select),
+            input if input.eq_ignore_ascii_case("INSERT") => Ok(Self::Insert),
+            input if input.eq_ignore_ascii_case("UPDATE") => Ok(Self::Update),
+            input if input.eq_ignore_ascii_case("DELETE") => Ok(Self::Delete),
+            _ => Err(ParseRlsCommandError::Invalid {
+                input: s.to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(RlsCommand::All)]
+    #[case(RlsCommand::Select)]
+    #[case(RlsCommand::Insert)]
+    #[case(RlsCommand::Update)]
+    #[case(RlsCommand::Delete)]
+    fn display_round_trips(#[case] command: RlsCommand) {
+        assert_eq!(command.to_string().parse::<RlsCommand>().unwrap(), command);
+    }
+
+    #[rstest]
+    #[case("*", RlsCommand::All)]
+    #[case("r", RlsCommand::Select)]
+    #[case("a", RlsCommand::Insert)]
+    #[case("w", RlsCommand::Update)]
+    #[case("d", RlsCommand::Delete)]
+    #[case("select", RlsCommand::Select)]
+    fn from_str_accepts_codes_and_labels(#[case] input: &str, #[case] expected: RlsCommand) {
+        assert_eq!(input.parse::<RlsCommand>().unwrap(), expected);
+    }
+
+    #[test]
+    fn from_str_rejects_unknown_command() {
+        assert!(matches!(
+            "x".parse::<RlsCommand>(),
+            Err(ParseRlsCommandError::Invalid { .. })
+        ));
     }
 }

--- a/src/domain/trigger.rs
+++ b/src/domain/trigger.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TriggerTiming {
@@ -36,6 +37,49 @@ impl fmt::Display for TriggerEvent {
     }
 }
 
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum ParseTriggerTimingError {
+    #[error("invalid trigger timing: {input}")]
+    Invalid { input: String },
+}
+
+impl FromStr for TriggerTiming {
+    type Err = ParseTriggerTimingError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            input if input.eq_ignore_ascii_case("BEFORE") => Ok(Self::Before),
+            input if input.eq_ignore_ascii_case("AFTER") => Ok(Self::After),
+            input if input.eq_ignore_ascii_case("INSTEAD OF") => Ok(Self::InsteadOf),
+            _ => Err(ParseTriggerTimingError::Invalid {
+                input: s.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum ParseTriggerEventError {
+    #[error("invalid trigger event: {input}")]
+    Invalid { input: String },
+}
+
+impl FromStr for TriggerEvent {
+    type Err = ParseTriggerEventError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            input if input.eq_ignore_ascii_case("INSERT") => Ok(Self::Insert),
+            input if input.eq_ignore_ascii_case("UPDATE") => Ok(Self::Update),
+            input if input.eq_ignore_ascii_case("DELETE") => Ok(Self::Delete),
+            input if input.eq_ignore_ascii_case("TRUNCATE") => Ok(Self::Truncate),
+            _ => Err(ParseTriggerEventError::Invalid {
+                input: s.to_string(),
+            }),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Trigger {
     pub name: String,
@@ -48,6 +92,7 @@ pub struct Trigger {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     mod trigger_timing_display {
         use super::*;
@@ -65,6 +110,22 @@ mod tests {
         #[test]
         fn instead_of_displays_with_space() {
             assert_eq!(TriggerTiming::InsteadOf.to_string(), "INSTEAD OF");
+        }
+
+        #[rstest]
+        #[case(TriggerTiming::Before)]
+        #[case(TriggerTiming::After)]
+        #[case(TriggerTiming::InsteadOf)]
+        fn display_round_trips(#[case] timing: TriggerTiming) {
+            assert_eq!(timing.to_string().parse::<TriggerTiming>().unwrap(), timing);
+        }
+
+        #[test]
+        fn from_str_rejects_unknown_timing() {
+            assert!(matches!(
+                "unknown".parse::<TriggerTiming>(),
+                Err(ParseTriggerTimingError::Invalid { .. })
+            ));
         }
     }
 
@@ -89,6 +150,23 @@ mod tests {
         #[test]
         fn truncate_displays_uppercase() {
             assert_eq!(TriggerEvent::Truncate.to_string(), "TRUNCATE");
+        }
+
+        #[rstest]
+        #[case(TriggerEvent::Insert)]
+        #[case(TriggerEvent::Update)]
+        #[case(TriggerEvent::Delete)]
+        #[case(TriggerEvent::Truncate)]
+        fn display_round_trips(#[case] event: TriggerEvent) {
+            assert_eq!(event.to_string().parse::<TriggerEvent>().unwrap(), event);
+        }
+
+        #[test]
+        fn from_str_rejects_unknown_event() {
+            assert!(matches!(
+                "merge".parse::<TriggerEvent>(),
+                Err(ParseTriggerEventError::Invalid { .. })
+            ));
         }
     }
 }

--- a/src/infra/adapters/postgres/psql/parser/metadata.rs
+++ b/src/infra/adapters/postgres/psql/parser/metadata.rs
@@ -238,8 +238,7 @@ impl PostgresAdapter {
 
         let raw: Vec<RawForeignKey> = serde_json::from_str(trimmed)?;
 
-        Ok(raw
-            .into_iter()
+        raw.into_iter()
             .map(|fk| {
                 let on_delete = fk
                     .on_delete
@@ -262,7 +261,7 @@ impl PostgresAdapter {
                 })
             })
             .collect::<Result<Vec<_>, MetadataParseError>>()
-            .map_err(DbOperationError::from)?)
+            .map_err(DbOperationError::from)
     }
 
     pub(in crate::infra::adapters::postgres) fn parse_rls(
@@ -336,8 +335,7 @@ impl PostgresAdapter {
 
         let raw: Vec<RawTrigger> = serde_json::from_str(trimmed)?;
 
-        Ok(raw
-            .into_iter()
+        raw.into_iter()
             .map(|t| {
                 let timing = t
                     .timing
@@ -361,7 +359,7 @@ impl PostgresAdapter {
                 })
             })
             .collect::<Result<Vec<_>, MetadataParseError>>()
-            .map_err(DbOperationError::from)?)
+            .map_err(DbOperationError::from)
     }
 
     pub(in crate::infra::adapters::postgres) fn parse_table_detail_combined(

--- a/src/infra/adapters/postgres/psql/parser/metadata.rs
+++ b/src/infra/adapters/postgres/psql/parser/metadata.rs
@@ -202,22 +202,18 @@ impl PostgresAdapter {
 
         Ok(raw
             .into_iter()
-            .map(|i| {
-                let index_type = i
-                    .index_type
-                    .parse::<IndexType>()
-                    .map_err(|never| match never {})?;
-                Ok(Index {
-                    name: i.name,
-                    columns: i.columns,
-                    is_unique: i.is_unique,
-                    is_primary: i.is_primary,
-                    index_type,
-                    definition: i.definition,
-                })
+            .map(|i| Index {
+                name: i.name,
+                columns: i.columns,
+                is_unique: i.is_unique,
+                is_primary: i.is_primary,
+                index_type: match i.index_type.parse::<IndexType>() {
+                    Ok(index_type) => index_type,
+                    Err(never) => match never {},
+                },
+                definition: i.definition,
             })
-            .collect::<Result<Vec<_>, std::convert::Infallible>>()
-            .map_err(|never| match never {})?)
+            .collect())
     }
 
     pub(in crate::infra::adapters::postgres) fn parse_foreign_keys(

--- a/src/infra/adapters/postgres/psql/parser/metadata.rs
+++ b/src/infra/adapters/postgres/psql/parser/metadata.rs
@@ -15,6 +15,24 @@ pub(in crate::infra::adapters::postgres) type TableDetailCombined = (
     TableInfo,
 );
 
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+enum MetadataParseError {
+    #[error("foreign key action parse failed: {0}")]
+    ForeignKeyAction(String),
+    #[error("RLS command parse failed: {0}")]
+    RlsCommand(String),
+    #[error("trigger timing parse failed: {0}")]
+    TriggerTiming(String),
+    #[error("trigger event parse failed: {0}")]
+    TriggerEvent(String),
+}
+
+impl From<MetadataParseError> for DbOperationError {
+    fn from(error: MetadataParseError) -> Self {
+        Self::MetadataParseFailed(error.to_string())
+    }
+}
+
 fn non_empty_json(raw: &str) -> Option<&str> {
     let trimmed = raw.trim();
     if trimmed.is_empty() || trimmed == "null" {
@@ -184,22 +202,22 @@ impl PostgresAdapter {
 
         Ok(raw
             .into_iter()
-            .map(|i| Index {
-                name: i.name,
-                columns: i.columns,
-                is_unique: i.is_unique,
-                is_primary: i.is_primary,
-                index_type: match i.index_type.as_str() {
-                    "btree" => IndexType::BTree,
-                    "hash" => IndexType::Hash,
-                    "gist" => IndexType::Gist,
-                    "gin" => IndexType::Gin,
-                    "brin" => IndexType::Brin,
-                    other => IndexType::Other(other.to_string()),
-                },
-                definition: i.definition,
+            .map(|i| {
+                let index_type = i
+                    .index_type
+                    .parse::<IndexType>()
+                    .map_err(|never| match never {})?;
+                Ok(Index {
+                    name: i.name,
+                    columns: i.columns,
+                    is_unique: i.is_unique,
+                    is_primary: i.is_primary,
+                    index_type,
+                    definition: i.definition,
+                })
             })
-            .collect())
+            .collect::<Result<Vec<_>, std::convert::Infallible>>()
+            .map_err(|never| match never {})?)
     }
 
     pub(in crate::infra::adapters::postgres) fn parse_foreign_keys(
@@ -222,32 +240,33 @@ impl PostgresAdapter {
             on_update: String,
         }
 
-        fn parse_fk_action(code: &str) -> FkAction {
-            match code {
-                "r" => FkAction::Restrict,
-                "c" => FkAction::Cascade,
-                "n" => FkAction::SetNull,
-                "d" => FkAction::SetDefault,
-                _ => FkAction::NoAction,
-            }
-        }
-
         let raw: Vec<RawForeignKey> = serde_json::from_str(trimmed)?;
 
         Ok(raw
             .into_iter()
-            .map(|fk| ForeignKey {
-                name: fk.name,
-                from_schema: fk.from_schema,
-                from_table: fk.from_table,
-                from_columns: fk.from_columns,
-                to_schema: fk.to_schema,
-                to_table: fk.to_table,
-                to_columns: fk.to_columns,
-                on_delete: parse_fk_action(&fk.on_delete),
-                on_update: parse_fk_action(&fk.on_update),
+            .map(|fk| {
+                let on_delete = fk
+                    .on_delete
+                    .parse::<FkAction>()
+                    .map_err(|error| MetadataParseError::ForeignKeyAction(error.to_string()))?;
+                let on_update = fk
+                    .on_update
+                    .parse::<FkAction>()
+                    .map_err(|error| MetadataParseError::ForeignKeyAction(error.to_string()))?;
+                Ok(ForeignKey {
+                    name: fk.name,
+                    from_schema: fk.from_schema,
+                    from_table: fk.from_table,
+                    from_columns: fk.from_columns,
+                    to_schema: fk.to_schema,
+                    to_table: fk.to_table,
+                    to_columns: fk.to_columns,
+                    on_delete,
+                    on_update,
+                })
             })
-            .collect())
+            .collect::<Result<Vec<_>, MetadataParseError>>()
+            .map_err(DbOperationError::from)?)
     }
 
     pub(in crate::infra::adapters::postgres) fn parse_rls(
@@ -279,21 +298,22 @@ impl PostgresAdapter {
         let policies = raw
             .policies
             .into_iter()
-            .map(|p| RlsPolicy {
-                name: p.name,
-                permissive: p.permissive,
-                roles: p.roles.unwrap_or_default(),
-                cmd: match p.cmd.as_str() {
-                    "r" => RlsCommand::Select,
-                    "a" => RlsCommand::Insert,
-                    "w" => RlsCommand::Update,
-                    "d" => RlsCommand::Delete,
-                    _ => RlsCommand::All,
-                },
-                qual: p.qual,
-                with_check: p.with_check,
+            .map(|p| {
+                let cmd = p
+                    .cmd
+                    .parse::<RlsCommand>()
+                    .map_err(|error| MetadataParseError::RlsCommand(error.to_string()))?;
+                Ok(RlsPolicy {
+                    name: p.name,
+                    permissive: p.permissive,
+                    roles: p.roles.unwrap_or_default(),
+                    cmd,
+                    qual: p.qual,
+                    with_check: p.with_check,
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>, MetadataParseError>>()
+            .map_err(DbOperationError::from)?;
 
         Ok(Some(RlsInfo {
             enabled: raw.enabled,
@@ -322,28 +342,30 @@ impl PostgresAdapter {
 
         Ok(raw
             .into_iter()
-            .map(|t| Trigger {
-                name: t.name,
-                timing: match t.timing.as_str() {
-                    "BEFORE" => TriggerTiming::Before,
-                    "INSTEAD OF" => TriggerTiming::InsteadOf,
-                    _ => TriggerTiming::After,
-                },
-                events: t
+            .map(|t| {
+                let timing = t
+                    .timing
+                    .parse::<TriggerTiming>()
+                    .map_err(|error| MetadataParseError::TriggerTiming(error.to_string()))?;
+                let events = t
                     .events
-                    .iter()
-                    .filter_map(|e| match e.as_str() {
-                        "INSERT" => Some(TriggerEvent::Insert),
-                        "UPDATE" => Some(TriggerEvent::Update),
-                        "DELETE" => Some(TriggerEvent::Delete),
-                        "TRUNCATE" => Some(TriggerEvent::Truncate),
-                        _ => None,
+                    .into_iter()
+                    .map(|event| {
+                        event
+                            .parse::<TriggerEvent>()
+                            .map_err(|error| MetadataParseError::TriggerEvent(error.to_string()))
                     })
-                    .collect(),
-                function_name: t.function_name,
-                security_definer: t.security_definer,
+                    .collect::<Result<Vec<_>, MetadataParseError>>()?;
+                Ok(Trigger {
+                    name: t.name,
+                    timing,
+                    events,
+                    function_name: t.function_name,
+                    security_definer: t.security_definer,
+                })
             })
-            .collect())
+            .collect::<Result<Vec<_>, MetadataParseError>>()
+            .map_err(DbOperationError::from)?)
     }
 
     pub(in crate::infra::adapters::postgres) fn parse_table_detail_combined(
@@ -542,7 +564,6 @@ mod tests {
         #[case("a", RlsCommand::Insert)]
         #[case("w", RlsCommand::Update)]
         #[case("d", RlsCommand::Delete)]
-        #[case("x", RlsCommand::All)] // unknown defaults to All
         fn cmd_code_maps_to_rls_command(#[case] cmd: &str, #[case] expected: RlsCommand) {
             let json = format!(
                 r#"{{"enabled": true, "force": false, "policies": [{{
@@ -555,6 +576,29 @@ mod tests {
             let rls = result.unwrap();
 
             assert_eq!(rls.policies[0].cmd, expected);
+        }
+
+        #[test]
+        fn unknown_command_returns_metadata_parse_error() {
+            let json = r#"{
+                "enabled": true,
+                "force": false,
+                "policies": [{
+                    "name": "test",
+                    "permissive": true,
+                    "roles": null,
+                    "cmd": "x",
+                    "qual": null,
+                    "with_check": null
+                }]
+            }"#;
+
+            let result = PostgresAdapter::parse_rls(json);
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::MetadataParseFailed(_))
+            ));
         }
 
         #[test]
@@ -582,6 +626,7 @@ mod tests {
 
     mod json_parse_errors {
         use super::*;
+        use crate::domain::IndexType;
 
         #[test]
         fn parse_tables_with_malformed_json_returns_error() {
@@ -608,6 +653,25 @@ mod tests {
                 r#"[{"name": "idx_test", "columns": "id", "unique": false, "primary": false}]"#;
             let result = PostgresAdapter::parse_indexes(json);
             assert!(matches!(result, Err(DbOperationError::InvalidJson(_))));
+        }
+
+        #[test]
+        fn parse_indexes_with_unknown_access_method_preserves_other() {
+            let json = r#"[{
+                "name": "idx_custom",
+                "columns": ["id"],
+                "is_unique": false,
+                "is_primary": false,
+                "index_type": "ivfflat",
+                "definition": null
+            }]"#;
+
+            let result = PostgresAdapter::parse_indexes(json).unwrap();
+
+            assert_eq!(
+                result[0].index_type,
+                IndexType::Other("ivfflat".to_string())
+            );
         }
 
         #[test]
@@ -729,7 +793,6 @@ mod tests {
         #[case("BEFORE", TriggerTiming::Before)]
         #[case("AFTER", TriggerTiming::After)]
         #[case("INSTEAD OF", TriggerTiming::InsteadOf)]
-        #[case("UNKNOWN", TriggerTiming::After)] // unknown defaults to After
         fn timing_code_maps_to_trigger_timing(
             #[case] timing: &str,
             #[case] expected: TriggerTiming,
@@ -743,6 +806,24 @@ mod tests {
 
             let result = PostgresAdapter::parse_triggers(&json).unwrap();
             assert_eq!(result[0].timing, expected);
+        }
+
+        #[test]
+        fn unknown_timing_returns_metadata_parse_error() {
+            let json = r#"[{
+                "name": "test",
+                "timing": "UNKNOWN",
+                "events": ["INSERT"],
+                "function_name": "func",
+                "security_definer": false
+            }]"#;
+
+            let result = PostgresAdapter::parse_triggers(json);
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::MetadataParseFailed(_))
+            ));
         }
 
         #[test]
@@ -792,6 +873,24 @@ mod tests {
 
             let result = PostgresAdapter::parse_triggers(json).unwrap();
             assert!(!result[0].security_definer);
+        }
+
+        #[test]
+        fn unknown_event_returns_metadata_parse_error() {
+            let json = r#"[{
+                "name": "test",
+                "timing": "AFTER",
+                "events": ["INSERT", "MERGE"],
+                "function_name": "func",
+                "security_definer": false
+            }]"#;
+
+            let result = PostgresAdapter::parse_triggers(json);
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::MetadataParseFailed(_))
+            ));
         }
     }
 
@@ -905,7 +1004,6 @@ mod tests {
         #[case("c", FkAction::Cascade)]
         #[case("n", FkAction::SetNull)]
         #[case("d", FkAction::SetDefault)]
-        #[case("x", FkAction::NoAction)]
         fn fk_code_maps_to_fk_action(#[case] action_code: &str, #[case] expected: FkAction) {
             let json = format!(
                 r#"[{{
@@ -923,6 +1021,28 @@ mod tests {
 
             let result = PostgresAdapter::parse_foreign_keys(&json).unwrap();
             assert_eq!(result[0].on_delete, expected);
+        }
+
+        #[test]
+        fn unknown_action_returns_metadata_parse_error() {
+            let json = r#"[{
+                "name": "test_fk",
+                "from_schema": "public",
+                "from_table": "t1",
+                "from_columns": ["id"],
+                "to_schema": "public",
+                "to_table": "t2",
+                "to_columns": ["id"],
+                "on_delete": "x",
+                "on_update": "a"
+            }]"#;
+
+            let result = PostgresAdapter::parse_foreign_keys(json);
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::MetadataParseFailed(_))
+            ));
         }
 
         #[test]


### PR DESCRIPTION
## Problem
The PostgreSQL metadata parser duplicated enum conversion logic in adapter-local matches, which made parsing rules drift away from the domain representations and silently accepted invalid metadata values.

## Background
This parser area is already being tightened around explicit parsing boundaries, so keeping metadata enum conversion outside the domain would continue the split source of truth.

## Approach
Move metadata enum conversion behind `FromStr` so the parser uses one entrypoint for foreign key actions, RLS commands, trigger metadata, and index access methods. Tighten invalid metadata handling into explicit parse failures, keep index access methods lossless through `Other(String)`, and preserve PostgreSQL-specific parse details inside adapter-local error mapping.

## Scope
- Refactor PostgreSQL metadata parsing to route enum conversion through domain parsing
- Remove silent fallback behavior for invalid foreign key, RLS, and trigger metadata values
- Add domain-level parsing coverage and parser regression coverage for strict metadata handling

## Screenshots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * メタデータのパース機能が強化されました。外部キーアクション、インデックスタイプ、RLSコマンド、トリガータイミング・イベントなど、複数のエレメントについて文字列からのパースサポートが追加されました。

* **Bug Fixes**
  * メタデータパース時のエラーハンドリングが改善されました。不正なデータに対してより詳細なエラー情報が返却されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->