### PR TITLE
refactor: split layers into workspace crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - run: cargo clippy --all-targets --all-features -- -D warnings
-      - run: cargo clippy --all-targets --no-default-features -- -D warnings
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - run: cargo clippy --workspace --all-targets --no-default-features -- -D warnings
       - run: ./scripts/lint_all.sh
 
   test:
@@ -46,10 +46,10 @@ jobs:
           tool: nextest
       - id: test_all_features
         continue-on-error: true
-        run: cargo nextest run --profile ci-all --all-features --show-progress=none --status-level=fail --final-status-level=fail
+        run: cargo nextest run --workspace --profile ci-all --all-features --show-progress=none --status-level=fail --final-status-level=fail
       - id: test_no_default_features
         continue-on-error: true
-        run: cargo nextest run --profile ci-no-default --no-default-features --show-progress=none --status-level=fail --final-status-level=fail
+        run: cargo nextest run --workspace --profile ci-no-default --no-default-features --show-progress=none --status-level=fail --final-status-level=fail
       - name: Summarize failed tests
         if: steps.test_all_features.outcome == 'failure' || steps.test_no_default_features.outcome == 'failure'
         run: |
@@ -67,8 +67,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - run: cargo build --release
-      - run: cargo build --release --no-default-features
+      - run: cargo build --workspace --release
+      - run: cargo build --workspace --release --no-default-features
 
   audit:
     name: Security Audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,6 +2583,10 @@ dependencies = [
  "nucleo-matcher",
  "ratatui",
  "rstest",
+ "sabiql-app",
+ "sabiql-domain",
+ "sabiql-infra",
+ "sabiql-ui",
  "self_update",
  "serde",
  "serde_json",
@@ -2595,6 +2599,82 @@ dependencies = [
  "unicode-width",
  "urlencoding",
  "uuid",
+]
+
+[[package]]
+name = "sabiql-app"
+version = "0.1.0"
+dependencies = [
+ "arboard",
+ "async-trait",
+ "color-eyre",
+ "crossterm",
+ "csv",
+ "dirs",
+ "futures",
+ "lru",
+ "mockall",
+ "nucleo-matcher",
+ "rstest",
+ "sabiql-domain",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "unicode-casefold",
+ "unicode-width",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
+name = "sabiql-domain"
+version = "0.1.0"
+dependencies = [
+ "rstest",
+ "serde",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "sabiql-infra"
+version = "0.1.0"
+dependencies = [
+ "arboard",
+ "async-trait",
+ "csv",
+ "dirs",
+ "rstest",
+ "sabiql-app",
+ "sabiql-domain",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "urlencoding",
+]
+
+[[package]]
+name = "sabiql-ui"
+version = "0.1.0"
+dependencies = [
+ "color-eyre",
+ "crossterm",
+ "futures",
+ "insta",
+ "ratatui",
+ "rstest",
+ "sabiql-app",
+ "sabiql-domain",
+ "tokio",
+ "tokio-util",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,19 +2568,12 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 name = "sabiql"
 version = "1.11.0"
 dependencies = [
- "arboard",
- "async-trait",
  "clap",
  "color-eyre",
  "crossterm",
- "csv",
- "dirs",
  "dotenvy",
- "futures",
  "insta",
- "lru",
  "mockall",
- "nucleo-matcher",
  "ratatui",
  "rstest",
  "sabiql-app",
@@ -2588,17 +2581,8 @@ dependencies = [
  "sabiql-infra",
  "sabiql-ui",
  "self_update",
- "serde",
- "serde_json",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
- "tokio-util",
- "toml",
- "unicode-casefold",
- "unicode-width",
- "urlencoding",
- "uuid",
 ]
 
 [[package]]
@@ -2611,7 +2595,6 @@ dependencies = [
  "crossterm",
  "csv",
  "dirs",
- "futures",
  "lru",
  "mockall",
  "nucleo-matcher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2636,6 +2636,7 @@ version = "0.1.0"
 dependencies = [
  "rstest",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,31 +49,13 @@ keywords = ["postgresql", "tui", "database", "cli", "sql"]
 categories = ["command-line-utilities", "database"]
 
 [dependencies]
-ratatui.workspace = true
 crossterm.workspace = true
 tokio.workspace = true
-tokio-util.workspace = true
-futures.workspace = true
 color-eyre.workspace = true
-toml.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-async-trait.workspace = true
-thiserror.workspace = true
 clap.workspace = true
-dirs.workspace = true
 dotenvy.workspace = true
-csv.workspace = true
-uuid.workspace = true
-urlencoding.workspace = true
-arboard.workspace = true
-nucleo-matcher.workspace = true
-unicode-width.workspace = true
-unicode-casefold.workspace = true
-lru.workspace = true
 self_update = { workspace = true, optional = true }
 sabiql-app = { path = "crates/app" }
-sabiql-domain = { path = "crates/domain" }
 sabiql-infra = { path = "crates/infra" }
 sabiql-ui = { path = "crates/ui" }
 
@@ -82,8 +64,10 @@ default = []
 self-update = ["dep:self_update"]
 
 [dev-dependencies]
+sabiql-domain = { path = "crates/domain" }
 sabiql-app = { path = "crates/app", features = ["test-support"] }
 sabiql-ui = { path = "crates/ui", features = ["test-support"] }
+ratatui.workspace = true
 rstest.workspace = true
 tempfile.workspace = true
 insta.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,41 @@
+[workspace]
+members = [
+    "crates/app",
+    "crates/domain",
+    "crates/infra",
+    "crates/ui",
+]
+resolver = "2"
+
+[workspace.dependencies]
+arboard = "3"
+async-trait = "0.1"
+clap = { version = "4", features = ["derive"] }
+color-eyre = "0.6"
+crossterm = { version = "0.29", features = ["event-stream"] }
+csv = "1"
+dirs = "5"
+dotenvy = "0.15"
+futures = "0.3"
+insta = "1"
+lru = "0.16"
+mockall = "0.13"
+nucleo-matcher = "0.3"
+ratatui = "0.30"
+rstest = "0.19"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+self_update = { version = "0.42", default-features = false, features = ["archive-tar", "archive-zip", "compression-flate2", "rustls"] }
+tempfile = "3"
+thiserror = "2"
+tokio = { version = "1", features = ["sync", "time", "io-util", "process", "rt-multi-thread", "macros", "fs"] }
+tokio-util = "0.7"
+toml = "0.8"
+unicode-casefold = "0.2"
+unicode-width = "0.2"
+urlencoding = "2"
+uuid = { version = "1", features = ["v4"] }
+
 [package]
 name = "sabiql"
 version = "1.11.0"
@@ -11,40 +49,44 @@ keywords = ["postgresql", "tui", "database", "cli", "sql"]
 categories = ["command-line-utilities", "database"]
 
 [dependencies]
-ratatui = "0.30"
-crossterm = { version = "0.29", features = ["event-stream"] }
-tokio = { version = "1", features = ["sync", "time", "io-util", "process", "rt-multi-thread", "macros", "fs"] }
-tokio-util = "0.7"
-futures = "0.3"
-color-eyre = "0.6"
-toml = "0.8"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-async-trait = "0.1"
-thiserror = "2"
-clap = { version = "4", features = ["derive"] }
-dirs = "5"
-dotenvy = "0.15"
-csv = "1"
-uuid = { version = "1", features = ["v4"] }
-urlencoding = "2"
-arboard = "3"
-nucleo-matcher = "0.3"
-unicode-width = "0.2"
-unicode-casefold = "0.2"
-lru = "0.16"
-self_update = { version = "0.42", default-features = false, features = ["archive-tar", "archive-zip", "compression-flate2", "rustls"], optional = true }
+ratatui.workspace = true
+crossterm.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+futures.workspace = true
+color-eyre.workspace = true
+toml.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+async-trait.workspace = true
+thiserror.workspace = true
+clap.workspace = true
+dirs.workspace = true
+dotenvy.workspace = true
+csv.workspace = true
+uuid.workspace = true
+urlencoding.workspace = true
+arboard.workspace = true
+nucleo-matcher.workspace = true
+unicode-width.workspace = true
+unicode-casefold.workspace = true
+lru.workspace = true
+self_update = { workspace = true, optional = true }
+sabiql-app = { path = "crates/app" }
+sabiql-domain = { path = "crates/domain" }
+sabiql-infra = { path = "crates/infra" }
+sabiql-ui = { path = "crates/ui" }
 
 [features]
 default = []
 self-update = ["dep:self_update"]
 
 [dev-dependencies]
-rstest = "0.19"
-tempfile = "3"
-insta = "1"
-mockall = "0.13"
-tokio = { version = "1", features = ["test-util"] }
+rstest.workspace = true
+tempfile.workspace = true
+insta.workspace = true
+mockall.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,8 @@ default = []
 self-update = ["dep:self_update"]
 
 [dev-dependencies]
+sabiql-app = { path = "crates/app", features = ["test-support"] }
+sabiql-ui = { path = "crates/ui", features = ["test-support"] }
 rstest.workspace = true
 tempfile.workspace = true
 insta.workspace = true

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 [lib]
 path = "../../src/app/mod.rs"
 
+[features]
+test-support = []
+
 [dependencies]
 arboard.workspace = true
 async-trait.workspace = true

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -15,7 +15,6 @@ async-trait.workspace = true
 color-eyre.workspace = true
 crossterm.workspace = true
 csv.workspace = true
-futures.workspace = true
 lru.workspace = true
 nucleo-matcher.workspace = true
 serde.workspace = true

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "sabiql-app"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "../../src/app/mod.rs"
+
+[dependencies]
+arboard.workspace = true
+async-trait.workspace = true
+color-eyre.workspace = true
+crossterm.workspace = true
+csv.workspace = true
+futures.workspace = true
+lru.workspace = true
+nucleo-matcher.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+toml.workspace = true
+unicode-casefold.workspace = true
+unicode-width.workspace = true
+urlencoding.workspace = true
+uuid.workspace = true
+dirs.workspace = true
+sabiql-domain = { path = "../domain" }
+
+[dev-dependencies]
+mockall.workspace = true
+rstest.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sabiql-domain"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "../../src/domain/mod.rs"
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+rstest.workspace = true

--- a/crates/domain/Cargo.toml
+++ b/crates/domain/Cargo.toml
@@ -13,3 +13,4 @@ uuid.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+serde_json.workspace = true

--- a/crates/infra/Cargo.toml
+++ b/crates/infra/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "sabiql-infra"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "../../src/infra/mod.rs"
+
+[dependencies]
+arboard.workspace = true
+async-trait.workspace = true
+csv.workspace = true
+dirs.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+toml.workspace = true
+urlencoding.workspace = true
+sabiql-app = { path = "../app" }
+sabiql-domain = { path = "../domain" }
+
+[dev-dependencies]
+rstest.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sabiql-ui"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "../../src/ui/mod.rs"
+
+[dependencies]
+color-eyre.workspace = true
+crossterm.workspace = true
+futures.workspace = true
+ratatui.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+unicode-width.workspace = true
+sabiql-app = { path = "../app" }
+sabiql-domain = { path = "../domain" }
+
+[dev-dependencies]
+insta.workspace = true
+rstest.workspace = true

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 [lib]
 path = "../../src/ui/mod.rs"
 
+[features]
+test-support = ["sabiql-app/test-support"]
+
 [dependencies]
 color-eyre.workspace = true
 crossterm.workspace = true
@@ -20,3 +23,4 @@ sabiql-domain = { path = "../domain" }
 [dev-dependencies]
 insta.workspace = true
 rstest.workspace = true
+sabiql-app = { path = "../app", features = ["test-support"] }

--- a/mise.toml
+++ b/mise.toml
@@ -34,7 +34,7 @@ run = "cargo test -q --workspace"
 
 [tasks."test:debug"]
 description = "Run specific test with output (e.g., mise run test:debug test_name)"
-run = "cargo test $1 -- --nocapture"
+run = "cargo test --workspace $1 -- --nocapture"
 
 [tasks."test:ignored"]
 description = "Run #[ignore] integration tests (requires PostgreSQL)"

--- a/mise.toml
+++ b/mise.toml
@@ -5,12 +5,12 @@ lefthook = "1.10.10"
 
 [tasks.build]
 description = "Build the project"
-run = "cargo build -q"
-sources = ["Cargo.toml", "src/**/*.rs"]
+run = "cargo build --workspace -q"
+sources = ["Cargo.toml", "Cargo.lock", "src/**/*.rs", "crates/**/*.rs", "crates/**/Cargo.toml"]
 
 [tasks."build:release"]
 description = "Build release binary"
-run = "cargo build --release -q"
+run = "cargo build --workspace --release -q"
 
 [tasks.fmt]
 description = "Format code"
@@ -18,7 +18,7 @@ run = "cargo fmt"
 
 [tasks.clippy]
 description = "Run lints"
-run = "cargo clippy -q --all-targets -- -D warnings"
+run = "cargo clippy -q --workspace --all-targets -- -D warnings"
 
 [tasks."lint:all"]
 description = "Run all custom lints in parallel"
@@ -26,11 +26,11 @@ run = "./scripts/lint_all.sh"
 
 [tasks."clippy:fix"]
 description = "Auto-fix clippy warnings"
-run = "cargo clippy --all-targets --fix --allow-dirty --allow-staged"
+run = "cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged"
 
 [tasks.test]
 description = "Run tests"
-run = "cargo test -q"
+run = "cargo test -q --workspace"
 
 [tasks."test:debug"]
 description = "Run specific test with output (e.g., mise run test:debug test_name)"
@@ -38,7 +38,7 @@ run = "cargo test $1 -- --nocapture"
 
 [tasks."test:ignored"]
 description = "Run #[ignore] integration tests (requires PostgreSQL)"
-run = "cargo test -- --ignored"
+run = "cargo test --workspace -- --ignored"
 
 [tasks.run]
 description = "Run application"

--- a/scripts/ci_test_failure_summary.py
+++ b/scripts/ci_test_failure_summary.py
@@ -36,15 +36,18 @@ def rerun_command(profile: str, test_name: str) -> str:
     quoted_test_name = shlex.quote(test_name)
     if profile == "ci-all":
         return (
-            "cargo nextest run --profile ci-all --all-features"
+            "cargo nextest run --workspace --profile ci-all --all-features"
             f" -- {quoted_test_name} --exact"
         )
     if profile == "ci-no-default":
         return (
-            "cargo nextest run --profile ci-no-default --no-default-features"
+            "cargo nextest run --workspace --profile ci-no-default --no-default-features"
             f" -- {quoted_test_name} --exact"
         )
-    return f"cargo nextest run --profile {profile} -- {quoted_test_name} --exact"
+    return (
+        f"cargo nextest run --workspace --profile {profile}"
+        f" -- {quoted_test_name} --exact"
+    )
 
 
 def collect_failures(report_path: Path) -> tuple[str, list[dict[str, str]]]:

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -403,10 +403,10 @@ impl EffectRunner {
 mod tests {
     use super::*;
     use crate::app::cmd::test_support::*;
-    use crate::app::ports::{RenderOutput, RenderResult};
     use crate::app::ports::connection_store::MockConnectionStore;
     use crate::app::ports::metadata::MockMetadataProvider;
     use crate::app::ports::query_executor::MockQueryExecutor;
+    use crate::app::ports::{RenderOutput, RenderResult};
     use crate::app::services::AppServices;
     use crate::domain::{DatabaseMetadata, TableSummary};
     use tokio::sync::mpsc;

--- a/src/app/cmd/test_support.rs
+++ b/src/app/cmd/test_support.rs
@@ -8,8 +8,9 @@ use crate::app::cmd::cache::TtlCache;
 use crate::app::cmd::runner::{EffectRunner, EffectRunnerBuilder};
 use crate::app::ports::{
     ClipboardError, ClipboardWriter, ConfigWriter, ConfigWriterError, ConnectionStore, DsnBuilder,
-    ErDiagramExporter, ErExportResult, ErLogWriter, FolderOpenError, FolderOpener, MetadataProvider,
-    PgServiceEntryReader, QueryExecutor, QueryHistoryError, QueryHistoryStore, ServiceFileError,
+    ErDiagramExporter, ErExportResult, ErLogWriter, FolderOpenError, FolderOpener,
+    MetadataProvider, PgServiceEntryReader, QueryExecutor, QueryHistoryError, QueryHistoryStore,
+    ServiceFileError,
 };
 use crate::app::update::action::Action;
 use crate::domain::connection::{ConnectionProfile, ServiceEntry};
@@ -18,10 +19,7 @@ use crate::domain::{ConnectionId, DatabaseMetadata, ErTableInfo, QueryResult, Qu
 
 pub struct NoopConfigWriter;
 impl ConfigWriter for NoopConfigWriter {
-    fn get_cache_dir(
-        &self,
-        _project_name: &str,
-    ) -> Result<PathBuf, ConfigWriterError> {
+    fn get_cache_dir(&self, _project_name: &str) -> Result<PathBuf, ConfigWriterError> {
         Ok(PathBuf::from("/tmp"))
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,3 +5,14 @@ pub mod update;
 
 pub mod ports;
 pub mod services;
+
+pub use sabiql_domain as domain;
+
+pub mod app {
+    pub use crate::cmd;
+    pub use crate::model;
+    pub use crate::policy;
+    pub use crate::ports;
+    pub use crate::services;
+    pub use crate::update;
+}

--- a/src/app/model/shared/db_capabilities.rs
+++ b/src/app/model/shared/db_capabilities.rs
@@ -1,6 +1,6 @@
-use crate::app::ports::{DatabaseCapabilities, InspectorFeature};
 use crate::app::model::shared::inspector_tab::InspectorTab;
 use crate::app::model::sql_editor::modal::SqlModalTab;
+use crate::app::ports::{DatabaseCapabilities, InspectorFeature};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DbCapabilities {
@@ -50,11 +50,7 @@ impl DbCapabilities {
 
     pub fn supported_sql_modal_tabs(&self) -> &'static [SqlModalTab] {
         if self.supports_explain() {
-            &[
-                SqlModalTab::Sql,
-                SqlModalTab::Plan,
-                SqlModalTab::Compare,
-            ]
+            &[SqlModalTab::Sql, SqlModalTab::Plan, SqlModalTab::Compare]
         } else {
             &[SqlModalTab::Sql]
         }

--- a/src/app/model/shared/multi_line_input.rs
+++ b/src/app/model/shared/multi_line_input.rs
@@ -118,10 +118,7 @@ impl MultiLineInputState {
                 let preferred_col = self.preferred_col.unwrap_or(current_col);
                 if current_line > 0 {
                     let previous = self.line_spans()[current_line - 1];
-                    self.set_cursor_from_line(
-                        current_line - 1,
-                        preferred_col.min(previous.len),
-                    );
+                    self.set_cursor_from_line(current_line - 1, preferred_col.min(previous.len));
                 }
                 self.preferred_col = Some(preferred_col);
             }
@@ -130,10 +127,7 @@ impl MultiLineInputState {
                 let preferred_col = self.preferred_col.unwrap_or(current_col);
                 if current_line + 1 < self.line_spans().len() {
                     let next = self.line_spans()[current_line + 1];
-                    self.set_cursor_from_line(
-                        current_line + 1,
-                        preferred_col.min(next.len),
-                    );
+                    self.set_cursor_from_line(current_line + 1, preferred_col.min(next.len));
                 }
                 self.preferred_col = Some(preferred_col);
             }
@@ -1033,5 +1027,4 @@ mod tests {
             assert_eq!(s.char_to_byte_index(100), 3);
         }
     }
-
 }

--- a/src/app/model/shared/multi_line_input/perf_tests.rs
+++ b/src/app/model/shared/multi_line_input/perf_tests.rs
@@ -200,9 +200,7 @@ impl BaselineMultiLineInputState {
                 }
                 self.preferred_col = Some(preferred_col);
             }
-            CursorMove::ViewportTop
-            | CursorMove::ViewportMiddle
-            | CursorMove::ViewportBottom => {}
+            CursorMove::ViewportTop | CursorMove::ViewportMiddle | CursorMove::ViewportBottom => {}
         }
     }
 

--- a/src/app/model/shared/text_input.rs
+++ b/src/app/model/shared/text_input.rs
@@ -832,5 +832,4 @@ mod tests {
             assert_eq!(s.viewport_offset(), 0);
         }
     }
-
 }

--- a/src/app/model/shared/theme_id.rs
+++ b/src/app/model/shared/theme_id.rs
@@ -10,5 +10,6 @@ pub enum ThemeId {
     #[default]
     Default,
     #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     TestContrast,
 }

--- a/src/app/model/shared/theme_id.rs
+++ b/src/app/model/shared/theme_id.rs
@@ -1,7 +1,11 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[allow(
+    clippy::manual_non_exhaustive,
+    reason = "hidden test-only palette variant keeps snapshot coverage without widening the runtime API"
+)]
 pub enum ThemeId {
     #[default]
     Default,
-    #[cfg(test)]
+    #[doc(hidden)]
     TestContrast,
 }

--- a/src/app/model/shared/theme_id.rs
+++ b/src/app/model/shared/theme_id.rs
@@ -1,11 +1,14 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[allow(
-    clippy::manual_non_exhaustive,
-    reason = "hidden test-only palette variant keeps snapshot coverage without widening the runtime API"
+#[cfg_attr(
+    any(test, feature = "test-support"),
+    allow(
+        clippy::manual_non_exhaustive,
+        reason = "hidden test-only palette variant keeps snapshot coverage without widening the runtime API"
+    )
 )]
 pub enum ThemeId {
     #[default]
     Default,
-    #[doc(hidden)]
+    #[cfg(any(test, feature = "test-support"))]
     TestContrast,
 }

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -10,7 +10,7 @@ pub struct AppServices {
 }
 
 impl AppServices {
-    #[doc(hidden)]
+    #[cfg(any(test, feature = "test-support"))]
     pub fn stub() -> Self {
         struct StubDdlGenerator;
         impl DdlGenerator for StubDdlGenerator {

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -9,8 +9,8 @@ pub struct AppServices {
     pub db_capabilities: DbCapabilities,
 }
 
-#[cfg(test)]
 impl AppServices {
+    #[doc(hidden)]
     pub fn stub() -> Self {
         struct StubDdlGenerator;
         impl DdlGenerator for StubDdlGenerator {

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -11,6 +11,7 @@ pub struct AppServices {
 
 impl AppServices {
     #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn stub() -> Self {
         struct StubDdlGenerator;
         impl DdlGenerator for StubDdlGenerator {

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -263,10 +263,8 @@ mod tests {
 
         fn services_without_ddl() -> AppServices {
             let mut services = AppServices::stub();
-            services.db_capabilities = DbCapabilities::new(
-                true,
-                vec![InspectorTab::Info, InspectorTab::Columns],
-            );
+            services.db_capabilities =
+                DbCapabilities::new(true, vec![InspectorTab::Info, InspectorTab::Columns]);
             services
         }
 

--- a/src/app/update/input/vim/actions/browse.rs
+++ b/src/app/update/input/vim/actions/browse.rs
@@ -10,7 +10,7 @@ use crate::app::update::input::vim::types::{
     VimOperator,
 };
 
-pub(in crate::app::update::input::vim) fn navigation(
+pub(in crate::update::input::vim) fn navigation(
     navigation: VimNavigation,
     ctx: BrowseVimContext,
 ) -> Action {
@@ -21,7 +21,7 @@ pub(in crate::app::update::input::vim) fn navigation(
     }
 }
 
-pub(in crate::app::update::input::vim) fn mode_transition(
+pub(in crate::update::input::vim) fn mode_transition(
     transition: VimModeTransition,
     ctx: BrowseVimContext,
 ) -> Action {
@@ -59,7 +59,7 @@ pub(in crate::app::update::input::vim) fn mode_transition(
     }
 }
 
-pub(in crate::app::update::input::vim) fn operator(
+pub(in crate::update::input::vim) fn operator(
     operator: VimOperator,
     ctx: BrowseVimContext,
 ) -> Option<Action> {

--- a/src/app/update/input/vim/actions/jsonb.rs
+++ b/src/app/update/input/vim/actions/jsonb.rs
@@ -5,7 +5,7 @@ use crate::app::update::input::vim::types::{
     VimOperator,
 };
 
-pub(in crate::app::update::input::vim) fn command(
+pub(in crate::update::input::vim) fn command(
     command: VimCommand,
     ctx: JsonbDetailVimContext,
 ) -> Option<Action> {

--- a/src/app/update/input/vim/actions/sql.rs
+++ b/src/app/update/input/vim/actions/sql.rs
@@ -7,7 +7,7 @@ use crate::app::update::input::vim::types::{
     SqlModalVimContext, VimCommand, VimModeTransition, VimNavigation, VimOperator,
 };
 
-pub(in crate::app::update::input::vim) fn command(
+pub(in crate::update::input::vim) fn command(
     command: VimCommand,
     ctx: SqlModalVimContext,
 ) -> Option<Action> {

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -16,6 +16,30 @@ pub mod table;
 pub mod trigger;
 pub mod write_result;
 
+pub mod domain {
+    pub use crate::column;
+    pub use crate::command_tag;
+    pub use crate::connection;
+    pub use crate::er;
+    pub use crate::explain_plan;
+    pub use crate::foreign_key;
+    pub use crate::index;
+    pub use crate::metadata;
+    pub use crate::query_history;
+    pub use crate::query_result;
+    pub use crate::rls;
+    pub use crate::schema;
+    pub use crate::table;
+    pub use crate::trigger;
+    pub use crate::write_result;
+    pub use crate::{
+        Column, CommandTag, ConnectionId, ConnectionProfile, DatabaseMetadata, ErTableInfo,
+        FkAction, ForeignKey, Index, IndexType, MetadataState, QueryResult, QuerySource,
+        RlsCommand, RlsInfo, RlsPolicy, Schema, SslMode, Table, TableSignature, TableSummary,
+        Trigger, TriggerEvent, TriggerTiming, WriteExecutionResult,
+    };
+}
+
 pub use column::Column;
 pub use command_tag::CommandTag;
 #[cfg(test)]

--- a/src/infra/adapters/config_writer.rs
+++ b/src/infra/adapters/config_writer.rs
@@ -27,10 +27,7 @@ impl From<CacheDirError> for ConfigWriterError {
 }
 
 impl ConfigWriter for FileConfigWriter {
-    fn get_cache_dir(
-        &self,
-        project_name: &str,
-    ) -> Result<PathBuf, ConfigWriterError> {
+    fn get_cache_dir(&self, project_name: &str) -> Result<PathBuf, ConfigWriterError> {
         Ok(get_cache_dir(project_name)?)
     }
 }
@@ -50,11 +47,8 @@ mod tests {
 
     #[test]
     fn io_not_found_remains_io_error() {
-        let error: ConfigWriterError = CacheDirError::Io(io::Error::new(
-            io::ErrorKind::NotFound,
-            "missing parent",
-        ))
-        .into();
+        let error: ConfigWriterError =
+            CacheDirError::Io(io::Error::new(io::ErrorKind::NotFound, "missing parent")).into();
 
         match error {
             ConfigWriterError::Io(source) => {

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -209,7 +209,7 @@ impl PostgresAdapter {
         })
     }
 
-    pub(in crate::infra::adapters::postgres) async fn execute_query(
+    pub(in crate::adapters::postgres) async fn execute_query(
         &self,
         dsn: &str,
         query: &str,
@@ -223,7 +223,7 @@ impl PostgresAdapter {
         Ok(output.stdout)
     }
 
-    pub(in crate::infra::adapters::postgres) async fn execute_query_raw(
+    pub(in crate::adapters::postgres) async fn execute_query_raw(
         &self,
         dsn: &str,
         query: &str,
@@ -287,7 +287,7 @@ impl PostgresAdapter {
         ))
     }
 
-    pub(in crate::infra::adapters::postgres) async fn execute_write_raw(
+    pub(in crate::adapters::postgres) async fn execute_write_raw(
         &self,
         dsn: &str,
         query: &str,
@@ -305,10 +305,11 @@ impl PostgresAdapter {
             ));
         }
 
-        let affected_rows = Self::parse_affected_rows_with_source(&output.stdout)
-            .map_err(|error: ParseCommandTagError| {
+        let affected_rows = Self::parse_affected_rows_with_source(&output.stdout).map_err(
+            |error: ParseCommandTagError| {
                 DbOperationError::CommandTagParseFailed(error.to_string())
-            })?;
+            },
+        )?;
 
         Ok(WriteExecutionResult {
             affected_rows,
@@ -316,7 +317,7 @@ impl PostgresAdapter {
         })
     }
 
-    pub(in crate::infra::adapters::postgres) async fn count_rows(
+    pub(in crate::adapters::postgres) async fn count_rows(
         &self,
         dsn: &str,
         query: &str,
@@ -331,7 +332,7 @@ impl PostgresAdapter {
         })
     }
 
-    pub(in crate::infra::adapters::postgres) async fn export_csv_to_file(
+    pub(in crate::adapters::postgres) async fn export_csv_to_file(
         &self,
         dsn: &str,
         query: &str,
@@ -412,7 +413,7 @@ impl PostgresAdapter {
         Ok(row_count)
     }
 
-    pub(in crate::infra::adapters::postgres) async fn fetch_preview_order_columns(
+    pub(in crate::adapters::postgres) async fn fetch_preview_order_columns(
         &self,
         dsn: &str,
         schema: &str,
@@ -428,9 +429,7 @@ impl PostgresAdapter {
         serde_json::from_str(trimmed).map_err(Into::into)
     }
 
-    fn parse_affected_rows_with_source(
-        stdout: &str,
-    ) -> Result<usize, ParseCommandTagError> {
+    fn parse_affected_rows_with_source(stdout: &str) -> Result<usize, ParseCommandTagError> {
         let tag = Self::parse_command_tag(stdout)?;
         tag.affected_rows()
             .map(|n| n as usize)
@@ -439,14 +438,15 @@ impl PostgresAdapter {
             })
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_affected_rows(stdout: &str) -> Option<usize> {
+    #[cfg(test)]
+    pub(in crate::adapters::postgres) fn parse_affected_rows(stdout: &str) -> Option<usize> {
         Self::parse_affected_rows_with_source(stdout).ok()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::infra::adapters::postgres::PostgresAdapter;
+    use crate::adapters::postgres::PostgresAdapter;
 
     mod extract_last_csv_block {
         use super::super::extract_last_csv_block;
@@ -755,8 +755,8 @@ mod tests {
     }
 
     mod execute_query_raw_command_tag {
+        use crate::adapters::postgres::PostgresAdapter;
         use crate::domain::CommandTag;
-        use crate::infra::adapters::postgres::PostgresAdapter;
 
         fn dml_stdout_returns_command_tag(
             stdout: &str,

--- a/src/infra/adapters/postgres/psql/mod.rs
+++ b/src/infra/adapters/postgres/psql/mod.rs
@@ -1,2 +1,2 @@
-pub(in crate::infra::adapters::postgres) mod executor;
-pub(in crate::infra::adapters::postgres) mod parser;
+pub(in crate::adapters::postgres) mod executor;
+pub(in crate::adapters::postgres) mod parser;

--- a/src/infra/adapters/postgres/psql/parser/command_tag.rs
+++ b/src/infra/adapters/postgres/psql/parser/command_tag.rs
@@ -4,7 +4,7 @@ use super::super::super::PostgresAdapter;
 use super::lexer::{has_select_into, split_sql_statements};
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
-pub(in crate::infra::adapters::postgres) enum ParseCommandTagError {
+pub(in crate::adapters::postgres) enum ParseCommandTagError {
     #[error("empty command tag")]
     Empty,
     #[error("invalid command tag: {input}")]
@@ -77,7 +77,7 @@ impl PostgresAdapter {
         }
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_command_tag(
+    pub(in crate::adapters::postgres) fn parse_command_tag(
         stdout: &str,
     ) -> Result<CommandTag, ParseCommandTagError> {
         stdout
@@ -88,9 +88,8 @@ impl PostgresAdapter {
             .and_then(Self::parse_command_tag_str)
     }
 
-    pub(in crate::infra::adapters::postgres) fn extract_command_tag(
-        stdout: &str,
-    ) -> Option<CommandTag> {
+    #[cfg(test)]
+    pub(in crate::adapters::postgres) fn extract_command_tag(stdout: &str) -> Option<CommandTag> {
         Self::parse_command_tag(stdout).ok()
     }
 
@@ -182,7 +181,7 @@ impl PostgresAdapter {
 
     // -- CTAS / SELECT INTO correction (newspaper style: high→low) --
 
-    pub(in crate::infra::adapters::postgres) fn parse_aggregate_command_tag(
+    pub(in crate::adapters::postgres) fn parse_aggregate_command_tag(
         stdout: &str,
         sql: &str,
     ) -> Option<CommandTag> {
@@ -238,13 +237,13 @@ impl PostgresAdapter {
 }
 
 #[cfg_attr(test, derive(Debug))]
-pub(in crate::infra::adapters::postgres) struct ResolvedTags {
+pub(in crate::adapters::postgres) struct ResolvedTags {
     all: Vec<CommandTag>,
     effective: Vec<CommandTag>,
 }
 
 impl ResolvedTags {
-    pub(in crate::infra::adapters::postgres) fn resolve(stdout: &str, sql: &str) -> Option<Self> {
+    pub(in crate::adapters::postgres) fn resolve(stdout: &str, sql: &str) -> Option<Self> {
         let parsed = PostgresAdapter::parse_all_tags(stdout)?;
         let corrected = PostgresAdapter::correct_ctas_tags(sql, parsed);
         let effective = PostgresAdapter::discard_rolled_back(&corrected);
@@ -254,7 +253,7 @@ impl ResolvedTags {
         })
     }
 
-    pub(in crate::infra::adapters::postgres) fn aggregate(&self) -> Option<CommandTag> {
+    pub(in crate::adapters::postgres) fn aggregate(&self) -> Option<CommandTag> {
         if let Some(tag) = self.effective.iter().find(|t| t.is_schema_modifying()) {
             return Some(tag.clone());
         }
@@ -273,9 +272,9 @@ impl ResolvedTags {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::CommandTag;
-    use crate::infra::adapters::postgres::PostgresAdapter;
     use super::ParseCommandTagError;
+    use crate::adapters::postgres::PostgresAdapter;
+    use crate::domain::CommandTag;
 
     mod detect_create_as_kind {
         use super::*;

--- a/src/infra/adapters/postgres/psql/parser/lexer.rs
+++ b/src/infra/adapters/postgres/psql/parser/lexer.rs
@@ -73,7 +73,7 @@ pub(super) fn skip_block_comment(bytes: &[u8], mut i: usize) -> usize {
     i
 }
 
-pub(in crate::infra::adapters::postgres) fn split_sql_statements(sql: &str) -> Vec<&str> {
+pub(in crate::adapters::postgres) fn split_sql_statements(sql: &str) -> Vec<&str> {
     let bytes = sql.as_bytes();
     let mut stmts = Vec::new();
     let mut start = 0;

--- a/src/infra/adapters/postgres/psql/parser/metadata.rs
+++ b/src/infra/adapters/postgres/psql/parser/metadata.rs
@@ -6,7 +6,7 @@ use crate::domain::{
 
 use super::super::super::PostgresAdapter;
 
-pub(in crate::infra::adapters::postgres) type TableDetailCombined = (
+pub(in crate::adapters::postgres) type TableDetailCombined = (
     Vec<Column>,
     Vec<Index>,
     Vec<ForeignKey>,
@@ -42,14 +42,14 @@ fn non_empty_json(raw: &str) -> Option<&str> {
     }
 }
 
-pub(in crate::infra::adapters::postgres) struct TableInfo {
+pub(in crate::adapters::postgres) struct TableInfo {
     pub owner: Option<String>,
     pub comment: Option<String>,
     pub row_count_estimate: Option<i64>,
 }
 
 impl PostgresAdapter {
-    pub(in crate::infra::adapters::postgres) fn parse_table_info(
+    pub(in crate::adapters::postgres) fn parse_table_info(
         json: &str,
     ) -> Result<TableInfo, DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
@@ -79,7 +79,7 @@ impl PostgresAdapter {
         })
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_tables(
+    pub(in crate::adapters::postgres) fn parse_tables(
         json: &str,
     ) -> Result<Vec<TableSummary>, DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
@@ -102,7 +102,7 @@ impl PostgresAdapter {
             .collect())
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_table_signatures(
+    pub(in crate::adapters::postgres) fn parse_table_signatures(
         json: &str,
     ) -> Result<Vec<TableSignature>, DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
@@ -128,7 +128,7 @@ impl PostgresAdapter {
             .collect())
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_schemas(
+    pub(in crate::adapters::postgres) fn parse_schemas(
         json: &str,
     ) -> Result<Vec<Schema>, DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
@@ -145,7 +145,7 @@ impl PostgresAdapter {
         Ok(raw.into_iter().map(|s| Schema::new(s.name)).collect())
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_columns(
+    pub(in crate::adapters::postgres) fn parse_columns(
         json: &str,
     ) -> Result<Vec<Column>, DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
@@ -181,7 +181,7 @@ impl PostgresAdapter {
             .collect())
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_indexes(
+    pub(in crate::adapters::postgres) fn parse_indexes(
         json: &str,
     ) -> Result<Vec<Index>, DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
@@ -216,7 +216,7 @@ impl PostgresAdapter {
             .collect())
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_foreign_keys(
+    pub(in crate::adapters::postgres) fn parse_foreign_keys(
         json: &str,
     ) -> Result<Vec<ForeignKey>, DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
@@ -264,7 +264,7 @@ impl PostgresAdapter {
             .map_err(DbOperationError::from)
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_rls(
+    pub(in crate::adapters::postgres) fn parse_rls(
         json: &str,
     ) -> Result<Option<RlsInfo>, DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
@@ -317,7 +317,7 @@ impl PostgresAdapter {
         }))
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_triggers(
+    pub(in crate::adapters::postgres) fn parse_triggers(
         json: &str,
     ) -> Result<Vec<Trigger>, DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
@@ -362,7 +362,7 @@ impl PostgresAdapter {
             .map_err(DbOperationError::from)
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_table_detail_combined(
+    pub(in crate::adapters::postgres) fn parse_table_detail_combined(
         json: &str,
     ) -> Result<TableDetailCombined, DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
@@ -394,7 +394,7 @@ impl PostgresAdapter {
         Ok((columns, indexes, foreign_keys, rls, triggers, table_info))
     }
 
-    pub(in crate::infra::adapters::postgres) fn parse_table_columns_and_fks(
+    pub(in crate::adapters::postgres) fn parse_table_columns_and_fks(
         json: &str,
     ) -> Result<(Vec<Column>, Vec<ForeignKey>), DbOperationError> {
         let Some(trimmed) = non_empty_json(json) else {
@@ -421,8 +421,8 @@ impl PostgresAdapter {
 
 #[cfg(test)]
 mod tests {
+    use crate::adapters::postgres::PostgresAdapter;
     use crate::app::ports::DbOperationError;
-    use crate::infra::adapters::postgres::PostgresAdapter;
 
     mod table_signature_parsing {
         use super::*;

--- a/src/infra/adapters/postgres/psql/parser/mod.rs
+++ b/src/infra/adapters/postgres/psql/parser/mod.rs
@@ -2,5 +2,5 @@ mod command_tag;
 mod lexer;
 mod metadata;
 
-pub(in crate::infra::adapters::postgres) use command_tag::ParseCommandTagError;
-pub(in crate::infra::adapters::postgres) use lexer::split_sql_statements;
+pub(in crate::adapters::postgres) use command_tag::ParseCommandTagError;
+pub(in crate::adapters::postgres) use lexer::split_sql_statements;

--- a/src/infra/adapters/postgres/sql/ddl.rs
+++ b/src/infra/adapters/postgres/sql/ddl.rs
@@ -77,9 +77,9 @@ impl DdlGenerator for PostgresAdapter {
 
 #[cfg(test)]
 mod tests {
+    use crate::adapters::postgres::PostgresAdapter;
     use crate::app::ports::DdlGenerator;
     use crate::domain::{Column, Table};
-    use crate::infra::adapters::postgres::PostgresAdapter;
 
     fn make_column(name: &str, data_type: &str, nullable: bool) -> Column {
         Column {

--- a/src/infra/adapters/postgres/sql/dialect.rs
+++ b/src/infra/adapters/postgres/sql/dialect.rs
@@ -97,8 +97,8 @@ impl SqlDialect for PostgresAdapter {
 
 #[cfg(test)]
 mod tests {
+    use crate::adapters::postgres::PostgresAdapter;
     use crate::app::ports::SqlDialect;
-    use crate::infra::adapters::postgres::PostgresAdapter;
 
     mod sql_dialect_update {
         use super::*;

--- a/src/infra/adapters/postgres/sql/mod.rs
+++ b/src/infra/adapters/postgres/sql/mod.rs
@@ -6,9 +6,9 @@ fn quote_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
-pub(in crate::infra::adapters::postgres) mod ddl;
-pub(in crate::infra::adapters::postgres) mod dialect;
-pub(in crate::infra::adapters::postgres) mod query;
+pub(in crate::adapters::postgres) mod ddl;
+pub(in crate::adapters::postgres) mod dialect;
+pub(in crate::adapters::postgres) mod query;
 
 #[cfg(test)]
 mod tests {

--- a/src/infra/adapters/postgres/sql/query.rs
+++ b/src/infra/adapters/postgres/sql/query.rs
@@ -2,7 +2,7 @@ use super::super::PostgresAdapter;
 use super::{quote_ident, quote_literal};
 
 impl PostgresAdapter {
-    pub(in crate::infra::adapters::postgres) fn tables_query() -> &'static str {
+    pub(in crate::adapters::postgres) fn tables_query() -> &'static str {
         r"
         SELECT json_agg(row_to_json(t))
         FROM (
@@ -29,7 +29,7 @@ impl PostgresAdapter {
         "
     }
 
-    pub(in crate::infra::adapters::postgres) fn table_signatures_query() -> &'static str {
+    pub(in crate::adapters::postgres) fn table_signatures_query() -> &'static str {
         r"
         SELECT json_agg(row_to_json(t))
         FROM (
@@ -79,7 +79,7 @@ impl PostgresAdapter {
         "
     }
 
-    pub(in crate::infra::adapters::postgres) fn schemas_query() -> &'static str {
+    pub(in crate::adapters::postgres) fn schemas_query() -> &'static str {
         r"
         SELECT json_agg(row_to_json(s))
         FROM (
@@ -93,7 +93,7 @@ impl PostgresAdapter {
         "
     }
 
-    pub(in crate::infra::adapters::postgres) fn columns_query(schema: &str, table: &str) -> String {
+    pub(in crate::adapters::postgres) fn columns_query(schema: &str, table: &str) -> String {
         format!(
             r"
             SELECT json_agg(row_to_json(c) ORDER BY c.ordinal_position)
@@ -134,7 +134,7 @@ impl PostgresAdapter {
         )
     }
 
-    pub(in crate::infra::adapters::postgres) fn preview_pk_columns_query(
+    pub(in crate::adapters::postgres) fn preview_pk_columns_query(
         schema: &str,
         table: &str,
     ) -> String {
@@ -154,7 +154,7 @@ impl PostgresAdapter {
         )
     }
 
-    pub(in crate::infra::adapters::postgres) fn build_preview_query(
+    pub(in crate::adapters::postgres) fn build_preview_query(
         schema: &str,
         table: &str,
         order_columns: &[String],
@@ -182,7 +182,7 @@ impl PostgresAdapter {
         )
     }
 
-    pub(in crate::infra::adapters::postgres) fn indexes_query(schema: &str, table: &str) -> String {
+    pub(in crate::adapters::postgres) fn indexes_query(schema: &str, table: &str) -> String {
         format!(
             r"
             SELECT json_agg(row_to_json(i))
@@ -211,10 +211,7 @@ impl PostgresAdapter {
         )
     }
 
-    pub(in crate::infra::adapters::postgres) fn foreign_keys_query(
-        schema: &str,
-        table: &str,
-    ) -> String {
+    pub(in crate::adapters::postgres) fn foreign_keys_query(schema: &str, table: &str) -> String {
         format!(
             r"
             SELECT json_agg(row_to_json(fk))
@@ -247,7 +244,7 @@ impl PostgresAdapter {
         )
     }
 
-    pub(in crate::infra::adapters::postgres) fn rls_query(schema: &str, table: &str) -> String {
+    pub(in crate::adapters::postgres) fn rls_query(schema: &str, table: &str) -> String {
         format!(
             r"
             SELECT json_build_object(
@@ -280,10 +277,7 @@ impl PostgresAdapter {
         )
     }
 
-    pub(in crate::infra::adapters::postgres) fn triggers_query(
-        schema: &str,
-        table: &str,
-    ) -> String {
+    pub(in crate::adapters::postgres) fn triggers_query(schema: &str, table: &str) -> String {
         format!(
             r"
             SELECT json_agg(row_to_json(t) ORDER BY t.name)
@@ -317,10 +311,7 @@ impl PostgresAdapter {
         )
     }
 
-    pub(in crate::infra::adapters::postgres) fn table_info_query(
-        schema: &str,
-        table: &str,
-    ) -> String {
+    pub(in crate::adapters::postgres) fn table_info_query(schema: &str, table: &str) -> String {
         format!(
             r"
             SELECT row_to_json(t)
@@ -340,7 +331,7 @@ impl PostgresAdapter {
         )
     }
 
-    pub(in crate::infra::adapters::postgres) fn table_columns_and_fks_query(
+    pub(in crate::adapters::postgres) fn table_columns_and_fks_query(
         schema: &str,
         table: &str,
     ) -> String {
@@ -356,10 +347,7 @@ impl PostgresAdapter {
         )
     }
 
-    pub(in crate::infra::adapters::postgres) fn table_detail_query(
-        schema: &str,
-        table: &str,
-    ) -> String {
+    pub(in crate::adapters::postgres) fn table_detail_query(schema: &str, table: &str) -> String {
         format!(
             r"
             SELECT json_build_object(
@@ -383,7 +371,7 @@ impl PostgresAdapter {
 
 #[cfg(test)]
 mod tests {
-    use crate::infra::adapters::postgres::PostgresAdapter;
+    use crate::adapters::postgres::PostgresAdapter;
 
     mod preview_query {
         use super::*;

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;

--- a/src/infra/export/dot.rs
+++ b/src/infra/export/dot.rs
@@ -216,7 +216,7 @@ impl<G: GraphvizRunner + 'static, V: ViewerLauncher + 'static> ErDiagramExporter
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::ErFkInfo;
+    use crate::domain::er::ErFkInfo;
 
     fn make_test_tables() -> Vec<ErTableInfo> {
         vec![

--- a/src/infra/mod.rs
+++ b/src/infra/mod.rs
@@ -1,3 +1,12 @@
 pub mod adapters;
 pub mod config;
 pub mod export;
+
+pub use sabiql_app as app;
+pub use sabiql_domain as domain;
+
+pub mod infra {
+    pub use crate::adapters;
+    pub use crate::config;
+    pub use crate::export;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,7 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 use color_eyre::eyre::Result;
 use sabiql_app as app;
-#[allow(
-    unused_imports,
-    reason = "binary-root test modules import crate::domain during all-targets verification"
-)]
+#[cfg(test)]
 pub(crate) use sabiql_domain as domain;
 use sabiql_infra as infra;
 use sabiql_ui as ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,26 +4,18 @@ use std::time::{Duration, Instant};
 
 use clap::Parser;
 use color_eyre::eyre::Result;
+use sabiql_app as app;
+#[allow(
+    unused_imports,
+    reason = "binary-root test modules import crate::domain during all-targets verification"
+)]
+pub(crate) use sabiql_domain as domain;
+use sabiql_infra as infra;
+use sabiql_ui as ui;
 use tokio::sync::mpsc;
 use tokio::time::sleep_until;
 
-macro_rules! internal_module {
-    ($name:ident) => {
-        #[allow(
-            dead_code,
-            unused_imports,
-            clippy::redundant_pub_crate,
-            reason = "binary-only packaging keeps internal module APIs wider than the CLI entrypoint uses directly"
-        )]
-        mod $name;
-    };
-}
-
-internal_module!(app);
-internal_module!(domain);
-internal_module!(error);
-internal_module!(infra);
-internal_module!(ui);
+mod error;
 
 #[cfg(test)]
 mod tests;

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -94,11 +94,7 @@ impl SqlModal {
                 _ => {
                     let compare_can_yank =
                         state.explain.left.is_some() && state.explain.right.is_some();
-                    Self::border_hint(
-                        active_tab,
-                        compare_can_yank,
-                        services,
-                    )
+                    Self::border_hint(active_tab, compare_can_yank, services)
                 }
             };
             Self::render_modal_with_tabs(frame, active_tab, hint, services, theme)
@@ -145,7 +141,8 @@ impl SqlModal {
                 completion::render_completion_popup(frame, area, main_area, state, theme);
             }
         } else if active_tab == SqlModalTab::Plan {
-            let plan_viewport_height = explain::render(frame, main_area, state, services, now, theme);
+            let plan_viewport_height =
+                explain::render(frame, main_area, state, services, now, theme);
             status::render_status(frame, status_area, state, theme);
             return Some(plan_viewport_height);
         } else {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -5,3 +5,16 @@ pub mod primitives;
 pub mod shell;
 pub mod theme;
 pub mod tui;
+
+pub use sabiql_app as app;
+pub use sabiql_domain as domain;
+
+pub mod ui {
+    pub use crate::adapters;
+    pub use crate::event;
+    pub use crate::features;
+    pub use crate::primitives;
+    pub use crate::shell;
+    pub use crate::theme;
+    pub use crate::tui;
+}

--- a/src/ui/shell/layout.rs
+++ b/src/ui/shell/layout.rs
@@ -48,9 +48,8 @@ impl MainLayout {
         )
     }
 
-    #[cfg(test)]
     // `render_with_theme` exists only as a test seam for injected palettes.
-    // It is hidden from docs and omitted from production builds.
+    // It is hidden from docs.
     #[doc(hidden)]
     pub fn render_with_theme(
         frame: &mut Frame,

--- a/src/ui/shell/layout.rs
+++ b/src/ui/shell/layout.rs
@@ -50,6 +50,7 @@ impl MainLayout {
 
     // `render_with_theme` exists only as a test seam for injected palettes.
     #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn render_with_theme(
         frame: &mut Frame,
         state: &AppState,

--- a/src/ui/shell/layout.rs
+++ b/src/ui/shell/layout.rs
@@ -49,8 +49,7 @@ impl MainLayout {
     }
 
     // `render_with_theme` exists only as a test seam for injected palettes.
-    // It is hidden from docs.
-    #[doc(hidden)]
+    #[cfg(any(test, feature = "test-support"))]
     pub fn render_with_theme(
         frame: &mut Frame,
         state: &AppState,

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -265,7 +265,7 @@ pub const DEFAULT_THEME: ThemePalette = ThemePalette {
     },
 };
 
-#[doc(hidden)]
+#[cfg(any(test, feature = "test-support"))]
 pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
     semantic: SemanticTokens {
         surface: SurfaceTokens {
@@ -342,6 +342,7 @@ pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
 pub fn palette_for(theme_id: ThemeId) -> &'static ThemePalette {
     match theme_id {
         ThemeId::Default => &DEFAULT_THEME,
+        #[cfg(any(test, feature = "test-support"))]
         ThemeId::TestContrast => &TEST_CONTRAST_THEME,
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -266,6 +266,7 @@ pub const DEFAULT_THEME: ThemePalette = ThemePalette {
 };
 
 #[cfg(any(test, feature = "test-support"))]
+#[doc(hidden)]
 pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
     semantic: SemanticTokens {
         surface: SurfaceTokens {

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -265,7 +265,7 @@ pub const DEFAULT_THEME: ThemePalette = ThemePalette {
     },
 };
 
-#[cfg(test)]
+#[doc(hidden)]
 pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
     semantic: SemanticTokens {
         surface: SurfaceTokens {
@@ -342,7 +342,6 @@ pub const TEST_CONTRAST_THEME: ThemePalette = ThemePalette {
 pub fn palette_for(theme_id: ThemeId) -> &'static ThemePalette {
     match theme_id {
         ThemeId::Default => &DEFAULT_THEME,
-        #[cfg(test)]
         ThemeId::TestContrast => &TEST_CONTRAST_THEME,
     }
 }


### PR DESCRIPTION
## Problem
SAB-221 introduces workspace crates so layer boundaries are enforced by crate boundaries instead of a single binary crate.

## Background
The previous binary-only layout relied on internal visibility conventions that the compiler could not enforce across layers. This change also aligns verification commands with the workspace so crate-level tests and checks are not skipped.

## Approach
Scope: introduce the four-crate workspace split, keep the root package as the composition root, and preserve behavior through compatibility shims while the module layout remains under src/. Follow-up review fixes keep test-only seams out of production builds and make workspace-targeted verification the default.

## Screenshots
