### PR TITLE
Refactor string borrow boundaries

### DIFF
--- a/src/domain/connection/id.rs
+++ b/src/domain/connection/id.rs
@@ -18,6 +18,12 @@ impl ConnectionId {
     }
 }
 
+impl AsRef<str> for ConnectionId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 impl Default for ConnectionId {
     fn default() -> Self {
         Self::new()

--- a/src/domain/connection/name.rs
+++ b/src/domain/connection/name.rs
@@ -44,6 +44,12 @@ impl ConnectionName {
     }
 }
 
+impl AsRef<str> for ConnectionName {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 impl fmt::Display for ConnectionName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)

--- a/src/domain/query_history.rs
+++ b/src/domain/query_history.rs
@@ -16,6 +16,12 @@ impl Iso8601Timestamp {
     }
 }
 
+impl AsRef<str> for Iso8601Timestamp {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 impl std::fmt::Display for Iso8601Timestamp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)

--- a/src/ui/features/pickers/query_history_picker.rs
+++ b/src/ui/features/pickers/query_history_picker.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wra
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::sql_editor::query_history::GroupedEntry;
-use crate::domain::query_history::QueryResultStatus;
+use crate::domain::query_history::{Iso8601Timestamp, QueryResultStatus};
 use crate::primitives::molecules::render_modal;
 use crate::theme::{StatusTone, ThemePalette};
 
@@ -21,7 +21,9 @@ const MONTH_ABBR: [&str; 12] = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
 
-fn format_short_timestamp(iso: &str) -> String {
+fn format_short_timestamp(iso: impl AsRef<str>) -> String {
+    let iso = iso.as_ref();
+
     // "2026-03-17T00:48:52Z" -> "Mar 17 00:48 UTC"
     if iso.len() < 16 {
         return iso.to_string();
@@ -63,11 +65,11 @@ fn compute_preview_height(inner_height: u16) -> u16 {
     desired.min(max_preview)
 }
 
-struct PreviewData {
-    query: String,
+struct PreviewData<'a> {
+    query: &'a str,
     result_status: QueryResultStatus,
     affected_rows: Option<u64>,
-    executed_at: String,
+    executed_at: &'a Iso8601Timestamp,
 }
 
 pub struct QueryHistoryPicker;
@@ -174,10 +176,10 @@ impl QueryHistoryPicker {
         let query_max = available_width.saturating_sub(STATUS_WIDTH + TIMESTAMP_WIDTH + 4);
 
         let preview_data = grouped.get(selected_idx).map(|ge| PreviewData {
-            query: ge.entry.query.clone(),
+            query: ge.entry.query.as_str(),
             result_status: ge.entry.result_status,
             affected_rows: ge.entry.affected_rows,
-            executed_at: ge.entry.executed_at.as_str().to_string(),
+            executed_at: &ge.entry.executed_at,
         });
 
         let items: Vec<ListItem> = grouped
@@ -186,7 +188,6 @@ impl QueryHistoryPicker {
             .map(|(i, ge)| build_list_item(ge, i, selected_idx, query_max, theme))
             .collect();
 
-        drop(grouped);
         if let Some(pa) = preview_area {
             if let Some(ref pd) = preview_data {
                 render_preview(frame, pa, pd, theme);
@@ -194,6 +195,7 @@ impl QueryHistoryPicker {
                 render_empty_preview(frame, pa, theme);
             }
         }
+        drop(grouped);
 
         let list = List::new(items)
             .highlight_style(theme.picker_selected_style())
@@ -223,7 +225,7 @@ fn build_list_item(
         query_display
     };
 
-    let ts_short = format_short_timestamp(ge.entry.executed_at.as_str());
+    let ts_short = format_short_timestamp(&ge.entry.executed_at);
 
     let mut spans = vec![status_span(ge.entry.result_status, theme)];
 
@@ -318,7 +320,7 @@ fn render_preview(
         ));
     }
     meta_spans.push(Span::styled(
-        format!("  \u{2502} {}", format_short_timestamp(&pd.executed_at)),
+        format!("  \u{2502} {}", format_short_timestamp(pd.executed_at)),
         Style::default().fg(theme.semantic.text.dim),
     ));
     lines.push(Line::from(meta_spans));

--- a/src/ui/features/sql_modal/status.rs
+++ b/src/ui/features/sql_modal/status.rs
@@ -16,7 +16,7 @@ pub(super) fn render_status(frame: &mut Frame, area: Rect, state: &AppState, the
         target_name,
     } = state.sql_modal.status()
     {
-        render_confirming_high_status(frame, area, decision, input, target_name.as_ref(), theme);
+        render_confirming_high_status(frame, area, decision, input, target_name.as_deref(), theme);
         return;
     }
 
@@ -130,7 +130,7 @@ fn render_confirming_high_status(
     area: Rect,
     decision: &crate::app::policy::write::write_guardrails::AdhocRiskDecision,
     input: &crate::app::model::shared::text_input::TextInputState,
-    target_name: Option<&String>,
+    target_name: Option<&str>,
     theme: &ThemePalette,
 ) {
     let error_style = Style::default().fg(theme.semantic.status.error);


### PR DESCRIPTION
## Problem
Scope: SAB-219. Some string-backed domain value objects could only be borrowed through their inherent string accessors, and one UI confirmation renderer accepted an owned-string reference shape where a string slice is sufficient.

## Background
These are small consistency gaps left after the domain value-object cleanup. They do not require broader call-site migration or changes to completion cache APIs.

## Approach
Expose the domain values through the standard borrowed-string trait while keeping existing APIs intact. Align the high-risk confirmation renderer with the existing slice-oriented UI pattern.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * コアインフラストラクチャモジュール全体の内部コードの一貫性と保守性を向上させました。
  * システム全体の文字列処理メカニズムを簡素化し、コード構成と信頼性を強化しました。
  * 基盤コンポーネントを最適化し、長期的な安定性と開発効率を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->