### PR TITLE
refactor: encapsulate result operator pending state

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake
+use flake --no-warn-dirty

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
             extensions = [
               "clippy"
               "rust-analyzer"
+              "rust-src"
               "rustfmt"
             ];
           };
@@ -89,6 +90,7 @@
             extensions = [
               "clippy"
               "rust-analyzer"
+              "rust-src"
               "rustfmt"
             ];
           };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.94.0"
-components = ["rustfmt", "clippy", "rust-analyzer"]
+components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]

--- a/src/app/model/browse/result_interaction.rs
+++ b/src/app/model/browse/result_interaction.rs
@@ -276,44 +276,48 @@ mod tests {
         assert!(ri.yank_flash.is_some());
     }
 
-    #[test]
-    fn clear_operator_pending_clears_both() {
-        let mut ri = ResultInteraction::default();
-        ri.start_delete_operator();
+    mod operator_pending {
+        use super::*;
 
-        ri.clear_operator_pending();
+        #[test]
+        fn clear_clears_both() {
+            let mut ri = ResultInteraction::default();
+            ri.start_delete_operator();
 
-        assert!(!ri.is_delete_operator_pending());
-        assert!(!ri.is_yank_operator_pending());
+            ri.clear_operator_pending();
 
-        ri.start_yank_operator();
+            assert!(!ri.is_delete_operator_pending());
+            assert!(!ri.is_yank_operator_pending());
 
-        ri.clear_operator_pending();
+            ri.start_yank_operator();
 
-        assert!(!ri.is_delete_operator_pending());
-        assert!(!ri.is_yank_operator_pending());
-    }
+            ri.clear_operator_pending();
 
-    #[test]
-    fn starting_yank_operator_clears_delete_operator() {
-        let mut ri = ResultInteraction::default();
+            assert!(!ri.is_delete_operator_pending());
+            assert!(!ri.is_yank_operator_pending());
+        }
 
-        ri.start_delete_operator();
-        ri.start_yank_operator();
+        #[test]
+        fn start_yank_clears_delete() {
+            let mut ri = ResultInteraction::default();
 
-        assert!(!ri.is_delete_operator_pending());
-        assert!(ri.is_yank_operator_pending());
-    }
+            ri.start_delete_operator();
+            ri.start_yank_operator();
 
-    #[test]
-    fn starting_delete_operator_clears_yank_operator() {
-        let mut ri = ResultInteraction::default();
+            assert!(!ri.is_delete_operator_pending());
+            assert!(ri.is_yank_operator_pending());
+        }
 
-        ri.start_yank_operator();
-        ri.start_delete_operator();
+        #[test]
+        fn start_delete_clears_yank() {
+            let mut ri = ResultInteraction::default();
 
-        assert!(ri.is_delete_operator_pending());
-        assert!(!ri.is_yank_operator_pending());
+            ri.start_yank_operator();
+            ri.start_delete_operator();
+
+            assert!(ri.is_delete_operator_pending());
+            assert!(!ri.is_yank_operator_pending());
+        }
     }
 
     #[test]

--- a/src/app/model/browse/result_interaction.rs
+++ b/src/app/model/browse/result_interaction.rs
@@ -14,10 +14,10 @@ use crate::policy::write::write_guardrails::WritePreview;
 pub struct ResultInteraction {
     pub scroll_offset: usize,
     pub horizontal_offset: usize,
-    pub delete_op_pending: bool,
-    pub yank_op_pending: bool,
     pub yank_flash: Option<YankFlash>,
 
+    delete_op_pending: bool,
+    yank_op_pending: bool,
     selection: ResultSelection,
     cell_edit: CellEditState,
     staged_delete_rows: BTreeSet<usize>,
@@ -118,13 +118,27 @@ impl ResultInteraction {
         self.clear_active_cell_state();
     }
 
-    pub fn clear_operator_pending(&mut self, keep_delete: bool, keep_yank: bool) {
-        if !keep_delete {
-            self.delete_op_pending = false;
-        }
-        if !keep_yank {
-            self.yank_op_pending = false;
-        }
+    pub fn start_delete_operator(&mut self) {
+        self.delete_op_pending = true;
+        self.yank_op_pending = false;
+    }
+
+    pub fn start_yank_operator(&mut self) {
+        self.yank_op_pending = true;
+        self.delete_op_pending = false;
+    }
+
+    pub fn clear_operator_pending(&mut self) {
+        self.delete_op_pending = false;
+        self.yank_op_pending = false;
+    }
+
+    pub fn is_delete_operator_pending(&self) -> bool {
+        self.delete_op_pending
+    }
+
+    pub fn is_yank_operator_pending(&self) -> bool {
+        self.yank_op_pending
     }
 
     pub fn clear_expired_flash(&mut self, now: Instant) {
@@ -263,17 +277,43 @@ mod tests {
     }
 
     #[test]
-    fn clear_operator_pending_selective() {
-        let mut ri = ResultInteraction {
-            delete_op_pending: true,
-            yank_op_pending: true,
-            ..Default::default()
-        };
+    fn clear_operator_pending_clears_both() {
+        let mut ri = ResultInteraction::default();
+        ri.start_delete_operator();
 
-        ri.clear_operator_pending(true, false);
+        ri.clear_operator_pending();
 
-        assert!(ri.delete_op_pending);
-        assert!(!ri.yank_op_pending);
+        assert!(!ri.is_delete_operator_pending());
+        assert!(!ri.is_yank_operator_pending());
+
+        ri.start_yank_operator();
+
+        ri.clear_operator_pending();
+
+        assert!(!ri.is_delete_operator_pending());
+        assert!(!ri.is_yank_operator_pending());
+    }
+
+    #[test]
+    fn starting_yank_operator_clears_delete_operator() {
+        let mut ri = ResultInteraction::default();
+
+        ri.start_delete_operator();
+        ri.start_yank_operator();
+
+        assert!(!ri.is_delete_operator_pending());
+        assert!(ri.is_yank_operator_pending());
+    }
+
+    #[test]
+    fn starting_delete_operator_clears_yank_operator() {
+        let mut ri = ResultInteraction::default();
+
+        ri.start_yank_operator();
+        ri.start_delete_operator();
+
+        assert!(ri.is_delete_operator_pending());
+        assert!(!ri.is_yank_operator_pending());
     }
 
     #[test]

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -57,7 +57,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             Some(vec![])
         }
         Action::ResultDeleteOperatorPending => {
-            state.result_interaction.delete_op_pending = true;
+            state.result_interaction.start_delete_operator();
             Some(vec![])
         }
         Action::StageRowForDelete => {

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -51,7 +51,7 @@ pub fn reduce(
             }
         }
         Action::ResultRowYankOperatorPending => {
-            state.result_interaction.yank_op_pending = true;
+            state.result_interaction.start_yank_operator();
             Some(vec![])
         }
         Action::DdlYank => {
@@ -224,7 +224,7 @@ mod tests {
             .unwrap();
 
             assert!(effects.is_empty());
-            assert!(state.result_interaction.yank_op_pending);
+            assert!(state.result_interaction.is_yank_operator_pending());
         }
 
         #[test]

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -1016,7 +1016,7 @@ mod tests {
             #[test]
             fn dd_stages_row_for_delete() {
                 let mut state = active_cell_state();
-                state.result_interaction.delete_op_pending = true;
+                state.result_interaction.start_delete_operator();
 
                 let result = handle_normal_mode(combo(Key::Char('d')), &state);
 
@@ -1035,7 +1035,7 @@ mod tests {
             #[test]
             fn yy_triggers_row_yank() {
                 let mut state = active_cell_state();
-                state.result_interaction.yank_op_pending = true;
+                state.result_interaction.start_yank_operator();
 
                 let result = handle_normal_mode(combo(Key::Char('y')), &state);
 

--- a/src/app/update/input/vim/types.rs
+++ b/src/app/update/input/vim/types.rs
@@ -101,8 +101,8 @@ impl From<&AppState> for BrowseVimContext {
             return Self::Result(ResultVimContext {
                 mode: state.result_interaction.selection().mode(),
                 has_pending_draft: state.result_interaction.cell_edit().has_pending_draft(),
-                yank_pending: state.result_interaction.yank_op_pending,
-                delete_pending: state.result_interaction.delete_op_pending,
+                yank_pending: state.result_interaction.is_yank_operator_pending(),
+                delete_pending: state.result_interaction.is_delete_operator_pending(),
             });
         }
 
@@ -144,8 +144,7 @@ mod tests {
         let mut state = AppState::new("test".to_string());
         state.ui.focused_pane = FocusedPane::Result;
         state.result_interaction.activate_cell(0, 0);
-        state.result_interaction.yank_op_pending = true;
-        state.result_interaction.delete_op_pending = true;
+        state.result_interaction.start_yank_operator();
 
         let BrowseVimContext::Result(result_ctx) = BrowseVimContext::from(&state) else {
             panic!("expected result context");
@@ -153,6 +152,22 @@ mod tests {
 
         assert_eq!(result_ctx.mode, ResultNavMode::CellActive);
         assert!(result_ctx.yank_pending);
+        assert!(!result_ctx.delete_pending);
+    }
+
+    #[test]
+    fn browse_context_detects_result_delete_pending_state() {
+        let mut state = AppState::new("test".to_string());
+        state.ui.focused_pane = FocusedPane::Result;
+        state.result_interaction.activate_cell(0, 0);
+        state.result_interaction.start_delete_operator();
+
+        let BrowseVimContext::Result(result_ctx) = BrowseVimContext::from(&state) else {
+            panic!("expected result context");
+        };
+
+        assert_eq!(result_ctx.mode, ResultNavMode::CellActive);
+        assert!(!result_ctx.yank_pending);
         assert!(result_ctx.delete_pending);
     }
 }

--- a/src/app/update/input/vim/types.rs
+++ b/src/app/update/input/vim/types.rs
@@ -139,35 +139,45 @@ mod tests {
     use super::*;
     use crate::model::app_state::AppState;
 
-    #[test]
-    fn browse_context_detects_result_pending_state() {
-        let mut state = AppState::new("test".to_string());
-        state.ui.focused_pane = FocusedPane::Result;
-        state.result_interaction.activate_cell(0, 0);
-        state.result_interaction.start_yank_operator();
+    mod browse_context {
+        use super::*;
 
-        let BrowseVimContext::Result(result_ctx) = BrowseVimContext::from(&state) else {
-            panic!("expected result context");
-        };
+        fn result_context(state: &AppState) -> ResultVimContext {
+            let BrowseVimContext::Result(result_ctx) = BrowseVimContext::from(state) else {
+                panic!("expected result context");
+            };
+            result_ctx
+        }
 
-        assert_eq!(result_ctx.mode, ResultNavMode::CellActive);
-        assert!(result_ctx.yank_pending);
-        assert!(!result_ctx.delete_pending);
-    }
+        fn result_state() -> AppState {
+            let mut state = AppState::new("test".to_string());
+            state.ui.focused_pane = FocusedPane::Result;
+            state.result_interaction.activate_cell(0, 0);
+            state
+        }
 
-    #[test]
-    fn browse_context_detects_result_delete_pending_state() {
-        let mut state = AppState::new("test".to_string());
-        state.ui.focused_pane = FocusedPane::Result;
-        state.result_interaction.activate_cell(0, 0);
-        state.result_interaction.start_delete_operator();
+        #[test]
+        fn result_yank_pending_is_detected() {
+            let mut state = result_state();
+            state.result_interaction.start_yank_operator();
 
-        let BrowseVimContext::Result(result_ctx) = BrowseVimContext::from(&state) else {
-            panic!("expected result context");
-        };
+            let result_ctx = result_context(&state);
 
-        assert_eq!(result_ctx.mode, ResultNavMode::CellActive);
-        assert!(!result_ctx.yank_pending);
-        assert!(result_ctx.delete_pending);
+            assert_eq!(result_ctx.mode, ResultNavMode::CellActive);
+            assert!(result_ctx.yank_pending);
+            assert!(!result_ctx.delete_pending);
+        }
+
+        #[test]
+        fn result_delete_pending_is_detected() {
+            let mut state = result_state();
+            state.result_interaction.start_delete_operator();
+
+            let result_ctx = result_context(&state);
+
+            assert_eq!(result_ctx.mode, ResultNavMode::CellActive);
+            assert!(!result_ctx.yank_pending);
+            assert!(result_ctx.delete_pending);
+        }
     }
 }

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -43,12 +43,7 @@ fn reduce_inner(
     now: Instant,
     services: &AppServices,
 ) -> Vec<Effect> {
-    if !matches!(
-        action,
-        Action::ResultDeleteOperatorPending | Action::ResultRowYankOperatorPending
-    ) {
-        state.result_interaction.clear_operator_pending();
-    }
+    state.result_interaction.clear_operator_pending();
 
     // reduce_result must precede reduce_query: passthrough actions (e.g. ResultNextPage)
     // reset view state here and return None, relying on reduce_query for the actual page change.

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -43,10 +43,12 @@ fn reduce_inner(
     now: Instant,
     services: &AppServices,
 ) -> Vec<Effect> {
-    state.result_interaction.clear_operator_pending(
-        matches!(action, Action::ResultDeleteOperatorPending),
-        matches!(action, Action::ResultRowYankOperatorPending),
-    );
+    if !matches!(
+        action,
+        Action::ResultDeleteOperatorPending | Action::ResultRowYankOperatorPending
+    ) {
+        state.result_interaction.clear_operator_pending();
+    }
 
     // reduce_result must precede reduce_query: passthrough actions (e.g. ResultNextPage)
     // reset view state here and return None, relying on reduce_query for the actual page change.
@@ -2593,7 +2595,7 @@ mod tests {
         #[test]
         fn yank_pending_reset_on_non_yank_action() {
             let mut state = create_test_state();
-            state.result_interaction.yank_op_pending = true;
+            state.result_interaction.start_yank_operator();
             let now = Instant::now();
 
             reduce(
@@ -2603,7 +2605,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert!(!state.result_interaction.yank_op_pending);
+            assert!(!state.result_interaction.is_yank_operator_pending());
         }
 
         #[test]
@@ -2619,8 +2621,8 @@ mod tests {
                 now,
                 &AppServices::stub(),
             );
-            assert!(state.result_interaction.yank_op_pending);
-            assert!(!state.result_interaction.delete_op_pending);
+            assert!(state.result_interaction.is_yank_operator_pending());
+            assert!(!state.result_interaction.is_delete_operator_pending());
 
             reduce(
                 &mut state,
@@ -2628,8 +2630,34 @@ mod tests {
                 now,
                 &AppServices::stub(),
             );
-            assert!(!state.result_interaction.yank_op_pending);
-            assert!(state.result_interaction.delete_op_pending);
+            assert!(!state.result_interaction.is_yank_operator_pending());
+            assert!(state.result_interaction.is_delete_operator_pending());
+        }
+
+        #[test]
+        fn d_then_y_cancels_delete_starts_yank() {
+            let mut state = create_test_state();
+            state.ui.focused_pane = FocusedPane::Result;
+            state.result_interaction.activate_cell(0, 0);
+            let now = Instant::now();
+
+            reduce(
+                &mut state,
+                Action::ResultDeleteOperatorPending,
+                now,
+                &AppServices::stub(),
+            );
+            assert!(state.result_interaction.is_delete_operator_pending());
+            assert!(!state.result_interaction.is_yank_operator_pending());
+
+            reduce(
+                &mut state,
+                Action::ResultRowYankOperatorPending,
+                now,
+                &AppServices::stub(),
+            );
+            assert!(!state.result_interaction.is_delete_operator_pending());
+            assert!(state.result_interaction.is_yank_operator_pending());
         }
     }
 }


### PR DESCRIPTION
## Scope
- ResultInteraction の Vim operator pending state を aggregate API 経由に寄せる
- pending operator の相互排他を ResultInteraction 側の遷移として表現する
- reducer / input context / tests の直接 field 参照を query/transition method に置き換える

## Design intent
Result pane の入力途中状態を ResultInteraction が所有する形に揃え、reducer 側には action dispatch と reset timing だけを残します。これにより、yank/delete operator の片方が開始された時にもう片方を解除する制約が、call site の bool 操作ではなく aggregate の遷移として読めるようになります。

## Verification
- cargo test -q --workspace
- cargo clippy -q --workspace --all-targets -- -D warnings