### PR TITLE
refactor: consolidate modal actions

### DIFF
--- a/src/app/model/shared/picker.rs
+++ b/src/app/model/shared/picker.rs
@@ -1,3 +1,5 @@
+use crate::update::action::CursorMove;
+
 use super::text_input::TextInputState;
 
 #[derive(Debug, Clone, Default)]
@@ -30,6 +32,39 @@ impl PickerState {
     pub fn reset(&mut self) {
         self.selected = 0;
         self.scroll_offset = 0;
+    }
+
+    pub fn clear_filter_and_reset(&mut self) {
+        self.filter_input.clear();
+        self.reset();
+    }
+
+    pub fn clear_filter(&mut self) {
+        self.filter_input.clear();
+    }
+
+    pub fn insert_filter_char(&mut self, ch: char) {
+        self.filter_input.insert_char(ch);
+        self.filter_input.update_viewport(self.filter_visible_width);
+        self.reset();
+    }
+
+    pub fn insert_filter_str(&mut self, text: &str) {
+        let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+        self.filter_input.insert_str(&clean);
+        self.filter_input.update_viewport(self.filter_visible_width);
+        self.reset();
+    }
+
+    pub fn backspace_filter(&mut self) {
+        self.filter_input.backspace();
+        self.filter_input.update_viewport(self.filter_visible_width);
+        self.reset();
+    }
+
+    pub fn move_filter_cursor(&mut self, direction: CursorMove) {
+        self.filter_input.move_cursor(direction);
+        self.filter_input.update_viewport(self.filter_visible_width);
     }
 }
 

--- a/src/app/model/shared/picker.rs
+++ b/src/app/model/shared/picker.rs
@@ -50,8 +50,12 @@ impl PickerState {
     }
 
     pub fn insert_filter_str(&mut self, text: &str) {
-        let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-        self.filter_input.insert_str(&clean);
+        if text.contains(['\n', '\r']) {
+            let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+            self.filter_input.insert_str(&clean);
+        } else {
+            self.filter_input.insert_str(text);
+        }
         self.filter_input.update_viewport(self.filter_visible_width);
         self.reset();
     }

--- a/src/app/model/sql_editor/query_history.rs
+++ b/src/app/model/sql_editor/query_history.rs
@@ -39,8 +39,12 @@ impl QueryHistoryPickerState {
     }
 
     pub fn insert_filter_str(&mut self, text: &str) {
-        let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-        self.filter_input.insert_str(&clean);
+        if text.contains(['\n', '\r']) {
+            let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+            self.filter_input.insert_str(&clean);
+        } else {
+            self.filter_input.insert_str(text);
+        }
         self.reset_selection();
     }
 
@@ -134,6 +138,62 @@ mod tests {
     use super::*;
     use crate::domain::ConnectionId;
 
+    fn state_with_selection() -> QueryHistoryPickerState {
+        QueryHistoryPickerState {
+            selected: 3,
+            scroll_offset: 2,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn insert_filter_char_resets_selection() {
+        let mut state = state_with_selection();
+
+        state.insert_filter_char('a');
+
+        assert_eq!(state.filter_input.content(), "a");
+        assert_eq!(state.selected, 0);
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn insert_filter_str_strips_newlines_and_resets_selection() {
+        let mut state = state_with_selection();
+
+        state.insert_filter_str("a\nb\rc");
+
+        assert_eq!(state.filter_input.content(), "abc");
+        assert_eq!(state.selected, 0);
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn backspace_filter_resets_selection() {
+        let mut state = QueryHistoryPickerState {
+            filter_input: TextInputState::new("abc", 3),
+            ..state_with_selection()
+        };
+
+        state.backspace_filter();
+
+        assert_eq!(state.filter_input.content(), "ab");
+        assert_eq!(state.selected, 0);
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    #[test]
+    fn move_filter_cursor_preserves_selection() {
+        let mut state = QueryHistoryPickerState {
+            filter_input: TextInputState::new("abc", 3),
+            ..state_with_selection()
+        };
+
+        state.move_filter_cursor(CursorMove::Left);
+
+        assert_eq!(state.selected, 3);
+        assert_eq!(state.scroll_offset, 2);
+    }
     fn make_entry(query: &str) -> QueryHistoryEntry {
         use crate::domain::query_history::QueryResultStatus;
         QueryHistoryEntry::new(

--- a/src/app/model/sql_editor/query_history.rs
+++ b/src/app/model/sql_editor/query_history.rs
@@ -3,6 +3,7 @@ use nucleo_matcher::{Config, Matcher};
 
 use crate::domain::query_history::QueryHistoryEntry;
 use crate::model::shared::text_input::TextInputState;
+use crate::update::action::CursorMove;
 
 #[derive(Debug, Clone, Default)]
 pub struct QueryHistoryPickerState {
@@ -28,6 +29,31 @@ impl QueryHistoryPickerState {
     pub fn reset(&mut self) {
         self.entries.clear();
         self.filter_input.clear();
+        self.selected = 0;
+        self.scroll_offset = 0;
+    }
+
+    pub fn insert_filter_char(&mut self, ch: char) {
+        self.filter_input.insert_char(ch);
+        self.reset_selection();
+    }
+
+    pub fn insert_filter_str(&mut self, text: &str) {
+        let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+        self.filter_input.insert_str(&clean);
+        self.reset_selection();
+    }
+
+    pub fn backspace_filter(&mut self) {
+        self.filter_input.backspace();
+        self.reset_selection();
+    }
+
+    pub fn move_filter_cursor(&mut self, direction: CursorMove) {
+        self.filter_input.move_cursor(direction);
+    }
+
+    pub fn reset_selection(&mut self) {
         self.selected = 0;
         self.scroll_offset = 0;
     }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -182,6 +182,20 @@ pub enum ListMotion {
     Previous,
 }
 
+/// Payload-free modal lifecycle kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModalKind {
+    TablePicker,
+    CommandPalette,
+    Help,
+    SqlModal,
+    ErTablePicker,
+    QueryHistoryPicker,
+    JsonbDetail,
+    ConnectionSetup,
+    ConnectionSelector,
+}
+
 #[derive(Debug, Clone)]
 pub struct SmartErRefreshResult {
     pub run_id: u64,
@@ -268,22 +282,17 @@ pub enum Action {
         motion: ListMotion,
     },
 
-    // Overlay toggles
-    OpenTablePicker,
-    CloseTablePicker,
-    OpenCommandPalette,
-    CloseCommandPalette,
-    OpenHelp,
-    CloseHelp,
+    // Modal lifecycle
+    OpenModal(ModalKind),
+    CloseModal(ModalKind),
+    ToggleModal(ModalKind),
 
     // Connection lifecycle
     TryConnect,
     SwitchConnection(ConnectionTarget),
 
     // Connection Setup
-    OpenConnectionSetup,
     StartEditConnection(ConnectionId),
-    CloseConnectionSetup,
     ConnectionSetupNextField,
     ConnectionSetupPrevField,
     ConnectionSetupToggleDropdown,
@@ -297,9 +306,6 @@ pub enum Action {
     ConnectionSaveFailed(ConnectionSaveError),
     ConnectionEditLoaded(Box<ConnectionProfile>),
     ConnectionEditLoadFailed(ConnectionStoreError),
-
-    // Connection Selector
-    OpenConnectionSelector,
 
     // Connection Error
     ShowConnectionError(ConnectionErrorInfo),
@@ -388,8 +394,6 @@ pub enum Action {
     Paste(String),
 
     // SQL Modal
-    OpenSqlModal,
-    CloseSqlModal,
     SqlModalAppendInsert,
     SqlModalEnterInsert,
     SqlModalEnterNormal,
@@ -494,15 +498,11 @@ pub enum Action {
     ToggleReadOnly,
 
     // ER Table Picker
-    OpenErTablePicker,
-    CloseErTablePicker,
     ErToggleSelection,
     ErSelectAll,
     ErConfirmSelection,
 
     // Query History Picker
-    OpenQueryHistoryPicker,
-    CloseQueryHistoryPicker,
     QueryHistoryLoaded(
         crate::domain::ConnectionId,
         Vec<crate::domain::query_history::QueryHistoryEntry>,
@@ -530,8 +530,6 @@ pub enum Action {
     CsvExportFailed(DbOperationError),
 
     // JSONB Detail View
-    OpenJsonbDetail,
-    CloseJsonbDetail,
     JsonbYankAll,
     JsonbEnterEdit,
     JsonbAppendInsert,

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -8,7 +8,7 @@ use crate::model::connection::error::ConnectionErrorInfo;
 use crate::model::er_state::ErStatus;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::FailedPrefetchEntry;
-use crate::update::action::{Action, TableTarget};
+use crate::update::action::{Action, ModalKind, TableTarget};
 
 const BASE_BACKOFF_SECS: u64 = 1;
 const MAX_BACKOFF_SECS: u64 = 4;
@@ -117,7 +117,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
             if state.ui.pending_er_picker && state.modal.active_mode() == InputMode::Normal {
                 state.ui.pending_er_picker = false;
-                effects.push(Effect::DispatchActions(vec![Action::OpenErTablePicker]));
+                effects.push(Effect::DispatchActions(vec![Action::OpenModal(
+                    ModalKind::ErTablePicker,
+                )]));
             } else {
                 state.ui.pending_er_picker = false;
             }

--- a/src/app/update/browse/navigation/input.rs
+++ b/src/app/update/browse/navigation/input.rs
@@ -8,25 +8,11 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
     match action {
         Action::Paste(text) => match state.modal.active_mode() {
             InputMode::TablePicker => {
-                let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-                state.ui.table_picker.filter_input.insert_str(&clean);
-                state
-                    .ui
-                    .table_picker
-                    .filter_input
-                    .update_viewport(state.ui.table_picker.filter_visible_width);
-                state.ui.table_picker.reset();
+                state.ui.table_picker.insert_filter_str(text);
                 Some(vec![])
             }
             InputMode::ErTablePicker => {
-                let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-                state.ui.er_picker.filter_input.insert_str(&clean);
-                state
-                    .ui
-                    .er_picker
-                    .filter_input
-                    .update_viewport(state.ui.er_picker.filter_visible_width);
-                state.ui.er_picker.reset();
+                state.ui.er_picker.insert_filter_str(text);
                 Some(vec![])
             }
             InputMode::CommandLine => {
@@ -46,10 +32,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 Some(vec![])
             }
             InputMode::QueryHistoryPicker => {
-                let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-                state.query_history_picker.filter_input.insert_str(&clean);
-                state.query_history_picker.selected = 0;
-                state.query_history_picker.scroll_offset = 0;
+                state.query_history_picker.insert_filter_str(text);
                 Some(vec![])
             }
             _ => None,
@@ -59,37 +42,20 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
             target: InputTarget::Filter,
             ch: c,
         } => {
-            state.ui.table_picker.filter_input.insert_char(*c);
-            state
-                .ui
-                .table_picker
-                .filter_input
-                .update_viewport(state.ui.table_picker.filter_visible_width);
-            state.ui.table_picker.reset();
+            state.ui.table_picker.insert_filter_char(*c);
             Some(vec![])
         }
         Action::TextBackspace {
             target: InputTarget::Filter,
         } => {
-            state.ui.table_picker.filter_input.backspace();
-            state
-                .ui
-                .table_picker
-                .filter_input
-                .update_viewport(state.ui.table_picker.filter_visible_width);
-            state.ui.table_picker.reset();
+            state.ui.table_picker.backspace_filter();
             Some(vec![])
         }
         Action::TextMoveCursor {
             target: InputTarget::Filter,
             direction: movement,
         } => {
-            state.ui.table_picker.filter_input.move_cursor(*movement);
-            state
-                .ui
-                .table_picker
-                .filter_input
-                .update_viewport(state.ui.table_picker.filter_visible_width);
+            state.ui.table_picker.move_filter_cursor(*movement);
             Some(vec![])
         }
 

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -8,7 +8,7 @@ use crate::model::browse::query_execution::{PREVIEW_PAGE_SIZE, PostDeleteRowSele
 use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::{AdhocSuccessSnapshot, SqlModalStatus};
 use crate::services::AppServices;
-use crate::update::action::{Action, TableTarget};
+use crate::update::action::{Action, ModalKind, TableTarget};
 use crate::update::input::command::{command_to_action, parse_command};
 
 fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult) -> Vec<Effect> {
@@ -187,11 +187,11 @@ pub fn reduce(
                     state.should_quit = true;
                     vec![]
                 }
-                Action::OpenHelp => {
+                Action::ToggleModal(ModalKind::Help) => {
                     state.modal.set_mode(InputMode::Help);
                     vec![]
                 }
-                Action::OpenSqlModal => {
+                Action::OpenModal(ModalKind::SqlModal) => {
                     state.modal.set_mode(InputMode::SqlModal);
                     state.sql_modal.set_status(SqlModalStatus::Normal);
                     if !state.sql_modal.is_prefetch_started() && state.session.metadata().is_some()
@@ -201,8 +201,11 @@ pub fn reduce(
                         vec![]
                     }
                 }
-                Action::OpenErTablePicker => {
-                    vec![Effect::DispatchActions(vec![Action::OpenErTablePicker])]
+                Action::OpenModal(ModalKind::ErTablePicker) => {
+                    // Defer to modal reducer so metadata readiness checks stay in one place.
+                    vec![Effect::DispatchActions(vec![Action::OpenModal(
+                        ModalKind::ErTablePicker,
+                    )])]
                 }
                 Action::SubmitCellEditWrite => {
                     vec![Effect::DispatchActions(vec![Action::SubmitCellEditWrite])]
@@ -336,7 +339,10 @@ mod tests {
             assert_eq!(effects.len(), 1);
             match &effects[0] {
                 Effect::DispatchActions(actions) => {
-                    assert!(matches!(actions[0], Action::OpenErTablePicker));
+                    assert!(matches!(
+                        actions[0],
+                        Action::OpenModal(ModalKind::ErTablePicker)
+                    ));
                 }
                 other => panic!("expected DispatchActions, got {other:?}"),
             }

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -6,7 +6,7 @@ use crate::domain::{QueryResult, QuerySource};
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{PREVIEW_PAGE_SIZE, PostDeleteRowSelection};
 use crate::model::shared::input_mode::InputMode;
-use crate::model::sql_editor::modal::{AdhocSuccessSnapshot, SqlModalStatus};
+use crate::model::sql_editor::modal::AdhocSuccessSnapshot;
 use crate::services::AppServices;
 use crate::update::action::{Action, ModalKind, TableTarget};
 use crate::update::input::command::{command_to_action, parse_command};
@@ -192,14 +192,9 @@ pub fn reduce(
                     vec![]
                 }
                 Action::OpenModal(ModalKind::SqlModal) => {
-                    state.modal.set_mode(InputMode::SqlModal);
-                    state.sql_modal.set_status(SqlModalStatus::Normal);
-                    if !state.sql_modal.is_prefetch_started() && state.session.metadata().is_some()
-                    {
-                        vec![Effect::DispatchActions(vec![Action::StartPrefetchAll])]
-                    } else {
-                        vec![]
-                    }
+                    vec![Effect::DispatchActions(vec![Action::OpenModal(
+                        ModalKind::SqlModal,
+                    )])]
                 }
                 Action::OpenModal(ModalKind::ErTablePicker) => {
                     // Defer to modal reducer so metadata readiness checks stay in one place.

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -6,7 +6,7 @@ use crate::domain::ColumnAttributes;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::write::write_update::build_pk_pairs;
-use crate::update::action::{Action, InputTarget};
+use crate::update::action::{Action, InputTarget, ModalKind};
 
 use crate::update::helpers::{EditGuardrailError, editable_preview_base};
 
@@ -76,7 +76,9 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
 
             // JSONB columns open the dedicated detail modal instead of inline edit
             if is_jsonb_cell(state) {
-                return Some(vec![Effect::DispatchActions(vec![Action::OpenJsonbDetail])]);
+                return Some(vec![Effect::DispatchActions(vec![Action::OpenModal(
+                    ModalKind::JsonbDetail,
+                )])]);
             }
 
             match editable_cell_context(state) {
@@ -342,7 +344,7 @@ mod tests {
             assert_eq!(effects.len(), 1);
             assert!(matches!(
                 &effects[0],
-                Effect::DispatchActions(actions) if matches!(actions.as_slice(), [Action::OpenJsonbDetail])
+                Effect::DispatchActions(actions) if matches!(actions.as_slice(), [Action::OpenModal(crate::update::action::ModalKind::JsonbDetail)])
             ));
         }
     }

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -344,7 +344,7 @@ mod tests {
             assert_eq!(effects.len(), 1);
             assert!(matches!(
                 &effects[0],
-                Effect::DispatchActions(actions) if matches!(actions.as_slice(), [Action::OpenModal(crate::update::action::ModalKind::JsonbDetail)])
+                Effect::DispatchActions(actions) if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonbDetail)])
             ));
         }
     }

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -13,11 +13,11 @@ use crate::model::shared::key_sequence::KeySequenceState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::shared::ui_state::DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS;
 use crate::ports::outbound::ClipboardError;
-use crate::update::action::{Action, CursorMove, InputTarget};
+use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
 
 pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
     match action {
-        Action::OpenJsonbDetail => {
+        Action::OpenModal(ModalKind::JsonbDetail) => {
             let result = match state.query.visible_result() {
                 Some(r) if r.source == QuerySource::Preview && !r.is_error() => r,
                 _ => return Some(vec![]),
@@ -77,7 +77,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             Some(vec![])
         }
 
-        Action::CloseJsonbDetail => {
+        Action::CloseModal(ModalKind::JsonbDetail) => {
             apply_pending_edit_as_draft(state);
             state.jsonb_detail.close();
             state.modal.pop_mode();
@@ -460,7 +460,11 @@ mod tests {
     }
 
     fn open_detail(state: &mut AppState) {
-        reduce(state, &Action::OpenJsonbDetail, Instant::now());
+        reduce(
+            state,
+            &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+            Instant::now(),
+        );
     }
 
     fn cursor_position(content: &str, cursor: usize) -> (usize, usize) {
@@ -489,7 +493,11 @@ mod tests {
         fn opens_on_valid_jsonb_cell() {
             let mut state = state_with_jsonb_cell();
 
-            reduce(&mut state, &Action::OpenJsonbDetail, Instant::now());
+            reduce(
+                &mut state,
+                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                Instant::now(),
+            );
 
             assert!(state.jsonb_detail.is_active());
             assert_eq!(state.input_mode(), InputMode::JsonbDetail);
@@ -500,7 +508,11 @@ mod tests {
             let mut state = state_with_jsonb_cell();
             state.result_interaction.move_cell(0);
 
-            reduce(&mut state, &Action::OpenJsonbDetail, Instant::now());
+            reduce(
+                &mut state,
+                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                Instant::now(),
+            );
 
             assert!(!state.jsonb_detail.is_active());
             assert_eq!(state.input_mode(), InputMode::Normal);
@@ -521,7 +533,11 @@ mod tests {
                 command_tag: None,
             }));
 
-            reduce(&mut state, &Action::OpenJsonbDetail, Instant::now());
+            reduce(
+                &mut state,
+                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                Instant::now(),
+            );
 
             assert!(!state.jsonb_detail.is_active());
         }
@@ -541,7 +557,11 @@ mod tests {
                 command_tag: None,
             }));
 
-            reduce(&mut state, &Action::OpenJsonbDetail, Instant::now());
+            reduce(
+                &mut state,
+                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                Instant::now(),
+            );
 
             assert!(!state.jsonb_detail.is_active());
         }
@@ -551,7 +571,11 @@ mod tests {
             let mut state = state_with_jsonb_cell();
             state.session.set_table_detail_raw(None);
 
-            reduce(&mut state, &Action::OpenJsonbDetail, Instant::now());
+            reduce(
+                &mut state,
+                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                Instant::now(),
+            );
 
             assert!(!state.jsonb_detail.is_active());
         }
@@ -563,10 +587,18 @@ mod tests {
         #[test]
         fn close_clears_state() {
             let mut state = state_with_jsonb_cell();
-            reduce(&mut state, &Action::OpenJsonbDetail, Instant::now());
+            reduce(
+                &mut state,
+                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                Instant::now(),
+            );
             assert!(state.jsonb_detail.is_active());
 
-            reduce(&mut state, &Action::CloseJsonbDetail, Instant::now());
+            reduce(
+                &mut state,
+                &Action::CloseModal(crate::update::action::ModalKind::JsonbDetail),
+                Instant::now(),
+            );
 
             assert!(!state.jsonb_detail.is_active());
             assert_eq!(state.input_mode(), InputMode::Normal);
@@ -780,7 +812,11 @@ mod tests {
                 .set_content(r#"{"theme":"light","count":5}"#.to_string());
             reduce(&mut state, &Action::JsonbExitEdit, Instant::now());
 
-            reduce(&mut state, &Action::CloseJsonbDetail, Instant::now());
+            reduce(
+                &mut state,
+                &Action::CloseModal(crate::update::action::ModalKind::JsonbDetail),
+                Instant::now(),
+            );
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(!state.jsonb_detail.is_active());
@@ -794,7 +830,11 @@ mod tests {
             reduce(&mut state, &Action::JsonbEnterEdit, Instant::now());
             reduce(&mut state, &Action::JsonbExitEdit, Instant::now());
 
-            reduce(&mut state, &Action::CloseJsonbDetail, Instant::now());
+            reduce(
+                &mut state,
+                &Action::CloseModal(crate::update::action::ModalKind::JsonbDetail),
+                Instant::now(),
+            );
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(!state.result_interaction.cell_edit().has_pending_draft());
@@ -808,7 +848,11 @@ mod tests {
         #[test]
         fn copies_all_text_to_clipboard() {
             let mut state = state_with_jsonb_cell();
-            reduce(&mut state, &Action::OpenJsonbDetail, Instant::now());
+            reduce(
+                &mut state,
+                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                Instant::now(),
+            );
 
             let effects = reduce(&mut state, &Action::JsonbYankAll, Instant::now());
 

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -3,11 +3,11 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
-use crate::update::action::Action;
+use crate::update::action::{Action, ModalKind};
 
 pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
     match action {
-        Action::OpenConnectionSelector => {
+        Action::OpenModal(ModalKind::ConnectionSelector) => {
             state.modal.set_mode(InputMode::ConnectionSelector);
             state.ui.set_connection_list_selection(Some(0));
             Some(vec![Effect::LoadConnections])
@@ -121,7 +121,11 @@ mod tests {
         fn sets_mode_and_loads_connections() {
             let mut state = AppState::new("test".to_string());
 
-            let effects = reduce(&mut state, &Action::OpenConnectionSelector, Instant::now());
+            let effects = reduce(
+                &mut state,
+                &Action::OpenModal(ModalKind::ConnectionSelector),
+                Instant::now(),
+            );
 
             assert_eq!(state.input_mode(), InputMode::ConnectionSelector);
             let effects = effects.unwrap();
@@ -133,7 +137,11 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.ui.set_connection_list_selection(Some(3));
 
-            reduce(&mut state, &Action::OpenConnectionSelector, Instant::now());
+            reduce(
+                &mut state,
+                &Action::OpenModal(ModalKind::ConnectionSelector),
+                Instant::now(),
+            );
 
             assert_eq!(state.ui.connection_list_selected, 0);
         }

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -7,12 +7,12 @@ use crate::model::connection::setup::{
     CONNECTION_INPUT_VISIBLE_WIDTH, ConnectionField, ConnectionSetupState,
 };
 use crate::model::shared::input_mode::InputMode;
-use crate::update::action::{Action, ConnectionTarget, InputTarget};
+use crate::update::action::{Action, ConnectionTarget, InputTarget, ModalKind};
 use crate::update::helpers::{validate_all, validate_field};
 
 pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
     match action {
-        Action::OpenConnectionSetup => {
+        Action::OpenModal(ModalKind::ConnectionSetup) => {
             state.connection_setup.reset();
             if !state.connections().is_empty() || state.session.dsn.is_some() {
                 state.connection_setup.is_first_run = false;
@@ -32,7 +32,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             state.messages.set_error_at(e.to_string(), now);
             Some(vec![])
         }
-        Action::CloseConnectionSetup => {
+        Action::CloseModal(ModalKind::ConnectionSetup) => {
             state.modal.set_mode(InputMode::Normal);
             Some(vec![])
         }
@@ -415,7 +415,11 @@ mod tests {
         fn is_first_run_true_when_no_connections() {
             let mut state = AppState::new("test".to_string());
 
-            reduce(&mut state, &Action::OpenConnectionSetup, Instant::now());
+            reduce(
+                &mut state,
+                &Action::OpenModal(ModalKind::ConnectionSetup),
+                Instant::now(),
+            );
 
             assert!(state.connection_setup.is_first_run);
         }
@@ -426,7 +430,11 @@ mod tests {
             let profile = create_profile("test");
             state.set_connections(vec![profile]);
 
-            reduce(&mut state, &Action::OpenConnectionSetup, Instant::now());
+            reduce(
+                &mut state,
+                &Action::OpenModal(ModalKind::ConnectionSetup),
+                Instant::now(),
+            );
 
             assert!(!state.connection_setup.is_first_run);
         }
@@ -436,7 +444,11 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.session.dsn = Some("postgres://localhost/db".to_string());
 
-            reduce(&mut state, &Action::OpenConnectionSetup, Instant::now());
+            reduce(
+                &mut state,
+                &Action::OpenModal(ModalKind::ConnectionSetup),
+                Instant::now(),
+            );
 
             assert!(!state.connection_setup.is_first_run);
         }

--- a/src/app/update/input/command.rs
+++ b/src/app/update/input/command.rs
@@ -1,4 +1,4 @@
-use crate::update::action::Action;
+use crate::update::action::{Action, ModalKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Command {
@@ -24,9 +24,9 @@ pub fn parse_command(input: &str) -> Command {
 pub fn command_to_action(cmd: Command) -> Action {
     match cmd {
         Command::Quit => Action::Quit,
-        Command::Help => Action::OpenHelp,
-        Command::Sql => Action::OpenSqlModal,
-        Command::Erd => Action::OpenErTablePicker,
+        Command::Help => Action::ToggleModal(ModalKind::Help),
+        Command::Sql => Action::OpenModal(ModalKind::SqlModal),
+        Command::Erd => Action::OpenModal(ModalKind::ErTablePicker),
         Command::Write => Action::SubmitCellEditWrite,
         Command::Unknown(_) => Action::None,
     }
@@ -117,21 +117,24 @@ mod tests {
         fn help_returns_open_help_action() {
             let result = command_to_action(Command::Help);
 
-            assert!(matches!(result, Action::OpenHelp));
+            assert!(matches!(result, Action::ToggleModal(ModalKind::Help)));
         }
 
         #[test]
         fn sql_returns_open_sql_modal_action() {
             let result = command_to_action(Command::Sql);
 
-            assert!(matches!(result, Action::OpenSqlModal));
+            assert!(matches!(result, Action::OpenModal(ModalKind::SqlModal)));
         }
 
         #[test]
         fn erd_returns_open_er_table_picker_action() {
             let result = command_to_action(Command::Erd);
 
-            assert!(matches!(result, Action::OpenErTablePicker));
+            assert!(matches!(
+                result,
+                Action::OpenModal(ModalKind::ErTablePicker)
+            ));
         }
 
         #[test]

--- a/src/app/update/input/handlers/connections.rs
+++ b/src/app/update/input/handlers/connections.rs
@@ -87,7 +87,7 @@ mod tests {
     use super::*;
     use crate::model::shared::input_mode::InputMode;
     use crate::update::action::{
-        ListMotion, ListTarget, ScrollAmount, ScrollDirection, ScrollTarget,
+        ListMotion, ListTarget, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget,
     };
     use crate::update::input::keybindings::{Key, KeyCombo, Modifiers};
     use rstest::rstest;
@@ -312,7 +312,10 @@ mod tests {
                 Expected::Close => assert!(matches!(result, Action::CloseConnectionError)),
                 Expected::Reenter => assert!(matches!(result, Action::ReenterConnectionSetup)),
                 Expected::OpenSelector => {
-                    assert!(matches!(result, Action::OpenConnectionSelector));
+                    assert!(matches!(
+                        result,
+                        Action::OpenModal(ModalKind::ConnectionSelector)
+                    ));
                 }
                 Expected::ToggleDetails => {
                     assert!(matches!(result, Action::ToggleConnectionErrorDetails));
@@ -394,7 +397,7 @@ mod tests {
 
         #[rstest]
         #[case(Key::Enter, Action::ConfirmConnectionSelection)]
-        #[case(Key::Char('n'), Action::OpenConnectionSetup)]
+        #[case(Key::Char('n'), Action::OpenModal(ModalKind::ConnectionSetup))]
         #[case(Key::Char('e'), Action::RequestEditSelectedConnection)]
         #[case(Key::Char('d'), Action::RequestDeleteSelectedConnection)]
         fn selector_action_keys(#[case] code: Key, #[case] expected: Action) {

--- a/src/app/update/input/handlers/connections.rs
+++ b/src/app/update/input/handlers/connections.rs
@@ -403,10 +403,7 @@ mod tests {
         fn selector_action_keys(#[case] code: Key, #[case] expected: Action) {
             let result = handle_connection_selector_keys(combo(code));
 
-            assert_eq!(
-                std::mem::discriminant(&result),
-                std::mem::discriminant(&expected)
-            );
+            assert_eq!(format!("{result:?}"), format!("{expected:?}"));
         }
 
         #[test]

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -79,6 +79,7 @@ fn handle_key_event(combo: KeyCombo, state: &AppState, services: &AppServices) -
 mod tests {
     use super::*;
     use crate::ports::inbound::Key;
+    use crate::update::action::ModalKind;
 
     fn combo(k: Key) -> KeyCombo {
         KeyCombo::plain(k)
@@ -112,7 +113,7 @@ mod tests {
             // Esc in SqlModal (Normal mode, the default) should close modal
             let result = handle_key_event(combo(Key::Esc), &state, &services);
 
-            assert!(matches!(result, Action::CloseSqlModal));
+            assert!(matches!(result, Action::CloseModal(ModalKind::SqlModal)));
         }
 
         #[test]

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -1,7 +1,7 @@
 use crate::model::app_state::AppState;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::key_sequence::Prefix;
-use crate::update::action::Action;
+use crate::update::action::{Action, ModalKind};
 use crate::update::input::keybindings::{self as kb, Key, KeyCombo, Modifiers};
 use crate::update::input::vim::{
     BrowseVimContext, VimCommand, VimSurfaceContext, action_for_input, action_for_key,
@@ -29,19 +29,19 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
                 };
             }
             Key::Char('k') if !state.query.is_history_mode() => {
-                return Action::OpenCommandPalette;
+                return Action::OpenModal(ModalKind::CommandPalette);
             }
             Key::Char('r') => {
                 return Action::ToggleReadOnly;
             }
             Key::Char('o') if !state.query.is_history_mode() => {
-                return Action::OpenQueryHistoryPicker;
+                return Action::OpenModal(ModalKind::QueryHistoryPicker);
             }
             Key::Char('e') if state.can_request_csv_export() => {
                 return Action::RequestCsvExport;
             }
             Key::Char('p') if !state.query.is_history_mode() => {
-                return Action::OpenTablePicker;
+                return Action::OpenModal(ModalKind::TablePicker);
             }
             // Ctrl+N/P navigation disabled on main screen; use j/k or arrows.
             // Modals/pickers handle Ctrl+N/P via their own bindings.
@@ -81,7 +81,7 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
         match combo.key {
             Key::Char('[') => return Action::HistoryOlder,
             Key::Char(']') => return Action::HistoryNewer,
-            Key::Char('?') => return Action::OpenHelp,
+            Key::Char('?') => return Action::ToggleModal(ModalKind::Help),
             // Home/End/PageDown/PageUp are blocked in history mode
             // (only char keys g/G and Ctrl+D/U/F/B are allowed for these motions)
             Key::Home | Key::End | Key::PageDown | Key::PageUp => return Action::None,
@@ -97,7 +97,7 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
         return Action::Quit;
     }
     if kb::is_help(&combo) {
-        return Action::OpenHelp;
+        return Action::ToggleModal(ModalKind::Help);
     }
     if kb::is_command_line(&combo) {
         return Action::EnterCommandLine;
@@ -160,10 +160,10 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
         {
             Action::ResultCellYank
         }
-        Key::Char('s') => Action::OpenSqlModal,
-        Key::Char('e') => Action::OpenErTablePicker,
+        Key::Char('s') => Action::OpenModal(ModalKind::SqlModal),
+        Key::Char('e') => Action::OpenModal(ModalKind::ErTablePicker),
         Key::Char('c') if state.ui.focused_pane == FocusedPane::Explorer => {
-            Action::OpenConnectionSelector
+            Action::OpenModal(ModalKind::ConnectionSelector)
         }
 
         Key::Char('z') => Action::BeginKeySequence(Prefix::Z),
@@ -227,7 +227,7 @@ mod tests {
 
                 let result = handle_normal_mode(combo_ctrl(Key::Char('p')), &state);
 
-                assert!(matches!(result, Action::OpenTablePicker));
+                assert!(matches!(result, Action::OpenModal(ModalKind::TablePicker)));
             }
 
             #[test]
@@ -245,7 +245,10 @@ mod tests {
 
                 let result = handle_normal_mode(combo_ctrl(Key::Char('k')), &state);
 
-                assert!(matches!(result, Action::OpenCommandPalette));
+                assert!(matches!(
+                    result,
+                    Action::OpenModal(ModalKind::CommandPalette)
+                ));
             }
 
             #[test]
@@ -263,7 +266,7 @@ mod tests {
 
                 let result = handle_normal_mode(combo(Key::Char('?')), &state);
 
-                assert!(matches!(result, Action::OpenHelp));
+                assert!(matches!(result, Action::ToggleModal(ModalKind::Help)));
             }
 
             #[test]
@@ -547,7 +550,10 @@ mod tests {
 
                 let result = handle_normal_mode(combo(Key::Char('c')), &state);
 
-                assert!(matches!(result, Action::OpenConnectionSelector));
+                assert!(matches!(
+                    result,
+                    Action::OpenModal(ModalKind::ConnectionSelector)
+                ));
             }
         }
 
@@ -596,7 +602,7 @@ mod tests {
 
                 let result = handle_normal_mode(combo_ctrl(Key::Char('p')), &state);
 
-                assert!(matches!(result, Action::OpenTablePicker));
+                assert!(matches!(result, Action::OpenModal(ModalKind::TablePicker)));
             }
 
             #[rstest]
@@ -1192,7 +1198,7 @@ mod tests {
 
                     let result = handle_normal_mode(combo(Key::Char('?')), &state);
 
-                    assert!(matches!(result, Action::OpenHelp));
+                    assert!(matches!(result, Action::ToggleModal(ModalKind::Help)));
                 }
 
                 #[rstest]

--- a/src/app/update/input/handlers/overlays.rs
+++ b/src/app/update/input/handlers/overlays.rs
@@ -13,6 +13,7 @@ pub fn handle_confirm_dialog_keys(combo: KeyCombo) -> Action {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::update::action::ModalKind;
     use crate::update::action::{ScrollAmount, ScrollDirection, ScrollTarget};
     use crate::update::input::keybindings::{Key, KeyCombo};
     use rstest::rstest;
@@ -43,14 +44,14 @@ mod tests {
         fn esc_closes_help() {
             let result = handle_help_keys(combo(Key::Esc));
 
-            assert!(matches!(result, Action::CloseHelp));
+            assert!(matches!(result, Action::CloseModal(ModalKind::Help)));
         }
 
         #[test]
         fn question_mark_closes_help() {
             let result = handle_help_keys(combo(Key::Char('?')));
 
-            assert!(matches!(result, Action::CloseHelp));
+            assert!(matches!(result, Action::CloseModal(ModalKind::Help)));
         }
 
         #[test]

--- a/src/app/update/input/handlers/pickers.rs
+++ b/src/app/update/input/handlers/pickers.rs
@@ -50,6 +50,7 @@ pub fn handle_er_table_picker_keys(combo: KeyCombo) -> Action {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::update::action::ModalKind;
     use crate::update::action::{ListMotion, ListTarget};
     use crate::update::input::keybindings::{Key, KeyCombo};
     use rstest::rstest;
@@ -88,7 +89,9 @@ mod tests {
             let result = handle_table_picker_keys(combo(code));
 
             match expected {
-                Expected::Close => assert!(matches!(result, Action::CloseTablePicker)),
+                Expected::Close => {
+                    assert!(matches!(result, Action::CloseModal(ModalKind::TablePicker)))
+                }
                 Expected::Confirm => assert!(matches!(result, Action::ConfirmSelection)),
                 Expected::SelectPrev => {
                     assert!(matches!(
@@ -160,7 +163,10 @@ mod tests {
             let result = handle_command_palette_keys(combo(code));
 
             match expected {
-                Expected::Close => assert!(matches!(result, Action::CloseCommandPalette)),
+                Expected::Close => assert!(matches!(
+                    result,
+                    Action::CloseModal(ModalKind::CommandPalette)
+                )),
                 Expected::Confirm => assert!(matches!(result, Action::ConfirmSelection)),
                 Expected::SelectPrev => {
                     assert!(matches!(
@@ -193,7 +199,7 @@ mod tests {
         #[case(Key::Up, Action::ListSelect { target: ListTarget::QueryHistory, motion: ListMotion::Previous })]
         #[case(Key::Down, Action::ListSelect { target: ListTarget::QueryHistory, motion: ListMotion::Next })]
         #[case(Key::Backspace, Action::TextBackspace { target: InputTarget::QueryHistoryFilter })]
-        #[case(Key::Esc, Action::CloseQueryHistoryPicker)]
+        #[case(Key::Esc, Action::CloseModal(ModalKind::QueryHistoryPicker))]
         fn picker_keys(#[case] key: Key, #[case] expected: Action) {
             let result = handle_query_history_picker_keys(combo(key));
 
@@ -235,8 +241,11 @@ mod tests {
                         }
                     ));
                 }
-                Action::CloseQueryHistoryPicker => {
-                    assert!(matches!(result, Action::CloseQueryHistoryPicker));
+                Action::CloseModal(ModalKind::QueryHistoryPicker) => {
+                    assert!(matches!(
+                        result,
+                        Action::CloseModal(ModalKind::QueryHistoryPicker)
+                    ));
                 }
                 _ => unreachable!("unexpected test case"),
             }
@@ -278,7 +287,10 @@ mod tests {
         fn esc_returns_close_er_table_picker() {
             let result = handle_er_table_picker_keys(combo(Key::Esc));
 
-            assert!(matches!(result, Action::CloseErTablePicker));
+            assert!(matches!(
+                result,
+                Action::CloseModal(ModalKind::ErTablePicker)
+            ));
         }
 
         #[test]

--- a/src/app/update/input/handlers/pickers.rs
+++ b/src/app/update/input/handlers/pickers.rs
@@ -203,52 +203,7 @@ mod tests {
         fn picker_keys(#[case] key: Key, #[case] expected: Action) {
             let result = handle_query_history_picker_keys(combo(key));
 
-            match expected {
-                Action::QueryHistoryConfirmSelection => {
-                    assert!(matches!(result, Action::QueryHistoryConfirmSelection));
-                }
-                Action::ListSelect {
-                    target: ListTarget::QueryHistory,
-                    motion: ListMotion::Previous,
-                } => {
-                    assert!(matches!(
-                        result,
-                        Action::ListSelect {
-                            target: ListTarget::QueryHistory,
-                            motion: ListMotion::Previous,
-                        }
-                    ));
-                }
-                Action::ListSelect {
-                    target: ListTarget::QueryHistory,
-                    motion: ListMotion::Next,
-                } => {
-                    assert!(matches!(
-                        result,
-                        Action::ListSelect {
-                            target: ListTarget::QueryHistory,
-                            motion: ListMotion::Next,
-                        }
-                    ));
-                }
-                Action::TextBackspace {
-                    target: InputTarget::QueryHistoryFilter,
-                } => {
-                    assert!(matches!(
-                        result,
-                        Action::TextBackspace {
-                            target: InputTarget::QueryHistoryFilter,
-                        }
-                    ));
-                }
-                Action::CloseModal(ModalKind::QueryHistoryPicker) => {
-                    assert!(matches!(
-                        result,
-                        Action::CloseModal(ModalKind::QueryHistoryPicker)
-                    ));
-                }
-                _ => unreachable!("unexpected test case"),
-            }
+            assert_eq!(format!("{result:?}"), format!("{expected:?}"));
         }
 
         #[test]

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -1,6 +1,8 @@
 use crate::model::shared::key_sequence::Prefix;
 use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
-use crate::update::action::{Action, InputTarget, ScrollAmount, ScrollDirection, ScrollTarget};
+use crate::update::action::{
+    Action, InputTarget, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget,
+};
 use crate::update::input::keybindings::{Key, KeyCombo, Modifiers};
 use crate::update::input::vim::{
     SqlModalVimContext, VimSurfaceContext, action_for_input, action_for_key,
@@ -105,7 +107,7 @@ pub fn handle_sql_modal_keys_with_prefix(
             return Action::ExplainAnalyzeRequest;
         }
         if ctrl && combo.key == Key::Char('o') {
-            return Action::OpenQueryHistoryPicker;
+            return Action::OpenModal(ModalKind::QueryHistoryPicker);
         }
         if ctrl && combo.key == Key::Char('l') {
             return Action::SqlModalClear;
@@ -239,7 +241,7 @@ pub fn handle_sql_modal_keys_with_prefix(
     }
 
     if ctrl && combo.key == Key::Char('o') {
-        return Action::OpenQueryHistoryPicker;
+        return Action::OpenModal(ModalKind::QueryHistoryPicker);
     }
 
     if ctrl && combo.key == Key::Char(' ') {
@@ -347,7 +349,7 @@ mod tests {
         SqlModalDelete,
         SqlModalInput(char),
         SqlModalMoveCursor(CursorMove),
-        CloseSqlModal,
+        CloseModal(ModalKind),
         SqlModalAppendInsert,
         SqlModalEnterInsert,
         SqlModalEnterNormal,
@@ -357,7 +359,7 @@ mod tests {
         CompletionDismiss,
         CompletionPrev,
         CompletionNext,
-        OpenQueryHistoryPicker,
+        OpenModal(ModalKind),
         SqlModalClear,
         ExplainRequest,
         ExplainAnalyzeRequest,
@@ -398,7 +400,9 @@ mod tests {
                     matches!(result, Action::TextMoveCursor { target: InputTarget::SqlModal, direction: x } if x == m)
                 );
             }
-            Expected::CloseSqlModal => assert!(matches!(result, Action::CloseSqlModal)),
+            Expected::CloseModal(expected_kind) => {
+                assert!(matches!(result, Action::CloseModal(kind) if kind == expected_kind))
+            }
             Expected::SqlModalAppendInsert => {
                 assert!(matches!(result, Action::SqlModalAppendInsert));
             }
@@ -414,8 +418,8 @@ mod tests {
             Expected::CompletionDismiss => assert!(matches!(result, Action::CompletionDismiss)),
             Expected::CompletionPrev => assert!(matches!(result, Action::CompletionPrev)),
             Expected::CompletionNext => assert!(matches!(result, Action::CompletionNext)),
-            Expected::OpenQueryHistoryPicker => {
-                assert!(matches!(result, Action::OpenQueryHistoryPicker));
+            Expected::OpenModal(expected_kind) => {
+                assert!(matches!(result, Action::OpenModal(kind) if kind == expected_kind));
             }
             Expected::SqlModalClear => assert!(matches!(result, Action::SqlModalClear)),
             Expected::ExplainRequest => assert!(matches!(result, Action::ExplainRequest)),
@@ -603,7 +607,10 @@ mod tests {
                 SqlModalTab::Sql,
             );
 
-            assert!(matches!(result, Action::OpenQueryHistoryPicker));
+            assert!(matches!(
+                result,
+                Action::OpenModal(ModalKind::QueryHistoryPicker)
+            ));
         }
 
         #[test]
@@ -898,7 +905,7 @@ mod tests {
                 SqlModalTab::Sql,
             );
 
-            assert_action(result, Expected::CloseSqlModal);
+            assert_action(result, Expected::CloseModal(ModalKind::SqlModal));
         }
 
         #[test]
@@ -934,7 +941,7 @@ mod tests {
                 SqlModalTab::Sql,
             );
 
-            assert_action(result, Expected::OpenQueryHistoryPicker);
+            assert_action(result, Expected::OpenModal(ModalKind::QueryHistoryPicker));
         }
 
         #[test]
@@ -960,7 +967,7 @@ mod tests {
 
             assert_action(yank, Expected::SqlModalYank);
             assert_action(enter, Expected::None);
-            assert_action(close, Expected::CloseSqlModal);
+            assert_action(close, Expected::CloseModal(ModalKind::SqlModal));
         }
 
         #[test]
@@ -1064,7 +1071,7 @@ mod tests {
             let result =
                 handle_sql_modal_keys(combo(Key::Esc), false, &SqlModalStatus::Normal, tab);
 
-            assert_action(result, Expected::CloseSqlModal);
+            assert_action(result, Expected::CloseModal(ModalKind::SqlModal));
         }
 
         #[rstest]
@@ -1211,7 +1218,7 @@ mod tests {
             let close = handle_sql_modal_keys(combo(Key::Esc), false, &status, SqlModalTab::Plan);
 
             assert_action(scroll, Expected::ExplainPlanScrollDown);
-            assert_action(close, Expected::CloseSqlModal);
+            assert_action(close, Expected::CloseModal(ModalKind::SqlModal));
         }
 
         #[rstest]
@@ -1230,7 +1237,7 @@ mod tests {
             );
 
             assert_action(scroll, Expected::ExplainCompareScrollDown);
-            assert_action(close, Expected::CloseSqlModal);
+            assert_action(close, Expected::CloseModal(ModalKind::SqlModal));
             assert_action(explain, Expected::ExplainRequest);
         }
     }

--- a/src/app/update/input/keybindings/connections.rs
+++ b/src/app/update/input/keybindings/connections.rs
@@ -1,7 +1,7 @@
 use super::{ExecBinding, KeyBinding, ModeRow};
 use super::{Key, KeyCombo};
 use crate::update::action::{
-    Action, ListMotion, ListTarget, ScrollAmount, ScrollDirection, ScrollTarget,
+    Action, ListMotion, ListTarget, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget,
 };
 
 // =============================================================================
@@ -88,7 +88,7 @@ pub const CONNECTION_ERROR_ROWS: &[ModeRow] = &[
         desc_short: "Switch",
         description: "Switch to another connection",
         bindings: &[ExecBinding {
-            action: Action::OpenConnectionSelector,
+            action: Action::OpenModal(ModalKind::ConnectionSelector),
             combos: &[KeyCombo::plain(Key::Char('s'))],
         }],
     },
@@ -217,7 +217,7 @@ pub const CONNECTION_SELECTOR_ROWS: &[ModeRow] = &[
         desc_short: "New",
         description: "New connection",
         bindings: &[ExecBinding {
-            action: Action::OpenConnectionSetup,
+            action: Action::OpenModal(ModalKind::ConnectionSetup),
             combos: &[KeyCombo::plain(Key::Char('n'))],
         }],
     },

--- a/src/app/update/input/keybindings/editors.rs
+++ b/src/app/update/input/keybindings/editors.rs
@@ -1,6 +1,6 @@
 use super::KeyBinding;
 use super::{Key, KeyCombo};
-use crate::update::action::Action;
+use crate::update::action::{Action, ModalKind};
 
 // =============================================================================
 // SQL Modal (Normal mode — default when opened)
@@ -68,7 +68,7 @@ pub const SQL_MODAL_NORMAL_KEYS: &[KeyBinding] = &[
         key: "Esc",
         desc_short: "Close",
         description: "Close editor",
-        action: Action::CloseSqlModal,
+        action: Action::CloseModal(ModalKind::SqlModal),
         combos: &[KeyCombo::plain(Key::Esc)],
     },
     KeyBinding {
@@ -84,7 +84,7 @@ pub const SQL_MODAL_NORMAL_KEYS: &[KeyBinding] = &[
         key: "Ctrl+O",
         desc_short: "History",
         description: "Open Query History",
-        action: Action::OpenQueryHistoryPicker,
+        action: Action::OpenModal(ModalKind::QueryHistoryPicker),
         combos: &[KeyCombo::ctrl(Key::Char('o'))],
     },
 ];
@@ -147,7 +147,7 @@ pub const SQL_MODAL_PLAN_KEYS: &[KeyBinding] = &[
         key: "Esc",
         desc_short: "Close",
         description: "Close editor",
-        action: Action::CloseSqlModal,
+        action: Action::CloseModal(ModalKind::SqlModal),
         combos: &[KeyCombo::plain(Key::Esc)],
     },
 ];
@@ -218,7 +218,7 @@ pub const SQL_MODAL_COMPARE_KEYS: &[KeyBinding] = &[
         key: "Esc",
         desc_short: "Close",
         description: "Close editor",
-        action: Action::CloseSqlModal,
+        action: Action::CloseModal(ModalKind::SqlModal),
         combos: &[KeyCombo::plain(Key::Esc)],
     },
 ];
@@ -289,7 +289,7 @@ pub const SQL_MODAL_KEYS: &[KeyBinding] = &[
         key: "Ctrl+O",
         desc_short: "History",
         description: "Open Query History",
-        action: Action::OpenQueryHistoryPicker,
+        action: Action::OpenModal(ModalKind::QueryHistoryPicker),
         combos: &[KeyCombo::ctrl(Key::Char('o'))],
     },
 ];
@@ -322,7 +322,7 @@ pub const COMMAND_LINE_KEYS: &[KeyBinding] = &[
         key: ":help",
         desc_short: "Help",
         description: "Show help",
-        action: Action::OpenHelp,
+        action: Action::ToggleModal(ModalKind::Help),
         combos: &[],
     },
     KeyBinding {
@@ -330,7 +330,7 @@ pub const COMMAND_LINE_KEYS: &[KeyBinding] = &[
         key: ":sql",
         desc_short: "SQL",
         description: "Open SQL Editor",
-        action: Action::OpenSqlModal,
+        action: Action::OpenModal(ModalKind::SqlModal),
         combos: &[],
     },
     KeyBinding {
@@ -338,7 +338,7 @@ pub const COMMAND_LINE_KEYS: &[KeyBinding] = &[
         key: ":erd",
         desc_short: "ER Diagram",
         description: "Open ER Diagram",
-        action: Action::OpenErTablePicker,
+        action: Action::OpenModal(ModalKind::ErTablePicker),
         combos: &[],
     },
     KeyBinding {

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -658,12 +658,7 @@ mod tests {
                 Action::OpenModal(ModalKind::QueryHistoryPicker)
             )]
             fn global_key_action_matches(#[case] i: usize, #[case] expected: Action) {
-                assert!(
-                    std::mem::discriminant(&GLOBAL_KEYS[i].action)
-                        == std::mem::discriminant(&expected),
-                    "GLOBAL_KEYS[{i}] has action {:?}, expected {expected:?}",
-                    GLOBAL_KEYS[i].action
-                );
+                assert_action_eq(&GLOBAL_KEYS[i].action, &expected, "GLOBAL_KEYS", i);
             }
 
             #[test]
@@ -714,11 +709,11 @@ mod tests {
             #[case(idx::sql_modal_plan::BACKTAB, Action::SqlModalPrevTab)]
             #[case(idx::sql_modal_plan::CLOSE, Action::CloseModal(ModalKind::SqlModal))]
             fn plan_key_action_matches(#[case] i: usize, #[case] expected: Action) {
-                assert!(
-                    std::mem::discriminant(&SQL_MODAL_PLAN_KEYS[i].action)
-                        == std::mem::discriminant(&expected),
-                    "SQL_MODAL_PLAN_KEYS[{i}] has action {:?}, expected {expected:?}",
-                    SQL_MODAL_PLAN_KEYS[i].action
+                assert_action_eq(
+                    &SQL_MODAL_PLAN_KEYS[i].action,
+                    &expected,
+                    "SQL_MODAL_PLAN_KEYS",
+                    i,
                 );
             }
 
@@ -731,12 +726,28 @@ mod tests {
             #[case(idx::sql_modal_compare::BACKTAB, Action::SqlModalPrevTab)]
             #[case(idx::sql_modal_compare::CLOSE, Action::CloseModal(ModalKind::SqlModal))]
             fn compare_key_action_matches(#[case] i: usize, #[case] expected: Action) {
-                assert!(
-                    std::mem::discriminant(&SQL_MODAL_COMPARE_KEYS[i].action)
-                        == std::mem::discriminant(&expected),
-                    "SQL_MODAL_COMPARE_KEYS[{i}] has action {:?}, expected {expected:?}",
-                    SQL_MODAL_COMPARE_KEYS[i].action
+                assert_action_eq(
+                    &SQL_MODAL_COMPARE_KEYS[i].action,
+                    &expected,
+                    "SQL_MODAL_COMPARE_KEYS",
+                    i,
                 );
+            }
+
+            fn assert_action_eq(actual: &Action, expected: &Action, label: &str, i: usize) {
+                assert!(
+                    same_action(actual, expected),
+                    "{label}[{i}] has action {actual:?}, expected {expected:?}",
+                );
+            }
+
+            fn same_action(actual: &Action, expected: &Action) -> bool {
+                match (actual, expected) {
+                    (Action::OpenModal(a), Action::OpenModal(b))
+                    | (Action::CloseModal(a), Action::CloseModal(b))
+                    | (Action::ToggleModal(a), Action::ToggleModal(b)) => a == b,
+                    _ => std::mem::discriminant(actual) == std::mem::discriminant(expected),
+                }
             }
         }
 

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -391,6 +391,7 @@ pub fn is_open_er(combo: &KeyCombo) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::update::action::ModalKind;
     use crate::update::action::{ScrollAmount, ScrollDirection, ScrollTarget};
 
     mod structure {
@@ -638,18 +639,24 @@ mod tests {
 
             #[rstest]
             #[case(idx::global::QUIT, Action::Quit)]
-            #[case(idx::global::HELP, Action::OpenHelp)]
-            #[case(idx::global::TABLE_PICKER, Action::OpenTablePicker)]
-            #[case(idx::global::PALETTE, Action::OpenCommandPalette)]
+            #[case(idx::global::HELP, Action::ToggleModal(ModalKind::Help))]
+            #[case(idx::global::TABLE_PICKER, Action::OpenModal(ModalKind::TablePicker))]
+            #[case(idx::global::PALETTE, Action::OpenModal(ModalKind::CommandPalette))]
             #[case(idx::global::COMMAND_LINE, Action::EnterCommandLine)]
             #[case(idx::global::RELOAD, Action::ReloadMetadata)]
-            #[case(idx::global::SQL, Action::OpenSqlModal)]
-            #[case(idx::global::ER_DIAGRAM, Action::OpenErTablePicker)]
-            #[case(idx::global::CONNECTIONS, Action::OpenConnectionSelector)]
+            #[case(idx::global::SQL, Action::OpenModal(ModalKind::SqlModal))]
+            #[case(idx::global::ER_DIAGRAM, Action::OpenModal(ModalKind::ErTablePicker))]
+            #[case(
+                idx::global::CONNECTIONS,
+                Action::OpenModal(ModalKind::ConnectionSelector)
+            )]
             #[case(idx::global::CSV_EXPORT, Action::RequestCsvExport)]
             #[case(idx::global::READ_ONLY, Action::ToggleReadOnly)]
             #[case(idx::global::EXIT_READ_ONLY, Action::ToggleReadOnly)]
-            #[case(idx::global::QUERY_HISTORY, Action::OpenQueryHistoryPicker)]
+            #[case(
+                idx::global::QUERY_HISTORY,
+                Action::OpenModal(ModalKind::QueryHistoryPicker)
+            )]
             fn global_key_action_matches(#[case] i: usize, #[case] expected: Action) {
                 assert!(
                     std::mem::discriminant(&GLOBAL_KEYS[i].action)
@@ -705,7 +712,7 @@ mod tests {
             #[case(idx::sql_modal_plan::YANK, Action::SqlModalYank)]
             #[case(idx::sql_modal_plan::TAB, Action::SqlModalNextTab)]
             #[case(idx::sql_modal_plan::BACKTAB, Action::SqlModalPrevTab)]
-            #[case(idx::sql_modal_plan::CLOSE, Action::CloseSqlModal)]
+            #[case(idx::sql_modal_plan::CLOSE, Action::CloseModal(ModalKind::SqlModal))]
             fn plan_key_action_matches(#[case] i: usize, #[case] expected: Action) {
                 assert!(
                     std::mem::discriminant(&SQL_MODAL_PLAN_KEYS[i].action)
@@ -722,7 +729,7 @@ mod tests {
             #[case(idx::sql_modal_compare::YANK, Action::SqlModalYank)]
             #[case(idx::sql_modal_compare::TAB, Action::SqlModalNextTab)]
             #[case(idx::sql_modal_compare::BACKTAB, Action::SqlModalPrevTab)]
-            #[case(idx::sql_modal_compare::CLOSE, Action::CloseSqlModal)]
+            #[case(idx::sql_modal_compare::CLOSE, Action::CloseModal(ModalKind::SqlModal))]
             fn compare_key_action_matches(#[case] i: usize, #[case] expected: Action) {
                 assert!(
                     std::mem::discriminant(&SQL_MODAL_COMPARE_KEYS[i].action)

--- a/src/app/update/input/keybindings/normal.rs
+++ b/src/app/update/input/keybindings/normal.rs
@@ -1,6 +1,6 @@
 use super::KeyBinding;
 use super::{Key, KeyCombo};
-use crate::update::action::Action;
+use crate::update::action::{Action, ModalKind};
 
 // =============================================================================
 // Global Keys (Normal mode)
@@ -20,7 +20,7 @@ pub const GLOBAL_KEYS: &[KeyBinding] = &[
         key: "?",
         desc_short: "Help",
         description: "Toggle help",
-        action: Action::OpenHelp,
+        action: Action::ToggleModal(ModalKind::Help),
         combos: &[KeyCombo::plain(Key::Char('?'))],
     },
     KeyBinding {
@@ -28,7 +28,7 @@ pub const GLOBAL_KEYS: &[KeyBinding] = &[
         key: "Ctrl+P",
         desc_short: "Tables",
         description: "Open Table Picker",
-        action: Action::OpenTablePicker,
+        action: Action::OpenModal(ModalKind::TablePicker),
         combos: &[KeyCombo::ctrl(Key::Char('p'))],
     },
     KeyBinding {
@@ -36,7 +36,7 @@ pub const GLOBAL_KEYS: &[KeyBinding] = &[
         key: "Ctrl+K",
         desc_short: "Palette",
         description: "Open Command Palette",
-        action: Action::OpenCommandPalette,
+        action: Action::OpenModal(ModalKind::CommandPalette),
         combos: &[KeyCombo::ctrl(Key::Char('k'))],
     },
     KeyBinding {
@@ -94,7 +94,7 @@ pub const GLOBAL_KEYS: &[KeyBinding] = &[
         key: "s",
         desc_short: "SQL",
         description: "Open SQL Editor",
-        action: Action::OpenSqlModal,
+        action: Action::OpenModal(ModalKind::SqlModal),
         combos: &[KeyCombo::plain(Key::Char('s'))],
     },
     KeyBinding {
@@ -102,7 +102,7 @@ pub const GLOBAL_KEYS: &[KeyBinding] = &[
         key: "e",
         desc_short: "ER Diagram",
         description: "Open ER Diagram",
-        action: Action::OpenErTablePicker,
+        action: Action::OpenModal(ModalKind::ErTablePicker),
         combos: &[KeyCombo::plain(Key::Char('e'))],
     },
     KeyBinding {
@@ -110,7 +110,7 @@ pub const GLOBAL_KEYS: &[KeyBinding] = &[
         key: "c",
         desc_short: "Connections",
         description: "Open Connection Selector",
-        action: Action::OpenConnectionSelector,
+        action: Action::OpenModal(ModalKind::ConnectionSelector),
         combos: &[KeyCombo::plain(Key::Char('c'))],
     },
     KeyBinding {
@@ -144,7 +144,7 @@ pub const GLOBAL_KEYS: &[KeyBinding] = &[
         key: "Ctrl+O",
         desc_short: "History",
         description: "Open Query History",
-        action: Action::OpenQueryHistoryPicker,
+        action: Action::OpenModal(ModalKind::QueryHistoryPicker),
         combos: &[KeyCombo::ctrl(Key::Char('o'))],
     },
 ];

--- a/src/app/update/input/keybindings/overlays.rs
+++ b/src/app/update/input/keybindings/overlays.rs
@@ -1,8 +1,8 @@
 use super::{ExecBinding, KeyBinding, ModeRow};
 use super::{Key, KeyCombo};
 use crate::update::action::{
-    Action, CursorMove, InputTarget, ListMotion, ListTarget, ScrollAmount, ScrollDirection,
-    ScrollTarget,
+    Action, CursorMove, InputTarget, ListMotion, ListTarget, ModalKind, ScrollAmount,
+    ScrollDirection, ScrollTarget,
 };
 
 // =============================================================================
@@ -186,7 +186,7 @@ pub const HELP_ROWS: &[ModeRow] = &[
         desc_short: "Close",
         description: "Close help",
         bindings: &[ExecBinding {
-            action: Action::CloseHelp,
+            action: Action::CloseModal(ModalKind::Help),
             combos: &[KeyCombo::plain(Key::Char('?')), KeyCombo::plain(Key::Esc)],
         }],
     },
@@ -277,7 +277,7 @@ pub const TABLE_PICKER_ROWS: &[ModeRow] = &[
         desc_short: "Close",
         description: "Close",
         bindings: &[ExecBinding {
-            action: Action::CloseTablePicker,
+            action: Action::CloseModal(ModalKind::TablePicker),
             combos: &[KeyCombo::plain(Key::Esc)],
         }],
     },
@@ -388,7 +388,7 @@ pub const ER_PICKER_ROWS: &[ModeRow] = &[
         desc_short: "Close",
         description: "Close",
         bindings: &[ExecBinding {
-            action: Action::CloseErTablePicker,
+            action: Action::CloseModal(ModalKind::ErTablePicker),
             combos: &[KeyCombo::plain(Key::Esc)],
         }],
     },
@@ -479,7 +479,7 @@ pub const QUERY_HISTORY_PICKER_ROWS: &[ModeRow] = &[
         desc_short: "Close",
         description: "Close",
         bindings: &[ExecBinding {
-            action: Action::CloseQueryHistoryPicker,
+            action: Action::CloseModal(ModalKind::QueryHistoryPicker),
             combos: &[KeyCombo::plain(Key::Esc)],
         }],
     },
@@ -536,7 +536,7 @@ pub const COMMAND_PALETTE_ROWS: &[ModeRow] = &[
         desc_short: "Close",
         description: "Close",
         bindings: &[ExecBinding {
-            action: Action::CloseCommandPalette,
+            action: Action::CloseModal(ModalKind::CommandPalette),
             combos: &[KeyCombo::plain(Key::Esc)],
         }],
     },
@@ -776,7 +776,7 @@ pub const JSONB_DETAIL_ROWS: &[ModeRow] = &[
         desc_short: "Close",
         description: "Close JSONB detail",
         bindings: &[ExecBinding {
-            action: Action::CloseJsonbDetail,
+            action: Action::CloseModal(ModalKind::JsonbDetail),
             combos: &[KeyCombo::plain(Key::Esc), KeyCombo::plain(Key::Char('q'))],
         }],
     },

--- a/src/app/update/input/keymap.rs
+++ b/src/app/update/input/keymap.rs
@@ -23,6 +23,7 @@ pub fn resolve_mode(combo: &KeyCombo, rows: &[ModeRow]) -> Option<Action> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::update::action::ModalKind;
     use crate::update::input::keybindings::{Key, KeyCombo};
 
     static QUIT_COMBOS: &[KeyCombo] = &[KeyCombo::plain(Key::Char('q'))];
@@ -58,7 +59,7 @@ mod tests {
             key: "?",
             desc_short: "Help",
             description: "Help",
-            action: Action::OpenHelp,
+            action: Action::ToggleModal(ModalKind::Help),
             combos: HELP_COMBOS,
         }
     }
@@ -145,7 +146,7 @@ mod tests {
         fn matches_binding_in_rows() {
             let result = resolve_mode(&KeyCombo::plain(Key::Esc), HELP_ROWS);
 
-            assert!(matches!(result, Some(Action::CloseHelp)));
+            assert!(matches!(result, Some(Action::CloseModal(ModalKind::Help))));
         }
 
         #[test]

--- a/src/app/update/input/vim/actions/jsonb.rs
+++ b/src/app/update/input/vim/actions/jsonb.rs
@@ -1,4 +1,4 @@
-use crate::update::action::{Action, CursorMove, InputTarget};
+use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
 
 use crate::update::input::vim::types::{
     JsonbDetailVimContext, SearchContinuation, VimCommand, VimModeTransition, VimNavigation,
@@ -12,7 +12,9 @@ pub(in crate::update::input::vim) fn command(
     match ctx {
         JsonbDetailVimContext::Viewing => match command {
             VimCommand::Navigation(navigation) => navigation_action(navigation),
-            VimCommand::ModeTransition(VimModeTransition::Escape) => Some(Action::CloseJsonbDetail),
+            VimCommand::ModeTransition(VimModeTransition::Escape) => {
+                Some(Action::CloseModal(ModalKind::JsonbDetail))
+            }
             VimCommand::ModeTransition(VimModeTransition::Insert) => Some(Action::JsonbEnterEdit),
             VimCommand::ModeTransition(VimModeTransition::Append) => {
                 Some(Action::JsonbAppendInsert)

--- a/src/app/update/input/vim/actions/sql.rs
+++ b/src/app/update/input/vim/actions/sql.rs
@@ -1,5 +1,5 @@
 use crate::update::action::{
-    Action, CursorMove, InputTarget, ScrollAmount, ScrollDirection, ScrollTarget,
+    Action, CursorMove, InputTarget, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget,
 };
 
 use super::scroll;
@@ -14,7 +14,9 @@ pub(in crate::update::input::vim) fn command(
     match ctx {
         SqlModalVimContext::QueryNormal => match command {
             VimCommand::Navigation(navigation) => query_navigation(navigation),
-            VimCommand::ModeTransition(VimModeTransition::Escape) => Some(Action::CloseSqlModal),
+            VimCommand::ModeTransition(VimModeTransition::Escape) => {
+                Some(Action::CloseModal(ModalKind::SqlModal))
+            }
             VimCommand::ModeTransition(VimModeTransition::Append) => {
                 Some(Action::SqlModalAppendInsert)
             }
@@ -67,7 +69,9 @@ fn viewer(command: VimCommand, target: ScrollTarget) -> Option<Action> {
         VimCommand::Navigation(VimNavigation::MoveUp) => {
             Some(scroll(target, ScrollDirection::Up, ScrollAmount::Line))
         }
-        VimCommand::ModeTransition(VimModeTransition::Escape) => Some(Action::CloseSqlModal),
+        VimCommand::ModeTransition(VimModeTransition::Escape) => {
+            Some(Action::CloseModal(ModalKind::SqlModal))
+        }
         VimCommand::Operator(VimOperator::Yank) => Some(Action::SqlModalYank),
         _ => None,
     }

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -38,6 +38,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
         Action::ToggleModal(ModalKind::Help) => {
             if state.modal.active_mode() == InputMode::Help {
                 state.modal.set_mode(InputMode::Normal);
+                state.ui.help_scroll_offset = 0;
             } else {
                 state.modal.set_mode(InputMode::Help);
             }

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -6,7 +6,8 @@ use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{
-    Action, InputTarget, ListMotion, ListTarget, ScrollAmount, ScrollDirection, ScrollTarget,
+    Action, InputTarget, ListMotion, ListTarget, ModalKind, ScrollAmount, ScrollDirection,
+    ScrollTarget,
 };
 
 fn scroll_help_by(state: &mut AppState, direction: ScrollDirection, delta: usize) {
@@ -17,22 +18,24 @@ fn scroll_help_by(state: &mut AppState, direction: ScrollDirection, delta: usize
 
 pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
     match action {
-        Action::OpenTablePicker => {
+        Action::OpenModal(ModalKind::TablePicker) => {
             state.modal.set_mode(InputMode::TablePicker);
-            state.ui.table_picker.filter_input.clear();
-            state.ui.table_picker.reset();
+            state.ui.table_picker.clear_filter_and_reset();
             Some(vec![])
         }
-        Action::CloseTablePicker | Action::CloseCommandPalette | Action::Escape => {
+        Action::CloseModal(ModalKind::TablePicker)
+        | Action::CloseModal(ModalKind::CommandPalette)
+        | Action::Escape => {
             state.modal.set_mode(InputMode::Normal);
             Some(vec![])
         }
-        Action::OpenCommandPalette => {
+        Action::OpenModal(ModalKind::CommandPalette) => {
             state.modal.set_mode(InputMode::CommandPalette);
+            // Command palette currently reuses the generic picker selection state.
             state.ui.table_picker.reset();
             Some(vec![])
         }
-        Action::OpenHelp => {
+        Action::ToggleModal(ModalKind::Help) => {
             if state.modal.active_mode() == InputMode::Help {
                 state.modal.set_mode(InputMode::Normal);
             } else {
@@ -40,7 +43,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             }
             Some(vec![])
         }
-        Action::CloseHelp => {
+        Action::CloseModal(ModalKind::Help) => {
             state.modal.set_mode(InputMode::Normal);
             state.ui.help_scroll_offset = 0;
             Some(vec![])
@@ -78,14 +81,14 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             ) as u16;
             Some(vec![])
         }
-        Action::CloseSqlModal => {
+        Action::CloseModal(ModalKind::SqlModal) => {
             state.modal.set_mode(InputMode::Normal);
             state.sql_modal.completion.visible = false;
             state.sql_modal.completion_debounce = None;
             state.flash_timers.clear(FlashId::SqlModal);
             Some(vec![])
         }
-        Action::OpenErTablePicker => {
+        Action::OpenModal(ModalKind::ErTablePicker) => {
             if state.session.metadata().is_none() {
                 state.ui.pending_er_picker = true;
                 state.set_success("Waiting for metadata...".to_string());
@@ -94,13 +97,12 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             state.ui.pending_er_picker = false;
             state.ui.er_selected_tables.clear();
             state.modal.set_mode(InputMode::ErTablePicker);
-            state.ui.er_picker.filter_input.clear();
-            state.ui.er_picker.reset();
+            state.ui.er_picker.clear_filter_and_reset();
             Some(vec![])
         }
-        Action::CloseErTablePicker => {
+        Action::CloseModal(ModalKind::ErTablePicker) => {
             state.modal.set_mode(InputMode::Normal);
-            state.ui.er_picker.filter_input.clear();
+            state.ui.er_picker.clear_filter();
             state.ui.er_selected_tables.clear();
             state.ui.pending_er_picker = false;
             Some(vec![])
@@ -109,37 +111,20 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             target: InputTarget::ErFilter,
             ch: c,
         } => {
-            state.ui.er_picker.filter_input.insert_char(*c);
-            state
-                .ui
-                .er_picker
-                .filter_input
-                .update_viewport(state.ui.er_picker.filter_visible_width);
-            state.ui.er_picker.reset();
+            state.ui.er_picker.insert_filter_char(*c);
             Some(vec![])
         }
         Action::TextBackspace {
             target: InputTarget::ErFilter,
         } => {
-            state.ui.er_picker.filter_input.backspace();
-            state
-                .ui
-                .er_picker
-                .filter_input
-                .update_viewport(state.ui.er_picker.filter_visible_width);
-            state.ui.er_picker.reset();
+            state.ui.er_picker.backspace_filter();
             Some(vec![])
         }
         Action::TextMoveCursor {
             target: InputTarget::ErFilter,
             direction: movement,
         } => {
-            state.ui.er_picker.filter_input.move_cursor(*movement);
-            state
-                .ui
-                .er_picker
-                .filter_input
-                .update_viewport(state.ui.er_picker.filter_visible_width);
+            state.ui.er_picker.move_filter_cursor(*movement);
             Some(vec![])
         }
         Action::ErToggleSelection => {
@@ -170,11 +155,11 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             state.er_preparation.target_tables =
                 state.ui.er_selected_tables.iter().cloned().collect();
             state.modal.set_mode(InputMode::Normal);
-            state.ui.er_picker.filter_input.clear();
+            state.ui.er_picker.clear_filter();
             state.ui.er_selected_tables.clear();
             Some(vec![Effect::DispatchActions(vec![Action::ErOpenDiagram])])
         }
-        Action::OpenQueryHistoryPicker => {
+        Action::OpenModal(ModalKind::QueryHistoryPicker) => {
             if state.session.active_connection_id.is_none() {
                 return Some(vec![]);
             }
@@ -199,7 +184,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                 connection_id: conn_id.clone(),
             }])
         }
-        Action::CloseQueryHistoryPicker => {
+        Action::CloseModal(ModalKind::QueryHistoryPicker) => {
             state.modal.pop_mode();
             state.query_history_picker.reset();
             Some(vec![])
@@ -228,17 +213,13 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             target: InputTarget::QueryHistoryFilter,
             ch: c,
         } => {
-            state.query_history_picker.filter_input.insert_char(*c);
-            state.query_history_picker.selected = 0;
-            state.query_history_picker.scroll_offset = 0;
+            state.query_history_picker.insert_filter_char(*c);
             Some(vec![])
         }
         Action::TextBackspace {
             target: InputTarget::QueryHistoryFilter,
         } => {
-            state.query_history_picker.filter_input.backspace();
-            state.query_history_picker.selected = 0;
-            state.query_history_picker.scroll_offset = 0;
+            state.query_history_picker.backspace_filter();
             Some(vec![])
         }
         Action::ListSelect {
@@ -797,9 +778,12 @@ mod tests {
                 let mut state = create_test_state();
                 state.session.active_connection_id = None;
 
-                let effects =
-                    reduce_modal(&mut state, &Action::OpenQueryHistoryPicker, Instant::now())
-                        .unwrap();
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::OpenModal(ModalKind::QueryHistoryPicker),
+                    Instant::now(),
+                )
+                .unwrap();
 
                 assert_eq!(state.input_mode(), InputMode::Normal);
                 assert!(effects.is_empty());
@@ -810,9 +794,12 @@ mod tests {
                 let mut state = connected_state();
                 state.query.begin_running(Instant::now());
 
-                let effects =
-                    reduce_modal(&mut state, &Action::OpenQueryHistoryPicker, Instant::now())
-                        .unwrap();
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::OpenModal(ModalKind::QueryHistoryPicker),
+                    Instant::now(),
+                )
+                .unwrap();
 
                 assert_eq!(state.input_mode(), InputMode::Normal);
                 assert!(effects.is_empty());
@@ -826,9 +813,12 @@ mod tests {
             fn open_from_normal_sets_mode_and_emits_load_effect() {
                 let mut state = connected_state();
 
-                let effects =
-                    reduce_modal(&mut state, &Action::OpenQueryHistoryPicker, Instant::now())
-                        .unwrap();
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::OpenModal(ModalKind::QueryHistoryPicker),
+                    Instant::now(),
+                )
+                .unwrap();
 
                 assert_eq!(state.input_mode(), InputMode::QueryHistoryPicker);
                 assert_eq!(state.modal.return_destination(), InputMode::Normal);
@@ -842,9 +832,12 @@ mod tests {
                 state.modal.set_mode(InputMode::SqlModal);
                 state.modal.push_mode(InputMode::QueryHistoryPicker);
 
-                let effects =
-                    reduce_modal(&mut state, &Action::CloseQueryHistoryPicker, Instant::now())
-                        .unwrap();
+                let effects = reduce_modal(
+                    &mut state,
+                    &Action::CloseModal(ModalKind::QueryHistoryPicker),
+                    Instant::now(),
+                )
+                .unwrap();
 
                 assert_eq!(state.input_mode(), InputMode::SqlModal);
                 assert!(effects.is_empty());

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -173,6 +173,7 @@ mod tests {
     use super::*;
     use crate::ports::outbound::DbOperationError;
     use crate::ports::outbound::connection_store::ConnectionStoreError;
+    use crate::update::action::ModalKind;
     use crate::update::action::{ConnectionSaveError, ConnectionTarget};
     use crate::update::action::{InputTarget, SelectMotion};
 
@@ -526,7 +527,7 @@ mod tests {
 
             let effects = reduce(
                 &mut state,
-                Action::OpenTablePicker,
+                Action::OpenModal(ModalKind::TablePicker),
                 now,
                 &AppServices::stub(),
             );
@@ -545,7 +546,7 @@ mod tests {
 
             let effects = reduce(
                 &mut state,
-                Action::CloseTablePicker,
+                Action::CloseModal(ModalKind::TablePicker),
                 now,
                 &AppServices::stub(),
             );
@@ -560,12 +561,22 @@ mod tests {
             let now = Instant::now();
 
             // First open
-            let effects = reduce(&mut state, Action::OpenHelp, now, &AppServices::stub());
+            let effects = reduce(
+                &mut state,
+                Action::ToggleModal(ModalKind::Help),
+                now,
+                &AppServices::stub(),
+            );
             assert_eq!(state.input_mode(), InputMode::Help);
             assert!(effects.is_empty());
 
             // Toggle back to normal
-            let effects = reduce(&mut state, Action::OpenHelp, now, &AppServices::stub());
+            let effects = reduce(
+                &mut state,
+                Action::ToggleModal(ModalKind::Help),
+                now,
+                &AppServices::stub(),
+            );
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(effects.is_empty());
         }
@@ -577,7 +588,12 @@ mod tests {
             state.ui.help_scroll_offset = 12;
             let now = Instant::now();
 
-            let effects = reduce(&mut state, Action::CloseHelp, now, &AppServices::stub());
+            let effects = reduce(
+                &mut state,
+                Action::CloseModal(ModalKind::Help),
+                now,
+                &AppServices::stub(),
+            );
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert_eq!(state.ui.help_scroll_offset, 0);
@@ -2110,7 +2126,7 @@ mod tests {
 
             let effects = reduce(
                 &mut state,
-                Action::OpenErTablePicker,
+                Action::OpenModal(ModalKind::ErTablePicker),
                 now,
                 &AppServices::stub(),
             );
@@ -2128,7 +2144,7 @@ mod tests {
 
             let effects = reduce(
                 &mut state,
-                Action::OpenErTablePicker,
+                Action::OpenModal(ModalKind::ErTablePicker),
                 now,
                 &AppServices::stub(),
             );
@@ -2156,7 +2172,7 @@ mod tests {
         fn has_open_er_dispatch(effects: &[Effect]) -> bool {
             effects.iter().any(|e| {
                 matches!(e, Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::OpenErTablePicker)))
+                    if actions.iter().any(|a| matches!(a, Action::OpenModal(ModalKind::ErTablePicker))))
             })
         }
 
@@ -2226,7 +2242,7 @@ mod tests {
 
             let effects = reduce(
                 &mut state,
-                Action::CloseErTablePicker,
+                Action::CloseModal(ModalKind::ErTablePicker),
                 now,
                 &AppServices::stub(),
             );
@@ -2513,17 +2529,24 @@ mod tests {
                 .expect("action must exist in palette")
         }
 
+        fn same_palette_action(left: &Action, right: &Action) -> bool {
+            match (left, right) {
+                (Action::OpenModal(a), Action::OpenModal(b))
+                | (Action::CloseModal(a), Action::CloseModal(b))
+                | (Action::ToggleModal(a), Action::ToggleModal(b)) => a == b,
+                _ => std::mem::discriminant(left) == std::mem::discriminant(right),
+            }
+        }
+
         #[rstest]
-        #[case(Action::OpenHelp, InputMode::Help)]
-        #[case(Action::OpenTablePicker, InputMode::TablePicker)]
-        #[case(Action::OpenSqlModal, InputMode::SqlModal)]
+        #[case(Action::ToggleModal(ModalKind::Help), InputMode::Help)]
+        #[case(Action::OpenModal(ModalKind::TablePicker), InputMode::TablePicker)]
+        #[case(Action::OpenModal(ModalKind::SqlModal), InputMode::SqlModal)]
         fn confirm_selection_applies_sub_action(
             #[case] target_action: Action,
             #[case] expected_mode: InputMode,
         ) {
-            let entry_index = palette_index_of(|a| {
-                std::mem::discriminant(a) == std::mem::discriminant(&target_action)
-            });
+            let entry_index = palette_index_of(|a| same_palette_action(a, &target_action));
 
             let mut state = state_in_palette_mode();
             state.ui.table_picker.set_selection(entry_index);
@@ -2563,7 +2586,8 @@ mod tests {
 
         #[test]
         fn confirm_selection_open_connection_selector_closes_palette() {
-            let entry_index = palette_index_of(|a| matches!(a, Action::OpenConnectionSelector));
+            let entry_index =
+                palette_index_of(|a| matches!(a, Action::OpenModal(ModalKind::ConnectionSelector)));
 
             let mut state = state_in_palette_mode();
             state.ui.table_picker.set_selection(entry_index);

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -18,7 +18,7 @@ use crate::policy::write::sql_risk::{
 };
 use crate::policy::write::write_guardrails::{AdhocRiskDecision, RiskLevel, evaluate_sql_risk};
 use crate::ports::outbound::ClipboardError;
-use crate::update::action::{Action, CursorMove, InputTarget};
+use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
 
 pub fn reduce_sql_modal(
     state: &mut AppState,
@@ -164,7 +164,7 @@ pub fn reduce_sql_modal(
         }
 
         // Modal open/submit
-        Action::OpenSqlModal => {
+        Action::OpenModal(ModalKind::SqlModal) => {
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.set_status(SqlModalStatus::Normal);
             state.sql_modal.active_tab = SqlModalTab::Sql;
@@ -1264,7 +1264,11 @@ mod tests {
         fn open_sql_modal_starts_in_normal() {
             let mut state = AppState::new("test".to_string());
 
-            reduce_sql_modal(&mut state, &Action::OpenSqlModal, Instant::now());
+            reduce_sql_modal(
+                &mut state,
+                &Action::OpenModal(ModalKind::SqlModal),
+                Instant::now(),
+            );
 
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Normal);
         }
@@ -1274,7 +1278,11 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.sql_modal.active_tab = SqlModalTab::Plan;
 
-            reduce_sql_modal(&mut state, &Action::OpenSqlModal, Instant::now());
+            reduce_sql_modal(
+                &mut state,
+                &Action::OpenModal(ModalKind::SqlModal),
+                Instant::now(),
+            );
 
             assert_eq!(state.sql_modal.active_tab, SqlModalTab::Sql);
         }

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::app::model::app_state::AppState;
 use crate::app::services::AppServices;
-use crate::app::update::action::{Action, CursorMove, InputTarget};
+use crate::app::update::action::{Action, CursorMove, InputTarget, ModalKind};
 use crate::app::update::browse::result::reduce_result;
 use crate::domain::{Column, ColumnAttributes, QueryResult};
 use harness::{table_detail_loaded_state, with_current_result};
@@ -206,7 +206,7 @@ fn result_pane_jsonb_detail_mode() {
 
     reduce_result(
         &mut state,
-        &Action::OpenJsonbDetail,
+        &Action::OpenModal(ModalKind::JsonbDetail),
         &AppServices::stub(),
         now,
     );
@@ -224,7 +224,7 @@ fn result_pane_jsonb_edit_mode() {
 
     reduce_result(
         &mut state,
-        &Action::OpenJsonbDetail,
+        &Action::OpenModal(ModalKind::JsonbDetail),
         &AppServices::stub(),
         now,
     );

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -6,7 +6,7 @@ use crate::app::model::app_state::AppState;
 use crate::app::model::shared::input_mode::InputMode;
 use crate::app::model::sql_editor::modal::SqlModalStatus;
 use crate::app::services::AppServices;
-use crate::app::update::action::{Action, CursorMove, InputTarget};
+use crate::app::update::action::{Action, CursorMove, InputTarget, ModalKind};
 use crate::app::update::browse::result::reduce_result;
 use crate::domain::{Column, ColumnAttributes, QueryResult, QuerySource};
 use crate::ui::theme::{
@@ -74,7 +74,7 @@ fn jsonb_detail_state() -> (AppState, Instant) {
     state.result_interaction.activate_cell(0, 3);
     reduce_result(
         &mut state,
-        &Action::OpenJsonbDetail,
+        &Action::OpenModal(ModalKind::JsonbDetail),
         &AppServices::stub(),
         now,
     );


### PR DESCRIPTION
## Problem
Modal lifecycle actions are modeled as many open/close variants, so each new overlay adds more reducer and input mapping boilerplate.

## Background
The reducer already uses parametric actions for several repeated interaction patterns. Modal lifecycle was the remaining broad action group with per-modal variants.

## Approach
Scope: consolidate modal lifecycle actions and keep modal-specific state transitions at their existing reducer boundaries.

Introduce a modal kind as the lifecycle target, and move filter reset behavior into picker aggregates where the selection and scroll invariants already live.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * モーダルウィンドウの操作性を向上させ、一貫性のある表示/非表示動作を実装しました。
  * ピッカー機能のフィルタ入力処理を改善し、テキスト挿入、削除、カーソル移動をより堅牢に処理するようにしました。
  * SQL履歴、テーブルピッカー、JSON詳細ビューを含むモーダルの入力ハンドリングを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->