### PR TITLE
refactor: tighten aggregate-owned picker state

### DIFF
--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -278,6 +278,9 @@ impl EffectRunner {
                 if let Some(height) = output.query_history_picker_pane_height {
                     state.query_history_picker.pane_height = height;
                 }
+                if let Some(width) = output.query_history_picker_filter_visible_width {
+                    state.query_history_picker.filter_visible_width = width;
+                }
                 if let Some(visible_rows) = output.jsonb_detail_editor_visible_rows {
                     state.ui.jsonb_detail_editor_visible_rows = visible_rows;
                     state.jsonb_detail.editor_mut().update_scroll(visible_rows);

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -134,7 +134,7 @@ impl AppState {
     }
 
     pub fn filtered_tables(&self) -> Vec<&TableSummary> {
-        let filter_lower = self.ui.table_picker.filter_input.content().to_lowercase();
+        let filter_lower = self.ui.table_picker.filter_input().content().to_lowercase();
         self.session
             .metadata()
             .map(|m| {
@@ -147,7 +147,7 @@ impl AppState {
     }
 
     pub fn er_filtered_tables(&self) -> Vec<&TableSummary> {
-        let filter_lower = self.ui.er_picker.filter_input.content().to_lowercase();
+        let filter_lower = self.ui.er_picker.filter_input().content().to_lowercase();
         self.session
             .metadata()
             .map(|m| {
@@ -371,11 +371,7 @@ mod tests {
                 TableSummary::new("public".to_string(), "users".to_string(), Some(100), false),
                 TableSummary::new("public".to_string(), "posts".to_string(), Some(50), false),
             ])));
-            state
-                .ui
-                .table_picker
-                .filter_input
-                .set_content(String::new());
+            state.ui.table_picker.clear_filter();
 
             let filtered = state.filtered_tables();
 
@@ -389,11 +385,7 @@ mod tests {
                 TableSummary::new("public".to_string(), "users".to_string(), Some(100), false),
                 TableSummary::new("public".to_string(), "posts".to_string(), Some(50), false),
             ])));
-            state
-                .ui
-                .table_picker
-                .filter_input
-                .set_content("user".to_string());
+            state.ui.table_picker.insert_filter_str("user");
 
             let filtered = state.filtered_tables();
 
@@ -412,11 +404,7 @@ mod tests {
                     Some(100),
                     false,
                 )])));
-            state
-                .ui
-                .table_picker
-                .filter_input
-                .set_content("user".to_string());
+            state.ui.table_picker.insert_filter_str("user");
 
             let filtered = state.filtered_tables();
 

--- a/src/app/model/shared/picker.rs
+++ b/src/app/model/shared/picker.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::update::action::CursorMove;
 
 use super::text_input::TextInputState;
@@ -54,12 +56,7 @@ impl PickerState {
     }
 
     pub fn insert_filter_str(&mut self, text: &str) {
-        if text.contains(['\n', '\r']) {
-            let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-            self.filter_input.insert_str(&clean);
-        } else {
-            self.filter_input.insert_str(text);
-        }
+        self.filter_input.insert_str(&sanitize_filter_text(text));
         self.filter_input.update_viewport(self.filter_visible_width);
         self.reset();
     }
@@ -73,6 +70,17 @@ impl PickerState {
     pub fn move_filter_cursor(&mut self, direction: CursorMove) {
         self.filter_input.move_cursor(direction);
         self.filter_input.update_viewport(self.filter_visible_width);
+    }
+}
+
+pub(crate) fn sanitize_filter_text(text: &str) -> Cow<'_, str> {
+    if text.contains(['\n', '\r']) {
+        text.chars()
+            .filter(|c| *c != '\n' && *c != '\r')
+            .collect::<String>()
+            .into()
+    } else {
+        text.into()
     }
 }
 

--- a/src/app/model/shared/picker.rs
+++ b/src/app/model/shared/picker.rs
@@ -8,10 +8,14 @@ pub struct PickerState {
     scroll_offset: usize,
     pub pane_height: u16,
     pub filter_visible_width: usize,
-    pub filter_input: TextInputState,
+    filter_input: TextInputState,
 }
 
 impl PickerState {
+    pub fn filter_input(&self) -> &TextInputState {
+        &self.filter_input
+    }
+
     pub fn selected(&self) -> usize {
         self.selected
     }

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -316,7 +316,7 @@ mod tests {
             assert_eq!(state.focused_pane, FocusedPane::default());
             assert_eq!(state.focus_mode, FocusMode::Normal);
             assert_eq!(state.explorer_selected, 0);
-            assert!(state.table_picker.filter_input.content().is_empty());
+            assert!(state.table_picker.filter_input().content().is_empty());
         }
 
         #[test]

--- a/src/app/model/sql_editor/query_history.rs
+++ b/src/app/model/sql_editor/query_history.rs
@@ -2,15 +2,16 @@ use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher};
 
 use crate::domain::query_history::QueryHistoryEntry;
+use crate::model::shared::picker::clamp_scroll_offset;
 use crate::model::shared::text_input::TextInputState;
 use crate::update::action::CursorMove;
 
 #[derive(Debug, Clone, Default)]
 pub struct QueryHistoryPickerState {
-    pub entries: Vec<QueryHistoryEntry>,
-    pub filter_input: TextInputState,
-    pub selected: usize,
-    pub scroll_offset: usize,
+    entries: Vec<QueryHistoryEntry>,
+    filter_input: TextInputState,
+    selected: usize,
+    scroll_offset: usize,
     pub pane_height: u16,
 }
 
@@ -26,6 +27,27 @@ pub struct GroupedEntry<'a> {
 }
 
 impl QueryHistoryPickerState {
+    pub fn entries(&self) -> &[QueryHistoryEntry] {
+        &self.entries
+    }
+
+    pub fn filter_input(&self) -> &TextInputState {
+        &self.filter_input
+    }
+
+    pub fn selected(&self) -> usize {
+        self.selected
+    }
+
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    pub fn replace_entries(&mut self, entries: Vec<QueryHistoryEntry>) {
+        self.entries = entries;
+        self.reset_selection();
+    }
+
     pub fn reset(&mut self) {
         self.entries.clear();
         self.filter_input.clear();
@@ -60,6 +82,28 @@ impl QueryHistoryPickerState {
     pub fn reset_selection(&mut self) {
         self.selected = 0;
         self.scroll_offset = 0;
+    }
+
+    pub fn select_next(&mut self) {
+        let count = self.grouped_count();
+        if count > 0 {
+            self.set_selection((self.selected + 1).min(count - 1));
+        }
+    }
+
+    pub fn select_previous(&mut self) {
+        self.set_selection(self.selected.saturating_sub(1));
+    }
+
+    fn set_selection(&mut self, index: usize) {
+        self.scroll_offset =
+            clamp_scroll_offset(index, self.scroll_offset, self.pane_height as usize);
+        self.selected = index;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_selection_for_test(&mut self, selected: usize) {
+        self.selected = selected;
     }
 
     pub fn filtered_entries(&self) -> Vec<FilteredEntry<'_>> {

--- a/src/app/model/sql_editor/query_history.rs
+++ b/src/app/model/sql_editor/query_history.rs
@@ -88,12 +88,12 @@ impl QueryHistoryPickerState {
     pub fn select_next(&mut self) {
         let count = self.grouped_count();
         if count > 0 {
-            self.set_selection((self.selected + 1).min(count - 1));
+            self.set_selection((self.clamped_selected() + 1).min(count - 1));
         }
     }
 
     pub fn select_previous(&mut self) {
-        self.set_selection(self.selected.saturating_sub(1));
+        self.set_selection(self.clamped_selected().saturating_sub(1));
     }
 
     fn set_selection(&mut self, index: usize) {
@@ -406,6 +406,21 @@ mod tests {
 
         assert_eq!(state.selected(), 1);
         assert_eq!(state.scroll_offset(), 1);
+    }
+
+    #[test]
+    fn select_previous_starts_from_clamped_selection() {
+        let mut state = QueryHistoryPickerState {
+            entries: vec![make_entry("SELECT 1"), make_entry("SELECT 2")],
+            selected: 10,
+            pane_height: 5,
+            ..Default::default()
+        };
+
+        state.select_previous();
+
+        assert_eq!(state.selected(), 0);
+        assert_eq!(state.scroll_offset(), 0);
     }
 
     #[test]

--- a/src/app/model/sql_editor/query_history.rs
+++ b/src/app/model/sql_editor/query_history.rs
@@ -2,7 +2,7 @@ use nucleo_matcher::pattern::{CaseMatching, Normalization, Pattern};
 use nucleo_matcher::{Config, Matcher};
 
 use crate::domain::query_history::QueryHistoryEntry;
-use crate::model::shared::picker::clamp_scroll_offset;
+use crate::model::shared::picker::{clamp_scroll_offset, sanitize_filter_text};
 use crate::model::shared::text_input::TextInputState;
 use crate::update::action::CursorMove;
 
@@ -61,12 +61,7 @@ impl QueryHistoryPickerState {
     }
 
     pub fn insert_filter_str(&mut self, text: &str) {
-        if text.contains(['\n', '\r']) {
-            let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-            self.filter_input.insert_str(&clean);
-        } else {
-            self.filter_input.insert_str(text);
-        }
+        self.filter_input.insert_str(&sanitize_filter_text(text));
         self.reset_selection();
     }
 

--- a/src/app/model/sql_editor/query_history.rs
+++ b/src/app/model/sql_editor/query_history.rs
@@ -13,6 +13,7 @@ pub struct QueryHistoryPickerState {
     selected: usize,
     scroll_offset: usize,
     pub pane_height: u16,
+    pub filter_visible_width: usize,
 }
 
 pub struct FilteredEntry<'a> {
@@ -43,8 +44,9 @@ impl QueryHistoryPickerState {
         self.scroll_offset
     }
 
-    pub fn replace_entries(&mut self, entries: Vec<QueryHistoryEntry>) {
-        self.entries = entries;
+    pub fn replace_entries(&mut self, entries: &[QueryHistoryEntry]) {
+        self.entries.clear();
+        self.entries.extend_from_slice(entries);
         self.reset_selection();
     }
 
@@ -57,21 +59,25 @@ impl QueryHistoryPickerState {
 
     pub fn insert_filter_char(&mut self, ch: char) {
         self.filter_input.insert_char(ch);
+        self.filter_input.update_viewport(self.filter_visible_width);
         self.reset_selection();
     }
 
     pub fn insert_filter_str(&mut self, text: &str) {
         self.filter_input.insert_str(&sanitize_filter_text(text));
+        self.filter_input.update_viewport(self.filter_visible_width);
         self.reset_selection();
     }
 
     pub fn backspace_filter(&mut self) {
         self.filter_input.backspace();
+        self.filter_input.update_viewport(self.filter_visible_width);
         self.reset_selection();
     }
 
     pub fn move_filter_cursor(&mut self, direction: CursorMove) {
         self.filter_input.move_cursor(direction);
+        self.filter_input.update_viewport(self.filter_visible_width);
     }
 
     pub fn reset_selection(&mut self) {
@@ -233,6 +239,20 @@ mod tests {
         assert_eq!(state.selected, 3);
         assert_eq!(state.scroll_offset, 2);
     }
+
+    #[test]
+    fn filter_input_updates_viewport() {
+        let mut state = QueryHistoryPickerState {
+            filter_visible_width: 3,
+            ..Default::default()
+        };
+
+        state.insert_filter_str("abcd");
+
+        assert_eq!(state.filter_input.content(), "abcd");
+        assert_eq!(state.filter_input.viewport_offset(), 3);
+    }
+
     fn make_entry(query: &str) -> QueryHistoryEntry {
         use crate::domain::query_history::QueryResultStatus;
         QueryHistoryEntry::new(
@@ -344,6 +364,48 @@ mod tests {
         };
 
         assert_eq!(state.clamped_selected(), 1);
+    }
+
+    #[test]
+    fn select_next_updates_scroll_offset() {
+        let mut state = QueryHistoryPickerState {
+            entries: vec![
+                make_entry("SELECT 1"),
+                make_entry("SELECT 2"),
+                make_entry("SELECT 3"),
+                make_entry("SELECT 4"),
+            ],
+            pane_height: 2,
+            ..Default::default()
+        };
+
+        state.select_next();
+        state.select_next();
+
+        assert_eq!(state.selected(), 2);
+        assert_eq!(state.scroll_offset(), 1);
+    }
+
+    #[test]
+    fn select_previous_updates_scroll_offset() {
+        let mut state = QueryHistoryPickerState {
+            entries: vec![
+                make_entry("SELECT 1"),
+                make_entry("SELECT 2"),
+                make_entry("SELECT 3"),
+                make_entry("SELECT 4"),
+            ],
+            selected: 3,
+            scroll_offset: 2,
+            pane_height: 2,
+            ..Default::default()
+        };
+
+        state.select_previous();
+        state.select_previous();
+
+        assert_eq!(state.selected(), 1);
+        assert_eq!(state.scroll_offset(), 1);
     }
 
     #[test]

--- a/src/app/ports/outbound/renderer.rs
+++ b/src/app/ports/outbound/renderer.rs
@@ -35,6 +35,7 @@ pub struct RenderOutput {
     pub er_picker_pane_height: Option<u16>,
     pub er_picker_filter_visible_width: Option<usize>,
     pub query_history_picker_pane_height: Option<u16>,
+    pub query_history_picker_filter_visible_width: Option<usize>,
     pub jsonb_detail_editor_visible_rows: Option<usize>,
     pub confirm_preview_viewport_height: Option<u16>,
     pub confirm_preview_content_height: Option<u16>,

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -183,6 +183,10 @@ pub enum ListMotion {
 }
 
 /// Payload-free modal lifecycle kinds.
+///
+/// Modal lifecycle actions stay generic only while opening does not need a
+/// payload. Payload-bearing modals keep explicit actions until there is a
+/// repeated payload pattern worth abstracting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModalKind {
     TablePicker,
@@ -309,7 +313,8 @@ pub enum Action {
     ConnectionEditLoaded(Box<ConnectionProfile>),
     ConnectionEditLoadFailed(ConnectionStoreError),
 
-    // Connection Error
+    // Connection Error: opening carries ConnectionErrorInfo, so this remains
+    // outside payload-free ModalKind lifecycle actions.
     ShowConnectionError(ConnectionErrorInfo),
     CloseConnectionError,
     ToggleConnectionErrorDetails,

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -313,8 +313,7 @@ pub enum Action {
     ConnectionEditLoaded(Box<ConnectionProfile>),
     ConnectionEditLoadFailed(ConnectionStoreError),
 
-    // Connection Error: opening carries ConnectionErrorInfo, so this remains
-    // outside payload-free ModalKind lifecycle actions.
+    // Connection Error
     ShowConnectionError(ConnectionErrorInfo),
     CloseConnectionError,
     ToggleConnectionErrorDetails,

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -244,6 +244,8 @@ pub struct ConnectionTarget {
     pub name: String,
 }
 
+// Do not derive PartialEq here: payload variants carry domain snapshots and
+// errors that are not all value-comparable.
 #[derive(Debug, Clone)]
 pub enum Action {
     None,

--- a/src/app/update/browse/navigation/input.rs
+++ b/src/app/update/browse/navigation/input.rs
@@ -188,7 +188,7 @@ mod tests {
             );
 
             assert!(effects.is_some());
-            assert_eq!(state.ui.table_picker.filter_input.content(), "hello");
+            assert_eq!(state.ui.table_picker.filter_input().content(), "hello");
         }
 
         #[test]
@@ -203,7 +203,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.table_picker.filter_input.content(), "hello");
+            assert_eq!(state.ui.table_picker.filter_input().content(), "hello");
         }
 
         #[test]
@@ -280,7 +280,7 @@ mod tests {
             );
 
             assert!(effects.is_some());
-            assert_eq!(state.ui.er_picker.filter_input.content(), "public.users");
+            assert_eq!(state.ui.er_picker.filter_input().content(), "public.users");
             assert_eq!(state.ui.er_picker.selected(), 0);
         }
 
@@ -296,14 +296,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.er_picker.filter_input.content(), "public.users");
+            assert_eq!(state.ui.er_picker.filter_input().content(), "public.users");
         }
 
         #[test]
         fn query_history_picker_appends_to_filter() {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::QueryHistoryPicker);
-            state.query_history_picker.selected = 3;
+            state.query_history_picker.set_selection_for_test(3);
 
             let effects = reduce_navigation(
                 &mut state,
@@ -313,8 +313,8 @@ mod tests {
             );
 
             assert!(effects.is_some());
-            assert_eq!(state.query_history_picker.filter_input.content(), "users");
-            assert_eq!(state.query_history_picker.selected, 0);
+            assert_eq!(state.query_history_picker.filter_input().content(), "users");
+            assert_eq!(state.query_history_picker.selected(), 0);
         }
 
         #[test]
@@ -329,7 +329,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.query_history_picker.filter_input.content(), "users");
+            assert_eq!(state.query_history_picker.filter_input().content(), "users");
         }
     }
 

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -658,7 +658,7 @@ mod tests {
                 Action::OpenModal(ModalKind::QueryHistoryPicker)
             )]
             fn global_key_action_matches(#[case] i: usize, #[case] expected: Action) {
-                assert_action_eq(&GLOBAL_KEYS[i].action, &expected, "GLOBAL_KEYS", i);
+                assert_payload_free_action_eq(&GLOBAL_KEYS[i].action, &expected, "GLOBAL_KEYS", i);
             }
 
             #[test]
@@ -709,7 +709,7 @@ mod tests {
             #[case(idx::sql_modal_plan::BACKTAB, Action::SqlModalPrevTab)]
             #[case(idx::sql_modal_plan::CLOSE, Action::CloseModal(ModalKind::SqlModal))]
             fn plan_key_action_matches(#[case] i: usize, #[case] expected: Action) {
-                assert_action_eq(
+                assert_payload_free_action_eq(
                     &SQL_MODAL_PLAN_KEYS[i].action,
                     &expected,
                     "SQL_MODAL_PLAN_KEYS",
@@ -726,7 +726,7 @@ mod tests {
             #[case(idx::sql_modal_compare::BACKTAB, Action::SqlModalPrevTab)]
             #[case(idx::sql_modal_compare::CLOSE, Action::CloseModal(ModalKind::SqlModal))]
             fn compare_key_action_matches(#[case] i: usize, #[case] expected: Action) {
-                assert_action_eq(
+                assert_payload_free_action_eq(
                     &SQL_MODAL_COMPARE_KEYS[i].action,
                     &expected,
                     "SQL_MODAL_COMPARE_KEYS",
@@ -734,14 +734,19 @@ mod tests {
                 );
             }
 
-            fn assert_action_eq(actual: &Action, expected: &Action, label: &str, i: usize) {
+            fn assert_payload_free_action_eq(
+                actual: &Action,
+                expected: &Action,
+                label: &str,
+                i: usize,
+            ) {
                 assert!(
-                    same_action(actual, expected),
+                    same_payload_free_action(actual, expected),
                     "{label}[{i}] has action {actual:?}, expected {expected:?}",
                 );
             }
 
-            fn same_action(actual: &Action, expected: &Action) -> bool {
+            fn same_payload_free_action(actual: &Action, expected: &Action) -> bool {
                 match (actual, expected) {
                     (Action::OpenModal(a), Action::OpenModal(b))
                     | (Action::CloseModal(a), Action::CloseModal(b))

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -197,7 +197,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             if state.session.active_connection_id.as_ref() != Some(conn_id) {
                 return Some(vec![]);
             }
-            state.query_history_picker.replace_entries(entries.clone());
+            state.query_history_picker.replace_entries(entries);
             Some(vec![])
         }
         Action::QueryHistoryLoadFailed(e) => {
@@ -978,7 +978,7 @@ mod tests {
             fn select_next_increments() {
                 let mut state = connected_state();
                 let test_conn = ConnectionId::from_string("test-conn");
-                state.query_history_picker.replace_entries(vec![
+                state.query_history_picker.replace_entries(&[
                     make_entry("SELECT 1", &test_conn),
                     make_entry("SELECT 2", &test_conn),
                 ]);
@@ -1002,7 +1002,7 @@ mod tests {
                 let test_conn = ConnectionId::from_string("test-conn");
                 state
                     .query_history_picker
-                    .replace_entries(vec![make_entry("SELECT 1", &test_conn)]);
+                    .replace_entries(&[make_entry("SELECT 1", &test_conn)]);
 
                 reduce_modal(
                     &mut state,
@@ -1050,7 +1050,7 @@ mod tests {
                 let test_conn = ConnectionId::from_string("test-conn");
                 state
                     .query_history_picker
-                    .replace_entries(vec![make_entry(&query, &test_conn)]);
+                    .replace_entries(&[make_entry(&query, &test_conn)]);
 
                 reduce_modal(
                     &mut state,
@@ -1069,7 +1069,7 @@ mod tests {
                 let test_conn = ConnectionId::from_string("test-conn");
                 state
                     .query_history_picker
-                    .replace_entries(vec![make_entry("SELECT * FROM users", &test_conn)]);
+                    .replace_entries(&[make_entry("SELECT * FROM users", &test_conn)]);
 
                 let effects = reduce_modal(
                     &mut state,
@@ -1106,7 +1106,7 @@ mod tests {
                 let test_conn = ConnectionId::from_string("test-conn");
                 state
                     .query_history_picker
-                    .replace_entries(vec![make_entry("new query", &test_conn)]);
+                    .replace_entries(&[make_entry("new query", &test_conn)]);
 
                 reduce_modal(
                     &mut state,

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -197,9 +197,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             if state.session.active_connection_id.as_ref() != Some(conn_id) {
                 return Some(vec![]);
             }
-            state.query_history_picker.entries.clone_from(entries);
-            state.query_history_picker.selected = 0;
-            state.query_history_picker.scroll_offset = 0;
+            state.query_history_picker.replace_entries(entries.clone());
             Some(vec![])
         }
         Action::QueryHistoryLoadFailed(e) => {
@@ -227,18 +225,14 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             target: ListTarget::QueryHistory,
             motion: ListMotion::Next,
         } => {
-            let count = state.query_history_picker.grouped_count();
-            if count > 0 && state.query_history_picker.selected < count - 1 {
-                state.query_history_picker.selected += 1;
-            }
+            state.query_history_picker.select_next();
             Some(vec![])
         }
         Action::ListSelect {
             target: ListTarget::QueryHistory,
             motion: ListMotion::Previous,
         } => {
-            state.query_history_picker.selected =
-                state.query_history_picker.selected.saturating_sub(1);
+            state.query_history_picker.select_previous();
             Some(vec![])
         }
         Action::QueryHistoryConfirmSelection => {
@@ -862,7 +856,7 @@ mod tests {
                 )
                 .unwrap();
 
-                assert_eq!(state.query_history_picker.entries.len(), 1);
+                assert_eq!(state.query_history_picker.entries().len(), 1);
                 assert!(effects.is_empty());
             }
 
@@ -880,7 +874,7 @@ mod tests {
                 )
                 .unwrap();
 
-                assert!(state.query_history_picker.entries.is_empty());
+                assert!(state.query_history_picker.entries().is_empty());
             }
 
             #[test]
@@ -896,7 +890,7 @@ mod tests {
                 )
                 .unwrap();
 
-                assert!(state.query_history_picker.entries.is_empty());
+                assert!(state.query_history_picker.entries().is_empty());
             }
 
             #[test]
@@ -963,7 +957,7 @@ mod tests {
             #[test]
             fn filter_input_resets_selection() {
                 let mut state = connected_state();
-                state.query_history_picker.selected = 5;
+                state.query_history_picker.set_selection_for_test(5);
 
                 let effects = reduce_modal(
                     &mut state,
@@ -975,8 +969,8 @@ mod tests {
                 )
                 .unwrap();
 
-                assert_eq!(state.query_history_picker.selected, 0);
-                assert_eq!(state.query_history_picker.filter_input.content(), "a");
+                assert_eq!(state.query_history_picker.selected(), 0);
+                assert_eq!(state.query_history_picker.filter_input().content(), "a");
                 assert!(effects.is_empty());
             }
 
@@ -984,11 +978,10 @@ mod tests {
             fn select_next_increments() {
                 let mut state = connected_state();
                 let test_conn = ConnectionId::from_string("test-conn");
-                state.query_history_picker.entries = vec![
+                state.query_history_picker.replace_entries(vec![
                     make_entry("SELECT 1", &test_conn),
                     make_entry("SELECT 2", &test_conn),
-                ];
-                state.query_history_picker.selected = 0;
+                ]);
 
                 reduce_modal(
                     &mut state,
@@ -1000,15 +993,16 @@ mod tests {
                 )
                 .unwrap();
 
-                assert_eq!(state.query_history_picker.selected, 1);
+                assert_eq!(state.query_history_picker.selected(), 1);
             }
 
             #[test]
             fn select_next_clamps_at_end() {
                 let mut state = connected_state();
                 let test_conn = ConnectionId::from_string("test-conn");
-                state.query_history_picker.entries = vec![make_entry("SELECT 1", &test_conn)];
-                state.query_history_picker.selected = 0;
+                state
+                    .query_history_picker
+                    .replace_entries(vec![make_entry("SELECT 1", &test_conn)]);
 
                 reduce_modal(
                     &mut state,
@@ -1020,13 +1014,13 @@ mod tests {
                 )
                 .unwrap();
 
-                assert_eq!(state.query_history_picker.selected, 0);
+                assert_eq!(state.query_history_picker.selected(), 0);
             }
 
             #[test]
             fn select_previous_decrements() {
                 let mut state = connected_state();
-                state.query_history_picker.selected = 1;
+                state.query_history_picker.set_selection_for_test(1);
 
                 reduce_modal(
                     &mut state,
@@ -1038,7 +1032,7 @@ mod tests {
                 )
                 .unwrap();
 
-                assert_eq!(state.query_history_picker.selected, 0);
+                assert_eq!(state.query_history_picker.selected(), 0);
             }
         }
 
@@ -1054,7 +1048,9 @@ mod tests {
                 let expected_chars = query.chars().count(); // 13
                 assert_ne!(query.len(), expected_chars); // sanity: bytes != chars
                 let test_conn = ConnectionId::from_string("test-conn");
-                state.query_history_picker.entries = vec![make_entry(&query, &test_conn)];
+                state
+                    .query_history_picker
+                    .replace_entries(vec![make_entry(&query, &test_conn)]);
 
                 reduce_modal(
                     &mut state,
@@ -1071,9 +1067,9 @@ mod tests {
                 let mut state = connected_state();
                 enter_query_history(&mut state, InputMode::Normal);
                 let test_conn = ConnectionId::from_string("test-conn");
-                state.query_history_picker.entries =
-                    vec![make_entry("SELECT * FROM users", &test_conn)];
-                state.query_history_picker.selected = 0;
+                state
+                    .query_history_picker
+                    .replace_entries(vec![make_entry("SELECT * FROM users", &test_conn)]);
 
                 let effects = reduce_modal(
                     &mut state,
@@ -1108,8 +1104,9 @@ mod tests {
                     }];
                 state.sql_modal.completion.selected_index = 3;
                 let test_conn = ConnectionId::from_string("test-conn");
-                state.query_history_picker.entries = vec![make_entry("new query", &test_conn)];
-                state.query_history_picker.selected = 0;
+                state
+                    .query_history_picker
+                    .replace_entries(vec![make_entry("new query", &test_conn)]);
 
                 reduce_modal(
                     &mut state,

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -518,11 +518,7 @@ mod tests {
         #[test]
         fn open_table_picker_sets_mode_and_clears_filter() {
             let mut state = create_test_state();
-            state
-                .ui
-                .table_picker
-                .filter_input
-                .set_content("test".to_string());
+            state.ui.table_picker.insert_filter_str("test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -533,7 +529,7 @@ mod tests {
             );
 
             assert_eq!(state.input_mode(), InputMode::TablePicker);
-            assert!(state.ui.table_picker.filter_input.content().is_empty());
+            assert!(state.ui.table_picker.filter_input().content().is_empty());
             assert_eq!(state.ui.table_picker.selected(), 0);
             assert!(effects.is_empty());
         }
@@ -2113,11 +2109,7 @@ mod tests {
         #[test]
         fn open_clears_selections_and_filter() {
             let mut state = state_with_metadata();
-            state
-                .ui
-                .er_picker
-                .filter_input
-                .set_content("old".to_string());
+            state.ui.er_picker.insert_filter_str("old");
             state
                 .ui
                 .er_selected_tables
@@ -2132,7 +2124,7 @@ mod tests {
             );
 
             assert_eq!(state.input_mode(), InputMode::ErTablePicker);
-            assert!(state.ui.er_picker.filter_input.content().is_empty());
+            assert!(state.ui.er_picker.filter_input().content().is_empty());
             assert!(state.ui.er_selected_tables.is_empty());
             assert!(effects.is_empty());
         }
@@ -2233,11 +2225,7 @@ mod tests {
             let mut state = state_with_metadata();
             state.modal.set_mode(InputMode::ErTablePicker);
 
-            state
-                .ui
-                .er_picker
-                .filter_input
-                .set_content("test".to_string());
+            state.ui.er_picker.insert_filter_str("test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -2248,7 +2236,7 @@ mod tests {
             );
 
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert!(state.ui.er_picker.filter_input.content().is_empty());
+            assert!(state.ui.er_picker.filter_input().content().is_empty());
             assert!(effects.is_empty());
         }
 

--- a/src/tests/render_snapshots/er_diagram.rs
+++ b/src/tests/render_snapshots/er_diagram.rs
@@ -40,11 +40,7 @@ fn er_table_picker_filtered() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::ErTablePicker);
-    state
-        .ui
-        .er_picker
-        .filter_input
-        .set_content("user".to_string());
+    state.ui.er_picker.insert_filter_str("user");
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -402,7 +402,7 @@ fn query_history_picker_with_entries() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::QueryHistoryPicker);
-    state.query_history_picker.replace_entries(vec![
+    state.query_history_picker.replace_entries(&[
         QueryHistoryEntry::new(
             "SELECT * FROM users WHERE id = 1".to_string(),
             "2026-03-13T10:00:00Z".to_string(),
@@ -449,7 +449,7 @@ fn query_history_picker_filter_mode() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::QueryHistoryPicker);
-    state.query_history_picker.replace_entries(vec![
+    state.query_history_picker.replace_entries(&[
         QueryHistoryEntry::new(
             "SELECT * FROM users".to_string(),
             "2026-03-13T10:00:00Z".to_string(),

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -376,11 +376,7 @@ fn table_picker_overlay() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::TablePicker);
-    state
-        .ui
-        .table_picker
-        .filter_input
-        .set_content("user".to_string());
+    state.ui.table_picker.insert_filter_str("user");
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -406,7 +402,7 @@ fn query_history_picker_with_entries() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::QueryHistoryPicker);
-    state.query_history_picker.entries = vec![
+    state.query_history_picker.replace_entries(vec![
         QueryHistoryEntry::new(
             "SELECT * FROM users WHERE id = 1".to_string(),
             "2026-03-13T10:00:00Z".to_string(),
@@ -428,7 +424,7 @@ fn query_history_picker_with_entries() {
             QueryResultStatus::Failed,
             None,
         ),
-    ];
+    ]);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -453,7 +449,7 @@ fn query_history_picker_filter_mode() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::QueryHistoryPicker);
-    state.query_history_picker.entries = vec![
+    state.query_history_picker.replace_entries(vec![
         QueryHistoryEntry::new(
             "SELECT * FROM users".to_string(),
             "2026-03-13T10:00:00Z".to_string(),
@@ -468,8 +464,8 @@ fn query_history_picker_filter_mode() {
             QueryResultStatus::Success,
             None,
         ),
-    ];
-    state.query_history_picker.filter_input.insert_str("user");
+    ]);
+    state.query_history_picker.insert_filter_str("user");
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_filter_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_filter_mode.snap
@@ -1,5 +1,6 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
+assertion_line: 472
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -10,7 +11,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │                  ││                                                          │
 │                  ││                                                          │
 │           ╭ Query History ───────────────────────────────────────╮           │
-│           │  > user█                                             │           │
+│           │  > user                                              │           │
 │           │▸ ✓ SELECT * FROM users             Mar 13 10:00 UTC  │           │
 │           │                                                      │           │
 │           │                                                      │───────────┘

--- a/src/ui/features/pickers/er_table_picker.rs
+++ b/src/ui/features/pickers/er_table_picker.rs
@@ -83,7 +83,7 @@ impl ErTablePicker {
         let raw_width = filter_area.width.saturating_sub(4) as usize;
 
         // Filter input
-        let input = &state.ui.er_picker.filter_input;
+        let input = state.ui.er_picker.filter_input();
         let visible_width = if input.cursor() == input.char_count() {
             raw_width.saturating_sub(1)
         } else {

--- a/src/ui/features/pickers/er_table_picker.rs
+++ b/src/ui/features/pickers/er_table_picker.rs
@@ -9,6 +9,7 @@ use crate::domain::er::er_output_filename;
 use crate::primitives::atoms::text_cursor_spans;
 use crate::theme::ThemePalette;
 
+use crate::features::pickers::table_picker::filter_visible_width;
 use crate::primitives::molecules::render_modal;
 
 pub struct ErTablePicker;
@@ -84,11 +85,7 @@ impl ErTablePicker {
 
         // Filter input
         let input = state.ui.er_picker.filter_input();
-        let visible_width = if input.cursor() == input.char_count() {
-            raw_width.saturating_sub(1)
-        } else {
-            raw_width
-        };
+        let visible_width = filter_visible_width(raw_width, input.cursor(), input.char_count());
         let cursor_spans = text_cursor_spans(
             input.content(),
             input.cursor(),
@@ -161,7 +158,7 @@ impl ErTablePicker {
         frame.render_stateful_widget(list, list_area, &mut list_state);
         ErTablePickerRenderMetrics {
             pane_height: list_area.height,
-            filter_visible_width: raw_width,
+            filter_visible_width: visible_width,
         }
     }
 }

--- a/src/ui/features/pickers/query_history_picker.rs
+++ b/src/ui/features/pickers/query_history_picker.rs
@@ -7,6 +7,7 @@ use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wra
 use crate::app::model::app_state::AppState;
 use crate::app::model::sql_editor::query_history::GroupedEntry;
 use crate::domain::query_history::{Iso8601Timestamp, QueryResultStatus};
+use crate::features::pickers::table_picker::filter_visible_width;
 use crate::primitives::atoms::text_cursor_spans;
 use crate::primitives::molecules::render_modal;
 use crate::theme::{StatusTone, ThemePalette};
@@ -143,17 +144,13 @@ impl QueryHistoryPicker {
         let raw_width = filter_area.width.saturating_sub(4) as usize;
 
         let input = state.query_history_picker.filter_input();
+        let visible_width = filter_visible_width(raw_width, input.cursor(), input.char_count());
         let filter_line = if input.content().is_empty() {
             Line::from(Span::styled(
                 "  type to filter",
                 Style::default().fg(theme.semantic.text.placeholder),
             ))
         } else {
-            let visible_width = if input.cursor() == input.char_count() {
-                raw_width.saturating_sub(1)
-            } else {
-                raw_width
-            };
             let cursor_spans = text_cursor_spans(
                 input.content(),
                 input.cursor(),
@@ -187,7 +184,7 @@ impl QueryHistoryPicker {
             }
             return QueryHistoryPickerRenderMetrics {
                 pane_height: list_area.height,
-                filter_visible_width: raw_width,
+                filter_visible_width: visible_width,
             };
         }
 
@@ -226,7 +223,7 @@ impl QueryHistoryPicker {
         frame.render_stateful_widget(list, list_area, &mut list_state);
         QueryHistoryPickerRenderMetrics {
             pane_height: list_area.height,
-            filter_visible_width: raw_width,
+            filter_visible_width: visible_width,
         }
     }
 }

--- a/src/ui/features/pickers/query_history_picker.rs
+++ b/src/ui/features/pickers/query_history_picker.rs
@@ -76,14 +76,18 @@ pub struct QueryHistoryPicker;
 
 impl QueryHistoryPicker {
     pub fn render(frame: &mut Frame, state: &AppState, theme: &ThemePalette) -> u16 {
-        let filter_is_empty = state.query_history_picker.filter_input.content().is_empty();
+        let filter_is_empty = state
+            .query_history_picker
+            .filter_input()
+            .content()
+            .is_empty();
         let filter_content = state
             .query_history_picker
-            .filter_input
+            .filter_input()
             .content()
             .to_string();
-        let scroll_offset = state.query_history_picker.scroll_offset;
-        let raw_selected = state.query_history_picker.selected;
+        let scroll_offset = state.query_history_picker.scroll_offset();
+        let raw_selected = state.query_history_picker.selected();
 
         let grouped = state.query_history_picker.grouped_filtered_entries();
         let grouped_count = grouped.len();

--- a/src/ui/features/pickers/query_history_picker.rs
+++ b/src/ui/features/pickers/query_history_picker.rs
@@ -7,6 +7,7 @@ use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wra
 use crate::app::model::app_state::AppState;
 use crate::app::model::sql_editor::query_history::GroupedEntry;
 use crate::domain::query_history::{Iso8601Timestamp, QueryResultStatus};
+use crate::primitives::atoms::text_cursor_spans;
 use crate::primitives::molecules::render_modal;
 use crate::theme::{StatusTone, ThemePalette};
 
@@ -74,18 +75,22 @@ struct PreviewData<'a> {
 
 pub struct QueryHistoryPicker;
 
+pub struct QueryHistoryPickerRenderMetrics {
+    pub pane_height: u16,
+    pub filter_visible_width: usize,
+}
+
 impl QueryHistoryPicker {
-    pub fn render(frame: &mut Frame, state: &AppState, theme: &ThemePalette) -> u16 {
+    pub fn render(
+        frame: &mut Frame,
+        state: &AppState,
+        theme: &ThemePalette,
+    ) -> QueryHistoryPickerRenderMetrics {
         let filter_is_empty = state
             .query_history_picker
             .filter_input()
             .content()
             .is_empty();
-        let filter_content = state
-            .query_history_picker
-            .filter_input()
-            .content()
-            .to_string();
         let scroll_offset = state.query_history_picker.scroll_offset();
         let raw_selected = state.query_history_picker.selected();
 
@@ -135,26 +140,33 @@ impl QueryHistoryPicker {
             (filter_area, list_area, None)
         };
         let (filter_area, list_area, preview_area) = areas;
+        let raw_width = filter_area.width.saturating_sub(4) as usize;
 
-        let filter_line = if filter_content.is_empty() {
+        let input = state.query_history_picker.filter_input();
+        let filter_line = if input.content().is_empty() {
             Line::from(Span::styled(
                 "  type to filter",
                 Style::default().fg(theme.semantic.text.placeholder),
             ))
         } else {
-            Line::from(vec![
-                Span::styled("  > ", Style::default().fg(theme.component.modal.title)),
-                Span::styled(
-                    filter_content,
-                    Style::default().fg(theme.semantic.text.primary),
-                ),
-                Span::styled(
-                    "\u{2588}",
-                    Style::default()
-                        .fg(theme.semantic.cursor.fg)
-                        .add_modifier(Modifier::SLOW_BLINK),
-                ),
-            ])
+            let visible_width = if input.cursor() == input.char_count() {
+                raw_width.saturating_sub(1)
+            } else {
+                raw_width
+            };
+            let cursor_spans = text_cursor_spans(
+                input.content(),
+                input.cursor(),
+                input.viewport_offset(),
+                visible_width,
+                theme,
+            );
+            let mut spans = vec![Span::styled(
+                "  > ",
+                Style::default().fg(theme.component.modal.title),
+            )];
+            spans.extend(cursor_spans);
+            Line::from(spans)
         };
         frame.render_widget(Paragraph::new(filter_line), filter_area);
 
@@ -173,7 +185,10 @@ impl QueryHistoryPicker {
             if let Some(pa) = preview_area {
                 render_empty_preview(frame, pa, theme);
             }
-            return list_area.height;
+            return QueryHistoryPickerRenderMetrics {
+                pane_height: list_area.height,
+                filter_visible_width: raw_width,
+            };
         }
 
         let available_width = list_area.width as usize;
@@ -209,7 +224,10 @@ impl QueryHistoryPicker {
             .with_selected(Some(selected_idx))
             .with_offset(scroll_offset);
         frame.render_stateful_widget(list, list_area, &mut list_state);
-        list_area.height
+        QueryHistoryPickerRenderMetrics {
+            pane_height: list_area.height,
+            filter_visible_width: raw_width,
+        }
     }
 }
 

--- a/src/ui/features/pickers/table_picker.rs
+++ b/src/ui/features/pickers/table_picker.rs
@@ -9,6 +9,14 @@ use crate::primitives::atoms::text_cursor_spans;
 use crate::primitives::molecules::render_modal;
 use crate::theme::ThemePalette;
 
+pub(super) fn filter_visible_width(raw_width: usize, cursor: usize, char_count: usize) -> usize {
+    if cursor == char_count {
+        raw_width.saturating_sub(1)
+    } else {
+        raw_width
+    }
+}
+
 pub struct TablePicker;
 
 pub struct TablePickerRenderMetrics {
@@ -38,11 +46,7 @@ impl TablePicker {
         let raw_width = filter_area.width.saturating_sub(4) as usize; // "  > " prefix
 
         let input = state.ui.table_picker.filter_input();
-        let visible_width = if input.cursor() == input.char_count() {
-            raw_width.saturating_sub(1)
-        } else {
-            raw_width
-        };
+        let visible_width = filter_visible_width(raw_width, input.cursor(), input.char_count());
         let cursor_spans = text_cursor_spans(
             input.content(),
             input.cursor(),
@@ -83,7 +87,7 @@ impl TablePicker {
         frame.render_stateful_widget(list, list_area, &mut list_state);
         TablePickerRenderMetrics {
             pane_height: list_area.height,
-            filter_visible_width: raw_width,
+            filter_visible_width: visible_width,
         }
     }
 }

--- a/src/ui/features/pickers/table_picker.rs
+++ b/src/ui/features/pickers/table_picker.rs
@@ -37,7 +37,7 @@ impl TablePicker {
 
         let raw_width = filter_area.width.saturating_sub(4) as usize; // "  > " prefix
 
-        let input = &state.ui.table_picker.filter_input;
+        let input = state.ui.table_picker.filter_input();
         let visible_width = if input.cursor() == input.char_count() {
             raw_width.saturating_sub(1)
         } else {

--- a/src/ui/shell/layout.rs
+++ b/src/ui/shell/layout.rs
@@ -20,7 +20,9 @@ use crate::features::overlays::confirm_dialog::{ConfirmDialog, ConfirmPreviewMet
 use crate::features::overlays::help::HelpOverlay;
 use crate::features::pickers::command_palette::CommandPalette;
 use crate::features::pickers::er_table_picker::{ErTablePicker, ErTablePickerRenderMetrics};
-use crate::features::pickers::query_history_picker::QueryHistoryPicker;
+use crate::features::pickers::query_history_picker::{
+    QueryHistoryPicker, QueryHistoryPickerRenderMetrics,
+};
 use crate::features::pickers::table_picker::{TablePicker, TablePickerRenderMetrics};
 use crate::features::sql_modal::SqlModal;
 use crate::shell::command_line::CommandLine;
@@ -113,10 +115,17 @@ impl MainLayout {
             _ => (None, None),
         };
 
-        let query_history_picker_pane_height = match state.input_mode() {
-            InputMode::QueryHistoryPicker => Some(QueryHistoryPicker::render(frame, state, theme)),
-            _ => None,
-        };
+        let (query_history_picker_pane_height, query_history_picker_filter_visible_width) =
+            match state.input_mode() {
+                InputMode::QueryHistoryPicker => {
+                    let QueryHistoryPickerRenderMetrics {
+                        pane_height,
+                        filter_visible_width,
+                    } = QueryHistoryPicker::render(frame, state, theme);
+                    (Some(pane_height), Some(filter_visible_width))
+                }
+                _ => (None, None),
+            };
 
         let (
             confirm_preview_viewport_height,
@@ -167,6 +176,7 @@ impl MainLayout {
             er_picker_pane_height,
             er_picker_filter_visible_width,
             query_history_picker_pane_height,
+            query_history_picker_filter_visible_width,
             jsonb_detail_editor_visible_rows,
             confirm_preview_viewport_height,
             confirm_preview_content_height,


### PR DESCRIPTION
## Problem
Aggregate APIs were supposed to keep picker filter, selection, and scroll state consistent, but several mutable fields still remained externally writable. That left reducer, renderer, and test code able to bypass the intended transition APIs.

## Background
SAB-226 tracks the follow-up from the modal/filter consolidation work. The scope is the first pass: make the concrete aggregate-owned fields private, evaluate the nearby optional follow-ups, and avoid larger modal or state-machine redesigns.

## Approach
Encapsulate picker-owned mutable fields behind read accessors and intent-level mutation methods. Keep the shared filter behavior small by extracting only the duplicated sanitization rule, and document why payload-bearing modal opens such as connection errors remain outside payload-free modal lifecycle actions.

## Scope
- Picker and query-history picker aggregate-owned field visibility
- Shared filter text sanitization between picker aggregates
- Payload-free action assertion naming and `Action: PartialEq` non-goal
- Modal payload lifecycle policy for `ConnectionError`

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * クエリ履歴フィルターのカーソル表示精度を改善しました。

* **Refactor**
  * クエリ履歴ピッカーの内部状態管理を改善し、フィルター入力とスクロール動作の一貫性を強化しました。
  * テーブルピッカーとクエリ履歴ピッカーのフィルター処理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->