### PR TITLE
refactor: encapsulate SQL modal workflow state

### DIFF
--- a/src/app/cmd/render_schedule.rs
+++ b/src/app/cmd/render_schedule.rs
@@ -23,7 +23,7 @@ pub fn next_animation_deadline(state: &AppState, now: Instant) -> Option<Instant
         earliest = min_instant(earliest, Some(highlight_until));
     }
 
-    if let Some(debounce_until) = state.sql_modal.completion_debounce {
+    if let Some(debounce_until) = state.sql_modal.completion_debounce() {
         earliest = min_instant(earliest, Some(debounce_until));
     }
 
@@ -223,7 +223,9 @@ mod tests {
             let mut state = create_test_state();
             let now = Instant::now();
             let debounce_until = now + Duration::from_millis(100);
-            state.sql_modal.completion_debounce = Some(debounce_until);
+            state
+                .sql_modal
+                .set_completion_debounce_for_test(Some(debounce_until));
 
             let deadline = next_animation_deadline(&state, now);
 

--- a/src/app/cmd/sql_editor/completion.rs
+++ b/src/app/cmd/sql_editor/completion.rs
@@ -72,7 +72,7 @@ pub async fn run(
             let (candidates, token_len, visible) = {
                 let engine = completion_engine.borrow();
                 let token_len = CompletionEngine::current_token_len_prepared(&prep);
-                let recent_cols = state.sql_modal.completion.recent_columns_vec();
+                let recent_cols = state.sql_modal.completion().recent_columns_vec();
                 let candidates = engine.get_candidates_prepared(
                     content,
                     cursor,

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -6,7 +6,7 @@ use crate::model::shared::multi_line_input::MultiLineInputState;
 use crate::model::shared::text_input::TextInputState;
 use crate::policy::write::write_guardrails::AdhocRiskDecision;
 
-use super::completion::CompletionState;
+use super::completion::{CompletionCandidate, CompletionState};
 
 // Sized so that prompt + input + checkmark fits within the 80-col modal inner width (~62 cols).
 pub const HIGH_RISK_INPUT_VISIBLE_WIDTH: usize = 30;
@@ -74,13 +74,13 @@ pub struct SqlModalContext {
     status: SqlModalStatus,
     last_adhoc_success: Option<AdhocSuccessSnapshot>,
     last_adhoc_error: Option<String>,
-    pub completion: CompletionState,
-    pub completion_debounce: Option<Instant>,
+    completion: CompletionState,
+    completion_debounce: Option<Instant>,
     pub prefetch_queue: VecDeque<String>,
     pub prefetching_tables: HashSet<String>,
     pub failed_prefetch_tables: HashMap<String, FailedPrefetchEntry>,
     prefetch_started: bool,
-    pub active_tab: SqlModalTab,
+    active_tab: SqlModalTab,
 }
 
 impl SqlModalContext {
@@ -110,23 +110,57 @@ impl SqlModalContext {
 
     // ── Adhoc status ────────────────────────────────────────────────
 
-    pub fn mark_adhoc_error(&mut self, error: String) {
+    pub fn begin_adhoc_running(&mut self) {
+        self.status = SqlModalStatus::Running;
+        self.dismiss_completion();
+    }
+
+    pub fn finish_adhoc_error(&mut self, error: String) {
         self.status = SqlModalStatus::Error;
         self.last_adhoc_error = Some(error);
         self.last_adhoc_success = None;
     }
 
-    pub fn mark_adhoc_success(&mut self, snapshot: AdhocSuccessSnapshot) {
+    pub fn finish_adhoc_success(&mut self, snapshot: AdhocSuccessSnapshot) {
         self.status = SqlModalStatus::Success;
         self.last_adhoc_success = Some(snapshot);
         self.last_adhoc_error = None;
     }
 
-    pub fn set_status(&mut self, status: SqlModalStatus) {
-        debug_assert!(
-            !matches!(status, SqlModalStatus::Error | SqlModalStatus::Success),
-            "adhoc completion must use mark_adhoc_error/mark_adhoc_success to maintain mutual exclusion"
-        );
+    pub fn begin_confirming_high(
+        &mut self,
+        decision: AdhocRiskDecision,
+        target_name: Option<String>,
+    ) {
+        self.status = SqlModalStatus::ConfirmingHigh {
+            decision,
+            input: TextInputState::default(),
+            target_name,
+        };
+        self.dismiss_completion();
+    }
+
+    pub fn begin_confirming_analyze_high(&mut self, query: String, target_name: Option<String>) {
+        self.status = SqlModalStatus::ConfirmingAnalyzeHigh {
+            query,
+            input: TextInputState::default(),
+            target_name,
+        };
+        self.active_tab = SqlModalTab::Plan;
+        self.dismiss_completion();
+    }
+
+    pub fn cancel_confirmation(&mut self) {
+        if matches!(
+            self.status,
+            SqlModalStatus::ConfirmingHigh { .. } | SqlModalStatus::ConfirmingAnalyzeHigh { .. }
+        ) {
+            self.status = SqlModalStatus::Normal;
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn set_status_for_test(&mut self, status: SqlModalStatus) {
         self.status = status;
     }
 
@@ -140,6 +174,94 @@ impl SqlModalContext {
 
     pub fn last_adhoc_success(&self) -> Option<&AdhocSuccessSnapshot> {
         self.last_adhoc_success.as_ref()
+    }
+
+    pub fn active_tab(&self) -> SqlModalTab {
+        self.active_tab
+    }
+
+    pub fn set_active_tab(&mut self, tab: SqlModalTab) {
+        self.active_tab = tab;
+    }
+
+    pub fn cycle_active_tab(&mut self, tab: SqlModalTab) {
+        self.active_tab = tab;
+    }
+
+    pub fn open_sql_tab(&mut self) {
+        self.status = SqlModalStatus::Normal;
+        self.active_tab = SqlModalTab::Sql;
+        self.reset_completion();
+    }
+
+    pub fn close(&mut self) {
+        self.dismiss_completion();
+    }
+
+    pub fn enter_editing(&mut self) {
+        self.status = SqlModalStatus::Editing;
+    }
+
+    pub fn enter_normal(&mut self) {
+        self.status = SqlModalStatus::Normal;
+        self.dismiss_completion();
+    }
+
+    pub fn load_query_from_history(&mut self, query: String) {
+        self.editor.set_content(query);
+        self.open_sql_tab();
+    }
+
+    pub fn load_query_for_editing(&mut self, query: String) {
+        self.editor.set_content(query);
+        self.status = SqlModalStatus::Editing;
+        self.active_tab = SqlModalTab::Sql;
+        self.reset_completion();
+    }
+
+    pub fn completion(&self) -> &CompletionState {
+        &self.completion
+    }
+
+    pub fn completion_mut_for_navigation(&mut self) -> &mut CompletionState {
+        &mut self.completion
+    }
+
+    pub fn completion_debounce(&self) -> Option<Instant> {
+        self.completion_debounce
+    }
+
+    pub fn schedule_completion(&mut self, debounce_until: Instant) {
+        self.completion.visible = false;
+        self.completion_debounce = Some(debounce_until);
+    }
+
+    pub fn consume_completion_debounce(&mut self) -> Option<Instant> {
+        self.completion_debounce.take()
+    }
+
+    pub fn dismiss_completion(&mut self) {
+        self.completion.visible = false;
+        self.completion_debounce = None;
+    }
+
+    pub fn reset_completion(&mut self) {
+        self.completion.visible = false;
+        self.completion.candidates.clear();
+        self.completion.selected_index = 0;
+        self.completion_debounce = None;
+    }
+
+    pub fn apply_completion_update(
+        &mut self,
+        candidates: &[CompletionCandidate],
+        trigger_position: usize,
+        visible: bool,
+    ) {
+        self.completion.candidates.clone_from(&candidates.to_vec());
+        self.completion.trigger_position = trigger_position;
+        self.completion.visible = visible;
+        self.completion.selected_index = 0;
     }
 
     pub fn confirming_high_input_mut(&mut self) -> Option<&mut TextInputState> {
@@ -157,21 +279,23 @@ impl SqlModalContext {
             None
         }
     }
-
-    pub fn reset_completion(&mut self) {
-        self.completion.visible = false;
-        self.completion.candidates.clear();
-        self.completion.selected_index = 0;
-        self.completion_debounce = None;
-    }
 }
 
-#[cfg(test)]
 impl SqlModalContext {
+    #[doc(hidden)]
     pub fn clear_content(&mut self) {
         self.editor.clear();
-        self.completion.visible = false;
-        self.completion.candidates.clear();
+        self.reset_completion();
+    }
+
+    #[doc(hidden)]
+    pub fn set_completion_for_test(&mut self, completion: CompletionState) {
+        self.completion = completion;
+    }
+
+    #[doc(hidden)]
+    pub fn set_completion_debounce_for_test(&mut self, debounce: Option<Instant>) {
+        self.completion_debounce = debounce;
     }
 }
 

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -159,6 +159,7 @@ impl SqlModalContext {
         }
     }
 
+    #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn set_status_for_test(&mut self, status: SqlModalStatus) {
         self.status = status;
@@ -184,17 +185,13 @@ impl SqlModalContext {
         self.active_tab = tab;
     }
 
-    pub fn cycle_active_tab(&mut self, tab: SqlModalTab) {
-        self.active_tab = tab;
-    }
-
     pub fn open_sql_tab(&mut self) {
         self.status = SqlModalStatus::Normal;
         self.active_tab = SqlModalTab::Sql;
         self.reset_completion();
     }
 
-    pub fn close(&mut self) {
+    pub fn cleanup_on_close(&mut self) {
         self.dismiss_completion();
     }
 
@@ -223,17 +220,17 @@ impl SqlModalContext {
         &self.completion
     }
 
-    pub fn completion_mut_for_navigation(&mut self) -> &mut CompletionState {
-        &mut self.completion
-    }
-
     pub fn completion_debounce(&self) -> Option<Instant> {
         self.completion_debounce
     }
 
     pub fn schedule_completion(&mut self, debounce_until: Instant) {
-        self.completion.visible = false;
         self.completion_debounce = Some(debounce_until);
+    }
+
+    pub fn schedule_completion_after_dismiss(&mut self, debounce_until: Instant) {
+        self.completion.visible = false;
+        self.schedule_completion(debounce_until);
     }
 
     pub fn consume_completion_debounce(&mut self) -> Option<Instant> {
@@ -258,10 +255,45 @@ impl SqlModalContext {
         trigger_position: usize,
         visible: bool,
     ) {
-        self.completion.candidates.clone_from(&candidates.to_vec());
+        self.completion.candidates.clear();
+        self.completion.candidates.extend_from_slice(candidates);
         self.completion.trigger_position = trigger_position;
         self.completion.visible = visible;
         self.completion.selected_index = 0;
+    }
+
+    pub fn completion_next(&mut self) {
+        if self.completion.candidates.is_empty() {
+            return;
+        }
+        let max = self.completion.candidates.len() - 1;
+        self.completion.selected_index = if self.completion.selected_index >= max {
+            0
+        } else {
+            self.completion.selected_index + 1
+        };
+    }
+
+    pub fn completion_prev(&mut self) {
+        if self.completion.candidates.is_empty() {
+            return;
+        }
+        let max = self.completion.candidates.len() - 1;
+        self.completion.selected_index = if self.completion.selected_index == 0 {
+            max
+        } else {
+            self.completion.selected_index - 1
+        };
+    }
+
+    pub fn selected_completion_replacement(&self) -> Option<(usize, String)> {
+        if !self.completion.visible || self.completion.candidates.is_empty() {
+            return None;
+        }
+        self.completion
+            .candidates
+            .get(self.completion.selected_index)
+            .map(|candidate| (self.completion.trigger_position, candidate.text.clone()))
     }
 
     pub fn confirming_high_input_mut(&mut self) -> Option<&mut TextInputState> {
@@ -282,17 +314,26 @@ impl SqlModalContext {
 }
 
 impl SqlModalContext {
+    #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn clear_content(&mut self) {
         self.editor.clear();
         self.reset_completion();
     }
 
+    #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn set_completion_for_test(&mut self, completion: CompletionState) {
         self.completion = completion;
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn completion_mut_for_test(&mut self) -> &mut CompletionState {
+        &mut self.completion
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn set_completion_debounce_for_test(&mut self, debounce: Option<Instant>) {
         self.completion_debounce = debounce;
@@ -305,111 +346,234 @@ mod tests {
     use crate::model::shared::text_input::TextInputLike;
     use crate::model::sql_editor::completion::{CompletionCandidate, CompletionKind};
 
-    #[test]
-    fn default_creates_empty_context() {
-        let ctx = SqlModalContext::default();
-
-        assert!(ctx.editor.content().is_empty());
-        assert_eq!(ctx.editor.cursor(), 0);
-        assert_eq!(ctx.status, SqlModalStatus::Normal);
-        assert!(!ctx.completion.visible);
-        assert!(!ctx.is_prefetch_started());
+    fn candidate(text: &str) -> CompletionCandidate {
+        CompletionCandidate {
+            text: text.to_string(),
+            kind: CompletionKind::Keyword,
+            score: 1,
+        }
     }
 
-    #[test]
-    fn reset_prefetch_clears_all_prefetch_state() {
-        let mut ctx = SqlModalContext::default();
-        ctx.begin_prefetch();
-        ctx.prefetch_queue.push_back("public.users".to_string());
-        ctx.prefetching_tables.insert("public.posts".to_string());
-        ctx.failed_prefetch_tables.insert(
-            "public.failed".to_string(),
-            FailedPrefetchEntry {
-                failed_at: Instant::now(),
-                error: "error".to_string(),
-                retry_count: 0,
-            },
-        );
+    mod lifecycle {
+        use super::*;
 
-        ctx.reset_prefetch();
+        #[test]
+        fn default_creates_empty_context() {
+            let ctx = SqlModalContext::default();
 
-        assert!(!ctx.is_prefetch_started());
-        assert!(ctx.prefetch_queue.is_empty());
-        assert!(ctx.prefetching_tables.is_empty());
-        assert!(ctx.failed_prefetch_tables.is_empty());
+            assert!(ctx.editor.content().is_empty());
+            assert_eq!(ctx.editor.cursor(), 0);
+            assert_eq!(ctx.status, SqlModalStatus::Normal);
+            assert!(!ctx.completion.visible);
+            assert!(!ctx.is_prefetch_started());
+        }
+
+        #[test]
+        fn clear_content_resets_editor_state() {
+            let mut ctx = SqlModalContext::default();
+            ctx.editor.set_content("SELECT * FROM users".to_string());
+            ctx.completion.visible = true;
+            ctx.completion.candidates.push(CompletionCandidate {
+                text: "test".to_string(),
+                kind: CompletionKind::Table,
+                score: 100,
+            });
+
+            ctx.clear_content();
+
+            assert!(ctx.editor.content().is_empty());
+            assert_eq!(ctx.editor.cursor(), 0);
+            assert!(!ctx.completion.visible);
+            assert!(ctx.completion.candidates.is_empty());
+        }
     }
 
-    #[test]
-    fn clear_content_resets_editor_state() {
-        let mut ctx = SqlModalContext::default();
-        ctx.editor.set_content("SELECT * FROM users".to_string());
-        ctx.completion.visible = true;
-        ctx.completion.candidates.push(CompletionCandidate {
-            text: "test".to_string(),
-            kind: CompletionKind::Table,
-            score: 100,
-        });
+    mod prefetch {
+        use super::*;
 
-        ctx.clear_content();
+        #[test]
+        fn reset_clears_all_state() {
+            let mut ctx = SqlModalContext::default();
+            ctx.begin_prefetch();
+            ctx.prefetch_queue.push_back("public.users".to_string());
+            ctx.prefetching_tables.insert("public.posts".to_string());
+            ctx.failed_prefetch_tables.insert(
+                "public.failed".to_string(),
+                FailedPrefetchEntry {
+                    failed_at: Instant::now(),
+                    error: "error".to_string(),
+                    retry_count: 0,
+                },
+            );
 
-        assert!(ctx.editor.content().is_empty());
-        assert_eq!(ctx.editor.cursor(), 0);
-        assert!(!ctx.completion.visible);
-        assert!(ctx.completion.candidates.is_empty());
+            ctx.reset_prefetch();
+
+            assert!(!ctx.is_prefetch_started());
+            assert!(ctx.prefetch_queue.is_empty());
+            assert!(ctx.prefetching_tables.is_empty());
+            assert!(ctx.failed_prefetch_tables.is_empty());
+        }
     }
 
-    #[test]
-    fn confirming_high_with_target_name() {
+    mod confirmation {
+        use super::*;
         use crate::policy::write::write_guardrails::RiskLevel;
 
-        let status = SqlModalStatus::ConfirmingHigh {
-            decision: AdhocRiskDecision {
-                risk_level: RiskLevel::High,
-                label: "DROP",
-            },
-            input: TextInputState::default(),
-            target_name: Some("users".to_string()),
-        };
+        #[test]
+        fn high_status_keeps_target_name() {
+            let status = SqlModalStatus::ConfirmingHigh {
+                decision: AdhocRiskDecision {
+                    risk_level: RiskLevel::High,
+                    label: "DROP",
+                },
+                input: TextInputState::default(),
+                target_name: Some("users".to_string()),
+            };
 
-        assert!(matches!(
-            status,
-            SqlModalStatus::ConfirmingHigh {
-                target_name: Some(_),
-                ..
-            }
-        ));
-    }
+            assert!(matches!(
+                status,
+                SqlModalStatus::ConfirmingHigh {
+                    target_name: Some(_),
+                    ..
+                }
+            ));
+        }
 
-    #[test]
-    fn confirming_high_without_target_name() {
-        use crate::policy::write::write_guardrails::RiskLevel;
-
-        let status = SqlModalStatus::ConfirmingHigh {
-            decision: AdhocRiskDecision {
-                risk_level: RiskLevel::High,
-                label: "SQL",
-            },
-            input: TextInputState::default(),
-            target_name: None,
-        };
-
-        assert!(matches!(
-            status,
-            SqlModalStatus::ConfirmingHigh {
+        #[test]
+        fn high_status_allows_missing_target_name() {
+            let status = SqlModalStatus::ConfirmingHigh {
+                decision: AdhocRiskDecision {
+                    risk_level: RiskLevel::High,
+                    label: "SQL",
+                },
+                input: TextInputState::default(),
                 target_name: None,
-                ..
-            }
-        ));
+            };
+
+            assert!(matches!(
+                status,
+                SqlModalStatus::ConfirmingHigh {
+                    target_name: None,
+                    ..
+                }
+            ));
+        }
+
+        #[test]
+        fn cancel_only_resets_confirmation_status() {
+            let mut ctx = SqlModalContext::default();
+            ctx.cancel_confirmation();
+            assert_eq!(ctx.status, SqlModalStatus::Normal);
+
+            ctx.begin_adhoc_running();
+            ctx.cancel_confirmation();
+            assert_eq!(ctx.status, SqlModalStatus::Running);
+
+            ctx.begin_confirming_high(
+                AdhocRiskDecision {
+                    risk_level: RiskLevel::High,
+                    label: "DROP",
+                },
+                Some("users".to_string()),
+            );
+            ctx.cancel_confirmation();
+            assert_eq!(ctx.status, SqlModalStatus::Normal);
+        }
     }
 
-    #[test]
-    fn visible_rows_uses_fallback_when_terminal_height_is_zero() {
-        assert_eq!(sql_modal_visible_rows(0), SQL_MODAL_VISIBLE_ROWS_FALLBACK);
+    mod completion {
+        use super::*;
+
+        #[test]
+        fn schedule_preserves_popup_visibility() {
+            let mut ctx = SqlModalContext::default();
+            let debounce_until = Instant::now();
+            ctx.completion.visible = true;
+
+            ctx.schedule_completion(debounce_until);
+
+            assert!(ctx.completion.visible);
+            assert_eq!(ctx.completion_debounce, Some(debounce_until));
+        }
+
+        #[test]
+        fn schedule_after_dismiss_hides_popup() {
+            let mut ctx = SqlModalContext::default();
+            let debounce_until = Instant::now();
+            ctx.completion.visible = true;
+
+            ctx.schedule_completion_after_dismiss(debounce_until);
+
+            assert!(!ctx.completion.visible);
+            assert_eq!(ctx.completion_debounce, Some(debounce_until));
+        }
+
+        #[test]
+        fn navigation_wraps_selection() {
+            let mut ctx = SqlModalContext::default();
+            ctx.apply_completion_update(&[candidate("a"), candidate("b")], 0, true);
+
+            ctx.completion_prev();
+            assert_eq!(ctx.completion.selected_index, 1);
+
+            ctx.completion_next();
+            assert_eq!(ctx.completion.selected_index, 0);
+        }
+
+        #[test]
+        fn selected_replacement_returns_trigger_and_text() {
+            let mut ctx = SqlModalContext::default();
+            ctx.apply_completion_update(
+                &[CompletionCandidate {
+                    text: "users".to_string(),
+                    kind: CompletionKind::Table,
+                    score: 1,
+                }],
+                7,
+                true,
+            );
+
+            assert_eq!(
+                ctx.selected_completion_replacement(),
+                Some((7, "users".to_string()))
+            );
+        }
     }
 
-    #[test]
-    fn visible_rows_clamps_to_one_for_small_terminal() {
-        assert_eq!(sql_modal_visible_rows(1), 1);
-        assert_eq!(sql_modal_visible_rows(8), 1);
+    mod adhoc_status {
+        use super::*;
+
+        #[test]
+        fn finish_statuses_clear_opposite_snapshot() {
+            let mut ctx = SqlModalContext::default();
+
+            ctx.finish_adhoc_success(AdhocSuccessSnapshot {
+                command_tag: None,
+                row_count: 1,
+                execution_time_ms: 10,
+            });
+            assert!(ctx.last_adhoc_success().is_some());
+            assert!(ctx.last_adhoc_error().is_none());
+
+            ctx.finish_adhoc_error("syntax error".to_string());
+
+            assert!(ctx.last_adhoc_success().is_none());
+            assert_eq!(ctx.last_adhoc_error(), Some("syntax error"));
+        }
+    }
+
+    mod visible_rows {
+        use super::*;
+
+        #[test]
+        fn uses_fallback_when_terminal_height_is_zero() {
+            assert_eq!(sql_modal_visible_rows(0), SQL_MODAL_VISIBLE_ROWS_FALLBACK);
+        }
+
+        #[test]
+        fn clamps_to_one_for_small_terminal() {
+            assert_eq!(sql_modal_visible_rows(1), 1);
+            assert_eq!(sql_modal_visible_rows(8), 1);
+        }
     }
 }

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -81,9 +81,9 @@ pub fn reduce(
                     if result.is_error() {
                         state
                             .sql_modal
-                            .mark_adhoc_error(result.error.clone().unwrap_or_default());
+                            .finish_adhoc_error(result.error.clone().unwrap_or_default());
                     } else {
-                        state.sql_modal.mark_adhoc_success(AdhocSuccessSnapshot {
+                        state.sql_modal.finish_adhoc_success(AdhocSuccessSnapshot {
                             command_tag: result.command_tag.clone(),
                             row_count: result.row_count,
                             execution_time_ms: result.execution_time_ms,
@@ -170,7 +170,7 @@ pub fn reduce(
                 } else {
                     let user_message = error.user_message();
                     state.set_error(user_message.clone());
-                    state.sql_modal.mark_adhoc_error(user_message);
+                    state.sql_modal.finish_adhoc_error(user_message);
                 }
             }
             Some(vec![])
@@ -673,7 +673,7 @@ mod tests {
             state.modal.set_mode(InputMode::SqlModal);
             state
                 .sql_modal
-                .mark_adhoc_error("previous adhoc error".to_string());
+                .finish_adhoc_error("previous adhoc error".to_string());
 
             reduce_query(
                 &mut state,

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -282,7 +282,7 @@ pub fn reduce_explain_with_services(
             let tab = services
                 .db_capabilities
                 .next_sql_modal_tab(state.sql_modal.active_tab());
-            state.sql_modal.cycle_active_tab(tab);
+            state.sql_modal.set_active_tab(tab);
             Some(vec![])
         }
 
@@ -290,7 +290,7 @@ pub fn reduce_explain_with_services(
             let tab = services
                 .db_capabilities
                 .prev_sql_modal_tab(state.sql_modal.active_tab());
-            state.sql_modal.cycle_active_tab(tab);
+            state.sql_modal.set_active_tab(tab);
             Some(vec![])
         }
 

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -3,8 +3,7 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::explain_context::ExplainContext;
-use crate::model::shared::text_input::{TextInputLike, TextInputState};
-use crate::model::sql_editor::completion::CompletionState;
+use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
 use crate::policy::sql::statement_classifier::{self, StatementKind};
 use crate::policy::write::sql_risk::{ConfirmationType, evaluate_sql_risk, split_statements};
@@ -19,9 +18,44 @@ fn mark_explain_unavailable(state: &mut AppState, services: &AppServices) {
     state
         .explain
         .set_error("EXPLAIN is unavailable for this database".to_string());
-    state.sql_modal.active_tab = services
+    let tab = services
         .db_capabilities
-        .normalize_sql_modal_tab(state.sql_modal.active_tab);
+        .normalize_sql_modal_tab(state.sql_modal.active_tab());
+    state.sql_modal.set_active_tab(tab);
+}
+
+fn show_explain_error_on_plan(state: &mut AppState, message: impl Into<String>) {
+    state.explain.set_error(message.into());
+    state.sql_modal.set_active_tab(SqlModalTab::Plan);
+}
+
+fn begin_explain_running(state: &mut AppState, now: Instant) {
+    state.sql_modal.begin_adhoc_running();
+    state.sql_modal.set_active_tab(SqlModalTab::Plan);
+    state.explain.reset();
+    state.query.begin_running(now);
+}
+
+fn finish_explain_success(
+    state: &mut AppState,
+    plan_text: String,
+    is_analyze: bool,
+    execution_time_ms: u64,
+    query: &str,
+) {
+    state
+        .explain
+        .set_plan(plan_text, is_analyze, execution_time_ms, query);
+    state.sql_modal.enter_normal();
+    state.sql_modal.set_active_tab(SqlModalTab::Plan);
+    state.query.mark_idle();
+}
+
+fn finish_explain_error(state: &mut AppState, error: impl Into<String>) {
+    state.explain.set_error(error.into());
+    state.sql_modal.enter_normal();
+    state.sql_modal.set_active_tab(SqlModalTab::Plan);
+    state.query.mark_idle();
 }
 
 fn reject_unsupported_explain(state: &mut AppState, services: &AppServices) -> bool {
@@ -48,17 +82,14 @@ pub fn reduce_explain_with_services(
             if content.is_empty() {
                 return Some(vec![]);
             }
-            let Some(dsn) = &state.session.dsn else {
+            let Some(dsn) = state.session.dsn.clone() else {
                 return Some(vec![]);
             };
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {
                 return Some(vec![]);
             }
             if is_multi_statement(&content) {
-                state
-                    .explain
-                    .set_error("EXPLAIN does not support multiple statements".to_string());
-                state.sql_modal.active_tab = SqlModalTab::Plan;
+                show_explain_error_on_plan(state, "EXPLAIN does not support multiple statements");
                 return Some(vec![]);
             }
 
@@ -66,13 +97,10 @@ pub fn reduce_explain_with_services(
                 mark_explain_unavailable(state, services);
                 return Some(vec![]);
             };
-            state.sql_modal.set_status(SqlModalStatus::Running);
-            state.sql_modal.active_tab = SqlModalTab::Plan;
-            state.explain.reset();
-            state.query.begin_running(now);
+            begin_explain_running(state, now);
 
             Some(vec![Effect::ExecuteExplain {
-                dsn: dsn.clone(),
+                dsn,
                 query,
                 is_analyze: false,
                 read_only: true,
@@ -95,10 +123,10 @@ pub fn reduce_explain_with_services(
                 return Some(vec![]);
             }
             if is_multi_statement(&content) {
-                state
-                    .explain
-                    .set_error("EXPLAIN ANALYZE does not support multiple statements".to_string());
-                state.sql_modal.active_tab = SqlModalTab::Plan;
+                show_explain_error_on_plan(
+                    state,
+                    "EXPLAIN ANALYZE does not support multiple statements",
+                );
                 return Some(vec![]);
             }
             let kind = statement_classifier::classify(&content);
@@ -107,10 +135,10 @@ pub fn reduce_explain_with_services(
             let is_dml = !matches!(kind, StatementKind::Select | StatementKind::Transaction);
 
             if state.session.read_only && is_dml {
-                state.explain.set_error(
-                    "Read-only mode: EXPLAIN ANALYZE is blocked for DML statements.".into(),
+                show_explain_error_on_plan(
+                    state,
+                    "Read-only mode: EXPLAIN ANALYZE is blocked for DML statements.",
                 );
-                state.sql_modal.active_tab = SqlModalTab::Plan;
                 return Some(vec![]);
             }
 
@@ -120,12 +148,7 @@ pub fn reduce_explain_with_services(
                 ConfirmationType::TableNameInput { target } => {
                     state
                         .sql_modal
-                        .set_status(SqlModalStatus::ConfirmingAnalyzeHigh {
-                            query: content,
-                            input: TextInputState::default(),
-                            target_name: Some(target),
-                        });
-                    state.sql_modal.active_tab = SqlModalTab::Plan;
+                        .begin_confirming_analyze_high(content, Some(target));
                 }
                 ConfirmationType::Immediate => {
                     let Some(explain_query) =
@@ -134,10 +157,7 @@ pub fn reduce_explain_with_services(
                         mark_explain_unavailable(state, services);
                         return Some(vec![]);
                     };
-                    state.sql_modal.set_status(SqlModalStatus::Running);
-                    state.sql_modal.active_tab = SqlModalTab::Plan;
-                    state.explain.reset();
-                    state.query.begin_running(now);
+                    begin_explain_running(state, now);
                     return Some(vec![Effect::ExecuteExplain {
                         dsn,
                         query: explain_query,
@@ -166,18 +186,16 @@ pub fn reduce_explain_with_services(
                 _ => None,
             };
             if let Some(query) = query
-                && let Some(dsn) = &state.session.dsn
+                && let Some(dsn) = state.session.dsn.clone()
             {
                 let Some(explain_query) = services.sql_dialect.build_explain_analyze_sql(&query)
                 else {
                     mark_explain_unavailable(state, services);
                     return Some(vec![]);
                 };
-                state.sql_modal.set_status(SqlModalStatus::Running);
-                state.explain.reset();
-                state.query.begin_running(now);
+                begin_explain_running(state, now);
                 return Some(vec![Effect::ExecuteExplain {
-                    dsn: dsn.clone(),
+                    dsn,
                     query: explain_query,
                     is_analyze: true,
                     read_only: state.session.read_only,
@@ -191,7 +209,7 @@ pub fn reduce_explain_with_services(
                 state.sql_modal.status(),
                 SqlModalStatus::ConfirmingAnalyzeHigh { .. }
             ) {
-                state.sql_modal.set_status(SqlModalStatus::Normal);
+                state.sql_modal.cancel_confirmation();
             }
             Some(vec![])
         }
@@ -202,20 +220,18 @@ pub fn reduce_explain_with_services(
             execution_time_ms,
         } => {
             let query = state.sql_modal.editor.content().to_string();
-            state
-                .explain
-                .set_plan(plan_text.clone(), *is_analyze, *execution_time_ms, &query);
-            state.sql_modal.set_status(SqlModalStatus::Normal);
-            state.sql_modal.active_tab = SqlModalTab::Plan;
-            state.query.mark_idle();
+            finish_explain_success(
+                state,
+                plan_text.clone(),
+                *is_analyze,
+                *execution_time_ms,
+                &query,
+            );
             Some(vec![])
         }
 
         Action::ExplainFailed(error) => {
-            state.explain.set_error(error.user_message());
-            state.sql_modal.set_status(SqlModalStatus::Normal);
-            state.sql_modal.active_tab = SqlModalTab::Plan;
-            state.query.mark_idle();
+            finish_explain_error(state, error.user_message());
             Some(vec![])
         }
 
@@ -257,25 +273,24 @@ pub fn reduce_explain_with_services(
         Action::CompareEditQuery => {
             if let Some(ref right) = state.explain.right {
                 let query = right.full_query.clone();
-                state.sql_modal.editor.set_content(query);
-                state.sql_modal.set_status(SqlModalStatus::Editing);
-                state.sql_modal.completion = CompletionState::default();
-                state.sql_modal.active_tab = SqlModalTab::Sql;
+                state.sql_modal.load_query_for_editing(query);
             }
             Some(vec![])
         }
 
         Action::SqlModalNextTab => {
-            state.sql_modal.active_tab = services
+            let tab = services
                 .db_capabilities
-                .next_sql_modal_tab(state.sql_modal.active_tab);
+                .next_sql_modal_tab(state.sql_modal.active_tab());
+            state.sql_modal.cycle_active_tab(tab);
             Some(vec![])
         }
 
         Action::SqlModalPrevTab => {
-            state.sql_modal.active_tab = services
+            let tab = services
                 .db_capabilities
-                .prev_sql_modal_tab(state.sql_modal.active_tab);
+                .prev_sql_modal_tab(state.sql_modal.active_tab());
+            state.sql_modal.cycle_active_tab(tab);
             Some(vec![])
         }
 
@@ -341,7 +356,7 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
             state.session.dsn = Some("dsn://test".to_string());
-            state.sql_modal.set_status(SqlModalStatus::Running);
+            state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainRequest, Instant::now()).unwrap();
@@ -368,7 +383,7 @@ mod tests {
                 state.explain.error.as_deref(),
                 Some("EXPLAIN is unavailable for this database")
             );
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
         #[test]
@@ -388,7 +403,7 @@ mod tests {
                 state.explain.error.as_deref(),
                 Some("EXPLAIN does not support multiple statements")
             );
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Plan);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
         }
 
         #[test]
@@ -423,7 +438,7 @@ mod tests {
                 } if query == "EXPLAIN SELECT 1"
             ));
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Plan);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
         }
     }
 
@@ -458,7 +473,7 @@ mod tests {
                 state.explain.error.as_deref(),
                 Some("EXPLAIN ANALYZE does not support multiple statements")
             );
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Plan);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
             assert!(state.confirm_dialog.intent().is_none());
         }
 
@@ -481,7 +496,7 @@ mod tests {
                 state.explain.error.as_deref(),
                 Some("EXPLAIN is unavailable for this database")
             );
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
         #[test]
@@ -658,7 +673,7 @@ mod tests {
                     .unwrap()
                     .contains("Read-only")
             );
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Plan);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
             assert!(state.confirm_dialog.intent().is_none());
         }
 
@@ -711,6 +726,7 @@ mod tests {
 
     mod analyze_confirm_cancel {
         use super::*;
+        use crate::model::shared::text_input::TextInputState;
 
         #[test]
         fn confirm_from_high_with_matching_table_emits_effect() {
@@ -722,7 +738,7 @@ mod tests {
             }
             state
                 .sql_modal
-                .set_status(SqlModalStatus::ConfirmingAnalyzeHigh {
+                .set_status_for_test(SqlModalStatus::ConfirmingAnalyzeHigh {
                     query: "DELETE FROM users".to_string(),
                     input,
                     target_name: Some("users".to_string()),
@@ -743,7 +759,7 @@ mod tests {
             input.insert_char('x');
             state
                 .sql_modal
-                .set_status(SqlModalStatus::ConfirmingAnalyzeHigh {
+                .set_status_for_test(SqlModalStatus::ConfirmingAnalyzeHigh {
                     query: "DELETE FROM users".to_string(),
                     input,
                     target_name: Some("users".to_string()),
@@ -764,7 +780,7 @@ mod tests {
             let mut state = sql_modal_state();
             state
                 .sql_modal
-                .set_status(SqlModalStatus::ConfirmingAnalyzeHigh {
+                .set_status_for_test(SqlModalStatus::ConfirmingAnalyzeHigh {
                     query: "DROP TABLE users".to_string(),
                     input: TextInputState::default(),
                     target_name: Some("users".to_string()),
@@ -782,7 +798,7 @@ mod tests {
         #[test]
         fn sets_plan_and_switches_to_plan_tab() {
             let mut state = sql_modal_state();
-            state.sql_modal.set_status(SqlModalStatus::Running);
+            state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
             reduce_explain(
                 &mut state,
@@ -796,7 +812,7 @@ mod tests {
 
             assert_eq!(state.explain.plan_text.as_deref(), Some("Seq Scan"));
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Normal);
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Plan);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
             assert!(!state.query.is_running());
         }
     }
@@ -808,7 +824,7 @@ mod tests {
         #[test]
         fn sets_error_and_switches_to_plan_tab() {
             let mut state = sql_modal_state();
-            state.sql_modal.set_status(SqlModalStatus::Running);
+            state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
             reduce_explain(
                 &mut state,
@@ -821,7 +837,7 @@ mod tests {
                 Some("Query failed: syntax error. Review the database error details and SQL.")
             );
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Normal);
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Plan);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
             assert!(!state.query.is_running());
         }
     }
@@ -1077,37 +1093,37 @@ mod tests {
         #[test]
         fn next_tab_switches_sql_to_plan() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Sql;
+            state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
             reduce_explain(&mut state, &Action::SqlModalNextTab, Instant::now());
 
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Plan);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
         }
 
         #[test]
         fn next_tab_switches_plan_to_compare() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Plan;
+            state.sql_modal.set_active_tab(SqlModalTab::Plan);
 
             reduce_explain(&mut state, &Action::SqlModalNextTab, Instant::now());
 
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Compare);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Compare);
         }
 
         #[test]
         fn next_tab_switches_compare_to_sql() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Compare;
+            state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
             reduce_explain(&mut state, &Action::SqlModalNextTab, Instant::now());
 
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
         #[test]
         fn next_tab_stays_on_sql_when_explain_is_unsupported() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Sql;
+            state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
             reduce_explain_with_services(
                 &mut state,
@@ -1116,13 +1132,13 @@ mod tests {
                 &services_without_explain(),
             );
 
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
         #[test]
         fn next_tab_normalizes_stale_plan_to_sql_when_explain_is_unsupported() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Plan;
+            state.sql_modal.set_active_tab(SqlModalTab::Plan);
 
             reduce_explain_with_services(
                 &mut state,
@@ -1131,43 +1147,43 @@ mod tests {
                 &services_without_explain(),
             );
 
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
         #[test]
         fn prev_tab_switches_sql_to_compare() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Sql;
+            state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
             reduce_explain(&mut state, &Action::SqlModalPrevTab, Instant::now());
 
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Compare);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Compare);
         }
 
         #[test]
         fn prev_tab_switches_compare_to_plan() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Compare;
+            state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
             reduce_explain(&mut state, &Action::SqlModalPrevTab, Instant::now());
 
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Plan);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
         }
 
         #[test]
         fn prev_tab_switches_plan_to_sql() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Plan;
+            state.sql_modal.set_active_tab(SqlModalTab::Plan);
 
             reduce_explain(&mut state, &Action::SqlModalPrevTab, Instant::now());
 
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
         #[test]
         fn prev_tab_stays_on_sql_when_explain_is_unsupported() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Sql;
+            state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
             reduce_explain_with_services(
                 &mut state,
@@ -1176,13 +1192,13 @@ mod tests {
                 &services_without_explain(),
             );
 
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
         #[test]
         fn prev_tab_normalizes_stale_compare_to_sql_when_explain_is_unsupported() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Compare;
+            state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
             reduce_explain_with_services(
                 &mut state,
@@ -1191,7 +1207,7 @@ mod tests {
                 &services_without_explain(),
             );
 
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
     }
 }

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -45,15 +45,15 @@ fn handle_key_event(combo: KeyCombo, state: &AppState, services: &AppServices) -
         InputMode::CommandPalette => pickers::handle_command_palette_keys(combo),
         InputMode::Help => overlays::handle_help_keys(combo),
         InputMode::SqlModal => {
-            let completion_visible = state.sql_modal.completion.visible
-                && !state.sql_modal.completion.candidates.is_empty();
+            let completion_visible = state.sql_modal.completion().visible
+                && !state.sql_modal.completion().candidates.is_empty();
             sql_modal::handle_sql_modal_keys_with_prefix(
                 combo,
                 completion_visible,
                 state.sql_modal.status(),
                 services
                     .db_capabilities
-                    .normalize_sql_modal_tab(state.sql_modal.active_tab),
+                    .normalize_sql_modal_tab(state.sql_modal.active_tab()),
                 state.ui.key_sequence.pending_prefix(),
             )
         }
@@ -119,7 +119,9 @@ mod tests {
         #[test]
         fn sql_modal_normalizes_unsupported_tab_before_handling_keys() {
             let mut state = make_state(InputMode::SqlModal);
-            state.sql_modal.active_tab = crate::model::sql_editor::modal::SqlModalTab::Plan;
+            state
+                .sql_modal
+                .set_active_tab(crate::model::sql_editor::modal::SqlModalTab::Plan);
 
             let mut services = AppServices::stub();
             services.db_capabilities = crate::model::shared::db_capabilities::DbCapabilities::new(

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -84,7 +84,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
         }
         Action::CloseModal(ModalKind::SqlModal) => {
             state.modal.set_mode(InputMode::Normal);
-            state.sql_modal.close();
+            state.sql_modal.cleanup_on_close();
             state.flash_timers.clear(FlashId::SqlModal);
             Some(vec![])
         }
@@ -1084,17 +1084,14 @@ mod tests {
                 state
                     .sql_modal
                     .set_status_for_test(crate::model::sql_editor::modal::SqlModalStatus::Editing);
-                state.sql_modal.completion_mut_for_navigation().visible = true;
-                state.sql_modal.completion_mut_for_navigation().candidates =
+                state.sql_modal.completion_mut_for_test().visible = true;
+                state.sql_modal.completion_mut_for_test().candidates =
                     vec![crate::model::sql_editor::completion::CompletionCandidate {
                         text: "stale".to_string(),
                         kind: crate::model::sql_editor::completion::CompletionKind::Keyword,
                         score: 1,
                     }];
-                state
-                    .sql_modal
-                    .completion_mut_for_navigation()
-                    .selected_index = 3;
+                state.sql_modal.completion_mut_for_test().selected_index = 3;
                 let test_conn = ConnectionId::from_string("test-conn");
                 state
                     .query_history_picker
@@ -1113,21 +1110,9 @@ mod tests {
                     state.sql_modal.status(),
                     crate::model::sql_editor::modal::SqlModalStatus::Normal
                 ));
-                assert!(!state.sql_modal.completion_mut_for_navigation().visible);
-                assert!(
-                    state
-                        .sql_modal
-                        .completion_mut_for_navigation()
-                        .candidates
-                        .is_empty()
-                );
-                assert_eq!(
-                    state
-                        .sql_modal
-                        .completion_mut_for_navigation()
-                        .selected_index,
-                    0
-                );
+                assert!(!state.sql_modal.completion().visible);
+                assert!(state.sql_modal.completion().candidates.is_empty());
+                assert_eq!(state.sql_modal.completion().selected_index, 0);
             }
 
             #[test]

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -84,8 +84,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
         }
         Action::CloseModal(ModalKind::SqlModal) => {
             state.modal.set_mode(InputMode::Normal);
-            state.sql_modal.completion.visible = false;
-            state.sql_modal.completion_debounce = None;
+            state.sql_modal.close();
             state.flash_timers.clear(FlashId::SqlModal);
             Some(vec![])
         }
@@ -170,8 +169,8 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             if state.modal.active_mode() == InputMode::ConfirmDialog {
                 return Some(vec![]);
             }
-            if state.sql_modal.completion.visible
-                && !state.sql_modal.completion.candidates.is_empty()
+            if state.sql_modal.completion().visible
+                && !state.sql_modal.completion().candidates.is_empty()
             {
                 return Some(vec![]);
             }
@@ -250,20 +249,10 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             match origin {
                 InputMode::Normal => {
                     state.modal.set_mode(InputMode::SqlModal);
-                    state.sql_modal.active_tab = crate::model::sql_editor::modal::SqlModalTab::Sql;
-                    state
-                        .sql_modal
-                        .set_status(crate::model::sql_editor::modal::SqlModalStatus::Normal);
-                    state.sql_modal.editor.set_content(query);
-                    state.sql_modal.reset_completion();
+                    state.sql_modal.load_query_from_history(query);
                 }
                 InputMode::SqlModal => {
-                    state.sql_modal.active_tab = crate::model::sql_editor::modal::SqlModalTab::Sql;
-                    state.sql_modal.editor.set_content(query);
-                    state
-                        .sql_modal
-                        .set_status(crate::model::sql_editor::modal::SqlModalStatus::Normal);
-                    state.sql_modal.reset_completion();
+                    state.sql_modal.load_query_from_history(query);
                 }
                 _ => {}
             }
@@ -1094,15 +1083,18 @@ mod tests {
                 state.sql_modal.editor.set_content("old query".to_string());
                 state
                     .sql_modal
-                    .set_status(crate::model::sql_editor::modal::SqlModalStatus::Editing);
-                state.sql_modal.completion.visible = true;
-                state.sql_modal.completion.candidates =
+                    .set_status_for_test(crate::model::sql_editor::modal::SqlModalStatus::Editing);
+                state.sql_modal.completion_mut_for_navigation().visible = true;
+                state.sql_modal.completion_mut_for_navigation().candidates =
                     vec![crate::model::sql_editor::completion::CompletionCandidate {
                         text: "stale".to_string(),
                         kind: crate::model::sql_editor::completion::CompletionKind::Keyword,
                         score: 1,
                     }];
-                state.sql_modal.completion.selected_index = 3;
+                state
+                    .sql_modal
+                    .completion_mut_for_navigation()
+                    .selected_index = 3;
                 let test_conn = ConnectionId::from_string("test-conn");
                 state
                     .query_history_picker
@@ -1121,9 +1113,21 @@ mod tests {
                     state.sql_modal.status(),
                     crate::model::sql_editor::modal::SqlModalStatus::Normal
                 ));
-                assert!(!state.sql_modal.completion.visible);
-                assert!(state.sql_modal.completion.candidates.is_empty());
-                assert_eq!(state.sql_modal.completion.selected_index, 0);
+                assert!(!state.sql_modal.completion_mut_for_navigation().visible);
+                assert!(
+                    state
+                        .sql_modal
+                        .completion_mut_for_navigation()
+                        .candidates
+                        .is_empty()
+                );
+                assert_eq!(
+                    state
+                        .sql_modal
+                        .completion_mut_for_navigation()
+                        .selected_index,
+                    0
+                );
             }
 
             #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -621,7 +621,7 @@ mod tests {
             assert_eq!(state.sql_modal.editor.content(), "a");
             assert_eq!(state.sql_modal.editor.cursor(), 1);
             assert!(effects.is_empty());
-            assert!(state.sql_modal.completion_debounce.is_some());
+            assert!(state.sql_modal.completion_debounce().is_some());
         }
 
         #[test]
@@ -642,7 +642,7 @@ mod tests {
             assert_eq!(state.sql_modal.editor.content(), "a");
             assert_eq!(state.sql_modal.editor.cursor(), 1);
             assert!(effects.is_empty());
-            assert!(state.sql_modal.completion_debounce.is_some());
+            assert!(state.sql_modal.completion_debounce().is_some());
         }
 
         #[test]
@@ -661,7 +661,7 @@ mod tests {
             );
 
             let expected = now + Duration::from_millis(100);
-            assert_eq!(state.sql_modal.completion_debounce, Some(expected));
+            assert_eq!(state.sql_modal.completion_debounce(), Some(expected));
         }
     }
 
@@ -680,8 +680,12 @@ mod tests {
         #[test]
         fn completion_next_wraps_around() {
             let mut state = create_test_state();
-            state.sql_modal.completion.candidates = vec![make_candidate("a"), make_candidate("b")];
-            state.sql_modal.completion.selected_index = 1;
+            state.sql_modal.completion_mut_for_navigation().candidates =
+                vec![make_candidate("a"), make_candidate("b")];
+            state
+                .sql_modal
+                .completion_mut_for_navigation()
+                .selected_index = 1;
             let now = Instant::now();
 
             let effects = reduce(
@@ -691,15 +695,25 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.sql_modal.completion.selected_index, 0);
+            assert_eq!(
+                state
+                    .sql_modal
+                    .completion_mut_for_navigation()
+                    .selected_index,
+                0
+            );
             assert!(effects.is_empty());
         }
 
         #[test]
         fn completion_prev_wraps_around() {
             let mut state = create_test_state();
-            state.sql_modal.completion.candidates = vec![make_candidate("a"), make_candidate("b")];
-            state.sql_modal.completion.selected_index = 0;
+            state.sql_modal.completion_mut_for_navigation().candidates =
+                vec![make_candidate("a"), make_candidate("b")];
+            state
+                .sql_modal
+                .completion_mut_for_navigation()
+                .selected_index = 0;
             let now = Instant::now();
 
             let effects = reduce(
@@ -709,7 +723,13 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.sql_modal.completion.selected_index, 1);
+            assert_eq!(
+                state
+                    .sql_modal
+                    .completion_mut_for_navigation()
+                    .selected_index,
+                1
+            );
             assert!(effects.is_empty());
         }
     }

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -600,6 +600,7 @@ mod tests {
     mod sql_modal_debounce {
         use super::*;
         use crate::model::shared::text_input::TextInputLike;
+        use crate::model::sql_editor::modal::SqlModalStatus;
         use std::time::Duration;
 
         #[test]
@@ -663,6 +664,31 @@ mod tests {
             let expected = now + Duration::from_millis(100);
             assert_eq!(state.sql_modal.completion_debounce(), Some(expected));
         }
+
+        #[test]
+        fn text_input_preserves_visible_completion_popup() {
+            let mut state = create_test_state();
+            state.modal.set_mode(InputMode::SqlModal);
+            state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
+            state.sql_modal.completion_mut_for_test().visible = true;
+            let now = Instant::now();
+
+            reduce(
+                &mut state,
+                Action::TextInput {
+                    target: InputTarget::SqlModal,
+                    ch: 'x',
+                },
+                now,
+                &AppServices::stub(),
+            );
+
+            assert!(state.sql_modal.completion().visible);
+            assert_eq!(
+                state.sql_modal.completion_debounce(),
+                Some(now + Duration::from_millis(100))
+            );
+        }
     }
 
     mod completion_ui {
@@ -680,12 +706,9 @@ mod tests {
         #[test]
         fn completion_next_wraps_around() {
             let mut state = create_test_state();
-            state.sql_modal.completion_mut_for_navigation().candidates =
+            state.sql_modal.completion_mut_for_test().candidates =
                 vec![make_candidate("a"), make_candidate("b")];
-            state
-                .sql_modal
-                .completion_mut_for_navigation()
-                .selected_index = 1;
+            state.sql_modal.completion_mut_for_test().selected_index = 1;
             let now = Instant::now();
 
             let effects = reduce(
@@ -695,25 +718,16 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(
-                state
-                    .sql_modal
-                    .completion_mut_for_navigation()
-                    .selected_index,
-                0
-            );
+            assert_eq!(state.sql_modal.completion().selected_index, 0);
             assert!(effects.is_empty());
         }
 
         #[test]
         fn completion_prev_wraps_around() {
             let mut state = create_test_state();
-            state.sql_modal.completion_mut_for_navigation().candidates =
+            state.sql_modal.completion_mut_for_test().candidates =
                 vec![make_candidate("a"), make_candidate("b")];
-            state
-                .sql_modal
-                .completion_mut_for_navigation()
-                .selected_index = 0;
+            state.sql_modal.completion_mut_for_test().selected_index = 0;
             let now = Instant::now();
 
             let effects = reduce(
@@ -723,13 +737,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(
-                state
-                    .sql_modal
-                    .completion_mut_for_navigation()
-                    .selected_index,
-                1
-            );
+            assert_eq!(state.sql_modal.completion().selected_index, 1);
             assert!(effects.is_empty());
         }
     }

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -693,6 +693,7 @@ mod tests {
 
     mod completion_ui {
         use super::*;
+        use crate::model::shared::text_input::TextInputLike;
         use crate::model::sql_editor::completion::{CompletionCandidate, CompletionKind};
 
         fn make_candidate(text: &str) -> CompletionCandidate {
@@ -738,6 +739,32 @@ mod tests {
             );
 
             assert_eq!(state.sql_modal.completion().selected_index, 1);
+            assert!(effects.is_empty());
+        }
+
+        #[test]
+        fn completion_accept_dismisses_when_cursor_precedes_trigger() {
+            let mut state = create_test_state();
+            state.modal.set_mode(InputMode::SqlModal);
+            state
+                .sql_modal
+                .editor
+                .set_content_with_cursor("SELECT ".to_string(), 0);
+            state
+                .sql_modal
+                .apply_completion_update(&[make_candidate("users")], 7, true);
+            let now = Instant::now();
+
+            let effects = reduce(
+                &mut state,
+                Action::CompletionAccept,
+                now,
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.sql_modal.editor.content(), "SELECT ");
+            assert_eq!(state.sql_modal.editor.cursor(), 0);
+            assert!(!state.sql_modal.completion().visible);
             assert!(effects.is_empty());
         }
     }

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -290,6 +290,11 @@ pub fn reduce_sql_modal(
             if let Some((trigger_pos, replacement)) =
                 state.sql_modal.selected_completion_replacement()
             {
+                if state.sql_modal.editor.cursor() < trigger_pos {
+                    state.sql_modal.dismiss_completion();
+                    return Some(vec![]);
+                }
+
                 let start_byte = state.sql_modal.editor.char_to_byte_index(trigger_pos);
                 let end_byte = state
                     .sql_modal

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -29,32 +29,31 @@ pub fn reduce_sql_modal(
     match action {
         // Completion navigation
         Action::CompletionNext => {
-            if !state.sql_modal.completion.candidates.is_empty() {
-                let max = state.sql_modal.completion.candidates.len() - 1;
-                state.sql_modal.completion.selected_index =
-                    if state.sql_modal.completion.selected_index >= max {
-                        0
-                    } else {
-                        state.sql_modal.completion.selected_index + 1
-                    };
+            let completion = state.sql_modal.completion_mut_for_navigation();
+            if !completion.candidates.is_empty() {
+                let max = completion.candidates.len() - 1;
+                completion.selected_index = if completion.selected_index >= max {
+                    0
+                } else {
+                    completion.selected_index + 1
+                };
             }
             Some(vec![])
         }
         Action::CompletionPrev => {
-            if !state.sql_modal.completion.candidates.is_empty() {
-                let max = state.sql_modal.completion.candidates.len() - 1;
-                state.sql_modal.completion.selected_index =
-                    if state.sql_modal.completion.selected_index == 0 {
-                        max
-                    } else {
-                        state.sql_modal.completion.selected_index - 1
-                    };
+            let completion = state.sql_modal.completion_mut_for_navigation();
+            if !completion.candidates.is_empty() {
+                let max = completion.candidates.len() - 1;
+                completion.selected_index = if completion.selected_index == 0 {
+                    max
+                } else {
+                    completion.selected_index - 1
+                };
             }
             Some(vec![])
         }
         Action::CompletionDismiss => {
-            state.sql_modal.completion.visible = false;
-            state.sql_modal.completion_debounce = None;
+            state.sql_modal.dismiss_completion();
             Some(vec![])
         }
 
@@ -69,9 +68,10 @@ pub fn reduce_sql_modal(
                 .sql_modal
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
-            state.sql_modal.completion.visible = false;
-            state.sql_modal.completion_debounce = Some(now + Duration::from_millis(100));
-            state.sql_modal.set_status(SqlModalStatus::Editing);
+            state
+                .sql_modal
+                .schedule_completion(now + Duration::from_millis(100));
+            state.sql_modal.enter_editing();
             Some(vec![])
         }
 
@@ -80,57 +80,67 @@ pub fn reduce_sql_modal(
             target: InputTarget::SqlModal,
             ch: c,
         } => {
-            state.sql_modal.set_status(SqlModalStatus::Editing);
+            state.sql_modal.enter_editing();
             state.sql_modal.editor.insert_char(*c);
             state
                 .sql_modal
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
-            state.sql_modal.completion_debounce = Some(now + Duration::from_millis(100));
+            state
+                .sql_modal
+                .schedule_completion(now + Duration::from_millis(100));
             Some(vec![])
         }
         Action::TextBackspace {
             target: InputTarget::SqlModal,
         } => {
-            state.sql_modal.set_status(SqlModalStatus::Editing);
+            state.sql_modal.enter_editing();
             state.sql_modal.editor.backspace();
             state
                 .sql_modal
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
-            state.sql_modal.completion_debounce = Some(now + Duration::from_millis(100));
+            state
+                .sql_modal
+                .schedule_completion(now + Duration::from_millis(100));
             Some(vec![])
         }
         Action::TextDelete {
             target: InputTarget::SqlModal,
         } => {
-            state.sql_modal.set_status(SqlModalStatus::Editing);
+            state.sql_modal.enter_editing();
             state.sql_modal.editor.delete();
             state
                 .sql_modal
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
-            state.sql_modal.completion_debounce = Some(now + Duration::from_millis(100));
+            state
+                .sql_modal
+                .schedule_completion(now + Duration::from_millis(100));
             Some(vec![])
         }
         Action::SqlModalNewLine => {
-            state.sql_modal.set_status(SqlModalStatus::Editing);
+            state.sql_modal.enter_editing();
             state.sql_modal.editor.insert_newline();
             state
                 .sql_modal
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
-            state.sql_modal.completion_debounce = Some(now + Duration::from_millis(100));
+            state
+                .sql_modal
+                .schedule_completion(now + Duration::from_millis(100));
             Some(vec![])
         }
         Action::SqlModalTab => {
-            state.sql_modal.set_status(SqlModalStatus::Editing);
+            state.sql_modal.enter_editing();
             state.sql_modal.editor.insert_tab();
             state
                 .sql_modal
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
-            state.sql_modal.completion_debounce = Some(now + Duration::from_millis(100));
+            state
+                .sql_modal
+                .schedule_completion(now + Duration::from_millis(100));
             Some(vec![])
         }
         Action::TextMoveCursor {
@@ -157,8 +167,7 @@ pub fn reduce_sql_modal(
         }
         Action::SqlModalClear => {
             state.sql_modal.editor.clear();
-            state.sql_modal.completion.visible = false;
-            state.sql_modal.completion.candidates.clear();
+            state.sql_modal.reset_completion();
             state.ui.key_sequence = KeySequenceState::Idle;
             Some(vec![])
         }
@@ -166,12 +175,7 @@ pub fn reduce_sql_modal(
         // Modal open/submit
         Action::OpenModal(ModalKind::SqlModal) => {
             state.modal.set_mode(InputMode::SqlModal);
-            state.sql_modal.set_status(SqlModalStatus::Normal);
-            state.sql_modal.active_tab = SqlModalTab::Sql;
-            state.sql_modal.completion.visible = false;
-            state.sql_modal.completion.candidates.clear();
-            state.sql_modal.completion.selected_index = 0;
-            state.sql_modal.completion_debounce = None;
+            state.sql_modal.open_sql_tab();
             state.flash_timers.clear(FlashId::SqlModal);
             if !state.sql_modal.is_prefetch_started() && state.session.metadata().is_some() {
                 Some(vec![Effect::DispatchActions(vec![
@@ -186,11 +190,11 @@ pub fn reduce_sql_modal(
             if query.is_empty() {
                 return Some(vec![]);
             }
-            state.sql_modal.completion.visible = false;
+            state.sql_modal.dismiss_completion();
 
             match evaluate_multi_statement(&query) {
                 MultiStatementDecision::Block { reason } => {
-                    state.sql_modal.mark_adhoc_error(reason);
+                    state.sql_modal.finish_adhoc_error(reason);
                     Some(vec![])
                 }
                 MultiStatementDecision::Allow {
@@ -208,22 +212,20 @@ pub fn reduce_sql_modal(
                         !matches!(kind, StatementKind::Select | StatementKind::Transaction)
                     });
                     if state.session.read_only && has_write {
-                        state.sql_modal.mark_adhoc_error(
+                        state.sql_modal.finish_adhoc_error(
                             "Read-only mode: write operations are disabled".to_string(),
                         );
                         return Some(vec![]);
                     }
                     match risk.confirmation {
                         ConfirmationType::Immediate => {
-                            state.sql_modal.set_status(SqlModalStatus::Running);
+                            state.sql_modal.begin_adhoc_running();
                             Some(adhoc_effects(state, query))
                         }
                         ConfirmationType::TableNameInput { target } => {
-                            state.sql_modal.set_status(SqlModalStatus::ConfirmingHigh {
-                                decision,
-                                input: TextInputState::default(),
-                                target_name: Some(target),
-                            });
+                            state
+                                .sql_modal
+                                .begin_confirming_high(decision, Some(target));
                             Some(vec![])
                         }
                     }
@@ -235,7 +237,7 @@ pub fn reduce_sql_modal(
                 state.sql_modal.status(),
                 SqlModalStatus::ConfirmingHigh { .. }
             ) {
-                state.sql_modal.set_status(SqlModalStatus::Normal);
+                state.sql_modal.cancel_confirmation();
                 state.ui.key_sequence = KeySequenceState::Idle;
                 Some(vec![])
             } else {
@@ -287,7 +289,7 @@ pub fn reduce_sql_modal(
             );
             if matched {
                 let query = state.sql_modal.editor.content().trim().to_string();
-                state.sql_modal.set_status(SqlModalStatus::Running);
+                state.sql_modal.begin_adhoc_running();
                 if let Some(dsn) = &state.session.dsn {
                     return Some(vec![Effect::ExecuteAdhoc {
                         dsn: dsn.clone(),
@@ -301,12 +303,13 @@ pub fn reduce_sql_modal(
 
         // Completion accept
         Action::CompletionAccept => {
-            if state.sql_modal.completion.visible
-                && !state.sql_modal.completion.candidates.is_empty()
+            if state.sql_modal.completion().visible
+                && !state.sql_modal.completion().candidates.is_empty()
             {
-                let selected_idx = state.sql_modal.completion.selected_index;
-                let trigger_pos = state.sql_modal.completion.trigger_position;
-                let candidates = std::mem::take(&mut state.sql_modal.completion.candidates);
+                let selected_idx = state.sql_modal.completion().selected_index;
+                let trigger_pos = state.sql_modal.completion().trigger_position;
+                let candidates =
+                    std::mem::take(&mut state.sql_modal.completion_mut_for_navigation().candidates);
 
                 if let Some(candidate) = candidates.into_iter().nth(selected_idx) {
                     let start_byte = state.sql_modal.editor.char_to_byte_index(trigger_pos);
@@ -330,8 +333,7 @@ pub fn reduce_sql_modal(
                         .editor
                         .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
                 }
-                state.sql_modal.completion.visible = false;
-                state.sql_modal.completion_debounce = None;
+                state.sql_modal.dismiss_completion();
             }
             Some(vec![])
         }
@@ -343,10 +345,9 @@ pub fn reduce_sql_modal(
             trigger_position,
             visible,
         } => {
-            state.sql_modal.completion.candidates.clone_from(candidates);
-            state.sql_modal.completion.trigger_position = *trigger_position;
-            state.sql_modal.completion.visible = *visible;
-            state.sql_modal.completion.selected_index = 0;
+            state
+                .sql_modal
+                .apply_completion_update(candidates, *trigger_position, *visible);
             Some(vec![])
         }
 
@@ -356,23 +357,21 @@ pub fn reduce_sql_modal(
                 .sql_modal
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
-            state.sql_modal.set_status(SqlModalStatus::Editing);
+            state.sql_modal.enter_editing();
             Some(vec![])
         }
         Action::SqlModalEnterInsert => {
-            state.sql_modal.set_status(SqlModalStatus::Editing);
+            state.sql_modal.enter_editing();
             Some(vec![])
         }
         Action::SqlModalEnterNormal => {
-            state.sql_modal.set_status(SqlModalStatus::Normal);
-            state.sql_modal.completion.visible = false;
-            state.sql_modal.completion_debounce = None;
+            state.sql_modal.enter_normal();
             Some(vec![])
         }
         Action::SqlModalYank => {
             let active_tab = services
                 .db_capabilities
-                .normalize_sql_modal_tab(state.sql_modal.active_tab);
+                .normalize_sql_modal_tab(state.sql_modal.active_tab());
             let content = match active_tab {
                 SqlModalTab::Plan => state.explain.plan_text.clone(),
                 SqlModalTab::Compare => match (&state.explain.left, &state.explain.right) {
@@ -498,7 +497,7 @@ mod tests {
 
         fn editing_state() -> AppState {
             let mut state = sql_modal_state();
-            state.sql_modal.set_status(SqlModalStatus::Editing);
+            state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
             state
         }
 
@@ -561,11 +560,11 @@ mod tests {
         #[test]
         fn dismisses_completion() {
             let mut state = editing_state();
-            state.sql_modal.completion.visible = true;
+            state.sql_modal.completion_mut_for_navigation().visible = true;
 
             reduce_sql_modal(&mut state, &Action::Paste("x".to_string()), Instant::now());
 
-            assert!(!state.sql_modal.completion.visible);
+            assert!(!state.sql_modal.completion_mut_for_navigation().visible);
         }
 
         #[test]
@@ -593,14 +592,16 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DROP TABLE users".to_string());
-            state.sql_modal.set_status(SqlModalStatus::ConfirmingHigh {
-                decision: crate::policy::write::write_guardrails::AdhocRiskDecision {
-                    risk_level: RiskLevel::High,
-                    label: "DROP",
-                },
-                input: TextInputState::default(),
-                target_name: Some("users".to_string()),
-            });
+            state
+                .sql_modal
+                .set_status_for_test(SqlModalStatus::ConfirmingHigh {
+                    decision: crate::policy::write::write_guardrails::AdhocRiskDecision {
+                        risk_level: RiskLevel::High,
+                        label: "DROP",
+                    },
+                    input: TextInputState::default(),
+                    target_name: Some("users".to_string()),
+                });
 
             reduce_sql_modal(
                 &mut state,
@@ -624,7 +625,7 @@ mod tests {
         fn moves_down_without_scrolling_while_cursor_stays_inside_visible_rows() {
             let mut state = sql_modal_state();
             state.ui.terminal_height = 20;
-            state.sql_modal.set_status(SqlModalStatus::Normal);
+            state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
             state
                 .sql_modal
                 .editor
@@ -649,7 +650,7 @@ mod tests {
         fn scrolls_once_cursor_moves_past_visible_rows() {
             let mut state = sql_modal_state();
             state.ui.terminal_height = 20;
-            state.sql_modal.set_status(SqlModalStatus::Normal);
+            state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
             state
                 .sql_modal
                 .editor
@@ -679,14 +680,16 @@ mod tests {
         fn confirming_high_state(content: &str, target: Option<&str>) -> AppState {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content(content.to_string());
-            state.sql_modal.set_status(SqlModalStatus::ConfirmingHigh {
-                decision: AdhocRiskDecision {
-                    risk_level: RiskLevel::High,
-                    label: "DROP",
-                },
-                input: TextInputState::default(),
-                target_name: target.map(ToString::to_string),
-            });
+            state
+                .sql_modal
+                .set_status_for_test(SqlModalStatus::ConfirmingHigh {
+                    decision: AdhocRiskDecision {
+                        risk_level: RiskLevel::High,
+                        label: "DROP",
+                    },
+                    input: TextInputState::default(),
+                    target_name: target.map(ToString::to_string),
+                });
             state
         }
 
@@ -1053,7 +1056,7 @@ mod tests {
             state.session.read_only = true;
 
             // Simulate a prior adhoc success
-            state.sql_modal.mark_adhoc_success(
+            state.sql_modal.finish_adhoc_success(
                 crate::model::sql_editor::modal::AdhocSuccessSnapshot {
                     command_tag: None,
                     row_count: 5,
@@ -1152,7 +1155,7 @@ mod tests {
         #[test]
         fn append_insert_moves_to_line_end_and_transitions_to_editing() {
             let mut state = sql_modal_state();
-            state.sql_modal.set_status(SqlModalStatus::Normal);
+            state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
             state
                 .sql_modal
                 .editor
@@ -1176,19 +1179,19 @@ mod tests {
         #[test]
         fn enter_normal_transitions_to_normal() {
             let mut state = sql_modal_state();
-            state.sql_modal.set_status(SqlModalStatus::Editing);
-            state.sql_modal.completion.visible = true;
+            state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
+            state.sql_modal.completion_mut_for_navigation().visible = true;
 
             reduce_sql_modal(&mut state, &Action::SqlModalEnterNormal, Instant::now());
 
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Normal);
-            assert!(!state.sql_modal.completion.visible);
+            assert!(!state.sql_modal.completion_mut_for_navigation().visible);
         }
 
         #[test]
         fn vertical_move_after_edit_uses_current_column() {
             let mut state = sql_modal_state();
-            state.sql_modal.set_status(SqlModalStatus::Normal);
+            state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
             state
                 .sql_modal
                 .editor
@@ -1276,7 +1279,7 @@ mod tests {
         #[test]
         fn open_sql_modal_resets_active_tab_to_sql() {
             let mut state = AppState::new("test".to_string());
-            state.sql_modal.active_tab = SqlModalTab::Plan;
+            state.sql_modal.set_active_tab(SqlModalTab::Plan);
 
             reduce_sql_modal(
                 &mut state,
@@ -1284,7 +1287,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.sql_modal.active_tab, SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
         #[test]
@@ -1327,7 +1330,7 @@ mod tests {
         fn sql_tab_yank_copies_content() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.sql_modal.active_tab = SqlModalTab::Sql;
+            state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
@@ -1342,7 +1345,7 @@ mod tests {
         fn sql_tab_yank_empty_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content(String::new());
-            state.sql_modal.active_tab = SqlModalTab::Sql;
+            state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
@@ -1353,7 +1356,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_copies_plan_text() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Plan;
+            state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = Some("Seq Scan on users".to_string());
 
             let effects =
@@ -1368,7 +1371,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_no_plan_is_noop() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Plan;
+            state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = None;
 
             let effects =
@@ -1380,7 +1383,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_error_state_is_noop() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Plan;
+            state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = None;
             state.explain.error = Some("syntax error".to_string());
 
@@ -1393,7 +1396,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_both_slots() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Compare;
+            state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 420, SlotSource::AutoPrevious));
             state.explain.right = Some(make_slot("Index Scan", true, 50, SlotSource::AutoLatest));
 
@@ -1417,7 +1420,7 @@ mod tests {
         #[test]
         fn both_auto_slots_yank_returns_distinguishable_headers() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Compare;
+            state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 300, SlotSource::AutoPrevious));
             state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
 
@@ -1436,7 +1439,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_right_only_is_noop() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Compare;
+            state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = None;
             state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
 
@@ -1449,7 +1452,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_left_only_is_noop() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Compare;
+            state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 200, SlotSource::AutoPrevious));
             state.explain.right = None;
 
@@ -1462,7 +1465,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_empty_is_noop() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Compare;
+            state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = None;
             state.explain.right = None;
 
@@ -1475,7 +1478,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_includes_verdict_with_reasons() {
             let mut state = sql_modal_state();
-            state.sql_modal.active_tab = SqlModalTab::Compare;
+            state.sql_modal.set_active_tab(SqlModalTab::Compare);
             // Use parseable EXPLAIN output so compare_plans produces a real verdict
             state.explain.left = Some(CompareSlot {
                 plan: ExplainPlan {

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -29,27 +29,11 @@ pub fn reduce_sql_modal(
     match action {
         // Completion navigation
         Action::CompletionNext => {
-            let completion = state.sql_modal.completion_mut_for_navigation();
-            if !completion.candidates.is_empty() {
-                let max = completion.candidates.len() - 1;
-                completion.selected_index = if completion.selected_index >= max {
-                    0
-                } else {
-                    completion.selected_index + 1
-                };
-            }
+            state.sql_modal.completion_next();
             Some(vec![])
         }
         Action::CompletionPrev => {
-            let completion = state.sql_modal.completion_mut_for_navigation();
-            if !completion.candidates.is_empty() {
-                let max = completion.candidates.len() - 1;
-                completion.selected_index = if completion.selected_index == 0 {
-                    max
-                } else {
-                    completion.selected_index - 1
-                };
-            }
+            state.sql_modal.completion_prev();
             Some(vec![])
         }
         Action::CompletionDismiss => {
@@ -70,7 +54,7 @@ pub fn reduce_sql_modal(
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
             state
                 .sql_modal
-                .schedule_completion(now + Duration::from_millis(100));
+                .schedule_completion_after_dismiss(now + Duration::from_millis(100));
             state.sql_modal.enter_editing();
             Some(vec![])
         }
@@ -303,36 +287,29 @@ pub fn reduce_sql_modal(
 
         // Completion accept
         Action::CompletionAccept => {
-            if state.sql_modal.completion().visible
-                && !state.sql_modal.completion().candidates.is_empty()
+            if let Some((trigger_pos, replacement)) =
+                state.sql_modal.selected_completion_replacement()
             {
-                let selected_idx = state.sql_modal.completion().selected_index;
-                let trigger_pos = state.sql_modal.completion().trigger_position;
-                let candidates =
-                    std::mem::take(&mut state.sql_modal.completion_mut_for_navigation().candidates);
-
-                if let Some(candidate) = candidates.into_iter().nth(selected_idx) {
-                    let start_byte = state.sql_modal.editor.char_to_byte_index(trigger_pos);
-                    let end_byte = state
-                        .sql_modal
-                        .editor
-                        .char_to_byte_index(state.sql_modal.editor.cursor());
-                    // Manually manipulate the underlying content for drain + insert_str at byte level.
-                    // This is the one place where we need byte-level access that MultiLineInputState
-                    // doesn't directly support, so we rebuild via set_content.
-                    let mut content = state.sql_modal.editor.content().to_string();
-                    content.drain(start_byte..end_byte);
-                    content.insert_str(start_byte, &candidate.text);
-                    let new_cursor = trigger_pos + candidate.text.chars().count();
-                    state
-                        .sql_modal
-                        .editor
-                        .set_content_with_cursor(content, new_cursor);
-                    state
-                        .sql_modal
-                        .editor
-                        .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
-                }
+                let start_byte = state.sql_modal.editor.char_to_byte_index(trigger_pos);
+                let end_byte = state
+                    .sql_modal
+                    .editor
+                    .char_to_byte_index(state.sql_modal.editor.cursor());
+                // Manually manipulate the underlying content for drain + insert_str at byte level.
+                // This is the one place where we need byte-level access that MultiLineInputState
+                // doesn't directly support, so we rebuild via set_content.
+                let mut content = state.sql_modal.editor.content().to_string();
+                content.drain(start_byte..end_byte);
+                content.insert_str(start_byte, &replacement);
+                let new_cursor = trigger_pos + replacement.chars().count();
+                state
+                    .sql_modal
+                    .editor
+                    .set_content_with_cursor(content, new_cursor);
+                state
+                    .sql_modal
+                    .editor
+                    .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
                 state.sql_modal.dismiss_completion();
             }
             Some(vec![])
@@ -560,11 +537,11 @@ mod tests {
         #[test]
         fn dismisses_completion() {
             let mut state = editing_state();
-            state.sql_modal.completion_mut_for_navigation().visible = true;
+            state.sql_modal.completion_mut_for_test().visible = true;
 
             reduce_sql_modal(&mut state, &Action::Paste("x".to_string()), Instant::now());
 
-            assert!(!state.sql_modal.completion_mut_for_navigation().visible);
+            assert!(!state.sql_modal.completion().visible);
         }
 
         #[test]
@@ -1180,12 +1157,12 @@ mod tests {
         fn enter_normal_transitions_to_normal() {
             let mut state = sql_modal_state();
             state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
-            state.sql_modal.completion_mut_for_navigation().visible = true;
+            state.sql_modal.completion_mut_for_test().visible = true;
 
             reduce_sql_modal(&mut state, &Action::SqlModalEnterNormal, Instant::now());
 
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Normal);
-            assert!(!state.sql_modal.completion_mut_for_navigation().visible);
+            assert!(!state.sql_modal.completion().visible);
         }
 
         #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,10 +206,10 @@ async fn main() -> Result<()> {
             }
         }
 
-        if let Some(debounce_until) = state.sql_modal.completion_debounce
+        if let Some(debounce_until) = state.sql_modal.completion_debounce()
             && Instant::now() >= debounce_until
         {
-            state.sql_modal.completion_debounce = None;
+            state.sql_modal.consume_completion_debounce();
             process_action(
                 Action::CompletionTrigger,
                 &mut state,

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -32,12 +32,9 @@ fn sql_modal_completion_popup_with_scroll() {
     state.sql_modal.editor.set_content("SELECT ".to_string());
     state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
-    state.sql_modal.completion_mut_for_navigation().visible = true;
-    state
-        .sql_modal
-        .completion_mut_for_navigation()
-        .selected_index = 5;
-    state.sql_modal.completion_mut_for_navigation().candidates = vec![
+    state.sql_modal.completion_mut_for_test().visible = true;
+    state.sql_modal.completion_mut_for_test().selected_index = 5;
+    state.sql_modal.completion_mut_for_test().candidates = vec![
         CompletionCandidate {
             text: "users".into(),
             kind: CompletionKind::Table,

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -16,7 +16,7 @@ fn sql_modal_with_completion() {
         .sql_modal
         .editor
         .set_content("SELECT * FROM us".to_string());
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -30,11 +30,14 @@ fn sql_modal_completion_popup_with_scroll() {
 
     state.modal.set_mode(InputMode::SqlModal);
     state.sql_modal.editor.set_content("SELECT ".to_string());
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
-    state.sql_modal.completion.visible = true;
-    state.sql_modal.completion.selected_index = 5;
-    state.sql_modal.completion.candidates = vec![
+    state.sql_modal.completion_mut_for_navigation().visible = true;
+    state
+        .sql_modal
+        .completion_mut_for_navigation()
+        .selected_index = 5;
+    state.sql_modal.completion_mut_for_navigation().candidates = vec![
         CompletionCandidate {
             text: "users".into(),
             kind: CompletionKind::Table,
@@ -99,7 +102,7 @@ fn sql_modal_cursor_at_head() {
 
     state.modal.set_mode(InputMode::SqlModal);
     state.sql_modal.editor = MultiLineInputState::new("SELECT 1", 0);
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -113,7 +116,7 @@ fn sql_modal_cursor_at_middle() {
 
     state.modal.set_mode(InputMode::SqlModal);
     state.sql_modal.editor = MultiLineInputState::new("SELECT 1", 4);
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -127,7 +130,7 @@ fn sql_modal_cursor_at_tail() {
 
     state.modal.set_mode(InputMode::SqlModal);
     state.sql_modal.editor.set_content("SELECT 1".to_string());
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -141,7 +144,7 @@ fn sql_modal_normal_cursor_at_tail() {
 
     state.modal.set_mode(InputMode::SqlModal);
     state.sql_modal.editor.set_content("SELECT 1".to_string());
-    state.sql_modal.set_status(SqlModalStatus::Normal);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -159,7 +162,7 @@ fn sql_modal_success_select() {
         .sql_modal
         .editor
         .set_content("SELECT * FROM users".to_string());
-    state.sql_modal.mark_adhoc_success(AdhocSuccessSnapshot {
+    state.sql_modal.finish_adhoc_success(AdhocSuccessSnapshot {
         command_tag: None,
         row_count: 2,
         execution_time_ms: 15,
@@ -195,7 +198,7 @@ fn sql_modal_success_dml_with_command_tag() {
         .sql_modal
         .editor
         .set_content("DELETE FROM users WHERE id = 1".to_string());
-    state.sql_modal.mark_adhoc_success(AdhocSuccessSnapshot {
+    state.sql_modal.finish_adhoc_success(AdhocSuccessSnapshot {
         command_tag: Some(CommandTag::Delete(3)),
         row_count: 3,
         execution_time_ms: 12,
@@ -228,7 +231,7 @@ fn sql_modal_success_ddl_create_table() {
         .sql_modal
         .editor
         .set_content("CREATE TABLE backup AS SELECT * FROM users".to_string());
-    state.sql_modal.mark_adhoc_success(AdhocSuccessSnapshot {
+    state.sql_modal.finish_adhoc_success(AdhocSuccessSnapshot {
         command_tag: Some(CommandTag::Create("TABLE".to_string())),
         row_count: 0,
         execution_time_ms: 45,
@@ -260,7 +263,7 @@ fn sql_modal_error_with_message() {
         .sql_modal
         .editor
         .set_content("SELECT * FORM users".to_string());
-    state.sql_modal.mark_adhoc_error(
+    state.sql_modal.finish_adhoc_error(
         "ERROR:  syntax error at or near \"FORM\"\nLINE 1: SELECT * FORM users\n                 ^"
             .to_string(),
     );
@@ -282,14 +285,16 @@ fn sql_modal_confirming_high_matched() {
         .set_content("DROP TABLE users".to_string());
     let mut input = TextInputState::default();
     input.set_content("users".to_string());
-    state.sql_modal.set_status(SqlModalStatus::ConfirmingHigh {
-        decision: AdhocRiskDecision {
-            risk_level: RiskLevel::High,
-            label: "DROP",
-        },
-        input,
-        target_name: Some("users".to_string()),
-    });
+    state
+        .sql_modal
+        .set_status_for_test(SqlModalStatus::ConfirmingHigh {
+            decision: AdhocRiskDecision {
+                risk_level: RiskLevel::High,
+                label: "DROP",
+            },
+            input,
+            target_name: Some("users".to_string()),
+        });
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -308,14 +313,16 @@ fn sql_modal_confirming_high_unmatched() {
         .set_content("DROP TABLE users".to_string());
     let mut input = TextInputState::default();
     input.set_content("use".to_string());
-    state.sql_modal.set_status(SqlModalStatus::ConfirmingHigh {
-        decision: AdhocRiskDecision {
-            risk_level: RiskLevel::High,
-            label: "DROP",
-        },
-        input,
-        target_name: Some("users".to_string()),
-    });
+    state
+        .sql_modal
+        .set_status_for_test(SqlModalStatus::ConfirmingHigh {
+            decision: AdhocRiskDecision {
+                risk_level: RiskLevel::High,
+                label: "DROP",
+            },
+            input,
+            target_name: Some("users".to_string()),
+        });
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -332,14 +339,16 @@ fn sql_modal_confirming_high_no_target() {
         .sql_modal
         .editor
         .set_content("DROP TABLE users".to_string());
-    state.sql_modal.set_status(SqlModalStatus::ConfirmingHigh {
-        decision: AdhocRiskDecision {
-            risk_level: RiskLevel::High,
-            label: "DROP",
-        },
-        input: TextInputState::default(),
-        target_name: None,
-    });
+    state
+        .sql_modal
+        .set_status_for_test(SqlModalStatus::ConfirmingHigh {
+            decision: AdhocRiskDecision {
+                risk_level: RiskLevel::High,
+                label: "DROP",
+            },
+            input: TextInputState::default(),
+            target_name: None,
+        });
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -478,7 +487,7 @@ fn sql_modal_plan_tab_placeholder() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::SqlModal);
-    state.sql_modal.active_tab = SqlModalTab::Plan;
+    state.sql_modal.set_active_tab(SqlModalTab::Plan);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -491,7 +500,7 @@ fn sql_modal_plan_tab_with_plan_text() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::SqlModal);
-    state.sql_modal.active_tab = SqlModalTab::Plan;
+    state.sql_modal.set_active_tab(SqlModalTab::Plan);
     state.explain.set_plan(
         "Seq Scan on users  (cost=0.00..35.50 rows=2550 width=36)\n  Filter: (id > 10)".to_string(),
         false,
@@ -510,7 +519,7 @@ fn sql_modal_plan_tab_with_error() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::SqlModal);
-    state.sql_modal.active_tab = SqlModalTab::Plan;
+    state.sql_modal.set_active_tab(SqlModalTab::Plan);
     state
         .explain
         .set_error("ERROR: relation \"nonexistent\" does not exist".to_string());
@@ -526,7 +535,7 @@ fn sql_modal_compare_tab_empty() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::SqlModal);
-    state.sql_modal.active_tab = SqlModalTab::Compare;
+    state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -547,7 +556,7 @@ fn sql_modal_compare_tab_right_only() {
         "SELECT * FROM users WHERE email_verified",
     );
     // Only right slot populated (first EXPLAIN), no left yet
-    state.sql_modal.active_tab = SqlModalTab::Compare;
+    state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -576,7 +585,7 @@ fn sql_modal_compare_tab_with_verdict() {
         5,
         "SELECT * FROM users WHERE id > 10",
     );
-    state.sql_modal.active_tab = SqlModalTab::Compare;
+    state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -603,7 +612,7 @@ fn sql_modal_compare_tab_unavailable() {
         0,
         "ALTER TABLE foo",
     );
-    state.sql_modal.active_tab = SqlModalTab::Compare;
+    state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -633,7 +642,7 @@ fn sql_modal_compare_tab_narrow_stacked() {
         5,
         "SELECT * FROM users WHERE id > 10",
     );
-    state.sql_modal.active_tab = SqlModalTab::Compare;
+    state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -426,7 +426,7 @@ fn sql_modal_keyword_and_number_use_syntax_colors() {
 
     state.modal.set_mode(InputMode::SqlModal);
     state.sql_modal.editor.set_content("SELECT 42".to_string());
-    state.sql_modal.set_status(SqlModalStatus::Normal);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -467,7 +467,7 @@ fn sql_modal_string_comment_and_operator_use_syntax_colors() {
         .sql_modal
         .editor
         .set_content("SELECT 'x'::text -- note".to_string());
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -508,7 +508,7 @@ fn test_contrast_theme_applies_sql_syntax_colors() {
         .sql_modal
         .editor
         .set_content("SELECT 'x' + 42 -- note".to_string());
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let buffer = render_and_get_buffer_at_with_theme(
         &mut terminal,
@@ -582,7 +582,7 @@ fn sql_modal_normal_and_insert_use_distinct_cursor_styles() {
 
     state.modal.set_mode(InputMode::SqlModal);
     state.sql_modal.editor.set_content("SELECT 1".to_string());
-    state.sql_modal.set_status(SqlModalStatus::Normal);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
 
     let normal_buffer = render_and_get_buffer(&mut terminal, &mut state);
     let has_block_cursor = (0..TEST_HEIGHT)
@@ -594,7 +594,7 @@ fn sql_modal_normal_and_insert_use_distinct_cursor_styles() {
             })
         });
 
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let insert_buffer = render_and_get_buffer(&mut terminal, &mut state);
     let has_insert_glyph = (0..TEST_HEIGHT)
@@ -639,7 +639,7 @@ fn sql_modal_normal_cursor_position_tracks_head_middle_and_tail() {
         .sql_modal
         .editor
         .set_content_with_cursor(content.clone(), 0);
-    state.sql_modal.set_status(SqlModalStatus::Normal);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
 
     let head_buffer = render_and_get_buffer(&mut terminal, &mut state);
     let head = sql_modal_block_cursor_position(&head_buffer)
@@ -686,7 +686,7 @@ fn sql_modal_insert_cursor_position_tracks_head_middle_and_tail() {
         .sql_modal
         .editor
         .set_content_with_cursor(content.clone(), 0);
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let head = render_and_get_cursor_position(&mut terminal, &mut state);
 
@@ -719,7 +719,7 @@ fn sql_modal_insert_cursor_uses_display_width_for_wide_chars() {
         .sql_modal
         .editor
         .set_content_with_cursor(content.clone(), 0);
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let head = render_and_get_cursor_position(&mut terminal, &mut state);
 
@@ -741,7 +741,7 @@ fn sql_modal_insert_cursor_advances_visual_row_when_line_wraps() {
         .sql_modal
         .editor
         .set_content_with_cursor(content.clone(), 0);
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let head = render_and_get_cursor_position(&mut terminal, &mut state);
 
@@ -846,7 +846,7 @@ fn sql_modal_unterminated_string_keeps_string_highlight() {
         .sql_modal
         .editor
         .set_content("SELECT 'unterminated".to_string());
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -875,7 +875,7 @@ fn sql_modal_unterminated_block_comment_keeps_comment_highlight() {
         .sql_modal
         .editor
         .set_content("SELECT /* pending".to_string());
-    state.sql_modal.set_status(SqlModalStatus::Editing);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -966,7 +966,7 @@ fn injected_palette_changes_shell_modal_and_picker_styles() {
     );
 
     state.modal.set_mode(InputMode::SqlModal);
-    state.sql_modal.set_status(SqlModalStatus::Normal);
+    state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
     let sql_buffer = render_and_get_buffer_at_with_theme(&mut terminal, &mut state, now, &theme);
     let has_custom_sql_hint = (0..TEST_HEIGHT)
         .flat_map(|y| (0..TEST_WIDTH).map(move |x| (x, y)))
@@ -1062,10 +1062,13 @@ fn sql_completion_popup_uses_injected_theme_styles() {
 
     state.modal.set_mode(InputMode::SqlModal);
     state.sql_modal.editor.set_content("SELECT ".to_string());
-    state.sql_modal.set_status(SqlModalStatus::Editing);
-    state.sql_modal.completion.visible = true;
-    state.sql_modal.completion.selected_index = 0;
-    state.sql_modal.completion.candidates = vec![
+    state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
+    state.sql_modal.completion_mut_for_navigation().visible = true;
+    state
+        .sql_modal
+        .completion_mut_for_navigation()
+        .selected_index = 0;
+    state.sql_modal.completion_mut_for_navigation().candidates = vec![
         CompletionCandidate {
             text: "users".into(),
             kind: CompletionKind::Table,
@@ -1108,7 +1111,7 @@ fn sql_completion_popup_uses_injected_theme_styles() {
     let cursor_col = cursor_col as u16;
     let cursor_row = cursor_row as u16;
     let scroll_row = state.sql_modal.editor.scroll_row() as u16;
-    let visible_count = state.sql_modal.completion.candidates.len().min(8) as u16;
+    let visible_count = state.sql_modal.completion().candidates.len().min(8) as u16;
     let popup_height = visible_count + 2;
     let popup_width = 45u16.min(modal_area.width);
     let popup_x = if modal_area.width < popup_width {

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -1063,12 +1063,9 @@ fn sql_completion_popup_uses_injected_theme_styles() {
     state.modal.set_mode(InputMode::SqlModal);
     state.sql_modal.editor.set_content("SELECT ".to_string());
     state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
-    state.sql_modal.completion_mut_for_navigation().visible = true;
-    state
-        .sql_modal
-        .completion_mut_for_navigation()
-        .selected_index = 0;
-    state.sql_modal.completion_mut_for_navigation().candidates = vec![
+    state.sql_modal.completion_mut_for_test().visible = true;
+    state.sql_modal.completion_mut_for_test().selected_index = 0;
+    state.sql_modal.completion_mut_for_test().candidates = vec![
         CompletionCandidate {
             text: "users".into(),
             kind: CompletionKind::Table,

--- a/src/ui/features/sql_modal/completion.rs
+++ b/src/ui/features/sql_modal/completion.rs
@@ -17,8 +17,9 @@ pub(super) fn render_completion_popup(
     let (cursor_row, cursor_col) = state.sql_modal.editor.cursor_to_position();
     let scroll_row = state.sql_modal.editor.scroll_row();
 
+    let completion = state.sql_modal.completion();
     let max_items = 8;
-    let visible_count = state.sql_modal.completion().candidates.len().min(max_items);
+    let visible_count = completion.candidates.len().min(max_items);
     let popup_height = (visible_count as u16) + 2;
     let popup_width = 45u16.min(modal_area.width);
 
@@ -40,8 +41,8 @@ pub(super) fn render_completion_popup(
 
     frame.render_widget(Clear, popup_area);
 
-    let selected = state.sql_modal.completion().selected_index;
-    let total = state.sql_modal.completion().candidates.len();
+    let selected = completion.selected_index;
+    let total = completion.candidates.len();
     let scroll_offset = if total <= max_items {
         0
     } else {
@@ -55,9 +56,7 @@ pub(super) fn render_completion_popup(
         }
     };
 
-    let max_text_width = state
-        .sql_modal
-        .completion()
+    let max_text_width = completion
         .candidates
         .iter()
         .skip(scroll_offset)
@@ -66,9 +65,7 @@ pub(super) fn render_completion_popup(
         .max()
         .unwrap_or(0);
 
-    let items: Vec<ListItem> = state
-        .sql_modal
-        .completion()
+    let items: Vec<ListItem> = completion
         .candidates
         .iter()
         .enumerate()

--- a/src/ui/features/sql_modal/completion.rs
+++ b/src/ui/features/sql_modal/completion.rs
@@ -18,7 +18,7 @@ pub(super) fn render_completion_popup(
     let scroll_row = state.sql_modal.editor.scroll_row();
 
     let max_items = 8;
-    let visible_count = state.sql_modal.completion.candidates.len().min(max_items);
+    let visible_count = state.sql_modal.completion().candidates.len().min(max_items);
     let popup_height = (visible_count as u16) + 2;
     let popup_width = 45u16.min(modal_area.width);
 
@@ -40,8 +40,8 @@ pub(super) fn render_completion_popup(
 
     frame.render_widget(Clear, popup_area);
 
-    let selected = state.sql_modal.completion.selected_index;
-    let total = state.sql_modal.completion.candidates.len();
+    let selected = state.sql_modal.completion().selected_index;
+    let total = state.sql_modal.completion().candidates.len();
     let scroll_offset = if total <= max_items {
         0
     } else {
@@ -57,7 +57,7 @@ pub(super) fn render_completion_popup(
 
     let max_text_width = state
         .sql_modal
-        .completion
+        .completion()
         .candidates
         .iter()
         .skip(scroll_offset)
@@ -68,7 +68,7 @@ pub(super) fn render_completion_popup(
 
     let items: Vec<ListItem> = state
         .sql_modal
-        .completion
+        .completion()
         .candidates
         .iter()
         .enumerate()

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -42,7 +42,7 @@ impl SqlModal {
         );
         let active_tab = services
             .db_capabilities
-            .normalize_sql_modal_tab(state.sql_modal.active_tab);
+            .normalize_sql_modal_tab(state.sql_modal.active_tab());
 
         let (area, inner) = if is_confirming {
             match state.sql_modal.status() {
@@ -135,8 +135,8 @@ impl SqlModal {
             status::render_status(frame, status_area, state, theme);
 
             if matches!(state.sql_modal.status(), SqlModalStatus::Editing)
-                && state.sql_modal.completion.visible
-                && !state.sql_modal.completion.candidates.is_empty()
+                && state.sql_modal.completion().visible
+                && !state.sql_modal.completion().candidates.is_empty()
             {
                 completion::render_completion_popup(frame, area, main_area, state, theme);
             }


### PR DESCRIPTION
## Problem
SQL modal and Explain workflows still coordinated status, active tab, completion, debounce, and running state through reducer-side field mutation.

## Background
Scope: SAB-228. The app-state rules favor aggregate-owned transitions for co-dependent state, and SQL modal completion is now treated as aggregate-owned instead of deferred debt.

## Approach
Add intent-level APIs around SQL modal workflow state and keep Explain's cross-aggregate transitions in reducer-local helpers. Preserve existing SQL modal and Explain behavior while making completion, tab, debounce, and adhoc status updates flow through the aggregate boundary.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * SQL モーダルの内部実装をリファクタリングし、API を改善しました。完了候補、タブ状態、デバウンス処理などの管理が効率化され、コード保守性が向上しました。

* **Tests**
  * SQL モーダルテストを新しい API に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->