### PR TITLE
test: cover JSONB detail reducer flow

### DIFF
--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -35,21 +35,38 @@ impl AppServices {
 
             fn build_update_sql(
                 &self,
-                _schema: &str,
-                _table: &str,
-                _column: &str,
-                _new_value: &str,
-                _pk_pairs: &[(String, String)],
+                schema: &str,
+                table: &str,
+                column: &str,
+                new_value: &str,
+                pk_pairs: &[(String, String)],
             ) -> String {
-                unimplemented!("inject a real SqlDialect via AppServices")
+                let set_clause = format!("\"{column}\" = '{new_value}'");
+                let where_clause = pk_pairs
+                    .iter()
+                    .map(|(key, value)| format!("\"{key}\" = '{value}'"))
+                    .collect::<Vec<_>>()
+                    .join(" AND ");
+                format!("UPDATE \"{schema}\".\"{table}\" SET {set_clause} WHERE {where_clause}")
             }
             fn build_bulk_delete_sql(
                 &self,
-                _schema: &str,
-                _table: &str,
-                _pk_pairs_per_row: &[Vec<(String, String)>],
+                schema: &str,
+                table: &str,
+                pk_pairs_per_row: &[Vec<(String, String)>],
             ) -> String {
-                unimplemented!("inject a real SqlDialect via AppServices")
+                let where_clause = pk_pairs_per_row
+                    .iter()
+                    .map(|pk_pairs| {
+                        pk_pairs
+                            .iter()
+                            .map(|(key, value)| format!("\"{key}\" = '{value}'"))
+                            .collect::<Vec<_>>()
+                            .join(" AND ")
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" OR ");
+                format!("DELETE FROM \"{schema}\".\"{table}\" WHERE {where_clause}")
             }
         }
 

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -386,54 +386,6 @@ mod tests {
 
     mod write_flow {
         use super::*;
-        use crate::ports::outbound::SqlDialect;
-
-        struct FakeSqlDialect;
-        impl SqlDialect for FakeSqlDialect {
-            fn build_explain_sql(&self, query: &str) -> Option<String> {
-                Some(format!("EXPLAIN {query}"))
-            }
-
-            fn build_explain_analyze_sql(&self, query: &str) -> Option<String> {
-                Some(format!("EXPLAIN ANALYZE {query}"))
-            }
-
-            fn build_update_sql(
-                &self,
-                schema: &str,
-                table: &str,
-                column: &str,
-                new_value: &str,
-                pk_pairs: &[(String, String)],
-            ) -> String {
-                let set_clause = format!("\"{column}\" = '{new_value}'");
-                let where_clause: Vec<String> = pk_pairs
-                    .iter()
-                    .map(|(k, v)| format!("\"{k}\" = '{v}'"))
-                    .collect();
-                format!(
-                    "UPDATE \"{}\".\"{}\" SET {} WHERE {}",
-                    schema,
-                    table,
-                    set_clause,
-                    where_clause.join(" AND ")
-                )
-            }
-            fn build_bulk_delete_sql(
-                &self,
-                _schema: &str,
-                _table: &str,
-                _pk_pairs_per_row: &[Vec<(String, String)>],
-            ) -> String {
-                String::new()
-            }
-        }
-
-        fn fake_services() -> AppServices {
-            let mut services = AppServices::stub();
-            services.sql_dialect = std::sync::Arc::new(FakeSqlDialect);
-            services
-        }
 
         fn editable_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
@@ -520,7 +472,7 @@ mod tests {
                 &mut state,
                 &Action::SubmitCellEditWrite,
                 Instant::now(),
-                &fake_services(),
+                &AppServices::stub(),
             )
             .unwrap();
             assert_eq!(effects.len(), 1);
@@ -568,7 +520,7 @@ mod tests {
                 &mut state,
                 &Action::SubmitCellEditWrite,
                 Instant::now(),
-                &fake_services(),
+                &AppServices::stub(),
             )
             .unwrap();
 
@@ -601,7 +553,7 @@ mod tests {
                 &mut state,
                 &Action::SubmitCellEditWrite,
                 Instant::now(),
-                &fake_services(),
+                &AppServices::stub(),
             )
             .unwrap();
 
@@ -626,7 +578,7 @@ mod tests {
                 &mut state,
                 &Action::SubmitCellEditWrite,
                 Instant::now(),
-                &fake_services(),
+                &AppServices::stub(),
             )
             .unwrap();
             let preview = match &effects[0] {

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -400,6 +400,7 @@ mod tests {
     use super::*;
     use crate::domain::column::Column;
     use crate::domain::{QueryResult, QuerySource, Table};
+    use crate::services::AppServices;
     use std::sync::Arc;
 
     fn jsonb_table() -> Table {
@@ -1072,6 +1073,160 @@ mod tests {
             let matches = find_text_matches("theme theme", "theme");
 
             assert_eq!(matches, vec![0, 6]);
+        }
+    }
+
+    mod reducer_chain {
+        use super::*;
+        use crate::cmd::effect::Effect;
+        use crate::model::browse::jsonb_detail::JsonbDetailMode;
+        use crate::model::shared::confirm_dialog::ConfirmIntent;
+        use crate::update::reducer::reduce as reduce_app;
+
+        #[test]
+        fn jsonb_detail_actions_flow_through_top_reducer() {
+            let mut state = state_with_jsonb_cell();
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            assert_eq!(state.input_mode(), InputMode::JsonbDetail);
+
+            reduce_app(&mut state, Action::JsonbEnterSearch, now, &services);
+            reduce_app(
+                &mut state,
+                Action::TextInput {
+                    target: InputTarget::JsonbSearch,
+                    ch: 't',
+                },
+                now,
+                &services,
+            );
+            assert!(!state.jsonb_detail.search().matches.is_empty());
+
+            reduce_app(&mut state, Action::JsonbSearchNext, now, &services);
+            reduce_app(&mut state, Action::JsonbSearchSubmit, now, &services);
+            assert!(!state.jsonb_detail.search().active);
+
+            let effects = reduce_app(&mut state, Action::JsonbYankAll, now, &services);
+            assert!(matches!(
+                effects.first(),
+                Some(Effect::CopyToClipboard { content, .. }) if content.contains("theme")
+            ));
+
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            assert_eq!(state.input_mode(), InputMode::JsonbEdit);
+            assert_eq!(state.jsonb_detail.mode(), JsonbDetailMode::Editing);
+
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            assert_eq!(state.input_mode(), InputMode::JsonbDetail);
+
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert!(!state.jsonb_detail.is_active());
+        }
+
+        #[test]
+        fn jsonb_edit_input_actions_flow_through_top_reducer() {
+            let mut state = state_with_jsonb_cell();
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::TextInput {
+                    target: InputTarget::JsonbEdit,
+                    ch: ' ',
+                },
+                now,
+                &services,
+            );
+            reduce_app(
+                &mut state,
+                Action::TextBackspace {
+                    target: InputTarget::JsonbEdit,
+                },
+                now,
+                &services,
+            );
+            reduce_app(
+                &mut state,
+                Action::TextDelete {
+                    target: InputTarget::JsonbEdit,
+                },
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::Paste(" ".to_string()), now, &services);
+
+            assert_eq!(state.input_mode(), InputMode::JsonbEdit);
+            assert_eq!(state.jsonb_detail.mode(), JsonbDetailMode::Editing);
+        }
+
+        #[test]
+        fn jsonb_edit_close_can_continue_to_write_preview() {
+            let mut state = state_with_jsonb_cell();
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content(r#"{"theme":"light","count":5}"#.to_string());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+            let preview = match effects.first() {
+                Some(Effect::DispatchActions(actions)) => match actions.first() {
+                    Some(Action::OpenWritePreviewConfirm(preview)) => preview.clone(),
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+
+            reduce_app(
+                &mut state,
+                Action::OpenWritePreviewConfirm(preview),
+                now,
+                &services,
+            );
+
+            assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
+            assert!(state.result_interaction.pending_write_preview().is_some());
+            assert!(matches!(
+                state.confirm_dialog.intent(),
+                Some(ConfirmIntent::ExecuteWrite { blocked: false, .. })
+            ));
         }
     }
 }


### PR DESCRIPTION
## Problem
JSONB detail actions already route through the reducer chain, but the expected workflow was not protected by a top-level regression test.

## Background
Scope: SAB-229. This PR verifies the reducer wiring from JSONB detail actions through edit draft creation and write preview confirmation without changing production workflow behavior.

## Approach
Add reducer-level regression coverage for JSONB detail actions and make the test service stub capable of exercising write-preview SQL generation without per-test fake dialects.

## Screenshots
N/A