### PR TITLE
SAB-204 DB-aware connection groundwork

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake --no-warn-dirty
+use flake .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -253,7 +253,7 @@ mod tests {
         struct SqliteDsnBuilder;
         impl DsnBuilder for SqliteDsnBuilder {
             fn build_dsn(&self, profile: &ConnectionProfile) -> String {
-                format!("sqlite://{}", profile.sqlite_config().unwrap().path)
+                format!("sqlite://{}", profile.sqlite_config().unwrap().path())
             }
         }
 

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 use crate::cmd::cache::TtlCache;
 use crate::cmd::effect::Effect;
 use crate::domain::DatabaseMetadata;
-use crate::domain::connection::{ConnectionProfile, DatabaseType};
+use crate::domain::connection::{ConnectionId, ConnectionProfile, DatabaseType};
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{
     ConnectionStore, ConnectionStoreError, DsnBuilder, MetadataProvider, PgServiceEntryReader,
@@ -26,16 +26,8 @@ pub(crate) async fn run(
 ) -> Result<()> {
     match effect {
         Effect::SaveAndConnect { id, name, config } => {
-            let profile = match id {
-                Some(existing_id) => {
-                    ConnectionProfile::with_id_and_config(existing_id, name, config)
-                }
-                None => ConnectionProfile::with_id_and_config(
-                    crate::domain::connection::ConnectionId::new(),
-                    name,
-                    config,
-                ),
-            };
+            let id = id.unwrap_or_else(ConnectionId::new);
+            let profile = ConnectionProfile::with_id_and_config(id, name, config);
             let profile = match profile {
                 Ok(p) => p,
                 Err(e) => {

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -48,6 +48,7 @@ pub(crate) async fn run(
             let id = profile.id.clone();
             let dsn = dsn_builder.build_dsn(&profile);
             let name = profile.name.as_str().to_string();
+            let database_type = profile.database_type();
             let store = Arc::clone(connection_store);
             let tx = action_tx.clone();
 
@@ -58,6 +59,7 @@ pub(crate) async fn run(
                             id,
                             dsn,
                             name,
+                            database_type,
                         }))
                         .ok();
                     }
@@ -81,6 +83,7 @@ pub(crate) async fn run(
                                     id,
                                     dsn,
                                     name,
+                                    database_type,
                                 }))
                                 .await
                                 .ok();
@@ -170,8 +173,14 @@ pub(crate) async fn run(
                 let dsn = dsn_builder.build_dsn(profile);
                 let name = profile.display_name().to_string();
                 let id = profile.id.clone();
+                let database_type = profile.database_type();
                 action_tx
-                    .send(Action::SwitchConnection(ConnectionTarget { id, dsn, name }))
+                    .send(Action::SwitchConnection(ConnectionTarget {
+                        id,
+                        dsn,
+                        name,
+                        database_type,
+                    }))
                     .await
                     .ok();
             }
@@ -184,7 +193,12 @@ pub(crate) async fn run(
                 let dsn = entry.to_string();
                 let name = entry.display_name().to_owned();
                 action_tx
-                    .send(Action::SwitchConnection(ConnectionTarget { id, dsn, name }))
+                    .send(Action::SwitchConnection(ConnectionTarget {
+                        id,
+                        dsn,
+                        name,
+                        database_type: DatabaseType::PostgreSQL,
+                    }))
                     .await
                     .ok();
             }
@@ -272,9 +286,9 @@ mod tests {
                     vec![Effect::SaveAndConnect {
                         id: None,
                         name: "Local".to_string(),
-                        config: ConnectionConfig::SQLite(SqliteConnectionConfig::new(
-                            "/tmp/app.db",
-                        )),
+                        config: ConnectionConfig::SQLite(
+                            SqliteConnectionConfig::new("/tmp/app.db").unwrap(),
+                        ),
                     }],
                     &mut renderer,
                     state,
@@ -550,10 +564,16 @@ mod tests {
 
             let action = rx.recv().await.expect("action dispatched");
             match action {
-                Action::SwitchConnection(ConnectionTarget { id, dsn, name }) => {
+                Action::SwitchConnection(ConnectionTarget {
+                    id,
+                    dsn,
+                    name,
+                    database_type,
+                }) => {
                     assert_eq!(dsn, "fake://db.example.com:5432/mydb");
                     assert_eq!(name, "My DB");
                     assert_eq!(id, state.connections()[0].id);
+                    assert_eq!(database_type, DatabaseType::PostgreSQL);
                 }
                 other => panic!("expected SwitchConnection, got {other:?}"),
             }

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -40,7 +40,8 @@ pub(crate) async fn run(
                 Ok(p) => p,
                 Err(e) => {
                     action_tx
-                        .blocking_send(Action::ConnectionSaveFailed(e.into()))
+                        .send(Action::ConnectionSaveFailed(e.into()))
+                        .await
                         .ok();
                     return Ok(());
                 }

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -6,7 +6,7 @@ use tokio::sync::mpsc;
 use crate::cmd::cache::TtlCache;
 use crate::cmd::effect::Effect;
 use crate::domain::DatabaseMetadata;
-use crate::domain::connection::ConnectionProfile;
+use crate::domain::connection::{ConnectionProfile, DatabaseType};
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{
     ConnectionStore, ConnectionStoreError, DsnBuilder, MetadataProvider, PgServiceEntryReader,
@@ -25,49 +25,24 @@ pub(crate) async fn run(
     state: &AppState,
 ) -> Result<()> {
     match effect {
-        Effect::SaveAndConnect {
-            id,
-            name,
-            host,
-            port,
-            database,
-            user,
-            password,
-            ssl_mode,
-        } => {
+        Effect::SaveAndConnect { id, name, config } => {
             let profile = match id {
                 Some(existing_id) => {
-                    match ConnectionProfile::with_id(
-                        existing_id,
-                        name,
-                        host,
-                        port,
-                        database,
-                        user,
-                        password,
-                        ssl_mode,
-                    ) {
-                        Ok(p) => p,
-                        Err(e) => {
-                            action_tx
-                                .blocking_send(Action::ConnectionSaveFailed(e.into()))
-                                .ok();
-                            return Ok(());
-                        }
-                    }
+                    ConnectionProfile::with_id_and_config(existing_id, name, config)
                 }
-                None => {
-                    match ConnectionProfile::new(
-                        name, host, port, database, user, password, ssl_mode,
-                    ) {
-                        Ok(p) => p,
-                        Err(e) => {
-                            action_tx
-                                .blocking_send(Action::ConnectionSaveFailed(e.into()))
-                                .ok();
-                            return Ok(());
-                        }
-                    }
+                None => ConnectionProfile::with_id_and_config(
+                    crate::domain::connection::ConnectionId::new(),
+                    name,
+                    config,
+                ),
+            };
+            let profile = match profile {
+                Ok(p) => p,
+                Err(e) => {
+                    action_tx
+                        .blocking_send(Action::ConnectionSaveFailed(e.into()))
+                        .ok();
+                    return Ok(());
                 }
             };
             let id = profile.id.clone();
@@ -75,6 +50,24 @@ pub(crate) async fn run(
             let name = profile.name.as_str().to_string();
             let store = Arc::clone(connection_store);
             let tx = action_tx.clone();
+
+            if profile.database_type() == DatabaseType::SQLite {
+                tokio::task::spawn_blocking(move || match store.save(&profile) {
+                    Ok(()) => {
+                        tx.blocking_send(Action::ConnectionSaveCompleted(ConnectionTarget {
+                            id,
+                            dsn,
+                            name,
+                        }))
+                        .ok();
+                    }
+                    Err(e) => {
+                        tx.blocking_send(Action::ConnectionSaveFailed(e.into()))
+                            .ok();
+                    }
+                });
+                return Ok(());
+            }
 
             let provider = Arc::clone(metadata_provider);
             let cache = metadata_cache.clone();
@@ -214,7 +207,10 @@ mod tests {
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
     use crate::cmd::test_support::*;
-    use crate::domain::connection::{ConnectionId, ConnectionProfile, SslMode};
+    use crate::domain::connection::{
+        ConnectionConfig, ConnectionId, ConnectionProfile, DatabaseType, SqliteConnectionConfig,
+        SslMode,
+    };
     use crate::model::app_state::AppState;
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
@@ -234,6 +230,68 @@ mod tests {
             _now: Instant,
         ) -> RenderResult<RenderOutput> {
             Ok(RenderOutput::default())
+        }
+    }
+
+    mod save_connection {
+        use super::*;
+
+        struct SqliteDsnBuilder;
+        impl DsnBuilder for SqliteDsnBuilder {
+            fn build_dsn(&self, profile: &ConnectionProfile) -> String {
+                format!("sqlite://{}", profile.sqlite_config().unwrap().path)
+            }
+        }
+
+        #[tokio::test]
+        async fn sqlite_profile_is_saved_before_adapter_metadata_exists() {
+            let mut mock_store = MockConnectionStore::new();
+            mock_store.expect_save().once().returning(|profile| {
+                assert_eq!(profile.database_type(), DatabaseType::SQLite);
+                Ok(())
+            });
+
+            let cache = TtlCache::new(300);
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = make_runner_builder(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(mock_store),
+                cache,
+                tx,
+            )
+            .dsn_builder(Arc::new(SqliteDsnBuilder))
+            .build();
+
+            let state = &mut AppState::new("test".to_string());
+            let ce = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .run(
+                    vec![Effect::SaveAndConnect {
+                        id: None,
+                        name: "Local".to_string(),
+                        config: ConnectionConfig::SQLite(SqliteConnectionConfig::new(
+                            "/tmp/app.db",
+                        )),
+                    }],
+                    &mut renderer,
+                    state,
+                    &ce,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            let action = tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+                .await
+                .expect("action timeout")
+                .expect("channel closed");
+            assert!(
+                matches!(action, Action::ConnectionSaveCompleted(ConnectionTarget { ref dsn, .. }) if dsn == "sqlite:///tmp/app.db"),
+                "expected sqlite ConnectionSaveCompleted, got {action:?}"
+            );
         }
     }
 
@@ -438,10 +496,8 @@ mod tests {
         struct FakeDsnBuilder;
         impl DsnBuilder for FakeDsnBuilder {
             fn build_dsn(&self, profile: &ConnectionProfile) -> String {
-                format!(
-                    "fake://{}:{}/{}",
-                    profile.host, profile.port, profile.database
-                )
+                let config = profile.postgres_config().unwrap();
+                format!("fake://{}:{}/{}", config.host, config.port, config.database)
             }
         }
 

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -1,5 +1,5 @@
 use crate::domain::Table;
-use crate::domain::connection::{ConnectionId, SslMode};
+use crate::domain::connection::{ConnectionConfig, ConnectionId};
 use crate::update::action::Action;
 
 #[derive(Debug, Clone)]
@@ -9,12 +9,7 @@ pub enum Effect {
     SaveAndConnect {
         id: Option<ConnectionId>,
         name: String,
-        host: String,
-        port: u16,
-        database: String,
-        user: String,
-        password: String,
-        ssl_mode: SslMode,
+        config: ConnectionConfig,
     },
     LoadConnectionForEdit {
         id: ConnectionId,

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -701,20 +701,20 @@ mod tests {
 
     mod connection_catalog {
         use super::*;
-        use crate::domain::connection::{ConnectionId, ConnectionName, ConnectionProfile, SslMode};
+        use crate::domain::connection::{ConnectionProfile, SslMode};
         use crate::model::connection::list::ConnectionListItem;
 
         fn make_profile(name: &str) -> ConnectionProfile {
-            ConnectionProfile {
-                id: ConnectionId::new(),
-                name: ConnectionName::new(name).unwrap(),
-                host: "localhost".to_string(),
-                port: 5432,
-                database: "test".to_string(),
-                username: "user".to_string(),
-                password: "pass".to_string(),
-                ssl_mode: SslMode::Prefer,
-            }
+            ConnectionProfile::new(
+                name,
+                "localhost",
+                5432,
+                "test",
+                "user",
+                "pass",
+                SslMode::Prefer,
+            )
+            .unwrap()
         }
 
         fn make_service(name: &str) -> crate::domain::connection::ServiceEntry {

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -93,6 +93,19 @@ impl BrowseSession {
         self.mark_connecting();
     }
 
+    pub fn set_active_connection(
+        &mut self,
+        id: &ConnectionId,
+        name: &str,
+        database_type: DatabaseType,
+        dsn: &str,
+    ) {
+        self.active_connection_id = Some(id.clone());
+        self.active_connection_name = Some(name.to_string());
+        self.active_database_type = Some(database_type);
+        self.dsn = Some(dsn.to_string());
+    }
+
     pub fn mark_connected(&mut self, metadata: Arc<DatabaseMetadata>) {
         self.connection_state = ConnectionState::Connected;
         self.metadata_state = MetadataState::Loaded;

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::domain::{
-    ConnectionId, DatabaseMetadata, MetadataState, QueryResult, Table, TableSummary,
+    ConnectionId, DatabaseMetadata, DatabaseType, MetadataState, QueryResult, Table, TableSummary,
 };
 use crate::model::browse::query_execution::{PaginationState, QueryExecution};
 use crate::model::browse::result_history::ResultHistory;
@@ -40,6 +40,7 @@ pub struct BrowseSession {
     pub dsn: Option<String>,
     pub active_connection_id: Option<ConnectionId>,
     pub active_connection_name: Option<String>,
+    pub active_database_type: Option<DatabaseType>,
     pub read_only: bool,
     pub is_reloading: bool,
 }
@@ -175,6 +176,7 @@ impl BrowseSession {
         self.dsn = None;
         self.active_connection_id = None;
         self.active_connection_name = None;
+        self.active_database_type = None;
         self.read_only = false;
         self.is_reloading = false;
         query.pagination.reset();
@@ -619,6 +621,7 @@ mod tests {
             session.dsn = Some("postgres://host/db".to_string());
             session.active_connection_id = Some(ConnectionId::new());
             session.active_connection_name = Some("mydb".to_string());
+            session.active_database_type = Some(DatabaseType::PostgreSQL);
             session.read_only = true;
             session.is_reloading = true;
             let mut query = QueryExecution::default();
@@ -644,6 +647,7 @@ mod tests {
             assert!(session.dsn.is_none());
             assert!(session.active_connection_id.is_none());
             assert!(session.active_connection_name.is_none());
+            assert!(session.active_database_type.is_none());
             assert!(!session.read_only);
             assert!(!session.is_reloading);
             assert_eq!(query.pagination.current_page, 0);

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::domain::connection::{
-    ConnectionConfig, ConnectionId, ConnectionProfile, DatabaseType, SslMode,
+    ConnectionConfig, ConnectionId, ConnectionProfile, DatabaseType, SqliteConnectionConfigError,
+    SslMode,
 };
 use crate::model::shared::text_input::TextInputState;
 
@@ -232,8 +233,8 @@ impl ConnectionSetupState {
             .retain(|field, _| visible_fields.contains(field));
     }
 
-    pub fn to_connection_config(&self) -> ConnectionConfig {
-        match self.database_type {
+    pub fn to_connection_config(&self) -> Result<ConnectionConfig, SqliteConnectionConfigError> {
+        Ok(match self.database_type {
             DatabaseType::PostgreSQL => ConnectionConfig::PostgreSQL(
                 crate::domain::connection::PostgresConnectionConfig::new(
                     self.host.content().to_string(),
@@ -244,13 +245,12 @@ impl ConnectionSetupState {
                     self.ssl_mode,
                 ),
             ),
-            DatabaseType::SQLite => ConnectionConfig::SQLite(
-                crate::domain::connection::SqliteConnectionConfig::new(
+            DatabaseType::SQLite => {
+                ConnectionConfig::SQLite(crate::domain::connection::SqliteConnectionConfig::new(
                     self.sqlite_path.content().to_string(),
-                )
-                .expect("SQLite connection setup validates path before building config"),
-            ),
-        }
+                )?)
+            }
+        })
     }
 }
 
@@ -316,7 +316,7 @@ impl From<&ConnectionProfile> for ConnectionSetupState {
             ConnectionConfig::SQLite(config) => Self {
                 database_type: DatabaseType::SQLite,
                 name: TextInputState::new(profile.name.as_str(), name_len),
-                sqlite_path: TextInputState::new(&config.path, config.path.chars().count()),
+                sqlite_path: TextInputState::new(config.path(), config.path().chars().count()),
                 host: TextInputState::new("localhost", 9),
                 port: TextInputState::new("5432", 4),
                 database: TextInputState::default(),
@@ -408,6 +408,21 @@ mod tests {
             state.sqlite_path.set_content("/tmp/app.db".to_string());
 
             assert_eq!(state.default_name(), "app.db");
+        }
+
+        #[test]
+        fn sqlite_config_build_returns_validation_error() {
+            let state = ConnectionSetupState {
+                database_type: DatabaseType::SQLite,
+                ..ConnectionSetupState::default()
+            };
+
+            let result = state.to_connection_config();
+
+            assert!(matches!(
+                result,
+                Err(SqliteConnectionConfigError::EmptyPath)
+            ));
         }
 
         #[test]

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use crate::domain::connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, DatabaseType, SslMode,
@@ -143,9 +144,7 @@ impl ConnectionSetupState {
             DatabaseType::SQLite => self
                 .sqlite_path
                 .content()
-                .rsplit('/')
-                .next()
-                .filter(|name| !name.is_empty())
+                .file_name_for_display()
                 .unwrap_or("SQLite")
                 .to_string(),
         }
@@ -245,12 +244,26 @@ impl ConnectionSetupState {
                     self.ssl_mode,
                 ),
             ),
-            DatabaseType::SQLite => {
-                ConnectionConfig::SQLite(crate::domain::connection::SqliteConnectionConfig::new(
+            DatabaseType::SQLite => ConnectionConfig::SQLite(
+                crate::domain::connection::SqliteConnectionConfig::new(
                     self.sqlite_path.content().to_string(),
-                ))
-            }
+                )
+                .expect("SQLite connection setup validates path before building config"),
+            ),
         }
+    }
+}
+
+trait PathDisplayName {
+    fn file_name_for_display(&self) -> Option<&str>;
+}
+
+impl PathDisplayName for str {
+    fn file_name_for_display(&self) -> Option<&str> {
+        Path::new(self)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
     }
 }
 
@@ -384,6 +397,17 @@ mod tests {
             let mut state = ConnectionSetupState::default();
             state.database.set_content("mydb".to_string());
             assert_eq!(state.default_name(), "mydb@localhost");
+        }
+
+        #[test]
+        fn sqlite_default_name_uses_path_file_name() {
+            let mut state = ConnectionSetupState {
+                database_type: DatabaseType::SQLite,
+                ..ConnectionSetupState::default()
+            };
+            state.sqlite_path.set_content("/tmp/app.db".to_string());
+
+            assert_eq!(state.default_name(), "app.db");
         }
 
         #[test]

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -332,7 +332,10 @@ impl ConnectionSetupState {
             DatabaseType::PostgreSQL => ConnectionConfig::PostgreSQL(
                 crate::domain::connection::PostgresConnectionConfig::new(
                     self.host.content().to_string(),
-                    self.port.content().parse().unwrap_or(5432),
+                    self.port
+                        .content()
+                        .parse()
+                        .expect("port validated before building connection config"),
                     self.database.content().to_string(),
                     self.user.content().to_string(),
                     self.password.content().to_string(),

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-use crate::domain::connection::{ConnectionId, ConnectionProfile, SslMode};
+use crate::domain::connection::{
+    ConnectionConfig, ConnectionId, ConnectionProfile, DatabaseType, SslMode,
+};
 use crate::model::shared::text_input::TextInputState;
 
 pub const CONNECTION_INPUT_WIDTH: u16 = 30;
@@ -8,7 +10,9 @@ pub const CONNECTION_INPUT_VISIBLE_WIDTH: usize = (CONNECTION_INPUT_WIDTH - 4) a
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ConnectionField {
+    DatabaseType,
     Name,
+    SqlitePath,
     Host,
     Port,
     Database,
@@ -20,7 +24,9 @@ pub enum ConnectionField {
 impl ConnectionField {
     pub fn all() -> &'static [Self] {
         &[
+            Self::DatabaseType,
             Self::Name,
+            Self::SqlitePath,
             Self::Host,
             Self::Port,
             Self::Database,
@@ -30,40 +36,34 @@ impl ConnectionField {
         ]
     }
 
-    pub fn next(self) -> Option<Self> {
-        match self {
-            Self::Name => Some(Self::Host),
-            Self::Host => Some(Self::Port),
-            Self::Port => Some(Self::Database),
-            Self::Database => Some(Self::User),
-            Self::User => Some(Self::Password),
-            Self::Password => Some(Self::SslMode),
-            Self::SslMode => None,
-        }
-    }
-
-    pub fn prev(self) -> Option<Self> {
-        match self {
-            Self::Name => None,
-            Self::Host => Some(Self::Name),
-            Self::Port => Some(Self::Host),
-            Self::Database => Some(Self::Port),
-            Self::User => Some(Self::Database),
-            Self::Password => Some(Self::User),
-            Self::SslMode => Some(Self::Password),
+    pub fn fields_for(database_type: DatabaseType) -> &'static [Self] {
+        match database_type {
+            DatabaseType::PostgreSQL => &[
+                Self::DatabaseType,
+                Self::Name,
+                Self::Host,
+                Self::Port,
+                Self::Database,
+                Self::User,
+                Self::Password,
+                Self::SslMode,
+            ],
+            DatabaseType::SQLite => &[Self::DatabaseType, Self::Name, Self::SqlitePath],
         }
     }
 
     pub fn is_required(self) -> bool {
         matches!(
             self,
-            Self::Name | Self::Host | Self::Port | Self::Database | Self::User
+            Self::Name | Self::SqlitePath | Self::Host | Self::Port | Self::Database | Self::User
         )
     }
 
     pub fn label(self) -> &'static str {
         match self {
+            Self::DatabaseType => "Type:",
             Self::Name => "Name:",
+            Self::SqlitePath => "Path:",
             Self::Host => "Host:",
             Self::Port => "Port:",
             Self::Database => "Database:",
@@ -80,9 +80,17 @@ pub struct SslModeDropdown {
     pub selected_index: usize,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct DatabaseTypeDropdown {
+    pub is_open: bool,
+    pub selected_index: usize,
+}
+
 #[derive(Debug, Clone)]
 pub struct ConnectionSetupState {
+    pub database_type: DatabaseType,
     pub name: TextInputState,
+    pub sqlite_path: TextInputState,
     pub host: TextInputState,
     pub port: TextInputState,
     pub database: TextInputState,
@@ -91,6 +99,7 @@ pub struct ConnectionSetupState {
     pub ssl_mode: SslMode,
 
     pub focused_field: ConnectionField,
+    pub database_type_dropdown: DatabaseTypeDropdown,
     pub ssl_dropdown: SslModeDropdown,
     pub validation_errors: HashMap<ConnectionField, String>,
 
@@ -102,14 +111,17 @@ pub struct ConnectionSetupState {
 impl Default for ConnectionSetupState {
     fn default() -> Self {
         Self {
+            database_type: DatabaseType::PostgreSQL,
             name: TextInputState::default(),
+            sqlite_path: TextInputState::default(),
             host: TextInputState::new("localhost", 9),
             port: TextInputState::new("5432", 4),
             database: TextInputState::default(),
             user: TextInputState::default(),
             password: TextInputState::default(),
             ssl_mode: SslMode::Prefer,
-            focused_field: ConnectionField::Name,
+            focused_field: ConnectionField::DatabaseType,
+            database_type_dropdown: DatabaseTypeDropdown::default(),
             ssl_dropdown: SslModeDropdown::default(),
             validation_errors: HashMap::new(),
             is_first_run: true,
@@ -120,16 +132,30 @@ impl Default for ConnectionSetupState {
 
 impl ConnectionSetupState {
     pub fn default_name(&self) -> String {
-        if self.database.content().is_empty() {
-            self.host.content().to_string()
-        } else {
-            format!("{}@{}", self.database.content(), self.host.content())
+        match self.database_type {
+            DatabaseType::PostgreSQL => {
+                if self.database.content().is_empty() {
+                    self.host.content().to_string()
+                } else {
+                    format!("{}@{}", self.database.content(), self.host.content())
+                }
+            }
+            DatabaseType::SQLite => self
+                .sqlite_path
+                .content()
+                .rsplit('/')
+                .next()
+                .filter(|name| !name.is_empty())
+                .unwrap_or("SQLite")
+                .to_string(),
         }
     }
 
     pub fn field_value(&self, field: ConnectionField) -> &str {
         match field {
+            ConnectionField::DatabaseType => "",
             ConnectionField::Name => self.name.content(),
+            ConnectionField::SqlitePath => self.sqlite_path.content(),
             ConnectionField::Host => self.host.content(),
             ConnectionField::Port => self.port.content(),
             ConnectionField::Database => self.database.content(),
@@ -141,7 +167,9 @@ impl ConnectionSetupState {
 
     pub fn focused_input(&self) -> Option<&TextInputState> {
         match self.focused_field {
+            ConnectionField::DatabaseType => None,
             ConnectionField::Name => Some(&self.name),
+            ConnectionField::SqlitePath => Some(&self.sqlite_path),
             ConnectionField::Host => Some(&self.host),
             ConnectionField::Port => Some(&self.port),
             ConnectionField::Database => Some(&self.database),
@@ -153,7 +181,9 @@ impl ConnectionSetupState {
 
     pub fn focused_input_mut(&mut self) -> Option<&mut TextInputState> {
         match self.focused_field {
+            ConnectionField::DatabaseType => None,
             ConnectionField::Name => Some(&mut self.name),
+            ConnectionField::SqlitePath => Some(&mut self.sqlite_path),
             ConnectionField::Host => Some(&mut self.host),
             ConnectionField::Port => Some(&mut self.port),
             ConnectionField::Database => Some(&mut self.database),
@@ -178,30 +208,115 @@ impl ConnectionSetupState {
     pub fn is_edit_mode(&self) -> bool {
         self.editing_id.is_some()
     }
+
+    pub fn visible_fields(&self) -> &'static [ConnectionField] {
+        ConnectionField::fields_for(self.database_type)
+    }
+
+    pub fn next_field(&self) -> Option<ConnectionField> {
+        next_visible_field(self.visible_fields(), self.focused_field)
+    }
+
+    pub fn prev_field(&self) -> Option<ConnectionField> {
+        prev_visible_field(self.visible_fields(), self.focused_field)
+    }
+
+    pub fn set_database_type(&mut self, database_type: DatabaseType) {
+        self.database_type = database_type;
+        self.database_type_dropdown.is_open = false;
+        self.ssl_dropdown.is_open = false;
+        if !self.visible_fields().contains(&self.focused_field) {
+            self.focused_field = ConnectionField::DatabaseType;
+        }
+        let visible_fields = self.visible_fields();
+        self.validation_errors
+            .retain(|field, _| visible_fields.contains(field));
+    }
+
+    pub fn to_connection_config(&self) -> ConnectionConfig {
+        match self.database_type {
+            DatabaseType::PostgreSQL => ConnectionConfig::PostgreSQL(
+                crate::domain::connection::PostgresConnectionConfig::new(
+                    self.host.content().to_string(),
+                    self.port.content().parse().unwrap_or(5432),
+                    self.database.content().to_string(),
+                    self.user.content().to_string(),
+                    self.password.content().to_string(),
+                    self.ssl_mode,
+                ),
+            ),
+            DatabaseType::SQLite => {
+                ConnectionConfig::SQLite(crate::domain::connection::SqliteConnectionConfig::new(
+                    self.sqlite_path.content().to_string(),
+                ))
+            }
+        }
+    }
+}
+
+fn next_visible_field(
+    fields: &[ConnectionField],
+    current: ConnectionField,
+) -> Option<ConnectionField> {
+    let idx = fields.iter().position(|field| *field == current)?;
+    fields.get(idx + 1).copied()
+}
+
+fn prev_visible_field(
+    fields: &[ConnectionField],
+    current: ConnectionField,
+) -> Option<ConnectionField> {
+    let idx = fields.iter().position(|field| *field == current)?;
+    idx.checked_sub(1).and_then(|idx| fields.get(idx).copied())
 }
 
 impl From<&ConnectionProfile> for ConnectionSetupState {
     fn from(profile: &ConnectionProfile) -> Self {
         let name_len = profile.name.as_str().chars().count();
-        let host_len = profile.host.chars().count();
-        let port_str = profile.port.to_string();
-        let port_len = port_str.chars().count();
-        let db_len = profile.database.chars().count();
-        let user_len = profile.username.chars().count();
-        let pw_len = profile.password.chars().count();
-        Self {
-            name: TextInputState::new(profile.name.as_str(), name_len),
-            host: TextInputState::new(&profile.host, host_len),
-            port: TextInputState::new(&port_str, port_len),
-            database: TextInputState::new(&profile.database, db_len),
-            user: TextInputState::new(&profile.username, user_len),
-            password: TextInputState::new(&profile.password, pw_len),
-            ssl_mode: profile.ssl_mode,
-            focused_field: ConnectionField::Name,
-            ssl_dropdown: SslModeDropdown::default(),
-            validation_errors: HashMap::new(),
-            is_first_run: false,
-            editing_id: Some(profile.id.clone()),
+        match &profile.config {
+            ConnectionConfig::PostgreSQL(config) => {
+                let port_str = config.port.to_string();
+                Self {
+                    database_type: DatabaseType::PostgreSQL,
+                    name: TextInputState::new(profile.name.as_str(), name_len),
+                    sqlite_path: TextInputState::default(),
+                    host: TextInputState::new(&config.host, config.host.chars().count()),
+                    port: TextInputState::new(&port_str, port_str.chars().count()),
+                    database: TextInputState::new(
+                        &config.database,
+                        config.database.chars().count(),
+                    ),
+                    user: TextInputState::new(&config.username, config.username.chars().count()),
+                    password: TextInputState::new(
+                        &config.password,
+                        config.password.chars().count(),
+                    ),
+                    ssl_mode: config.ssl_mode,
+                    focused_field: ConnectionField::DatabaseType,
+                    database_type_dropdown: DatabaseTypeDropdown::default(),
+                    ssl_dropdown: SslModeDropdown::default(),
+                    validation_errors: HashMap::new(),
+                    is_first_run: false,
+                    editing_id: Some(profile.id.clone()),
+                }
+            }
+            ConnectionConfig::SQLite(config) => Self {
+                database_type: DatabaseType::SQLite,
+                name: TextInputState::new(profile.name.as_str(), name_len),
+                sqlite_path: TextInputState::new(&config.path, config.path.chars().count()),
+                host: TextInputState::new("localhost", 9),
+                port: TextInputState::new("5432", 4),
+                database: TextInputState::default(),
+                user: TextInputState::default(),
+                password: TextInputState::default(),
+                ssl_mode: SslMode::Prefer,
+                focused_field: ConnectionField::DatabaseType,
+                database_type_dropdown: DatabaseTypeDropdown::default(),
+                ssl_dropdown: SslModeDropdown::default(),
+                validation_errors: HashMap::new(),
+                is_first_run: false,
+                editing_id: Some(profile.id.clone()),
+            },
         }
     }
 }
@@ -215,37 +330,9 @@ mod tests {
         use super::*;
 
         #[rstest]
-        #[case(ConnectionField::Name, Some(ConnectionField::Host))]
-        #[case(ConnectionField::Host, Some(ConnectionField::Port))]
-        #[case(ConnectionField::Port, Some(ConnectionField::Database))]
-        #[case(ConnectionField::Database, Some(ConnectionField::User))]
-        #[case(ConnectionField::User, Some(ConnectionField::Password))]
-        #[case(ConnectionField::Password, Some(ConnectionField::SslMode))]
-        #[case(ConnectionField::SslMode, None)]
-        fn next_returns_correct_field(
-            #[case] field: ConnectionField,
-            #[case] expected: Option<ConnectionField>,
-        ) {
-            assert_eq!(field.next(), expected);
-        }
-
-        #[rstest]
-        #[case(ConnectionField::Name, None)]
-        #[case(ConnectionField::Host, Some(ConnectionField::Name))]
-        #[case(ConnectionField::Port, Some(ConnectionField::Host))]
-        #[case(ConnectionField::Database, Some(ConnectionField::Port))]
-        #[case(ConnectionField::User, Some(ConnectionField::Database))]
-        #[case(ConnectionField::Password, Some(ConnectionField::User))]
-        #[case(ConnectionField::SslMode, Some(ConnectionField::Password))]
-        fn prev_returns_correct_field(
-            #[case] field: ConnectionField,
-            #[case] expected: Option<ConnectionField>,
-        ) {
-            assert_eq!(field.prev(), expected);
-        }
-
-        #[rstest]
+        #[case(ConnectionField::DatabaseType, false)]
         #[case(ConnectionField::Name, true)]
+        #[case(ConnectionField::SqlitePath, true)]
         #[case(ConnectionField::Host, true)]
         #[case(ConnectionField::Port, true)]
         #[case(ConnectionField::Database, true)]
@@ -262,9 +349,9 @@ mod tests {
         #[test]
         fn all_returns_fields_in_order() {
             let all = ConnectionField::all();
-            assert_eq!(all.len(), 7);
-            assert_eq!(all[0], ConnectionField::Name);
-            assert_eq!(all[6], ConnectionField::SslMode);
+            assert_eq!(all.len(), 9);
+            assert_eq!(all[0], ConnectionField::DatabaseType);
+            assert_eq!(all[8], ConnectionField::SslMode);
         }
     }
 
@@ -281,7 +368,7 @@ mod tests {
             assert!(state.user.content().is_empty());
             assert!(state.password.content().is_empty());
             assert_eq!(state.ssl_mode, SslMode::Prefer);
-            assert_eq!(state.focused_field, ConnectionField::Name);
+            assert_eq!(state.focused_field, ConnectionField::DatabaseType);
             assert!(state.is_first_run);
             assert!(state.editing_id.is_none());
         }

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -201,6 +201,10 @@ impl ConnectionSetupState {
         *self = Self::default();
     }
 
+    pub fn set_first_run(&mut self, is_first_run: bool) {
+        self.is_first_run = is_first_run;
+    }
+
     pub fn has_errors(&self) -> bool {
         !self.validation_errors.is_empty()
     }
@@ -221,6 +225,18 @@ impl ConnectionSetupState {
         prev_visible_field(self.visible_fields(), self.focused_field)
     }
 
+    pub fn focus_next_field(&mut self) {
+        if let Some(next) = self.next_field() {
+            self.focused_field = next;
+        }
+    }
+
+    pub fn focus_prev_field(&mut self) {
+        if let Some(prev) = self.prev_field() {
+            self.focused_field = prev;
+        }
+    }
+
     pub fn set_database_type(&mut self, database_type: DatabaseType) {
         self.database_type = database_type;
         self.database_type_dropdown.is_open = false;
@@ -231,6 +247,84 @@ impl ConnectionSetupState {
         let visible_fields = self.visible_fields();
         self.validation_errors
             .retain(|field, _| visible_fields.contains(field));
+    }
+
+    pub fn toggle_focused_dropdown(&mut self) {
+        match self.focused_field {
+            ConnectionField::DatabaseType => {
+                self.database_type_dropdown.is_open = !self.database_type_dropdown.is_open;
+                self.ssl_dropdown.is_open = false;
+                if self.database_type_dropdown.is_open {
+                    self.database_type_dropdown.selected_index = DatabaseType::all()
+                        .iter()
+                        .position(|v| *v == self.database_type)
+                        .unwrap_or(0);
+                }
+            }
+            ConnectionField::SslMode => {
+                self.ssl_dropdown.is_open = !self.ssl_dropdown.is_open;
+                self.database_type_dropdown.is_open = false;
+                if self.ssl_dropdown.is_open {
+                    self.ssl_dropdown.selected_index = SslMode::all_variants()
+                        .iter()
+                        .position(|v| *v == self.ssl_mode)
+                        .unwrap_or(2);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub fn dropdown_next(&mut self) {
+        if self.database_type_dropdown.is_open {
+            let max = DatabaseType::all().len() - 1;
+            if self.database_type_dropdown.selected_index < max {
+                self.database_type_dropdown.selected_index += 1;
+            }
+        } else if self.ssl_dropdown.is_open {
+            let max = SslMode::all_variants().len() - 1;
+            if self.ssl_dropdown.selected_index < max {
+                self.ssl_dropdown.selected_index += 1;
+            }
+        }
+    }
+
+    pub fn dropdown_prev(&mut self) {
+        if self.database_type_dropdown.is_open {
+            self.database_type_dropdown.selected_index =
+                self.database_type_dropdown.selected_index.saturating_sub(1);
+        } else if self.ssl_dropdown.is_open {
+            self.ssl_dropdown.selected_index = self.ssl_dropdown.selected_index.saturating_sub(1);
+        }
+    }
+
+    pub fn confirm_dropdown(&mut self) {
+        if self.database_type_dropdown.is_open {
+            if let Some(database_type) =
+                DatabaseType::all().get(self.database_type_dropdown.selected_index)
+            {
+                self.set_database_type(*database_type);
+            }
+        } else if self.ssl_dropdown.is_open {
+            if let Some(mode) = SslMode::all_variants().get(self.ssl_dropdown.selected_index) {
+                self.ssl_mode = *mode;
+            }
+            self.ssl_dropdown.is_open = false;
+        }
+    }
+
+    pub fn cancel_dropdown(&mut self) {
+        self.database_type_dropdown.is_open = false;
+        self.ssl_dropdown.is_open = false;
+    }
+
+    pub fn record_sqlite_config_error(&mut self, error: SqliteConnectionConfigError) {
+        let message = match error {
+            SqliteConnectionConfigError::EmptyPath => "Required",
+            SqliteConnectionConfigError::UnsupportedPath => "Unsupported characters",
+        };
+        self.validation_errors
+            .insert(ConnectionField::SqlitePath, message.to_string());
     }
 
     pub fn to_connection_config(&self) -> Result<ConnectionConfig, SqliteConnectionConfigError> {
@@ -251,6 +345,16 @@ impl ConnectionSetupState {
                 )?)
             }
         })
+    }
+}
+
+fn base_from_profile(profile: &ConnectionProfile) -> ConnectionSetupState {
+    let name = profile.name.as_str();
+    ConnectionSetupState {
+        name: TextInputState::new(name, name.chars().count()),
+        is_first_run: false,
+        editing_id: Some(profile.id.clone()),
+        ..ConnectionSetupState::default()
     }
 }
 
@@ -285,52 +389,27 @@ fn prev_visible_field(
 
 impl From<&ConnectionProfile> for ConnectionSetupState {
     fn from(profile: &ConnectionProfile) -> Self {
-        let name_len = profile.name.as_str().chars().count();
+        let mut state = base_from_profile(profile);
         match &profile.config {
             ConnectionConfig::PostgreSQL(config) => {
                 let port_str = config.port.to_string();
-                Self {
-                    database_type: DatabaseType::PostgreSQL,
-                    name: TextInputState::new(profile.name.as_str(), name_len),
-                    sqlite_path: TextInputState::default(),
-                    host: TextInputState::new(&config.host, config.host.chars().count()),
-                    port: TextInputState::new(&port_str, port_str.chars().count()),
-                    database: TextInputState::new(
-                        &config.database,
-                        config.database.chars().count(),
-                    ),
-                    user: TextInputState::new(&config.username, config.username.chars().count()),
-                    password: TextInputState::new(
-                        &config.password,
-                        config.password.chars().count(),
-                    ),
-                    ssl_mode: config.ssl_mode,
-                    focused_field: ConnectionField::DatabaseType,
-                    database_type_dropdown: DatabaseTypeDropdown::default(),
-                    ssl_dropdown: SslModeDropdown::default(),
-                    validation_errors: HashMap::new(),
-                    is_first_run: false,
-                    editing_id: Some(profile.id.clone()),
-                }
+                state.database_type = DatabaseType::PostgreSQL;
+                state.host = TextInputState::new(&config.host, config.host.chars().count());
+                state.port = TextInputState::new(&port_str, port_str.chars().count());
+                state.database =
+                    TextInputState::new(&config.database, config.database.chars().count());
+                state.user = TextInputState::new(&config.username, config.username.chars().count());
+                state.password =
+                    TextInputState::new(&config.password, config.password.chars().count());
+                state.ssl_mode = config.ssl_mode;
             }
-            ConnectionConfig::SQLite(config) => Self {
-                database_type: DatabaseType::SQLite,
-                name: TextInputState::new(profile.name.as_str(), name_len),
-                sqlite_path: TextInputState::new(config.path(), config.path().chars().count()),
-                host: TextInputState::new("localhost", 9),
-                port: TextInputState::new("5432", 4),
-                database: TextInputState::default(),
-                user: TextInputState::default(),
-                password: TextInputState::default(),
-                ssl_mode: SslMode::Prefer,
-                focused_field: ConnectionField::DatabaseType,
-                database_type_dropdown: DatabaseTypeDropdown::default(),
-                ssl_dropdown: SslModeDropdown::default(),
-                validation_errors: HashMap::new(),
-                is_first_run: false,
-                editing_id: Some(profile.id.clone()),
-            },
+            ConnectionConfig::SQLite(config) => {
+                state.database_type = DatabaseType::SQLite;
+                state.sqlite_path =
+                    TextInputState::new(config.path(), config.path().chars().count());
+            }
         }
+        state
     }
 }
 

--- a/src/app/ports/outbound/connection_store.rs
+++ b/src/app/ports/outbound/connection_store.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::domain::connection::{ConnectionId, ConnectionNameError, ConnectionProfile};
+use crate::domain::connection::{ConnectionId, ConnectionProfile, ConnectionProfileError};
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ConnectionStoreError {
@@ -14,7 +14,7 @@ pub enum ConnectionStoreError {
     #[error("TOML deserialize error: {0}")]
     TomlDeserialize(#[source] Arc<toml::de::Error>),
     #[error("Invalid profile: {0}")]
-    InvalidProfile(#[source] ConnectionNameError),
+    InvalidProfile(#[source] ConnectionProfileError),
     #[error("Connection name already exists: {0}")]
     DuplicateName(String),
     #[error("Connection not found: {0}")]

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use crate::domain::connection::{ConnectionProfile, ConnectionProfileError, ServiceEntry};
+use crate::domain::connection::{
+    ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
+};
 use crate::model::connection::error::ConnectionErrorInfo;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::key_sequence::Prefix;
@@ -246,6 +248,7 @@ pub struct ConnectionTarget {
     pub id: ConnectionId,
     pub dsn: String,
     pub name: String,
+    pub database_type: DatabaseType,
 }
 
 // Do not derive PartialEq here: payload variants carry domain snapshots and

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::domain::connection::{ConnectionNameError, ConnectionProfile, ServiceEntry};
+use crate::domain::connection::{ConnectionProfile, ConnectionProfileError, ServiceEntry};
 use crate::model::connection::error::ConnectionErrorInfo;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::key_sequence::Prefix;
@@ -18,7 +18,7 @@ use crate::domain::{ConnectionId, DatabaseMetadata, QueryResult, QuerySource, Ta
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ConnectionSaveError {
     #[error("{0}")]
-    Validation(#[from] ConnectionNameError),
+    Validation(#[from] ConnectionProfileError),
     #[error("{0}")]
     Store(#[from] ConnectionStoreError),
 }

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -102,21 +102,21 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::connection::{ConnectionId, ConnectionName, ConnectionProfile, SslMode};
+    use crate::domain::connection::{ConnectionId, ConnectionProfile, SslMode};
     use crate::services::AppServices;
     use crate::update::browse::navigation::reduce_navigation;
 
     fn create_test_profile(name: &str) -> ConnectionProfile {
-        ConnectionProfile {
-            id: ConnectionId::new(),
-            name: ConnectionName::new(name).unwrap(),
-            host: "localhost".to_string(),
-            port: 5432,
-            database: "test".to_string(),
-            username: "user".to_string(),
-            password: "pass".to_string(),
-            ssl_mode: SslMode::Prefer,
-        }
+        ConnectionProfile::new(
+            name,
+            "localhost",
+            5432,
+            "test",
+            "user",
+            "pass",
+            SslMode::Prefer,
+        )
+        .unwrap()
     }
 
     mod connection_list_navigation {
@@ -302,16 +302,17 @@ mod tests {
         use super::*;
 
         fn create_test_profile_with_id(name: &str, id: ConnectionId) -> ConnectionProfile {
-            ConnectionProfile {
+            ConnectionProfile::with_id(
                 id,
-                name: ConnectionName::new(name).unwrap(),
-                host: "localhost".to_string(),
-                port: 5432,
-                database: "test".to_string(),
-                username: "user".to_string(),
-                password: "pass".to_string(),
-                ssl_mode: SslMode::Prefer,
-            }
+                name,
+                "localhost",
+                5432,
+                "test",
+                "user",
+                "pass",
+                SslMode::Prefer,
+            )
+            .unwrap()
         }
 
         #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -9,12 +9,19 @@ use crate::update::action::{Action, ConnectionTarget};
 
 use super::helpers::{restore_cache, save_current_cache};
 
-fn reset_for_new_connection(state: &mut AppState, id: &ConnectionId, dsn: &str, name: &str) {
+fn reset_for_new_connection(
+    state: &mut AppState,
+    id: &ConnectionId,
+    dsn: &str,
+    name: &str,
+    database_type: DatabaseType,
+) {
     state.session.reset(&mut state.query);
     state.result_interaction.reset_view();
     state.ui.set_explorer_selection(None);
     state.session.active_connection_id = Some(id.clone());
     state.session.active_connection_name = Some(name.to_string());
+    state.session.active_database_type = Some(database_type);
     state.session.dsn = Some(dsn.to_string());
     state.session.read_only = false;
 }
@@ -30,6 +37,9 @@ pub fn reduce(
             if state.session.connection_state().is_not_connected()
                 && state.modal.active_mode() == InputMode::Normal
             {
+                if state.session.active_database_type == Some(DatabaseType::SQLite) {
+                    return Some(vec![]);
+                }
                 if let Some(dsn) = state.session.dsn.clone() {
                     state.session.begin_connecting(&dsn);
                     Some(vec![Effect::FetchMetadata { dsn }])
@@ -52,21 +62,22 @@ pub fn reduce(
                 state.connection_caches.save(&current_id, cache);
             }
 
-            // Try to restore from cache
-            if let Some(cached) = state.connection_caches.get(id).cloned() {
+            if *database_type == DatabaseType::SQLite {
+                state.connection_caches.remove(id);
+                reset_for_new_connection(state, id, dsn, name, *database_type);
+                state.session.mark_disconnected();
+                Some(vec![Effect::ClearCompletionEngineCache])
+            } else if let Some(cached) = state.connection_caches.get(id).cloned() {
                 restore_cache(state, &cached, services);
                 state.session.active_connection_id = Some(id.clone());
                 state.session.dsn = Some(dsn.clone());
                 state.session.active_connection_name = Some(name.clone());
+                state.session.active_database_type = Some(*database_type);
                 state.session.read_only = false;
-                Some(vec![Effect::ClearCompletionEngineCache])
-            } else if *database_type == DatabaseType::SQLite {
-                reset_for_new_connection(state, id, dsn, name);
-                state.session.mark_disconnected();
                 Some(vec![Effect::ClearCompletionEngineCache])
             } else {
                 // No cache: reset and fetch metadata
-                reset_for_new_connection(state, id, dsn, name);
+                reset_for_new_connection(state, id, dsn, name, *database_type);
                 state.session.begin_connecting(dsn);
                 Some(vec![
                     Effect::ClearCompletionEngineCache,
@@ -133,6 +144,10 @@ mod tests {
 
         assert_eq!(state.ui.explorer_selected, 42);
         assert_eq!(state.ui.inspector_tab, InspectorTab::ForeignKeys);
+        assert_eq!(
+            state.session.active_database_type,
+            Some(DatabaseType::PostgreSQL)
+        );
     }
 
     #[test]
@@ -198,6 +213,63 @@ mod tests {
                 .any(|e| matches!(e, Effect::FetchMetadata { .. }))
         );
         assert!(state.session.connection_state().is_not_connected());
+        assert_eq!(
+            state.session.active_database_type,
+            Some(DatabaseType::SQLite)
+        );
+    }
+
+    #[test]
+    fn sqlite_switch_ignores_stale_cache() {
+        let mut state = AppState::new("test".to_string());
+        let target_id = ConnectionId::new();
+        let services = AppServices::stub();
+        state.ui.explorer_selected = 7;
+        state.connection_caches.save(
+            &target_id,
+            ConnectionCache {
+                explorer_selected: 42,
+                inspector_tab: InspectorTab::ForeignKeys,
+                ..Default::default()
+            },
+        );
+
+        let action = Action::SwitchConnection(ConnectionTarget {
+            id: target_id.clone(),
+            dsn: "sqlite:///tmp/app.db".to_string(),
+            name: "app.db".to_string(),
+            database_type: DatabaseType::SQLite,
+        });
+        let effects = reduce(&mut state, &action, Instant::now(), &services).unwrap();
+
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::FetchMetadata { .. }))
+        );
+        assert!(state.connection_caches.get(&target_id).is_none());
+        assert_eq!(state.ui.explorer_selected, 0);
+        assert_eq!(
+            state.session.active_database_type,
+            Some(DatabaseType::SQLite)
+        );
+        assert!(state.session.connection_state().is_not_connected());
+    }
+
+    #[test]
+    fn sqlite_try_connect_does_not_fetch_metadata() {
+        let mut state = AppState::new("test".to_string());
+        let services = AppServices::stub();
+        state.session.dsn = Some("sqlite:///tmp/app.db".to_string());
+        state.session.active_database_type = Some(DatabaseType::SQLite);
+        state
+            .session
+            .set_connection_state(ConnectionState::NotConnected);
+
+        let effects = reduce(&mut state, &Action::TryConnect, Instant::now(), &services).unwrap();
+
+        assert!(effects.is_empty());
+        assert!(state.session.connection_state().is_not_connected());
     }
 
     #[test]
@@ -217,6 +289,10 @@ mod tests {
         assert_eq!(
             state.session.active_connection_name,
             Some("target_db".to_string())
+        );
+        assert_eq!(
+            state.session.active_database_type,
+            Some(DatabaseType::PostgreSQL)
         );
     }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1,13 +1,23 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::connection::DatabaseType;
+use crate::domain::connection::{ConnectionId, DatabaseType};
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
 use crate::update::action::{Action, ConnectionTarget};
 
 use super::helpers::{restore_cache, save_current_cache};
+
+fn reset_for_new_connection(state: &mut AppState, id: &ConnectionId, dsn: &str, name: &str) {
+    state.session.reset(&mut state.query);
+    state.result_interaction.reset_view();
+    state.ui.set_explorer_selection(None);
+    state.session.active_connection_id = Some(id.clone());
+    state.session.active_connection_name = Some(name.to_string());
+    state.session.dsn = Some(dsn.to_string());
+    state.session.read_only = false;
+}
 
 pub fn reduce(
     state: &mut AppState,
@@ -51,23 +61,12 @@ pub fn reduce(
                 state.session.read_only = false;
                 Some(vec![Effect::ClearCompletionEngineCache])
             } else if *database_type == DatabaseType::SQLite {
-                state.session.reset(&mut state.query);
-                state.result_interaction.reset_view();
-                state.ui.set_explorer_selection(None);
-                state.session.active_connection_id = Some(id.clone());
-                state.session.active_connection_name = Some(name.clone());
-                state.session.dsn = Some(dsn.clone());
-                state.session.read_only = false;
+                reset_for_new_connection(state, id, dsn, name);
                 state.session.mark_disconnected();
                 Some(vec![Effect::ClearCompletionEngineCache])
             } else {
                 // No cache: reset and fetch metadata
-                state.session.reset(&mut state.query);
-                state.result_interaction.reset_view();
-                state.ui.set_explorer_selection(None);
-                state.session.active_connection_id = Some(id.clone());
-                state.session.active_connection_name = Some(name.clone());
-                state.session.read_only = false;
+                reset_for_new_connection(state, id, dsn, name);
                 state.session.begin_connecting(dsn);
                 Some(vec![
                     Effect::ClearCompletionEngineCache,

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::connection::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
@@ -30,7 +31,12 @@ pub fn reduce(
             }
         }
 
-        Action::SwitchConnection(ConnectionTarget { id, dsn, name }) => {
+        Action::SwitchConnection(ConnectionTarget {
+            id,
+            dsn,
+            name,
+            database_type,
+        }) => {
             if let Some(current_id) = state.session.active_connection_id.clone() {
                 let cache = save_current_cache(state);
                 state.connection_caches.save(&current_id, cache);
@@ -43,6 +49,16 @@ pub fn reduce(
                 state.session.dsn = Some(dsn.clone());
                 state.session.active_connection_name = Some(name.clone());
                 state.session.read_only = false;
+                Some(vec![Effect::ClearCompletionEngineCache])
+            } else if *database_type == DatabaseType::SQLite {
+                state.session.reset(&mut state.query);
+                state.result_interaction.reset_view();
+                state.ui.set_explorer_selection(None);
+                state.session.active_connection_id = Some(id.clone());
+                state.session.active_connection_name = Some(name.clone());
+                state.session.dsn = Some(dsn.clone());
+                state.session.read_only = false;
+                state.session.mark_disconnected();
                 Some(vec![Effect::ClearCompletionEngineCache])
             } else {
                 // No cache: reset and fetch metadata
@@ -77,6 +93,7 @@ mod tests {
             id: id.clone(),
             dsn: format!("postgres://localhost/{name}"),
             name: name.to_string(),
+            database_type: DatabaseType::PostgreSQL,
         })
     }
 
@@ -160,6 +177,28 @@ mod tests {
             state.session.connection_state(),
             ConnectionState::Connecting
         );
+    }
+
+    #[test]
+    fn sqlite_switch_without_cache_does_not_fetch_metadata() {
+        let mut state = AppState::new("test".to_string());
+        let new_id = ConnectionId::new();
+        let services = AppServices::stub();
+
+        let action = Action::SwitchConnection(ConnectionTarget {
+            id: new_id,
+            dsn: "sqlite:///tmp/app.db".to_string(),
+            name: "app.db".to_string(),
+            database_type: DatabaseType::SQLite,
+        });
+        let effects = reduce(&mut state, &action, Instant::now(), &services).unwrap();
+
+        assert!(
+            !effects
+                .iter()
+                .any(|e| matches!(e, Effect::FetchMetadata { .. }))
+        );
+        assert!(state.session.connection_state().is_not_connected());
     }
 
     #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -19,10 +19,9 @@ fn reset_for_new_connection(
     state.session.reset(&mut state.query);
     state.result_interaction.reset_view();
     state.ui.set_explorer_selection(None);
-    state.session.active_connection_id = Some(id.clone());
-    state.session.active_connection_name = Some(name.to_string());
-    state.session.active_database_type = Some(database_type);
-    state.session.dsn = Some(dsn.to_string());
+    state
+        .session
+        .set_active_connection(id, name, database_type, dsn);
     state.session.read_only = false;
 }
 
@@ -69,10 +68,9 @@ pub fn reduce(
                 Some(vec![Effect::ClearCompletionEngineCache])
             } else if let Some(cached) = state.connection_caches.get(id).cloned() {
                 restore_cache(state, &cached, services);
-                state.session.active_connection_id = Some(id.clone());
-                state.session.dsn = Some(dsn.clone());
-                state.session.active_connection_name = Some(name.clone());
-                state.session.active_database_type = Some(*database_type);
+                state
+                    .session
+                    .set_active_connection(id, name, *database_type, dsn);
                 state.session.read_only = false;
                 Some(vec![Effect::ClearCompletionEngineCache])
             } else {

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::connection::{DatabaseType, SslMode};
+use crate::domain::connection::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::connection::setup::{
     CONNECTION_INPUT_VISIBLE_WIDTH, ConnectionField, ConnectionSetupState,
@@ -15,7 +15,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         Action::OpenModal(ModalKind::ConnectionSetup) => {
             state.connection_setup.reset();
             if !state.connections().is_empty() || state.session.dsn.is_some() {
-                state.connection_setup.is_first_run = false;
+                state.connection_setup.set_first_run(false);
             }
             state.modal.set_mode(InputMode::ConnectionSetup);
             Some(vec![])
@@ -113,93 +113,33 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         Action::ConnectionSetupNextField => {
             let setup = &mut state.connection_setup;
             validate_field(setup, setup.focused_field);
-            if let Some(next) = setup.next_field() {
-                setup.focused_field = next;
-            }
+            setup.focus_next_field();
             Some(vec![])
         }
         Action::ConnectionSetupPrevField => {
             let setup = &mut state.connection_setup;
             validate_field(setup, setup.focused_field);
-            if let Some(prev) = setup.prev_field() {
-                setup.focused_field = prev;
-            }
+            setup.focus_prev_field();
             Some(vec![])
         }
         Action::ConnectionSetupToggleDropdown => {
-            let setup = &mut state.connection_setup;
-            match setup.focused_field {
-                ConnectionField::DatabaseType => {
-                    setup.database_type_dropdown.is_open = !setup.database_type_dropdown.is_open;
-                    setup.ssl_dropdown.is_open = false;
-                    if setup.database_type_dropdown.is_open {
-                        setup.database_type_dropdown.selected_index = DatabaseType::all()
-                            .iter()
-                            .position(|v| *v == setup.database_type)
-                            .unwrap_or(0);
-                    }
-                }
-                ConnectionField::SslMode => {
-                    setup.ssl_dropdown.is_open = !setup.ssl_dropdown.is_open;
-                    setup.database_type_dropdown.is_open = false;
-                    if setup.ssl_dropdown.is_open {
-                        setup.ssl_dropdown.selected_index = SslMode::all_variants()
-                            .iter()
-                            .position(|v| *v == setup.ssl_mode)
-                            .unwrap_or(2);
-                    }
-                }
-                _ => {}
-            }
+            state.connection_setup.toggle_focused_dropdown();
             Some(vec![])
         }
         Action::ConnectionSetupDropdownNext => {
-            let setup = &mut state.connection_setup;
-            if setup.database_type_dropdown.is_open {
-                let max = DatabaseType::all().len() - 1;
-                if setup.database_type_dropdown.selected_index < max {
-                    setup.database_type_dropdown.selected_index += 1;
-                }
-            } else if setup.ssl_dropdown.is_open {
-                let max = SslMode::all_variants().len() - 1;
-                if setup.ssl_dropdown.selected_index < max {
-                    setup.ssl_dropdown.selected_index += 1;
-                }
-            }
+            state.connection_setup.dropdown_next();
             Some(vec![])
         }
         Action::ConnectionSetupDropdownPrev => {
-            let setup = &mut state.connection_setup;
-            if setup.database_type_dropdown.is_open {
-                setup.database_type_dropdown.selected_index = setup
-                    .database_type_dropdown
-                    .selected_index
-                    .saturating_sub(1);
-            } else if setup.ssl_dropdown.is_open {
-                setup.ssl_dropdown.selected_index =
-                    setup.ssl_dropdown.selected_index.saturating_sub(1);
-            }
+            state.connection_setup.dropdown_prev();
             Some(vec![])
         }
         Action::ConnectionSetupDropdownConfirm => {
-            let setup = &mut state.connection_setup;
-            if setup.database_type_dropdown.is_open {
-                if let Some(database_type) =
-                    DatabaseType::all().get(setup.database_type_dropdown.selected_index)
-                {
-                    setup.set_database_type(*database_type);
-                }
-            } else if setup.ssl_dropdown.is_open {
-                if let Some(mode) = SslMode::all_variants().get(setup.ssl_dropdown.selected_index) {
-                    setup.ssl_mode = *mode;
-                }
-                setup.ssl_dropdown.is_open = false;
-            }
+            state.connection_setup.confirm_dropdown();
             Some(vec![])
         }
         Action::ConnectionSetupDropdownCancel => {
-            state.connection_setup.database_type_dropdown.is_open = false;
-            state.connection_setup.ssl_dropdown.is_open = false;
+            state.connection_setup.cancel_dropdown();
             Some(vec![])
         }
         Action::ConnectionSetupSave => {
@@ -208,19 +148,8 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             if setup.validation_errors.is_empty() {
                 let config = match setup.to_connection_config() {
                     Ok(config) => config,
-                    Err(crate::domain::connection::SqliteConnectionConfigError::EmptyPath) => {
-                        setup
-                            .validation_errors
-                            .insert(ConnectionField::SqlitePath, "Required".to_string());
-                        return Some(vec![]);
-                    }
-                    Err(
-                        crate::domain::connection::SqliteConnectionConfigError::UnsupportedPath,
-                    ) => {
-                        setup.validation_errors.insert(
-                            ConnectionField::SqlitePath,
-                            "Unsupported characters".to_string(),
-                        );
+                    Err(error) => {
+                        setup.record_sqlite_config_error(error);
                         return Some(vec![]);
                     }
                 };
@@ -256,7 +185,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             name,
             database_type,
         }) => {
-            state.connection_setup.is_first_run = false;
+            state.connection_setup.set_first_run(false);
             state.modal.set_mode(InputMode::Normal);
             state.session.active_connection_id = Some(id.clone());
             state.session.active_connection_name = Some(name.clone());
@@ -284,7 +213,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::connection::ConnectionProfile;
+    use crate::domain::connection::{ConnectionProfile, SslMode};
     fn create_profile(name: &str) -> ConnectionProfile {
         ConnectionProfile::new(
             name.to_string(),

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -206,11 +206,29 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             let setup = &mut state.connection_setup;
             validate_all(setup);
             if setup.validation_errors.is_empty() {
+                let config = match setup.to_connection_config() {
+                    Ok(config) => config,
+                    Err(crate::domain::connection::SqliteConnectionConfigError::EmptyPath) => {
+                        setup
+                            .validation_errors
+                            .insert(ConnectionField::SqlitePath, "Required".to_string());
+                        return Some(vec![]);
+                    }
+                    Err(
+                        crate::domain::connection::SqliteConnectionConfigError::UnsupportedPath,
+                    ) => {
+                        setup.validation_errors.insert(
+                            ConnectionField::SqlitePath,
+                            "Unsupported characters".to_string(),
+                        );
+                        return Some(vec![]);
+                    }
+                };
                 state.session.mark_connecting();
                 Some(vec![Effect::SaveAndConnect {
                     id: setup.editing_id.clone(),
                     name: setup.name.content().to_string(),
-                    config: setup.to_connection_config(),
+                    config,
                 }])
             } else {
                 Some(vec![])

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -187,12 +187,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         }) => {
             state.connection_setup.set_first_run(false);
             state.modal.set_mode(InputMode::Normal);
-            state.session.active_connection_id = Some(id.clone());
-            state.session.active_connection_name = Some(name.clone());
-            state.session.active_database_type = Some(*database_type);
+            state
+                .session
+                .set_active_connection(id, name, *database_type, dsn);
             state.session.read_only = false;
             if *database_type == DatabaseType::SQLite {
-                state.session.dsn = Some(dsn.clone());
                 state.session.mark_disconnected();
                 return Some(vec![]);
             }

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -224,7 +224,9 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                         return Some(vec![]);
                     }
                 };
-                state.session.mark_connecting();
+                if config.database_type() != DatabaseType::SQLite {
+                    state.session.mark_connecting();
+                }
                 Some(vec![Effect::SaveAndConnect {
                     id: setup.editing_id.clone(),
                     name: setup.name.content().to_string(),
@@ -442,6 +444,30 @@ mod tests {
                 ConnectionState::Connecting
             );
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
+        }
+
+        #[test]
+        fn sqlite_save_does_not_enter_connecting_state() {
+            let mut state = AppState::new("test".to_string());
+            state.connection_setup.database_type = DatabaseType::SQLite;
+            state.connection_setup.name.set_content("Local".to_string());
+            state
+                .connection_setup
+                .sqlite_path
+                .set_content("/tmp/app.db".to_string());
+
+            let effects = reduce(&mut state, &Action::ConnectionSetupSave, Instant::now())
+                .expect("save handled");
+
+            assert_eq!(
+                state.session.connection_state(),
+                ConnectionState::NotConnected
+            );
+            assert_eq!(state.session.metadata_state(), &MetadataState::NotLoaded);
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::SaveAndConnect { .. }]
+            ));
         }
 
         #[test]

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -230,12 +230,22 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 Some(vec![Effect::DispatchActions(vec![Action::TryConnect])])
             }
         }
-        Action::ConnectionSaveCompleted(ConnectionTarget { id, dsn, name }) => {
+        Action::ConnectionSaveCompleted(ConnectionTarget {
+            id,
+            dsn,
+            name,
+            database_type,
+        }) => {
             state.connection_setup.is_first_run = false;
             state.modal.set_mode(InputMode::Normal);
             state.session.active_connection_id = Some(id.clone());
             state.session.active_connection_name = Some(name.clone());
             state.session.read_only = false;
+            if *database_type == DatabaseType::SQLite {
+                state.session.dsn = Some(dsn.clone());
+                state.session.mark_disconnected();
+                return Some(vec![]);
+            }
             state.session.begin_connecting(dsn);
             Some(vec![Effect::FetchMetadata { dsn: dsn.clone() }])
         }
@@ -425,10 +435,28 @@ mod tests {
                 id: crate::domain::ConnectionId::new(),
                 dsn: "postgres://localhost/new_db".to_string(),
                 name: "new_db".to_string(),
+                database_type: DatabaseType::PostgreSQL,
             });
             reduce(&mut state, &action, Instant::now());
 
             assert!(!state.session.read_only);
+        }
+
+        #[test]
+        fn sqlite_save_completed_does_not_fetch_metadata() {
+            let mut state = AppState::new("test".to_string());
+
+            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
+                id: crate::domain::ConnectionId::new(),
+                dsn: "sqlite:///tmp/app.db".to_string(),
+                name: "app.db".to_string(),
+                database_type: DatabaseType::SQLite,
+            });
+            let effects = reduce(&mut state, &action, Instant::now()).unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(state.session.dsn, Some("sqlite:///tmp/app.db".to_string()));
+            assert!(state.session.connection_state().is_not_connected());
         }
     }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::connection::SslMode;
+use crate::domain::connection::{DatabaseType, SslMode};
 use crate::model::app_state::AppState;
 use crate::model::connection::setup::{
     CONNECTION_INPUT_VISIBLE_WIDTH, ConnectionField, ConnectionSetupState,
@@ -55,7 +55,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                         setup.port.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
                     }
                 }
-                ConnectionField::SslMode => {}
+                ConnectionField::DatabaseType | ConnectionField::SslMode => {}
                 _ => {
                     if let Some(input) = setup.focused_input_mut() {
                         input.insert_str(&clean);
@@ -79,7 +79,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                         setup.port.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
                     }
                 }
-                ConnectionField::SslMode => {}
+                ConnectionField::DatabaseType | ConnectionField::SslMode => {}
                 _ => {
                     if let Some(input) = setup.focused_input_mut() {
                         input.insert_char(*c);
@@ -113,7 +113,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         Action::ConnectionSetupNextField => {
             let setup = &mut state.connection_setup;
             validate_field(setup, setup.focused_field);
-            if let Some(next) = setup.focused_field.next() {
+            if let Some(next) = setup.next_field() {
                 setup.focused_field = next;
             }
             Some(vec![])
@@ -121,27 +121,46 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         Action::ConnectionSetupPrevField => {
             let setup = &mut state.connection_setup;
             validate_field(setup, setup.focused_field);
-            if let Some(prev) = setup.focused_field.prev() {
+            if let Some(prev) = setup.prev_field() {
                 setup.focused_field = prev;
             }
             Some(vec![])
         }
         Action::ConnectionSetupToggleDropdown => {
             let setup = &mut state.connection_setup;
-            if setup.focused_field == ConnectionField::SslMode {
-                setup.ssl_dropdown.is_open = !setup.ssl_dropdown.is_open;
-                if setup.ssl_dropdown.is_open {
-                    setup.ssl_dropdown.selected_index = SslMode::all_variants()
-                        .iter()
-                        .position(|v| *v == setup.ssl_mode)
-                        .unwrap_or(2);
+            match setup.focused_field {
+                ConnectionField::DatabaseType => {
+                    setup.database_type_dropdown.is_open = !setup.database_type_dropdown.is_open;
+                    setup.ssl_dropdown.is_open = false;
+                    if setup.database_type_dropdown.is_open {
+                        setup.database_type_dropdown.selected_index = DatabaseType::all()
+                            .iter()
+                            .position(|v| *v == setup.database_type)
+                            .unwrap_or(0);
+                    }
                 }
+                ConnectionField::SslMode => {
+                    setup.ssl_dropdown.is_open = !setup.ssl_dropdown.is_open;
+                    setup.database_type_dropdown.is_open = false;
+                    if setup.ssl_dropdown.is_open {
+                        setup.ssl_dropdown.selected_index = SslMode::all_variants()
+                            .iter()
+                            .position(|v| *v == setup.ssl_mode)
+                            .unwrap_or(2);
+                    }
+                }
+                _ => {}
             }
             Some(vec![])
         }
         Action::ConnectionSetupDropdownNext => {
             let setup = &mut state.connection_setup;
-            if setup.ssl_dropdown.is_open {
+            if setup.database_type_dropdown.is_open {
+                let max = DatabaseType::all().len() - 1;
+                if setup.database_type_dropdown.selected_index < max {
+                    setup.database_type_dropdown.selected_index += 1;
+                }
+            } else if setup.ssl_dropdown.is_open {
                 let max = SslMode::all_variants().len() - 1;
                 if setup.ssl_dropdown.selected_index < max {
                     setup.ssl_dropdown.selected_index += 1;
@@ -151,7 +170,12 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         }
         Action::ConnectionSetupDropdownPrev => {
             let setup = &mut state.connection_setup;
-            if setup.ssl_dropdown.is_open {
+            if setup.database_type_dropdown.is_open {
+                setup.database_type_dropdown.selected_index = setup
+                    .database_type_dropdown
+                    .selected_index
+                    .saturating_sub(1);
+            } else if setup.ssl_dropdown.is_open {
                 setup.ssl_dropdown.selected_index =
                     setup.ssl_dropdown.selected_index.saturating_sub(1);
             }
@@ -159,7 +183,13 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         }
         Action::ConnectionSetupDropdownConfirm => {
             let setup = &mut state.connection_setup;
-            if setup.ssl_dropdown.is_open {
+            if setup.database_type_dropdown.is_open {
+                if let Some(database_type) =
+                    DatabaseType::all().get(setup.database_type_dropdown.selected_index)
+                {
+                    setup.set_database_type(*database_type);
+                }
+            } else if setup.ssl_dropdown.is_open {
                 if let Some(mode) = SslMode::all_variants().get(setup.ssl_dropdown.selected_index) {
                     setup.ssl_mode = *mode;
                 }
@@ -168,6 +198,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             Some(vec![])
         }
         Action::ConnectionSetupDropdownCancel => {
+            state.connection_setup.database_type_dropdown.is_open = false;
             state.connection_setup.ssl_dropdown.is_open = false;
             Some(vec![])
         }
@@ -175,17 +206,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             let setup = &mut state.connection_setup;
             validate_all(setup);
             if setup.validation_errors.is_empty() {
-                let port = setup.port.content().parse().unwrap_or(5432);
                 state.session.mark_connecting();
                 Some(vec![Effect::SaveAndConnect {
                     id: setup.editing_id.clone(),
                     name: setup.name.content().to_string(),
-                    host: setup.host.content().to_string(),
-                    port,
-                    database: setup.database.content().to_string(),
-                    user: setup.user.content().to_string(),
-                    password: setup.password.content().to_string(),
-                    ssl_mode: setup.ssl_mode,
+                    config: setup.to_connection_config(),
                 }])
             } else {
                 Some(vec![])
@@ -230,7 +255,6 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
 mod tests {
     use super::*;
     use crate::domain::connection::ConnectionProfile;
-
     fn create_profile(name: &str) -> ConnectionProfile {
         ConnectionProfile::new(
             name.to_string(),

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -189,6 +189,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             state.modal.set_mode(InputMode::Normal);
             state.session.active_connection_id = Some(id.clone());
             state.session.active_connection_name = Some(name.clone());
+            state.session.active_database_type = Some(*database_type);
             state.session.read_only = false;
             if *database_type == DatabaseType::SQLite {
                 state.session.dsn = Some(dsn.clone());
@@ -429,6 +430,10 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(state.session.dsn, Some("sqlite:///tmp/app.db".to_string()));
+            assert_eq!(
+                state.session.active_database_type,
+                Some(DatabaseType::SQLite)
+            );
             assert!(state.session.connection_state().is_not_connected());
         }
     }

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -209,10 +209,20 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
     match field {
         ConnectionField::DatabaseType => {}
         ConnectionField::SqlitePath => {
-            if state.sqlite_path.content().trim().is_empty() {
-                state
-                    .validation_errors
-                    .insert(field, "Required".to_string());
+            match crate::domain::connection::SqliteConnectionConfig::new(
+                state.sqlite_path.content().to_string(),
+            ) {
+                Ok(_) => {}
+                Err(crate::domain::connection::SqliteConnectionConfigError::EmptyPath) => {
+                    state
+                        .validation_errors
+                        .insert(field, "Required".to_string());
+                }
+                Err(crate::domain::connection::SqliteConnectionConfigError::UnsupportedPath) => {
+                    state
+                        .validation_errors
+                        .insert(field, "Unsupported characters".to_string());
+                }
             }
         }
         ConnectionField::Host => {
@@ -347,6 +357,27 @@ mod tests {
             validate_field(&mut state, ConnectionField::Name);
 
             assert!(!state.validation_errors.contains_key(&ConnectionField::Name));
+        }
+    }
+
+    mod validate_sqlite_path {
+        use super::*;
+        use crate::domain::connection::DatabaseType;
+
+        #[test]
+        fn unsupported_path_characters_set_error() {
+            let mut state = ConnectionSetupState {
+                database_type: DatabaseType::SQLite,
+                ..ConnectionSetupState::default()
+            };
+            state.sqlite_path.set_content("/tmp/app\0.db".to_string());
+
+            validate_field(&mut state, ConnectionField::SqlitePath);
+
+            assert_eq!(
+                state.validation_errors.get(&ConnectionField::SqlitePath),
+                Some(&"Unsupported characters".to_string())
+            );
         }
     }
 

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -207,6 +207,14 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
     state.validation_errors.remove(&field);
 
     match field {
+        ConnectionField::DatabaseType => {}
+        ConnectionField::SqlitePath => {
+            if state.sqlite_path.content().trim().is_empty() {
+                state
+                    .validation_errors
+                    .insert(field, "Required".to_string());
+            }
+        }
         ConnectionField::Host => {
             if state.host.content().trim().is_empty() {
                 state
@@ -261,14 +269,12 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
                     .insert(field, "Name must be 50 characters or less".to_string());
             }
         }
-        ConnectionField::Password | ConnectionField::SslMode => {
-            // Optional fields, no validation needed
-        }
+        ConnectionField::Password | ConnectionField::SslMode => {}
     }
 }
 
 pub fn validate_all(state: &mut ConnectionSetupState) {
-    for field in ConnectionField::all() {
+    for field in ConnectionField::fields_for(state.database_type) {
         validate_field(state, *field);
     }
 }

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -284,7 +284,11 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
 }
 
 pub fn validate_all(state: &mut ConnectionSetupState) {
-    for field in ConnectionField::fields_for(state.database_type) {
+    let active_fields = ConnectionField::fields_for(state.database_type);
+    state
+        .validation_errors
+        .retain(|field, _| active_fields.contains(field));
+    for field in active_fields {
         validate_field(state, *field);
     }
 }
@@ -365,6 +369,22 @@ mod tests {
         use crate::domain::connection::DatabaseType;
 
         #[test]
+        fn empty_path_sets_required_error() {
+            let mut state = ConnectionSetupState {
+                database_type: DatabaseType::SQLite,
+                ..ConnectionSetupState::default()
+            };
+            state.sqlite_path.set_content("   ".to_string());
+
+            validate_field(&mut state, ConnectionField::SqlitePath);
+
+            assert_eq!(
+                state.validation_errors.get(&ConnectionField::SqlitePath),
+                Some(&"Required".to_string())
+            );
+        }
+
+        #[test]
         fn unsupported_path_characters_set_error() {
             let mut state = ConnectionSetupState {
                 database_type: DatabaseType::SQLite,
@@ -378,6 +398,22 @@ mod tests {
                 state.validation_errors.get(&ConnectionField::SqlitePath),
                 Some(&"Unsupported characters".to_string())
             );
+        }
+
+        #[test]
+        fn validate_all_removes_errors_for_hidden_fields() {
+            let mut state = ConnectionSetupState {
+                database_type: DatabaseType::SQLite,
+                ..ConnectionSetupState::default()
+            };
+            state
+                .validation_errors
+                .insert(ConnectionField::Host, "Required".to_string());
+            state.sqlite_path.set_content("/tmp/app.db".to_string());
+
+            validate_all(&mut state);
+
+            assert!(!state.validation_errors.contains_key(&ConnectionField::Host));
         }
     }
 

--- a/src/app/update/input/handlers/connections.rs
+++ b/src/app/update/input/handlers/connections.rs
@@ -6,7 +6,8 @@ pub fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) -> Action
     use crate::model::connection::setup::ConnectionField;
     use crate::update::action::CursorMove;
 
-    let dropdown_open = state.connection_setup.ssl_dropdown.is_open;
+    let dropdown_open = state.connection_setup.database_type_dropdown.is_open
+        || state.connection_setup.ssl_dropdown.is_open;
     let ctrl = combo.modifiers.contains(Modifiers::CTRL);
     let alt = combo.modifiers.contains(Modifiers::ALT);
     let shift = combo.modifiers.contains(Modifiers::SHIFT);
@@ -34,8 +35,12 @@ pub fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) -> Action
         Key::BackTab => Action::ConnectionSetupPrevField,
         Key::Esc => Action::ConnectionSetupCancel,
 
-        // SSL Mode toggle (Enter on SslMode field)
-        Key::Enter if state.connection_setup.focused_field == ConnectionField::SslMode => {
+        Key::Enter
+            if matches!(
+                state.connection_setup.focused_field,
+                ConnectionField::DatabaseType | ConnectionField::SslMode
+            ) =>
+        {
             Action::ConnectionSetupToggleDropdown
         }
 

--- a/src/app/update/input/handlers/connections.rs
+++ b/src/app/update/input/handlers/connections.rs
@@ -237,12 +237,28 @@ mod tests {
             assert!(matches!(result, Action::ConnectionSetupToggleDropdown));
         }
 
+        #[test]
+        fn enter_on_database_type_field_toggles_dropdown() {
+            let mut state = setup_state();
+            state.connection_setup.focused_field = ConnectionField::DatabaseType;
+
+            let result = handle_connection_setup_keys(combo(Key::Enter), &state);
+
+            assert!(matches!(result, Action::ConnectionSetupToggleDropdown));
+        }
+
         mod dropdown_open {
             use super::*;
 
             fn dropdown_state() -> AppState {
                 let mut state = setup_state();
                 state.connection_setup.ssl_dropdown.is_open = true;
+                state
+            }
+
+            fn database_type_dropdown_state() -> AppState {
+                let mut state = setup_state();
+                state.connection_setup.database_type_dropdown.is_open = true;
                 state
             }
 
@@ -260,6 +276,15 @@ mod tests {
                     std::mem::discriminant(&result),
                     std::mem::discriminant(&expected)
                 );
+            }
+
+            #[test]
+            fn database_type_dropdown_routes_navigation() {
+                let state = database_type_dropdown_state();
+
+                let result = handle_connection_setup_keys(combo(Key::Up), &state);
+
+                assert!(matches!(result, Action::ConnectionSetupDropdownPrev));
             }
 
             #[rstest]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1515,7 +1515,7 @@ mod tests {
 
     mod connection_setup_transitions {
         use super::*;
-        use crate::domain::ConnectionId;
+        use crate::domain::{ConnectionId, DatabaseType};
 
         #[test]
         fn save_completed_sets_dsn_and_returns_fetch_effect() {
@@ -1539,6 +1539,7 @@ mod tests {
                     id: ConnectionId::new(),
                     dsn: "postgres://db.example.com/mydb".to_string(),
                     name: "Test Connection".to_string(),
+                    database_type: DatabaseType::PostgreSQL,
                 }),
                 now,
                 &AppServices::stub(),
@@ -1797,7 +1798,7 @@ mod tests {
 
     mod connection_state_tests {
         use super::*;
-        use crate::domain::{ConnectionId, DatabaseMetadata, MetadataState};
+        use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, MetadataState};
         use crate::model::connection::state::ConnectionState;
 
         #[test]
@@ -2040,6 +2041,7 @@ mod tests {
                     id: ConnectionId::new(),
                     dsn: "postgres://localhost/test".to_string(),
                     name: "Test".to_string(),
+                    database_type: DatabaseType::PostgreSQL,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2073,6 +2075,7 @@ mod tests {
                     id: conn_b.clone(),
                     dsn: "postgres://localhost/other".to_string(),
                     name: "Other".to_string(),
+                    database_type: DatabaseType::PostgreSQL,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2126,6 +2129,7 @@ mod tests {
                     id: conn_b.clone(),
                     dsn: "postgres://localhost/cached".to_string(),
                     name: "Cached".to_string(),
+                    database_type: DatabaseType::PostgreSQL,
                 }),
                 now,
                 &AppServices::stub(),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1554,6 +1554,10 @@ mod tests {
                 state.session.active_connection_name,
                 Some("Test Connection".to_string())
             );
+            assert_eq!(
+                state.session.active_database_type,
+                Some(DatabaseType::PostgreSQL)
+            );
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert_eq!(effects.len(), 1);
             assert!(matches!(effects[0], Effect::FetchMetadata { .. }));

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -34,7 +34,7 @@ impl PostgresConnectionConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SqliteConnectionConfig {
-    pub path: String,
+    path: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -52,8 +52,12 @@ impl SqliteConnectionConfig {
         Ok(Self { path })
     }
 
-    pub fn validate(&self) -> Result<(), SqliteConnectionConfigError> {
+    pub(crate) fn validate(&self) -> Result<(), SqliteConnectionConfigError> {
         validate_sqlite_path(&self.path)
+    }
+
+    pub fn path(&self) -> &str {
+        &self.path
     }
 }
 

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -1,0 +1,73 @@
+use serde::{Deserialize, Serialize};
+
+use super::ssl_mode::SslMode;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PostgresConnectionConfig {
+    pub host: String,
+    pub port: u16,
+    pub database: String,
+    pub username: String,
+    pub password: String,
+    pub ssl_mode: SslMode,
+}
+
+impl PostgresConnectionConfig {
+    pub fn new(
+        host: impl Into<String>,
+        port: u16,
+        database: impl Into<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+        ssl_mode: SslMode,
+    ) -> Self {
+        Self {
+            host: host.into(),
+            port,
+            database: database.into(),
+            username: username.into(),
+            password: password.into(),
+            ssl_mode,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SqliteConnectionConfig {
+    pub path: String,
+}
+
+impl SqliteConnectionConfig {
+    pub fn new(path: impl Into<String>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConnectionConfig {
+    PostgreSQL(PostgresConnectionConfig),
+    SQLite(SqliteConnectionConfig),
+}
+
+impl ConnectionConfig {
+    pub fn database_type(&self) -> super::DatabaseType {
+        match self {
+            Self::PostgreSQL(_) => super::DatabaseType::PostgreSQL,
+            Self::SQLite(_) => super::DatabaseType::SQLite,
+        }
+    }
+
+    pub fn as_postgres(&self) -> Option<&PostgresConnectionConfig> {
+        match self {
+            Self::PostgreSQL(config) => Some(config),
+            Self::SQLite(_) => None,
+        }
+    }
+
+    pub fn as_sqlite(&self) -> Option<&SqliteConnectionConfig> {
+        match self {
+            Self::SQLite(config) => Some(config),
+            Self::PostgreSQL(_) => None,
+        }
+    }
+}

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -37,10 +37,34 @@ pub struct SqliteConnectionConfig {
     pub path: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SqliteConnectionConfigError {
+    #[error("SQLite database path is required")]
+    EmptyPath,
+    #[error("SQLite database path contains unsupported characters")]
+    UnsupportedPath,
+}
+
 impl SqliteConnectionConfig {
-    pub fn new(path: impl Into<String>) -> Self {
-        Self { path: path.into() }
+    pub fn new(path: impl Into<String>) -> Result<Self, SqliteConnectionConfigError> {
+        let path = path.into();
+        validate_sqlite_path(&path)?;
+        Ok(Self { path })
     }
+
+    pub fn validate(&self) -> Result<(), SqliteConnectionConfigError> {
+        validate_sqlite_path(&self.path)
+    }
+}
+
+fn validate_sqlite_path(path: &str) -> Result<(), SqliteConnectionConfigError> {
+    if path.trim().is_empty() {
+        return Err(SqliteConnectionConfigError::EmptyPath);
+    }
+    if path.chars().any(|c| c == '\0' || c.is_control()) {
+        return Err(SqliteConnectionConfigError::UnsupportedPath);
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/domain/connection/database_type.rs
+++ b/src/domain/connection/database_type.rs
@@ -12,7 +12,7 @@ pub enum DatabaseType {
 }
 
 impl DatabaseType {
-    pub fn all() -> &'static [Self] {
+    pub const fn all() -> &'static [Self] {
         &[Self::PostgreSQL, Self::SQLite]
     }
 

--- a/src/domain/connection/database_type.rs
+++ b/src/domain/connection/database_type.rs
@@ -1,0 +1,31 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum DatabaseType {
+    #[serde(rename = "postgresql")]
+    #[default]
+    PostgreSQL,
+    #[serde(rename = "sqlite")]
+    SQLite,
+}
+
+impl DatabaseType {
+    pub fn all() -> &'static [Self] {
+        &[Self::PostgreSQL, Self::SQLite]
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::PostgreSQL => "PostgreSQL",
+            Self::SQLite => "SQLite",
+        }
+    }
+}
+
+impl fmt::Display for DatabaseType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}

--- a/src/domain/connection/mod.rs
+++ b/src/domain/connection/mod.rs
@@ -1,11 +1,15 @@
+mod config;
+mod database_type;
 mod id;
 mod name;
 mod profile;
 mod service_entry;
 mod ssl_mode;
 
+pub use config::{ConnectionConfig, PostgresConnectionConfig, SqliteConnectionConfig};
+pub use database_type::DatabaseType;
 pub use id::ConnectionId;
 pub use name::{ConnectionName, ConnectionNameError};
-pub use profile::ConnectionProfile;
+pub use profile::{ConnectionProfile, ConnectionProfileError};
 pub use service_entry::ServiceEntry;
 pub use ssl_mode::SslMode;

--- a/src/domain/connection/mod.rs
+++ b/src/domain/connection/mod.rs
@@ -6,7 +6,9 @@ mod profile;
 mod service_entry;
 mod ssl_mode;
 
-pub use config::{ConnectionConfig, PostgresConnectionConfig, SqliteConnectionConfig};
+pub use config::{
+    ConnectionConfig, PostgresConnectionConfig, SqliteConnectionConfig, SqliteConnectionConfigError,
+};
 pub use database_type::DatabaseType;
 pub use id::ConnectionId;
 pub use name::{ConnectionName, ConnectionNameError};

--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -1,19 +1,24 @@
 use serde::{Deserialize, Serialize};
 
+use super::config::{ConnectionConfig, PostgresConnectionConfig, SqliteConnectionConfig};
+use super::database_type::DatabaseType;
 use super::id::ConnectionId;
 use super::name::{ConnectionName, ConnectionNameError};
 use super::ssl_mode::SslMode;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ConnectionProfileError {
+    #[error("{0}")]
+    Name(#[from] ConnectionNameError),
+    #[error("SQLite database path is required")]
+    EmptySqlitePath,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConnectionProfile {
     pub id: ConnectionId,
     pub name: ConnectionName,
-    pub host: String,
-    pub port: u16,
-    pub database: String,
-    pub username: String,
-    pub password: String,
-    pub ssl_mode: SslMode,
+    pub config: ConnectionConfig,
 }
 
 impl ConnectionProfile {
@@ -26,15 +31,44 @@ impl ConnectionProfile {
         password: impl Into<String>,
         ssl_mode: SslMode,
     ) -> Result<Self, ConnectionNameError> {
+        Self::new_postgres(name, host, port, database, username, password, ssl_mode).map_err(|e| {
+            match e {
+                ConnectionProfileError::Name(e) => e,
+                ConnectionProfileError::EmptySqlitePath => unreachable!("postgres constructor"),
+            }
+        })
+    }
+
+    pub fn new_postgres(
+        name: impl Into<String>,
+        host: impl Into<String>,
+        port: u16,
+        database: impl Into<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+        ssl_mode: SslMode,
+    ) -> Result<Self, ConnectionProfileError> {
         Ok(Self {
             id: ConnectionId::new(),
             name: ConnectionName::new(name)?,
-            host: host.into(),
-            port,
-            database: database.into(),
-            username: username.into(),
-            password: password.into(),
-            ssl_mode,
+            config: ConnectionConfig::PostgreSQL(PostgresConnectionConfig::new(
+                host, port, database, username, password, ssl_mode,
+            )),
+        })
+    }
+
+    pub fn new_sqlite(
+        name: impl Into<String>,
+        path: impl Into<String>,
+    ) -> Result<Self, ConnectionProfileError> {
+        let path = path.into();
+        if path.trim().is_empty() {
+            return Err(ConnectionProfileError::EmptySqlitePath);
+        }
+        Ok(Self {
+            id: ConnectionId::new(),
+            name: ConnectionName::new(name)?,
+            config: ConnectionConfig::SQLite(SqliteConnectionConfig::new(path)),
         })
     }
 
@@ -48,16 +82,75 @@ impl ConnectionProfile {
         password: impl Into<String>,
         ssl_mode: SslMode,
     ) -> Result<Self, ConnectionNameError> {
+        Self::with_id_postgres(id, name, host, port, database, username, password, ssl_mode)
+            .map_err(|e| match e {
+                ConnectionProfileError::Name(e) => e,
+                ConnectionProfileError::EmptySqlitePath => unreachable!("postgres constructor"),
+            })
+    }
+
+    pub fn with_id_postgres(
+        id: ConnectionId,
+        name: impl Into<String>,
+        host: impl Into<String>,
+        port: u16,
+        database: impl Into<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+        ssl_mode: SslMode,
+    ) -> Result<Self, ConnectionProfileError> {
         Ok(Self {
             id,
             name: ConnectionName::new(name)?,
-            host: host.into(),
-            port,
-            database: database.into(),
-            username: username.into(),
-            password: password.into(),
-            ssl_mode,
+            config: ConnectionConfig::PostgreSQL(PostgresConnectionConfig::new(
+                host, port, database, username, password, ssl_mode,
+            )),
         })
+    }
+
+    pub fn with_id_sqlite(
+        id: ConnectionId,
+        name: impl Into<String>,
+        path: impl Into<String>,
+    ) -> Result<Self, ConnectionProfileError> {
+        let path = path.into();
+        if path.trim().is_empty() {
+            return Err(ConnectionProfileError::EmptySqlitePath);
+        }
+        Ok(Self {
+            id,
+            name: ConnectionName::new(name)?,
+            config: ConnectionConfig::SQLite(SqliteConnectionConfig::new(path)),
+        })
+    }
+
+    pub fn with_id_and_config(
+        id: ConnectionId,
+        name: impl Into<String>,
+        config: ConnectionConfig,
+    ) -> Result<Self, ConnectionProfileError> {
+        if let ConnectionConfig::SQLite(sqlite) = &config
+            && sqlite.path.trim().is_empty()
+        {
+            return Err(ConnectionProfileError::EmptySqlitePath);
+        }
+        Ok(Self {
+            id,
+            name: ConnectionName::new(name)?,
+            config,
+        })
+    }
+
+    pub fn database_type(&self) -> DatabaseType {
+        self.config.database_type()
+    }
+
+    pub fn postgres_config(&self) -> Option<&PostgresConnectionConfig> {
+        self.config.as_postgres()
+    }
+
+    pub fn sqlite_config(&self) -> Option<&SqliteConnectionConfig> {
+        self.config.as_sqlite()
     }
 
     pub fn display_name(&self) -> &str {
@@ -114,6 +207,34 @@ mod tests {
         fn formats_connection_name() {
             let profile = make_test_profile();
             assert_eq!(profile.display_name(), "Test Connection");
+        }
+    }
+
+    mod database_type {
+        use super::*;
+
+        #[test]
+        fn postgres_profile_reports_postgresql() {
+            let profile = make_test_profile();
+
+            assert_eq!(profile.database_type(), DatabaseType::PostgreSQL);
+        }
+
+        #[test]
+        fn sqlite_profile_reports_sqlite() {
+            let profile = ConnectionProfile::new_sqlite("Local", "/tmp/app.db").unwrap();
+
+            assert_eq!(profile.database_type(), DatabaseType::SQLite);
+        }
+
+        #[test]
+        fn sqlite_profile_rejects_empty_path() {
+            let result = ConnectionProfile::new_sqlite("Local", " ");
+
+            assert!(matches!(
+                result,
+                Err(ConnectionProfileError::EmptySqlitePath)
+            ));
         }
     }
 }

--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use super::config::{ConnectionConfig, PostgresConnectionConfig, SqliteConnectionConfig};
+use super::config::{
+    ConnectionConfig, PostgresConnectionConfig, SqliteConnectionConfig, SqliteConnectionConfigError,
+};
 use super::database_type::DatabaseType;
 use super::id::ConnectionId;
 use super::name::{ConnectionName, ConnectionNameError};
@@ -12,6 +14,19 @@ pub enum ConnectionProfileError {
     Name(#[from] ConnectionNameError),
     #[error("SQLite database path is required")]
     EmptySqlitePath,
+    #[error("SQLite database path contains unsupported characters")]
+    InvalidSqlitePath,
+    #[error("PostgreSQL connection field `{0}` is required")]
+    MissingPostgresField(&'static str),
+}
+
+impl From<SqliteConnectionConfigError> for ConnectionProfileError {
+    fn from(error: SqliteConnectionConfigError) -> Self {
+        match error {
+            SqliteConnectionConfigError::EmptyPath => Self::EmptySqlitePath,
+            SqliteConnectionConfigError::UnsupportedPath => Self::InvalidSqlitePath,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -35,6 +50,12 @@ impl ConnectionProfile {
             match e {
                 ConnectionProfileError::Name(e) => e,
                 ConnectionProfileError::EmptySqlitePath => unreachable!("postgres constructor"),
+                ConnectionProfileError::InvalidSqlitePath => {
+                    unreachable!("postgres constructor")
+                }
+                ConnectionProfileError::MissingPostgresField(_) => {
+                    unreachable!("postgres constructor")
+                }
             }
         })
     }
@@ -61,14 +82,10 @@ impl ConnectionProfile {
         name: impl Into<String>,
         path: impl Into<String>,
     ) -> Result<Self, ConnectionProfileError> {
-        let path = path.into();
-        if path.trim().is_empty() {
-            return Err(ConnectionProfileError::EmptySqlitePath);
-        }
         Ok(Self {
             id: ConnectionId::new(),
             name: ConnectionName::new(name)?,
-            config: ConnectionConfig::SQLite(SqliteConnectionConfig::new(path)),
+            config: ConnectionConfig::SQLite(SqliteConnectionConfig::new(path)?),
         })
     }
 
@@ -86,6 +103,12 @@ impl ConnectionProfile {
             .map_err(|e| match e {
                 ConnectionProfileError::Name(e) => e,
                 ConnectionProfileError::EmptySqlitePath => unreachable!("postgres constructor"),
+                ConnectionProfileError::InvalidSqlitePath => {
+                    unreachable!("postgres constructor")
+                }
+                ConnectionProfileError::MissingPostgresField(_) => {
+                    unreachable!("postgres constructor")
+                }
             })
     }
 
@@ -113,14 +136,10 @@ impl ConnectionProfile {
         name: impl Into<String>,
         path: impl Into<String>,
     ) -> Result<Self, ConnectionProfileError> {
-        let path = path.into();
-        if path.trim().is_empty() {
-            return Err(ConnectionProfileError::EmptySqlitePath);
-        }
         Ok(Self {
             id,
             name: ConnectionName::new(name)?,
-            config: ConnectionConfig::SQLite(SqliteConnectionConfig::new(path)),
+            config: ConnectionConfig::SQLite(SqliteConnectionConfig::new(path)?),
         })
     }
 
@@ -129,10 +148,8 @@ impl ConnectionProfile {
         name: impl Into<String>,
         config: ConnectionConfig,
     ) -> Result<Self, ConnectionProfileError> {
-        if let ConnectionConfig::SQLite(sqlite) = &config
-            && sqlite.path.trim().is_empty()
-        {
-            return Err(ConnectionProfileError::EmptySqlitePath);
+        if let ConnectionConfig::SQLite(sqlite) = &config {
+            sqlite.validate()?;
         }
         Ok(Self {
             id,
@@ -230,6 +247,32 @@ mod tests {
         #[test]
         fn sqlite_profile_rejects_empty_path() {
             let result = ConnectionProfile::new_sqlite("Local", " ");
+
+            assert!(matches!(
+                result,
+                Err(ConnectionProfileError::EmptySqlitePath)
+            ));
+        }
+
+        #[test]
+        fn sqlite_profile_rejects_unsupported_path_characters() {
+            let result = ConnectionProfile::new_sqlite("Local", "/tmp/app\0.db");
+
+            assert!(matches!(
+                result,
+                Err(ConnectionProfileError::InvalidSqlitePath)
+            ));
+        }
+
+        #[test]
+        fn profile_rejects_invalid_sqlite_config() {
+            let result = ConnectionProfile::with_id_and_config(
+                ConnectionId::new(),
+                "Local",
+                ConnectionConfig::SQLite(SqliteConnectionConfig {
+                    path: String::new(),
+                }),
+            );
 
             assert!(matches!(
                 result,

--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -263,21 +263,5 @@ mod tests {
                 Err(ConnectionProfileError::InvalidSqlitePath)
             ));
         }
-
-        #[test]
-        fn profile_rejects_invalid_sqlite_config() {
-            let result = ConnectionProfile::with_id_and_config(
-                ConnectionId::new(),
-                "Local",
-                ConnectionConfig::SQLite(SqliteConnectionConfig {
-                    path: String::new(),
-                }),
-            );
-
-            assert!(matches!(
-                result,
-                Err(ConnectionProfileError::EmptySqlitePath)
-            ));
-        }
     }
 }

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -31,4 +31,7 @@ pub use table::{Table, TableSignature, TableSummary};
 pub use trigger::{Trigger, TriggerEvent, TriggerTiming};
 pub use write_result::WriteExecutionResult;
 
-pub use connection::{ConnectionId, ConnectionProfile, SslMode};
+pub use connection::{
+    ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
+    PostgresConnectionConfig, SqliteConnectionConfig, SslMode,
+};

--- a/src/infra/adapters/connection_store.rs
+++ b/src/infra/adapters/connection_store.rs
@@ -440,7 +440,7 @@ ssl_mode = "prefer"
             let loaded = store.load().unwrap().unwrap();
 
             assert_eq!(loaded.database_type(), crate::domain::DatabaseType::SQLite);
-            assert_eq!(loaded.sqlite_config().unwrap().path, "/tmp/app.db");
+            assert_eq!(loaded.sqlite_config().unwrap().path(), "/tmp/app.db");
         }
 
         #[test]

--- a/src/infra/adapters/connection_store.rs
+++ b/src/infra/adapters/connection_store.rs
@@ -85,7 +85,7 @@ impl ConnectionStore for TomlConnectionStore {
         // Check version first to detect v1 format before full parse fails
         let version_check: ConfigVersionCheck = toml::from_str(&content)?;
 
-        if version_check.version != CURRENT_VERSION {
+        if version_check.version != 2 && version_check.version != CURRENT_VERSION {
             return Err(ConnectionStoreError::VersionMismatch {
                 found: version_check.version,
                 expected: CURRENT_VERSION,
@@ -225,7 +225,7 @@ ssl_mode = "prefer"
                 result,
                 Err(ConnectionStoreError::VersionMismatch {
                     found: 1,
-                    expected: 2
+                    expected: 3
                 })
             ));
         }
@@ -244,6 +244,42 @@ ssl_mode = "prefer"
                 result,
                 Err(ConnectionStoreError::TomlDeserialize(_))
             ));
+        }
+
+        #[test]
+        fn loads_v2_entries_as_postgresql() {
+            let temp_dir = TempDir::new().unwrap();
+            let config_path = temp_dir.path().join(CONFIG_FILE_NAME);
+
+            let content = r#"
+version = 2
+
+[[connections]]
+id = "test-id"
+name = "Production"
+host = "localhost"
+port = 5432
+database = "testdb"
+username = "testuser"
+password = "testpass"
+ssl_mode = "prefer"
+"#;
+            fs::write(&config_path, content).unwrap();
+
+            let store = TomlConnectionStore::with_config_dir(temp_dir.path().to_path_buf());
+            let profiles = store.load_all().unwrap();
+
+            assert_eq!(profiles.len(), 1);
+            assert_eq!(
+                profiles[0].database_type(),
+                crate::domain::DatabaseType::PostgreSQL
+            );
+            assert_eq!(profiles[0].postgres_config().unwrap().database, "testdb");
+            assert!(
+                fs::read_to_string(&config_path)
+                    .unwrap()
+                    .contains("version = 2")
+            );
         }
     }
 
@@ -288,7 +324,16 @@ ssl_mode = "prefer"
             let mut profile = make_test_profile("Production");
             store.save(&profile).unwrap();
 
-            profile.host = "newhost".to_string();
+            profile.config = crate::domain::ConnectionConfig::PostgreSQL(
+                crate::domain::PostgresConnectionConfig::new(
+                    "newhost",
+                    5432,
+                    "testdb",
+                    "testuser",
+                    "testpass",
+                    SslMode::Prefer,
+                ),
+            );
             let result = store.save(&profile);
 
             assert!(result.is_ok());
@@ -382,12 +427,45 @@ ssl_mode = "prefer"
             assert!(loaded.is_some());
             let loaded = loaded.unwrap();
             assert_eq!(loaded.name.as_str(), profile.name.as_str());
-            assert_eq!(loaded.host, profile.host);
-            assert_eq!(loaded.port, profile.port);
-            assert_eq!(loaded.database, profile.database);
-            assert_eq!(loaded.username, profile.username);
-            assert_eq!(loaded.password, profile.password);
-            assert_eq!(loaded.ssl_mode, profile.ssl_mode);
+            assert_eq!(loaded.config, profile.config);
+        }
+
+        #[test]
+        fn save_and_load_preserves_sqlite_data() {
+            let temp_dir = TempDir::new().unwrap();
+            let store = TomlConnectionStore::with_config_dir(temp_dir.path().to_path_buf());
+            let profile = ConnectionProfile::new_sqlite("Local", "/tmp/app.db").unwrap();
+
+            store.save(&profile).unwrap();
+            let loaded = store.load().unwrap().unwrap();
+
+            assert_eq!(loaded.database_type(), crate::domain::DatabaseType::SQLite);
+            assert_eq!(loaded.sqlite_config().unwrap().path, "/tmp/app.db");
+        }
+
+        #[test]
+        fn empty_sqlite_path_returns_invalid_profile() {
+            let temp_dir = TempDir::new().unwrap();
+            let config_path = temp_dir.path().join(CONFIG_FILE_NAME);
+
+            let content = r#"
+version = 3
+
+[[connections]]
+id = "sqlite-id"
+name = "Local"
+db_type = "sqlite"
+path = ""
+"#;
+            fs::write(&config_path, content).unwrap();
+
+            let store = TomlConnectionStore::with_config_dir(temp_dir.path().to_path_buf());
+            let result = store.load_all();
+
+            assert!(matches!(
+                result,
+                Err(ConnectionStoreError::InvalidProfile(_))
+            ));
         }
     }
 
@@ -435,7 +513,7 @@ ssl_mode = "prefer"
                 result,
                 Err(ConnectionStoreError::VersionMismatch {
                     found: 1,
-                    expected: 2
+                    expected: 3
                 })
             ));
 
@@ -479,16 +557,26 @@ ssl_mode = "prefer"
             store.save(&profile1).unwrap();
             store.save(&profile2).unwrap();
 
-            profile2.host = "updated-host".to_string();
+            profile2.config = crate::domain::ConnectionConfig::PostgreSQL(
+                crate::domain::PostgresConnectionConfig::new(
+                    "updated-host",
+                    5432,
+                    "testdb",
+                    "testuser",
+                    "testpass",
+                    SslMode::Prefer,
+                ),
+            );
             store.save(&profile2).unwrap();
 
             let all = store.load_all().unwrap();
             assert_eq!(all.len(), 2);
             assert!(all.iter().any(|p| p.name.as_str() == "First"));
-            assert!(
-                all.iter()
-                    .any(|p| p.name.as_str() == "Second" && p.host == "updated-host")
-            );
+            assert!(all.iter().any(|p| {
+                p.name.as_str() == "Second"
+                    && p.postgres_config()
+                        .is_some_and(|config| config.host == "updated-host")
+            }));
         }
     }
 }

--- a/src/infra/adapters/mod.rs
+++ b/src/infra/adapters/mod.rs
@@ -7,6 +7,7 @@ pub mod mysql;
 pub mod pg_service;
 pub mod postgres;
 pub mod query_history;
+pub mod registry;
 
 pub use clipboard::ArboardClipboard;
 pub use config_writer::FileConfigWriter;
@@ -16,3 +17,4 @@ pub use folder_opener::NativeFolderOpener;
 pub use pg_service::PgServiceFileReader;
 pub use postgres::PostgresAdapter;
 pub use query_history::FileQueryHistoryStore;
+pub use registry::DbAdapterRegistry;

--- a/src/infra/adapters/postgres/dsn.rs
+++ b/src/infra/adapters/postgres/dsn.rs
@@ -28,14 +28,17 @@ impl PostgresAdapter {
 
 impl DsnBuilder for PostgresAdapter {
     fn build_dsn(&self, profile: &ConnectionProfile) -> String {
+        let config = profile
+            .postgres_config()
+            .expect("PostgresAdapter requires a PostgreSQL profile");
         format!(
             "postgres://{}:{}@{}:{}/{}?sslmode={}",
-            urlencoding::encode(&profile.username),
-            urlencoding::encode(&profile.password),
-            &profile.host,
-            profile.port,
-            urlencoding::encode(&profile.database),
-            profile.ssl_mode
+            urlencoding::encode(&config.username),
+            urlencoding::encode(&config.password),
+            &config.host,
+            config.port,
+            urlencoding::encode(&config.database),
+            config.ssl_mode
         )
     }
 }

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -184,6 +184,8 @@ impl QueryExecutor for DbAdapterRegistry {
     }
 }
 
+// SAB-204 only introduces connection groundwork. SQLite DDL/dialect dispatch
+// belongs with the SQLite adapter skeleton.
 impl DdlGenerator for DbAdapterRegistry {
     fn generate_ddl(&self, table: &Table) -> String {
         self.postgres.generate_ddl(table)

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -48,7 +48,7 @@ impl DsnBuilder for DbAdapterRegistry {
                 let path = &profile
                     .sqlite_config()
                     .expect("SQLite profile requires SQLite config")
-                    .path;
+                    .path();
                 format!("sqlite://{path}")
             }
         }

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -20,12 +20,16 @@ impl DbAdapterRegistry {
         Self { postgres }
     }
 
-    fn db_type_from_dsn(dsn: &str) -> DatabaseType {
+    fn db_type_from_dsn(dsn: &str) -> Result<DatabaseType, DbOperationError> {
         if dsn.starts_with("sqlite://") {
-            DatabaseType::SQLite
-        } else {
-            DatabaseType::PostgreSQL
+            return Ok(DatabaseType::SQLite);
         }
+        if dsn.starts_with("postgres://") || dsn.starts_with("service=") {
+            return Ok(DatabaseType::PostgreSQL);
+        }
+        Err(DbOperationError::ConnectionFailed(format!(
+            "Unsupported database DSN scheme: {dsn}"
+        )))
     }
 
     fn sqlite_not_implemented() -> DbOperationError {
@@ -60,7 +64,7 @@ impl DatabaseCapabilityProvider for DbAdapterRegistry {
 #[async_trait]
 impl MetadataProvider for DbAdapterRegistry {
     async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
-        match Self::db_type_from_dsn(dsn) {
+        match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.fetch_metadata(dsn).await,
             DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
         }
@@ -72,7 +76,7 @@ impl MetadataProvider for DbAdapterRegistry {
         schema: &str,
         table: &str,
     ) -> Result<Table, DbOperationError> {
-        match Self::db_type_from_dsn(dsn) {
+        match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.fetch_table_detail(dsn, schema, table).await,
             DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
         }
@@ -84,7 +88,7 @@ impl MetadataProvider for DbAdapterRegistry {
         schema: &str,
         table: &str,
     ) -> Result<Table, DbOperationError> {
-        match Self::db_type_from_dsn(dsn) {
+        match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => {
                 self.postgres
                     .fetch_table_columns_and_fks(dsn, schema, table)
@@ -98,7 +102,7 @@ impl MetadataProvider for DbAdapterRegistry {
         &self,
         dsn: &str,
     ) -> Result<Vec<TableSignature>, DbOperationError> {
-        match Self::db_type_from_dsn(dsn) {
+        match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.fetch_table_signatures(dsn).await,
             DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
         }
@@ -116,7 +120,7 @@ impl QueryExecutor for DbAdapterRegistry {
         offset: usize,
         read_only: bool,
     ) -> Result<QueryResult, DbOperationError> {
-        match Self::db_type_from_dsn(dsn) {
+        match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => {
                 self.postgres
                     .execute_preview(dsn, schema, table, limit, offset, read_only)
@@ -132,7 +136,7 @@ impl QueryExecutor for DbAdapterRegistry {
         query: &str,
         read_only: bool,
     ) -> Result<QueryResult, DbOperationError> {
-        match Self::db_type_from_dsn(dsn) {
+        match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.execute_adhoc(dsn, query, read_only).await,
             DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
         }
@@ -144,7 +148,7 @@ impl QueryExecutor for DbAdapterRegistry {
         query: &str,
         read_only: bool,
     ) -> Result<WriteExecutionResult, DbOperationError> {
-        match Self::db_type_from_dsn(dsn) {
+        match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.execute_write(dsn, query, read_only).await,
             DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
         }
@@ -156,7 +160,7 @@ impl QueryExecutor for DbAdapterRegistry {
         query: &str,
         read_only: bool,
     ) -> Result<usize, DbOperationError> {
-        match Self::db_type_from_dsn(dsn) {
+        match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.count_query_rows(dsn, query, read_only).await,
             DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
         }
@@ -169,7 +173,7 @@ impl QueryExecutor for DbAdapterRegistry {
         path: &Path,
         read_only: bool,
     ) -> Result<usize, DbOperationError> {
-        match Self::db_type_from_dsn(dsn) {
+        match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => {
                 self.postgres
                     .export_to_csv(dsn, query, path, read_only)
@@ -250,5 +254,14 @@ mod tests {
         let dsn = registry.build_dsn(&profile);
 
         assert_eq!(dsn, "sqlite:///tmp/app.db");
+    }
+
+    #[tokio::test]
+    async fn unknown_dsn_scheme_is_rejected() {
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+
+        let result = registry.fetch_metadata("mysql://localhost/db").await;
+
+        assert!(matches!(result, Err(DbOperationError::ConnectionFailed(_))));
     }
 }

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -57,6 +57,8 @@ impl DsnBuilder for DbAdapterRegistry {
 
 impl DatabaseCapabilityProvider for DbAdapterRegistry {
     fn capabilities(&self) -> DatabaseCapabilities {
+        // SAB-204 keeps capabilities startup-wide. Per-connection capability
+        // dispatch belongs with the SQLite adapter skeleton.
         self.postgres.capabilities()
     }
 }

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -1,0 +1,254 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use app::ports::outbound::{
+    DatabaseCapabilities, DatabaseCapabilityProvider, DbOperationError, DdlGenerator, DsnBuilder,
+    MetadataProvider, QueryExecutor, SqlDialect,
+};
+use async_trait::async_trait;
+use domain::connection::{ConnectionProfile, DatabaseType};
+use domain::{DatabaseMetadata, QueryResult, Table, TableSignature, WriteExecutionResult};
+
+use super::postgres::PostgresAdapter;
+
+pub struct DbAdapterRegistry {
+    postgres: Arc<PostgresAdapter>,
+}
+
+impl DbAdapterRegistry {
+    pub fn new(postgres: Arc<PostgresAdapter>) -> Self {
+        Self { postgres }
+    }
+
+    fn db_type_from_dsn(dsn: &str) -> DatabaseType {
+        if dsn.starts_with("sqlite://") {
+            DatabaseType::SQLite
+        } else {
+            DatabaseType::PostgreSQL
+        }
+    }
+
+    fn sqlite_not_implemented() -> DbOperationError {
+        DbOperationError::ConnectionFailed(
+            "SQLite adapter is not implemented yet; SAB-204 only adds connection groundwork"
+                .to_string(),
+        )
+    }
+}
+
+impl DsnBuilder for DbAdapterRegistry {
+    fn build_dsn(&self, profile: &ConnectionProfile) -> String {
+        match profile.database_type() {
+            DatabaseType::PostgreSQL => self.postgres.build_dsn(profile),
+            DatabaseType::SQLite => {
+                let path = &profile
+                    .sqlite_config()
+                    .expect("SQLite profile requires SQLite config")
+                    .path;
+                format!("sqlite://{path}")
+            }
+        }
+    }
+}
+
+impl DatabaseCapabilityProvider for DbAdapterRegistry {
+    fn capabilities(&self) -> DatabaseCapabilities {
+        self.postgres.capabilities()
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for DbAdapterRegistry {
+    async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
+        match Self::db_type_from_dsn(dsn) {
+            DatabaseType::PostgreSQL => self.postgres.fetch_metadata(dsn).await,
+            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+        }
+    }
+
+    async fn fetch_table_detail(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Table, DbOperationError> {
+        match Self::db_type_from_dsn(dsn) {
+            DatabaseType::PostgreSQL => self.postgres.fetch_table_detail(dsn, schema, table).await,
+            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+        }
+    }
+
+    async fn fetch_table_columns_and_fks(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Table, DbOperationError> {
+        match Self::db_type_from_dsn(dsn) {
+            DatabaseType::PostgreSQL => {
+                self.postgres
+                    .fetch_table_columns_and_fks(dsn, schema, table)
+                    .await
+            }
+            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+        }
+    }
+
+    async fn fetch_table_signatures(
+        &self,
+        dsn: &str,
+    ) -> Result<Vec<TableSignature>, DbOperationError> {
+        match Self::db_type_from_dsn(dsn) {
+            DatabaseType::PostgreSQL => self.postgres.fetch_table_signatures(dsn).await,
+            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+        }
+    }
+}
+
+#[async_trait]
+impl QueryExecutor for DbAdapterRegistry {
+    async fn execute_preview(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+        limit: usize,
+        offset: usize,
+        read_only: bool,
+    ) -> Result<QueryResult, DbOperationError> {
+        match Self::db_type_from_dsn(dsn) {
+            DatabaseType::PostgreSQL => {
+                self.postgres
+                    .execute_preview(dsn, schema, table, limit, offset, read_only)
+                    .await
+            }
+            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+        }
+    }
+
+    async fn execute_adhoc(
+        &self,
+        dsn: &str,
+        query: &str,
+        read_only: bool,
+    ) -> Result<QueryResult, DbOperationError> {
+        match Self::db_type_from_dsn(dsn) {
+            DatabaseType::PostgreSQL => self.postgres.execute_adhoc(dsn, query, read_only).await,
+            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+        }
+    }
+
+    async fn execute_write(
+        &self,
+        dsn: &str,
+        query: &str,
+        read_only: bool,
+    ) -> Result<WriteExecutionResult, DbOperationError> {
+        match Self::db_type_from_dsn(dsn) {
+            DatabaseType::PostgreSQL => self.postgres.execute_write(dsn, query, read_only).await,
+            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+        }
+    }
+
+    async fn count_query_rows(
+        &self,
+        dsn: &str,
+        query: &str,
+        read_only: bool,
+    ) -> Result<usize, DbOperationError> {
+        match Self::db_type_from_dsn(dsn) {
+            DatabaseType::PostgreSQL => self.postgres.count_query_rows(dsn, query, read_only).await,
+            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+        }
+    }
+
+    async fn export_to_csv(
+        &self,
+        dsn: &str,
+        query: &str,
+        path: &Path,
+        read_only: bool,
+    ) -> Result<usize, DbOperationError> {
+        match Self::db_type_from_dsn(dsn) {
+            DatabaseType::PostgreSQL => {
+                self.postgres
+                    .export_to_csv(dsn, query, path, read_only)
+                    .await
+            }
+            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+        }
+    }
+}
+
+impl DdlGenerator for DbAdapterRegistry {
+    fn generate_ddl(&self, table: &Table) -> String {
+        self.postgres.generate_ddl(table)
+    }
+}
+
+impl SqlDialect for DbAdapterRegistry {
+    fn build_explain_sql(&self, query: &str) -> Option<String> {
+        self.postgres.build_explain_sql(query)
+    }
+
+    fn build_explain_analyze_sql(&self, query: &str) -> Option<String> {
+        self.postgres.build_explain_analyze_sql(query)
+    }
+
+    fn build_update_sql(
+        &self,
+        schema: &str,
+        table: &str,
+        column: &str,
+        new_value: &str,
+        pk_pairs: &[(String, String)],
+    ) -> String {
+        self.postgres
+            .build_update_sql(schema, table, column, new_value, pk_pairs)
+    }
+
+    fn build_bulk_delete_sql(
+        &self,
+        schema: &str,
+        table: &str,
+        pk_pairs_per_row: &[Vec<(String, String)>],
+    ) -> String {
+        self.postgres
+            .build_bulk_delete_sql(schema, table, pk_pairs_per_row)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use domain::connection::SslMode;
+
+    #[test]
+    fn builds_postgres_dsn_from_postgres_profile() {
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+        let profile = ConnectionProfile::new(
+            "Test",
+            "localhost",
+            5432,
+            "db",
+            "user",
+            "pass",
+            SslMode::Prefer,
+        )
+        .unwrap();
+
+        let dsn = registry.build_dsn(&profile);
+
+        assert!(dsn.starts_with("postgres://"));
+    }
+
+    #[test]
+    fn builds_sqlite_dsn_from_sqlite_profile() {
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+        let profile = ConnectionProfile::new_sqlite("Local", "/tmp/app.db").unwrap();
+
+        let dsn = registry.build_dsn(&profile);
+
+        assert_eq!(dsn, "sqlite:///tmp/app.db");
+    }
+}

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -85,7 +85,7 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
                 entry.ssl_mode = Some(config.ssl_mode);
             }
             crate::domain::ConnectionConfig::SQLite(config) => {
-                entry.path = Some(config.path.clone());
+                entry.path = Some(config.path().to_string());
             }
         }
         entry

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::domain::connection::{
-    ConnectionId, ConnectionName, ConnectionProfile, ConnectionProfileError, DatabaseType,
-    PostgresConnectionConfig, SqliteConnectionConfig, SslMode,
+    ConnectionConfig, ConnectionId, ConnectionName, ConnectionProfile, ConnectionProfileError,
+    DatabaseType, PostgresConnectionConfig, SqliteConnectionConfig, SslMode,
 };
 
 pub const CURRENT_VERSION: u32 = 3;
@@ -76,7 +76,7 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
             path: None,
         };
         match &profile.config {
-            crate::domain::ConnectionConfig::PostgreSQL(config) => {
+            ConnectionConfig::PostgreSQL(config) => {
                 entry.host = Some(config.host.clone());
                 entry.port = Some(config.port);
                 entry.database = Some(config.database.clone());
@@ -84,7 +84,7 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
                 entry.password = Some(config.password.clone());
                 entry.ssl_mode = Some(config.ssl_mode);
             }
-            crate::domain::ConnectionConfig::SQLite(config) => {
+            ConnectionConfig::SQLite(config) => {
                 entry.path = Some(config.path().to_string());
             }
         }
@@ -102,7 +102,7 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
             DatabaseType::PostgreSQL => ConnectionProfile::with_id_and_config(
                 id,
                 name.as_str().to_string(),
-                crate::domain::ConnectionConfig::PostgreSQL(PostgresConnectionConfig::new(
+                ConnectionConfig::PostgreSQL(PostgresConnectionConfig::new(
                     required_postgres_field(&entry.host, "host")?,
                     entry.port.unwrap_or(5432),
                     required_postgres_field(&entry.database, "database")?,
@@ -114,7 +114,7 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
             DatabaseType::SQLite => ConnectionProfile::with_id_and_config(
                 id,
                 name.as_str().to_string(),
-                crate::domain::ConnectionConfig::SQLite(SqliteConnectionConfig::new(
+                ConnectionConfig::SQLite(SqliteConnectionConfig::new(
                     entry.path.clone().unwrap_or_default(),
                 )?),
             ),

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -168,6 +168,27 @@ mod tests {
     }
 
     #[test]
+    fn v2_entry_defaults_to_postgres() {
+        let entry: ConnectionConfigEntry = serde_json::from_str(
+            r#"{
+                "id": "legacy-id",
+                "name": "Legacy",
+                "host": "localhost",
+                "port": 5432,
+                "database": "app",
+                "username": "user",
+                "password": "secret",
+                "ssl_mode": "prefer"
+            }"#,
+        )
+        .unwrap();
+
+        let profile = ConnectionProfile::try_from(&entry).unwrap();
+
+        assert_eq!(profile.database_type(), DatabaseType::PostgreSQL);
+    }
+
+    #[test]
     fn sqlite_entry_rejects_invalid_path() {
         let entry = ConnectionConfigEntry {
             id: "sqlite-id".to_string(),

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -103,10 +103,10 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
                 id,
                 name.as_str().to_string(),
                 crate::domain::ConnectionConfig::PostgreSQL(PostgresConnectionConfig::new(
-                    entry.host.clone().unwrap_or_default(),
+                    required_postgres_field(&entry.host, "host")?,
                     entry.port.unwrap_or(5432),
-                    entry.database.clone().unwrap_or_default(),
-                    entry.username.clone().unwrap_or_default(),
+                    required_postgres_field(&entry.database, "database")?,
+                    required_postgres_field(&entry.username, "username")?,
                     entry.password.clone().unwrap_or_default(),
                     entry.ssl_mode.unwrap_or_default(),
                 )),
@@ -116,8 +116,77 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
                 name.as_str().to_string(),
                 crate::domain::ConnectionConfig::SQLite(SqliteConnectionConfig::new(
                     entry.path.clone().unwrap_or_default(),
-                )),
+                )?),
             ),
         }
+    }
+}
+
+fn required_postgres_field(
+    value: &Option<String>,
+    field: &'static str,
+) -> Result<String, ConnectionProfileError> {
+    let value = value
+        .as_ref()
+        .ok_or(ConnectionProfileError::MissingPostgresField(field))?;
+    if value.trim().is_empty() {
+        return Err(ConnectionProfileError::MissingPostgresField(field));
+    }
+    Ok(value.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn postgres_entry() -> ConnectionConfigEntry {
+        ConnectionConfigEntry {
+            id: "test-id".to_string(),
+            name: "Test".to_string(),
+            db_type: DatabaseType::PostgreSQL,
+            host: Some("localhost".to_string()),
+            port: Some(5432),
+            database: Some("app".to_string()),
+            username: Some("user".to_string()),
+            password: None,
+            ssl_mode: Some(SslMode::Prefer),
+            path: None,
+        }
+    }
+
+    #[test]
+    fn postgres_entry_rejects_missing_required_field() {
+        let mut entry = postgres_entry();
+        entry.host = None;
+
+        let result = ConnectionProfile::try_from(&entry);
+
+        assert!(matches!(
+            result,
+            Err(ConnectionProfileError::MissingPostgresField("host"))
+        ));
+    }
+
+    #[test]
+    fn sqlite_entry_rejects_invalid_path() {
+        let entry = ConnectionConfigEntry {
+            id: "sqlite-id".to_string(),
+            name: "Local".to_string(),
+            db_type: DatabaseType::SQLite,
+            host: None,
+            port: None,
+            database: None,
+            username: None,
+            password: None,
+            ssl_mode: None,
+            path: Some("/tmp/app\0.db".to_string()),
+        };
+
+        let result = ConnectionProfile::try_from(&entry);
+
+        assert!(matches!(
+            result,
+            Err(ConnectionProfileError::InvalidSqlitePath)
+        ));
     }
 }

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 use crate::domain::connection::{
-    ConnectionId, ConnectionName, ConnectionNameError, ConnectionProfile, SslMode,
+    ConnectionId, ConnectionName, ConnectionProfile, ConnectionProfileError, DatabaseType,
+    PostgresConnectionConfig, SqliteConnectionConfig, SslMode,
 };
 
-pub const CURRENT_VERSION: u32 = 2;
+pub const CURRENT_VERSION: u32 = 3;
 
 #[derive(Debug, Deserialize)]
 pub struct ConfigVersionCheck {
@@ -21,54 +22,102 @@ pub struct ConnectionConfigFile {
 pub struct ConnectionConfigEntry {
     pub id: String,
     pub name: String,
-    pub host: String,
-    pub port: u16,
-    pub database: String,
-    pub username: String,
-    pub password: String,
-    pub ssl_mode: SslMode,
+    #[serde(default)]
+    pub db_type: DatabaseType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssl_mode: Option<SslMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 impl From<&[ConnectionProfile]> for ConnectionConfigFile {
     fn from(profiles: &[ConnectionProfile]) -> Self {
         Self {
             version: CURRENT_VERSION,
-            connections: profiles
-                .iter()
-                .map(|p| ConnectionConfigEntry {
-                    id: p.id.as_str().to_string(),
-                    name: p.name.as_str().to_string(),
-                    host: p.host.clone(),
-                    port: p.port,
-                    database: p.database.clone(),
-                    username: p.username.clone(),
-                    password: p.password.clone(),
-                    ssl_mode: p.ssl_mode,
-                })
-                .collect(),
+            connections: profiles.iter().map(ConnectionConfigEntry::from).collect(),
         }
     }
 }
 
 impl TryFrom<&ConnectionConfigFile> for Vec<ConnectionProfile> {
-    type Error = ConnectionNameError;
+    type Error = ConnectionProfileError;
 
     fn try_from(config: &ConnectionConfigFile) -> Result<Self, Self::Error> {
         config
             .connections
             .iter()
-            .map(|entry| {
-                Ok(ConnectionProfile {
-                    id: ConnectionId::from_string(&entry.id),
-                    name: ConnectionName::new(&entry.name)?,
-                    host: entry.host.clone(),
-                    port: entry.port,
-                    database: entry.database.clone(),
-                    username: entry.username.clone(),
-                    password: entry.password.clone(),
-                    ssl_mode: entry.ssl_mode,
-                })
-            })
+            .map(ConnectionProfile::try_from)
             .collect()
+    }
+}
+
+impl From<&ConnectionProfile> for ConnectionConfigEntry {
+    fn from(profile: &ConnectionProfile) -> Self {
+        let mut entry = Self {
+            id: profile.id.as_str().to_string(),
+            name: profile.name.as_str().to_string(),
+            db_type: profile.database_type(),
+            host: None,
+            port: None,
+            database: None,
+            username: None,
+            password: None,
+            ssl_mode: None,
+            path: None,
+        };
+        match &profile.config {
+            crate::domain::ConnectionConfig::PostgreSQL(config) => {
+                entry.host = Some(config.host.clone());
+                entry.port = Some(config.port);
+                entry.database = Some(config.database.clone());
+                entry.username = Some(config.username.clone());
+                entry.password = Some(config.password.clone());
+                entry.ssl_mode = Some(config.ssl_mode);
+            }
+            crate::domain::ConnectionConfig::SQLite(config) => {
+                entry.path = Some(config.path.clone());
+            }
+        }
+        entry
+    }
+}
+
+impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
+    type Error = ConnectionProfileError;
+
+    fn try_from(entry: &ConnectionConfigEntry) -> Result<Self, Self::Error> {
+        let id = ConnectionId::from_string(&entry.id);
+        let name = ConnectionName::new(&entry.name)?;
+        match entry.db_type {
+            DatabaseType::PostgreSQL => ConnectionProfile::with_id_and_config(
+                id,
+                name.as_str().to_string(),
+                crate::domain::ConnectionConfig::PostgreSQL(PostgresConnectionConfig::new(
+                    entry.host.clone().unwrap_or_default(),
+                    entry.port.unwrap_or(5432),
+                    entry.database.clone().unwrap_or_default(),
+                    entry.username.clone().unwrap_or_default(),
+                    entry.password.clone().unwrap_or_default(),
+                    entry.ssl_mode.unwrap_or_default(),
+                )),
+            ),
+            DatabaseType::SQLite => ConnectionProfile::with_id_and_config(
+                id,
+                name.as_str().to_string(),
+                crate::domain::ConnectionConfig::SQLite(SqliteConnectionConfig::new(
+                    entry.path.clone().unwrap_or_default(),
+                )),
+            ),
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,8 @@ use app::update::action::Action;
 use app::update::input::handle_event;
 use app::update::reducer::reduce;
 use infra::adapters::{
-    ArboardClipboard, FileConfigWriter, FileQueryHistoryStore, FsErLogWriter, NativeFolderOpener,
-    PgServiceFileReader, PostgresAdapter, TomlConnectionStore,
+    ArboardClipboard, DbAdapterRegistry, FileConfigWriter, FileQueryHistoryStore, FsErLogWriter,
+    NativeFolderOpener, PgServiceFileReader, PostgresAdapter, TomlConnectionStore,
 };
 use infra::config::project_root::{find_project_root, get_project_name};
 use infra::export::DotExporter;
@@ -86,21 +86,22 @@ async fn main() -> Result<()> {
 
     let (action_tx, mut action_rx) = mpsc::channel::<Action>(256);
 
-    let adapter = Arc::new(PostgresAdapter::new());
+    let postgres_adapter = Arc::new(PostgresAdapter::new());
+    let adapter_registry = Arc::new(DbAdapterRegistry::new(Arc::clone(&postgres_adapter)));
     let metadata_cache = TtlCache::new(300);
     let completion_engine = RefCell::new(CompletionEngine::new());
     let connection_store = TomlConnectionStore::new()?;
     let all_profiles = connection_store.load_all();
     let connection_store = Arc::new(connection_store);
 
-    let db_capabilities: DbCapabilities = adapter.capabilities().into();
+    let db_capabilities: DbCapabilities = adapter_registry.capabilities().into();
     let pg_service_entry_reader: Arc<dyn PgServiceEntryReader> =
         Arc::new(PgServiceFileReader::new());
 
     let effect_runner = EffectRunner::builder()
-        .metadata_provider(Arc::clone(&adapter) as _)
-        .query_executor(Arc::clone(&adapter) as _)
-        .dsn_builder(Arc::clone(&adapter) as _)
+        .metadata_provider(Arc::clone(&adapter_registry) as _)
+        .query_executor(Arc::clone(&adapter_registry) as _)
+        .dsn_builder(Arc::clone(&adapter_registry) as _)
         .er_exporter(Arc::new(DotExporter::new()))
         .config_writer(Arc::new(FileConfigWriter::new()))
         .er_log_writer(Arc::new(FsErLogWriter))
@@ -114,8 +115,8 @@ async fn main() -> Result<()> {
         .build();
 
     let services = AppServices {
-        ddl_generator: Arc::clone(&adapter) as _,
-        sql_dialect: Arc::clone(&adapter) as _,
+        ddl_generator: Arc::clone(&adapter_registry) as _,
+        sql_dialect: Arc::clone(&adapter_registry) as _,
         db_capabilities,
     };
 

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -21,6 +21,25 @@ fn connection_setup_form() {
 }
 
 #[test]
+fn connection_setup_sqlite_form() {
+    let mut state = create_test_state();
+    let mut terminal = create_test_terminal();
+
+    state.modal.set_mode(InputMode::ConnectionSetup);
+    state
+        .connection_setup
+        .set_database_type(DatabaseType::SQLite);
+    state
+        .connection_setup
+        .sqlite_path
+        .set_content("/tmp/app.db".to_string());
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn connection_setup_cursor_at_head() {
     let mut state = create_test_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/connection_management.rs
+++ b/src/tests/render_snapshots/connection_management.rs
@@ -1,41 +1,42 @@
 use super::*;
 use app::model::shared::confirm_dialog::ConfirmIntent;
 use domain::connection::ServiceEntry;
-use domain::connection::{ConnectionId, ConnectionName, ConnectionProfile, SslMode};
+use domain::connection::{ConnectionId, ConnectionProfile, SslMode};
 
 fn three_connections() -> (ConnectionId, Vec<ConnectionProfile>) {
     let active_id = ConnectionId::new();
     let profiles = vec![
-        ConnectionProfile {
-            id: active_id.clone(),
-            name: ConnectionName::new("Production").unwrap(),
-            host: "prod.example.com".to_string(),
-            port: 5432,
-            database: "prod_db".to_string(),
-            username: "admin".to_string(),
-            password: "secret".to_string(),
-            ssl_mode: SslMode::Require,
-        },
-        ConnectionProfile {
-            id: ConnectionId::new(),
-            name: ConnectionName::new("Staging").unwrap(),
-            host: "staging.example.com".to_string(),
-            port: 5432,
-            database: "staging_db".to_string(),
-            username: "user".to_string(),
-            password: "pass".to_string(),
-            ssl_mode: SslMode::Prefer,
-        },
-        ConnectionProfile {
-            id: ConnectionId::new(),
-            name: ConnectionName::new("Local Dev").unwrap(),
-            host: "localhost".to_string(),
-            port: 5432,
-            database: "dev_db".to_string(),
-            username: "dev".to_string(),
-            password: "dev".to_string(),
-            ssl_mode: SslMode::Disable,
-        },
+        ConnectionProfile::with_id(
+            active_id.clone(),
+            "Production",
+            "prod.example.com",
+            5432,
+            "prod_db",
+            "admin",
+            "secret",
+            SslMode::Require,
+        )
+        .unwrap(),
+        ConnectionProfile::new(
+            "Staging",
+            "staging.example.com",
+            5432,
+            "staging_db",
+            "user",
+            "pass",
+            SslMode::Prefer,
+        )
+        .unwrap(),
+        ConnectionProfile::new(
+            "Local Dev",
+            "localhost",
+            5432,
+            "dev_db",
+            "dev",
+            "dev",
+            SslMode::Disable,
+        )
+        .unwrap(),
     ];
     (active_id, profiles)
 }

--- a/src/tests/render_snapshots/mod.rs
+++ b/src/tests/render_snapshots/mod.rs
@@ -23,7 +23,7 @@ use app::policy::write::write_guardrails::{
     WritePreview,
 };
 use app::policy::write::write_update::normalize_for_diff;
-use domain::{CommandTag, QuerySource};
+use domain::{CommandTag, DatabaseType, QuerySource};
 
 mod confirm_dialogs;
 mod connection_flow;

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
@@ -1,5 +1,6 @@
 ---
-source: tests/render_snapshots/connection_flow.rs
+source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 34
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -7,9 +8,9 @@ test_project | - | - | no dsn | localhost:5432/test
 │ Press 'r' to load│┌ [2] Inspector ───────────────────────────────────────────┐
 │                  ││(select a table)                                          │
 │                  ││                                                          │
-│                  ││                                                          │
 │        ╭ New Connection ────────────────────────────────────────────╮        │
 │        │                                                            │        │
+│        │  Type:       [ PostgreSQL               ▼ ]                │        │
 │        │  Name:       [                            ]                │        │
 │        │  Host:       [ db.example.com             ]                │        │
 │        │  Port:       [ 5432                       ]                │        │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
@@ -1,5 +1,6 @@
 ---
-source: tests/render_snapshots/connection_flow.rs
+source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 48
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -7,9 +8,9 @@ test_project | - | - | no dsn | localhost:5432/test
 │ Press 'r' to load│┌ [2] Inspector ───────────────────────────────────────────┐
 │                  ││(select a table)                                          │
 │                  ││                                                          │
-│                  ││                                                          │
 │        ╭ New Connection ────────────────────────────────────────────╮        │
 │        │                                                            │        │
+│        │  Type:       [ PostgreSQL               ▼ ]                │        │
 │        │  Name:       [                            ]                │        │
 │        │  Host:       [ db.example.com             ]                │        │
 │        │  Port:       [ 5432                       ]                │        │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
@@ -1,5 +1,6 @@
 ---
-source: tests/render_snapshots/connection_flow.rs
+source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 65
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -7,9 +8,9 @@ test_project | - | - | no dsn | localhost:5432/test
 │ Press 'r' to load│┌ [2] Inspector ───────────────────────────────────────────┐
 │                  ││(select a table)                                          │
 │                  ││                                                          │
-│                  ││                                                          │
 │        ╭ New Connection ────────────────────────────────────────────╮        │
 │        │                                                            │        │
+│        │  Type:       [ PostgreSQL               ▼ ]                │        │
 │        │  Name:       [                            ]                │        │
 │        │  Host:       [ db.example.com             ]                │        │
 │        │  Port:       [ 5432                       ]                │        │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
@@ -1,5 +1,6 @@
 ---
-source: tests/render_snapshots/connection_flow.rs
+source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 20
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -7,9 +8,9 @@ test_project | - | - | no dsn | localhost:5432/test
 │ Press 'r' to load│┌ [2] Inspector ───────────────────────────────────────────┐
 │                  ││(select a table)                                          │
 │                  ││                                                          │
-│                  ││                                                          │
 │        ╭ New Connection ────────────────────────────────────────────╮        │
 │        │                                                            │        │
+│        │  Type:       [ PostgreSQL               ▼ ]                │        │
 │        │  Name:       [                            ]                │        │
 │        │  Host:       [ localhost                  ]                │        │
 │        │  Port:       [ 5432                       ]                │        │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_sqlite_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_sqlite_form.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
-assertion_line: 92
+assertion_line: 37
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -8,20 +8,20 @@ test_project | - | - | no dsn | localhost:5432/test
 │ Press 'r' to load│┌ [2] Inspector ───────────────────────────────────────────┐
 │                  ││(select a table)                                          │
 │                  ││                                                          │
+│                  ││                                                          │
+│                  ││                                                          │
+│                  ││                                                          │
 │        ╭ New Connection ────────────────────────────────────────────╮        │
 │        │                                                            │        │
-│        │  Type:       [ PostgreSQL               ▼ ]                │        │
-│        │  Name:       [                            ]                │        │
-│        │  Host:       [                            ] Required       │        │
-│        │  Port:       [ 5432                       ]                │        │
-│        │  Database:   [                            ] Required       │────────┘
-│        │  User:       [                            ] Required       │────────┐
-│        │  Password:   [                            ]                │        │
-│        │  SSL Mode:   [ prefer                   ▼ ]                │        │
+│        │  Type:       [ SQLite                   ▼ ]                │        │
+│        │  Name:       [                            ]                │────────┘
+│        │  Path:       [ /tmp/app.db                ]                │────────┐
 │        │                                                            │        │
 │        │  Note: Connection info is stored locally in plain text     │        │
 │        │                                                            │        │
 │        ╰ Tab: Next │ Shift+Tab: Prev │ Ctrl+S: Connect │ Esc: Cancel╯        │
+│                  ││                                                          │
+│                  ││                                                          │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -6,7 +6,7 @@ use crate::app::model::app_state::AppState;
 use crate::app::model::connection::setup::{
     CONNECTION_INPUT_VISIBLE_WIDTH, CONNECTION_INPUT_WIDTH, ConnectionField, ConnectionSetupState,
 };
-use crate::domain::connection::SslMode;
+use crate::domain::connection::{DatabaseType, SslMode};
 use crate::primitives::atoms::text_cursor_spans;
 use crate::primitives::molecules::render_modal;
 use crate::theme::ThemePalette;
@@ -15,7 +15,8 @@ const LABEL_WIDTH: u16 = 12;
 const INPUT_WIDTH: u16 = CONNECTION_INPUT_WIDTH;
 const ERROR_WIDTH: u16 = 12;
 const FIELD_HEIGHT: u16 = 1;
-const DROPDOWN_ITEM_COUNT: usize = 6;
+const SSL_DROPDOWN_ITEM_COUNT: usize = 6;
+const DB_TYPE_DROPDOWN_ITEM_COUNT: usize = 2;
 
 fn bracketed_input(content: &str, border_style: Style, theme: &ThemePalette) -> Line<'static> {
     Line::from(vec![
@@ -35,7 +36,10 @@ impl ConnectionSetup {
         let form_state = &state.connection_setup;
 
         let modal_width = LABEL_WIDTH + INPUT_WIDTH + ERROR_WIDTH + 8;
-        let modal_height = 13;
+        let modal_height = match form_state.database_type {
+            DatabaseType::PostgreSQL => 14,
+            DatabaseType::SQLite => 9,
+        };
 
         let (title, hint) = if form_state.is_edit_mode() {
             (
@@ -58,84 +62,60 @@ impl ConnectionSetup {
         );
 
         let inner = modal_inner.inner(Margin::new(2, 1));
-        let chunks = Layout::vertical([
-            Constraint::Length(FIELD_HEIGHT), // Name
-            Constraint::Length(FIELD_HEIGHT), // Host
-            Constraint::Length(FIELD_HEIGHT), // Port
-            Constraint::Length(FIELD_HEIGHT), // Database
-            Constraint::Length(FIELD_HEIGHT), // User
-            Constraint::Length(FIELD_HEIGHT), // Password
-            Constraint::Length(FIELD_HEIGHT), // SslMode
-            Constraint::Length(1),            // spacer
-            Constraint::Length(1),            // notice
-        ])
-        .split(inner);
+        let field_count = form_state.visible_fields().len();
+        let mut constraints = vec![Constraint::Length(FIELD_HEIGHT); field_count];
+        constraints.push(Constraint::Length(1));
+        constraints.push(Constraint::Length(1));
+        let chunks = Layout::vertical(constraints).split(inner);
 
-        Self::render_text_field(
-            frame,
-            chunks[0],
-            form_state,
-            ConnectionField::Name,
-            false,
-            theme,
-        );
-        Self::render_text_field(
-            frame,
-            chunks[1],
-            form_state,
-            ConnectionField::Host,
-            false,
-            theme,
-        );
-        Self::render_text_field(
-            frame,
-            chunks[2],
-            form_state,
-            ConnectionField::Port,
-            false,
-            theme,
-        );
-        Self::render_text_field(
-            frame,
-            chunks[3],
-            form_state,
-            ConnectionField::Database,
-            false,
-            theme,
-        );
-        Self::render_text_field(
-            frame,
-            chunks[4],
-            form_state,
-            ConnectionField::User,
-            false,
-            theme,
-        );
-        Self::render_text_field(
-            frame,
-            chunks[5],
-            form_state,
-            ConnectionField::Password,
-            true,
-            theme,
-        );
-        Self::render_ssl_field(
-            frame,
-            chunks[6],
-            form_state.ssl_mode,
-            form_state.focused_field == ConnectionField::SslMode,
-            theme,
-        );
+        for (idx, field) in form_state.visible_fields().iter().enumerate() {
+            match field {
+                ConnectionField::DatabaseType => Self::render_database_type_field(
+                    frame,
+                    chunks[idx],
+                    form_state.database_type,
+                    form_state.focused_field == ConnectionField::DatabaseType,
+                    theme,
+                ),
+                ConnectionField::SslMode => Self::render_ssl_field(
+                    frame,
+                    chunks[idx],
+                    form_state.ssl_mode,
+                    form_state.focused_field == ConnectionField::SslMode,
+                    theme,
+                ),
+                field => Self::render_text_field(
+                    frame,
+                    chunks[idx],
+                    form_state,
+                    *field,
+                    *field == ConnectionField::Password,
+                    theme,
+                ),
+            }
+        }
 
         let notice = "Note: Connection info is stored locally in plain text";
         let notice_para =
             Paragraph::new(notice).style(Style::default().fg(theme.component.feedback.note_text));
-        frame.render_widget(notice_para, chunks[8]);
+        frame.render_widget(notice_para, chunks[field_count + 1]);
 
-        if form_state.ssl_dropdown.is_open {
+        if form_state.database_type_dropdown.is_open {
+            Self::render_database_type_dropdown(
+                frame,
+                chunks[0],
+                form_state.database_type_dropdown.selected_index,
+                theme,
+            );
+        } else if form_state.ssl_dropdown.is_open {
+            let ssl_idx = form_state
+                .visible_fields()
+                .iter()
+                .position(|field| *field == ConnectionField::SslMode)
+                .unwrap_or(0);
             Self::render_dropdown(
                 frame,
-                chunks[6],
+                chunks[ssl_idx],
                 form_state.ssl_dropdown.selected_index,
                 theme,
             );
@@ -267,6 +247,82 @@ impl ConnectionSetup {
         frame.render_widget(input_para, chunks[1]);
     }
 
+    fn render_database_type_field(
+        frame: &mut Frame,
+        area: Rect,
+        database_type: DatabaseType,
+        is_focused: bool,
+        theme: &ThemePalette,
+    ) {
+        let chunks = Layout::horizontal([
+            Constraint::Length(LABEL_WIDTH),
+            Constraint::Length(INPUT_WIDTH),
+            Constraint::Length(ERROR_WIDTH),
+        ])
+        .split(area);
+
+        let label_style = if is_focused {
+            Style::default().fg(theme.semantic.text.secondary).bold()
+        } else {
+            Style::default().fg(theme.semantic.text.secondary)
+        };
+        frame.render_widget(Paragraph::new("Type:").style(label_style), chunks[0]);
+
+        let content_width = CONNECTION_INPUT_VISIBLE_WIDTH;
+        let value = database_type.to_string();
+        let display_content = format!("{:<1$} ▼", value, content_width - 2);
+        let border_style = theme.modal_input_border_style(is_focused, false);
+
+        frame.render_widget(
+            Paragraph::new(bracketed_input(&display_content, border_style, theme)),
+            chunks[1],
+        );
+    }
+
+    fn render_database_type_dropdown(
+        frame: &mut Frame,
+        field_area: Rect,
+        selected_index: usize,
+        theme: &ThemePalette,
+    ) {
+        let chunks = Layout::horizontal([
+            Constraint::Length(LABEL_WIDTH),
+            Constraint::Length(INPUT_WIDTH),
+            Constraint::Length(ERROR_WIDTH),
+        ])
+        .split(field_area);
+
+        let dropdown_area = Rect {
+            x: chunks[1].x,
+            y: chunks[1].y + 1,
+            width: INPUT_WIDTH,
+            height: DB_TYPE_DROPDOWN_ITEM_COUNT as u16 + 2,
+        };
+
+        frame.render_widget(Clear, dropdown_area);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(theme.modal_border_style())
+            .style(Style::default());
+        frame.render_widget(block, dropdown_area);
+
+        let inner = dropdown_area.inner(Margin::new(1, 1));
+        for (i, variant) in DatabaseType::all().iter().enumerate() {
+            let item_area = Rect {
+                x: inner.x,
+                y: inner.y + i as u16,
+                width: inner.width,
+                height: 1,
+            };
+            let style = if i == selected_index {
+                theme.picker_selected_style()
+            } else {
+                Style::default().fg(theme.semantic.text.secondary)
+            };
+            frame.render_widget(Paragraph::new(variant.to_string()).style(style), item_area);
+        }
+    }
+
     fn render_dropdown(
         frame: &mut Frame,
         ssl_field_area: Rect,
@@ -284,7 +340,7 @@ impl ConnectionSetup {
             x: chunks[1].x,
             y: chunks[1].y + 1,
             width: INPUT_WIDTH,
-            height: DROPDOWN_ITEM_COUNT as u16 + 2,
+            height: SSL_DROPDOWN_ITEM_COUNT as u16 + 2,
         };
 
         frame.render_widget(Clear, dropdown_area);
@@ -299,7 +355,7 @@ impl ConnectionSetup {
         let variants = SslMode::all_variants();
 
         for (i, variant) in variants.iter().enumerate() {
-            if i >= DROPDOWN_ITEM_COUNT {
+            if i >= SSL_DROPDOWN_ITEM_COUNT {
                 break;
             }
             let item_area = Rect {

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -16,7 +16,7 @@ const INPUT_WIDTH: u16 = CONNECTION_INPUT_WIDTH;
 const ERROR_WIDTH: u16 = 12;
 const FIELD_HEIGHT: u16 = 1;
 const SSL_DROPDOWN_ITEM_COUNT: usize = 6;
-const DB_TYPE_DROPDOWN_ITEM_COUNT: usize = 2;
+const DB_TYPE_DROPDOWN_ITEM_COUNT: usize = DatabaseType::all().len();
 
 fn bracketed_input(content: &str, border_style: Style, theme: &ThemePalette) -> Line<'static> {
     Line::from(vec![

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -15,6 +15,7 @@ const LABEL_WIDTH: u16 = 12;
 const INPUT_WIDTH: u16 = CONNECTION_INPUT_WIDTH;
 const ERROR_WIDTH: u16 = 12;
 const FIELD_HEIGHT: u16 = 1;
+const MODAL_VERTICAL_CHROME: u16 = 6;
 const SSL_DROPDOWN_ITEM_COUNT: usize = 6;
 const DB_TYPE_DROPDOWN_ITEM_COUNT: usize = DatabaseType::all().len();
 
@@ -34,12 +35,10 @@ pub struct ConnectionSetup;
 impl ConnectionSetup {
     pub fn render(frame: &mut Frame, state: &AppState, theme: &ThemePalette) {
         let form_state = &state.connection_setup;
+        let visible_fields = form_state.visible_fields();
 
         let modal_width = LABEL_WIDTH + INPUT_WIDTH + ERROR_WIDTH + 8;
-        let modal_height = match form_state.database_type {
-            DatabaseType::PostgreSQL => 14,
-            DatabaseType::SQLite => 9,
-        };
+        let modal_height = visible_fields.len() as u16 + MODAL_VERTICAL_CHROME;
 
         let (title, hint) = if form_state.is_edit_mode() {
             (
@@ -62,13 +61,13 @@ impl ConnectionSetup {
         );
 
         let inner = modal_inner.inner(Margin::new(2, 1));
-        let field_count = form_state.visible_fields().len();
+        let field_count = visible_fields.len();
         let mut constraints = vec![Constraint::Length(FIELD_HEIGHT); field_count];
         constraints.push(Constraint::Length(1));
         constraints.push(Constraint::Length(1));
         let chunks = Layout::vertical(constraints).split(inner);
 
-        for (idx, field) in form_state.visible_fields().iter().enumerate() {
+        for (idx, field) in visible_fields.iter().enumerate() {
             match field {
                 ConnectionField::DatabaseType => Self::render_database_type_field(
                     frame,
@@ -108,8 +107,7 @@ impl ConnectionSetup {
                 theme,
             );
         } else if form_state.ssl_dropdown.is_open {
-            let ssl_idx = form_state
-                .visible_fields()
+            let ssl_idx = visible_fields
                 .iter()
                 .position(|field| *field == ConnectionField::SslMode)
                 .unwrap_or(0);


### PR DESCRIPTION
## Problem
SQLite support needs DB-aware connection groundwork before adapter-specific metadata and query execution can be added.

## Background
The existing connection model, config format, and adapter wiring assumed PostgreSQL as the only backend. This PR creates the shared foundation for the SQLite follow-up stack while keeping SQLite execution out of scope.

## Approach
Scope: SAB-204 only. Introduce DB-specific connection configuration, config v3 compatibility, DB type-aware setup UX, and registry-based adapter dispatch. SQLite profiles can be saved, but SQLite metadata/query execution remains a follow-up.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * PostgreSQL と SQLite のマルチDB対応を追加。接続プロファイルが DB 種別を持ち、保存/切替時に種別に応じた挙動になります。
  * 接続設定に「データベース種別」ドロップダウンを導入。選択に応じて入力フォームが動的に切替わります。
  * SQLite はパス指定のショートパス処理を採用し、保存時に即座に完了/失敗を返します。

* **テスト**
  * SQLite 用の UI スナップショットと接続ワークフローの追加テストを導入。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->