### PR TITLE
refactor: encapsulate aggregate-owned state

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -187,7 +187,7 @@ pub async fn run(
             let history_store = Arc::clone(query_history_store);
             let history_tx = action_tx.clone();
             let project = state.runtime.project_name.clone();
-            let conn_id = state.session.active_connection_id.clone();
+            let conn_id = state.session.active_connection_id().cloned();
             let query_for_history = query.clone();
 
             tokio::spawn(async move {
@@ -251,7 +251,7 @@ pub async fn run(
             let history_store = Arc::clone(query_history_store);
             let history_tx = action_tx.clone();
             let project = state.runtime.project_name.clone();
-            let conn_id = state.session.active_connection_id.clone();
+            let conn_id = state.session.active_connection_id().cloned();
             let query_for_history = query.clone();
 
             tokio::spawn(async move {

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -50,7 +50,7 @@ pub(crate) async fn run(
                     Ok(()) => {
                         tx.blocking_send(Action::ConnectionSaveCompleted(ConnectionTarget {
                             id,
-                            dsn: dsn.clone(),
+                            dsn,
                             name,
                             database_type,
                         }))
@@ -170,7 +170,7 @@ pub(crate) async fn run(
                 action_tx
                     .send(Action::SwitchConnection(ConnectionTarget {
                         id,
-                        dsn: dsn.clone(),
+                        dsn,
                         name,
                         database_type,
                     }))
@@ -188,7 +188,7 @@ pub(crate) async fn run(
                 action_tx
                     .send(Action::SwitchConnection(ConnectionTarget {
                         id,
-                        dsn: dsn.clone(),
+                        dsn,
                         name,
                         database_type: DatabaseType::PostgreSQL,
                     }))

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -50,7 +50,7 @@ pub(crate) async fn run(
                     Ok(()) => {
                         tx.blocking_send(Action::ConnectionSaveCompleted(ConnectionTarget {
                             id,
-                            dsn,
+                            dsn: dsn.clone(),
                             name,
                             database_type,
                         }))
@@ -74,7 +74,7 @@ pub(crate) async fn run(
                             Ok(()) => {
                                 tx.send(Action::ConnectionSaveCompleted(ConnectionTarget {
                                     id,
-                                    dsn,
+                                    dsn: dsn.clone(),
                                     name,
                                     database_type,
                                 }))
@@ -170,7 +170,7 @@ pub(crate) async fn run(
                 action_tx
                     .send(Action::SwitchConnection(ConnectionTarget {
                         id,
-                        dsn,
+                        dsn: dsn.clone(),
                         name,
                         database_type,
                     }))
@@ -188,7 +188,7 @@ pub(crate) async fn run(
                 action_tx
                     .send(Action::SwitchConnection(ConnectionTarget {
                         id,
-                        dsn,
+                        dsn: dsn.clone(),
                         name,
                         database_type: DatabaseType::PostgreSQL,
                     }))

--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -176,7 +176,7 @@ fn handle_smart_refresh(
 ) {
     let provider = Arc::clone(metadata_provider);
     let tx = action_tx.clone();
-    let old_signatures = state.er_preparation.last_signatures.clone();
+    let old_signatures = state.er_preparation.last_signatures().clone();
     let cached_tables = collect_cached_table_names(completion_engine);
 
     tokio::spawn(async move {

--- a/src/app/cmd/render_schedule.rs
+++ b/src/app/cmd/render_schedule.rs
@@ -42,7 +42,7 @@ pub fn next_animation_deadline(state: &AppState, now: Instant) -> Option<Instant
 }
 
 fn has_active_spinner(state: &AppState) -> bool {
-    state.query.is_running() || state.er_preparation.status == ErStatus::Waiting
+    state.query.is_running() || state.er_preparation.status() == ErStatus::Waiting
 }
 
 fn has_blinking_cursor(state: &AppState) -> bool {
@@ -100,7 +100,7 @@ mod tests {
         #[test]
         fn er_waiting_returns_spinner_interval() {
             let mut state = create_test_state();
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             let now = Instant::now();
 
             let deadline = next_animation_deadline(&state, now);
@@ -261,7 +261,7 @@ mod tests {
         #[test]
         fn er_waiting_returns_true() {
             let mut state = create_test_state();
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
 
             assert!(has_active_spinner(&state));
         }
@@ -269,7 +269,7 @@ mod tests {
         #[test]
         fn er_rendering_returns_false() {
             let mut state = create_test_state();
-            state.er_preparation.status = ErStatus::Rendering;
+            state.er_preparation.mark_rendering();
 
             assert!(!has_active_spinner(&state));
         }

--- a/src/app/cmd/render_schedule.rs
+++ b/src/app/cmd/render_schedule.rs
@@ -15,7 +15,7 @@ pub fn next_animation_deadline(state: &AppState, now: Instant) -> Option<Instant
         earliest = min_instant(earliest, Some(now + SPINNER_INTERVAL));
     }
 
-    if let Some(expires_at) = state.messages.expires_at {
+    if let Some(expires_at) = state.messages.expires_at() {
         earliest = min_instant(earliest, Some(expires_at));
     }
 
@@ -115,7 +115,7 @@ mod tests {
             let mut state = create_test_state();
             let now = Instant::now();
             let expires_at = now + Duration::from_secs(2);
-            state.messages.expires_at = Some(expires_at);
+            state.messages.set_expires_at_for_test(Some(expires_at));
 
             let deadline = next_animation_deadline(&state, now);
 
@@ -194,7 +194,7 @@ mod tests {
             state.query.begin_running(now);
             // Message expires before spinner would update
             let expires_at = now + Duration::from_millis(50);
-            state.messages.expires_at = Some(expires_at);
+            state.messages.set_expires_at_for_test(Some(expires_at));
 
             let deadline = next_animation_deadline(&state, now);
 
@@ -207,7 +207,9 @@ mod tests {
             let now = Instant::now();
 
             state.query.begin_running(now);
-            state.messages.expires_at = Some(now + Duration::from_secs(2));
+            state
+                .messages
+                .set_expires_at_for_test(Some(now + Duration::from_secs(2)));
             state
                 .query
                 .set_result_highlight(now + Duration::from_millis(100));

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -290,7 +290,7 @@ impl EffectRunner {
                 state.confirm_dialog.preview_content_height = output.confirm_preview_content_height;
                 state.confirm_dialog.preview_scroll = output.confirm_preview_scroll;
                 if let Some(height) = output.explain_compare_viewport_height {
-                    state.explain.compare_viewport_height = Some(height);
+                    state.explain.set_compare_viewport_height(height);
                 }
                 Ok(vec![])
             }

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -456,24 +456,20 @@ mod tests {
         fn prefetch_queue_starts_empty() {
             let state = make_state();
 
-            assert!(state.sql_modal.prefetch_queue.is_empty());
+            assert!(state.sql_modal.prefetch_queue().is_empty());
             assert!(!state.sql_modal.is_prefetch_started());
         }
 
         #[test]
         fn prefetch_queue_is_fifo() {
             let mut state = make_state();
+            state.sql_modal.enqueue_prefetch("public.users".to_string());
             state
                 .sql_modal
-                .prefetch_queue
-                .push_back("public.users".to_string());
-            state
-                .sql_modal
-                .prefetch_queue
-                .push_back("public.orders".to_string());
+                .enqueue_prefetch("public.orders".to_string());
 
-            let first = state.sql_modal.prefetch_queue.pop_front();
-            let second = state.sql_modal.prefetch_queue.pop_front();
+            let first = state.sql_modal.pop_prefetch();
+            let second = state.sql_modal.pop_prefetch();
 
             assert_eq!(first, Some("public.users".to_string()));
             assert_eq!(second, Some("public.orders".to_string()));
@@ -483,13 +479,20 @@ mod tests {
         fn prefetching_tables_track_in_flight() {
             let mut state = make_state();
 
-            state
-                .sql_modal
-                .prefetching_tables
-                .insert("public.users".to_string());
+            state.sql_modal.mark_prefetching("public.users".to_string());
 
-            assert!(state.sql_modal.prefetching_tables.contains("public.users"));
-            assert!(!state.sql_modal.prefetching_tables.contains("public.orders"));
+            assert!(
+                state
+                    .sql_modal
+                    .prefetching_tables()
+                    .contains("public.users")
+            );
+            assert!(
+                !state
+                    .sql_modal
+                    .prefetching_tables()
+                    .contains("public.orders")
+            );
         }
 
         #[test]
@@ -497,7 +500,7 @@ mod tests {
             let mut state = make_state();
             let now = Instant::now();
 
-            state.sql_modal.failed_prefetch_tables.insert(
+            state.sql_modal.record_prefetch_failure(
                 "public.users".to_string(),
                 crate::model::sql_editor::modal::FailedPrefetchEntry {
                     failed_at: now,
@@ -509,12 +512,12 @@ mod tests {
             assert!(
                 state
                     .sql_modal
-                    .failed_prefetch_tables
+                    .failed_prefetch_tables()
                     .contains_key("public.users")
             );
             let entry = state
                 .sql_modal
-                .failed_prefetch_tables
+                .failed_prefetch_tables()
                 .get("public.users")
                 .unwrap();
             assert_eq!(entry.failed_at, now);
@@ -529,15 +532,11 @@ mod tests {
             let mut state = make_state();
             state.session.begin_connecting("postgres://localhost/test");
             state.sql_modal.begin_prefetch();
+            state.sql_modal.enqueue_prefetch("public.users".to_string());
             state
                 .sql_modal
-                .prefetch_queue
-                .push_back("public.users".to_string());
-            state
-                .sql_modal
-                .prefetching_tables
-                .insert("public.orders".to_string());
-            state.sql_modal.failed_prefetch_tables.insert(
+                .mark_prefetching("public.orders".to_string());
+            state.sql_modal.record_prefetch_failure(
                 "public.failed".to_string(),
                 crate::model::sql_editor::modal::FailedPrefetchEntry {
                     failed_at: Instant::now(),
@@ -555,9 +554,9 @@ mod tests {
             reduce_metadata(&mut state, &Action::ReloadMetadata, Instant::now());
 
             assert!(!state.sql_modal.is_prefetch_started());
-            assert!(state.sql_modal.prefetch_queue.is_empty());
-            assert!(state.sql_modal.prefetching_tables.is_empty());
-            assert!(state.sql_modal.failed_prefetch_tables.is_empty());
+            assert!(state.sql_modal.prefetch_queue().is_empty());
+            assert!(state.sql_modal.prefetching_tables().is_empty());
+            assert!(state.sql_modal.failed_prefetch_tables().is_empty());
         }
 
         #[test]

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -572,19 +572,21 @@ mod tests {
         #[test]
         fn clears_stale_messages() {
             let mut state = prepare_state_for_reload();
-            state.messages.last_error = Some("Old error".to_string());
-            state.messages.last_success = Some("Old success".to_string());
-            state.messages.expires_at = Some(Instant::now());
+            state.messages.set_messages_for_test(
+                Some("Old error".to_string()),
+                Some("Old success".to_string()),
+            );
+            state.messages.set_expires_at_for_test(Some(Instant::now()));
 
-            assert!(state.messages.last_error.is_some());
-            assert!(state.messages.last_success.is_some());
-            assert!(state.messages.expires_at.is_some());
+            assert!(state.messages.last_error().is_some());
+            assert!(state.messages.last_success().is_some());
+            assert!(state.messages.expires_at().is_some());
 
             reduce_metadata(&mut state, &Action::ReloadMetadata, Instant::now());
 
-            assert!(state.messages.last_error.is_none());
-            assert!(state.messages.last_success.is_none());
-            assert!(state.messages.expires_at.is_none());
+            assert!(state.messages.last_error().is_none());
+            assert!(state.messages.last_success().is_none());
+            assert!(state.messages.expires_at().is_none());
         }
     }
 

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -563,11 +563,11 @@ mod tests {
         #[test]
         fn resets_er_preparation() {
             let mut state = prepare_state_for_reload();
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
 
             reduce_metadata(&mut state, &Action::ReloadMetadata, Instant::now());
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
         }
 
         #[test]
@@ -653,7 +653,7 @@ mod tests {
             fn defaults_to_idle() {
                 let state = make_state();
 
-                assert_eq!(state.er_preparation.status, ErStatus::Idle);
+                assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             }
 
             #[rstest]
@@ -662,9 +662,9 @@ mod tests {
             fn accepts_status(#[case] status: ErStatus) {
                 let mut state = make_state();
 
-                state.er_preparation.status = status;
+                state.er_preparation.set_status_for_test(status);
 
-                assert_eq!(state.er_preparation.status, status);
+                assert_eq!(state.er_preparation.status(), status);
             }
         }
 

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -468,8 +468,8 @@ mod tests {
                 .sql_modal
                 .enqueue_prefetch("public.orders".to_string());
 
-            let first = state.sql_modal.pop_prefetch();
-            let second = state.sql_modal.pop_prefetch();
+            let first = state.sql_modal.start_prefetch();
+            let second = state.sql_modal.start_prefetch();
 
             assert_eq!(first, Some("public.users".to_string()));
             assert_eq!(second, Some("public.orders".to_string()));

--- a/src/app/model/browse/cell_edit.rs
+++ b/src/app/model/browse/cell_edit.rs
@@ -2,10 +2,10 @@ use crate::model::shared::text_input::TextInputState;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CellEditState {
-    pub row: Option<usize>,
-    pub col: Option<usize>,
-    pub original_value: String,
-    pub input: TextInputState,
+    row: Option<usize>,
+    col: Option<usize>,
+    original_value: String,
+    input: TextInputState,
 }
 
 impl CellEditState {
@@ -18,6 +18,26 @@ impl CellEditState {
 
     pub fn is_active(&self) -> bool {
         self.row.is_some() && self.col.is_some()
+    }
+
+    pub fn row(&self) -> Option<usize> {
+        self.row
+    }
+
+    pub fn col(&self) -> Option<usize> {
+        self.col
+    }
+
+    pub fn original_value(&self) -> &str {
+        &self.original_value
+    }
+
+    pub fn input(&self) -> &TextInputState {
+        &self.input
+    }
+
+    pub fn input_mut(&mut self) -> &mut TextInputState {
+        &mut self.input
     }
 
     pub fn has_pending_draft(&self) -> bool {

--- a/src/app/model/browse/jsonb_detail.rs
+++ b/src/app/model/browse/jsonb_detail.rs
@@ -175,10 +175,6 @@ impl JsonbDetailState {
         &mut self.search
     }
 
-    pub fn set_mode(&mut self, mode: JsonbDetailMode) {
-        self.mode = mode;
-    }
-
     pub fn enter_search(&mut self) {
         self.mode = JsonbDetailMode::Searching;
         self.search.reset();

--- a/src/app/model/browse/jsonb_detail.rs
+++ b/src/app/model/browse/jsonb_detail.rs
@@ -59,6 +59,20 @@ impl JsonbSearchState {
             self.current_match - 1
         };
     }
+
+    pub fn activate(&mut self) {
+        self.active = true;
+    }
+
+    pub fn deactivate(&mut self) {
+        self.active = false;
+    }
+
+    pub fn reset(&mut self) {
+        self.input.set_content(String::new());
+        self.matches.clear();
+        self.current_match = 0;
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -167,19 +181,17 @@ impl JsonbDetailState {
 
     pub fn enter_search(&mut self) {
         self.mode = JsonbDetailMode::Searching;
-        self.search.active = true;
-        self.search.input.set_content(String::new());
-        self.search.matches.clear();
-        self.search.current_match = 0;
+        self.search.reset();
+        self.search.activate();
     }
 
     pub fn exit_search(&mut self) {
-        self.search.active = false;
+        self.search.deactivate();
         self.mode = JsonbDetailMode::Viewing;
     }
 
     pub fn enter_edit(&mut self) {
-        self.search.active = false;
+        self.search.deactivate();
         self.validation_error = None;
         self.mode = JsonbDetailMode::Editing;
     }

--- a/src/app/model/browse/jsonb_detail.rs
+++ b/src/app/model/browse/jsonb_detail.rs
@@ -11,10 +11,41 @@ pub enum JsonbDetailMode {
 
 #[derive(Debug, Clone, Default)]
 pub struct JsonbSearchState {
-    pub input: TextInputState,
-    pub matches: Vec<usize>,
-    pub current_match: usize,
-    pub active: bool,
+    input: TextInputState,
+    matches: Vec<usize>,
+    current_match: usize,
+    active: bool,
+}
+
+impl JsonbSearchState {
+    pub fn input(&self) -> &TextInputState {
+        &self.input
+    }
+
+    pub fn input_mut(&mut self) -> &mut TextInputState {
+        &mut self.input
+    }
+
+    pub fn matches(&self) -> &[usize] {
+        &self.matches
+    }
+
+    pub fn current_match(&self) -> usize {
+        self.current_match
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub fn set_matches(&mut self, matches: Vec<usize>) {
+        self.matches = matches;
+        self.current_match = 0;
+    }
+
+    pub fn set_current_match(&mut self, current_match: usize) {
+        self.current_match = current_match;
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -236,6 +267,6 @@ mod tests {
 
         state.enter_edit();
 
-        assert!(!state.search().active);
+        assert!(!state.search().is_active());
     }
 }

--- a/src/app/model/browse/jsonb_detail.rs
+++ b/src/app/model/browse/jsonb_detail.rs
@@ -43,8 +43,21 @@ impl JsonbSearchState {
         self.current_match = 0;
     }
 
-    pub fn set_current_match(&mut self, current_match: usize) {
-        self.current_match = current_match;
+    pub fn advance_to_next_match(&mut self) {
+        if !self.matches.is_empty() {
+            self.current_match = (self.current_match + 1) % self.matches.len();
+        }
+    }
+
+    pub fn advance_to_prev_match(&mut self) {
+        if self.matches.is_empty() {
+            return;
+        }
+        self.current_match = if self.current_match == 0 {
+            self.matches.len() - 1
+        } else {
+            self.current_match - 1
+        };
     }
 }
 

--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -23,14 +23,38 @@ pub enum QueryStatus {
 
 #[derive(Debug, Clone, Default)]
 pub struct PaginationState {
-    pub current_page: usize,
-    pub total_rows_estimate: Option<i64>,
-    pub reached_end: bool,
-    pub schema: String,
-    pub table: String,
+    current_page: usize,
+    total_rows_estimate: Option<i64>,
+    reached_end: bool,
+    schema: String,
+    table: String,
 }
 
 impl PaginationState {
+    pub fn current_page(&self) -> usize {
+        self.current_page
+    }
+
+    pub fn total_rows_estimate(&self) -> Option<i64> {
+        self.total_rows_estimate
+    }
+
+    pub fn reached_end(&self) -> bool {
+        self.reached_end
+    }
+
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+
+    pub fn table(&self) -> &str {
+        &self.table
+    }
+
+    pub fn has_table(&self) -> bool {
+        !self.table.is_empty()
+    }
+
     pub fn offset(&self) -> usize {
         self.current_page * PREVIEW_PAGE_SIZE
     }
@@ -56,6 +80,38 @@ impl PaginationState {
         self.reached_end = false;
         self.schema.clear();
         self.table.clear();
+    }
+
+    pub fn reset_for_table(&mut self, schema: &str, table: &str) {
+        self.reset();
+        self.schema = schema.to_string();
+        self.table = table.to_string();
+    }
+
+    pub fn set_table(&mut self, schema: &str, table: &str) {
+        self.schema = schema.to_string();
+        self.table = table.to_string();
+    }
+
+    pub fn set_page(&mut self, page: usize) {
+        self.current_page = page;
+    }
+
+    pub fn set_total_rows_estimate(&mut self, estimate: Option<i64>) {
+        self.total_rows_estimate = estimate;
+    }
+
+    pub fn mark_reached_end(&mut self) {
+        self.reached_end = true;
+    }
+
+    pub fn clear_reached_end(&mut self) {
+        self.reached_end = false;
+    }
+
+    pub fn set_page_result(&mut self, page: usize, reached_end: bool) {
+        self.current_page = page;
+        self.reached_end = reached_end;
     }
 }
 

--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -88,30 +88,48 @@ impl PaginationState {
         self.table = table.to_string();
     }
 
-    pub fn set_table(&mut self, schema: &str, table: &str) {
-        self.schema = schema.to_string();
-        self.table = table.to_string();
-    }
-
-    pub fn set_page(&mut self, page: usize) {
-        self.current_page = page;
-    }
-
-    pub fn set_total_rows_estimate(&mut self, estimate: Option<i64>) {
+    pub fn reset_for_table_with_estimate(
+        &mut self,
+        schema: &str,
+        table: &str,
+        estimate: Option<i64>,
+    ) {
+        self.reset_for_table(schema, table);
         self.total_rows_estimate = estimate;
     }
 
-    pub fn mark_reached_end(&mut self) {
-        self.reached_end = true;
-    }
-
-    pub fn clear_reached_end(&mut self) {
+    pub fn allow_next_page_after_refresh(&mut self) {
         self.reached_end = false;
     }
 
     pub fn set_page_result(&mut self, page: usize, reached_end: bool) {
         self.current_page = page;
         self.reached_end = reached_end;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_table_for_test(&mut self, schema: &str, table: &str) {
+        self.schema = schema.to_string();
+        self.table = table.to_string();
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_page_for_test(&mut self, page: usize) {
+        self.current_page = page;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_total_rows_estimate_for_test(&mut self, estimate: Option<i64>) {
+        self.total_rows_estimate = estimate;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn mark_reached_end_for_test(&mut self) {
+        self.reached_end = true;
     }
 }
 
@@ -738,6 +756,49 @@ mod tests {
             assert!(!p.reached_end);
             assert!(p.schema.is_empty());
             assert!(p.table.is_empty());
+        }
+
+        #[test]
+        fn reset_for_table_with_estimate_sets_target_and_resets_page_state() {
+            let mut p = PaginationState {
+                current_page: 5,
+                total_rows_estimate: Some(1),
+                reached_end: true,
+                schema: "old".to_string(),
+                table: "old".to_string(),
+            };
+
+            p.reset_for_table_with_estimate("public", "users", Some(1200));
+
+            assert_eq!(p.current_page(), 0);
+            assert_eq!(p.total_rows_estimate(), Some(1200));
+            assert!(!p.reached_end());
+            assert_eq!(p.schema(), "public");
+            assert_eq!(p.table(), "users");
+        }
+
+        #[test]
+        fn set_page_result_updates_page_and_reached_end_together() {
+            let mut p = PaginationState::default();
+
+            p.set_page_result(2, true);
+
+            assert_eq!(p.current_page(), 2);
+            assert!(p.reached_end());
+        }
+
+        #[test]
+        fn allow_next_page_after_refresh_clears_reached_end_only() {
+            let mut p = PaginationState {
+                current_page: 3,
+                reached_end: true,
+                ..Default::default()
+            };
+
+            p.allow_next_page_after_refresh();
+
+            assert_eq!(p.current_page(), 3);
+            assert!(!p.reached_end());
         }
     }
 }

--- a/src/app/model/browse/result_interaction.rs
+++ b/src/app/model/browse/result_interaction.rs
@@ -68,7 +68,7 @@ impl ResultInteraction {
     }
 
     pub fn cell_edit_input_mut(&mut self) -> &mut TextInputState {
-        &mut self.cell_edit.input
+        self.cell_edit.input_mut()
     }
 
     pub fn clear_cell_edit(&mut self) {
@@ -350,8 +350,8 @@ mod tests {
         ri.begin_cell_edit(1, 2, "hello".to_string());
 
         assert!(ri.cell_edit().is_active());
-        assert_eq!(ri.cell_edit().row, Some(1));
-        assert_eq!(ri.cell_edit().col, Some(2));
+        assert_eq!(ri.cell_edit().row(), Some(1));
+        assert_eq!(ri.cell_edit().col(), Some(2));
     }
 
     #[test]

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -326,12 +326,6 @@ impl BrowseSession {
     pub fn set_active_database_type_for_test(&mut self, database_type: Option<DatabaseType>) {
         self.active_database_type = database_type;
     }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_reloading_for_test(&mut self, is_reloading: bool) {
-        self.is_reloading = is_reloading;
-    }
 }
 
 #[cfg(test)]

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -58,9 +58,7 @@ impl BrowseSession {
         self.selected_table_key = Some(format!("{schema}.{table}"));
         self.table_detail = None;
         self.selection_generation += 1;
-        pagination.reset();
-        pagination.schema = schema.to_string();
-        pagination.table = table.to_string();
+        pagination.reset_for_table(schema, table);
         self.selection_generation
     }
 
@@ -413,21 +411,19 @@ mod tests {
         #[test]
         fn resets_pagination() {
             let mut session = BrowseSession::default();
-            let mut pagination = PaginationState {
-                current_page: 5,
-                total_rows_estimate: Some(10000),
-                reached_end: true,
-                schema: "old".to_string(),
-                table: "old".to_string(),
-            };
+            let mut pagination = PaginationState::default();
+            pagination.set_page(5);
+            pagination.set_total_rows_estimate(Some(10000));
+            pagination.mark_reached_end();
+            pagination.set_table("old", "old");
 
             let _ = session.select_table("public", "users", &mut pagination);
 
-            assert_eq!(pagination.current_page, 0);
-            assert_eq!(pagination.total_rows_estimate, None);
-            assert!(!pagination.reached_end);
-            assert_eq!(pagination.schema, "public");
-            assert_eq!(pagination.table, "users");
+            assert_eq!(pagination.current_page(), 0);
+            assert_eq!(pagination.total_rows_estimate(), None);
+            assert!(!pagination.reached_end());
+            assert_eq!(pagination.schema(), "public");
+            assert_eq!(pagination.table(), "users");
         }
     }
 
@@ -475,7 +471,7 @@ mod tests {
 
         assert!(session.selected_table_key().is_none());
         assert!(session.table_detail().is_none());
-        assert_eq!(pagination.current_page, 0);
+        assert_eq!(pagination.current_page(), 0);
     }
 
     #[test]
@@ -699,13 +695,10 @@ mod tests {
             session.begin_reload();
             let mut query = QueryExecution::default();
             query.set_current_result(make_query_result());
-            query.pagination = PaginationState {
-                current_page: 3,
-                total_rows_estimate: Some(1000),
-                reached_end: true,
-                schema: "public".to_string(),
-                table: "users".to_string(),
-            };
+            query.pagination.set_page(3);
+            query.pagination.set_total_rows_estimate(Some(1000));
+            query.pagination.mark_reached_end();
+            query.pagination.set_table("public", "users");
             query.enter_history(2);
 
             session.reset(&mut query);
@@ -723,7 +716,7 @@ mod tests {
             assert!(session.active_database_type().is_none());
             assert!(!session.is_read_only());
             assert!(!session.is_reloading());
-            assert_eq!(query.pagination.current_page, 0);
+            assert_eq!(query.pagination.current_page(), 0);
             assert!(query.current_result().is_none());
             assert!(query.history_index().is_none());
         }

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -166,8 +166,7 @@ impl BrowseSession {
         }
     }
 
-    // Caller must also call `result_interaction.reset_view()` and restore UI state.
-    pub fn restore_from_cache(&mut self, cache: &ConnectionCache, query: &mut QueryExecution) {
+    fn restore_from_cache(&mut self, cache: &ConnectionCache, query: &mut QueryExecution) {
         self.metadata.clone_from(&cache.metadata);
         self.table_detail.clone_from(&cache.table_detail);
         self.selected_table_key

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -184,6 +184,20 @@ impl BrowseSession {
         query.exit_history();
     }
 
+    pub fn restore_from_cache_for_connection(
+        &mut self,
+        cache: &ConnectionCache,
+        query: &mut QueryExecution,
+        id: &ConnectionId,
+        name: &str,
+        database_type: DatabaseType,
+        dsn: &str,
+    ) {
+        self.restore_from_cache(cache, query);
+        self.set_active_connection(id, name, database_type, dsn);
+        self.disable_read_only();
+    }
+
     // Caller must also call `result_interaction.reset_view()` and restore UI state.
     pub fn reset(&mut self, query: &mut QueryExecution) {
         self.metadata = None;
@@ -412,10 +426,10 @@ mod tests {
         fn resets_pagination() {
             let mut session = BrowseSession::default();
             let mut pagination = PaginationState::default();
-            pagination.set_page(5);
-            pagination.set_total_rows_estimate(Some(10000));
-            pagination.mark_reached_end();
-            pagination.set_table("old", "old");
+            pagination.set_page_for_test(5);
+            pagination.set_total_rows_estimate_for_test(Some(10000));
+            pagination.mark_reached_end_for_test();
+            pagination.set_table_for_test("old", "old");
 
             let _ = session.select_table("public", "users", &mut pagination);
 
@@ -695,10 +709,12 @@ mod tests {
             session.begin_reload();
             let mut query = QueryExecution::default();
             query.set_current_result(make_query_result());
-            query.pagination.set_page(3);
-            query.pagination.set_total_rows_estimate(Some(1000));
-            query.pagination.mark_reached_end();
-            query.pagination.set_table("public", "users");
+            query.pagination.set_page_for_test(3);
+            query
+                .pagination
+                .set_total_rows_estimate_for_test(Some(1000));
+            query.pagination.mark_reached_end_for_test();
+            query.pagination.set_table_for_test("public", "users");
             query.enter_history(2);
 
             session.reset(&mut query);

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -36,13 +36,13 @@ pub struct BrowseSession {
     // -- lifecycle-gated --
     metadata: Option<Arc<DatabaseMetadata>>,
 
-    // -- public / independent --
-    pub dsn: Option<String>,
-    pub active_connection_id: Option<ConnectionId>,
-    pub active_connection_name: Option<String>,
-    pub active_database_type: Option<DatabaseType>,
-    pub read_only: bool,
-    pub is_reloading: bool,
+    // -- co-dependent: connection identity / lifecycle --
+    dsn: Option<String>,
+    active_connection_id: Option<ConnectionId>,
+    active_connection_name: Option<String>,
+    active_database_type: Option<DatabaseType>,
+    read_only: bool,
+    is_reloading: bool,
 }
 
 impl BrowseSession {
@@ -106,6 +106,13 @@ impl BrowseSession {
         self.dsn = Some(dsn.to_string());
     }
 
+    pub fn clear_active_connection(&mut self) {
+        self.active_connection_id = None;
+        self.active_connection_name = None;
+        self.active_database_type = None;
+        self.dsn = None;
+    }
+
     pub fn mark_connected(&mut self, metadata: Arc<DatabaseMetadata>) {
         self.connection_state = ConnectionState::Connected;
         self.metadata_state = MetadataState::Loaded;
@@ -138,6 +145,14 @@ impl BrowseSession {
 
     pub fn finish_reload(&mut self) {
         self.is_reloading = false;
+    }
+
+    pub fn enable_read_only(&mut self) {
+        self.read_only = true;
+    }
+
+    pub fn disable_read_only(&mut self) {
+        self.read_only = false;
     }
 
     // ── Cache operations ─────────────────────────────────────────────
@@ -228,6 +243,30 @@ impl BrowseSession {
         self.selection_generation
     }
 
+    pub fn dsn(&self) -> Option<&str> {
+        self.dsn.as_deref()
+    }
+
+    pub fn active_connection_id(&self) -> Option<&ConnectionId> {
+        self.active_connection_id.as_ref()
+    }
+
+    pub fn active_connection_name(&self) -> Option<&str> {
+        self.active_connection_name.as_deref()
+    }
+
+    pub fn active_database_type(&self) -> Option<DatabaseType> {
+        self.active_database_type
+    }
+
+    pub fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+
+    pub fn is_reloading(&self) -> bool {
+        self.is_reloading
+    }
+
     pub fn tables(&self) -> Vec<&TableSummary> {
         self.metadata
             .as_ref()
@@ -263,6 +302,42 @@ impl BrowseSession {
     #[allow(dead_code, reason = "test helper")]
     pub(crate) fn set_selection_generation(&mut self, value: u64) {
         self.selection_generation = value;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_dsn_for_test(&mut self, dsn: impl Into<String>) {
+        self.dsn = Some(dsn.into());
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn clear_dsn_for_test(&mut self) {
+        self.dsn = None;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_active_connection_id_for_test(&mut self, id: Option<ConnectionId>) {
+        self.active_connection_id = id;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_active_connection_name_for_test(&mut self, name: Option<String>) {
+        self.active_connection_name = name;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_active_database_type_for_test(&mut self, database_type: Option<DatabaseType>) {
+        self.active_database_type = database_type;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_reloading_for_test(&mut self, is_reloading: bool) {
+        self.is_reloading = is_reloading;
     }
 }
 
@@ -443,21 +518,19 @@ mod tests {
 
             assert!(session.connection_state().is_connecting());
             assert_eq!(session.metadata_state(), &MetadataState::Loading);
-            assert_eq!(session.dsn, Some("postgres://localhost/test".to_string()));
+            assert_eq!(session.dsn(), Some("postgres://localhost/test"));
         }
 
         #[test]
         fn mark_connecting_sets_pair_without_changing_dsn() {
-            let mut session = BrowseSession {
-                dsn: Some("postgres://localhost/test".to_string()),
-                ..Default::default()
-            };
+            let mut session = BrowseSession::default();
+            session.set_dsn_for_test("postgres://localhost/test");
 
             session.mark_connecting();
 
             assert!(session.connection_state().is_connecting());
             assert_eq!(session.metadata_state(), &MetadataState::Loading);
-            assert_eq!(session.dsn, Some("postgres://localhost/test".to_string()));
+            assert_eq!(session.dsn(), Some("postgres://localhost/test"));
         }
 
         #[test]
@@ -485,14 +558,14 @@ mod tests {
                 session.metadata_state(),
                 &MetadataState::Error("timeout".to_string())
             );
-            assert!(!session.is_reloading);
+            assert!(!session.is_reloading());
         }
 
         #[test]
         fn mark_connection_failed_when_connected_keeps_connected() {
             let mut session = BrowseSession::default();
             session.mark_connected(make_metadata("db"));
-            session.is_reloading = true;
+            session.begin_reload();
 
             session.mark_connection_failed("reload timeout".to_string());
 
@@ -501,7 +574,7 @@ mod tests {
                 session.metadata_state(),
                 &MetadataState::Error("reload timeout".to_string())
             );
-            assert!(!session.is_reloading);
+            assert!(!session.is_reloading());
         }
 
         #[test]
@@ -525,7 +598,7 @@ mod tests {
 
             assert!(session.connection_state().is_not_connected());
             assert_eq!(session.metadata_state(), &MetadataState::NotLoaded);
-            assert!(!session.is_reloading);
+            assert!(!session.is_reloading());
         }
 
         #[test]
@@ -533,10 +606,10 @@ mod tests {
             let mut session = BrowseSession::default();
 
             session.begin_reload();
-            assert!(session.is_reloading);
+            assert!(session.is_reloading());
 
             session.finish_reload();
-            assert!(!session.is_reloading);
+            assert!(!session.is_reloading());
         }
     }
 
@@ -580,19 +653,19 @@ mod tests {
             session.mark_connected(make_metadata("db"));
             let mut pagination = PaginationState::default();
             let _ = session.select_table("public", "users", &mut pagination);
-            session.is_reloading = true;
+            session.begin_reload();
             assert!(session.selection_generation() > 0);
 
             let cache = session.to_cache(0, InspectorTab::Info, None, ResultHistory::default());
 
             let mut new_session = BrowseSession::default();
             new_session.set_selection_generation(42);
-            new_session.is_reloading = true;
+            new_session.begin_reload();
             let mut query = QueryExecution::default();
             new_session.restore_from_cache(&cache, &mut query);
 
             assert_eq!(new_session.selection_generation(), 0);
-            assert!(!new_session.is_reloading);
+            assert!(!new_session.is_reloading());
         }
 
         #[test]
@@ -617,7 +690,7 @@ mod tests {
 
             assert_eq!(restored.selected_table_key(), Some("public.users"));
             assert!(restored.table_detail().is_some());
-            assert!(restored.is_reloading);
+            assert!(restored.is_reloading());
             assert!(restored.connection_state().is_connected());
         }
     }
@@ -631,12 +704,12 @@ mod tests {
         fn clears_session_and_query_state() {
             let mut session = BrowseSession::default();
             session.mark_connected(make_metadata("db"));
-            session.dsn = Some("postgres://host/db".to_string());
-            session.active_connection_id = Some(ConnectionId::new());
-            session.active_connection_name = Some("mydb".to_string());
-            session.active_database_type = Some(DatabaseType::PostgreSQL);
-            session.read_only = true;
-            session.is_reloading = true;
+            session.set_dsn_for_test("postgres://host/db");
+            session.set_active_connection_id_for_test(Some(ConnectionId::new()));
+            session.set_active_connection_name_for_test(Some("mydb".to_string()));
+            session.set_active_database_type_for_test(Some(DatabaseType::PostgreSQL));
+            session.enable_read_only();
+            session.begin_reload();
             let mut query = QueryExecution::default();
             query.set_current_result(make_query_result());
             query.pagination = PaginationState {
@@ -657,12 +730,12 @@ mod tests {
             assert!(session.selected_table_key().is_none());
             assert!(session.table_detail().is_none());
             assert_eq!(session.selection_generation(), 0);
-            assert!(session.dsn.is_none());
-            assert!(session.active_connection_id.is_none());
-            assert!(session.active_connection_name.is_none());
-            assert!(session.active_database_type.is_none());
-            assert!(!session.read_only);
-            assert!(!session.is_reloading);
+            assert!(session.dsn().is_none());
+            assert!(session.active_connection_id().is_none());
+            assert!(session.active_connection_name().is_none());
+            assert!(session.active_database_type().is_none());
+            assert!(!session.is_read_only());
+            assert!(!session.is_reloading());
             assert_eq!(query.pagination.current_page, 0);
             assert!(query.current_result().is_none());
             assert!(query.history_index().is_none());

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -106,13 +106,6 @@ impl BrowseSession {
         self.dsn = Some(dsn.to_string());
     }
 
-    pub fn clear_active_connection(&mut self) {
-        self.active_connection_id = None;
-        self.active_connection_name = None;
-        self.active_database_type = None;
-        self.dsn = None;
-    }
-
     pub fn mark_connected(&mut self, metadata: Arc<DatabaseMetadata>) {
         self.connection_state = ConnectionState::Connected;
         self.metadata_state = MetadataState::Loaded;

--- a/src/app/model/connection/error_state.rs
+++ b/src/app/model/connection/error_state.rs
@@ -134,6 +134,25 @@ mod tests {
             assert!(state.error_info().is_some());
             assert!(!state.details_expanded());
             assert_eq!(state.scroll_offset(), 0);
+            assert!(!state.is_copied_visible_at(now()));
+        }
+    }
+
+    mod reset_view {
+        use super::*;
+
+        #[test]
+        fn collapses_details_and_resets_scroll_without_clearing_error() {
+            let mut state = ConnectionErrorState::default();
+            state.set_error(sample_error());
+            state.expand_details();
+            state.set_scroll_offset_for_test(4);
+
+            state.reset_view();
+
+            assert!(state.error_info().is_some());
+            assert!(!state.details_expanded());
+            assert_eq!(state.scroll_offset(), 0);
         }
     }
 

--- a/src/app/model/connection/error_state.rs
+++ b/src/app/model/connection/error_state.rs
@@ -4,9 +4,9 @@ use super::error::ConnectionErrorInfo;
 
 #[derive(Debug, Clone, Default)]
 pub struct ConnectionErrorState {
-    pub error_info: Option<ConnectionErrorInfo>,
-    pub details_expanded: bool,
-    pub scroll_offset: usize,
+    error_info: Option<ConnectionErrorInfo>,
+    details_expanded: bool,
+    scroll_offset: usize,
     copied_feedback_expires: Option<Instant>,
 }
 
@@ -18,6 +18,31 @@ impl ConnectionErrorState {
         self.details_expanded = false;
         self.scroll_offset = 0;
         self.copied_feedback_expires = None;
+    }
+
+    pub fn error_info(&self) -> Option<&ConnectionErrorInfo> {
+        self.error_info.as_ref()
+    }
+
+    pub fn has_error(&self) -> bool {
+        self.error_info.is_some()
+    }
+
+    pub fn details_expanded(&self) -> bool {
+        self.details_expanded
+    }
+
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    pub fn reset_view(&mut self) {
+        self.details_expanded = false;
+        self.scroll_offset = 0;
+    }
+
+    pub fn expand_details(&mut self) {
+        self.details_expanded = true;
     }
 
     pub fn clear(&mut self) {

--- a/src/app/model/connection/error_state.rs
+++ b/src/app/model/connection/error_state.rs
@@ -45,6 +45,12 @@ impl ConnectionErrorState {
         self.details_expanded = true;
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_scroll_offset_for_test(&mut self, scroll_offset: usize) {
+        self.scroll_offset = scroll_offset;
+    }
+
     pub fn clear(&mut self) {
         self.error_info = None;
         self.details_expanded = false;
@@ -119,17 +125,15 @@ mod tests {
 
         #[test]
         fn stores_info_and_resets_ui() {
-            let mut state = ConnectionErrorState {
-                details_expanded: true,
-                scroll_offset: 5,
-                ..Default::default()
-            };
+            let mut state = ConnectionErrorState::default();
+            state.expand_details();
+            state.set_scroll_offset_for_test(5);
 
             state.set_error(sample_error());
 
-            assert!(state.error_info.is_some());
-            assert!(!state.details_expanded);
-            assert_eq!(state.scroll_offset, 0);
+            assert!(state.error_info().is_some());
+            assert!(!state.details_expanded());
+            assert_eq!(state.scroll_offset(), 0);
         }
     }
 
@@ -140,14 +144,14 @@ mod tests {
         fn resets_all_fields() {
             let mut state = ConnectionErrorState::default();
             state.set_error(sample_error());
-            state.details_expanded = true;
-            state.scroll_offset = 3;
+            state.expand_details();
+            state.set_scroll_offset_for_test(3);
 
             state.clear();
 
-            assert!(state.error_info.is_none());
-            assert!(!state.details_expanded);
-            assert_eq!(state.scroll_offset, 0);
+            assert!(state.error_info().is_none());
+            assert!(!state.details_expanded());
+            assert_eq!(state.scroll_offset(), 0);
         }
     }
 
@@ -159,23 +163,21 @@ mod tests {
             let mut state = ConnectionErrorState::default();
 
             state.toggle_details();
-            assert!(state.details_expanded);
+            assert!(state.details_expanded());
 
             state.toggle_details();
-            assert!(!state.details_expanded);
+            assert!(!state.details_expanded());
         }
 
         #[test]
         fn resets_scroll_on_collapse() {
-            let mut state = ConnectionErrorState {
-                details_expanded: true,
-                scroll_offset: 5,
-                ..Default::default()
-            };
+            let mut state = ConnectionErrorState::default();
+            state.expand_details();
+            state.set_scroll_offset_for_test(5);
 
             state.toggle_details();
 
-            assert_eq!(state.scroll_offset, 0);
+            assert_eq!(state.scroll_offset(), 0);
         }
     }
 
@@ -184,14 +186,12 @@ mod tests {
 
         #[test]
         fn up_decrements_offset() {
-            let mut state = ConnectionErrorState {
-                scroll_offset: 5,
-                ..Default::default()
-            };
+            let mut state = ConnectionErrorState::default();
+            state.set_scroll_offset_for_test(5);
 
             state.scroll_up();
 
-            assert_eq!(state.scroll_offset, 4);
+            assert_eq!(state.scroll_offset(), 4);
         }
 
         #[test]
@@ -200,7 +200,7 @@ mod tests {
 
             state.scroll_up();
 
-            assert_eq!(state.scroll_offset, 0);
+            assert_eq!(state.scroll_offset(), 0);
         }
 
         #[test]
@@ -209,19 +209,17 @@ mod tests {
 
             state.scroll_down(10);
 
-            assert_eq!(state.scroll_offset, 1);
+            assert_eq!(state.scroll_offset(), 1);
         }
 
         #[test]
         fn down_stops_at_max() {
-            let mut state = ConnectionErrorState {
-                scroll_offset: 10,
-                ..Default::default()
-            };
+            let mut state = ConnectionErrorState::default();
+            state.set_scroll_offset_for_test(10);
 
             state.scroll_down(10);
 
-            assert_eq!(state.scroll_offset, 10);
+            assert_eq!(state.scroll_offset(), 10);
         }
     }
 

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -233,32 +233,8 @@ impl ConnectionSetupState {
         }
     }
 
-    pub fn name(&self) -> &TextInputState {
-        &self.name
-    }
-
-    pub fn sqlite_path(&self) -> &TextInputState {
-        &self.sqlite_path
-    }
-
-    pub fn host(&self) -> &TextInputState {
-        &self.host
-    }
-
-    pub fn port(&self) -> &TextInputState {
-        &self.port
-    }
-
-    pub fn database(&self) -> &TextInputState {
-        &self.database
-    }
-
-    pub fn user(&self) -> &TextInputState {
-        &self.user
-    }
-
-    pub fn password(&self) -> &TextInputState {
-        &self.password
+    pub fn port_mut(&mut self) -> &mut TextInputState {
+        &mut self.port
     }
 
     pub fn default_name(&self) -> String {
@@ -276,20 +252,6 @@ impl ConnectionSetupState {
                 .file_name_for_display()
                 .unwrap_or("SQLite")
                 .to_string(),
-        }
-    }
-
-    pub fn field_value(&self, field: ConnectionField) -> &str {
-        match field {
-            ConnectionField::DatabaseType => "",
-            ConnectionField::Name => self.name.content(),
-            ConnectionField::SqlitePath => self.sqlite_path.content(),
-            ConnectionField::Host => self.host.content(),
-            ConnectionField::Port => self.port.content(),
-            ConnectionField::Database => self.database.content(),
-            ConnectionField::User => self.user.content(),
-            ConnectionField::Password => self.password.content(),
-            ConnectionField::SslMode => "",
         }
     }
 
@@ -331,10 +293,6 @@ impl ConnectionSetupState {
 
     pub fn set_first_run(&mut self, is_first_run: bool) {
         self.is_first_run = is_first_run;
-    }
-
-    pub fn has_errors(&self) -> bool {
-        self.has_validation_errors()
     }
 
     pub fn is_edit_mode(&self) -> bool {
@@ -679,7 +637,7 @@ mod tests {
         #[test]
         fn has_errors_returns_false_when_empty() {
             let state = ConnectionSetupState::default();
-            assert!(!state.has_errors());
+            assert!(!state.has_validation_errors());
         }
 
         #[test]
@@ -688,7 +646,7 @@ mod tests {
             state
                 .validation_errors
                 .insert(ConnectionField::Host, "Required".to_string());
-            assert!(state.has_errors());
+            assert!(state.has_validation_errors());
         }
 
         #[test]
@@ -701,7 +659,7 @@ mod tests {
                 .validation_errors
                 .insert(ConnectionField::Port, "Invalid".to_string());
             state.clear_errors();
-            assert!(!state.has_errors());
+            assert!(!state.has_validation_errors());
         }
 
         #[test]

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -78,14 +78,34 @@ impl ConnectionField {
 
 #[derive(Debug, Clone, Default)]
 pub struct SslModeDropdown {
-    pub is_open: bool,
-    pub selected_index: usize,
+    is_open: bool,
+    selected_index: usize,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct DatabaseTypeDropdown {
-    pub is_open: bool,
-    pub selected_index: usize,
+    is_open: bool,
+    selected_index: usize,
+}
+
+impl SslModeDropdown {
+    pub fn is_open(&self) -> bool {
+        self.is_open
+    }
+
+    pub fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+}
+
+impl DatabaseTypeDropdown {
+    pub fn is_open(&self) -> bool {
+        self.is_open
+    }
+
+    pub fn selected_index(&self) -> usize {
+        self.selected_index
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -316,6 +336,18 @@ impl ConnectionSetupState {
     pub fn cancel_dropdown(&mut self) {
         self.database_type_dropdown.is_open = false;
         self.ssl_dropdown.is_open = false;
+    }
+
+    pub fn has_open_dropdown(&self) -> bool {
+        self.database_type_dropdown.is_open || self.ssl_dropdown.is_open
+    }
+
+    pub fn open_ssl_dropdown_for_test(&mut self) {
+        self.ssl_dropdown.is_open = true;
+    }
+
+    pub fn open_database_type_dropdown_for_test(&mut self) {
+        self.database_type_dropdown.is_open = true;
     }
 
     pub fn record_sqlite_config_error(&mut self, error: SqliteConnectionConfigError) {

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -110,24 +110,24 @@ impl DatabaseTypeDropdown {
 
 #[derive(Debug, Clone)]
 pub struct ConnectionSetupState {
-    pub database_type: DatabaseType,
-    pub name: TextInputState,
-    pub sqlite_path: TextInputState,
-    pub host: TextInputState,
-    pub port: TextInputState,
-    pub database: TextInputState,
-    pub user: TextInputState,
-    pub password: TextInputState,
-    pub ssl_mode: SslMode,
+    database_type: DatabaseType,
+    name: TextInputState,
+    sqlite_path: TextInputState,
+    host: TextInputState,
+    port: TextInputState,
+    database: TextInputState,
+    user: TextInputState,
+    password: TextInputState,
+    ssl_mode: SslMode,
 
-    pub focused_field: ConnectionField,
-    pub database_type_dropdown: DatabaseTypeDropdown,
-    pub ssl_dropdown: SslModeDropdown,
-    pub validation_errors: HashMap<ConnectionField, String>,
+    focused_field: ConnectionField,
+    database_type_dropdown: DatabaseTypeDropdown,
+    ssl_dropdown: SslModeDropdown,
+    validation_errors: HashMap<ConnectionField, String>,
 
-    pub is_first_run: bool,
+    is_first_run: bool,
 
-    pub editing_id: Option<ConnectionId>,
+    editing_id: Option<ConnectionId>,
 }
 
 impl Default for ConnectionSetupState {
@@ -153,6 +153,114 @@ impl Default for ConnectionSetupState {
 }
 
 impl ConnectionSetupState {
+    pub fn database_type(&self) -> DatabaseType {
+        self.database_type
+    }
+
+    pub fn ssl_mode(&self) -> SslMode {
+        self.ssl_mode
+    }
+
+    pub fn focused_field(&self) -> ConnectionField {
+        self.focused_field
+    }
+
+    pub fn is_first_run(&self) -> bool {
+        self.is_first_run
+    }
+
+    pub fn editing_id(&self) -> Option<&ConnectionId> {
+        self.editing_id.as_ref()
+    }
+
+    pub fn database_type_dropdown(&self) -> &DatabaseTypeDropdown {
+        &self.database_type_dropdown
+    }
+
+    pub fn ssl_dropdown(&self) -> &SslModeDropdown {
+        &self.ssl_dropdown
+    }
+
+    pub fn validation_error(&self, field: ConnectionField) -> Option<&str> {
+        self.validation_errors.get(&field).map(String::as_str)
+    }
+
+    pub fn has_validation_error(&self, field: ConnectionField) -> bool {
+        self.validation_errors.contains_key(&field)
+    }
+
+    pub fn has_validation_errors(&self) -> bool {
+        !self.validation_errors.is_empty()
+    }
+
+    pub fn clear_validation_error(&mut self, field: ConnectionField) {
+        self.validation_errors.remove(&field);
+    }
+
+    pub fn set_validation_error(&mut self, field: ConnectionField, message: impl Into<String>) {
+        self.validation_errors.insert(field, message.into());
+    }
+
+    pub fn retain_validation_errors_for_visible_fields(&mut self) {
+        let visible_fields = self.visible_fields();
+        self.validation_errors
+            .retain(|field, _| visible_fields.contains(field));
+    }
+
+    pub fn input(&self, field: ConnectionField) -> Option<&TextInputState> {
+        match field {
+            ConnectionField::DatabaseType | ConnectionField::SslMode => None,
+            ConnectionField::Name => Some(&self.name),
+            ConnectionField::SqlitePath => Some(&self.sqlite_path),
+            ConnectionField::Host => Some(&self.host),
+            ConnectionField::Port => Some(&self.port),
+            ConnectionField::Database => Some(&self.database),
+            ConnectionField::User => Some(&self.user),
+            ConnectionField::Password => Some(&self.password),
+        }
+    }
+
+    pub fn input_mut(&mut self, field: ConnectionField) -> Option<&mut TextInputState> {
+        match field {
+            ConnectionField::DatabaseType | ConnectionField::SslMode => None,
+            ConnectionField::Name => Some(&mut self.name),
+            ConnectionField::SqlitePath => Some(&mut self.sqlite_path),
+            ConnectionField::Host => Some(&mut self.host),
+            ConnectionField::Port => Some(&mut self.port),
+            ConnectionField::Database => Some(&mut self.database),
+            ConnectionField::User => Some(&mut self.user),
+            ConnectionField::Password => Some(&mut self.password),
+        }
+    }
+
+    pub fn name(&self) -> &TextInputState {
+        &self.name
+    }
+
+    pub fn sqlite_path(&self) -> &TextInputState {
+        &self.sqlite_path
+    }
+
+    pub fn host(&self) -> &TextInputState {
+        &self.host
+    }
+
+    pub fn port(&self) -> &TextInputState {
+        &self.port
+    }
+
+    pub fn database(&self) -> &TextInputState {
+        &self.database
+    }
+
+    pub fn user(&self) -> &TextInputState {
+        &self.user
+    }
+
+    pub fn password(&self) -> &TextInputState {
+        &self.password
+    }
+
     pub fn default_name(&self) -> String {
         match self.database_type {
             DatabaseType::PostgreSQL => {
@@ -226,7 +334,7 @@ impl ConnectionSetupState {
     }
 
     pub fn has_errors(&self) -> bool {
-        !self.validation_errors.is_empty()
+        self.has_validation_errors()
     }
 
     pub fn is_edit_mode(&self) -> bool {
@@ -264,9 +372,7 @@ impl ConnectionSetupState {
         if !self.visible_fields().contains(&self.focused_field) {
             self.focused_field = ConnectionField::DatabaseType;
         }
-        let visible_fields = self.visible_fields();
-        self.validation_errors
-            .retain(|field, _| visible_fields.contains(field));
+        self.retain_validation_errors_for_visible_fields();
     }
 
     pub fn toggle_focused_dropdown(&mut self) {
@@ -342,12 +448,43 @@ impl ConnectionSetupState {
         self.database_type_dropdown.is_open || self.ssl_dropdown.is_open
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn open_ssl_dropdown_for_test(&mut self) {
         self.ssl_dropdown.is_open = true;
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn open_database_type_dropdown_for_test(&mut self) {
         self.database_type_dropdown.is_open = true;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_focused_field_for_test(&mut self, field: ConnectionField) {
+        self.focused_field = field;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_input_for_test(&mut self, field: ConnectionField, input: TextInputState) {
+        match field {
+            ConnectionField::DatabaseType | ConnectionField::SslMode => {}
+            ConnectionField::Name => self.name = input,
+            ConnectionField::SqlitePath => self.sqlite_path = input,
+            ConnectionField::Host => self.host = input,
+            ConnectionField::Port => self.port = input,
+            ConnectionField::Database => self.database = input,
+            ConnectionField::User => self.user = input,
+            ConnectionField::Password => self.password = input,
+        }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn validation_errors_for_test(&self) -> &HashMap<ConnectionField, String> {
+        &self.validation_errors
     }
 
     pub fn record_sqlite_config_error(&mut self, error: SqliteConnectionConfigError) {

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -410,12 +410,20 @@ impl ConnectionSetupState {
     #[doc(hidden)]
     pub fn open_ssl_dropdown_for_test(&mut self) {
         self.ssl_dropdown.is_open = true;
+        self.ssl_dropdown.selected_index = SslMode::all_variants()
+            .iter()
+            .position(|v| *v == self.ssl_mode)
+            .unwrap_or(2);
     }
 
     #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn open_database_type_dropdown_for_test(&mut self) {
         self.database_type_dropdown.is_open = true;
+        self.database_type_dropdown.selected_index = DatabaseType::all()
+            .iter()
+            .position(|v| *v == self.database_type)
+            .unwrap_or(0);
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -10,19 +10,59 @@ pub enum ErStatus {
 
 #[derive(Debug, Clone, Default)]
 pub struct ErPreparationState {
-    pub pending_tables: HashSet<String>,
-    pub fetching_tables: HashSet<String>,
-    pub failed_tables: HashMap<String, String>,
-    pub status: ErStatus,
-    pub total_tables: usize,
-    pub target_tables: Vec<String>,
-    pub seed_tables: Vec<String>,
-    pub fk_expanded: bool,
-    pub last_signatures: HashMap<String, String>,
-    pub run_id: u64,
+    pending_tables: HashSet<String>,
+    fetching_tables: HashSet<String>,
+    failed_tables: HashMap<String, String>,
+    status: ErStatus,
+    total_tables: usize,
+    target_tables: Vec<String>,
+    seed_tables: Vec<String>,
+    fk_expanded: bool,
+    last_signatures: HashMap<String, String>,
+    run_id: u64,
 }
 
 impl ErPreparationState {
+    pub fn status(&self) -> ErStatus {
+        self.status
+    }
+
+    pub fn run_id(&self) -> u64 {
+        self.run_id
+    }
+
+    pub fn pending_tables(&self) -> &HashSet<String> {
+        &self.pending_tables
+    }
+
+    pub fn fetching_tables(&self) -> &HashSet<String> {
+        &self.fetching_tables
+    }
+
+    pub fn failed_tables(&self) -> &HashMap<String, String> {
+        &self.failed_tables
+    }
+
+    pub fn total_tables(&self) -> usize {
+        self.total_tables
+    }
+
+    pub fn target_tables(&self) -> &[String] {
+        &self.target_tables
+    }
+
+    pub fn seed_tables(&self) -> &[String] {
+        &self.seed_tables
+    }
+
+    pub fn fk_expanded(&self) -> bool {
+        self.fk_expanded
+    }
+
+    pub fn last_signatures(&self) -> &HashMap<String, String> {
+        &self.last_signatures
+    }
+
     pub fn is_complete(&self) -> bool {
         self.pending_tables.is_empty() && self.fetching_tables.is_empty()
     }
@@ -49,6 +89,82 @@ impl ErPreparationState {
 
     pub fn reset(&mut self) {
         *self = Self::default();
+    }
+
+    pub fn mark_idle(&mut self) {
+        self.status = ErStatus::Idle;
+    }
+
+    pub fn mark_rendering(&mut self) {
+        self.status = ErStatus::Rendering;
+    }
+
+    pub fn start_waiting_run(&mut self) -> u64 {
+        self.run_id += 1;
+        self.status = ErStatus::Waiting;
+        self.run_id
+    }
+
+    pub fn set_total_tables(&mut self, total: usize) {
+        self.total_tables = total;
+    }
+
+    pub fn set_target_tables(&mut self, tables: Vec<String>) {
+        self.target_tables = tables;
+    }
+
+    pub fn set_seed_tables(&mut self, tables: Vec<String>) {
+        self.seed_tables = tables;
+    }
+
+    pub fn set_fk_expanded(&mut self, expanded: bool) {
+        self.fk_expanded = expanded;
+    }
+
+    pub fn set_last_signatures(&mut self, signatures: HashMap<String, String>) {
+        self.last_signatures = signatures;
+    }
+
+    pub fn clear_last_signatures(&mut self) {
+        self.last_signatures.clear();
+    }
+
+    pub fn set_pending_tables(&mut self, tables: HashSet<String>) {
+        self.pending_tables = tables;
+    }
+
+    pub fn set_fetching_tables(&mut self, tables: HashSet<String>) {
+        self.fetching_tables = tables;
+    }
+
+    pub fn clear_table_tracking(&mut self) {
+        self.pending_tables.clear();
+        self.fetching_tables.clear();
+        self.failed_tables.clear();
+    }
+
+    pub fn insert_pending_table(&mut self, table: String) {
+        self.pending_tables.insert(table);
+    }
+
+    pub fn remove_pending_table(&mut self, table: &str) {
+        self.pending_tables.remove(table);
+    }
+
+    pub fn insert_fetching_table(&mut self, table: String) {
+        self.fetching_tables.insert(table);
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_status_for_test(&mut self, status: ErStatus) {
+        self.status = status;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_run_id_for_test(&mut self, run_id: u64) {
+        self.run_id = run_id;
     }
 }
 

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -136,10 +136,6 @@ impl ErPreparationState {
         self.total_tables = total_tables;
     }
 
-    pub fn clear_last_signatures(&mut self) {
-        self.last_signatures.clear();
-    }
-
     #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn set_total_tables_for_test(&mut self, total: usize) {

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -22,6 +22,14 @@ pub struct ErPreparationState {
     run_id: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ErPreparationProgress {
+    pub cached: usize,
+    pub total: usize,
+    pub failed: usize,
+    pub remaining: usize,
+}
+
 impl ErPreparationState {
     pub fn status(&self) -> ErStatus {
         self.status
@@ -31,18 +39,45 @@ impl ErPreparationState {
         self.run_id
     }
 
+    pub fn progress(&self) -> ErPreparationProgress {
+        let failed = self.failed_tables.len();
+        let remaining = self.pending_tables.len() + self.fetching_tables.len();
+        let cached = self.total_tables.saturating_sub(remaining + failed);
+        ErPreparationProgress {
+            cached,
+            total: self.total_tables,
+            failed,
+            remaining,
+        }
+    }
+
+    pub fn failed_table_errors(&self) -> Vec<(String, String)> {
+        self.failed_tables
+            .iter()
+            .map(|(table, error)| (table.clone(), error.clone()))
+            .collect()
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn pending_tables(&self) -> &HashSet<String> {
         &self.pending_tables
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn fetching_tables(&self) -> &HashSet<String> {
         &self.fetching_tables
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn failed_tables(&self) -> &HashMap<String, String> {
         &self.failed_tables
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn total_tables(&self) -> usize {
         self.total_tables
     }

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -105,36 +105,45 @@ impl ErPreparationState {
         self.run_id
     }
 
-    pub fn set_total_tables(&mut self, total: usize) {
+    pub fn begin_full_prefetch(&mut self, total: usize) {
+        self.clear_table_tracking();
         self.total_tables = total;
+        self.seed_tables.clear();
+        self.fk_expanded = true;
     }
 
-    pub fn set_target_tables(&mut self, tables: Vec<String>) {
+    pub fn begin_scoped_prefetch(&mut self, tables: Vec<String>) {
+        self.clear_table_tracking();
+        self.total_tables = tables.len();
+        self.seed_tables = tables;
+        self.fk_expanded = false;
+    }
+
+    pub fn set_targets(&mut self, tables: Vec<String>) {
         self.target_tables = tables;
     }
 
-    pub fn set_seed_tables(&mut self, tables: Vec<String>) {
-        self.seed_tables = tables;
+    pub fn mark_fk_expanded(&mut self) {
+        self.fk_expanded = true;
     }
 
-    pub fn set_fk_expanded(&mut self, expanded: bool) {
-        self.fk_expanded = expanded;
-    }
-
-    pub fn set_last_signatures(&mut self, signatures: HashMap<String, String>) {
+    pub fn apply_refresh_metadata(
+        &mut self,
+        signatures: HashMap<String, String>,
+        total_tables: usize,
+    ) {
         self.last_signatures = signatures;
+        self.total_tables = total_tables;
     }
 
     pub fn clear_last_signatures(&mut self) {
         self.last_signatures.clear();
     }
 
-    pub fn set_pending_tables(&mut self, tables: HashSet<String>) {
-        self.pending_tables = tables;
-    }
-
-    pub fn set_fetching_tables(&mut self, tables: HashSet<String>) {
-        self.fetching_tables = tables;
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_total_tables_for_test(&mut self, total: usize) {
+        self.total_tables = total;
     }
 
     pub fn clear_table_tracking(&mut self) {

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -136,6 +136,11 @@ impl ErPreparationState {
         self.total_tables = total_tables;
     }
 
+    pub fn invalidate_refresh_signatures(&mut self, total_tables: usize) {
+        self.last_signatures.clear();
+        self.total_tables = total_tables;
+    }
+
     #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn set_total_tables_for_test(&mut self, total: usize) {

--- a/src/app/model/explain_context.rs
+++ b/src/app/model/explain_context.rs
@@ -30,24 +30,68 @@ const MAX_EXPLAIN_HISTORY: usize = 10;
 
 #[derive(Debug, Clone, Default)]
 pub struct ExplainContext {
-    pub plan_text: Option<String>,
-    pub plan_query_snippet: Option<String>,
-    pub error: Option<String>,
-    pub is_analyze: bool,
-    pub execution_time_ms: u64,
-    pub scroll_offset: usize,
+    plan_text: Option<String>,
+    plan_query_snippet: Option<String>,
+    error: Option<String>,
+    is_analyze: bool,
+    execution_time_ms: u64,
+    scroll_offset: usize,
 
-    pub left: Option<CompareSlot>,
-    pub right: Option<CompareSlot>,
-    pub compare_scroll_offset: usize,
+    left: Option<CompareSlot>,
+    right: Option<CompareSlot>,
+    compare_scroll_offset: usize,
 
-    pub history: VecDeque<CompareSlot>,
+    history: VecDeque<CompareSlot>,
 
-    pub compare_viewport_height: Option<u16>,
-    pub confirm_scroll_offset: usize,
+    compare_viewport_height: Option<u16>,
+    confirm_scroll_offset: usize,
 }
 
 impl ExplainContext {
+    pub fn plan_text(&self) -> Option<&str> {
+        self.plan_text.as_deref()
+    }
+
+    pub fn plan_query_snippet(&self) -> Option<&str> {
+        self.plan_query_snippet.as_deref()
+    }
+
+    pub fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    pub fn is_analyze(&self) -> bool {
+        self.is_analyze
+    }
+
+    pub fn execution_time_ms(&self) -> u64 {
+        self.execution_time_ms
+    }
+
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    pub fn left(&self) -> Option<&CompareSlot> {
+        self.left.as_ref()
+    }
+
+    pub fn right(&self) -> Option<&CompareSlot> {
+        self.right.as_ref()
+    }
+
+    pub fn history(&self) -> &VecDeque<CompareSlot> {
+        &self.history
+    }
+
+    pub fn compare_scroll_offset(&self) -> usize {
+        self.compare_scroll_offset
+    }
+
+    pub fn confirm_scroll_offset(&self) -> usize {
+        self.confirm_scroll_offset
+    }
+
     pub fn set_plan(
         &mut self,
         text: String,
@@ -88,6 +132,30 @@ impl ExplainContext {
         self.error = Some(error);
         self.plan_text = None;
         self.scroll_offset = 0;
+    }
+
+    pub fn reset_confirm_scroll(&mut self) {
+        self.confirm_scroll_offset = 0;
+    }
+
+    pub fn set_compare_viewport_height(&mut self, height: u16) {
+        self.compare_viewport_height = Some(height);
+    }
+
+    pub fn scroll_confirm_to(&mut self, offset: usize) {
+        self.confirm_scroll_offset = offset;
+    }
+
+    pub fn scroll_plan_to(&mut self, offset: usize) {
+        self.scroll_offset = offset;
+    }
+
+    pub fn scroll_compare_to(&mut self, offset: usize) {
+        self.compare_scroll_offset = offset;
+    }
+
+    pub fn right_full_query(&self) -> Option<&str> {
+        self.right.as_ref().map(|slot| slot.full_query.as_str())
     }
 
     pub fn reset(&mut self) {
@@ -140,6 +208,26 @@ impl ExplainContext {
             .compare_viewport_height
             .map_or_else(|| Self::modal_inner_height(terminal_height), |h| h as usize);
         self.compare_line_count().saturating_sub(viewport)
+    }
+}
+
+#[cfg(test)]
+impl ExplainContext {
+    pub fn set_plan_text_for_test(&mut self, plan_text: Option<String>) {
+        self.plan_text = plan_text;
+    }
+
+    pub fn set_error_for_test(&mut self, error: Option<String>) {
+        self.error = error;
+    }
+
+    pub fn set_compare_slots_for_test(
+        &mut self,
+        left: Option<CompareSlot>,
+        right: Option<CompareSlot>,
+    ) {
+        self.left = left;
+        self.right = right;
     }
 }
 

--- a/src/app/model/explain_context.rs
+++ b/src/app/model/explain_context.rs
@@ -158,7 +158,7 @@ impl ExplainContext {
         self.right.as_ref().map(|slot| slot.full_query.as_str())
     }
 
-    pub fn reset(&mut self) {
+    pub fn reset_for_new_run(&mut self) {
         let left = self.left.take();
         let right = self.right.take();
         let history = std::mem::take(&mut self.history);
@@ -333,7 +333,7 @@ mod tests {
         ctx.scroll_plan_to(10);
         ctx.scroll_compare_to(5);
 
-        ctx.reset();
+        ctx.reset_for_new_run();
 
         assert!(ctx.plan_text().is_none());
         assert!(ctx.error().is_none());

--- a/src/app/model/explain_context.rs
+++ b/src/app/model/explain_context.rs
@@ -211,7 +211,7 @@ impl ExplainContext {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 impl ExplainContext {
     pub fn set_plan_text_for_test(&mut self, plan_text: Option<String>) {
         self.plan_text = plan_text;
@@ -239,11 +239,11 @@ mod tests {
     fn default_has_no_content() {
         let ctx = ExplainContext::default();
 
-        assert!(ctx.plan_text.is_none());
-        assert!(ctx.error.is_none());
-        assert!(ctx.left.is_none());
-        assert!(ctx.right.is_none());
-        assert!(ctx.history.is_empty());
+        assert!(ctx.plan_text().is_none());
+        assert!(ctx.error().is_none());
+        assert!(ctx.left().is_none());
+        assert!(ctx.right().is_none());
+        assert!(ctx.history().is_empty());
     }
 
     #[test]
@@ -257,14 +257,11 @@ mod tests {
             "SELECT * FROM users",
         );
 
-        assert!(ctx.left.is_none());
-        assert!(ctx.right.is_some());
-        assert_eq!(ctx.right.as_ref().unwrap().plan.total_cost, Some(100.0));
-        assert_eq!(
-            ctx.right.as_ref().unwrap().query_snippet,
-            "SELECT * FROM users"
-        );
-        assert_eq!(ctx.right.as_ref().unwrap().source, SlotSource::AutoLatest);
+        assert!(ctx.left().is_none());
+        assert!(ctx.right().is_some());
+        assert_eq!(ctx.right().unwrap().plan.total_cost, Some(100.0));
+        assert_eq!(ctx.right().unwrap().query_snippet, "SELECT * FROM users");
+        assert_eq!(ctx.right().unwrap().source, SlotSource::AutoLatest);
     }
 
     #[test]
@@ -284,11 +281,11 @@ mod tests {
             "SELECT * FROM users WHERE id = 1",
         );
 
-        assert!(ctx.left.is_some());
-        assert_eq!(ctx.left.as_ref().unwrap().plan.total_cost, Some(100.0));
-        assert_eq!(ctx.left.as_ref().unwrap().source, SlotSource::AutoPrevious);
-        assert_eq!(ctx.right.as_ref().unwrap().plan.total_cost, Some(5.0));
-        assert_eq!(ctx.right.as_ref().unwrap().source, SlotSource::AutoLatest);
+        assert!(ctx.left().is_some());
+        assert_eq!(ctx.left().unwrap().plan.total_cost, Some(100.0));
+        assert_eq!(ctx.left().unwrap().source, SlotSource::AutoPrevious);
+        assert_eq!(ctx.right().unwrap().plan.total_cost, Some(5.0));
+        assert_eq!(ctx.right().unwrap().source, SlotSource::AutoLatest);
     }
 
     #[test]
@@ -313,9 +310,9 @@ mod tests {
             "C",
         );
 
-        assert_eq!(ctx.history.len(), 3);
-        assert_eq!(ctx.history[0].query_snippet, "C");
-        assert_eq!(ctx.history[2].query_snippet, "A");
+        assert_eq!(ctx.history().len(), 3);
+        assert_eq!(ctx.history()[0].query_snippet, "C");
+        assert_eq!(ctx.history()[2].query_snippet, "A");
     }
 
     #[test]
@@ -333,18 +330,18 @@ mod tests {
             0,
             "B",
         );
-        ctx.scroll_offset = 10;
-        ctx.compare_scroll_offset = 5;
+        ctx.scroll_plan_to(10);
+        ctx.scroll_compare_to(5);
 
         ctx.reset();
 
-        assert!(ctx.plan_text.is_none());
-        assert!(ctx.error.is_none());
-        assert_eq!(ctx.scroll_offset, 0);
-        assert_eq!(ctx.compare_scroll_offset, 0);
-        assert!(ctx.left.is_some());
-        assert!(ctx.right.is_some());
-        assert_eq!(ctx.history.len(), 2);
+        assert!(ctx.plan_text().is_none());
+        assert!(ctx.error().is_none());
+        assert_eq!(ctx.scroll_offset(), 0);
+        assert_eq!(ctx.compare_scroll_offset(), 0);
+        assert!(ctx.left().is_some());
+        assert!(ctx.right().is_some());
+        assert_eq!(ctx.history().len(), 2);
     }
 
     #[test]
@@ -359,7 +356,7 @@ mod tests {
 
         ctx.set_error("some error".to_string());
 
-        assert!(ctx.right.is_some());
+        assert!(ctx.right().is_some());
     }
 
     #[test]
@@ -374,7 +371,7 @@ mod tests {
             );
         }
 
-        assert_eq!(ctx.history.len(), MAX_EXPLAIN_HISTORY);
+        assert_eq!(ctx.history().len(), MAX_EXPLAIN_HISTORY);
     }
 
     #[test]
@@ -388,7 +385,7 @@ mod tests {
             "SELECT *\nFROM users\nWHERE id = 1",
         );
 
-        assert_eq!(ctx.right.as_ref().unwrap().query_snippet, "SELECT *");
+        assert_eq!(ctx.right().unwrap().query_snippet, "SELECT *");
     }
 
     #[test]

--- a/src/app/model/explain_context.rs
+++ b/src/app/model/explain_context.rs
@@ -72,10 +72,22 @@ impl ExplainContext {
         self.scroll_offset
     }
 
+    pub fn compare_slots(&self) -> (Option<&CompareSlot>, Option<&CompareSlot>) {
+        (self.left.as_ref(), self.right.as_ref())
+    }
+
+    pub fn can_yank_compare(&self) -> bool {
+        self.left.is_some() && self.right.is_some()
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn left(&self) -> Option<&CompareSlot> {
         self.left.as_ref()
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn right(&self) -> Option<&CompareSlot> {
         self.right.as_ref()
     }

--- a/src/app/model/shared/message.rs
+++ b/src/app/model/shared/message.rs
@@ -64,7 +64,7 @@ impl MessageState {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 impl MessageState {
     pub fn set_messages_for_test(&mut self, error: Option<String>, success: Option<String>) {
         self.last_error = error;
@@ -93,7 +93,7 @@ mod tests {
 
         state.set_error_at("Error!".to_string(), now);
 
-        assert_eq!(state.last_error, Some("Error!".to_string()));
+        assert_eq!(state.last_error(), Some("Error!"));
         assert!(state.last_success().is_none());
     }
 
@@ -106,7 +106,7 @@ mod tests {
 
         state.set_success_at("Success!".to_string(), now);
 
-        assert_eq!(state.last_success, Some("Success!".to_string()));
+        assert_eq!(state.last_success(), Some("Success!"));
         assert!(state.last_error().is_none());
     }
 
@@ -114,13 +114,13 @@ mod tests {
     fn set_error_sets_expiration_time() {
         let now = fixed_instant();
         let mut state = MessageState::default();
-        assert!(state.expires_at.is_none());
+        assert!(state.expires_at().is_none());
 
         state.set_error_at("Error!".to_string(), now);
 
-        assert!(state.expires_at.is_some());
+        assert!(state.expires_at().is_some());
         assert_eq!(
-            state.expires_at,
+            state.expires_at(),
             Some(now + Duration::from_secs(MessageState::ERROR_TIMEOUT_SECS))
         );
     }
@@ -128,31 +128,27 @@ mod tests {
     #[test]
     fn clear_expired_at_removes_expired_messages() {
         let now = fixed_instant();
-        let mut state = MessageState {
-            last_error: Some("Error".to_string()),
-            expires_at: Some(now.checked_sub(Duration::from_secs(1)).unwrap()),
-            ..Default::default()
-        };
+        let mut state = MessageState::default();
+        state.set_error_at("Error".to_string(), now);
+        state.set_expires_at_for_test(Some(now.checked_sub(Duration::from_secs(1)).unwrap()));
 
         state.clear_expired_at(now);
 
         assert!(state.last_error().is_none());
-        assert!(state.expires_at.is_none());
+        assert!(state.expires_at().is_none());
     }
 
     #[test]
     fn clear_expired_at_keeps_unexpired_messages() {
         let now = fixed_instant();
-        let mut state = MessageState {
-            last_error: Some("Error".to_string()),
-            expires_at: Some(now + Duration::from_secs(10)),
-            ..Default::default()
-        };
+        let mut state = MessageState::default();
+        state.set_error_at("Error".to_string(), now);
+        state.set_expires_at_for_test(Some(now + Duration::from_secs(10)));
 
         state.clear_expired_at(now);
 
         assert!(state.last_error().is_some());
-        assert!(state.expires_at.is_some());
+        assert!(state.expires_at().is_some());
     }
 
     #[test]
@@ -165,6 +161,6 @@ mod tests {
 
         assert!(state.last_error().is_none());
         assert!(state.last_success().is_none());
-        assert!(state.expires_at.is_none());
+        assert!(state.expires_at().is_none());
     }
 }

--- a/src/app/model/shared/message.rs
+++ b/src/app/model/shared/message.rs
@@ -2,14 +2,26 @@ use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Default)]
 pub struct MessageState {
-    pub last_error: Option<String>,
-    pub last_success: Option<String>,
-    pub expires_at: Option<Instant>,
+    last_error: Option<String>,
+    last_success: Option<String>,
+    expires_at: Option<Instant>,
 }
 
 impl MessageState {
     const ERROR_TIMEOUT_SECS: u64 = 3;
     const SUCCESS_TIMEOUT_SECS: u64 = 3;
+
+    pub fn last_error(&self) -> Option<&str> {
+        self.last_error.as_deref()
+    }
+
+    pub fn last_success(&self) -> Option<&str> {
+        self.last_success.as_deref()
+    }
+
+    pub fn expires_at(&self) -> Option<Instant> {
+        self.expires_at
+    }
 
     pub fn set_error_at(&mut self, msg: String, now: Instant) {
         self.last_error = Some(msg);
@@ -44,14 +56,23 @@ impl MessageState {
     pub fn clear_expired(&mut self) {
         self.clear_expired_at(Instant::now());
     }
-}
 
-#[cfg(test)]
-impl MessageState {
     pub fn clear(&mut self) {
         self.last_error = None;
         self.last_success = None;
         self.expires_at = None;
+    }
+}
+
+#[cfg(test)]
+impl MessageState {
+    pub fn set_messages_for_test(&mut self, error: Option<String>, success: Option<String>) {
+        self.last_error = error;
+        self.last_success = success;
+    }
+
+    pub fn set_expires_at_for_test(&mut self, expires_at: Option<Instant>) {
+        self.expires_at = expires_at;
     }
 }
 
@@ -68,12 +89,12 @@ mod tests {
         let now = fixed_instant();
         let mut state = MessageState::default();
         state.set_success_at("Success!".to_string(), now);
-        assert!(state.last_success.is_some());
+        assert!(state.last_success().is_some());
 
         state.set_error_at("Error!".to_string(), now);
 
         assert_eq!(state.last_error, Some("Error!".to_string()));
-        assert!(state.last_success.is_none());
+        assert!(state.last_success().is_none());
     }
 
     #[test]
@@ -81,12 +102,12 @@ mod tests {
         let now = fixed_instant();
         let mut state = MessageState::default();
         state.set_error_at("Error!".to_string(), now);
-        assert!(state.last_error.is_some());
+        assert!(state.last_error().is_some());
 
         state.set_success_at("Success!".to_string(), now);
 
         assert_eq!(state.last_success, Some("Success!".to_string()));
-        assert!(state.last_error.is_none());
+        assert!(state.last_error().is_none());
     }
 
     #[test]
@@ -115,7 +136,7 @@ mod tests {
 
         state.clear_expired_at(now);
 
-        assert!(state.last_error.is_none());
+        assert!(state.last_error().is_none());
         assert!(state.expires_at.is_none());
     }
 
@@ -130,7 +151,7 @@ mod tests {
 
         state.clear_expired_at(now);
 
-        assert!(state.last_error.is_some());
+        assert!(state.last_error().is_some());
         assert!(state.expires_at.is_some());
     }
 
@@ -142,8 +163,8 @@ mod tests {
 
         state.clear();
 
-        assert!(state.last_error.is_none());
-        assert!(state.last_success.is_none());
+        assert!(state.last_error().is_none());
+        assert!(state.last_success().is_none());
         assert!(state.expires_at.is_none());
     }
 }

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -121,25 +121,46 @@ impl SqlModalContext {
     }
 
     pub fn enqueue_prefetch(&mut self, table: String) {
+        if self.prefetching_tables.contains(&table) || self.prefetch_queue.contains(&table) {
+            return;
+        }
         self.prefetch_queue.push_back(table);
     }
 
-    pub fn pop_prefetch(&mut self) -> Option<String> {
-        self.prefetch_queue.pop_front()
+    pub fn start_prefetch(&mut self) -> Option<String> {
+        while let Some(table) = self.prefetch_queue.pop_front() {
+            if self.prefetching_tables.insert(table.clone()) {
+                return Some(table);
+            }
+        }
+        None
     }
 
     pub fn mark_prefetching(&mut self, table: String) {
+        self.prefetch_queue.retain(|queued| queued != &table);
         self.prefetching_tables.insert(table);
     }
 
     pub fn finish_prefetch(&mut self, table: &str) {
+        self.prefetch_queue.retain(|queued| queued != table);
         self.prefetching_tables.remove(table);
         self.failed_prefetch_tables.remove(table);
     }
 
     pub fn record_prefetch_failure(&mut self, table: String, entry: FailedPrefetchEntry) {
+        self.prefetch_queue.retain(|queued| queued != &table);
         self.prefetching_tables.remove(&table);
         self.failed_prefetch_tables.insert(table, entry);
+    }
+
+    pub fn defer_prefetch_retry(&mut self, table: String) {
+        self.prefetching_tables.remove(&table);
+        self.enqueue_prefetch(table);
+    }
+
+    pub fn abandon_prefetch(&mut self, table: &str) {
+        self.prefetch_queue.retain(|queued| queued != table);
+        self.prefetching_tables.remove(table);
     }
 
     // ── Adhoc status ────────────────────────────────────────────────

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -76,9 +76,9 @@ pub struct SqlModalContext {
     last_adhoc_error: Option<String>,
     completion: CompletionState,
     completion_debounce: Option<Instant>,
-    pub prefetch_queue: VecDeque<String>,
-    pub prefetching_tables: HashSet<String>,
-    pub failed_prefetch_tables: HashMap<String, FailedPrefetchEntry>,
+    prefetch_queue: VecDeque<String>,
+    prefetching_tables: HashSet<String>,
+    failed_prefetch_tables: HashMap<String, FailedPrefetchEntry>,
     prefetch_started: bool,
     active_tab: SqlModalTab,
 }
@@ -106,6 +106,44 @@ impl SqlModalContext {
 
     pub fn is_prefetch_started(&self) -> bool {
         self.prefetch_started
+    }
+
+    pub fn prefetch_queue(&self) -> &VecDeque<String> {
+        &self.prefetch_queue
+    }
+
+    pub fn prefetching_tables(&self) -> &HashSet<String> {
+        &self.prefetching_tables
+    }
+
+    pub fn failed_prefetch_tables(&self) -> &HashMap<String, FailedPrefetchEntry> {
+        &self.failed_prefetch_tables
+    }
+
+    pub fn enqueue_prefetch(&mut self, table: String) {
+        self.prefetch_queue.push_back(table);
+    }
+
+    pub fn pop_prefetch(&mut self) -> Option<String> {
+        self.prefetch_queue.pop_front()
+    }
+
+    pub fn mark_prefetching(&mut self, table: String) {
+        self.prefetching_tables.insert(table);
+    }
+
+    pub fn finish_prefetch(&mut self, table: &str) {
+        self.prefetching_tables.remove(table);
+        self.failed_prefetch_tables.remove(table);
+    }
+
+    pub fn record_prefetch_failure(&mut self, table: String, entry: FailedPrefetchEntry) {
+        self.prefetching_tables.remove(&table);
+        self.failed_prefetch_tables.insert(table, entry);
+    }
+
+    pub fn remove_failed_prefetch(&mut self, table: &str) {
+        self.failed_prefetch_tables.remove(table);
     }
 
     // ── Adhoc status ────────────────────────────────────────────────

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -108,14 +108,32 @@ impl SqlModalContext {
         self.prefetch_started
     }
 
+    pub fn has_pending_prefetch(&self) -> bool {
+        !self.prefetch_queue.is_empty()
+    }
+
+    pub fn prefetch_in_flight_count(&self) -> usize {
+        self.prefetching_tables.len()
+    }
+
+    pub fn failed_prefetch_entry(&self, table: &str) -> Option<&FailedPrefetchEntry> {
+        self.failed_prefetch_tables.get(table)
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn prefetch_queue(&self) -> &VecDeque<String> {
         &self.prefetch_queue
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn prefetching_tables(&self) -> &HashSet<String> {
         &self.prefetching_tables
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn failed_prefetch_tables(&self) -> &HashMap<String, FailedPrefetchEntry> {
         &self.failed_prefetch_tables
     }

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -142,10 +142,6 @@ impl SqlModalContext {
         self.failed_prefetch_tables.insert(table, entry);
     }
 
-    pub fn remove_failed_prefetch(&mut self, table: &str) {
-        self.failed_prefetch_tables.remove(table);
-    }
-
     // ── Adhoc status ────────────────────────────────────────────────
 
     pub fn begin_adhoc_running(&mut self) {

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -54,28 +54,28 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
             let mut effects = vec![];
 
-            if state.query.pagination.table.is_empty() {
+            if !state.query.pagination.has_table() {
                 state
                     .ui
                     .set_explorer_selection(if has_tables { Some(0) } else { None });
             } else {
-                let prev_schema = &state.query.pagination.schema;
-                let prev_table = &state.query.pagination.table;
+                let prev_schema = state.query.pagination.schema();
+                let prev_table = state.query.pagination.table();
                 let found_index = metadata
                     .table_summaries
                     .iter()
-                    .position(|t| &t.schema == prev_schema && &t.name == prev_table);
+                    .position(|t| t.schema == prev_schema && t.name == prev_table);
                 if let Some(idx) = found_index {
                     state.ui.set_explorer_selection(Some(idx));
                     // Refresh preview and detail: DDL or reload may have changed
                     // data/schema even though the table still exists.
                     if let Some(dsn) = state.session.dsn() {
-                        let page = state.query.pagination.current_page;
+                        let page = state.query.pagination.current_page();
                         let generation = state.session.selection_generation();
                         effects.push(Effect::ExecutePreview {
                             dsn: dsn.to_string(),
-                            schema: state.query.pagination.schema.clone(),
-                            table: state.query.pagination.table.clone(),
+                            schema: state.query.pagination.schema().to_string(),
+                            table: state.query.pagination.table().to_string(),
                             generation,
                             limit: PREVIEW_PAGE_SIZE,
                             offset: page * PREVIEW_PAGE_SIZE,
@@ -84,8 +84,8 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                         });
                         effects.push(Effect::FetchTableDetail {
                             dsn: dsn.to_string(),
-                            schema: state.query.pagination.schema.clone(),
-                            table: state.query.pagination.table.clone(),
+                            schema: state.query.pagination.schema().to_string(),
+                            table: state.query.pagination.table().to_string(),
                             generation,
                         });
                     }
@@ -736,7 +736,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(state.query.pagination.table.is_empty());
+            assert!(state.query.pagination.table().is_empty());
             assert!(state.query.current_result().is_none());
             assert!(state.session.table_detail().is_none());
             assert!(state.session.selected_table_key().is_none());
@@ -746,8 +746,7 @@ mod tests {
         #[test]
         fn table_still_exists_preserves_pagination_and_emits_refresh_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.set_table("public", "users");
 
             // "orders" comes before "users" alphabetically, so "users" → index 1
             let metadata = make_metadata(vec![("public", "orders"), ("public", "users")]);
@@ -758,7 +757,7 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(state.query.pagination.table, "users");
+            assert_eq!(state.query.pagination.table(), "users");
             assert_eq!(state.ui.explorer_selected, 1);
             assert!(
                 effects

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -31,12 +31,7 @@ fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
     }
 
     state.er_preparation.mark_idle();
-    let failed_data: Vec<(String, String)> = state
-        .er_preparation
-        .failed_tables()
-        .iter()
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
+    let failed_data = state.er_preparation.failed_table_errors();
     state.set_error(format!(
         "ER failed: {} table(s) failed. 'e' to retry.",
         failed_data.len()
@@ -265,7 +260,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
         Action::ProcessPrefetchQueue => {
             const MAX_CONCURRENT_PREFETCH: usize = 4;
-            let current_in_flight = state.sql_modal.prefetching_tables().len();
+            let current_in_flight = state.sql_modal.prefetch_in_flight_count();
             let available_slots = MAX_CONCURRENT_PREFETCH.saturating_sub(current_in_flight);
 
             let mut actions = Vec::new();
@@ -290,11 +285,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
         Action::PrefetchTableDetail { schema, table } => {
             let qualified_name = format!("{schema}.{table}");
 
-            if let Some(entry) = state
-                .sql_modal
-                .failed_prefetch_tables()
-                .get(&qualified_name)
-            {
+            if let Some(entry) = state.sql_modal.failed_prefetch_entry(&qualified_name) {
                 let retry_count = entry.retry_count;
                 let failed_at = entry.failed_at;
                 let error = entry.error.clone();
@@ -356,7 +347,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 table: detail.clone(),
             }];
 
-            if !state.sql_modal.prefetch_queue().is_empty() {
+            if state.sql_modal.has_pending_prefetch() {
                 effects.push(Effect::ProcessPrefetchQueue);
             }
 
@@ -373,8 +364,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
             let qualified_name = format!("{schema}.{table}");
             let prev_count = state
                 .sql_modal
-                .failed_prefetch_tables()
-                .get(&qualified_name)
+                .failed_prefetch_entry(&qualified_name)
                 .map_or(0, |e| e.retry_count);
             state.sql_modal.record_prefetch_failure(
                 qualified_name.clone(),
@@ -390,7 +380,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
             let mut effects = Vec::new();
 
-            if !state.sql_modal.prefetch_queue().is_empty() {
+            if state.sql_modal.has_pending_prefetch() {
                 effects.push(Effect::ProcessPrefetchQueue);
             }
 
@@ -406,7 +396,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
             let mut effects = Vec::new();
 
-            if !state.sql_modal.prefetch_queue().is_empty() {
+            if state.sql_modal.has_pending_prefetch() {
                 effects.push(Effect::ProcessPrefetchQueue);
             }
 

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -184,9 +184,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 state.er_preparation.reset();
                 state.ui.er_selected_tables.clear();
                 state.ui.pending_er_picker = false;
-                state.messages.last_error = None;
-                state.messages.last_success = None;
-                state.messages.expires_at = None;
+                state.messages.clear();
 
                 Some(vec![Effect::Sequence(vec![
                     Effect::CacheInvalidate {

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -216,10 +216,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
                 for table_summary in &metadata.table_summaries {
                     let qualified_name = table_summary.qualified_name();
-                    state
-                        .sql_modal
-                        .prefetch_queue
-                        .push_back(qualified_name.clone());
+                    state.sql_modal.enqueue_prefetch(qualified_name.clone());
                     state.er_preparation.insert_pending_table(qualified_name);
                 }
                 Some(vec![
@@ -244,10 +241,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 state.er_preparation.set_total_tables(tables.len());
 
                 for qualified_name in tables {
-                    state
-                        .sql_modal
-                        .prefetch_queue
-                        .push_back(qualified_name.clone());
+                    state.sql_modal.enqueue_prefetch(qualified_name.clone());
                     state
                         .er_preparation
                         .insert_pending_table(qualified_name.clone());
@@ -273,22 +267,19 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 state
                     .er_preparation
                     .insert_pending_table(qualified_name.clone());
-                state
-                    .sql_modal
-                    .prefetch_queue
-                    .push_back(qualified_name.clone());
+                state.sql_modal.enqueue_prefetch(qualified_name.clone());
             }
             Some(vec![Effect::ProcessPrefetchQueue])
         }
 
         Action::ProcessPrefetchQueue => {
             const MAX_CONCURRENT_PREFETCH: usize = 4;
-            let current_in_flight = state.sql_modal.prefetching_tables.len();
+            let current_in_flight = state.sql_modal.prefetching_tables().len();
             let available_slots = MAX_CONCURRENT_PREFETCH.saturating_sub(current_in_flight);
 
             let mut actions = Vec::new();
             for _ in 0..available_slots {
-                if let Some(qualified_name) = state.sql_modal.prefetch_queue.pop_front()
+                if let Some(qualified_name) = state.sql_modal.pop_prefetch()
                     && let Some((schema, table)) = qualified_name.split_once('.')
                 {
                     actions.push(Action::PrefetchTableDetail {
@@ -308,11 +299,19 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
         Action::PrefetchTableDetail { schema, table } => {
             let qualified_name = format!("{schema}.{table}");
 
-            if state.sql_modal.prefetching_tables.contains(&qualified_name) {
+            if state
+                .sql_modal
+                .prefetching_tables()
+                .contains(&qualified_name)
+            {
                 return Some(vec![]);
             }
 
-            if let Some(entry) = state.sql_modal.failed_prefetch_tables.get(&qualified_name) {
+            if let Some(entry) = state
+                .sql_modal
+                .failed_prefetch_tables()
+                .get(&qualified_name)
+            {
                 if entry.retry_count >= MAX_PREFETCH_RETRIES {
                     // Exceeded retry limit — give up, don't re-queue
                     state.er_preparation.remove_pending_table(&qualified_name);
@@ -334,17 +333,14 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                     // Still in backoff — re-queue at tail and schedule a delayed retry
                     // to avoid busy-looping while waiting for the backoff to expire.
                     let remaining = backoff_secs - elapsed;
-                    state.sql_modal.prefetch_queue.push_back(qualified_name);
+                    state.sql_modal.enqueue_prefetch(qualified_name);
                     return Some(vec![Effect::DelayedProcessPrefetchQueue {
                         delay_secs: remaining,
                     }]);
                 }
             }
 
-            state
-                .sql_modal
-                .prefetching_tables
-                .insert(qualified_name.clone());
+            state.sql_modal.mark_prefetching(qualified_name.clone());
             state.er_preparation.remove_pending_table(&qualified_name);
             state
                 .er_preparation
@@ -367,11 +363,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
             detail,
         } => {
             let qualified_name = format!("{schema}.{table}");
-            state.sql_modal.prefetching_tables.remove(&qualified_name);
-            state
-                .sql_modal
-                .failed_prefetch_tables
-                .remove(&qualified_name);
+            state.sql_modal.finish_prefetch(&qualified_name);
             state.er_preparation.on_table_cached(&qualified_name);
 
             let mut effects = vec![Effect::CacheTableInCompletionEngine {
@@ -379,7 +371,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 table: detail.clone(),
             }];
 
-            if !state.sql_modal.prefetch_queue.is_empty() {
+            if !state.sql_modal.prefetch_queue().is_empty() {
                 effects.push(Effect::ProcessPrefetchQueue);
             }
 
@@ -394,14 +386,12 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
             error,
         } => {
             let qualified_name = format!("{schema}.{table}");
-            state.sql_modal.prefetching_tables.remove(&qualified_name);
-
             let prev_count = state
                 .sql_modal
-                .failed_prefetch_tables
+                .failed_prefetch_tables()
                 .get(&qualified_name)
                 .map_or(0, |e| e.retry_count);
-            state.sql_modal.failed_prefetch_tables.insert(
+            state.sql_modal.record_prefetch_failure(
                 qualified_name.clone(),
                 FailedPrefetchEntry {
                     failed_at: now,
@@ -415,7 +405,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
             let mut effects = Vec::new();
 
-            if !state.sql_modal.prefetch_queue.is_empty() {
+            if !state.sql_modal.prefetch_queue().is_empty() {
                 effects.push(Effect::ProcessPrefetchQueue);
             }
 
@@ -426,16 +416,12 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
         Action::TableDetailAlreadyCached { schema, table } => {
             let qualified_name = format!("{schema}.{table}");
-            state.sql_modal.prefetching_tables.remove(&qualified_name);
-            state
-                .sql_modal
-                .failed_prefetch_tables
-                .remove(&qualified_name);
+            state.sql_modal.finish_prefetch(&qualified_name);
             state.er_preparation.on_table_cached(&qualified_name);
 
             let mut effects = Vec::new();
 
-            if !state.sql_modal.prefetch_queue.is_empty() {
+            if !state.sql_modal.prefetch_queue().is_empty() {
                 effects.push(Effect::ProcessPrefetchQueue);
             }
 
@@ -471,7 +457,7 @@ mod tests {
             state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             // Insert a recently failed entry (retry_count=1, just failed)
-            state.sql_modal.failed_prefetch_tables.insert(
+            state.sql_modal.record_prefetch_failure(
                 qualified.clone(),
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),
@@ -491,7 +477,7 @@ mod tests {
             .unwrap();
 
             // Should be re-queued at tail
-            assert_eq!(state.sql_modal.prefetch_queue.back(), Some(&qualified));
+            assert_eq!(state.sql_modal.prefetch_queue().back(), Some(&qualified));
             // Should return DelayedProcessPrefetchQueue (not an immediate busy-loop)
             assert!(
                 effects
@@ -506,7 +492,7 @@ mod tests {
             state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             state.er_preparation.insert_pending_table(qualified.clone());
-            state.sql_modal.failed_prefetch_tables.insert(
+            state.sql_modal.record_prefetch_failure(
                 qualified.clone(),
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),
@@ -524,7 +510,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(!state.sql_modal.prefetch_queue.contains(&qualified));
+            assert!(!state.sql_modal.prefetch_queue().contains(&qualified));
             assert!(
                 state
                     .er_preparation
@@ -543,7 +529,7 @@ mod tests {
             let qualified = "public.users".to_string();
             // Only table remaining; retry limit exceeded
             state.er_preparation.insert_pending_table(qualified.clone());
-            state.sql_modal.failed_prefetch_tables.insert(
+            state.sql_modal.record_prefetch_failure(
                 qualified,
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),
@@ -581,8 +567,8 @@ mod tests {
             // users exhausted retries; posts still awaiting in queue
             state.er_preparation.insert_pending_table(failed.clone());
             state.er_preparation.insert_pending_table(remaining.clone());
-            state.sql_modal.prefetch_queue.push_back(remaining);
-            state.sql_modal.failed_prefetch_tables.insert(
+            state.sql_modal.enqueue_prefetch(remaining);
+            state.sql_modal.record_prefetch_failure(
                 failed,
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),
@@ -615,7 +601,7 @@ mod tests {
             state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             // Failed 10 seconds ago with retry_count=1 (backoff = 2s, already expired)
-            state.sql_modal.failed_prefetch_tables.insert(
+            state.sql_modal.record_prefetch_failure(
                 qualified.clone(),
                 FailedPrefetchEntry {
                     failed_at: Instant::now().checked_sub(Duration::from_secs(10)).unwrap(),
@@ -635,7 +621,7 @@ mod tests {
             .unwrap();
 
             // Should proceed to fetching
-            assert!(state.sql_modal.prefetching_tables.contains(&qualified));
+            assert!(state.sql_modal.prefetching_tables().contains(&qualified));
             assert!(
                 effects
                     .iter()
@@ -652,8 +638,8 @@ mod tests {
         fn increments_retry_count() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let qualified = "public.users".to_string();
-            state.sql_modal.prefetching_tables.insert(qualified.clone());
-            state.sql_modal.failed_prefetch_tables.insert(
+            state.sql_modal.mark_prefetching(qualified.clone());
+            state.sql_modal.record_prefetch_failure(
                 qualified.clone(),
                 FailedPrefetchEntry {
                     failed_at: Instant::now().checked_sub(Duration::from_secs(60)).unwrap(),
@@ -675,7 +661,7 @@ mod tests {
 
             let entry = state
                 .sql_modal
-                .failed_prefetch_tables
+                .failed_prefetch_tables()
                 .get(&qualified)
                 .unwrap();
             assert_eq!(entry.retry_count, 2);
@@ -689,7 +675,7 @@ mod tests {
         fn first_failure_sets_retry_count_1() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let qualified = "public.users".to_string();
-            state.sql_modal.prefetching_tables.insert(qualified.clone());
+            state.sql_modal.mark_prefetching(qualified.clone());
 
             let now = Instant::now();
             reduce_metadata(
@@ -704,7 +690,7 @@ mod tests {
 
             let entry = state
                 .sql_modal
-                .failed_prefetch_tables
+                .failed_prefetch_tables()
                 .get(&qualified)
                 .unwrap();
             assert_eq!(entry.retry_count, 1);
@@ -939,7 +925,7 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(state.sql_modal.prefetch_queue.len(), 2);
+            assert_eq!(state.sql_modal.prefetch_queue().len(), 2);
             assert!(
                 state
                     .er_preparation
@@ -1049,7 +1035,7 @@ mod tests {
                     .pending_tables()
                     .contains("public.tags")
             );
-            assert_eq!(state.sql_modal.prefetch_queue.len(), 2);
+            assert_eq!(state.sql_modal.prefetch_queue().len(), 2);
             assert!(
                 effects
                     .iter()
@@ -1066,7 +1052,7 @@ mod tests {
             state.er_preparation.set_fk_expanded(true);
             let neighbor = "public.posts".to_string();
             state.er_preparation.insert_pending_table(neighbor.clone());
-            state.sql_modal.failed_prefetch_tables.insert(
+            state.sql_modal.record_prefetch_failure(
                 neighbor,
                 FailedPrefetchEntry {
                     failed_at: Instant::now(),

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -187,9 +187,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 state.messages.clear();
 
                 Some(vec![Effect::Sequence(vec![
-                    Effect::CacheInvalidate {
-                        dsn: dsn.to_string(),
-                    },
+                    Effect::CacheInvalidate { dsn: dsn.clone() },
                     Effect::ClearCompletionEngineCache,
                     Effect::FetchMetadata { dsn },
                 ])])
@@ -203,11 +201,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 && let Some(metadata) = state.session.metadata()
             {
                 state.sql_modal.begin_prefetch();
-                state.er_preparation.clear_table_tracking();
                 state
                     .er_preparation
-                    .set_total_tables(metadata.table_summaries.len());
-                state.er_preparation.set_fk_expanded(true);
+                    .begin_full_prefetch(metadata.table_summaries.len());
 
                 let table_count = metadata.table_summaries.len();
                 let resize_capacity = table_count.clamp(500, 10_000);
@@ -233,10 +229,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 Some(vec![])
             } else {
                 state.sql_modal.begin_prefetch();
-                state.er_preparation.clear_table_tracking();
-                state.er_preparation.set_fk_expanded(false);
-                state.er_preparation.set_seed_tables(tables.clone());
-                state.er_preparation.set_total_tables(tables.len());
+                state.er_preparation.begin_scoped_prefetch(tables.clone());
 
                 for qualified_name in tables {
                     state.sql_modal.enqueue_prefetch(qualified_name.clone());
@@ -254,7 +247,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
         }
 
         Action::FkNeighborsDiscovered { tables } => {
-            state.er_preparation.set_fk_expanded(true);
+            state.er_preparation.mark_fk_expanded();
 
             if tables.is_empty() {
                 // No new neighbors — proceed to generate with what we have
@@ -523,7 +516,7 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.sql_modal.begin_prefetch();
             state.er_preparation.set_status_for_test(ErStatus::Waiting);
-            state.er_preparation.set_fk_expanded(true);
+            state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
             // Only table remaining; retry limit exceeded
             state.er_preparation.insert_pending_table(qualified.clone());
@@ -559,7 +552,7 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.sql_modal.begin_prefetch();
             state.er_preparation.set_status_for_test(ErStatus::Waiting);
-            state.er_preparation.set_fk_expanded(true);
+            state.er_preparation.mark_fk_expanded();
             let failed = "public.users".to_string();
             let remaining = "public.posts".to_string();
             // users exhausted retries; posts still awaiting in queue
@@ -954,7 +947,7 @@ mod tests {
         fn complete_not_fk_expanded_dispatches_expand() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.er_preparation.set_status_for_test(ErStatus::Waiting);
-            state.er_preparation.set_fk_expanded(false);
+            state.er_preparation.begin_scoped_prefetch(Vec::new());
             // pending and fetching are empty → is_complete() = true
 
             let effects = check_er_completion(&mut state);
@@ -970,7 +963,7 @@ mod tests {
         fn complete_fk_expanded_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.er_preparation.set_status_for_test(ErStatus::Waiting);
-            state.er_preparation.set_fk_expanded(true);
+            state.er_preparation.mark_fk_expanded();
 
             let effects = check_er_completion(&mut state);
 
@@ -1047,7 +1040,7 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.sql_modal.begin_prefetch();
             state.er_preparation.set_status_for_test(ErStatus::Waiting);
-            state.er_preparation.set_fk_expanded(true);
+            state.er_preparation.mark_fk_expanded();
             let neighbor = "public.posts".to_string();
             state.er_preparation.insert_pending_table(neighbor.clone());
             state.sql_modal.record_prefetch_failure(

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -270,7 +270,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
             let mut actions = Vec::new();
             for _ in 0..available_slots {
-                if let Some(qualified_name) = state.sql_modal.pop_prefetch()
+                if let Some(qualified_name) = state.sql_modal.start_prefetch()
                     && let Some((schema, table)) = qualified_name.split_once('.')
                 {
                     actions.push(Action::PrefetchTableDetail {
@@ -290,25 +290,19 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
         Action::PrefetchTableDetail { schema, table } => {
             let qualified_name = format!("{schema}.{table}");
 
-            if state
-                .sql_modal
-                .prefetching_tables()
-                .contains(&qualified_name)
-            {
-                return Some(vec![]);
-            }
-
             if let Some(entry) = state
                 .sql_modal
                 .failed_prefetch_tables()
                 .get(&qualified_name)
             {
-                if entry.retry_count >= MAX_PREFETCH_RETRIES {
+                let retry_count = entry.retry_count;
+                let failed_at = entry.failed_at;
+                let error = entry.error.clone();
+                if retry_count >= MAX_PREFETCH_RETRIES {
                     // Exceeded retry limit — give up, don't re-queue
+                    state.sql_modal.abandon_prefetch(&qualified_name);
                     state.er_preparation.remove_pending_table(&qualified_name);
-                    state
-                        .er_preparation
-                        .on_table_failed(&qualified_name, entry.error.clone());
+                    state.er_preparation.on_table_failed(&qualified_name, error);
                     let mut effects = check_er_completion(state);
                     // No fetch started → no completion event to re-drive the queue.
                     if effects.is_empty() && state.er_preparation.status() == ErStatus::Waiting {
@@ -318,13 +312,13 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 }
 
                 let backoff_secs =
-                    (BASE_BACKOFF_SECS * 2u64.pow(entry.retry_count)).min(MAX_BACKOFF_SECS);
-                let elapsed = entry.failed_at.elapsed().as_secs();
+                    (BASE_BACKOFF_SECS * 2u64.pow(retry_count)).min(MAX_BACKOFF_SECS);
+                let elapsed = failed_at.elapsed().as_secs();
                 if elapsed < backoff_secs {
                     // Still in backoff — re-queue at tail and schedule a delayed retry
                     // to avoid busy-looping while waiting for the backoff to expire.
                     let remaining = backoff_secs - elapsed;
-                    state.sql_modal.enqueue_prefetch(qualified_name);
+                    state.sql_modal.defer_prefetch_retry(qualified_name);
                     return Some(vec![Effect::DelayedProcessPrefetchQueue {
                         delay_secs: remaining,
                     }]);

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -746,7 +746,7 @@ mod tests {
         #[test]
         fn table_still_exists_preserves_pagination_and_emits_refresh_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.query.pagination.set_table("public", "users");
+            state.query.pagination.set_table_for_test("public", "users");
 
             // "orders" comes before "users" alphabetically, so "users" → index 1
             let metadata = make_metadata(vec![("public", "orders"), ("public", "users")]);

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -15,25 +15,25 @@ const MAX_BACKOFF_SECS: u64 = 4;
 const MAX_PREFETCH_RETRIES: u32 = 3;
 
 fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
-    if state.er_preparation.status != ErStatus::Waiting || !state.er_preparation.is_complete() {
+    if state.er_preparation.status() != ErStatus::Waiting || !state.er_preparation.is_complete() {
         return vec![];
     }
 
-    if !state.er_preparation.fk_expanded {
+    if !state.er_preparation.fk_expanded() {
         return vec![Effect::DispatchActions(vec![
             Action::ExpandPrefetchWithFkNeighbors,
         ])];
     }
 
     if !state.er_preparation.has_failures() {
-        state.er_preparation.status = ErStatus::Idle;
+        state.er_preparation.mark_idle();
         return vec![Effect::DispatchActions(vec![Action::ErGenerateFromCache])];
     }
 
-    state.er_preparation.status = ErStatus::Idle;
+    state.er_preparation.mark_idle();
     let failed_data: Vec<(String, String)> = state
         .er_preparation
-        .failed_tables
+        .failed_tables()
         .iter()
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
@@ -134,8 +134,8 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
             if !was_connected {
                 state.modal.replace_mode(InputMode::ConnectionError);
             }
-            if state.er_preparation.status == ErStatus::Waiting {
-                state.er_preparation.status = ErStatus::Idle;
+            if state.er_preparation.status() == ErStatus::Waiting {
+                state.er_preparation.mark_idle();
             }
             Some(vec![])
         }
@@ -205,11 +205,11 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 && let Some(metadata) = state.session.metadata()
             {
                 state.sql_modal.begin_prefetch();
-                state.er_preparation.pending_tables.clear();
-                state.er_preparation.fetching_tables.clear();
-                state.er_preparation.failed_tables.clear();
-                state.er_preparation.total_tables = metadata.table_summaries.len();
-                state.er_preparation.fk_expanded = true;
+                state.er_preparation.clear_table_tracking();
+                state
+                    .er_preparation
+                    .set_total_tables(metadata.table_summaries.len());
+                state.er_preparation.set_fk_expanded(true);
 
                 let table_count = metadata.table_summaries.len();
                 let resize_capacity = table_count.clamp(500, 10_000);
@@ -220,7 +220,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                         .sql_modal
                         .prefetch_queue
                         .push_back(qualified_name.clone());
-                    state.er_preparation.pending_tables.insert(qualified_name);
+                    state.er_preparation.insert_pending_table(qualified_name);
                 }
                 Some(vec![
                     Effect::ResizeCompletionCache {
@@ -238,12 +238,10 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 Some(vec![])
             } else {
                 state.sql_modal.begin_prefetch();
-                state.er_preparation.pending_tables.clear();
-                state.er_preparation.fetching_tables.clear();
-                state.er_preparation.failed_tables.clear();
-                state.er_preparation.fk_expanded = false;
-                state.er_preparation.seed_tables.clone_from(tables);
-                state.er_preparation.total_tables = tables.len();
+                state.er_preparation.clear_table_tracking();
+                state.er_preparation.set_fk_expanded(false);
+                state.er_preparation.set_seed_tables(tables.clone());
+                state.er_preparation.set_total_tables(tables.len());
 
                 for qualified_name in tables {
                     state
@@ -252,20 +250,19 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                         .push_back(qualified_name.clone());
                     state
                         .er_preparation
-                        .pending_tables
-                        .insert(qualified_name.clone());
+                        .insert_pending_table(qualified_name.clone());
                 }
                 Some(vec![Effect::ProcessPrefetchQueue])
             }
         }
 
         Action::ExpandPrefetchWithFkNeighbors => {
-            let seed_tables = state.er_preparation.seed_tables.clone();
+            let seed_tables = state.er_preparation.seed_tables().to_vec();
             Some(vec![Effect::ExtractFkNeighbors { seed_tables }])
         }
 
         Action::FkNeighborsDiscovered { tables } => {
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.set_fk_expanded(true);
 
             if tables.is_empty() {
                 // No new neighbors — proceed to generate with what we have
@@ -275,8 +272,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
             for qualified_name in tables {
                 state
                     .er_preparation
-                    .pending_tables
-                    .insert(qualified_name.clone());
+                    .insert_pending_table(qualified_name.clone());
                 state
                     .sql_modal
                     .prefetch_queue
@@ -319,13 +315,13 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
             if let Some(entry) = state.sql_modal.failed_prefetch_tables.get(&qualified_name) {
                 if entry.retry_count >= MAX_PREFETCH_RETRIES {
                     // Exceeded retry limit — give up, don't re-queue
-                    state.er_preparation.pending_tables.remove(&qualified_name);
+                    state.er_preparation.remove_pending_table(&qualified_name);
                     state
                         .er_preparation
                         .on_table_failed(&qualified_name, entry.error.clone());
                     let mut effects = check_er_completion(state);
                     // No fetch started → no completion event to re-drive the queue.
-                    if effects.is_empty() && state.er_preparation.status == ErStatus::Waiting {
+                    if effects.is_empty() && state.er_preparation.status() == ErStatus::Waiting {
                         effects.push(Effect::ProcessPrefetchQueue);
                     }
                     return Some(effects);
@@ -349,11 +345,10 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 .sql_modal
                 .prefetching_tables
                 .insert(qualified_name.clone());
-            state.er_preparation.pending_tables.remove(&qualified_name);
+            state.er_preparation.remove_pending_table(&qualified_name);
             state
                 .er_preparation
-                .fetching_tables
-                .insert(qualified_name.clone());
+                .insert_fetching_table(qualified_name.clone());
 
             if let Some(dsn) = state.session.dsn() {
                 Some(vec![Effect::PrefetchTableDetail {
@@ -510,10 +505,7 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
-            state
-                .er_preparation
-                .pending_tables
-                .insert(qualified.clone());
+            state.er_preparation.insert_pending_table(qualified.clone());
             state.sql_modal.failed_prefetch_tables.insert(
                 qualified.clone(),
                 FailedPrefetchEntry {
@@ -533,22 +525,24 @@ mod tests {
             );
 
             assert!(!state.sql_modal.prefetch_queue.contains(&qualified));
-            assert!(state.er_preparation.failed_tables.contains_key(&qualified));
-            assert!(!state.er_preparation.pending_tables.contains(&qualified));
+            assert!(
+                state
+                    .er_preparation
+                    .failed_tables()
+                    .contains_key(&qualified)
+            );
+            assert!(!state.er_preparation.pending_tables().contains(&qualified));
         }
 
         #[test]
         fn retry_limit_exceeded_as_last_table_triggers_er_completion() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
+            state.er_preparation.set_fk_expanded(true);
             let qualified = "public.users".to_string();
             // Only table remaining; retry limit exceeded
-            state
-                .er_preparation
-                .pending_tables
-                .insert(qualified.clone());
+            state.er_preparation.insert_pending_table(qualified.clone());
             state.sql_modal.failed_prefetch_tables.insert(
                 qualified,
                 FailedPrefetchEntry {
@@ -568,7 +562,7 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(
                 effects
                     .iter()
@@ -580,16 +574,13 @@ mod tests {
         fn retry_limit_exceeded_with_queue_remaining_redrives_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
+            state.er_preparation.set_fk_expanded(true);
             let failed = "public.users".to_string();
             let remaining = "public.posts".to_string();
             // users exhausted retries; posts still awaiting in queue
-            state.er_preparation.pending_tables.insert(failed.clone());
-            state
-                .er_preparation
-                .pending_tables
-                .insert(remaining.clone());
+            state.er_preparation.insert_pending_table(failed.clone());
+            state.er_preparation.insert_pending_table(remaining.clone());
             state.sql_modal.prefetch_queue.push_back(remaining);
             state.sql_modal.failed_prefetch_tables.insert(
                 failed,
@@ -615,7 +606,7 @@ mod tests {
                     .iter()
                     .any(|e| matches!(e, Effect::ProcessPrefetchQueue))
             );
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
         }
 
         #[test]
@@ -900,7 +891,7 @@ mod tests {
 
             reduce_metadata(&mut state, &Action::StartPrefetchAll, Instant::now());
 
-            assert!(state.er_preparation.fk_expanded);
+            assert!(state.er_preparation.fk_expanded());
         }
     }
 
@@ -913,8 +904,7 @@ mod tests {
             state.sql_modal.begin_prefetch();
             state
                 .er_preparation
-                .pending_tables
-                .insert("public.users".to_string());
+                .insert_pending_table("public.users".to_string());
 
             let effects = reduce_metadata(
                 &mut state,
@@ -926,7 +916,12 @@ mod tests {
             .unwrap();
 
             // In-progress prefetch must not be silently reset
-            assert!(state.er_preparation.pending_tables.contains("public.users"));
+            assert!(
+                state
+                    .er_preparation
+                    .pending_tables()
+                    .contains("public.users")
+            );
             assert!(effects.is_empty());
         }
 
@@ -945,15 +940,20 @@ mod tests {
             .unwrap();
 
             assert_eq!(state.sql_modal.prefetch_queue.len(), 2);
-            assert!(state.er_preparation.pending_tables.contains("public.users"));
             assert!(
                 state
                     .er_preparation
-                    .pending_tables
+                    .pending_tables()
+                    .contains("public.users")
+            );
+            assert!(
+                state
+                    .er_preparation
+                    .pending_tables()
                     .contains("public.orders")
             );
-            assert!(!state.er_preparation.fk_expanded);
-            assert_eq!(state.er_preparation.seed_tables, tables);
+            assert!(!state.er_preparation.fk_expanded());
+            assert_eq!(state.er_preparation.seed_tables(), tables);
             assert!(
                 effects
                     .iter()
@@ -969,8 +969,8 @@ mod tests {
         #[test]
         fn complete_not_fk_expanded_dispatches_expand() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.fk_expanded = false;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
+            state.er_preparation.set_fk_expanded(false);
             // pending and fetching are empty → is_complete() = true
 
             let effects = check_er_completion(&mut state);
@@ -985,8 +985,8 @@ mod tests {
         #[test]
         fn complete_fk_expanded_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
+            state.er_preparation.set_fk_expanded(true);
 
             let effects = check_er_completion(&mut state);
 
@@ -1005,7 +1005,7 @@ mod tests {
         #[test]
         fn empty_neighbors_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
 
             let effects = reduce_metadata(
                 &mut state,
@@ -1014,7 +1014,7 @@ mod tests {
             )
             .unwrap();
 
-            assert!(state.er_preparation.fk_expanded);
+            assert!(state.er_preparation.fk_expanded());
             assert!(effects.iter().any(|e| matches!(
                 e,
                 Effect::DispatchActions(actions)
@@ -1025,7 +1025,7 @@ mod tests {
         #[test]
         fn non_empty_neighbors_adds_to_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
 
             let effects = reduce_metadata(
                 &mut state,
@@ -1036,9 +1036,19 @@ mod tests {
             )
             .unwrap();
 
-            assert!(state.er_preparation.fk_expanded);
-            assert!(state.er_preparation.pending_tables.contains("public.posts"));
-            assert!(state.er_preparation.pending_tables.contains("public.tags"));
+            assert!(state.er_preparation.fk_expanded());
+            assert!(
+                state
+                    .er_preparation
+                    .pending_tables()
+                    .contains("public.posts")
+            );
+            assert!(
+                state
+                    .er_preparation
+                    .pending_tables()
+                    .contains("public.tags")
+            );
             assert_eq!(state.sql_modal.prefetch_queue.len(), 2);
             assert!(
                 effects
@@ -1052,10 +1062,10 @@ mod tests {
             // All Phase 2 tables fail → completion must still fire
             let mut state = state_with_dsn("postgres://localhost/test");
             state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
+            state.er_preparation.set_fk_expanded(true);
             let neighbor = "public.posts".to_string();
-            state.er_preparation.pending_tables.insert(neighbor.clone());
+            state.er_preparation.insert_pending_table(neighbor.clone());
             state.sql_modal.failed_prefetch_tables.insert(
                 neighbor,
                 FailedPrefetchEntry {
@@ -1075,7 +1085,7 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(
                 effects
                     .iter()

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -69,21 +69,21 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                     state.ui.set_explorer_selection(Some(idx));
                     // Refresh preview and detail: DDL or reload may have changed
                     // data/schema even though the table still exists.
-                    if let Some(dsn) = &state.session.dsn {
+                    if let Some(dsn) = state.session.dsn() {
                         let page = state.query.pagination.current_page;
                         let generation = state.session.selection_generation();
                         effects.push(Effect::ExecutePreview {
-                            dsn: dsn.clone(),
+                            dsn: dsn.to_string(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation,
                             limit: PREVIEW_PAGE_SIZE,
                             offset: page * PREVIEW_PAGE_SIZE,
                             target_page: page,
-                            read_only: state.session.read_only,
+                            read_only: state.session.is_read_only(),
                         });
                         effects.push(Effect::FetchTableDetail {
-                            dsn: dsn.clone(),
+                            dsn: dsn.to_string(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation,
@@ -104,9 +104,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
             state.connection_error.clear();
 
-            if state.session.is_reloading {
+            if state.session.is_reloading() {
                 state.messages.set_success_at("Reloaded!".to_string(), now);
-                state.session.is_reloading = false;
+                state.session.finish_reload();
             }
 
             if state.modal.active_mode() == InputMode::SqlModal
@@ -153,7 +153,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
         }
 
         Action::LoadMetadata => {
-            if let Some(dsn) = state.session.dsn.clone() {
+            if let Some(dsn) = state.session.dsn().map(str::to_string) {
                 state.session.begin_metadata_refresh();
                 Some(vec![Effect::FetchMetadata { dsn }])
             } else {
@@ -165,9 +165,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
             table,
             generation,
         }) => {
-            if let Some(dsn) = &state.session.dsn {
+            if let Some(dsn) = state.session.dsn() {
                 Some(vec![Effect::FetchTableDetail {
-                    dsn: dsn.clone(),
+                    dsn: dsn.to_string(),
                     schema: schema.clone(),
                     table: table.clone(),
                     generation: *generation,
@@ -178,7 +178,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
         }
 
         Action::ReloadMetadata => {
-            if let Some(dsn) = state.session.dsn.clone() {
+            if let Some(dsn) = state.session.dsn().map(str::to_string) {
                 state.session.begin_reload();
                 state.sql_modal.reset_prefetch();
                 state.er_preparation.reset();
@@ -189,7 +189,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 state.messages.expires_at = None;
 
                 Some(vec![Effect::Sequence(vec![
-                    Effect::CacheInvalidate { dsn: dsn.clone() },
+                    Effect::CacheInvalidate {
+                        dsn: dsn.to_string(),
+                    },
                     Effect::ClearCompletionEngineCache,
                     Effect::FetchMetadata { dsn },
                 ])])
@@ -353,9 +355,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 .fetching_tables
                 .insert(qualified_name.clone());
 
-            if let Some(dsn) = &state.session.dsn {
+            if let Some(dsn) = state.session.dsn() {
                 Some(vec![Effect::PrefetchTableDetail {
-                    dsn: dsn.clone(),
+                    dsn: dsn.to_string(),
                     schema: schema.clone(),
                     table: table.clone(),
                 }])
@@ -460,7 +462,7 @@ mod tests {
 
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
-        state.session.dsn = Some(dsn.to_string());
+        state.session.set_dsn_for_test(dsn);
         state
     }
 

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -77,7 +77,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 Some(ConnectionListItem::Profile(i)) => state
                     .connections()
                     .get(*i)
-                    .filter(|c| state.session.active_connection_id.as_ref() != Some(&c.id))
+                    .filter(|c| state.session.active_connection_id() != Some(&c.id))
                     .map(|_| Effect::SwitchConnection {
                         connection_index: *i,
                     }),
@@ -325,7 +325,9 @@ mod tests {
                 create_test_profile_with_id("active", active_id.clone()),
                 create_test_profile_with_id("other", other_id),
             ]);
-            state.session.active_connection_id = Some(active_id);
+            state
+                .session
+                .set_active_connection_id_for_test(Some(active_id));
             state.ui.set_connection_list_selection(Some(1));
 
             let effects = reduce_navigation(
@@ -354,7 +356,9 @@ mod tests {
                 "active",
                 active_id.clone(),
             )]);
-            state.session.active_connection_id = Some(active_id);
+            state
+                .session
+                .set_active_connection_id_for_test(Some(active_id));
             state.ui.set_connection_list_selection(Some(0));
 
             let effects = reduce_navigation(
@@ -393,7 +397,9 @@ mod tests {
                 create_test_profile_with_id("active", active_id.clone()),
                 create_test_profile_with_id("other", other_id),
             ]);
-            state.session.active_connection_id = Some(active_id);
+            state
+                .session
+                .set_active_connection_id_for_test(Some(active_id));
             state.modal.set_mode(InputMode::ConnectionSelector);
             state.ui.set_connection_list_selection(Some(1));
 
@@ -420,7 +426,9 @@ mod tests {
                 "active",
                 active_id.clone(),
             )]);
-            state.session.active_connection_id = Some(active_id);
+            state
+                .session
+                .set_active_connection_id_for_test(Some(active_id));
             state.modal.set_mode(InputMode::ConnectionSelector);
             state.ui.set_connection_list_selection(Some(0));
 

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -294,7 +294,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
     }
 

--- a/src/app/update/browse/navigation/focus.rs
+++ b/src/app/update/browse/navigation/focus.rs
@@ -34,7 +34,7 @@ pub fn reduce(
             Some(vec![])
         }
         Action::ToggleReadOnly => {
-            if state.session.read_only {
+            if state.session.is_read_only() {
                 state.confirm_dialog.open(
                     "Disable Read-Only",
                     "Switch to read-write mode? Write operations will be allowed.",
@@ -42,7 +42,7 @@ pub fn reduce(
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
             } else {
-                state.session.read_only = true;
+                state.session.enable_read_only();
             }
             Some(vec![])
         }
@@ -77,7 +77,7 @@ mod tests {
         #[test]
         fn rw_to_ro_switches_immediately() {
             let mut state = AppState::new("test".to_string());
-            assert!(!state.session.read_only);
+            assert!(!state.session.is_read_only());
 
             reduce_navigation(
                 &mut state,
@@ -86,14 +86,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(state.session.read_only);
+            assert!(state.session.is_read_only());
             assert_eq!(state.input_mode(), InputMode::Normal);
         }
 
         #[test]
         fn ro_to_rw_opens_confirm_dialog() {
             let mut state = AppState::new("test".to_string());
-            state.session.read_only = true;
+            state.session.enable_read_only();
 
             reduce_navigation(
                 &mut state,
@@ -102,7 +102,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(state.session.read_only);
+            assert!(state.session.is_read_only());
             assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
             assert!(matches!(
                 state.confirm_dialog.intent(),

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -665,7 +665,7 @@ mod tests {
                     .as_deref()
                     .is_some_and(|message| message.contains("Permission denied"))
             );
-            assert!(state.messages.last_error.is_none());
+            assert!(state.messages.last_error().is_none());
         }
 
         #[test]

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -34,12 +34,12 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult) -> Vec<Effect> 
         effects.push(Effect::CacheInvalidate { dsn: dsn.clone() });
         effects.push(Effect::ClearCompletionEngineCache);
         effects.push(Effect::FetchMetadata { dsn });
-    } else if !state.query.pagination.table.is_empty() {
-        let page = state.query.pagination.current_page;
+    } else if state.query.pagination.has_table() {
+        let page = state.query.pagination.current_page();
         effects.push(Effect::ExecutePreview {
             dsn,
-            schema: state.query.pagination.schema.clone(),
-            table: state.query.pagination.table.clone(),
+            schema: state.query.pagination.schema().to_string(),
+            table: state.query.pagination.table().to_string(),
             generation: state.session.selection_generation(),
             limit: PREVIEW_PAGE_SIZE,
             offset: page * PREVIEW_PAGE_SIZE,
@@ -96,10 +96,10 @@ pub fn reduce(
                 }
 
                 if let Some(page) = target_page {
-                    state.query.pagination.current_page = *page;
-                    if result.rows.len() < PREVIEW_PAGE_SIZE {
-                        state.query.pagination.reached_end = true;
-                    }
+                    state
+                        .query
+                        .pagination
+                        .set_page_result(*page, result.rows.len() < PREVIEW_PAGE_SIZE);
                 }
 
                 if !result.is_error() || result.source != QuerySource::Adhoc {
@@ -153,12 +153,13 @@ pub fn reduce(
                         .query
                         .set_post_delete_selection(PostDeleteRowSelection::Keep);
                     state.query.clear_delete_refresh_target();
-                    let preview_query = if state.query.pagination.schema.is_empty() {
-                        state.query.pagination.table.clone()
+                    let preview_query = if state.query.pagination.schema().is_empty() {
+                        state.query.pagination.table().to_string()
                     } else {
                         format!(
                             "{}.{}",
-                            state.query.pagination.schema, state.query.pagination.table
+                            state.query.pagination.schema(),
+                            state.query.pagination.table()
                         )
                     };
                     state.query.set_current_result(Arc::new(QueryResult::error(
@@ -217,9 +218,7 @@ pub fn reduce(
             if let Some(dsn) = state.session.dsn() {
                 state.query.begin_running(now);
 
-                state.query.pagination.reset();
-                state.query.pagination.schema.clone_from(schema);
-                state.query.pagination.table.clone_from(table);
+                state.query.pagination.reset_for_table(schema, table);
 
                 let row_estimate = state
                     .session
@@ -234,7 +233,7 @@ pub fn reduce(
                             }
                         })
                     });
-                state.query.pagination.total_rows_estimate = row_estimate;
+                state.query.pagination.set_total_rows_estimate(row_estimate);
 
                 Some(vec![Effect::ExecutePreview {
                     dsn: dsn.to_string(),
@@ -271,7 +270,6 @@ pub fn reduce(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::browse::query_execution::PaginationState;
     use crate::update::browse::query::reduce_query;
     use crate::update::browse::query::tests::*;
 
@@ -350,13 +348,10 @@ mod tests {
         #[test]
         fn resets_pagination() {
             let mut state = create_test_state();
-            state.query.pagination = PaginationState {
-                current_page: 5,
-                total_rows_estimate: Some(10000),
-                reached_end: true,
-                schema: "old_schema".to_string(),
-                table: "old_table".to_string(),
-            };
+            state.query.pagination.set_page(5);
+            state.query.pagination.set_total_rows_estimate(Some(10000));
+            state.query.pagination.mark_reached_end();
+            state.query.pagination.set_table("old_schema", "old_table");
             let now = Instant::now();
 
             reduce_query(
@@ -370,10 +365,10 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.query.pagination.current_page, 0);
-            assert!(!state.query.pagination.reached_end);
-            assert_eq!(state.query.pagination.schema, "public");
-            assert_eq!(state.query.pagination.table, "users");
+            assert_eq!(state.query.pagination.current_page(), 0);
+            assert!(!state.query.pagination.reached_end());
+            assert_eq!(state.query.pagination.schema(), "public");
+            assert_eq!(state.query.pagination.table(), "users");
         }
     }
 
@@ -398,8 +393,8 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.query.pagination.current_page, 2);
-            assert!(state.query.pagination.reached_end);
+            assert_eq!(state.query.pagination.current_page(), 2);
+            assert!(state.query.pagination.reached_end());
         }
 
         #[test]
@@ -420,14 +415,14 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.query.pagination.current_page, 0);
-            assert!(!state.query.pagination.reached_end);
+            assert_eq!(state.query.pagination.current_page(), 0);
+            assert!(!state.query.pagination.reached_end());
         }
 
         #[test]
         fn adhoc_does_not_update_pagination() {
             let mut state = create_test_state();
-            state.query.pagination.current_page = 3;
+            state.query.pagination.set_page(3);
             let result = adhoc_result();
             let now = Instant::now();
 
@@ -442,7 +437,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.query.pagination.current_page, 3);
+            assert_eq!(state.query.pagination.current_page(), 3);
         }
 
         #[test]
@@ -981,7 +976,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(state.ui.explorer_selected, 1);
-            assert_eq!(state.query.pagination.table, "users");
+            assert_eq!(state.query.pagination.table(), "users");
             assert!(
                 meta_effects
                     .iter()
@@ -1019,7 +1014,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(state.query.pagination.table.is_empty());
+            assert!(state.query.pagination.table().is_empty());
             assert!(state.query.current_result().is_none());
             assert!(state.session.table_detail().is_none());
             assert_eq!(state.ui.explorer_selected, 0);

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -21,7 +21,7 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult) -> Vec<Effect> 
     if !tag.needs_refresh() {
         return vec![];
     }
-    let Some(dsn) = state.session.dsn.clone() else {
+    let Some(dsn) = state.session.dsn().map(str::to_string) else {
         return vec![];
     };
 
@@ -31,20 +31,22 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult) -> Vec<Effect> 
         state.sql_modal.reset_prefetch();
         state.session.set_table_detail_raw(None);
 
-        effects.push(Effect::CacheInvalidate { dsn: dsn.clone() });
+        effects.push(Effect::CacheInvalidate {
+            dsn: dsn.to_string(),
+        });
         effects.push(Effect::ClearCompletionEngineCache);
         effects.push(Effect::FetchMetadata { dsn });
     } else if !state.query.pagination.table.is_empty() {
         let page = state.query.pagination.current_page;
         effects.push(Effect::ExecutePreview {
-            dsn,
+            dsn: dsn.to_string(),
             schema: state.query.pagination.schema.clone(),
             table: state.query.pagination.table.clone(),
             generation: state.session.selection_generation(),
             limit: PREVIEW_PAGE_SIZE,
             offset: page * PREVIEW_PAGE_SIZE,
             target_page: page,
-            read_only: state.session.read_only,
+            read_only: state.session.is_read_only(),
         });
     }
 
@@ -214,7 +216,7 @@ pub fn reduce(
             table,
             generation,
         }) => {
-            if let Some(dsn) = &state.session.dsn {
+            if let Some(dsn) = state.session.dsn() {
                 state.query.begin_running(now);
 
                 state.query.pagination.reset();
@@ -237,14 +239,14 @@ pub fn reduce(
                 state.query.pagination.total_rows_estimate = row_estimate;
 
                 Some(vec![Effect::ExecutePreview {
-                    dsn: dsn.clone(),
+                    dsn: dsn.to_string(),
                     schema: schema.clone(),
                     table: table.clone(),
                     generation: *generation,
                     limit: PREVIEW_PAGE_SIZE,
                     offset: 0,
                     target_page: 0,
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             } else {
                 Some(vec![])
@@ -252,12 +254,12 @@ pub fn reduce(
         }
 
         Action::ExecuteAdhoc(query) => {
-            if let Some(dsn) = &state.session.dsn {
+            if let Some(dsn) = state.session.dsn() {
                 state.query.begin_running(now);
                 Some(vec![Effect::ExecuteAdhoc {
-                    dsn: dsn.clone(),
+                    dsn: dsn.to_string(),
                     query: query.clone(),
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             } else {
                 Some(vec![])

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -218,8 +218,6 @@ pub fn reduce(
             if let Some(dsn) = state.session.dsn() {
                 state.query.begin_running(now);
 
-                state.query.pagination.reset_for_table(schema, table);
-
                 let row_estimate = state
                     .session
                     .table_detail()
@@ -233,7 +231,10 @@ pub fn reduce(
                             }
                         })
                     });
-                state.query.pagination.set_total_rows_estimate(row_estimate);
+                state
+                    .query
+                    .pagination
+                    .reset_for_table_with_estimate(schema, table, row_estimate);
 
                 Some(vec![Effect::ExecutePreview {
                     dsn: dsn.to_string(),
@@ -348,10 +349,16 @@ mod tests {
         #[test]
         fn resets_pagination() {
             let mut state = create_test_state();
-            state.query.pagination.set_page(5);
-            state.query.pagination.set_total_rows_estimate(Some(10000));
-            state.query.pagination.mark_reached_end();
-            state.query.pagination.set_table("old_schema", "old_table");
+            state.query.pagination.set_page_for_test(5);
+            state
+                .query
+                .pagination
+                .set_total_rows_estimate_for_test(Some(10000));
+            state.query.pagination.mark_reached_end_for_test();
+            state
+                .query
+                .pagination
+                .set_table_for_test("old_schema", "old_table");
             let now = Instant::now();
 
             reduce_query(
@@ -422,7 +429,7 @@ mod tests {
         #[test]
         fn adhoc_does_not_update_pagination() {
             let mut state = create_test_state();
-            state.query.pagination.set_page(3);
+            state.query.pagination.set_page_for_test(3);
             let result = adhoc_result();
             let now = Instant::now();
 

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -785,10 +785,7 @@ mod tests {
         fn ddl_resets_prefetch_state_and_clears_table_detail() {
             let mut state = state_with_table("public", "users");
             state.sql_modal.begin_prefetch();
-            state
-                .sql_modal
-                .prefetch_queue
-                .push_back("public.users".to_string());
+            state.sql_modal.enqueue_prefetch("public.users".to_string());
             state
                 .session
                 .set_table_detail_raw(Some(users_table_detail()));
@@ -805,7 +802,7 @@ mod tests {
             );
 
             assert!(!state.sql_modal.is_prefetch_started());
-            assert!(state.sql_modal.prefetch_queue.is_empty());
+            assert!(state.sql_modal.prefetch_queue().is_empty());
             assert!(state.session.table_detail().is_none());
         }
 

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -31,15 +31,13 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult) -> Vec<Effect> 
         state.sql_modal.reset_prefetch();
         state.session.set_table_detail_raw(None);
 
-        effects.push(Effect::CacheInvalidate {
-            dsn: dsn.to_string(),
-        });
+        effects.push(Effect::CacheInvalidate { dsn: dsn.clone() });
         effects.push(Effect::ClearCompletionEngineCache);
         effects.push(Effect::FetchMetadata { dsn });
     } else if !state.query.pagination.table.is_empty() {
         let page = state.query.pagination.current_page;
         effects.push(Effect::ExecutePreview {
-            dsn: dsn.to_string(),
+            dsn,
             schema: state.query.pagination.schema.clone(),
             table: state.query.pagination.table.clone(),
             generation: state.session.selection_generation(),

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -181,7 +181,7 @@ pub(super) mod tests {
 
     pub fn state_with_table(schema: &str, table: &str) -> AppState {
         let mut state = create_test_state();
-        state.query.pagination.set_table(schema, table);
+        state.query.pagination.set_table_for_test(schema, table);
         state
     }
 }

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -181,8 +181,7 @@ pub(super) mod tests {
 
     pub fn state_with_table(schema: &str, table: &str) -> AppState {
         let mut state = create_test_state();
-        state.query.pagination.schema = schema.to_string();
-        state.query.pagination.table = table.to_string();
+        state.query.pagination.set_table(schema, table);
         state
     }
 }

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -33,7 +33,7 @@ pub(super) mod tests {
 
     pub fn create_test_state() -> AppState {
         let mut state = AppState::new("test_project".to_string());
-        state.session.dsn = Some("postgres://localhost/test".to_string());
+        state.session.set_dsn_for_test("postgres://localhost/test");
         state
     }
 

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -620,19 +620,11 @@ mod tests {
 
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::OpenFolder { .. }));
+            assert!(state.messages.last_success().unwrap().contains("42"));
             assert!(
                 state
                     .messages
-                    .last_success
-                    .as_deref()
-                    .unwrap()
-                    .contains("42")
-            );
-            assert!(
-                state
-                    .messages
-                    .last_success
-                    .as_deref()
+                    .last_success()
                     .unwrap()
                     .contains("/tmp/export.csv")
             );
@@ -652,7 +644,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.messages.last_error.as_deref(),
+                state.messages.last_error(),
                 Some("Query failed: psql error. Review the database error details and SQL.")
             );
         }

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -181,7 +181,7 @@ pub fn reduce(
                 let prev_page = state.query.pagination.current_page() - 1;
                 state.query.begin_running(now);
                 state.result_interaction.reset_view();
-                state.query.pagination.clear_reached_end();
+                state.query.pagination.allow_next_page_after_refresh();
                 Some(vec![Effect::ExecutePreview {
                     dsn,
                     schema: state.query.pagination.schema().to_string(),
@@ -236,9 +236,12 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination.set_page(0);
-            state.query.pagination.set_total_rows_estimate(Some(1500));
-            state.query.pagination.set_table("public", "users");
+            state.query.pagination.set_page_for_test(0);
+            state
+                .query
+                .pagination
+                .set_total_rows_estimate_for_test(Some(1500));
+            state.query.pagination.set_table_for_test("public", "users");
             let now = Instant::now();
 
             let effects = reduce_query(
@@ -267,7 +270,7 @@ mod tests {
         fn noop_when_reached_end() {
             let mut state = create_test_state();
             state.query.set_current_result(preview_result(100));
-            state.query.pagination.mark_reached_end();
+            state.query.pagination.mark_reached_end_for_test();
             let now = Instant::now();
 
             let effects = reduce_query(
@@ -324,7 +327,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result_with_two_columns(100));
-            state.query.pagination.mark_reached_end();
+            state.query.pagination.mark_reached_end_for_test();
             state.result_interaction.activate_cell(2, 1);
             state.result_interaction.stage_row(2);
 
@@ -346,9 +349,12 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination.set_page(0);
-            state.query.pagination.set_total_rows_estimate(Some(1500));
-            state.query.pagination.set_table("public", "users");
+            state.query.pagination.set_page_for_test(0);
+            state
+                .query
+                .pagination
+                .set_total_rows_estimate_for_test(Some(1500));
+            state.query.pagination.set_table_for_test("public", "users");
             state.result_interaction.activate_cell(3, 1);
             state.result_interaction.stage_row(3);
 
@@ -374,9 +380,12 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination.set_page(2);
-            state.query.pagination.set_total_rows_estimate(Some(1500));
-            state.query.pagination.set_table("public", "users");
+            state.query.pagination.set_page_for_test(2);
+            state
+                .query
+                .pagination
+                .set_total_rows_estimate_for_test(Some(1500));
+            state.query.pagination.set_table_for_test("public", "users");
             let now = Instant::now();
 
             let effects = reduce_query(
@@ -407,7 +416,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination.set_page(0);
+            state.query.pagination.set_page_for_test(0);
             let now = Instant::now();
 
             let effects = reduce_query(
@@ -427,7 +436,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result_with_two_columns(PREVIEW_PAGE_SIZE));
-            state.query.pagination.set_page(0);
+            state.query.pagination.set_page_for_test(0);
             state.result_interaction.activate_cell(1, 1);
             state.result_interaction.stage_row(1);
 
@@ -459,8 +468,11 @@ mod tests {
         fn request_with_preview_result_emits_count_effect() {
             let mut state = export_test_state();
             state.query.set_current_result(preview_result(10));
-            state.query.pagination.set_table("public", "users");
-            state.query.pagination.set_total_rows_estimate(Some(100));
+            state.query.pagination.set_table_for_test("public", "users");
+            state
+                .query
+                .pagination
+                .set_total_rows_estimate_for_test(Some(100));
 
             let effects = reduce_query(
                 &mut state,

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -50,7 +50,7 @@ pub fn reduce(
             let count_query = format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count");
 
             Some(vec![Effect::CountRowsForExport {
-                dsn: dsn.to_string(),
+                dsn,
                 count_query,
                 export_query,
                 file_name,
@@ -92,7 +92,7 @@ pub fn reduce(
                     None => return Some(vec![]),
                 };
                 Some(vec![Effect::ExportCsv {
-                    dsn: dsn.to_string(),
+                    dsn,
                     query: export_query.clone(),
                     file_name: file_name.clone(),
                     row_count: *row_count,
@@ -111,7 +111,7 @@ pub fn reduce(
                 None => return Some(vec![]),
             };
             Some(vec![Effect::ExportCsv {
-                dsn: dsn.to_string(),
+                dsn,
                 query: export_query.clone(),
                 file_name: file_name.clone(),
                 row_count: *row_count,
@@ -156,7 +156,7 @@ pub fn reduce(
                 state.query.begin_running(now);
                 state.result_interaction.reset_view();
                 Some(vec![Effect::ExecutePreview {
-                    dsn: dsn.to_string(),
+                    dsn,
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
                     generation: state.session.selection_generation(),
@@ -183,7 +183,7 @@ pub fn reduce(
                 state.result_interaction.reset_view();
                 state.query.pagination.reached_end = false;
                 Some(vec![Effect::ExecutePreview {
-                    dsn: dsn.to_string(),
+                    dsn,
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
                     generation: state.session.selection_generation(),

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -23,8 +23,8 @@ pub fn reduce(
             let Some(result) = state.query.visible_result() else {
                 return Some(vec![]);
             };
-            let dsn = match &state.session.dsn {
-                Some(d) => d.clone(),
+            let dsn = match state.session.dsn() {
+                Some(d) => d.to_string(),
                 None => return Some(vec![]),
             };
 
@@ -50,11 +50,11 @@ pub fn reduce(
             let count_query = format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count");
 
             Some(vec![Effect::CountRowsForExport {
-                dsn,
+                dsn: dsn.to_string(),
                 count_query,
                 export_query,
                 file_name,
-                read_only: state.session.read_only,
+                read_only: state.session.is_read_only(),
             }])
         }
 
@@ -87,16 +87,16 @@ pub fn reduce(
                 state.modal.push_mode(InputMode::ConfirmDialog);
                 Some(vec![])
             } else {
-                let dsn = match &state.session.dsn {
-                    Some(d) => d.clone(),
+                let dsn = match state.session.dsn() {
+                    Some(d) => d.to_string(),
                     None => return Some(vec![]),
                 };
                 Some(vec![Effect::ExportCsv {
-                    dsn,
+                    dsn: dsn.to_string(),
                     query: export_query.clone(),
                     file_name: file_name.clone(),
                     row_count: *row_count,
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             }
         }
@@ -106,16 +106,16 @@ pub fn reduce(
             file_name,
             row_count,
         } => {
-            let dsn = match &state.session.dsn {
-                Some(d) => d.clone(),
+            let dsn = match state.session.dsn() {
+                Some(d) => d.to_string(),
                 None => return Some(vec![]),
             };
             Some(vec![Effect::ExportCsv {
-                dsn,
+                dsn: dsn.to_string(),
                 query: export_query.clone(),
                 file_name: file_name.clone(),
                 row_count: *row_count,
-                read_only: state.session.read_only,
+                read_only: state.session.is_read_only(),
             }])
         }
 
@@ -151,19 +151,19 @@ pub fn reduce(
             if !state.query.pagination.can_next() {
                 return Some(vec![]);
             }
-            if let Some(dsn) = state.session.dsn.clone() {
+            if let Some(dsn) = state.session.dsn().map(str::to_string) {
                 let next_page = state.query.pagination.current_page + 1;
                 state.query.begin_running(now);
                 state.result_interaction.reset_view();
                 Some(vec![Effect::ExecutePreview {
-                    dsn,
+                    dsn: dsn.to_string(),
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
                     generation: state.session.selection_generation(),
                     limit: PREVIEW_PAGE_SIZE,
                     offset: next_page * PREVIEW_PAGE_SIZE,
                     target_page: next_page,
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             } else {
                 Some(vec![])
@@ -177,20 +177,20 @@ pub fn reduce(
             if !state.query.pagination.can_prev() {
                 return Some(vec![]);
             }
-            if let Some(dsn) = state.session.dsn.clone() {
+            if let Some(dsn) = state.session.dsn().map(str::to_string) {
                 let prev_page = state.query.pagination.current_page - 1;
                 state.query.begin_running(now);
                 state.result_interaction.reset_view();
                 state.query.pagination.reached_end = false;
                 Some(vec![Effect::ExecutePreview {
-                    dsn,
+                    dsn: dsn.to_string(),
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
                     generation: state.session.selection_generation(),
                     limit: PREVIEW_PAGE_SIZE,
                     offset: prev_page * PREVIEW_PAGE_SIZE,
                     target_page: prev_page,
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             } else {
                 Some(vec![])
@@ -464,7 +464,7 @@ mod tests {
 
         fn export_test_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
         }
 

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -31,7 +31,7 @@ pub fn reduce(
             let export_query = result.query.clone();
             let file_name = match result.source {
                 QuerySource::Preview => {
-                    let table = &state.query.pagination.table;
+                    let table = state.query.pagination.table();
                     table
                         .chars()
                         .map(|c| {
@@ -152,13 +152,13 @@ pub fn reduce(
                 return Some(vec![]);
             }
             if let Some(dsn) = state.session.dsn().map(str::to_string) {
-                let next_page = state.query.pagination.current_page + 1;
+                let next_page = state.query.pagination.current_page() + 1;
                 state.query.begin_running(now);
                 state.result_interaction.reset_view();
                 Some(vec![Effect::ExecutePreview {
                     dsn,
-                    schema: state.query.pagination.schema.clone(),
-                    table: state.query.pagination.table.clone(),
+                    schema: state.query.pagination.schema().to_string(),
+                    table: state.query.pagination.table().to_string(),
                     generation: state.session.selection_generation(),
                     limit: PREVIEW_PAGE_SIZE,
                     offset: next_page * PREVIEW_PAGE_SIZE,
@@ -178,14 +178,14 @@ pub fn reduce(
                 return Some(vec![]);
             }
             if let Some(dsn) = state.session.dsn().map(str::to_string) {
-                let prev_page = state.query.pagination.current_page - 1;
+                let prev_page = state.query.pagination.current_page() - 1;
                 state.query.begin_running(now);
                 state.result_interaction.reset_view();
-                state.query.pagination.reached_end = false;
+                state.query.pagination.clear_reached_end();
                 Some(vec![Effect::ExecutePreview {
                     dsn,
-                    schema: state.query.pagination.schema.clone(),
-                    table: state.query.pagination.table.clone(),
+                    schema: state.query.pagination.schema().to_string(),
+                    table: state.query.pagination.table().to_string(),
                     generation: state.session.selection_generation(),
                     limit: PREVIEW_PAGE_SIZE,
                     offset: prev_page * PREVIEW_PAGE_SIZE,
@@ -207,7 +207,6 @@ mod tests {
     use crate::domain::{QueryResult, QuerySource};
     use std::sync::Arc;
 
-    use crate::model::browse::query_execution::PaginationState;
     use crate::update::browse::query::reduce_query;
     use crate::update::browse::query::tests::*;
 
@@ -237,13 +236,9 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination = PaginationState {
-                current_page: 0,
-                total_rows_estimate: Some(1500),
-                reached_end: false,
-                schema: "public".to_string(),
-                table: "users".to_string(),
-            };
+            state.query.pagination.set_page(0);
+            state.query.pagination.set_total_rows_estimate(Some(1500));
+            state.query.pagination.set_table("public", "users");
             let now = Instant::now();
 
             let effects = reduce_query(
@@ -272,7 +267,7 @@ mod tests {
         fn noop_when_reached_end() {
             let mut state = create_test_state();
             state.query.set_current_result(preview_result(100));
-            state.query.pagination.reached_end = true;
+            state.query.pagination.mark_reached_end();
             let now = Instant::now();
 
             let effects = reduce_query(
@@ -329,7 +324,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result_with_two_columns(100));
-            state.query.pagination.reached_end = true;
+            state.query.pagination.mark_reached_end();
             state.result_interaction.activate_cell(2, 1);
             state.result_interaction.stage_row(2);
 
@@ -351,13 +346,9 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination = PaginationState {
-                current_page: 0,
-                total_rows_estimate: Some(1500),
-                reached_end: false,
-                schema: "public".to_string(),
-                table: "users".to_string(),
-            };
+            state.query.pagination.set_page(0);
+            state.query.pagination.set_total_rows_estimate(Some(1500));
+            state.query.pagination.set_table("public", "users");
             state.result_interaction.activate_cell(3, 1);
             state.result_interaction.stage_row(3);
 
@@ -383,13 +374,9 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination = PaginationState {
-                current_page: 2,
-                total_rows_estimate: Some(1500),
-                reached_end: false,
-                schema: "public".to_string(),
-                table: "users".to_string(),
-            };
+            state.query.pagination.set_page(2);
+            state.query.pagination.set_total_rows_estimate(Some(1500));
+            state.query.pagination.set_table("public", "users");
             let now = Instant::now();
 
             let effects = reduce_query(
@@ -420,7 +407,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination.current_page = 0;
+            state.query.pagination.set_page(0);
             let now = Instant::now();
 
             let effects = reduce_query(
@@ -440,7 +427,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result_with_two_columns(PREVIEW_PAGE_SIZE));
-            state.query.pagination.current_page = 0;
+            state.query.pagination.set_page(0);
             state.result_interaction.activate_cell(1, 1);
             state.result_interaction.stage_row(1);
 
@@ -472,9 +459,8 @@ mod tests {
         fn request_with_preview_result_emits_count_effect() {
             let mut state = export_test_state();
             state.query.set_current_result(preview_result(10));
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
-            state.query.pagination.total_rows_estimate = Some(100);
+            state.query.pagination.set_table("public", "users");
+            state.query.pagination.set_total_rows_estimate(Some(100));
 
             let effects = reduce_query(
                 &mut state,

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -420,7 +420,7 @@ mod tests {
             );
             assert!(effects.unwrap().is_empty());
             assert_eq!(
-                state.messages.last_error.as_deref(),
+                state.messages.last_error(),
                 Some("No active cell edit session")
             );
         }
@@ -438,7 +438,7 @@ mod tests {
             );
             assert!(effects.unwrap().is_empty());
             assert_eq!(
-                state.messages.last_error.as_deref(),
+                state.messages.last_error(),
                 Some("Write is unavailable while query is running")
             );
         }
@@ -459,7 +459,7 @@ mod tests {
             );
             assert!(effects.unwrap().is_empty());
             assert_eq!(
-                state.messages.last_error.as_deref(),
+                state.messages.last_error(),
                 Some("Table metadata does not match current preview target")
             );
         }
@@ -661,7 +661,7 @@ mod tests {
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::CellEdit);
             assert_eq!(
-                state.messages.last_error.as_deref(),
+                state.messages.last_error(),
                 Some("UPDATE expected 1 row, but affected 0 rows")
             );
         }
@@ -764,10 +764,7 @@ mod tests {
                 state.query.post_delete_row_selection(),
                 PostDeleteRowSelection::Select(499)
             );
-            assert_eq!(
-                state.messages.last_success.as_deref(),
-                Some("Deleted 1 row")
-            );
+            assert_eq!(state.messages.last_success(), Some("Deleted 1 row"));
             assert_eq!(effects.len(), 1);
             match &effects[0] {
                 Effect::ExecutePreview {
@@ -799,7 +796,7 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert_eq!(
-                state.messages.last_error.as_deref(),
+                state.messages.last_error(),
                 Some("DELETE expected 1 row, but affected 0 rows")
             );
             assert_eq!(effects.len(), 1);
@@ -821,7 +818,7 @@ mod tests {
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert_eq!(
-                state.messages.last_error.as_deref(),
+                state.messages.last_error(),
                 Some("Query failed: boom. Review the database error details and SQL.")
             );
         }

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -32,12 +32,12 @@ fn build_update_preview(
     let row_idx = state
         .result_interaction
         .cell_edit()
-        .row
+        .row()
         .ok_or(EditGuardrailError::NoRowSelectedForEdit)?;
     let col_idx = state
         .result_interaction
         .cell_edit()
-        .col
+        .col()
         .ok_or(EditGuardrailError::NoColumnSelectedForEdit)?;
 
     let row = result
@@ -82,7 +82,7 @@ fn build_update_preview(
         sql,
         target_summary: target,
         diff: {
-            let before = normalize_for_diff(&state.result_interaction.cell_edit().original_value);
+            let before = normalize_for_diff(state.result_interaction.cell_edit().original_value());
             let after = normalize_for_diff(state.result_interaction.cell_edit().draft_value());
             let is_jsonb = state
                 .session

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -334,7 +334,7 @@ pub fn reduce(
 
                     if let Some(dsn) = state.session.dsn() {
                         state.query.begin_running(now);
-                        state.query.pagination.clear_reached_end();
+                        state.query.pagination.allow_next_page_after_refresh();
                         Some(vec![Effect::ExecutePreview {
                             dsn: dsn.to_string(),
                             schema: state.query.pagination.schema().to_string(),
@@ -394,7 +394,7 @@ mod tests {
             state
                 .session
                 .set_table_detail_raw(Some(users_table_detail()));
-            state.query.pagination.set_table("public", "users");
+            state.query.pagination.set_table_for_test("public", "users");
             state.modal.set_mode(InputMode::CellEdit);
             state
                 .result_interaction
@@ -497,7 +497,7 @@ mod tests {
             state
                 .session
                 .set_table_detail_raw(Some(jsonb_table_detail()));
-            state.query.pagination.set_table("public", "users");
+            state.query.pagination.set_table_for_test("public", "users");
             state.modal.set_mode(InputMode::CellEdit);
             // col 2 = metadata (jsonb)
             state
@@ -617,7 +617,7 @@ mod tests {
         #[test]
         fn execute_write_success_refreshes_preview_page() {
             let mut state = editable_state();
-            state.query.pagination.set_page(2);
+            state.query.pagination.set_page_for_test(2);
 
             let effects = reduce_query(
                 &mut state,
@@ -744,7 +744,7 @@ mod tests {
         #[test]
         fn execute_write_success_for_delete_refreshes_target_page() {
             let mut state = create_test_state();
-            state.query.pagination.set_table("public", "users");
+            state.query.pagination.set_table_for_test("public", "users");
             state.query.set_delete_refresh_target(1, Some(499), 1);
             state.result_interaction.set_write_preview(delete_preview());
 
@@ -779,7 +779,7 @@ mod tests {
         #[test]
         fn execute_write_non_one_rows_for_delete_sets_error() {
             let mut state = create_test_state();
-            state.query.pagination.set_table("public", "users");
+            state.query.pagination.set_table_for_test("public", "users");
             state.result_interaction.set_write_preview(delete_preview());
 
             let effects = reduce_query(

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -56,8 +56,8 @@ fn build_update_preview(
 
     let pk_pairs = build_pk_pairs(&result.columns, row, pk_cols);
     let target = crate::policy::write::write_guardrails::TargetSummary {
-        schema: state.query.pagination.schema.clone(),
-        table: state.query.pagination.table.clone(),
+        schema: state.query.pagination.schema().to_string(),
+        table: state.query.pagination.table().to_string(),
         key_values: pk_pairs.clone().unwrap_or_default(),
     };
     let has_where = pk_pairs.as_ref().is_some_and(|pairs| !pairs.is_empty());
@@ -275,12 +275,12 @@ pub fn reduce(
                     state.modal.set_mode(InputMode::Normal);
 
                     if let Some(dsn) = state.session.dsn() {
-                        let page = state.query.pagination.current_page;
+                        let page = state.query.pagination.current_page();
                         state.query.begin_running(now);
                         Some(vec![Effect::ExecutePreview {
                             dsn: dsn.to_string(),
-                            schema: state.query.pagination.schema.clone(),
-                            table: state.query.pagination.table.clone(),
+                            schema: state.query.pagination.schema().to_string(),
+                            table: state.query.pagination.table().to_string(),
                             generation: state.session.selection_generation(),
                             limit: PREVIEW_PAGE_SIZE,
                             offset: page * PREVIEW_PAGE_SIZE,
@@ -300,7 +300,7 @@ pub fn reduce(
                         .query
                         .take_delete_refresh_target()
                         .unwrap_or(DeleteRefreshTarget {
-                            target_page: state.query.pagination.current_page,
+                            target_page: state.query.pagination.current_page(),
                             target_row: None,
                             expected_delete_count: 1,
                         });
@@ -334,11 +334,11 @@ pub fn reduce(
 
                     if let Some(dsn) = state.session.dsn() {
                         state.query.begin_running(now);
-                        state.query.pagination.reached_end = false;
+                        state.query.pagination.clear_reached_end();
                         Some(vec![Effect::ExecutePreview {
                             dsn: dsn.to_string(),
-                            schema: state.query.pagination.schema.clone(),
-                            table: state.query.pagination.table.clone(),
+                            schema: state.query.pagination.schema().to_string(),
+                            table: state.query.pagination.table().to_string(),
                             generation: state.session.selection_generation(),
                             limit: PREVIEW_PAGE_SIZE,
                             offset: target_page * PREVIEW_PAGE_SIZE,
@@ -394,8 +394,7 @@ mod tests {
             state
                 .session
                 .set_table_detail_raw(Some(users_table_detail()));
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.set_table("public", "users");
             state.modal.set_mode(InputMode::CellEdit);
             state
                 .result_interaction
@@ -498,8 +497,7 @@ mod tests {
             state
                 .session
                 .set_table_detail_raw(Some(jsonb_table_detail()));
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.set_table("public", "users");
             state.modal.set_mode(InputMode::CellEdit);
             // col 2 = metadata (jsonb)
             state
@@ -619,7 +617,7 @@ mod tests {
         #[test]
         fn execute_write_success_refreshes_preview_page() {
             let mut state = editable_state();
-            state.query.pagination.current_page = 2;
+            state.query.pagination.set_page(2);
 
             let effects = reduce_query(
                 &mut state,
@@ -746,8 +744,7 @@ mod tests {
         #[test]
         fn execute_write_success_for_delete_refreshes_target_page() {
             let mut state = create_test_state();
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.set_table("public", "users");
             state.query.set_delete_refresh_target(1, Some(499), 1);
             state.result_interaction.set_write_preview(delete_preview());
 
@@ -782,8 +779,7 @@ mod tests {
         #[test]
         fn execute_write_non_one_rows_for_delete_sets_error() {
             let mut state = create_test_state();
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.set_table("public", "users");
             state.result_interaction.set_write_preview(delete_preview());
 
             let effects = reduce_query(

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -181,7 +181,7 @@ pub fn reduce(
         }
 
         Action::OpenWritePreviewConfirm(preview) => {
-            if state.session.read_only {
+            if state.session.is_read_only() {
                 state.messages.set_error_at(
                     "Read-only mode: write operations are disabled".to_string(),
                     now,
@@ -228,19 +228,19 @@ pub fn reduce(
         }
 
         Action::ExecuteWrite(query) => {
-            if state.session.read_only {
+            if state.session.is_read_only() {
                 state.messages.set_error_at(
                     "Read-only mode: write operations are disabled".to_string(),
                     now,
                 );
                 return Some(vec![]);
             }
-            if let Some(dsn) = &state.session.dsn {
+            if let Some(dsn) = state.session.dsn() {
                 state.query.begin_running(now);
                 Some(vec![Effect::ExecuteWrite {
-                    dsn: dsn.clone(),
+                    dsn: dsn.to_string(),
                     query: query.clone(),
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             } else {
                 state
@@ -274,18 +274,18 @@ pub fn reduce(
                     state.result_interaction.clear_cell_edit();
                     state.modal.set_mode(InputMode::Normal);
 
-                    if let Some(dsn) = &state.session.dsn {
+                    if let Some(dsn) = state.session.dsn() {
                         let page = state.query.pagination.current_page;
                         state.query.begin_running(now);
                         Some(vec![Effect::ExecutePreview {
-                            dsn: dsn.clone(),
+                            dsn: dsn.to_string(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation: state.session.selection_generation(),
                             limit: PREVIEW_PAGE_SIZE,
                             offset: page * PREVIEW_PAGE_SIZE,
                             target_page: page,
-                            read_only: state.session.read_only,
+                            read_only: state.session.is_read_only(),
                         }])
                     } else {
                         Some(vec![])
@@ -332,18 +332,18 @@ pub fn reduce(
                         PostDeleteRowSelection::Select,
                     ));
 
-                    if let Some(dsn) = &state.session.dsn {
+                    if let Some(dsn) = state.session.dsn() {
                         state.query.begin_running(now);
                         state.query.pagination.reached_end = false;
                         Some(vec![Effect::ExecutePreview {
-                            dsn: dsn.clone(),
+                            dsn: dsn.to_string(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation: state.session.selection_generation(),
                             limit: PREVIEW_PAGE_SIZE,
                             offset: target_page * PREVIEW_PAGE_SIZE,
                             target_page,
-                            read_only: state.session.read_only,
+                            read_only: state.session.is_read_only(),
                         }])
                     } else {
                         Some(vec![])
@@ -389,7 +389,7 @@ mod tests {
 
         fn editable_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.query.set_current_result(editable_preview_result());
             state
                 .session
@@ -491,7 +491,7 @@ mod tests {
 
         fn editable_state_with_jsonb() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
                 .query
                 .set_current_result(editable_preview_result_with_jsonb());

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -67,7 +67,7 @@ fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), Edi
 pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
     match action {
         Action::ResultEnterCellEdit => {
-            if state.session.read_only {
+            if state.session.is_read_only() {
                 state
                     .messages
                     .set_error_at("Read-only mode: editing is disabled".to_string(), now);
@@ -358,7 +358,7 @@ mod tests {
             state
                 .session
                 .set_table_detail_raw(Some(cell_edit_entry_guardrails::minimal_users_table()));
-            state.session.read_only = true;
+            state.session.enable_read_only();
 
             let effects = reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now()).unwrap();
 

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -83,8 +83,8 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
 
             match editable_cell_context(state) {
                 Ok((row_idx, col_idx, value)) => {
-                    if state.result_interaction.cell_edit().row != Some(row_idx)
-                        || state.result_interaction.cell_edit().col != Some(col_idx)
+                    if state.result_interaction.cell_edit().row() != Some(row_idx)
+                        || state.result_interaction.cell_edit().col() != Some(col_idx)
                     {
                         state
                             .result_interaction
@@ -236,7 +236,7 @@ mod tests {
             reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now()).unwrap();
 
             assert_eq!(state.input_mode(), InputMode::CellEdit);
-            assert_eq!(state.result_interaction.cell_edit().col, Some(1));
+            assert_eq!(state.result_interaction.cell_edit().col(), Some(1));
             assert_eq!(state.result_interaction.cell_edit().draft_value(), "alice");
         }
 
@@ -397,7 +397,7 @@ mod tests {
             );
 
             assert_eq!(state.result_interaction.cell_edit().draft_value(), "acd");
-            assert_eq!(state.result_interaction.cell_edit().input.cursor(), 1);
+            assert_eq!(state.result_interaction.cell_edit().input().cursor(), 1);
         }
 
         #[test]
@@ -428,7 +428,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.result_interaction.cell_edit().input.cursor(), 1);
+            assert_eq!(state.result_interaction.cell_edit().input().cursor(), 1);
         }
 
         #[test]
@@ -444,7 +444,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.result_interaction.cell_edit().input.cursor(), 2);
+            assert_eq!(state.result_interaction.cell_edit().input().cursor(), 2);
         }
 
         #[test]
@@ -460,7 +460,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.result_interaction.cell_edit().input.cursor(), 0);
+            assert_eq!(state.result_interaction.cell_edit().input().cursor(), 0);
         }
 
         #[test]
@@ -476,7 +476,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.result_interaction.cell_edit().input.cursor(), 3);
+            assert_eq!(state.result_interaction.cell_edit().input().cursor(), 3);
         }
 
         #[test]
@@ -493,7 +493,7 @@ mod tests {
             );
 
             assert_eq!(state.result_interaction.cell_edit().draft_value(), "abc");
-            assert_eq!(state.result_interaction.cell_edit().input.cursor(), 2);
+            assert_eq!(state.result_interaction.cell_edit().input().cursor(), 2);
         }
 
         #[test]
@@ -509,7 +509,7 @@ mod tests {
             );
 
             assert_eq!(state.result_interaction.cell_edit().draft_value(), "ac");
-            assert_eq!(state.result_interaction.cell_edit().input.cursor(), 1);
+            assert_eq!(state.result_interaction.cell_edit().input().cursor(), 1);
         }
     }
 }

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -18,7 +18,7 @@ fn is_jsonb_cell(state: &AppState) -> bool {
         return false;
     };
     // Ensure table_detail matches current preview target
-    if td.schema != state.query.pagination.schema || td.name != state.query.pagination.table {
+    if td.schema != state.query.pagination.schema() || td.name != state.query.pagination.table() {
         return false;
     }
     td.columns
@@ -189,8 +189,7 @@ mod tests {
                 error: None,
                 command_tag: None,
             }));
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.set_table("public", "users");
             state.result_interaction.activate_cell(0, 1);
             state
         }

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -262,7 +262,7 @@ mod tests {
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert_eq!(
-                state.messages.last_error.as_deref(),
+                state.messages.last_error(),
                 Some("Table metadata does not match current preview target")
             );
         }
@@ -364,7 +364,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
     }
 

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -189,7 +189,7 @@ mod tests {
                 error: None,
                 command_tag: None,
             }));
-            state.query.pagination.set_table("public", "users");
+            state.query.pagination.set_table_for_test("public", "users");
             state.result_interaction.activate_cell(0, 1);
             state
         }

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -756,7 +756,7 @@ mod tests {
             reduce(&mut state, &Action::JsonbEnterEdit, Instant::now());
 
             assert_eq!(state.input_mode(), InputMode::JsonbDetail);
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
 
         #[test]
@@ -770,7 +770,7 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::JsonbDetail);
             assert_eq!(state.jsonb_detail.editor().cursor(), cursor_before);
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
 
         #[test]

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -29,8 +29,8 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
 
             let table_detail = match state.session.table_detail() {
                 Some(td)
-                    if td.schema == state.query.pagination.schema
-                        && td.name == state.query.pagination.table =>
+                    if td.schema == state.query.pagination.schema()
+                        && td.name == state.query.pagination.table() =>
                 {
                     td
                 }
@@ -444,8 +444,7 @@ mod tests {
             error: None,
             command_tag: None,
         }));
-        state.query.pagination.schema = "public".to_string();
-        state.query.pagination.table = "users".to_string();
+        state.query.pagination.set_table("public", "users");
         state.session.set_table_detail_raw(Some(jsonb_table()));
         state.result_interaction.activate_cell(0, 1);
         state

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -97,7 +97,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         }
 
         Action::JsonbEnterEdit => {
-            if state.session.read_only {
+            if state.session.is_read_only() {
                 state
                     .messages
                     .set_error_at("Read-only mode: editing is disabled".to_string(), now);
@@ -109,7 +109,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         }
 
         Action::JsonbAppendInsert => {
-            if state.session.read_only {
+            if state.session.is_read_only() {
                 state
                     .messages
                     .set_error_at("Read-only mode: editing is disabled".to_string(), now);
@@ -751,7 +751,7 @@ mod tests {
         fn enter_edit_blocked_in_read_only_mode() {
             let mut state = state_with_jsonb_cell();
             open_detail(&mut state);
-            state.session.read_only = true;
+            state.session.enable_read_only();
 
             reduce(&mut state, &Action::JsonbEnterEdit, Instant::now());
 
@@ -763,7 +763,7 @@ mod tests {
         fn append_insert_blocked_in_read_only_mode() {
             let mut state = state_with_jsonb_cell();
             open_detail(&mut state);
-            state.session.read_only = true;
+            state.session.enable_read_only();
             let cursor_before = state.jsonb_detail.editor().cursor();
 
             reduce(&mut state, &Action::JsonbAppendInsert, Instant::now());

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -210,26 +210,14 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         }
 
         Action::JsonbSearchNext => {
-            let search = state.jsonb_detail.search();
-            if !search.matches().is_empty() {
-                let next = (search.current_match() + 1) % search.matches().len();
-                state.jsonb_detail.search_mut().set_current_match(next);
-                jump_to_current_match(state);
-            }
+            state.jsonb_detail.search_mut().advance_to_next_match();
+            jump_to_current_match(state);
             Some(vec![])
         }
 
         Action::JsonbSearchPrev => {
-            let search = state.jsonb_detail.search();
-            if !search.matches().is_empty() {
-                let prev = if search.current_match() == 0 {
-                    search.matches().len() - 1
-                } else {
-                    search.current_match() - 1
-                };
-                state.jsonb_detail.search_mut().set_current_match(prev);
-                jump_to_current_match(state);
-            }
+            state.jsonb_detail.search_mut().advance_to_prev_match();
+            jump_to_current_match(state);
             Some(vec![])
         }
 

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -211,9 +211,9 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
 
         Action::JsonbSearchNext => {
             let search = state.jsonb_detail.search();
-            if !search.matches.is_empty() {
-                let next = (search.current_match + 1) % search.matches.len();
-                state.jsonb_detail.search_mut().current_match = next;
+            if !search.matches().is_empty() {
+                let next = (search.current_match() + 1) % search.matches().len();
+                state.jsonb_detail.search_mut().set_current_match(next);
                 jump_to_current_match(state);
             }
             Some(vec![])
@@ -221,13 +221,13 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
 
         Action::JsonbSearchPrev => {
             let search = state.jsonb_detail.search();
-            if !search.matches.is_empty() {
-                let prev = if search.current_match == 0 {
-                    search.matches.len() - 1
+            if !search.matches().is_empty() {
+                let prev = if search.current_match() == 0 {
+                    search.matches().len() - 1
                 } else {
-                    search.current_match - 1
+                    search.current_match() - 1
                 };
-                state.jsonb_detail.search_mut().current_match = prev;
+                state.jsonb_detail.search_mut().set_current_match(prev);
                 jump_to_current_match(state);
             }
             Some(vec![])
@@ -237,7 +237,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             target: InputTarget::JsonbSearch,
             ch,
         } => {
-            state.jsonb_detail.search_mut().input.insert_char(*ch);
+            state.jsonb_detail.search_mut().input_mut().insert_char(*ch);
             update_search_matches(state);
             Some(vec![])
         }
@@ -245,7 +245,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         Action::TextBackspace {
             target: InputTarget::JsonbSearch,
         } => {
-            state.jsonb_detail.search_mut().input.backspace();
+            state.jsonb_detail.search_mut().input_mut().backspace();
             update_search_matches(state);
             Some(vec![])
         }
@@ -253,17 +253,21 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         Action::TextDelete {
             target: InputTarget::JsonbSearch,
         } => {
-            state.jsonb_detail.search_mut().input.delete();
+            state.jsonb_detail.search_mut().input_mut().delete();
             update_search_matches(state);
             Some(vec![])
         }
 
         Action::Paste(text)
             if state.input_mode() == InputMode::JsonbDetail
-                && state.jsonb_detail.search().active =>
+                && state.jsonb_detail.search().is_active() =>
         {
             let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-            state.jsonb_detail.search_mut().input.insert_str(&clean);
+            state
+                .jsonb_detail
+                .search_mut()
+                .input_mut()
+                .insert_str(&clean);
             update_search_matches(state);
             Some(vec![])
         }
@@ -275,7 +279,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             state
                 .jsonb_detail
                 .search_mut()
-                .input
+                .input_mut()
                 .move_cursor(*direction);
             Some(vec![])
         }
@@ -285,15 +289,14 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
 }
 
 fn update_search_matches(state: &mut AppState) {
-    let query = state.jsonb_detail.search().input.content().to_string();
+    let query = state.jsonb_detail.search().input().content().to_string();
     let matches = find_text_matches(state.jsonb_detail.editor().content(), &query);
-    state.jsonb_detail.search_mut().matches = matches;
-    state.jsonb_detail.search_mut().current_match = 0;
+    state.jsonb_detail.search_mut().set_matches(matches);
 }
 
 fn jump_to_current_match(state: &mut AppState) {
     let search = state.jsonb_detail.search();
-    if let Some(&match_pos) = search.matches.get(search.current_match) {
+    if let Some(&match_pos) = search.matches().get(search.current_match()) {
         state.jsonb_detail.editor_mut().set_cursor(match_pos);
         update_editor_scroll(state);
     }
@@ -876,7 +879,7 @@ mod tests {
 
             reduce(&mut state, &Action::JsonbEnterSearch, Instant::now());
 
-            assert!(state.jsonb_detail.search().active);
+            assert!(state.jsonb_detail.search().is_active());
             assert_eq!(state.jsonb_detail.mode(), JsonbDetailMode::Searching);
         }
 
@@ -888,7 +891,7 @@ mod tests {
 
             reduce(&mut state, &Action::JsonbExitSearch, Instant::now());
 
-            assert!(!state.jsonb_detail.search().active);
+            assert!(!state.jsonb_detail.search().is_active());
             assert_eq!(state.jsonb_detail.mode(), JsonbDetailMode::Viewing);
         }
 
@@ -908,13 +911,13 @@ mod tests {
                     Instant::now(),
                 );
             }
-            let match_count = state.jsonb_detail.search().matches.len();
+            let match_count = state.jsonb_detail.search().matches().len();
             assert!(match_count > 0, "should find at least one match");
 
             reduce(&mut state, &Action::JsonbSearchSubmit, Instant::now());
 
-            assert!(!state.jsonb_detail.search().active);
-            let expected_cursor = state.jsonb_detail.search().matches[0];
+            assert!(!state.jsonb_detail.search().is_active());
+            let expected_cursor = state.jsonb_detail.search().matches()[0];
             assert_eq!(state.jsonb_detail.editor().cursor(), expected_cursor);
             assert_eq!(
                 state.jsonb_detail.editor().cursor_to_position(),
@@ -928,7 +931,7 @@ mod tests {
             open_detail(&mut state);
             reduce(&mut state, &Action::JsonbEnterSearch, Instant::now());
 
-            assert!(state.jsonb_detail.search().matches.is_empty());
+            assert!(state.jsonb_detail.search().matches().is_empty());
 
             for ch in "THEME".chars() {
                 reduce(
@@ -942,7 +945,7 @@ mod tests {
             }
 
             assert!(
-                !state.jsonb_detail.search().matches.is_empty(),
+                !state.jsonb_detail.search().matches().is_empty(),
                 "should find matches for 'THEME'"
             );
         }
@@ -963,17 +966,17 @@ mod tests {
                     Instant::now(),
                 );
             }
-            let match_count = state.jsonb_detail.search().matches.len();
+            let match_count = state.jsonb_detail.search().matches().len();
             assert!(
                 match_count > 1,
                 "test precondition: need 2+ matches for cycling test, got {match_count}"
             );
-            assert_eq!(state.jsonb_detail.search().current_match, 0);
+            assert_eq!(state.jsonb_detail.search().current_match(), 0);
 
             reduce(&mut state, &Action::JsonbSearchNext, Instant::now());
 
-            assert_eq!(state.jsonb_detail.search().current_match, 1);
-            let expected_cursor = state.jsonb_detail.search().matches[1];
+            assert_eq!(state.jsonb_detail.search().current_match(), 1);
+            let expected_cursor = state.jsonb_detail.search().matches()[1];
             assert_eq!(state.jsonb_detail.editor().cursor(), expected_cursor);
             assert_eq!(
                 state.jsonb_detail.editor().cursor_to_position(),
@@ -997,15 +1000,15 @@ mod tests {
                     Instant::now(),
                 );
             }
-            let match_count = state.jsonb_detail.search().matches.len();
+            let match_count = state.jsonb_detail.search().matches().len();
             assert!(
                 match_count > 1,
                 "test precondition: need 2+ matches for wrap test, got {match_count}"
             );
             reduce(&mut state, &Action::JsonbSearchPrev, Instant::now());
 
-            assert_eq!(state.jsonb_detail.search().current_match, match_count - 1);
-            let expected_cursor = state.jsonb_detail.search().matches[match_count - 1];
+            assert_eq!(state.jsonb_detail.search().current_match(), match_count - 1);
+            let expected_cursor = state.jsonb_detail.search().matches()[match_count - 1];
             assert_eq!(state.jsonb_detail.editor().cursor(), expected_cursor);
             assert_eq!(
                 state.jsonb_detail.editor().cursor_to_position(),
@@ -1107,11 +1110,11 @@ mod tests {
                 now,
                 &services,
             );
-            assert!(!state.jsonb_detail.search().matches.is_empty());
+            assert!(!state.jsonb_detail.search().matches().is_empty());
 
             reduce_app(&mut state, Action::JsonbSearchNext, now, &services);
             reduce_app(&mut state, Action::JsonbSearchSubmit, now, &services);
-            assert!(!state.jsonb_detail.search().active);
+            assert!(!state.jsonb_detail.search().is_active());
 
             let effects = reduce_app(&mut state, Action::JsonbYankAll, now, &services);
             assert!(matches!(

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -696,7 +696,7 @@ mod tests {
             state.ui.jsonb_detail_editor_visible_rows = 3;
             open_detail(&mut state);
             state.modal.replace_mode(InputMode::JsonbEdit);
-            state.jsonb_detail.set_mode(JsonbDetailMode::Editing);
+            state.jsonb_detail.enter_edit();
             state
                 .jsonb_detail
                 .editor_mut()
@@ -722,7 +722,7 @@ mod tests {
             let mut state = state_with_jsonb_cell();
             open_detail(&mut state);
             state.modal.replace_mode(InputMode::JsonbEdit);
-            state.jsonb_detail.set_mode(JsonbDetailMode::Editing);
+            state.jsonb_detail.enter_edit();
             state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::G);
 
             reduce(

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -444,7 +444,7 @@ mod tests {
             error: None,
             command_tag: None,
         }));
-        state.query.pagination.set_table("public", "users");
+        state.query.pagination.set_table_for_test("public", "users");
         state.session.set_table_detail_raw(Some(jsonb_table()));
         state.result_interaction.activate_cell(0, 1);
         state

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -106,9 +106,8 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.set_selection_generation(7);
-            state.query.pagination.current_page = current_page;
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.set_page(current_page);
+            state.query.pagination.set_table("public", "users");
             state.query.set_current_result(Arc::new(QueryResult {
                 query: "SELECT * FROM public.users".to_string(),
                 columns: vec!["id".to_string(), "name".to_string()],

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -233,7 +233,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert!(state.result_interaction.staged_delete_rows().is_empty());
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
     }
 

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -61,7 +61,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             Some(vec![])
         }
         Action::StageRowForDelete => {
-            if state.session.read_only {
+            if state.session.is_read_only() {
                 state.messages.set_error_at(
                     "Read-only mode: delete operations are disabled".to_string(),
                     now,
@@ -104,7 +104,7 @@ mod tests {
             current_page: usize,
         ) -> AppState {
             let mut state = AppState::new("test".to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.set_selection_generation(7);
             state.query.pagination.current_page = current_page;
             state.query.pagination.schema = "public".to_string();
@@ -227,7 +227,7 @@ mod tests {
         fn read_only_blocks_stage_row_for_delete() {
             let mut state = row_delete::base_state(Some(vec!["id"]), vec![vec!["1", "alice"]], 0);
             state.result_interaction.activate_cell(0, 0);
-            state.session.read_only = true;
+            state.session.enable_read_only();
 
             let effects = reduce(&mut state, &Action::StageRowForDelete, Instant::now()).unwrap();
 

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -106,8 +106,8 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.set_selection_generation(7);
-            state.query.pagination.set_page(current_page);
-            state.query.pagination.set_table("public", "users");
+            state.query.pagination.set_page_for_test(current_page);
+            state.query.pagination.set_table_for_test("public", "users");
             state.query.set_current_result(Arc::new(QueryResult {
                 query: "SELECT * FROM public.users".to_string(),
                 columns: vec!["id".to_string(), "name".to_string()],

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -168,7 +168,7 @@ mod tests {
             .unwrap();
 
             assert!(effects.is_empty());
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
 
         #[test]
@@ -185,7 +185,7 @@ mod tests {
             .unwrap();
 
             assert!(effects.is_empty());
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
 
         #[test]
@@ -269,7 +269,7 @@ mod tests {
             .unwrap();
 
             assert!(effects.is_empty());
-            assert!(state.messages.last_error.is_none());
+            assert!(state.messages.last_error().is_none());
         }
     }
 
@@ -405,7 +405,7 @@ mod tests {
             .unwrap();
 
             assert!(effects.is_empty());
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
 
         #[test]

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -13,8 +13,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             Some(vec![])
         }
         Action::CloseConnectionError => {
-            state.connection_error.details_expanded = false;
-            state.connection_error.scroll_offset = 0;
+            state.connection_error.reset_view();
             state.connection_error.clear_copied_feedback();
             state.modal.set_mode(InputMode::Normal);
             Some(vec![])
@@ -114,10 +113,10 @@ mod tests {
 
             reduce(&mut state, &action, now);
             reduce(&mut state, &action, now);
-            assert_eq!(state.connection_error.scroll_offset, 2);
+            assert_eq!(state.connection_error.scroll_offset(), 2);
 
             reduce(&mut state, &action, now);
-            assert_eq!(state.connection_error.scroll_offset, 2);
+            assert_eq!(state.connection_error.scroll_offset(), 2);
         }
     }
 

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -68,10 +68,10 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             Some(vec![])
         }
         Action::RetryServiceConnection => {
-            if let Some(dsn) = state.session.dsn.clone() {
+            if let Some(dsn) = state.session.dsn().map(str::to_string) {
                 state.connection_error.clear();
                 state.session.begin_connecting(&dsn);
-                state.session.read_only = false;
+                state.session.disable_read_only();
                 state.modal.set_mode(InputMode::Normal);
                 Some(vec![Effect::FetchMetadata { dsn }])
             } else {
@@ -127,7 +127,7 @@ mod tests {
         #[test]
         fn blocked_for_service_connection() {
             let mut state = AppState::new("test".to_string());
-            state.session.dsn = Some("service=mydb".to_string());
+            state.session.set_dsn_for_test("service=mydb");
             state.modal.set_mode(InputMode::ConnectionError);
 
             reduce(&mut state, &Action::ReenterConnectionSetup, Instant::now());
@@ -138,7 +138,7 @@ mod tests {
         #[test]
         fn allowed_for_profile_connection() {
             let mut state = AppState::new("test".to_string());
-            state.session.dsn = Some("postgres://localhost/db".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/db");
             state.modal.set_mode(InputMode::ConnectionError);
 
             reduce(&mut state, &Action::ReenterConnectionSetup, Instant::now());

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -1,3 +1,4 @@
+use crate::domain::connection::{ConnectionId, DatabaseType};
 use crate::model::app_state::AppState;
 use crate::model::connection::cache::ConnectionCache;
 use crate::services::AppServices;
@@ -11,8 +12,23 @@ pub(super) fn save_current_cache(state: &AppState) -> ConnectionCache {
     )
 }
 
-pub(super) fn restore_cache(state: &mut AppState, cache: &ConnectionCache, services: &AppServices) {
-    state.session.restore_from_cache(cache, &mut state.query);
+pub(super) fn restore_cache(
+    state: &mut AppState,
+    cache: &ConnectionCache,
+    id: &ConnectionId,
+    name: &str,
+    database_type: DatabaseType,
+    dsn: &str,
+    services: &AppServices,
+) {
+    state.session.restore_from_cache_for_connection(
+        cache,
+        &mut state.query,
+        id,
+        name,
+        database_type,
+        dsn,
+    );
     state.ui.explorer_selected = cache.explorer_selected;
     state.ui.inspector_tab = services
         .db_capabilities

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -22,7 +22,7 @@ fn reset_for_new_connection(
     state
         .session
         .set_active_connection(id, name, database_type, dsn);
-    state.session.read_only = false;
+    state.session.disable_read_only();
 }
 
 pub fn reduce(
@@ -36,10 +36,10 @@ pub fn reduce(
             if state.session.connection_state().is_not_connected()
                 && state.modal.active_mode() == InputMode::Normal
             {
-                if state.session.active_database_type == Some(DatabaseType::SQLite) {
+                if state.session.active_database_type() == Some(DatabaseType::SQLite) {
                     return Some(vec![]);
                 }
-                if let Some(dsn) = state.session.dsn.clone() {
+                if let Some(dsn) = state.session.dsn().map(str::to_string) {
                     state.session.begin_connecting(&dsn);
                     Some(vec![Effect::FetchMetadata { dsn }])
                 } else {
@@ -56,7 +56,7 @@ pub fn reduce(
             name,
             database_type,
         }) => {
-            if let Some(current_id) = state.session.active_connection_id.clone() {
+            if let Some(current_id) = state.session.active_connection_id().cloned() {
                 let cache = save_current_cache(state);
                 state.connection_caches.save(&current_id, cache);
             }
@@ -71,7 +71,7 @@ pub fn reduce(
                 state
                     .session
                     .set_active_connection(id, name, *database_type, dsn);
-                state.session.read_only = false;
+                state.session.disable_read_only();
                 Some(vec![Effect::ClearCompletionEngineCache])
             } else {
                 // No cache: reset and fetch metadata
@@ -79,7 +79,9 @@ pub fn reduce(
                 state.session.begin_connecting(dsn);
                 Some(vec![
                     Effect::ClearCompletionEngineCache,
-                    Effect::FetchMetadata { dsn: dsn.clone() },
+                    Effect::FetchMetadata {
+                        dsn: dsn.to_string(),
+                    },
                 ])
             }
         }
@@ -112,7 +114,9 @@ mod tests {
         let new_id = ConnectionId::new();
         let services = AppServices::stub();
 
-        state.session.active_connection_id = Some(current_id.clone());
+        state
+            .session
+            .set_active_connection_id_for_test(Some(current_id.clone()));
         state.ui.explorer_selected = 5;
         state.ui.inspector_tab = InspectorTab::Indexes;
 
@@ -143,7 +147,7 @@ mod tests {
         assert_eq!(state.ui.explorer_selected, 42);
         assert_eq!(state.ui.inspector_tab, InspectorTab::ForeignKeys);
         assert_eq!(
-            state.session.active_database_type,
+            state.session.active_database_type(),
             Some(DatabaseType::PostgreSQL)
         );
     }
@@ -212,7 +216,7 @@ mod tests {
         );
         assert!(state.session.connection_state().is_not_connected());
         assert_eq!(
-            state.session.active_database_type,
+            state.session.active_database_type(),
             Some(DatabaseType::SQLite)
         );
     }
@@ -248,7 +252,7 @@ mod tests {
         assert!(state.connection_caches.get(&target_id).is_none());
         assert_eq!(state.ui.explorer_selected, 0);
         assert_eq!(
-            state.session.active_database_type,
+            state.session.active_database_type(),
             Some(DatabaseType::SQLite)
         );
         assert!(state.session.connection_state().is_not_connected());
@@ -258,8 +262,10 @@ mod tests {
     fn sqlite_try_connect_does_not_fetch_metadata() {
         let mut state = AppState::new("test".to_string());
         let services = AppServices::stub();
-        state.session.dsn = Some("sqlite:///tmp/app.db".to_string());
-        state.session.active_database_type = Some(DatabaseType::SQLite);
+        state.session.set_dsn_for_test("sqlite:///tmp/app.db");
+        state
+            .session
+            .set_active_database_type_for_test(Some(DatabaseType::SQLite));
         state
             .session
             .set_connection_state(ConnectionState::NotConnected);
@@ -279,17 +285,11 @@ mod tests {
         let action = create_switch_action(&new_id, "target_db");
         reduce(&mut state, &action, Instant::now(), &services);
 
-        assert_eq!(state.session.active_connection_id, Some(new_id));
+        assert_eq!(state.session.active_connection_id(), Some(&new_id));
+        assert_eq!(state.session.dsn(), Some("postgres://localhost/target_db"));
+        assert_eq!(state.session.active_connection_name(), Some("target_db"));
         assert_eq!(
-            state.session.dsn,
-            Some("postgres://localhost/target_db".to_string())
-        );
-        assert_eq!(
-            state.session.active_connection_name,
-            Some("target_db".to_string())
-        );
-        assert_eq!(
-            state.session.active_database_type,
+            state.session.active_database_type(),
             Some(DatabaseType::PostgreSQL)
         );
     }
@@ -352,12 +352,12 @@ mod tests {
         let mut state = AppState::new("test".to_string());
         let new_id = ConnectionId::new();
         let services = AppServices::stub();
-        state.session.read_only = true;
+        state.session.enable_read_only();
 
         let action = create_switch_action(&new_id, "fresh_db");
         reduce(&mut state, &action, Instant::now(), &services);
 
-        assert!(!state.session.read_only);
+        assert!(!state.session.is_read_only());
     }
 
     #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -79,9 +79,7 @@ pub fn reduce(
                 state.session.begin_connecting(dsn);
                 Some(vec![
                     Effect::ClearCompletionEngineCache,
-                    Effect::FetchMetadata {
-                        dsn: dsn.to_string(),
-                    },
+                    Effect::FetchMetadata { dsn: dsn.clone() },
                 ])
             }
         }

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -67,11 +67,7 @@ pub fn reduce(
                 state.session.mark_disconnected();
                 Some(vec![Effect::ClearCompletionEngineCache])
             } else if let Some(cached) = state.connection_caches.get(id).cloned() {
-                restore_cache(state, &cached, services);
-                state
-                    .session
-                    .set_active_connection(id, name, *database_type, dsn);
-                state.session.disable_read_only();
+                restore_cache(state, &cached, id, name, *database_type, dsn, services);
                 Some(vec![Effect::ClearCompletionEngineCache])
             } else {
                 // No cache: reset and fetch metadata

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -326,7 +326,7 @@ mod tests {
 
             // Set state that was previously not reset by ConnectionDeleted
             state.query.enter_history(2);
-            state.query.pagination.current_page = 3;
+            state.query.pagination.set_page(3);
             state.result_interaction.activate_cell(5, 0);
             state.result_interaction.scroll_offset = 10;
             state.result_interaction.horizontal_offset = 20;
@@ -339,7 +339,7 @@ mod tests {
             );
 
             assert!(state.query.history_index().is_none());
-            assert_eq!(state.query.pagination.current_page, 0);
+            assert_eq!(state.query.pagination.current_page(), 0);
             assert_eq!(
                 state.result_interaction.selection().mode(),
                 crate::model::shared::ui_state::ResultNavMode::Scroll

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -61,7 +61,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
 
             if state.connections().is_empty() && state.service_entries().is_empty() {
                 state.connection_setup.reset();
-                state.connection_setup.is_first_run = false;
+                state.connection_setup.set_first_run(false);
                 state.modal.set_mode(InputMode::ConnectionSetup);
             }
 
@@ -326,7 +326,7 @@ mod tests {
 
             // Set state that was previously not reset by ConnectionDeleted
             state.query.enter_history(2);
-            state.query.pagination.set_page(3);
+            state.query.pagination.set_page_for_test(3);
             state.result_interaction.activate_cell(5, 0);
             state.result_interaction.scroll_offset = 10;
             state.result_interaction.horizontal_offset = 20;

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -24,7 +24,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             if let Some(connection) = state.connections().get(profile_idx) {
                 let id = connection.id.clone();
                 let name = connection.name.as_str().to_string();
-                let is_active = state.session.active_connection_id.as_ref() == Some(&id);
+                let is_active = state.session.active_connection_id() == Some(&id);
 
                 let message = if is_active {
                     format!(
@@ -44,7 +44,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         }
         Action::DeleteConnection(id) => Some(vec![Effect::DeleteConnection { id: id.clone() }]),
         Action::ConnectionDeleted(id) => {
-            if state.session.active_connection_id.as_ref() == Some(id) {
+            if state.session.active_connection_id() == Some(id) {
                 state.session.reset(&mut state.query);
                 state.result_interaction.reset_view();
                 state.ui.set_explorer_selection(None);
@@ -181,7 +181,9 @@ mod tests {
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
             state.ui.connection_list_selected = 0;
-            state.session.active_connection_id = Some(profile_id);
+            state
+                .session
+                .set_active_connection_id_for_test(Some(profile_id));
 
             reduce(
                 &mut state,
@@ -289,8 +291,10 @@ mod tests {
             let profile = create_profile("Production");
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
-            state.session.active_connection_id = Some(profile_id.clone());
-            state.session.dsn = Some("postgres://localhost/db".to_string());
+            state
+                .session
+                .set_active_connection_id_for_test(Some(profile_id.clone()));
+            state.session.set_dsn_for_test("postgres://localhost/db");
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -301,8 +305,8 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(state.session.active_connection_id.is_none());
-            assert!(state.session.dsn.is_none());
+            assert!(state.session.active_connection_id().is_none());
+            assert!(state.session.dsn().is_none());
             assert!(state.session.connection_state().is_not_connected());
         }
 
@@ -312,8 +316,10 @@ mod tests {
             let profile = create_profile("Production");
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
-            state.session.active_connection_id = Some(profile_id.clone());
-            state.session.dsn = Some("postgres://localhost/db".to_string());
+            state
+                .session
+                .set_active_connection_id_for_test(Some(profile_id.clone()));
+            state.session.set_dsn_for_test("postgres://localhost/db");
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -41,9 +41,12 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         Action::Paste(text) if state.modal.active_mode() == InputMode::ConnectionSetup => {
             let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
             let setup = &mut state.connection_setup;
-            match setup.focused_field {
+            match setup.focused_field() {
                 ConnectionField::Port => {
-                    let current_len = setup.port.char_count();
+                    let port = setup
+                        .input_mut(ConnectionField::Port)
+                        .expect("port is a text input");
+                    let current_len = port.char_count();
                     let remaining = 5usize.saturating_sub(current_len);
                     let digits: String = clean
                         .chars()
@@ -51,8 +54,8 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                         .take(remaining)
                         .collect();
                     if !digits.is_empty() {
-                        setup.port.insert_str(&digits);
-                        setup.port.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
+                        port.insert_str(&digits);
+                        port.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
                     }
                 }
                 ConnectionField::DatabaseType | ConnectionField::SslMode => {}
@@ -72,11 +75,14 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             ch: c,
         } => {
             let setup = &mut state.connection_setup;
-            match setup.focused_field {
+            match setup.focused_field() {
                 ConnectionField::Port => {
-                    if c.is_ascii_digit() && setup.port.char_count() < 5 {
-                        setup.port.insert_char(*c);
-                        setup.port.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
+                    let port = setup
+                        .input_mut(ConnectionField::Port)
+                        .expect("port is a text input");
+                    if c.is_ascii_digit() && port.char_count() < 5 {
+                        port.insert_char(*c);
+                        port.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
                     }
                 }
                 ConnectionField::DatabaseType | ConnectionField::SslMode => {}
@@ -112,13 +118,13 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         }
         Action::ConnectionSetupNextField => {
             let setup = &mut state.connection_setup;
-            validate_field(setup, setup.focused_field);
+            validate_field(setup, setup.focused_field());
             setup.focus_next_field();
             Some(vec![])
         }
         Action::ConnectionSetupPrevField => {
             let setup = &mut state.connection_setup;
-            validate_field(setup, setup.focused_field);
+            validate_field(setup, setup.focused_field());
             setup.focus_prev_field();
             Some(vec![])
         }
@@ -145,7 +151,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         Action::ConnectionSetupSave => {
             let setup = &mut state.connection_setup;
             validate_all(setup);
-            if setup.validation_errors.is_empty() {
+            if !setup.has_validation_errors() {
                 let config = match setup.to_connection_config() {
                     Ok(config) => config,
                     Err(error) => {
@@ -157,8 +163,12 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                     state.session.mark_connecting();
                 }
                 Some(vec![Effect::SaveAndConnect {
-                    id: setup.editing_id.clone(),
-                    name: setup.name.content().to_string(),
+                    id: setup.editing_id().cloned(),
+                    name: setup
+                        .input(ConnectionField::Name)
+                        .expect("name is a text input")
+                        .content()
+                        .to_string(),
                     config,
                 }])
             } else {
@@ -166,7 +176,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             }
         }
         Action::ConnectionSetupCancel => {
-            if state.connection_setup.is_first_run {
+            if state.connection_setup.is_first_run() {
                 state.confirm_dialog.open(
                     "Confirm",
                     "No connection configured.\nAre you sure you want to quit?",
@@ -235,14 +245,20 @@ mod tests {
         fn setup_state_with_field(field: ConnectionField) -> AppState {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::ConnectionSetup);
-            state.connection_setup.focused_field = field;
+            state.connection_setup.set_focused_field_for_test(field);
             // Clear default values so tests start clean
-            state.connection_setup.host = TextInputState::default();
-            state.connection_setup.port = TextInputState::default();
-            state.connection_setup.database = TextInputState::default();
-            state.connection_setup.user = TextInputState::default();
-            state.connection_setup.name = TextInputState::default();
-            state.connection_setup.password = TextInputState::default();
+            for field in [
+                ConnectionField::Host,
+                ConnectionField::Port,
+                ConnectionField::Database,
+                ConnectionField::User,
+                ConnectionField::Name,
+                ConnectionField::Password,
+            ] {
+                state
+                    .connection_setup
+                    .set_input_for_test(field, TextInputState::default());
+            }
             state
         }
 
@@ -256,7 +272,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.connection_setup.host.content(), "db.example.com");
+            assert_eq!(state.connection_setup.host().content(), "db.example.com");
         }
 
         #[test]
@@ -269,13 +285,17 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.connection_setup.port.content(), "5432");
+            assert_eq!(state.connection_setup.port().content(), "5432");
         }
 
         #[test]
         fn port_respects_limit() {
             let mut state = setup_state_with_field(ConnectionField::Port);
-            state.connection_setup.port.set_content("54".to_string());
+            state
+                .connection_setup
+                .input_mut(ConnectionField::Port)
+                .unwrap()
+                .set_content("54".to_string());
 
             reduce(
                 &mut state,
@@ -283,17 +303,21 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.connection_setup.port.content(), "54321");
+            assert_eq!(state.connection_setup.port().content(), "54321");
         }
 
         #[test]
         fn full_port_does_nothing() {
             let mut state = setup_state_with_field(ConnectionField::Port);
-            state.connection_setup.port.set_content("12345".to_string());
+            state
+                .connection_setup
+                .input_mut(ConnectionField::Port)
+                .unwrap()
+                .set_content("12345".to_string());
 
             reduce(&mut state, &Action::Paste("6".to_string()), Instant::now());
 
-            assert_eq!(state.connection_setup.port.content(), "12345");
+            assert_eq!(state.connection_setup.port().content(), "12345");
         }
 
         #[test]
@@ -306,13 +330,13 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.connection_setup.host.content(), "localhost");
+            assert_eq!(state.connection_setup.host().content(), "localhost");
         }
 
         #[test]
         fn ssl_mode_ignored() {
             let mut state = setup_state_with_field(ConnectionField::SslMode);
-            let ssl_mode_before = state.connection_setup.ssl_mode;
+            let ssl_mode_before = state.connection_setup.ssl_mode();
 
             reduce(
                 &mut state,
@@ -320,7 +344,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.connection_setup.ssl_mode, ssl_mode_before);
+            assert_eq!(state.connection_setup.ssl_mode(), ssl_mode_before);
         }
 
         #[test]
@@ -333,7 +357,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.connection_setup.host.cursor(), 14);
+            assert_eq!(state.connection_setup.host().cursor(), 14);
         }
     }
 
@@ -344,20 +368,35 @@ mod tests {
         use crate::update::action::ConnectionTarget;
 
         fn fill_valid_form(state: &mut AppState) {
-            state.connection_setup.name.set_content("test".to_string());
             state
                 .connection_setup
-                .host
+                .input_mut(ConnectionField::Name)
+                .unwrap()
+                .set_content("test".to_string());
+            state
+                .connection_setup
+                .input_mut(ConnectionField::Host)
+                .unwrap()
                 .set_content("localhost".to_string());
-            state.connection_setup.port.set_content("5432".to_string());
             state
                 .connection_setup
-                .database
+                .input_mut(ConnectionField::Port)
+                .unwrap()
+                .set_content("5432".to_string());
+            state
+                .connection_setup
+                .input_mut(ConnectionField::Database)
+                .unwrap()
                 .set_content("db".to_string());
-            state.connection_setup.user.set_content("user".to_string());
             state
                 .connection_setup
-                .password
+                .input_mut(ConnectionField::User)
+                .unwrap()
+                .set_content("user".to_string());
+            state
+                .connection_setup
+                .input_mut(ConnectionField::Password)
+                .unwrap()
                 .set_content("pass".to_string());
         }
 
@@ -378,11 +417,18 @@ mod tests {
         #[test]
         fn sqlite_save_does_not_enter_connecting_state() {
             let mut state = AppState::new("test".to_string());
-            state.connection_setup.database_type = DatabaseType::SQLite;
-            state.connection_setup.name.set_content("Local".to_string());
             state
                 .connection_setup
-                .sqlite_path
+                .set_database_type(DatabaseType::SQLite);
+            state
+                .connection_setup
+                .input_mut(ConnectionField::Name)
+                .unwrap()
+                .set_content("Local".to_string());
+            state
+                .connection_setup
+                .input_mut(ConnectionField::SqlitePath)
+                .unwrap()
                 .set_content("/tmp/app.db".to_string());
 
             let effects = reduce(&mut state, &Action::ConnectionSetupSave, Instant::now())
@@ -450,7 +496,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(state.connection_setup.is_first_run);
+            assert!(state.connection_setup.is_first_run());
         }
 
         #[test]
@@ -465,7 +511,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(!state.connection_setup.is_first_run);
+            assert!(!state.connection_setup.is_first_run());
         }
 
         #[test]
@@ -479,7 +525,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(!state.connection_setup.is_first_run);
+            assert!(!state.connection_setup.is_first_run());
         }
     }
 }

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -196,9 +196,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 return Some(vec![]);
             }
             state.session.begin_connecting(dsn);
-            Some(vec![Effect::FetchMetadata {
-                dsn: dsn.to_string(),
-            }])
+            Some(vec![Effect::FetchMetadata { dsn: dsn.clone() }])
         }
         Action::ConnectionSaveFailed(e) => {
             if !state.session.connection_state().is_connected() {

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -14,7 +14,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
     match action {
         Action::OpenModal(ModalKind::ConnectionSetup) => {
             state.connection_setup.reset();
-            if !state.connections().is_empty() || state.session.dsn.is_some() {
+            if !state.connections().is_empty() || state.session.dsn().is_some() {
                 state.connection_setup.set_first_run(false);
             }
             state.modal.set_mode(InputMode::ConnectionSetup);
@@ -190,13 +190,15 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             state
                 .session
                 .set_active_connection(id, name, *database_type, dsn);
-            state.session.read_only = false;
+            state.session.disable_read_only();
             if *database_type == DatabaseType::SQLite {
                 state.session.mark_disconnected();
                 return Some(vec![]);
             }
             state.session.begin_connecting(dsn);
-            Some(vec![Effect::FetchMetadata { dsn: dsn.clone() }])
+            Some(vec![Effect::FetchMetadata {
+                dsn: dsn.to_string(),
+            }])
         }
         Action::ConnectionSaveFailed(e) => {
             if !state.session.connection_state().is_connected() {
@@ -402,7 +404,7 @@ mod tests {
         #[test]
         fn save_completed_resets_read_only() {
             let mut state = AppState::new("test".to_string());
-            state.session.read_only = true;
+            state.session.enable_read_only();
 
             let action = Action::ConnectionSaveCompleted(ConnectionTarget {
                 id: crate::domain::ConnectionId::new(),
@@ -412,7 +414,7 @@ mod tests {
             });
             reduce(&mut state, &action, Instant::now());
 
-            assert!(!state.session.read_only);
+            assert!(!state.session.is_read_only());
         }
 
         #[test]
@@ -428,9 +430,9 @@ mod tests {
             let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
             assert!(effects.is_empty());
-            assert_eq!(state.session.dsn, Some("sqlite:///tmp/app.db".to_string()));
+            assert_eq!(state.session.dsn(), Some("sqlite:///tmp/app.db"));
             assert_eq!(
-                state.session.active_database_type,
+                state.session.active_database_type(),
                 Some(DatabaseType::SQLite)
             );
             assert!(state.session.connection_state().is_not_connected());
@@ -471,7 +473,7 @@ mod tests {
         #[test]
         fn is_first_run_false_when_already_connected() {
             let mut state = AppState::new("test".to_string());
-            state.session.dsn = Some("postgres://localhost/db".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/db");
 
             reduce(
                 &mut state,

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -43,9 +43,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             let setup = &mut state.connection_setup;
             match setup.focused_field() {
                 ConnectionField::Port => {
-                    let port = setup
-                        .input_mut(ConnectionField::Port)
-                        .expect("port is a text input");
+                    let port = setup.port_mut();
                     let current_len = port.char_count();
                     let remaining = 5usize.saturating_sub(current_len);
                     let digits: String = clean
@@ -77,9 +75,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             let setup = &mut state.connection_setup;
             match setup.focused_field() {
                 ConnectionField::Port => {
-                    let port = setup
-                        .input_mut(ConnectionField::Port)
-                        .expect("port is a text input");
+                    let port = setup.port_mut();
                     if c.is_ascii_digit() && port.char_count() < 5 {
                         port.insert_char(*c);
                         port.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
@@ -272,7 +268,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.connection_setup.host().content(), "db.example.com");
+            assert_eq!(
+                state
+                    .connection_setup
+                    .input(ConnectionField::Host)
+                    .unwrap()
+                    .content(),
+                "db.example.com"
+            );
         }
 
         #[test]
@@ -285,7 +288,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.connection_setup.port().content(), "5432");
+            assert_eq!(
+                state
+                    .connection_setup
+                    .input(ConnectionField::Port)
+                    .unwrap()
+                    .content(),
+                "5432"
+            );
         }
 
         #[test]
@@ -303,7 +313,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.connection_setup.port().content(), "54321");
+            assert_eq!(
+                state
+                    .connection_setup
+                    .input(ConnectionField::Port)
+                    .unwrap()
+                    .content(),
+                "54321"
+            );
         }
 
         #[test]
@@ -317,7 +334,14 @@ mod tests {
 
             reduce(&mut state, &Action::Paste("6".to_string()), Instant::now());
 
-            assert_eq!(state.connection_setup.port().content(), "12345");
+            assert_eq!(
+                state
+                    .connection_setup
+                    .input(ConnectionField::Port)
+                    .unwrap()
+                    .content(),
+                "12345"
+            );
         }
 
         #[test]
@@ -330,7 +354,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.connection_setup.host().content(), "localhost");
+            assert_eq!(
+                state
+                    .connection_setup
+                    .input(ConnectionField::Host)
+                    .unwrap()
+                    .content(),
+                "localhost"
+            );
         }
 
         #[test]
@@ -357,7 +388,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.connection_setup.host().cursor(), 14);
+            assert_eq!(
+                state
+                    .connection_setup
+                    .input(ConnectionField::Host)
+                    .unwrap()
+                    .cursor(),
+                14
+            );
         }
     }
 

--- a/src/app/update/er.rs
+++ b/src/app/update/er.rs
@@ -51,10 +51,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             let run_id = state.er_preparation.start_waiting_run();
             state.set_success("Checking for schema changes...".to_string());
 
-            Some(vec![Effect::SmartErRefresh {
-                dsn: dsn.to_string(),
-                run_id,
-            }])
+            Some(vec![Effect::SmartErRefresh { dsn, run_id }])
         }
 
         Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -73,10 +70,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             state.session.set_metadata(Some(Arc::clone(new_metadata)));
             state
                 .er_preparation
-                .set_last_signatures(new_signatures.clone());
-            state
-                .er_preparation
-                .set_total_tables(new_metadata.table_summaries.len());
+                .apply_refresh_metadata(new_signatures.clone(), new_metadata.table_summaries.len());
 
             let mut effects: Vec<Effect> = Vec::new();
 
@@ -138,8 +132,9 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             let is_scoped = !state.er_preparation.target_tables().is_empty()
                 && state.er_preparation.target_tables().len() < total_table_count;
 
-            state.er_preparation.set_total_tables(total_table_count);
-            state.er_preparation.clear_last_signatures();
+            state
+                .er_preparation
+                .apply_refresh_metadata(Default::default(), total_table_count);
             state.set_error(format!(
                 "Smart refresh failed ({error}), falling back to full refresh"
             ));
@@ -318,7 +313,7 @@ mod tests {
             })));
             state
                 .er_preparation
-                .set_target_tables(vec!["public.users".to_string()]);
+                .set_targets(vec!["public.users".to_string()]);
 
             let effects =
                 reduce_er(&mut state, &Action::ErGenerateFromCache, Instant::now()).unwrap();
@@ -577,12 +572,10 @@ mod tests {
             state.er_preparation.set_run_id_for_test(1);
             state.er_preparation.set_status_for_test(ErStatus::Waiting);
             state.session.set_metadata(Some(make_metadata(5)));
-            state
-                .er_preparation
-                .set_last_signatures(std::collections::HashMap::from([(
-                    "public.old".to_string(),
-                    "sig".to_string(),
-                )]));
+            state.er_preparation.apply_refresh_metadata(
+                std::collections::HashMap::from([("public.old".to_string(), "sig".to_string())]),
+                5,
+            );
 
             let effects = reduce_er(
                 &mut state,
@@ -617,7 +610,7 @@ mod tests {
             state.session.set_metadata(Some(make_metadata(10)));
             state
                 .er_preparation
-                .set_target_tables(vec!["public.t0".to_string()]);
+                .set_targets(vec!["public.t0".to_string()]);
 
             let effects = reduce_er(
                 &mut state,

--- a/src/app/update/er.rs
+++ b/src/app/update/er.rs
@@ -267,7 +267,7 @@ mod tests {
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
 
             assert!(effects.is_empty());
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
 
         #[test]
@@ -298,7 +298,7 @@ mod tests {
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
 
             assert!(effects.is_empty());
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
     }
 
@@ -596,7 +596,7 @@ mod tests {
             .unwrap();
 
             assert!(state.er_preparation.last_signatures().is_empty());
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
             assert!(
                 effects
                     .iter()
@@ -683,7 +683,7 @@ mod tests {
 
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(effects.is_empty());
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
 
         #[test]

--- a/src/app/update/er.rs
+++ b/src/app/update/er.rs
@@ -38,7 +38,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
                 return Some(vec![]);
             }
 
-            let Some(dsn) = state.session.dsn.clone() else {
+            let Some(dsn) = state.session.dsn().map(str::to_string) else {
                 state.set_error("No active connection".to_string());
                 return Some(vec![]);
             };
@@ -53,7 +53,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             state.set_success("Checking for schema changes...".to_string());
 
             Some(vec![Effect::SmartErRefresh {
-                dsn,
+                dsn: dsn.to_string(),
                 run_id: state.er_preparation.run_id,
             }])
         }
@@ -194,7 +194,7 @@ mod tests {
 
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
-        state.session.dsn = Some(dsn.to_string());
+        state.session.set_dsn_for_test(dsn);
         state
     }
 

--- a/src/app/update/er.rs
+++ b/src/app/update/er.rs
@@ -134,7 +134,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
 
             state
                 .er_preparation
-                .apply_refresh_metadata(Default::default(), total_table_count);
+                .invalidate_refresh_signatures(total_table_count);
             state.set_error(format!(
                 "Smart refresh failed ({error}), falling back to full refresh"
             ));

--- a/src/app/update/er.rs
+++ b/src/app/update/er.rs
@@ -13,7 +13,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             table_count,
             total_tables,
         }) => {
-            state.er_preparation.status = ErStatus::Idle;
+            state.er_preparation.mark_idle();
             // Reset so next ErOpenDiagram re-evaluates target_tables from scratch.
             state.sql_modal.invalidate_prefetch();
             state.set_success(format!(
@@ -22,7 +22,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             Some(vec![])
         }
         Action::ErDiagramFailed(error) => {
-            state.er_preparation.status = ErStatus::Idle;
+            state.er_preparation.mark_idle();
             state.set_error(error.to_string());
             Some(vec![])
         }
@@ -32,7 +32,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
         }
         Action::ErOpenDiagram => {
             if matches!(
-                state.er_preparation.status,
+                state.er_preparation.status(),
                 ErStatus::Rendering | ErStatus::Waiting
             ) {
                 return Some(vec![]);
@@ -48,13 +48,12 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             }
 
             state.sql_modal.invalidate_prefetch();
-            state.er_preparation.run_id += 1;
-            state.er_preparation.status = ErStatus::Waiting;
+            let run_id = state.er_preparation.start_waiting_run();
             state.set_success("Checking for schema changes...".to_string());
 
             Some(vec![Effect::SmartErRefresh {
                 dsn: dsn.to_string(),
-                run_id: state.er_preparation.run_id,
+                run_id,
             }])
         }
 
@@ -67,16 +66,17 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             missing_in_cache,
             new_signatures,
         }) => {
-            if *run_id != state.er_preparation.run_id {
+            if *run_id != state.er_preparation.run_id() {
                 return Some(vec![]);
             }
 
             state.session.set_metadata(Some(Arc::clone(new_metadata)));
             state
                 .er_preparation
-                .last_signatures
-                .clone_from(new_signatures);
-            state.er_preparation.total_tables = new_metadata.table_summaries.len();
+                .set_last_signatures(new_signatures.clone());
+            state
+                .er_preparation
+                .set_total_tables(new_metadata.table_summaries.len());
 
             let mut effects: Vec<Effect> = Vec::new();
 
@@ -121,7 +121,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             error,
             new_metadata,
         }) => {
-            if *run_id != state.er_preparation.run_id {
+            if *run_id != state.er_preparation.run_id() {
                 return Some(vec![]);
             }
 
@@ -130,22 +130,22 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             }
 
             let Some(metadata) = &state.session.metadata() else {
-                state.er_preparation.status = ErStatus::Idle;
+                state.er_preparation.mark_idle();
                 state.set_error("Metadata not loaded yet".to_string());
                 return Some(vec![]);
             };
             let total_table_count = metadata.table_summaries.len();
-            let is_scoped = !state.er_preparation.target_tables.is_empty()
-                && state.er_preparation.target_tables.len() < total_table_count;
+            let is_scoped = !state.er_preparation.target_tables().is_empty()
+                && state.er_preparation.target_tables().len() < total_table_count;
 
-            state.er_preparation.total_tables = total_table_count;
-            state.er_preparation.last_signatures.clear();
+            state.er_preparation.set_total_tables(total_table_count);
+            state.er_preparation.clear_last_signatures();
             state.set_error(format!(
                 "Smart refresh failed ({error}), falling back to full refresh"
             ));
 
             if is_scoped {
-                let scoped_tables = state.er_preparation.target_tables.clone();
+                let scoped_tables = state.er_preparation.target_tables().to_vec();
                 Some(vec![
                     Effect::ClearCompletionEngineCache,
                     Effect::DispatchActions(vec![Action::StartPrefetchScoped {
@@ -162,13 +162,13 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
 
         Action::ErGenerateFromCache => {
             if !matches!(
-                state.er_preparation.status,
+                state.er_preparation.status(),
                 ErStatus::Idle | ErStatus::Waiting
             ) {
                 return Some(vec![]);
             }
 
-            state.er_preparation.status = ErStatus::Rendering;
+            state.er_preparation.mark_rendering();
             let total_tables = state
                 .session
                 .metadata()
@@ -177,7 +177,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             Some(vec![Effect::GenerateErDiagramFromCache {
                 total_tables,
                 project_name: state.runtime.project_name.clone(),
-                target_tables: state.er_preparation.target_tables.clone(),
+                target_tables: state.er_preparation.target_tables().to_vec(),
             }])
         }
 
@@ -221,8 +221,8 @@ mod tests {
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
 
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
-            assert_eq!(state.er_preparation.run_id, 1);
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
+            assert_eq!(state.er_preparation.run_id(), 1);
             assert_eq!(effects.len(), 1);
             assert!(matches!(
                 &effects[0],
@@ -234,11 +234,11 @@ mod tests {
         fn increments_run_id_on_each_call() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(5)));
-            state.er_preparation.run_id = 3;
+            state.er_preparation.set_run_id_for_test(3);
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
 
-            assert_eq!(state.er_preparation.run_id, 4);
+            assert_eq!(state.er_preparation.run_id(), 4);
             assert!(matches!(
                 &effects[0],
                 Effect::SmartErRefresh { run_id: 4, .. }
@@ -254,7 +254,7 @@ mod tests {
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
 
             assert!(!state.sql_modal.is_prefetch_started());
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
         }
@@ -273,7 +273,7 @@ mod tests {
         #[test]
         fn rendering_status_returns_empty_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Rendering;
+            state.er_preparation.mark_rendering();
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
 
@@ -283,7 +283,7 @@ mod tests {
         #[test]
         fn waiting_status_returns_empty_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
 
@@ -309,14 +309,16 @@ mod tests {
         #[test]
         fn idle_status_returns_generate_effect() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Idle;
+            state.er_preparation.mark_idle();
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
                 table_summaries: vec![],
                 fetched_at: Instant::now(),
             })));
-            state.er_preparation.target_tables = vec!["public.users".to_string()];
+            state
+                .er_preparation
+                .set_target_tables(vec!["public.users".to_string()]);
 
             let effects =
                 reduce_er(&mut state, &Action::ErGenerateFromCache, Instant::now()).unwrap();
@@ -327,13 +329,13 @@ mod tests {
                 Effect::GenerateErDiagramFromCache { target_tables, .. }
                     if target_tables == &vec!["public.users".to_string()]
             ));
-            assert_eq!(state.er_preparation.status, ErStatus::Rendering);
+            assert_eq!(state.er_preparation.status(), ErStatus::Rendering);
         }
 
         #[test]
         fn rendering_status_returns_empty_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Rendering;
+            state.er_preparation.mark_rendering();
 
             let effects =
                 reduce_er(&mut state, &Action::ErGenerateFromCache, Instant::now()).unwrap();
@@ -363,8 +365,8 @@ mod tests {
         #[test]
         fn no_changes_dispatches_generate_from_cache() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(1);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -389,8 +391,8 @@ mod tests {
         #[test]
         fn stale_tables_trigger_evict_and_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(1);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -420,8 +422,8 @@ mod tests {
         #[test]
         fn added_tables_trigger_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(1);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -446,8 +448,8 @@ mod tests {
         #[test]
         fn removed_tables_trigger_evict() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(1);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -472,8 +474,8 @@ mod tests {
         #[test]
         fn missing_in_cache_triggers_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(1);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -498,8 +500,8 @@ mod tests {
         #[test]
         fn mismatched_run_id_returns_empty_for_completed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 5;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(5);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
                 run_id: 3,
@@ -519,8 +521,8 @@ mod tests {
         #[test]
         fn updates_metadata_and_signatures() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(1);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             state.session.set_metadata(Some(make_metadata(0)));
 
             let new_sigs: HashMap<String, String> =
@@ -548,7 +550,7 @@ mod tests {
                     .len(),
                 5
             );
-            assert_eq!(state.er_preparation.last_signatures, new_sigs);
+            assert_eq!(state.er_preparation.last_signatures(), &new_sigs);
         }
     }
 
@@ -572,13 +574,15 @@ mod tests {
         #[test]
         fn falls_back_to_full_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(1);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             state.session.set_metadata(Some(make_metadata(5)));
             state
                 .er_preparation
-                .last_signatures
-                .insert("public.old".to_string(), "sig".to_string());
+                .set_last_signatures(std::collections::HashMap::from([(
+                    "public.old".to_string(),
+                    "sig".to_string(),
+                )]));
 
             let effects = reduce_er(
                 &mut state,
@@ -591,7 +595,7 @@ mod tests {
             )
             .unwrap();
 
-            assert!(state.er_preparation.last_signatures.is_empty());
+            assert!(state.er_preparation.last_signatures().is_empty());
             assert!(state.messages.last_error.is_some());
             assert!(
                 effects
@@ -608,10 +612,12 @@ mod tests {
         #[test]
         fn falls_back_to_scoped_prefetch_when_targets_set() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(1);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             state.session.set_metadata(Some(make_metadata(10)));
-            state.er_preparation.target_tables = vec!["public.t0".to_string()];
+            state
+                .er_preparation
+                .set_target_tables(vec!["public.t0".to_string()]);
 
             let effects = reduce_er(
                 &mut state,
@@ -634,14 +640,14 @@ mod tests {
                 Effect::DispatchActions(actions)
                     if actions.iter().any(|a| matches!(a, Action::StartPrefetchScoped { .. }))
             )));
-            assert!(state.er_preparation.last_signatures.is_empty());
+            assert!(state.er_preparation.last_signatures().is_empty());
         }
 
         #[test]
         fn mismatched_run_id_returns_empty_for_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 5;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(5);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             state.session.set_metadata(Some(make_metadata(5)));
 
             let effects = reduce_er(
@@ -661,8 +667,8 @@ mod tests {
         #[test]
         fn no_metadata_sets_idle_and_error() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(1);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
 
             let effects = reduce_er(
                 &mut state,
@@ -675,7 +681,7 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(effects.is_empty());
             assert!(state.messages.last_error.is_some());
         }
@@ -683,8 +689,8 @@ mod tests {
         #[test]
         fn new_metadata_applied_before_fallback() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_run_id_for_test(1);
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             state.session.set_metadata(Some(make_metadata(3)));
 
             let effects = reduce_er(

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -141,7 +141,7 @@ pub fn reduce_explain_with_services(
                 return Some(vec![]);
             }
 
-            state.explain.confirm_scroll_offset = 0;
+            state.explain.reset_confirm_scroll();
 
             match risk.confirmation {
                 ConfirmationType::TableNameInput { target } => {
@@ -250,28 +250,34 @@ pub fn reduce_explain_with_services(
                         CONFIRM_HEADER_LINES + state.sql_modal.editor.content().lines().count();
                     let modal_inner = ExplainContext::modal_inner_height(state.ui.terminal_height);
                     (
-                        &mut state.explain.confirm_scroll_offset,
+                        state.explain.confirm_scroll_offset(),
                         content_lines.saturating_sub(modal_inner),
                     )
                 }
                 ScrollTarget::ExplainPlan => {
                     let modal_inner = ExplainContext::modal_inner_height(state.ui.terminal_height);
                     let max = state.explain.line_count().saturating_sub(modal_inner);
-                    (&mut state.explain.scroll_offset, max)
+                    (state.explain.scroll_offset(), max)
                 }
                 ScrollTarget::ExplainCompare => {
                     let max = state.explain.compare_max_scroll(state.ui.terminal_height);
-                    (&mut state.explain.compare_scroll_offset, max)
+                    (state.explain.compare_scroll_offset(), max)
                 }
                 _ => unreachable!(),
             };
-            *offset = direction.clamp_vertical_offset(*offset, max, 1);
+            let next_offset = direction.clamp_vertical_offset(offset, max, 1);
+            match target {
+                ScrollTarget::ExplainConfirm => state.explain.scroll_confirm_to(next_offset),
+                ScrollTarget::ExplainPlan => state.explain.scroll_plan_to(next_offset),
+                ScrollTarget::ExplainCompare => state.explain.scroll_compare_to(next_offset),
+                _ => unreachable!(),
+            }
             Some(vec![])
         }
 
         Action::CompareEditQuery => {
-            if let Some(ref right) = state.explain.right {
-                let query = right.full_query.clone();
+            if let Some(query) = state.explain.right_full_query() {
+                let query = query.to_string();
                 state.sql_modal.load_query_for_editing(query);
             }
             Some(vec![])
@@ -379,7 +385,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some("EXPLAIN is unavailable for this database")
             );
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
@@ -399,7 +405,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some("EXPLAIN does not support multiple statements")
             );
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
@@ -469,7 +475,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some("EXPLAIN ANALYZE does not support multiple statements")
             );
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
@@ -492,7 +498,7 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some("EXPLAIN is unavailable for this database")
             );
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
@@ -663,15 +669,8 @@ mod tests {
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
-            assert!(state.explain.error.is_some());
-            assert!(
-                state
-                    .explain
-                    .error
-                    .as_deref()
-                    .unwrap()
-                    .contains("Read-only")
-            );
+            assert!(state.explain.error().is_some());
+            assert!(state.explain.error().unwrap().contains("Read-only"));
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
             assert!(state.confirm_dialog.intent().is_none());
         }
@@ -689,7 +688,7 @@ mod tests {
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
 
-            assert!(state.explain.error.is_none());
+            assert!(state.explain.error().is_none());
             assert_eq!(effects.len(), 1);
             assert!(matches!(
                 &effects[0],
@@ -712,14 +711,7 @@ mod tests {
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
-            assert!(
-                state
-                    .explain
-                    .error
-                    .as_deref()
-                    .unwrap()
-                    .contains("Read-only")
-            );
+            assert!(state.explain.error().unwrap().contains("Read-only"));
         }
     }
 
@@ -809,7 +801,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.explain.plan_text.as_deref(), Some("Seq Scan"));
+            assert_eq!(state.explain.plan_text(), Some("Seq Scan"));
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Normal);
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
             assert!(!state.query.is_running());
@@ -832,7 +824,7 @@ mod tests {
             );
 
             assert_eq!(
-                state.explain.error.as_deref(),
+                state.explain.error(),
                 Some("Query failed: syntax error. Review the database error details and SQL.")
             );
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Normal);
@@ -862,8 +854,8 @@ mod tests {
                 },
                 now,
             );
-            assert!(state.explain.right.is_some());
-            assert!(state.explain.left.is_none());
+            assert!(state.explain.right().is_some());
+            assert!(state.explain.left().is_none());
 
             // Step 2: Second EXPLAIN — auto-advance moves right→left
             state.sql_modal.editor.set_content("SELECT 2".to_string());
@@ -878,16 +870,10 @@ mod tests {
                 now,
             );
 
-            assert!(state.explain.left.is_some());
-            assert!(state.explain.right.is_some());
-            assert_eq!(
-                state.explain.left.as_ref().unwrap().plan.total_cost,
-                Some(100.0)
-            );
-            assert_eq!(
-                state.explain.right.as_ref().unwrap().plan.total_cost,
-                Some(5.0)
-            );
+            assert!(state.explain.left().is_some());
+            assert!(state.explain.right().is_some());
+            assert_eq!(state.explain.left().unwrap().plan.total_cost, Some(100.0));
+            assert_eq!(state.explain.right().unwrap().plan.total_cost, Some(5.0));
         }
     }
 
@@ -897,7 +883,7 @@ mod tests {
         #[test]
         fn plan_scroll_up_saturates_at_zero() {
             let mut state = sql_modal_state();
-            state.explain.scroll_offset = 0;
+            state.explain.scroll_plan_to(0);
 
             reduce_explain(
                 &mut state,
@@ -909,7 +895,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.explain.scroll_offset, 0);
+            assert_eq!(state.explain.scroll_offset(), 0);
         }
 
         #[test]
@@ -932,7 +918,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.explain.scroll_offset, 1);
+            assert_eq!(state.explain.scroll_offset(), 1);
         }
 
         #[test]
@@ -948,7 +934,7 @@ mod tests {
                 state.ui.terminal_height,
             );
             let max = state.explain.line_count().saturating_sub(modal_inner);
-            state.explain.scroll_offset = max;
+            state.explain.scroll_plan_to(max);
 
             reduce_explain(
                 &mut state,
@@ -960,13 +946,13 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.explain.scroll_offset, max);
+            assert_eq!(state.explain.scroll_offset(), max);
         }
 
         #[test]
         fn compare_plan_scroll_up_saturates_at_zero() {
             let mut state = sql_modal_state();
-            state.explain.compare_scroll_offset = 0;
+            state.explain.scroll_compare_to(0);
 
             reduce_explain(
                 &mut state,
@@ -978,7 +964,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.explain.compare_scroll_offset, 0);
+            assert_eq!(state.explain.compare_scroll_offset(), 0);
         }
 
         #[test]
@@ -1001,7 +987,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.explain.compare_scroll_offset, 1);
+            assert_eq!(state.explain.compare_scroll_offset(), 1);
         }
 
         #[test]
@@ -1030,7 +1016,7 @@ mod tests {
                 );
             }
 
-            assert_eq!(state.explain.compare_scroll_offset, max);
+            assert_eq!(state.explain.compare_scroll_offset(), max);
 
             // k should immediately scroll back
             reduce_explain(
@@ -1042,7 +1028,7 @@ mod tests {
                 },
                 Instant::now(),
             );
-            assert_eq!(state.explain.compare_scroll_offset, max.saturating_sub(1));
+            assert_eq!(state.explain.compare_scroll_offset(), max.saturating_sub(1));
         }
 
         #[test]
@@ -1065,7 +1051,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.explain.compare_scroll_offset, 1);
+            assert_eq!(state.explain.compare_scroll_offset(), 1);
         }
 
         #[test]
@@ -1082,7 +1068,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.explain.compare_scroll_offset, 0);
+            assert_eq!(state.explain.compare_scroll_offset(), 0);
         }
     }
 

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -32,7 +32,7 @@ fn show_explain_error_on_plan(state: &mut AppState, message: impl Into<String>) 
 fn begin_explain_running(state: &mut AppState, now: Instant) {
     state.sql_modal.begin_adhoc_running();
     state.sql_modal.set_active_tab(SqlModalTab::Plan);
-    state.explain.reset();
+    state.explain.reset_for_new_run();
     state.query.begin_running(now);
 }
 

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -100,7 +100,7 @@ pub fn reduce_explain_with_services(
             begin_explain_running(state, now);
 
             Some(vec![Effect::ExecuteExplain {
-                dsn: dsn.to_string(),
+                dsn,
                 query,
                 is_analyze: false,
                 read_only: true,
@@ -194,7 +194,7 @@ pub fn reduce_explain_with_services(
                 };
                 begin_explain_running(state, now);
                 return Some(vec![Effect::ExecuteExplain {
-                    dsn: dsn.to_string(),
+                    dsn,
                     query: explain_query,
                     is_analyze: true,
                     read_only: state.session.is_read_only(),

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -82,7 +82,7 @@ pub fn reduce_explain_with_services(
             if content.is_empty() {
                 return Some(vec![]);
             }
-            let Some(dsn) = state.session.dsn.clone() else {
+            let Some(dsn) = state.session.dsn().map(str::to_string) else {
                 return Some(vec![]);
             };
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {
@@ -100,7 +100,7 @@ pub fn reduce_explain_with_services(
             begin_explain_running(state, now);
 
             Some(vec![Effect::ExecuteExplain {
-                dsn,
+                dsn: dsn.to_string(),
                 query,
                 is_analyze: false,
                 read_only: true,
@@ -115,10 +115,9 @@ pub fn reduce_explain_with_services(
             if content.is_empty() {
                 return Some(vec![]);
             }
-            let Some(dsn) = &state.session.dsn else {
+            let Some(dsn) = state.session.dsn().map(str::to_string) else {
                 return Some(vec![]);
             };
-            let dsn = dsn.clone();
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {
                 return Some(vec![]);
             }
@@ -134,7 +133,7 @@ pub fn reduce_explain_with_services(
 
             let is_dml = !matches!(kind, StatementKind::Select | StatementKind::Transaction);
 
-            if state.session.read_only && is_dml {
+            if state.session.is_read_only() && is_dml {
                 show_explain_error_on_plan(
                     state,
                     "Read-only mode: EXPLAIN ANALYZE is blocked for DML statements.",
@@ -162,7 +161,7 @@ pub fn reduce_explain_with_services(
                         dsn,
                         query: explain_query,
                         is_analyze: true,
-                        read_only: state.session.read_only,
+                        read_only: state.session.is_read_only(),
                     }]);
                 }
             }
@@ -186,7 +185,7 @@ pub fn reduce_explain_with_services(
                 _ => None,
             };
             if let Some(query) = query
-                && let Some(dsn) = state.session.dsn.clone()
+                && let Some(dsn) = state.session.dsn().map(str::to_string)
             {
                 let Some(explain_query) = services.sql_dialect.build_explain_analyze_sql(&query)
                 else {
@@ -195,10 +194,10 @@ pub fn reduce_explain_with_services(
                 };
                 begin_explain_running(state, now);
                 return Some(vec![Effect::ExecuteExplain {
-                    dsn,
+                    dsn: dsn.to_string(),
                     query: explain_query,
                     is_analyze: true,
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }]);
             }
             Some(vec![])
@@ -332,7 +331,7 @@ mod tests {
         fn empty_query_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("  ".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainRequest, Instant::now()).unwrap();
@@ -355,7 +354,7 @@ mod tests {
         fn running_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
             let effects =
@@ -368,7 +367,7 @@ mod tests {
         fn unsupported_database_sets_error_without_effects() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects = reduce_explain_with_services(
                 &mut state,
@@ -393,7 +392,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT 1; DELETE FROM users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainRequest, Instant::now()).unwrap();
@@ -410,7 +409,7 @@ mod tests {
         fn starts_query_timer() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainRequest, Instant::now());
 
@@ -422,7 +421,7 @@ mod tests {
         fn emits_execute_explain_effect() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainRequest, Instant::now()).unwrap();
@@ -448,7 +447,7 @@ mod tests {
         #[test]
         fn empty_query_is_noop() {
             let mut state = sql_modal_state();
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
@@ -463,7 +462,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT 1; DELETE FROM users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
@@ -481,7 +480,7 @@ mod tests {
         fn unsupported_database_sets_error_without_effects() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects = reduce_explain_with_services(
                 &mut state,
@@ -503,7 +502,7 @@ mod tests {
         fn select_executes_immediately_without_confirm() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
@@ -526,7 +525,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("INSERT INTO users VALUES (1)".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
@@ -549,7 +548,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("UPDATE users SET name='x' WHERE id=1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
@@ -572,7 +571,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -592,7 +591,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id=1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
@@ -615,7 +614,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DROP TABLE users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -635,7 +634,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("TRUNCATE users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -659,8 +658,8 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id=1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
-            state.session.read_only = true;
+            state.session.set_dsn_for_test("dsn://test");
+            state.session.enable_read_only();
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -684,8 +683,8 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT * FROM users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
-            state.session.read_only = true;
+            state.session.set_dsn_for_test("dsn://test");
+            state.session.enable_read_only();
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
@@ -708,8 +707,8 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("INSERT INTO users VALUES (1)".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
-            state.session.read_only = true;
+            state.session.set_dsn_for_test("dsn://test");
+            state.session.enable_read_only();
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -731,7 +730,7 @@ mod tests {
         #[test]
         fn confirm_from_high_with_matching_table_emits_effect() {
             let mut state = sql_modal_state();
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
             let mut input = crate::model::shared::text_input::TextInputState::default();
             for c in "users".chars() {
                 input.insert_char(c);
@@ -754,7 +753,7 @@ mod tests {
         #[test]
         fn confirm_from_high_with_mismatch_is_noop() {
             let mut state = sql_modal_state();
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
             let mut input = crate::model::shared::text_input::TextInputState::default();
             input.insert_char('x');
             state
@@ -849,7 +848,7 @@ mod tests {
         fn two_explains_auto_advance_returns_comparable_slots() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            state.session.set_dsn_for_test("dsn://test");
             let now = Instant::now();
 
             // Step 1: First EXPLAIN

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -113,7 +113,7 @@ pub fn build_bulk_delete_preview(
     if state.result_interaction.staged_delete_rows().is_empty() {
         return Err(EditGuardrailError::NoRowsStagedForDeletion);
     }
-    if state.session.dsn.is_none() {
+    if state.session.dsn().is_none() {
         return Err(EditGuardrailError::NoActiveConnection);
     }
     if state.query.status() != crate::model::browse::query_execution::QueryStatus::Idle {

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -204,79 +204,91 @@ pub fn char_to_byte_index(s: &str, char_idx: usize) -> usize {
 }
 
 pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) {
-    state.validation_errors.remove(&field);
+    state.clear_validation_error(field);
 
     match field {
         ConnectionField::DatabaseType => {}
         ConnectionField::SqlitePath => {
             match crate::domain::connection::SqliteConnectionConfig::new(
-                state.sqlite_path.content().to_string(),
+                state
+                    .input(ConnectionField::SqlitePath)
+                    .expect("sqlite path is a text input")
+                    .content()
+                    .to_string(),
             ) {
                 Ok(_) => {}
                 Err(crate::domain::connection::SqliteConnectionConfigError::EmptyPath) => {
-                    state
-                        .validation_errors
-                        .insert(field, "Required".to_string());
+                    state.set_validation_error(field, "Required");
                 }
                 Err(crate::domain::connection::SqliteConnectionConfigError::UnsupportedPath) => {
-                    state
-                        .validation_errors
-                        .insert(field, "Unsupported characters".to_string());
+                    state.set_validation_error(field, "Unsupported characters");
                 }
             }
         }
         ConnectionField::Host => {
-            if state.host.content().trim().is_empty() {
-                state
-                    .validation_errors
-                    .insert(field, "Required".to_string());
+            if state
+                .input(ConnectionField::Host)
+                .expect("host is a text input")
+                .content()
+                .trim()
+                .is_empty()
+            {
+                state.set_validation_error(field, "Required");
             }
         }
         ConnectionField::Port => {
-            if state.port.content().trim().is_empty() {
-                state
-                    .validation_errors
-                    .insert(field, "Required".to_string());
+            let port = state
+                .input(ConnectionField::Port)
+                .expect("port is a text input")
+                .content()
+                .trim();
+            if port.is_empty() {
+                state.set_validation_error(field, "Required");
             } else {
-                match state.port.content().trim().parse::<u16>() {
+                match port.parse::<u16>() {
                     Err(_) => {
-                        state
-                            .validation_errors
-                            .insert(field, "Invalid port".to_string());
+                        state.set_validation_error(field, "Invalid port");
                     }
                     Ok(0) => {
-                        state
-                            .validation_errors
-                            .insert(field, "Port must be > 0".to_string());
+                        state.set_validation_error(field, "Port must be > 0");
                     }
                     Ok(_) => {}
                 }
             }
         }
         ConnectionField::Database => {
-            if state.database.content().trim().is_empty() {
-                state
-                    .validation_errors
-                    .insert(field, "Required".to_string());
+            if state
+                .input(ConnectionField::Database)
+                .expect("database is a text input")
+                .content()
+                .trim()
+                .is_empty()
+            {
+                state.set_validation_error(field, "Required");
             }
         }
         ConnectionField::User => {
-            if state.user.content().trim().is_empty() {
-                state
-                    .validation_errors
-                    .insert(field, "Required".to_string());
+            if state
+                .input(ConnectionField::User)
+                .expect("user is a text input")
+                .content()
+                .trim()
+                .is_empty()
+            {
+                state.set_validation_error(field, "Required");
             }
         }
         ConnectionField::Name => {
-            let name = state.name.content().trim().to_string();
+            let name = state
+                .input(ConnectionField::Name)
+                .expect("name is a text input")
+                .content()
+                .trim()
+                .to_string();
             if name.is_empty() {
-                state
-                    .validation_errors
-                    .insert(field, "Name is required".to_string());
+                state.set_validation_error(field, "Name is required");
             } else if name.chars().count() > 50 {
-                state
-                    .validation_errors
-                    .insert(field, "Name must be 50 characters or less".to_string());
+                state.set_validation_error(field, "Name must be 50 characters or less");
             }
         }
         ConnectionField::Password | ConnectionField::SslMode => {}
@@ -284,10 +296,8 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
 }
 
 pub fn validate_all(state: &mut ConnectionSetupState) {
-    let active_fields = ConnectionField::fields_for(state.database_type);
-    state
-        .validation_errors
-        .retain(|field, _| active_fields.contains(field));
+    let active_fields = ConnectionField::fields_for(state.database_type());
+    state.retain_validation_errors_for_visible_fields();
     for field in active_fields {
         validate_field(state, *field);
     }
@@ -309,7 +319,9 @@ mod tests {
             validate_field(&mut state, ConnectionField::Name);
 
             assert_eq!(
-                state.validation_errors.get(&ConnectionField::Name),
+                state
+                    .validation_errors_for_test()
+                    .get(&ConnectionField::Name),
                 Some(&"Name is required".to_string())
             );
         }
@@ -321,12 +333,14 @@ mod tests {
         )]
         fn whitespace_only_name_sets_error() {
             let mut state = ConnectionSetupState::default();
-            state.name = TextInputState::new("   ", 3);
+            state.set_input_for_test(ConnectionField::Name, TextInputState::new("   ", 3));
 
             validate_field(&mut state, ConnectionField::Name);
 
             assert_eq!(
-                state.validation_errors.get(&ConnectionField::Name),
+                state
+                    .validation_errors_for_test()
+                    .get(&ConnectionField::Name),
                 Some(&"Name is required".to_string())
             );
         }
@@ -337,17 +351,23 @@ mod tests {
         fn name_length_validation(#[case] name: String, #[case] expect_error: bool) {
             let mut state = ConnectionSetupState::default();
             let len = name.chars().count();
-            state.name = TextInputState::new(name, len);
+            state.set_input_for_test(ConnectionField::Name, TextInputState::new(name, len));
 
             validate_field(&mut state, ConnectionField::Name);
 
             if expect_error {
                 assert_eq!(
-                    state.validation_errors.get(&ConnectionField::Name),
+                    state
+                        .validation_errors_for_test()
+                        .get(&ConnectionField::Name),
                     Some(&"Name must be 50 characters or less".to_string())
                 );
             } else {
-                assert!(!state.validation_errors.contains_key(&ConnectionField::Name));
+                assert!(
+                    !state
+                        .validation_errors_for_test()
+                        .contains_key(&ConnectionField::Name)
+                );
             }
         }
 
@@ -355,12 +375,23 @@ mod tests {
         fn valid_name_clears_previous_error() {
             let mut state = ConnectionSetupState::default();
             validate_field(&mut state, ConnectionField::Name);
-            assert!(state.validation_errors.contains_key(&ConnectionField::Name));
+            assert!(
+                state
+                    .validation_errors_for_test()
+                    .contains_key(&ConnectionField::Name)
+            );
 
-            state.name.set_content("Valid Name".to_string());
+            state
+                .input_mut(ConnectionField::Name)
+                .unwrap()
+                .set_content("Valid Name".to_string());
             validate_field(&mut state, ConnectionField::Name);
 
-            assert!(!state.validation_errors.contains_key(&ConnectionField::Name));
+            assert!(
+                !state
+                    .validation_errors_for_test()
+                    .contains_key(&ConnectionField::Name)
+            );
         }
     }
 
@@ -370,50 +401,59 @@ mod tests {
 
         #[test]
         fn empty_path_sets_required_error() {
-            let mut state = ConnectionSetupState {
-                database_type: DatabaseType::SQLite,
-                ..ConnectionSetupState::default()
-            };
-            state.sqlite_path.set_content("   ".to_string());
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::SQLite);
+            state
+                .input_mut(ConnectionField::SqlitePath)
+                .unwrap()
+                .set_content("   ".to_string());
 
             validate_field(&mut state, ConnectionField::SqlitePath);
 
             assert_eq!(
-                state.validation_errors.get(&ConnectionField::SqlitePath),
+                state
+                    .validation_errors_for_test()
+                    .get(&ConnectionField::SqlitePath),
                 Some(&"Required".to_string())
             );
         }
 
         #[test]
         fn unsupported_path_characters_set_error() {
-            let mut state = ConnectionSetupState {
-                database_type: DatabaseType::SQLite,
-                ..ConnectionSetupState::default()
-            };
-            state.sqlite_path.set_content("/tmp/app\0.db".to_string());
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::SQLite);
+            state
+                .input_mut(ConnectionField::SqlitePath)
+                .unwrap()
+                .set_content("/tmp/app\0.db".to_string());
 
             validate_field(&mut state, ConnectionField::SqlitePath);
 
             assert_eq!(
-                state.validation_errors.get(&ConnectionField::SqlitePath),
+                state
+                    .validation_errors_for_test()
+                    .get(&ConnectionField::SqlitePath),
                 Some(&"Unsupported characters".to_string())
             );
         }
 
         #[test]
         fn validate_all_removes_errors_for_hidden_fields() {
-            let mut state = ConnectionSetupState {
-                database_type: DatabaseType::SQLite,
-                ..ConnectionSetupState::default()
-            };
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::SQLite);
+            state.set_validation_error(ConnectionField::Host, "Required");
             state
-                .validation_errors
-                .insert(ConnectionField::Host, "Required".to_string());
-            state.sqlite_path.set_content("/tmp/app.db".to_string());
+                .input_mut(ConnectionField::SqlitePath)
+                .unwrap()
+                .set_content("/tmp/app.db".to_string());
 
             validate_all(&mut state);
 
-            assert!(!state.validation_errors.contains_key(&ConnectionField::Host));
+            assert!(
+                !state
+                    .validation_errors_for_test()
+                    .contains_key(&ConnectionField::Host)
+            );
         }
     }
 

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -81,7 +81,7 @@ pub fn editable_preview_base(
         return Err(EditGuardrailError::NotEditableResult);
     }
 
-    if state.query.pagination.schema.is_empty() || state.query.pagination.table.is_empty() {
+    if state.query.pagination.schema().is_empty() || state.query.pagination.table().is_empty() {
         return Err(EditGuardrailError::UnknownTable);
     }
 
@@ -90,8 +90,8 @@ pub fn editable_preview_base(
         .table_detail()
         .ok_or(EditGuardrailError::TableMetadataNotLoaded)?;
 
-    if table_detail.schema != state.query.pagination.schema
-        || table_detail.name != state.query.pagination.table
+    if table_detail.schema != state.query.pagination.schema()
+        || table_detail.name != state.query.pagination.table()
     {
         return Err(EditGuardrailError::StaleTableMetadata);
     }
@@ -139,8 +139,8 @@ pub fn build_bulk_delete_preview(
     }
 
     let sql = services.sql_dialect.build_bulk_delete_sql(
-        &state.query.pagination.schema,
-        &state.query.pagination.table,
+        state.query.pagination.schema(),
+        state.query.pagination.table(),
         &pk_pairs_per_row,
     );
 
@@ -155,12 +155,12 @@ pub fn build_bulk_delete_preview(
         result.rows.len(),
         staged_count,
         first_deleted_idx,
-        state.query.pagination.current_page,
+        state.query.pagination.current_page(),
     );
 
     let target = TargetSummary {
-        schema: state.query.pagination.schema.clone(),
-        table: state.query.pagination.table.clone(),
+        schema: state.query.pagination.schema().to_string(),
+        table: state.query.pagination.table().to_string(),
         key_values: pk_pairs_per_row.first().cloned().unwrap_or_default(),
     };
     let guardrail = evaluate_guardrails(true, true, Some(target.clone()));

--- a/src/app/update/input/handlers/connections.rs
+++ b/src/app/update/input/handlers/connections.rs
@@ -6,8 +6,7 @@ pub fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) -> Action
     use crate::model::connection::setup::ConnectionField;
     use crate::update::action::CursorMove;
 
-    let dropdown_open = state.connection_setup.database_type_dropdown.is_open
-        || state.connection_setup.ssl_dropdown.is_open;
+    let dropdown_open = state.connection_setup.has_open_dropdown();
     let ctrl = combo.modifiers.contains(Modifiers::CTRL);
     let alt = combo.modifiers.contains(Modifiers::ALT);
     let shift = combo.modifiers.contains(Modifiers::SHIFT);
@@ -252,13 +251,15 @@ mod tests {
 
             fn dropdown_state() -> AppState {
                 let mut state = setup_state();
-                state.connection_setup.ssl_dropdown.is_open = true;
+                state.connection_setup.open_ssl_dropdown_for_test();
                 state
             }
 
             fn database_type_dropdown_state() -> AppState {
                 let mut state = setup_state();
-                state.connection_setup.database_type_dropdown.is_open = true;
+                state
+                    .connection_setup
+                    .open_database_type_dropdown_for_test();
                 state
             }
 

--- a/src/app/update/input/handlers/connections.rs
+++ b/src/app/update/input/handlers/connections.rs
@@ -36,7 +36,7 @@ pub fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) -> Action
 
         Key::Enter
             if matches!(
-                state.connection_setup.focused_field,
+                state.connection_setup.focused_field(),
                 ConnectionField::DatabaseType | ConnectionField::SslMode
             ) =>
         {
@@ -229,7 +229,9 @@ mod tests {
         #[test]
         fn enter_on_ssl_field_toggles_dropdown() {
             let mut state = setup_state();
-            state.connection_setup.focused_field = ConnectionField::SslMode;
+            state
+                .connection_setup
+                .set_focused_field_for_test(ConnectionField::SslMode);
 
             let result = handle_connection_setup_keys(combo(Key::Enter), &state);
 
@@ -239,7 +241,9 @@ mod tests {
         #[test]
         fn enter_on_database_type_field_toggles_dropdown() {
             let mut state = setup_state();
-            state.connection_setup.focused_field = ConnectionField::DatabaseType;
+            state
+                .connection_setup
+                .set_focused_field_for_test(ConnectionField::DatabaseType);
 
             let result = handle_connection_setup_keys(combo(Key::Enter), &state);
 

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -64,7 +64,7 @@ fn handle_key_event(combo: KeyCombo, state: &AppState, services: &AppServices) -
         InputMode::ErTablePicker => pickers::handle_er_table_picker_keys(combo),
         InputMode::QueryHistoryPicker => pickers::handle_query_history_picker_keys(combo),
         InputMode::JsonbDetail => {
-            let is_searching = state.jsonb_detail.search().active;
+            let is_searching = state.jsonb_detail.search().is_active();
             jsonb::handle_jsonb_detail_keys(
                 combo,
                 is_searching,

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -108,10 +108,7 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
     if kb::is_focus_toggle(&combo) {
         return Action::ToggleFocus;
     }
-    if combo.key == Key::Enter
-        && combo.modifiers.is_empty()
-        && state.connection_error.error_info.is_some()
-    {
+    if combo.key == Key::Enter && combo.modifiers.is_empty() && state.connection_error.has_error() {
         return Action::ConfirmSelection;
     }
 
@@ -388,7 +385,9 @@ mod tests {
             #[test]
             fn alt_enter_noop_when_connection_error_is_open() {
                 let mut state = browse_state();
-                state.connection_error.error_info = Some(ConnectionErrorInfo::new("boom"));
+                state
+                    .connection_error
+                    .set_error(ConnectionErrorInfo::new("boom"));
 
                 let result = handle_normal_mode(KeyCombo::alt(Key::Enter), &state);
 
@@ -398,7 +397,9 @@ mod tests {
             #[test]
             fn plain_enter_confirms_connection_error() {
                 let mut state = browse_state();
-                state.connection_error.error_info = Some(ConnectionErrorInfo::new("boom"));
+                state
+                    .connection_error
+                    .set_error(ConnectionErrorInfo::new("boom"));
 
                 let result = handle_normal_mode(KeyCombo::plain(Key::Enter), &state);
 

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -154,7 +154,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             }
             state
                 .er_preparation
-                .set_target_tables(state.ui.er_selected_tables.iter().cloned().collect());
+                .set_targets(state.ui.er_selected_tables.iter().cloned().collect());
             state.modal.set_mode(InputMode::Normal);
             state.ui.er_picker.clear_filter();
             state.ui.er_selected_tables.clear();

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -160,7 +160,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             Some(vec![Effect::DispatchActions(vec![Action::ErOpenDiagram])])
         }
         Action::OpenModal(ModalKind::QueryHistoryPicker) => {
-            if state.session.active_connection_id.is_none() {
+            if state.session.active_connection_id().is_none() {
                 return Some(vec![]);
             }
             if state.query.is_running() {
@@ -178,7 +178,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             state.query_history_picker.reset();
             state.modal.push_mode(InputMode::QueryHistoryPicker);
 
-            let conn_id = state.session.active_connection_id.as_ref().unwrap();
+            let conn_id = state.session.active_connection_id().unwrap();
             Some(vec![Effect::LoadQueryHistory {
                 project_name: state.runtime.project_name.clone(),
                 connection_id: conn_id.clone(),
@@ -193,7 +193,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
                 return Some(vec![]);
             }
-            if state.session.active_connection_id.as_ref() != Some(conn_id) {
+            if state.session.active_connection_id() != Some(conn_id) {
                 return Some(vec![]);
             }
             state.query_history_picker.replace_entries(entries);
@@ -280,12 +280,12 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                     sql,
                     blocked: false,
                 }) => {
-                    if let Some(dsn) = &state.session.dsn {
+                    if let Some(dsn) = state.session.dsn() {
                         state.query.begin_running(now);
                         Some(vec![Effect::ExecuteWrite {
-                            dsn: dsn.clone(),
+                            dsn: dsn.to_string(),
                             query: sql,
-                            read_only: state.session.read_only,
+                            read_only: state.session.is_read_only(),
                         }])
                     } else {
                         state.result_interaction.clear_write_preview();
@@ -297,7 +297,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                     }
                 }
                 Some(ConfirmIntent::DisableReadOnly) => {
-                    state.session.read_only = false;
+                    state.session.disable_read_only();
                     Some(vec![])
                 }
                 Some(ConfirmIntent::CsvExport {
@@ -305,13 +305,13 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                     file_name,
                     row_count,
                 }) => {
-                    if let Some(dsn) = &state.session.dsn {
+                    if let Some(dsn) = state.session.dsn() {
                         Some(vec![Effect::ExportCsv {
-                            dsn: dsn.clone(),
+                            dsn: dsn.to_string(),
                             query: export_query,
                             file_name,
                             row_count,
-                            read_only: state.session.read_only,
+                            read_only: state.session.is_read_only(),
                         }])
                     } else {
                         Some(vec![])
@@ -327,7 +327,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
 
             if matches!(intent, Some(ConfirmIntent::QuitNoConnection)) {
                 state.connection_setup.reset();
-                if !state.connections().is_empty() || state.session.dsn.is_some() {
+                if !state.connections().is_empty() || state.session.dsn().is_some() {
                     state.connection_setup.is_first_run = false;
                 }
                 state.modal.pop_mode_override(InputMode::ConnectionSetup);
@@ -405,7 +405,7 @@ mod tests {
             fn execute_write_sets_running_state_and_returns_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::CellEdit);
-                state.session.dsn = Some("postgres://localhost/test".to_string());
+                state.session.set_dsn_for_test("postgres://localhost/test");
                 state.confirm_dialog.open(
                     "",
                     "",
@@ -429,7 +429,7 @@ mod tests {
             fn execute_write_no_dsn_sets_error() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                state.session.dsn = None;
+                state.session.clear_dsn_for_test();
                 state.confirm_dialog.open(
                     "",
                     "",
@@ -513,7 +513,7 @@ mod tests {
             fn csv_export_returns_export_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                state.session.dsn = Some("postgres://localhost/test".to_string());
+                state.session.set_dsn_for_test("postgres://localhost/test");
                 state.confirm_dialog.open(
                     "",
                     "",
@@ -535,7 +535,7 @@ mod tests {
             #[test]
             fn disable_read_only_confirm_sets_read_only_false() {
                 let mut state = create_test_state();
-                state.session.read_only = true;
+                state.session.enable_read_only();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
                 state
                     .confirm_dialog
@@ -545,7 +545,7 @@ mod tests {
                     reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now())
                         .unwrap();
 
-                assert!(!state.session.read_only);
+                assert!(!state.session.is_read_only());
                 assert_eq!(state.input_mode(), InputMode::Normal);
                 assert!(effects.is_empty());
             }
@@ -744,7 +744,9 @@ mod tests {
 
         fn connected_state() -> AppState {
             let mut state = create_test_state();
-            state.session.active_connection_id = Some(ConnectionId::from_string("test-conn"));
+            state
+                .session
+                .set_active_connection_id_for_test(Some(ConnectionId::from_string("test-conn")));
             state.runtime.project_name = "test-project".to_string();
             state
         }
@@ -760,7 +762,7 @@ mod tests {
             #[test]
             fn open_when_not_connected_is_noop() {
                 let mut state = create_test_state();
-                state.session.active_connection_id = None;
+                state.session.set_active_connection_id_for_test(None);
 
                 let effects = reduce_modal(
                     &mut state,

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -329,7 +329,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             if matches!(intent, Some(ConfirmIntent::QuitNoConnection)) {
                 state.connection_setup.reset();
                 if !state.connections().is_empty() || state.session.dsn().is_some() {
-                    state.connection_setup.is_first_run = false;
+                    state.connection_setup.set_first_run(false);
                 }
                 state.modal.pop_mode_override(InputMode::ConnectionSetup);
                 Some(vec![])

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -445,10 +445,7 @@ mod tests {
                         .unwrap();
 
                 assert!(effects.is_empty());
-                assert_eq!(
-                    state.messages.last_error.as_deref(),
-                    Some("No active connection")
-                );
+                assert_eq!(state.messages.last_error(), Some("No active connection"));
             }
 
             #[test]
@@ -900,11 +897,8 @@ mod tests {
                 )
                 .unwrap();
 
-                assert_eq!(
-                    state.messages.last_error.as_deref(),
-                    Some("IO error: disk error")
-                );
-                assert!(state.messages.expires_at.is_some());
+                assert_eq!(state.messages.last_error(), Some("IO error: disk error"));
+                assert!(state.messages.expires_at().is_some());
             }
 
             #[test]
@@ -921,7 +915,7 @@ mod tests {
                 )
                 .unwrap();
 
-                assert!(state.messages.last_error.is_none());
+                assert!(state.messages.last_error().is_none());
             }
 
             #[test]
@@ -938,7 +932,7 @@ mod tests {
                 )
                 .unwrap();
 
-                assert!(state.messages.last_error.is_none());
+                assert!(state.messages.last_error().is_none());
                 assert!(effects.is_empty());
             }
         }

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -152,8 +152,9 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                 state.set_error("No tables selected".to_string());
                 return Some(vec![]);
             }
-            state.er_preparation.target_tables =
-                state.ui.er_selected_tables.iter().cloned().collect();
+            state
+                .er_preparation
+                .set_target_tables(state.ui.er_selected_tables.iter().cloned().collect());
             state.modal.set_mode(InputMode::Normal);
             state.ui.er_picker.clear_filter();
             state.ui.er_selected_tables.clear();

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -148,9 +148,9 @@ fn select_table(state: &mut AppState, table: &TableSummary) -> Vec<Effect> {
     let table_name = table.name.clone();
 
     let mut effects = Vec::new();
-    if let Some(dsn) = &state.session.dsn {
+    if let Some(dsn) = state.session.dsn() {
         effects.push(Effect::FetchTableDetail {
-            dsn: dsn.clone(),
+            dsn: dsn.to_string(),
             schema: schema.clone(),
             table: table_name.clone(),
             generation,
@@ -1093,7 +1093,7 @@ mod tests {
         #[test]
         fn load_metadata_with_dsn_returns_fetch_effect() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::LoadMetadata, now, &AppServices::stub());
@@ -1109,7 +1109,7 @@ mod tests {
         #[test]
         fn load_metadata_without_dsn_returns_no_effects() {
             let mut state = create_test_state();
-            state.session.dsn = None;
+            state.session.clear_dsn_for_test();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::LoadMetadata, now, &AppServices::stub());
@@ -1120,7 +1120,7 @@ mod tests {
         #[test]
         fn reload_metadata_returns_sequence_effect() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -1144,7 +1144,7 @@ mod tests {
         #[test]
         fn reload_metadata_sets_is_reloading_flag() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let now = Instant::now();
 
             reduce(
@@ -1154,13 +1154,13 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert!(state.session.is_reloading);
+            assert!(state.session.is_reloading());
         }
 
         #[test]
         fn reload_then_metadata_loaded_shows_reloaded_message() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let now = Instant::now();
 
             // Trigger reload
@@ -1170,7 +1170,7 @@ mod tests {
                 now,
                 &AppServices::stub(),
             );
-            assert!(state.session.is_reloading);
+            assert!(state.session.is_reloading());
 
             // Metadata loaded
             let metadata = DatabaseMetadata {
@@ -1187,14 +1187,14 @@ mod tests {
             );
 
             // Check reloading flag is cleared and message is shown
-            assert!(!state.session.is_reloading);
+            assert!(!state.session.is_reloading());
             assert_eq!(state.messages.last_success, Some("Reloaded!".to_string()));
         }
 
         #[test]
         fn execute_adhoc_with_dsn_returns_effect() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -1228,7 +1228,7 @@ mod tests {
         #[test]
         fn always_emits_smart_refresh_even_with_pending_tables() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1253,7 +1253,7 @@ mod tests {
         #[test]
         fn prefetch_started_true_emits_smart_refresh() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1273,7 +1273,7 @@ mod tests {
         #[test]
         fn no_prefetch_emits_smart_refresh() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1546,16 +1546,13 @@ mod tests {
             );
 
             assert!(!state.connection_setup.is_first_run);
+            assert_eq!(state.session.dsn(), Some("postgres://db.example.com/mydb"));
             assert_eq!(
-                state.session.dsn,
-                Some("postgres://db.example.com/mydb".to_string())
+                state.session.active_connection_name(),
+                Some("Test Connection")
             );
             assert_eq!(
-                state.session.active_connection_name,
-                Some("Test Connection".to_string())
-            );
-            assert_eq!(
-                state.session.active_database_type,
+                state.session.active_database_type(),
                 Some(DatabaseType::PostgreSQL)
             );
             assert_eq!(state.input_mode(), InputMode::Normal);
@@ -1676,7 +1673,7 @@ mod tests {
             };
 
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             let delete_sql = "DELETE FROM \"public\".\"users\"\nWHERE \"id\" = '2';".to_string();
@@ -1749,7 +1746,7 @@ mod tests {
             };
 
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             state.result_interaction.set_write_preview(WritePreview {
@@ -1808,7 +1805,7 @@ mod tests {
         #[test]
         fn try_connect_with_dsn_starts_connecting() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -1829,7 +1826,7 @@ mod tests {
         #[test]
         fn try_connect_without_dsn_does_nothing() {
             let mut state = create_test_state();
-            state.session.dsn = None;
+            state.session.clear_dsn_for_test();
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -1845,7 +1842,7 @@ mod tests {
         #[test]
         fn try_connect_when_already_connecting_is_noop() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
@@ -1861,7 +1858,7 @@ mod tests {
         #[test]
         fn try_connect_when_already_connected_is_noop() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -1877,7 +1874,7 @@ mod tests {
         #[test]
         fn try_connect_when_not_in_normal_mode_is_noop() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -2066,7 +2063,9 @@ mod tests {
             let conn_a = ConnectionId::new();
             let conn_b = ConnectionId::new();
 
-            state.session.active_connection_id = Some(conn_a.clone());
+            state
+                .session
+                .set_active_connection_id_for_test(Some(conn_a.clone()));
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -2085,7 +2084,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.session.active_connection_id, Some(conn_b));
+            assert_eq!(state.session.active_connection_id().cloned(), Some(conn_b));
             assert!(state.session.connection_state().is_connecting());
             assert!(state.connection_caches.get(&conn_a).is_some());
             assert_eq!(
@@ -2107,7 +2106,9 @@ mod tests {
             let conn_a = ConnectionId::new();
             let conn_b = ConnectionId::new();
 
-            state.session.active_connection_id = Some(conn_a);
+            state
+                .session
+                .set_active_connection_id_for_test(Some(conn_a));
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -2139,7 +2140,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.session.active_connection_id, Some(conn_b));
+            assert_eq!(state.session.active_connection_id().cloned(), Some(conn_b));
             assert!(state.session.connection_state().is_connected());
             assert_eq!(state.ui.explorer_selected, 10);
             assert_eq!(state.ui.inspector_tab, InspectorTab::Indexes);
@@ -2352,7 +2353,7 @@ mod tests {
         #[test]
         fn target_tables_survive_er_open() {
             let mut state = state_with_metadata();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.sql_modal.begin_prefetch();
             state.er_preparation.target_tables = vec!["public.users".to_string()];
             let now = Instant::now();
@@ -2445,7 +2446,7 @@ mod tests {
 
         fn state_after_confirm_and_complete() -> (AppState, Instant) {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let now = Instant::now();
 
             // Load metadata with a table
@@ -2618,7 +2619,7 @@ mod tests {
             let entry_index = palette_index_of(|a| matches!(a, Action::ReloadMetadata));
 
             let mut state = state_in_palette_mode();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.ui.table_picker.set_selection(entry_index);
             let now = Instant::now();
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2513,11 +2513,11 @@ mod tests {
         fn confirm_selection_initializes_pagination_via_dispatch() {
             let (state, _now) = state_after_confirm_and_complete();
 
-            assert_eq!(state.query.pagination.schema, "public");
-            assert_eq!(state.query.pagination.table, "users");
-            assert_eq!(state.query.pagination.total_rows_estimate, Some(1200));
-            assert_eq!(state.query.pagination.current_page, 0);
-            assert!(!state.query.pagination.reached_end);
+            assert_eq!(state.query.pagination.schema(), "public");
+            assert_eq!(state.query.pagination.table(), "users");
+            assert_eq!(state.query.pagination.total_rows_estimate(), Some(1200));
+            assert_eq!(state.query.pagination.current_page(), 0);
+            assert!(!state.query.pagination.reached_end());
         }
 
         #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1342,10 +1342,7 @@ mod tests {
         #[test]
         fn emits_cache_effect() {
             let mut state = create_test_state();
-            state
-                .sql_modal
-                .prefetching_tables
-                .insert("public.users".to_string());
+            state.sql_modal.mark_prefetching("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(
@@ -1364,7 +1361,12 @@ mod tests {
                 effects[0],
                 Effect::CacheTableInCompletionEngine { .. }
             ));
-            assert!(!state.sql_modal.prefetching_tables.contains("public.users"));
+            assert!(
+                !state
+                    .sql_modal
+                    .prefetching_tables()
+                    .contains("public.users")
+            );
         }
 
         #[test]
@@ -1372,8 +1374,7 @@ mod tests {
             let mut state = create_test_state();
             state
                 .sql_modal
-                .prefetch_queue
-                .push_back("public.orders".to_string());
+                .enqueue_prefetch("public.orders".to_string());
             let now = Instant::now();
 
             let effects = reduce(

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2080,11 +2080,46 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.connection_setup.host().content(), "custom-host");
-            assert_eq!(state.connection_setup.port().content(), "5433");
-            assert_eq!(state.connection_setup.database().content(), "mydb");
-            assert_eq!(state.connection_setup.user().content(), "admin");
-            assert_eq!(state.connection_setup.password().content(), "secret");
+            assert_eq!(
+                state
+                    .connection_setup
+                    .input(ConnectionField::Host)
+                    .unwrap()
+                    .content(),
+                "custom-host"
+            );
+            assert_eq!(
+                state
+                    .connection_setup
+                    .input(ConnectionField::Port)
+                    .unwrap()
+                    .content(),
+                "5433"
+            );
+            assert_eq!(
+                state
+                    .connection_setup
+                    .input(ConnectionField::Database)
+                    .unwrap()
+                    .content(),
+                "mydb"
+            );
+            assert_eq!(
+                state
+                    .connection_setup
+                    .input(ConnectionField::User)
+                    .unwrap()
+                    .content(),
+                "admin"
+            );
+            assert_eq!(
+                state
+                    .connection_setup
+                    .input(ConnectionField::Password)
+                    .unwrap()
+                    .content(),
+                "secret"
+            );
         }
 
         #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1421,15 +1421,27 @@ mod tests {
         ) {
             let mut state = setup_state();
             match field {
-                ConnectionField::Host => state.host.set_content(value.to_string()),
-                ConnectionField::Database => state.database.set_content(value.to_string()),
-                ConnectionField::User => state.user.set_content(value.to_string()),
+                ConnectionField::Host => state
+                    .input_mut(ConnectionField::Host)
+                    .unwrap()
+                    .set_content(value.to_string()),
+                ConnectionField::Database => state
+                    .input_mut(ConnectionField::Database)
+                    .unwrap()
+                    .set_content(value.to_string()),
+                ConnectionField::User => state
+                    .input_mut(ConnectionField::User)
+                    .unwrap()
+                    .set_content(value.to_string()),
                 _ => {}
             }
 
             validate_field(&mut state, field);
 
-            assert_eq!(state.validation_errors.contains_key(&field), has_error);
+            assert_eq!(
+                state.validation_errors_for_test().contains_key(&field),
+                has_error
+            );
         }
 
         #[rstest]
@@ -1437,11 +1449,18 @@ mod tests {
         #[case("abc")]
         fn port_validation_invalid_format(#[case] value: &str) {
             let mut state = setup_state();
-            state.port.set_content(value.to_string());
+            state
+                .input_mut(ConnectionField::Port)
+                .unwrap()
+                .set_content(value.to_string());
 
             validate_field(&mut state, ConnectionField::Port);
 
-            assert!(state.validation_errors.contains_key(&ConnectionField::Port));
+            assert!(
+                state
+                    .validation_errors_for_test()
+                    .contains_key(&ConnectionField::Port)
+            );
         }
 
         #[rstest]
@@ -1450,11 +1469,18 @@ mod tests {
         #[case("99999")]
         fn port_validation_out_of_range(#[case] value: &str) {
             let mut state = setup_state();
-            state.port.set_content(value.to_string());
+            state
+                .input_mut(ConnectionField::Port)
+                .unwrap()
+                .set_content(value.to_string());
 
             validate_field(&mut state, ConnectionField::Port);
 
-            assert!(state.validation_errors.contains_key(&ConnectionField::Port));
+            assert!(
+                state
+                    .validation_errors_for_test()
+                    .contains_key(&ConnectionField::Port)
+            );
         }
 
         #[rstest]
@@ -1463,11 +1489,18 @@ mod tests {
         #[case("65535")]
         fn port_validation_valid_range(#[case] value: &str) {
             let mut state = setup_state();
-            state.port.set_content(value.to_string());
+            state
+                .input_mut(ConnectionField::Port)
+                .unwrap()
+                .set_content(value.to_string());
 
             validate_field(&mut state, ConnectionField::Port);
 
-            assert!(!state.validation_errors.contains_key(&ConnectionField::Port));
+            assert!(
+                !state
+                    .validation_errors_for_test()
+                    .contains_key(&ConnectionField::Port)
+            );
         }
 
         #[rstest]
@@ -1475,39 +1508,54 @@ mod tests {
         #[case(ConnectionField::SslMode)]
         fn optional_fields_never_error(#[case] field: ConnectionField) {
             let mut state = setup_state();
-            state.password = TextInputState::default();
+            state.set_input_for_test(ConnectionField::Password, TextInputState::default());
 
             validate_field(&mut state, field);
 
-            assert!(!state.validation_errors.contains_key(&field));
+            assert!(!state.validation_errors_for_test().contains_key(&field));
         }
 
         #[test]
         fn validate_all_checks_all_required_fields() {
             let mut state = setup_state();
-            state.host = TextInputState::default();
-            state.port.set_content("invalid".to_string());
-            state.database = TextInputState::default();
-            state.user = TextInputState::default();
+            state.set_input_for_test(ConnectionField::Host, TextInputState::default());
+            state
+                .input_mut(ConnectionField::Port)
+                .unwrap()
+                .set_content("invalid".to_string());
+            state.set_input_for_test(ConnectionField::Database, TextInputState::default());
+            state.set_input_for_test(ConnectionField::User, TextInputState::default());
 
             validate_all(&mut state);
 
-            assert!(state.validation_errors.contains_key(&ConnectionField::Host));
-            assert!(state.validation_errors.contains_key(&ConnectionField::Port));
             assert!(
                 state
-                    .validation_errors
+                    .validation_errors_for_test()
+                    .contains_key(&ConnectionField::Host)
+            );
+            assert!(
+                state
+                    .validation_errors_for_test()
+                    .contains_key(&ConnectionField::Port)
+            );
+            assert!(
+                state
+                    .validation_errors_for_test()
                     .contains_key(&ConnectionField::Database)
             );
-            assert!(state.validation_errors.contains_key(&ConnectionField::User));
+            assert!(
+                state
+                    .validation_errors_for_test()
+                    .contains_key(&ConnectionField::User)
+            );
             assert!(
                 !state
-                    .validation_errors
+                    .validation_errors_for_test()
                     .contains_key(&ConnectionField::Password)
             );
             assert!(
                 !state
-                    .validation_errors
+                    .validation_errors_for_test()
                     .contains_key(&ConnectionField::SslMode)
             );
         }
@@ -1516,20 +1564,27 @@ mod tests {
     mod connection_setup_transitions {
         use super::*;
         use crate::domain::{ConnectionId, DatabaseType};
+        use crate::model::connection::setup::ConnectionField;
 
         #[test]
         fn save_completed_sets_dsn_and_returns_fetch_effect() {
             let mut state = create_test_state();
             state.modal.set_mode(InputMode::ConnectionSetup);
-            state.connection_setup.is_first_run = true;
+            state.connection_setup.set_first_run(true);
             state
                 .connection_setup
-                .host
+                .input_mut(ConnectionField::Host)
+                .unwrap()
                 .set_content("db.example.com".to_string());
-            state.connection_setup.port.set_content("5432".to_string());
             state
                 .connection_setup
-                .database
+                .input_mut(ConnectionField::Port)
+                .unwrap()
+                .set_content("5432".to_string());
+            state
+                .connection_setup
+                .input_mut(ConnectionField::Database)
+                .unwrap()
                 .set_content("mydb".to_string());
             let now = Instant::now();
 
@@ -1545,7 +1600,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert!(!state.connection_setup.is_first_run);
+            assert!(!state.connection_setup.is_first_run());
             assert_eq!(state.session.dsn(), Some("postgres://db.example.com/mydb"));
             assert_eq!(
                 state.session.active_connection_name(),
@@ -1583,7 +1638,7 @@ mod tests {
         fn cancel_on_first_run_opens_confirm_dialog() {
             let mut state = create_test_state();
             state.modal.set_mode(InputMode::ConnectionSetup);
-            state.connection_setup.is_first_run = true;
+            state.connection_setup.set_first_run(true);
             let now = Instant::now();
 
             let effects = reduce(
@@ -1605,7 +1660,7 @@ mod tests {
         fn cancel_after_save_returns_to_normal_and_dispatches_try_connect() {
             let mut state = create_test_state();
             state.modal.set_mode(InputMode::ConnectionSetup);
-            state.connection_setup.is_first_run = false;
+            state.connection_setup.set_first_run(false);
             let now = Instant::now();
 
             let effects = reduce(
@@ -1793,6 +1848,7 @@ mod tests {
     mod connection_state_tests {
         use super::*;
         use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, MetadataState};
+        use crate::model::connection::setup::ConnectionField;
         use crate::model::connection::state::ConnectionState;
 
         #[test]
@@ -1991,17 +2047,28 @@ mod tests {
             let mut state = create_test_state();
             state
                 .connection_setup
-                .host
+                .input_mut(ConnectionField::Host)
+                .unwrap()
                 .set_content("custom-host".to_string());
-            state.connection_setup.port.set_content("5433".to_string());
             state
                 .connection_setup
-                .database
+                .input_mut(ConnectionField::Port)
+                .unwrap()
+                .set_content("5433".to_string());
+            state
+                .connection_setup
+                .input_mut(ConnectionField::Database)
+                .unwrap()
                 .set_content("mydb".to_string());
-            state.connection_setup.user.set_content("admin".to_string());
             state
                 .connection_setup
-                .password
+                .input_mut(ConnectionField::User)
+                .unwrap()
+                .set_content("admin".to_string());
+            state
+                .connection_setup
+                .input_mut(ConnectionField::Password)
+                .unwrap()
                 .set_content("secret".to_string());
             state.session.set_connection_state(ConnectionState::Failed);
             let now = Instant::now();
@@ -2013,11 +2080,11 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.connection_setup.host.content(), "custom-host");
-            assert_eq!(state.connection_setup.port.content(), "5433");
-            assert_eq!(state.connection_setup.database.content(), "mydb");
-            assert_eq!(state.connection_setup.user.content(), "admin");
-            assert_eq!(state.connection_setup.password.content(), "secret");
+            assert_eq!(state.connection_setup.host().content(), "custom-host");
+            assert_eq!(state.connection_setup.port().content(), "5433");
+            assert_eq!(state.connection_setup.database().content(), "mydb");
+            assert_eq!(state.connection_setup.user().content(), "admin");
+            assert_eq!(state.connection_setup.password().content(), "secret");
         }
 
         #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -93,7 +93,7 @@ fn reduce_inner(
                     return select_table(state, &table);
                 }
             } else if state.modal.active_mode() == InputMode::Normal {
-                if state.connection_error.error_info.is_some() {
+                if state.connection_error.has_error() {
                     state.modal.replace_mode(InputMode::ConnectionError);
                     return vec![];
                 }
@@ -844,7 +844,7 @@ mod tests {
                 MetadataState::Error(_)
             ));
             assert_eq!(state.input_mode(), InputMode::ConnectionError);
-            assert!(state.connection_error.error_info.is_some());
+            assert!(state.connection_error.has_error());
             assert!(effects.is_empty());
         }
 
@@ -887,8 +887,8 @@ mod tests {
         #[test]
         fn close_keeps_error_info_for_reopen() {
             let mut state = state_with_error();
-            state.connection_error.details_expanded = true;
-            state.connection_error.scroll_offset = 5;
+            state.connection_error.expand_details();
+            state.connection_error.scroll_down(5);
             let now = Instant::now();
 
             reduce(
@@ -899,11 +899,11 @@ mod tests {
             );
 
             // error_info is kept so Enter can re-open modal
-            assert!(state.connection_error.error_info.is_some());
+            assert!(state.connection_error.has_error());
             assert_eq!(state.input_mode(), InputMode::Normal);
             // UI state is reset
-            assert!(!state.connection_error.details_expanded);
-            assert_eq!(state.connection_error.scroll_offset, 0);
+            assert!(!state.connection_error.details_expanded());
+            assert_eq!(state.connection_error.scroll_offset(), 0);
         }
 
         #[test]
@@ -950,14 +950,14 @@ mod tests {
                 &AppServices::stub(),
             );
             assert_eq!(state.input_mode(), InputMode::ConnectionError);
-            assert!(state.connection_error.error_info.is_some());
+            assert!(state.connection_error.has_error());
         }
 
         #[test]
         fn toggle_details_flips_expanded_state() {
             let mut state = state_with_error();
             let now = Instant::now();
-            assert!(!state.connection_error.details_expanded);
+            assert!(!state.connection_error.details_expanded());
 
             reduce(
                 &mut state,
@@ -965,7 +965,7 @@ mod tests {
                 now,
                 &AppServices::stub(),
             );
-            assert!(state.connection_error.details_expanded);
+            assert!(state.connection_error.details_expanded());
 
             reduce(
                 &mut state,
@@ -973,7 +973,7 @@ mod tests {
                 now,
                 &AppServices::stub(),
             );
-            assert!(!state.connection_error.details_expanded);
+            assert!(!state.connection_error.details_expanded());
         }
 
         #[test]
@@ -1188,7 +1188,7 @@ mod tests {
 
             // Check reloading flag is cleared and message is shown
             assert!(!state.session.is_reloading());
-            assert_eq!(state.messages.last_success, Some("Reloaded!".to_string()));
+            assert_eq!(state.messages.last_success(), Some("Reloaded!"));
         }
 
         #[test]
@@ -1296,7 +1296,7 @@ mod tests {
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
 
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
             assert!(effects.is_empty());
         }
 
@@ -1575,7 +1575,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
             assert!(effects.is_empty());
         }
 
@@ -1727,14 +1727,7 @@ mod tests {
 
             // After success, preview is cleaned up and delete message is shown
             assert!(state.result_interaction.pending_write_preview().is_none());
-            assert!(
-                state
-                    .messages
-                    .last_success
-                    .as_deref()
-                    .unwrap()
-                    .contains("Deleted")
-            );
+            assert!(state.messages.last_success().unwrap().contains("Deleted"));
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::ExecutePreview { .. }));
         }
@@ -2206,7 +2199,7 @@ mod tests {
             );
 
             assert!(state.ui.pending_er_picker);
-            assert!(state.messages.last_success.is_some());
+            assert!(state.messages.last_success().is_some());
             assert_ne!(state.input_mode(), InputMode::ErTablePicker);
             assert!(effects.is_empty());
         }
@@ -2346,7 +2339,7 @@ mod tests {
             );
 
             assert_eq!(state.input_mode(), InputMode::ErTablePicker);
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
             assert!(effects.is_empty());
         }
 
@@ -2433,7 +2426,7 @@ mod tests {
                 matches!(e, Effect::DispatchActions(actions)
                     if actions.iter().any(|a| matches!(a, Action::ErOpenDiagram)))
             }));
-            assert!(state.messages.last_error.is_some());
+            assert!(state.messages.last_error().is_some());
         }
     }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1217,7 +1217,7 @@ mod tests {
         #[test]
         fn er_open_while_rendering_returns_no_effects() {
             let mut state = create_test_state();
-            state.er_preparation.status = ErStatus::Rendering;
+            state.er_preparation.mark_rendering();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
@@ -1238,13 +1238,12 @@ mod tests {
             state.sql_modal.begin_prefetch();
             state
                 .er_preparation
-                .pending_tables
-                .insert("public.users".to_string());
+                .insert_pending_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
 
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
             assert!(!state.sql_modal.is_prefetch_started());
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
@@ -1284,7 +1283,7 @@ mod tests {
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
 
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
         }
@@ -1304,7 +1303,7 @@ mod tests {
         #[test]
         fn metadata_failed_resets_er_waiting_to_idle() {
             let mut state = create_test_state();
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
             let now = Instant::now();
 
             reduce(
@@ -1316,7 +1315,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
         }
     }
 
@@ -2323,7 +2322,7 @@ mod tests {
             );
 
             assert_eq!(
-                state.er_preparation.target_tables,
+                state.er_preparation.target_tables(),
                 vec!["public.users".to_string()]
             );
             assert_eq!(state.input_mode(), InputMode::Normal);
@@ -2355,7 +2354,9 @@ mod tests {
             let mut state = state_with_metadata();
             state.session.set_dsn_for_test("postgres://localhost/test");
             state.sql_modal.begin_prefetch();
-            state.er_preparation.target_tables = vec!["public.users".to_string()];
+            state
+                .er_preparation
+                .set_target_tables(vec!["public.users".to_string()]);
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
@@ -2363,7 +2364,7 @@ mod tests {
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
             assert_eq!(
-                state.er_preparation.target_tables,
+                state.er_preparation.target_tables(),
                 vec!["public.users".to_string()]
             );
         }
@@ -2374,13 +2375,12 @@ mod tests {
 
             let mut state = state_with_metadata();
             state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.total_tables = 1;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
+            state.er_preparation.set_total_tables(1);
+            state.er_preparation.set_fk_expanded(true);
             state
                 .er_preparation
-                .pending_tables
-                .insert("public.users".to_string());
+                .insert_pending_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(
@@ -2393,7 +2393,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(effects.iter().any(|e| {
                 matches!(e, Effect::DispatchActions(actions)
                     if actions.iter().any(|a| matches!(a, Action::ErGenerateFromCache)))
@@ -2406,17 +2406,15 @@ mod tests {
 
             let mut state = state_with_metadata();
             state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.total_tables = 2;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.set_status_for_test(ErStatus::Waiting);
+            state.er_preparation.set_total_tables(2);
+            state.er_preparation.set_fk_expanded(true);
             state
                 .er_preparation
-                .failed_tables
-                .insert("public.posts".to_string(), "timeout".to_string());
+                .on_table_failed("public.posts", "timeout".to_string());
             state
                 .er_preparation
-                .pending_tables
-                .insert("public.users".to_string());
+                .insert_pending_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(
@@ -2429,7 +2427,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(!effects.iter().any(|e| {
                 matches!(e, Effect::DispatchActions(actions)
                     if actions.iter().any(|a| matches!(a, Action::ErOpenDiagram)))

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -888,7 +888,7 @@ mod tests {
         fn close_keeps_error_info_for_reopen() {
             let mut state = state_with_error();
             state.connection_error.expand_details();
-            state.connection_error.scroll_down(5);
+            state.connection_error.set_scroll_offset_for_test(5);
             let now = Instant::now();
 
             reduce(
@@ -2350,7 +2350,7 @@ mod tests {
             state.sql_modal.begin_prefetch();
             state
                 .er_preparation
-                .set_target_tables(vec!["public.users".to_string()]);
+                .set_targets(vec!["public.users".to_string()]);
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
@@ -2370,8 +2370,7 @@ mod tests {
             let mut state = state_with_metadata();
             state.sql_modal.begin_prefetch();
             state.er_preparation.set_status_for_test(ErStatus::Waiting);
-            state.er_preparation.set_total_tables(1);
-            state.er_preparation.set_fk_expanded(true);
+            state.er_preparation.begin_full_prefetch(1);
             state
                 .er_preparation
                 .insert_pending_table("public.users".to_string());
@@ -2401,8 +2400,7 @@ mod tests {
             let mut state = state_with_metadata();
             state.sql_modal.begin_prefetch();
             state.er_preparation.set_status_for_test(ErStatus::Waiting);
-            state.er_preparation.set_total_tables(2);
-            state.er_preparation.set_fk_expanded(true);
+            state.er_preparation.begin_full_prefetch(2);
             state
                 .er_preparation
                 .on_table_failed("public.posts", "timeout".to_string());

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -195,7 +195,7 @@ pub fn reduce_sql_modal(
                         let kind = statement_classifier::classify(s);
                         !matches!(kind, StatementKind::Select | StatementKind::Transaction)
                     });
-                    if state.session.read_only && has_write {
+                    if state.session.is_read_only() && has_write {
                         state.sql_modal.finish_adhoc_error(
                             "Read-only mode: write operations are disabled".to_string(),
                         );
@@ -274,11 +274,11 @@ pub fn reduce_sql_modal(
             if matched {
                 let query = state.sql_modal.editor.content().trim().to_string();
                 state.sql_modal.begin_adhoc_running();
-                if let Some(dsn) = &state.session.dsn {
+                if let Some(dsn) = state.session.dsn() {
                     return Some(vec![Effect::ExecuteAdhoc {
-                        dsn: dsn.clone(),
+                        dsn: dsn.to_string(),
                         query,
-                        read_only: state.session.read_only,
+                        read_only: state.session.is_read_only(),
                     }]);
                 }
             }
@@ -445,11 +445,11 @@ fn multi_statement_label(sql: &str) -> &'static str {
 }
 
 fn adhoc_effects(state: &AppState, query: String) -> Vec<Effect> {
-    match &state.session.dsn {
+    match state.session.dsn() {
         Some(dsn) => vec![Effect::ExecuteAdhoc {
-            dsn: dsn.clone(),
+            dsn: dsn.to_string(),
             query,
-            read_only: state.session.read_only,
+            read_only: state.session.is_read_only(),
         }],
         None => vec![],
     }
@@ -701,7 +701,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT * INTO backup FROM users".to_string());
-            state.session.dsn = Some("postgres://test".to_string());
+            state.session.set_dsn_for_test("postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -715,7 +715,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("COPY users FROM '/tmp/data.csv'".to_string());
-            state.session.dsn = Some("postgres://test".to_string());
+            state.session.set_dsn_for_test("postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -729,7 +729,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("UPDATE users SET x=1 WHERE id=1".to_string());
-            state.session.dsn = Some("postgres://test".to_string());
+            state.session.set_dsn_for_test("postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -794,7 +794,7 @@ mod tests {
         #[test]
         fn high_risk_confirm_executes_on_match() {
             let mut state = confirming_high_state("DROP TABLE users", Some("users"));
-            state.session.dsn = Some("postgres://test".to_string());
+            state.session.set_dsn_for_test("postgres://test");
             for c in "users".chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -979,7 +979,7 @@ mod tests {
             let full_name = "my_schema.very_long_table_name";
             let mut state =
                 confirming_high_state(&format!("DROP TABLE {full_name}"), Some(full_name));
-            state.session.dsn = Some("postgres://test".to_string());
+            state.session.set_dsn_for_test("postgres://test");
             for c in full_name.chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -1016,8 +1016,8 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id = 1".to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
-            state.session.read_only = true;
+            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.enable_read_only();
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now()).unwrap();
@@ -1034,8 +1034,8 @@ mod tests {
         fn read_only_reject_clears_prior_success() {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
-            state.session.dsn = Some("postgres://localhost/test".to_string());
-            state.session.read_only = true;
+            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.enable_read_only();
 
             // Simulate a prior adhoc success
             state.sql_modal.finish_adhoc_success(
@@ -1064,8 +1064,8 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
-            state.session.read_only = true;
+            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.enable_read_only();
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now()).unwrap();
@@ -1083,7 +1083,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content(query.to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
         }
 

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -356,7 +356,7 @@ pub fn reduce_sql_modal(
                 .normalize_sql_modal_tab(state.sql_modal.active_tab());
             let content = match active_tab {
                 SqlModalTab::Plan => state.explain.plan_text().map(str::to_string),
-                SqlModalTab::Compare => match (state.explain.left(), state.explain.right()) {
+                SqlModalTab::Compare => match state.explain.compare_slots() {
                     (Some(l), Some(r)) => {
                         let result = compare_plans(&l.plan, &r.plan);
                         let verdict = match result.verdict {

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -355,8 +355,8 @@ pub fn reduce_sql_modal(
                 .db_capabilities
                 .normalize_sql_modal_tab(state.sql_modal.active_tab());
             let content = match active_tab {
-                SqlModalTab::Plan => state.explain.plan_text.clone(),
-                SqlModalTab::Compare => match (&state.explain.left, &state.explain.right) {
+                SqlModalTab::Plan => state.explain.plan_text().map(str::to_string),
+                SqlModalTab::Compare => match (state.explain.left(), state.explain.right()) {
                     (Some(l), Some(r)) => {
                         let result = compare_plans(&l.plan, &r.plan);
                         let verdict = match result.verdict {
@@ -1339,7 +1339,9 @@ mod tests {
         fn plan_tab_yank_copies_plan_text() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
-            state.explain.plan_text = Some("Seq Scan on users".to_string());
+            state
+                .explain
+                .set_plan_text_for_test(Some("Seq Scan on users".to_string()));
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
@@ -1354,7 +1356,7 @@ mod tests {
         fn plan_tab_yank_no_plan_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
-            state.explain.plan_text = None;
+            state.explain.set_plan_text_for_test(None);
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
@@ -1366,8 +1368,10 @@ mod tests {
         fn plan_tab_yank_error_state_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
-            state.explain.plan_text = None;
-            state.explain.error = Some("syntax error".to_string());
+            state.explain.set_plan_text_for_test(None);
+            state
+                .explain
+                .set_error_for_test(Some("syntax error".to_string()));
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
@@ -1379,8 +1383,10 @@ mod tests {
         fn compare_tab_yank_both_slots() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
-            state.explain.left = Some(make_slot("Seq Scan", false, 420, SlotSource::AutoPrevious));
-            state.explain.right = Some(make_slot("Index Scan", true, 50, SlotSource::AutoLatest));
+            state.explain.set_compare_slots_for_test(
+                Some(make_slot("Seq Scan", false, 420, SlotSource::AutoPrevious)),
+                Some(make_slot("Index Scan", true, 50, SlotSource::AutoLatest)),
+            );
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
@@ -1403,8 +1409,10 @@ mod tests {
         fn both_auto_slots_yank_returns_distinguishable_headers() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
-            state.explain.left = Some(make_slot("Seq Scan", false, 300, SlotSource::AutoPrevious));
-            state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
+            state.explain.set_compare_slots_for_test(
+                Some(make_slot("Seq Scan", false, 300, SlotSource::AutoPrevious)),
+                Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest)),
+            );
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
@@ -1422,8 +1430,10 @@ mod tests {
         fn compare_tab_yank_right_only_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
-            state.explain.left = None;
-            state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
+            state.explain.set_compare_slots_for_test(
+                None,
+                Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest)),
+            );
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
@@ -1435,8 +1445,10 @@ mod tests {
         fn compare_tab_yank_left_only_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
-            state.explain.left = Some(make_slot("Seq Scan", false, 200, SlotSource::AutoPrevious));
-            state.explain.right = None;
+            state.explain.set_compare_slots_for_test(
+                Some(make_slot("Seq Scan", false, 200, SlotSource::AutoPrevious)),
+                None,
+            );
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
@@ -1448,8 +1460,7 @@ mod tests {
         fn compare_tab_yank_empty_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
-            state.explain.left = None;
-            state.explain.right = None;
+            state.explain.set_compare_slots_for_test(None, None);
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
@@ -1462,7 +1473,7 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             // Use parseable EXPLAIN output so compare_plans produces a real verdict
-            state.explain.left = Some(CompareSlot {
+            let left = CompareSlot {
                 plan: ExplainPlan {
                     raw_text: "Seq Scan on users  (cost=0.00..100.00 rows=10 width=32)".to_string(),
                     top_node_type: Some("Seq Scan".to_string()),
@@ -1474,8 +1485,8 @@ mod tests {
                 query_snippet: "SELECT *".to_string(),
                 full_query: "SELECT * FROM users".to_string(),
                 source: SlotSource::AutoPrevious,
-            });
-            state.explain.right = Some(CompareSlot {
+            };
+            let right = CompareSlot {
                 plan: ExplainPlan {
                     raw_text: "Index Scan using idx on users  (cost=0.00..5.00 rows=1 width=32)"
                         .to_string(),
@@ -1488,7 +1499,10 @@ mod tests {
                 query_snippet: "SELECT *".to_string(),
                 full_query: "SELECT * FROM users WHERE id=1".to_string(),
                 source: SlotSource::AutoLatest,
-            });
+            };
+            state
+                .explain
+                .set_compare_slots_for_test(Some(left), Some(right));
 
             let effects =
                 reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,7 +167,7 @@ async fn main() -> Result<()> {
     let initial_size = tui.terminal().size()?;
     state.ui.terminal_height = initial_size.height;
 
-    if state.session.dsn.is_some() && state.input_mode() == InputMode::Normal {
+    if state.session.dsn().is_some() && state.input_mode() == InputMode::Normal {
         process_action(
             Action::TryConnect,
             &mut state,

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ async fn main() -> Result<()> {
         Ok(profiles) if profiles.is_empty() => {
             load_service_entries(&mut state, Some(&*pg_service_entry_reader));
             if state.service_entries().is_empty() {
-                state.connection_setup.is_first_run = true;
+                state.connection_setup.set_first_run(true);
                 state.modal.set_mode(InputMode::ConnectionSetup);
             } else {
                 state.modal.set_mode(InputMode::ConnectionSelector);
@@ -156,7 +156,7 @@ async fn main() -> Result<()> {
             std::process::exit(1);
         }
         Err(_) => {
-            state.connection_setup.is_first_run = true;
+            state.connection_setup.set_first_run(true);
             state.modal.set_mode(InputMode::ConnectionSetup);
         }
     }

--- a/src/tests/harness/mod.rs
+++ b/src/tests/harness/mod.rs
@@ -23,7 +23,9 @@ pub fn test_instant() -> Instant {
 
 pub fn create_test_state() -> AppState {
     let mut state = AppState::new("test_project".to_string());
-    state.session.active_connection_name = Some("localhost:5432/test".to_string());
+    state
+        .session
+        .set_active_connection_name_for_test(Some("localhost:5432/test".to_string()));
     state
 }
 

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -123,7 +123,7 @@ fn connection_error_collapsed() {
             ConnectionErrorKind::HostUnreachable,
             "psql: error: could not translate host name \"db.example.com\" to address",
         ));
-    state.connection_error.details_expanded = false;
+    state.connection_error.reset_view();
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -140,7 +140,7 @@ fn connection_error_expanded() {
         ConnectionErrorKind::Timeout,
         "psql: error: connection to server at \"192.168.1.100\", port 5432 failed: timeout expired",
     ));
-    state.connection_error.details_expanded = true;
+    state.connection_error.expand_details();
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -157,7 +157,7 @@ fn connection_error_expanded_with_tabs() {
         ConnectionErrorKind::Unknown,
         "psql: error: connection to server at \"localhost\" (127.0.0.1), port 5433 failed: Connection refused\n\tIs the server running on that host and accepting TCP/IP connections?",
     ));
-    state.connection_error.details_expanded = true;
+    state.connection_error.expand_details();
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -181,7 +181,7 @@ fn connection_error_expanded_long_details_capped() {
             ConnectionErrorKind::Unknown,
             &long_details,
         ));
-    state.connection_error.details_expanded = true;
+    state.connection_error.expand_details();
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -193,7 +193,7 @@ fn footer_shows_success_message() {
     let mut state = create_test_state();
     let mut terminal = create_test_terminal();
 
-    state.messages.last_success = Some("Reconnected!".to_string());
+    state.messages.set_success("Reconnected!".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -8,11 +8,13 @@ fn connection_setup_form() {
     state.modal.set_mode(InputMode::ConnectionSetup);
     state
         .connection_setup
-        .database
+        .input_mut(ConnectionField::Database)
+        .unwrap()
         .set_content("mydb".to_string());
     state
         .connection_setup
-        .user
+        .input_mut(ConnectionField::User)
+        .unwrap()
         .set_content("postgres".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -31,7 +33,8 @@ fn connection_setup_sqlite_form() {
         .set_database_type(DatabaseType::SQLite);
     state
         .connection_setup
-        .sqlite_path
+        .input_mut(ConnectionField::SqlitePath)
+        .unwrap()
         .set_content("/tmp/app.db".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -45,8 +48,13 @@ fn connection_setup_cursor_at_head() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::ConnectionSetup);
-    state.connection_setup.focused_field = ConnectionField::Host;
-    state.connection_setup.host = TextInputState::new("db.example.com", 0);
+    state
+        .connection_setup
+        .set_focused_field_for_test(ConnectionField::Host);
+    state.connection_setup.set_input_for_test(
+        ConnectionField::Host,
+        TextInputState::new("db.example.com", 0),
+    );
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -59,8 +67,13 @@ fn connection_setup_cursor_at_middle() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::ConnectionSetup);
-    state.connection_setup.focused_field = ConnectionField::Host;
-    state.connection_setup.host = TextInputState::new("db.example.com", 7);
+    state
+        .connection_setup
+        .set_focused_field_for_test(ConnectionField::Host);
+    state.connection_setup.set_input_for_test(
+        ConnectionField::Host,
+        TextInputState::new("db.example.com", 7),
+    );
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -73,10 +86,13 @@ fn connection_setup_cursor_at_tail() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::ConnectionSetup);
-    state.connection_setup.focused_field = ConnectionField::Host;
     state
         .connection_setup
-        .host
+        .set_focused_field_for_test(ConnectionField::Host);
+    state
+        .connection_setup
+        .input_mut(ConnectionField::Host)
+        .unwrap()
         .set_content("db.example.com".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
@@ -90,21 +106,24 @@ fn connection_setup_with_validation_errors() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::ConnectionSetup);
-    state.connection_setup.host = TextInputState::default();
-    state.connection_setup.database = TextInputState::default();
-    state.connection_setup.user = TextInputState::default();
     state
         .connection_setup
-        .validation_errors
-        .insert(ConnectionField::Host, "Required".to_string());
+        .set_input_for_test(ConnectionField::Host, TextInputState::default());
     state
         .connection_setup
-        .validation_errors
-        .insert(ConnectionField::Database, "Required".to_string());
+        .set_input_for_test(ConnectionField::Database, TextInputState::default());
     state
         .connection_setup
-        .validation_errors
-        .insert(ConnectionField::User, "Required".to_string());
+        .set_input_for_test(ConnectionField::User, TextInputState::default());
+    state
+        .connection_setup
+        .set_validation_error(ConnectionField::Host, "Required");
+    state
+        .connection_setup
+        .set_validation_error(ConnectionField::Database, "Required");
+    state
+        .connection_setup
+        .set_validation_error(ConnectionField::User, "Required");
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/connection_management.rs
+++ b/src/tests/render_snapshots/connection_management.rs
@@ -48,7 +48,9 @@ fn connection_selector_with_multiple_connections() {
 
     let (active_id, connections) = three_connections();
     state.set_connections(connections);
-    state.session.active_connection_id = Some(active_id);
+    state
+        .session
+        .set_active_connection_id_for_test(Some(active_id));
     state.modal.set_mode(InputMode::ConnectionSelector);
     state.ui.set_connection_list_selection(Some(0));
 
@@ -82,7 +84,9 @@ fn connection_selector_with_service_entries() {
             },
         ],
     );
-    state.session.active_connection_id = Some(active_id);
+    state
+        .session
+        .set_active_connection_id_for_test(Some(active_id));
     state.modal.set_mode(InputMode::ConnectionSelector);
     state.ui.set_connection_list_selection(Some(0));
 
@@ -142,8 +146,11 @@ fn connection_selector_with_active_service() {
         },
     ]);
     // Set active connection to the first service entry
-    state.session.active_connection_id =
-        Some(ConnectionId::from_string("service:dev-local".to_string()));
+    state
+        .session
+        .set_active_connection_id_for_test(Some(ConnectionId::from_string(
+            "service:dev-local".to_string(),
+        )));
     state.modal.set_mode(InputMode::ConnectionSelector);
     state.ui.set_connection_list_selection(Some(0));
 

--- a/src/tests/render_snapshots/er_diagram.rs
+++ b/src/tests/render_snapshots/er_diagram.rs
@@ -6,16 +6,14 @@ fn er_waiting_progress() {
     let (mut state, _now) = explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    state.er_preparation.status = ErStatus::Waiting;
-    state.er_preparation.total_tables = 3;
+    state.er_preparation.set_status_for_test(ErStatus::Waiting);
+    state.er_preparation.set_total_tables(3);
     state
         .er_preparation
-        .pending_tables
-        .insert("public.comments".to_string());
+        .insert_pending_table("public.comments".to_string());
     state
         .er_preparation
-        .fetching_tables
-        .insert("public.posts".to_string());
+        .insert_fetching_table("public.posts".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/er_diagram.rs
+++ b/src/tests/render_snapshots/er_diagram.rs
@@ -7,7 +7,7 @@ fn er_waiting_progress() {
     let mut terminal = create_test_terminal();
 
     state.er_preparation.set_status_for_test(ErStatus::Waiting);
-    state.er_preparation.set_total_tables(3);
+    state.er_preparation.set_total_tables_for_test(3);
     state
         .er_preparation
         .insert_pending_table("public.comments".to_string());

--- a/src/tests/render_snapshots/initial_state.rs
+++ b/src/tests/render_snapshots/initial_state.rs
@@ -13,7 +13,7 @@ fn initial_state_no_metadata() {
 #[test]
 fn explorer_shows_not_connected_when_no_active_connection() {
     let mut state = create_test_state();
-    state.session.active_connection_name = None;
+    state.session.set_active_connection_name_for_test(None);
     let mut terminal = create_test_terminal();
 
     let output = render_to_string(&mut terminal, &mut state);

--- a/src/tests/render_snapshots/mod.rs
+++ b/src/tests/render_snapshots/mod.rs
@@ -6,9 +6,6 @@ use harness::{
     render_to_string, test_instant,
 };
 
-use std::sync::Arc;
-use std::time::Duration;
-
 use app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
 use app::model::connection::setup::ConnectionField;
 use app::model::er_state::ErStatus;
@@ -24,6 +21,7 @@ use app::policy::write::write_guardrails::{
 };
 use app::policy::write::write_update::normalize_for_diff;
 use domain::{CommandTag, DatabaseType, QuerySource};
+use std::sync::Arc;
 
 mod confirm_dialogs;
 mod connection_flow;

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -173,7 +173,7 @@ fn result_pane_cell_edit_cursor_at_tail() {
     state
         .result_interaction
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
-    let len = state.result_interaction.cell_edit().input.content().len();
+    let len = state.result_interaction.cell_edit().input().content().len();
     state
         .result_interaction
         .cell_edit_input_mut()

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -44,8 +44,7 @@ fn jsonb_detail_state() -> (AppState, std::time::Instant) {
         error: None,
         command_tag: None,
     }));
-    state.query.pagination.schema = "public".to_string();
-    state.query.pagination.table = "users".to_string();
+    state.query.pagination.set_table("public", "users");
     state.ui.focused_pane = FocusedPane::Result;
     state.result_interaction.activate_cell(0, 3);
     (state, now)

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -44,7 +44,7 @@ fn jsonb_detail_state() -> (AppState, std::time::Instant) {
         error: None,
         command_tag: None,
     }));
-    state.query.pagination.set_table("public", "users");
+    state.query.pagination.set_table_for_test("public", "users");
     state.ui.focused_pane = FocusedPane::Result;
     state.result_interaction.activate_cell(0, 3);
     (state, now)

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -68,8 +68,7 @@ fn jsonb_detail_state() -> (AppState, Instant) {
         error: None,
         command_tag: None,
     }));
-    state.query.pagination.schema = "public".to_string();
-    state.query.pagination.table = "users".to_string();
+    state.query.pagination.set_table("public", "users");
     state.ui.focused_pane = FocusedPane::Result;
     state.result_interaction.activate_cell(0, 3);
     reduce_result(

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -68,7 +68,7 @@ fn jsonb_detail_state() -> (AppState, Instant) {
         error: None,
         command_tag: None,
     }));
-    state.query.pagination.set_table("public", "users");
+    state.query.pagination.set_table_for_test("public", "users");
     state.ui.focused_pane = FocusedPane::Result;
     state.result_interaction.activate_cell(0, 3);
     reduce_result(

--- a/src/tests/render_snapshots/table_explorer.rs
+++ b/src/tests/render_snapshots/table_explorer.rs
@@ -49,8 +49,9 @@ fn error_message_in_footer() {
     let (mut state, now) = explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    state.messages.last_error = Some("Connection failed: timeout".to_string());
-    state.messages.expires_at = Some(now + Duration::from_secs(10));
+    state
+        .messages
+        .set_error_at("Connection failed: timeout".to_string(), now);
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/ui/adapters/tui_adapter.rs
+++ b/src/ui/adapters/tui_adapter.rs
@@ -54,7 +54,7 @@ impl Renderer for TuiAdapter<'_> {
 fn uses_insert_cursor(state: &AppState) -> bool {
     match state.input_mode() {
         InputMode::JsonbEdit => true,
-        InputMode::JsonbDetail => state.jsonb_detail.search().active,
+        InputMode::JsonbDetail => state.jsonb_detail.search().is_active(),
         InputMode::SqlModal => matches!(
             state.sql_modal.status(),
             crate::app::model::sql_editor::modal::SqlModalStatus::Editing

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -59,7 +59,7 @@ impl JsonbDetail {
             theme,
         );
 
-        let (editor_area, status_area, search_area) = if state.jsonb_detail.search().active {
+        let (editor_area, status_area, search_area) = if state.jsonb_detail.search().is_active() {
             let [editor_area, status_area, search_area] = Layout::vertical([
                 Constraint::Min(1),
                 Constraint::Length(1),
@@ -154,12 +154,12 @@ impl JsonbDetail {
 
     fn render_search(frame: &mut Frame, area: Rect, state: &AppState, theme: &ThemePalette) {
         let search = state.jsonb_detail.search();
-        let input = search.input.content();
-        let cursor = search.input.cursor();
-        let match_info = if search.matches.is_empty() {
+        let input = search.input().content();
+        let cursor = search.input().cursor();
+        let match_info = if search.matches().is_empty() {
             "0/0".to_string()
         } else {
-            format!("{}/{}", search.current_match + 1, search.matches.len())
+            format!("{}/{}", search.current_match() + 1, search.matches().len())
         };
         let suffix = format!("  {match_info}");
         let visible_width = area

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -66,12 +66,20 @@ impl ResultPane {
                     state.result_interaction.selection(),
                     if state.result_interaction.cell_edit().is_active() {
                         Some((
-                            state.result_interaction.cell_edit().row.unwrap_or_default(),
-                            state.result_interaction.cell_edit().col.unwrap_or_default(),
+                            state
+                                .result_interaction
+                                .cell_edit()
+                                .row()
+                                .unwrap_or_default(),
+                            state
+                                .result_interaction
+                                .cell_edit()
+                                .col()
+                                .unwrap_or_default(),
                             state.result_interaction.cell_edit().draft_value(),
                             state.input_mode()
                                 == crate::app::model::shared::input_mode::InputMode::CellEdit,
-                            state.result_interaction.cell_edit().input.cursor(),
+                            state.result_interaction.cell_edit().input().cursor(),
                         ))
                     } else {
                         None

--- a/src/ui/features/connections/error.rs
+++ b/src/ui/features/connections/error.rs
@@ -21,11 +21,11 @@ impl ConnectionError {
 
     pub fn render_at(frame: &mut Frame, state: &AppState, now: Instant, theme: &ThemePalette) {
         let error_state = &state.connection_error;
-        let Some(ref error_info) = error_state.error_info else {
+        let Some(error_info) = error_state.error_info() else {
             return;
         };
 
-        let details_expanded = error_state.details_expanded;
+        let details_expanded = error_state.details_expanded();
         let full_area = frame.area();
         let modal_outer_width = full_area.width * 70 / 100;
         let content_width = modal_outer_width.saturating_sub(4);
@@ -94,8 +94,7 @@ impl ConnectionError {
     fn render_hint(frame: &mut Frame, area: Rect, state: &AppState, theme: &ThemePalette) {
         let hint = state
             .connection_error
-            .error_info
-            .as_ref()
+            .error_info()
             .map_or("", |e| e.kind.hint());
         let mut spans = vec![
             Span::styled("Hint: ", Style::default().fg(theme.semantic.text.accent)),
@@ -136,7 +135,7 @@ impl ConnectionError {
                     .lines()
                     .map(|l| Line::from(l.replace('\t', "    ")))
                     .collect();
-                let scroll = error_state.scroll_offset;
+                let scroll = error_state.scroll_offset();
                 let para = Paragraph::new(lines)
                     .scroll((scroll as u16, 0))
                     .wrap(Wrap { trim: false })

--- a/src/ui/features/connections/selector.rs
+++ b/src/ui/features/connections/selector.rs
@@ -130,7 +130,7 @@ pub fn render_connection_list(
     state: &AppState,
     theme: &ThemePalette,
 ) -> u16 {
-    let active_id = state.session.active_connection_id.as_ref();
+    let active_id = state.session.active_connection_id();
 
     // highlight_symbol "> " takes 2 columns
     let content_width = area.width.saturating_sub(2) as usize;

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -72,15 +72,15 @@ impl ConnectionSetup {
                 ConnectionField::DatabaseType => Self::render_database_type_field(
                     frame,
                     chunks[idx],
-                    form_state.database_type,
-                    form_state.focused_field == ConnectionField::DatabaseType,
+                    form_state.database_type(),
+                    form_state.focused_field() == ConnectionField::DatabaseType,
                     theme,
                 ),
                 ConnectionField::SslMode => Self::render_ssl_field(
                     frame,
                     chunks[idx],
-                    form_state.ssl_mode,
-                    form_state.focused_field == ConnectionField::SslMode,
+                    form_state.ssl_mode(),
+                    form_state.focused_field() == ConnectionField::SslMode,
                     theme,
                 ),
                 field => Self::render_text_field(
@@ -99,14 +99,14 @@ impl ConnectionSetup {
             Paragraph::new(notice).style(Style::default().fg(theme.component.feedback.note_text));
         frame.render_widget(notice_para, chunks[field_count + 1]);
 
-        if form_state.database_type_dropdown.is_open() {
+        if form_state.database_type_dropdown().is_open() {
             Self::render_database_type_dropdown(
                 frame,
                 chunks[0],
-                form_state.database_type_dropdown.selected_index(),
+                form_state.database_type_dropdown().selected_index(),
                 theme,
             );
-        } else if form_state.ssl_dropdown.is_open() {
+        } else if form_state.ssl_dropdown().is_open() {
             let ssl_idx = visible_fields
                 .iter()
                 .position(|field| *field == ConnectionField::SslMode)
@@ -114,7 +114,7 @@ impl ConnectionSetup {
             Self::render_dropdown(
                 frame,
                 chunks[ssl_idx],
-                form_state.ssl_dropdown.selected_index(),
+                form_state.ssl_dropdown().selected_index(),
                 theme,
             );
         }
@@ -128,9 +128,9 @@ impl ConnectionSetup {
         mask: bool,
         theme: &ThemePalette,
     ) {
-        let is_focused = field == state.focused_field;
+        let is_focused = field == state.focused_field();
         let value = state.field_value(field);
-        let error = state.validation_errors.get(&field);
+        let error = state.validation_error(field);
 
         let chunks = Layout::horizontal([
             Constraint::Length(LABEL_WIDTH),

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -129,7 +129,7 @@ impl ConnectionSetup {
         theme: &ThemePalette,
     ) {
         let is_focused = field == state.focused_field();
-        let value = state.field_value(field);
+        let value = state.input(field).map_or("", |input| input.content());
         let error = state.validation_error(field);
 
         let chunks = Layout::horizontal([

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -99,14 +99,14 @@ impl ConnectionSetup {
             Paragraph::new(notice).style(Style::default().fg(theme.component.feedback.note_text));
         frame.render_widget(notice_para, chunks[field_count + 1]);
 
-        if form_state.database_type_dropdown.is_open {
+        if form_state.database_type_dropdown.is_open() {
             Self::render_database_type_dropdown(
                 frame,
                 chunks[0],
-                form_state.database_type_dropdown.selected_index,
+                form_state.database_type_dropdown.selected_index(),
                 theme,
             );
-        } else if form_state.ssl_dropdown.is_open {
+        } else if form_state.ssl_dropdown.is_open() {
             let ssl_idx = visible_fields
                 .iter()
                 .position(|field| *field == ConnectionField::SslMode)
@@ -114,7 +114,7 @@ impl ConnectionSetup {
             Self::render_dropdown(
                 frame,
                 chunks[ssl_idx],
-                form_state.ssl_dropdown.selected_index,
+                form_state.ssl_dropdown.selected_index(),
                 theme,
             );
         }

--- a/src/ui/features/sql_modal/compare.rs
+++ b/src/ui/features/sql_modal/compare.rs
@@ -19,10 +19,10 @@ pub fn render(
     now: Instant,
     theme: &ThemePalette,
 ) -> u16 {
-    let can_yank = state.explain.left.is_some() && state.explain.right.is_some();
-    let left = state.explain.left.as_ref();
-    let right = state.explain.right.as_ref();
-    let scroll_offset = state.explain.compare_scroll_offset;
+    let can_yank = state.explain.left().is_some() && state.explain.right().is_some();
+    let left = state.explain.left();
+    let right = state.explain.right();
+    let scroll_offset = state.explain.compare_scroll_offset();
 
     let mut lines: Vec<Line> = Vec::new();
     let mut flash_mask: Vec<bool> = Vec::new();

--- a/src/ui/features/sql_modal/compare.rs
+++ b/src/ui/features/sql_modal/compare.rs
@@ -19,9 +19,8 @@ pub fn render(
     now: Instant,
     theme: &ThemePalette,
 ) -> u16 {
-    let can_yank = state.explain.left().is_some() && state.explain.right().is_some();
-    let left = state.explain.left();
-    let right = state.explain.right();
+    let can_yank = state.explain.can_yank_compare();
+    let (left, right) = state.explain.compare_slots();
     let scroll_offset = state.explain.compare_scroll_offset();
 
     let mut lines: Vec<Line> = Vec::new();

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -38,11 +38,11 @@ pub fn render(
     } = state.sql_modal.status()
     {
         let lines = build_analyze_confirm_lines(area, query, input, target_name.as_deref(), theme);
-        render_scrolled(frame, area, lines, state.explain.confirm_scroll_offset);
+        render_scrolled(frame, area, lines, state.explain.confirm_scroll_offset());
         return area.height;
     }
 
-    if let Some(ref error) = state.explain.error {
+    if let Some(error) = state.explain.error() {
         let lines: Vec<Line> = error
             .lines()
             .map(|line| {
@@ -54,8 +54,8 @@ pub fn render(
             .collect();
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
         area.height
-    } else if let Some(ref plan_text) = state.explain.plan_text {
-        let (label, label_style) = if state.explain.is_analyze {
+    } else if let Some(plan_text) = state.explain.plan_text() {
+        let (label, label_style) = if state.explain.is_analyze() {
             (
                 "EXPLAIN ANALYZE",
                 Style::default()
@@ -70,7 +70,7 @@ pub fn render(
                     .add_modifier(Modifier::BOLD),
             )
         };
-        let time_secs = state.explain.execution_time_ms as f64 / 1000.0;
+        let time_secs = state.explain.execution_time_ms() as f64 / 1000.0;
         let header = Line::from(vec![
             Span::styled(format!("{label} "), label_style),
             Span::styled(
@@ -79,7 +79,7 @@ pub fn render(
             ),
         ]);
 
-        let query_snippet = state.explain.plan_query_snippet.as_deref().unwrap_or("");
+        let query_snippet = state.explain.plan_query_snippet().unwrap_or("");
         let query_line = Line::from(vec![
             Span::styled("  ", Style::default()),
             Span::styled(
@@ -88,7 +88,7 @@ pub fn render(
             ),
         ]);
 
-        let scroll = state.explain.scroll_offset;
+        let scroll = state.explain.scroll_offset();
         let mut lines = vec![header, query_line, Line::raw("")];
         lines.extend(
             plan_text

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -92,8 +92,7 @@ impl SqlModal {
                     }
                 }
                 _ => {
-                    let compare_can_yank =
-                        state.explain.left().is_some() && state.explain.right().is_some();
+                    let compare_can_yank = state.explain.can_yank_compare();
                     Self::border_hint(active_tab, compare_can_yank, services)
                 }
             };

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -93,7 +93,7 @@ impl SqlModal {
                 }
                 _ => {
                     let compare_can_yank =
-                        state.explain.left.is_some() && state.explain.right.is_some();
+                        state.explain.left().is_some() && state.explain.right().is_some();
                     Self::border_hint(active_tab, compare_can_yank, services)
                 }
             };

--- a/src/ui/features/sql_modal/status.rs
+++ b/src/ui/features/sql_modal/status.rs
@@ -22,7 +22,7 @@ pub(super) fn render_status(frame: &mut Frame, area: Rect, state: &AppState, the
 
     let (badge_text, badge_style, status_text, status_style) = match state.sql_modal.status() {
         SqlModalStatus::Normal => {
-            if let Some(ref msg) = state.messages.last_success {
+            if let Some(msg) = state.messages.last_success() {
                 (
                     "[NORMAL]",
                     Style::default().fg(theme.semantic.text.dim),

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -62,13 +62,12 @@ impl Footer {
         });
         let spinner = spinner_char(now_ms);
 
-        let total = state.er_preparation.total_tables();
-        let failed_count = state.er_preparation.failed_tables().len();
-        let remaining = state.er_preparation.pending_tables().len()
-            + state.er_preparation.fetching_tables().len();
-        let cached = total.saturating_sub(remaining + failed_count);
+        let progress = state.er_preparation.progress();
 
-        let text = format!("{spinner} Preparing ER... ({cached}/{total})");
+        let text = format!(
+            "{spinner} Preparing ER... ({}/{})",
+            progress.cached, progress.total
+        );
         Line::from(Span::styled(
             text,
             Style::default().fg(theme.semantic.text.accent),

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -37,17 +37,14 @@ impl Footer {
         if state.er_preparation.status() == ErStatus::Waiting {
             let line = Self::build_er_waiting_line(state, time_ms, theme);
             frame.render_widget(Paragraph::new(line).style(base_style), area);
-        } else if let Some(error) = &state.messages.last_error {
+        } else if let Some(error) = state.messages.last_error() {
             let line = StatusMessage::render_line(error, MessageType::Error, theme);
             frame.render_widget(Paragraph::new(line).style(base_style), area);
         } else {
             // Show hints with optional inline success message
             let hints = Self::get_context_hints(state, services);
-            let line = Self::build_hint_line_with_success(
-                &hints,
-                state.messages.last_success.as_deref(),
-                theme,
-            );
+            let line =
+                Self::build_hint_line_with_success(&hints, state.messages.last_success(), theme);
             frame.render_widget(Paragraph::new(line).style(base_style), area);
         }
     }
@@ -161,7 +158,7 @@ impl Footer {
                     }
                     list.push(GLOBAL_KEYS[idx::global::TABLE_PICKER].as_hint());
                     list.push(GLOBAL_KEYS[idx::global::QUERY_HISTORY].as_hint());
-                    if state.connection_error.error_info.is_some() {
+                    if state.connection_error.has_error() {
                         list.push(OVERLAY_KEYS[idx::overlay::ERROR_OPEN].as_hint());
                     }
                     if state.session.is_read_only() {

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -290,7 +290,7 @@ impl Footer {
                 QUERY_HISTORY_PICKER_ROWS[idx::qh_picker::ESC_CLOSE].as_hint(),
             ],
             InputMode::JsonbDetail => {
-                if state.jsonb_detail.search().active {
+                if state.jsonb_detail.search().is_active() {
                     vec![
                         JSONB_SEARCH_KEYS[idx::jsonb_search::TYPE_SEARCH].as_hint(),
                         JSONB_SEARCH_KEYS[idx::jsonb_search::CONFIRM].as_hint(),

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -34,7 +34,7 @@ impl Footer {
         theme: &ThemePalette,
     ) {
         let base_style = Style::default().fg(theme.semantic.text.primary);
-        if state.er_preparation.status == ErStatus::Waiting {
+        if state.er_preparation.status() == ErStatus::Waiting {
             let line = Self::build_er_waiting_line(state, time_ms, theme);
             frame.render_widget(Paragraph::new(line).style(base_style), area);
         } else if let Some(error) = &state.messages.last_error {
@@ -65,10 +65,10 @@ impl Footer {
         });
         let spinner = spinner_char(now_ms);
 
-        let total = state.er_preparation.total_tables;
-        let failed_count = state.er_preparation.failed_tables.len();
-        let remaining =
-            state.er_preparation.pending_tables.len() + state.er_preparation.fetching_tables.len();
+        let total = state.er_preparation.total_tables();
+        let failed_count = state.er_preparation.failed_tables().len();
+        let remaining = state.er_preparation.pending_tables().len()
+            + state.er_preparation.fetching_tables().len();
         let cached = total.saturating_sub(remaining + failed_count);
 
         let text = format!("{spinner} Preparing ER... ({cached}/{total})");

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -164,7 +164,7 @@ impl Footer {
                     if state.connection_error.error_info.is_some() {
                         list.push(OVERLAY_KEYS[idx::overlay::ERROR_OPEN].as_hint());
                     }
-                    if state.session.read_only {
+                    if state.session.is_read_only() {
                         list.push(GLOBAL_KEYS[idx::global::EXIT_READ_ONLY].as_hint());
                     } else {
                         list.push(GLOBAL_KEYS[idx::global::READ_ONLY].as_hint());

--- a/src/ui/shell/header.rs
+++ b/src/ui/shell/header.rs
@@ -18,7 +18,7 @@ impl Header {
         let sep_style = Style::default().fg(theme.semantic.text.muted);
         let item_style = Style::default().fg(theme.semantic.text.secondary);
 
-        let (status_text, status_color) = if state.session.dsn.is_none() {
+        let (status_text, status_color) = if state.session.dsn().is_none() {
             ("no dsn", theme.semantic.status.error)
         } else {
             match &state.session.metadata_state() {
@@ -29,11 +29,7 @@ impl Header {
             }
         };
 
-        let connection_name = state
-            .session
-            .active_connection_name
-            .as_deref()
-            .unwrap_or("-");
+        let connection_name = state.session.active_connection_name().unwrap_or("-");
 
         let mut line = Line::from(vec![
             Span::styled(&state.runtime.project_name, item_style),
@@ -46,7 +42,7 @@ impl Header {
             Span::styled(" | ", sep_style),
             Span::styled(connection_name, item_style),
         ]);
-        if state.session.read_only {
+        if state.session.is_read_only() {
             line.push_span(Span::styled(" | ", sep_style));
             line.push_span(Span::styled(
                 "READ-ONLY",


### PR DESCRIPTION
## Scope

- Close aggregate-owned mutable fields for BrowseSession, ER preparation, SQL modal prefetch, Explain, Message, Connection error, JSONB search, Cell edit, Pagination, and Connection setup dropdowns.
- Keep the remaining view geometry, form input, and display-only cleanup out of scope; it is tracked separately in SAB-237.
- Update local aggregate-field rules only; rule files are not part of this PR.

## Design Intent

This PR moves reads to accessors and writes to intent-level aggregate APIs so coupled state changes remain centralized. Runtime behavior is intended to stay unchanged.

The scope is intentionally limited to state with lifecycle, selection, pagination, dropdown, retry, reset, or similar transition semantics. The broader principle is now private-by-default, but lower-risk consistency cleanup is split out to keep this PR reviewable and revertable.

## How Has This Been Tested?

test code

- cargo test -q --workspace
- cargo clippy -q --workspace --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Improved internal code organization by encapsulating state management across the application. Internal fields are now accessed through controlled methods rather than direct access, enhancing maintainability and reducing coupling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->