### PR TITLE
feat: add SQLite metadata provider

### DIFF
--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -60,7 +60,7 @@ impl Default for BrowseSession {
             active_connection_id: None,
             active_connection_name: None,
             active_database_type: None,
-            active_db_capabilities: DbCapabilities::postgres_like(),
+            active_db_capabilities: DbCapabilities::disconnected(),
             read_only: false,
             is_reloading: false,
         }
@@ -232,7 +232,7 @@ impl BrowseSession {
         self.active_connection_id = None;
         self.active_connection_name = None;
         self.active_database_type = None;
-        self.active_db_capabilities = DbCapabilities::postgres_like();
+        self.active_db_capabilities = DbCapabilities::disconnected();
         self.read_only = false;
         self.is_reloading = false;
         query.pagination.reset();
@@ -363,7 +363,7 @@ impl BrowseSession {
         self.active_database_type = database_type;
         self.active_db_capabilities = database_type
             .map(DbCapabilities::for_database_type)
-            .unwrap_or_else(DbCapabilities::postgres_like);
+            .unwrap_or_else(DbCapabilities::disconnected);
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -763,6 +763,10 @@ mod tests {
             assert!(session.active_connection_id().is_none());
             assert!(session.active_connection_name().is_none());
             assert!(session.active_database_type().is_none());
+            assert_eq!(
+                session.active_db_capabilities(),
+                &DbCapabilities::disconnected()
+            );
             assert!(!session.is_read_only());
             assert!(!session.is_reloading());
             assert_eq!(query.pagination.current_page(), 0);

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -7,6 +7,7 @@ use crate::model::browse::query_execution::{PaginationState, QueryExecution};
 use crate::model::browse::result_history::ResultHistory;
 use crate::model::connection::cache::ConnectionCache;
 use crate::model::connection::state::ConnectionState;
+use crate::model::shared::db_capabilities::DbCapabilities;
 use crate::model::shared::inspector_tab::InspectorTab;
 
 // # Invariants
@@ -22,7 +23,7 @@ use crate::model::shared::inspector_tab::InspectorTab;
 // `set_metadata`, `set_table_detail_raw`, `set_connection_state`,
 // `set_metadata_state` are `pub(crate)` for reducers where the aggregate API
 // does not cover the exact semantics needed (e.g. ER refresh, reload).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct BrowseSession {
     // -- co-dependent: connection lifecycle --
     connection_state: ConnectionState,
@@ -41,8 +42,29 @@ pub struct BrowseSession {
     active_connection_id: Option<ConnectionId>,
     active_connection_name: Option<String>,
     active_database_type: Option<DatabaseType>,
+    active_db_capabilities: DbCapabilities,
     read_only: bool,
     is_reloading: bool,
+}
+
+impl Default for BrowseSession {
+    fn default() -> Self {
+        Self {
+            connection_state: ConnectionState::default(),
+            metadata_state: MetadataState::default(),
+            selected_table_key: None,
+            table_detail: None,
+            selection_generation: 0,
+            metadata: None,
+            dsn: None,
+            active_connection_id: None,
+            active_connection_name: None,
+            active_database_type: None,
+            active_db_capabilities: DbCapabilities::postgres_like(),
+            read_only: false,
+            is_reloading: false,
+        }
+    }
 }
 
 impl BrowseSession {
@@ -101,6 +123,7 @@ impl BrowseSession {
         self.active_connection_id = Some(id.clone());
         self.active_connection_name = Some(name.to_string());
         self.active_database_type = Some(database_type);
+        self.active_db_capabilities = DbCapabilities::for_database_type(database_type);
         self.dsn = Some(dsn.to_string());
     }
 
@@ -209,6 +232,7 @@ impl BrowseSession {
         self.active_connection_id = None;
         self.active_connection_name = None;
         self.active_database_type = None;
+        self.active_db_capabilities = DbCapabilities::postgres_like();
         self.read_only = false;
         self.is_reloading = false;
         query.pagination.reset();
@@ -261,6 +285,10 @@ impl BrowseSession {
 
     pub fn active_database_type(&self) -> Option<DatabaseType> {
         self.active_database_type
+    }
+
+    pub fn active_db_capabilities(&self) -> &DbCapabilities {
+        &self.active_db_capabilities
     }
 
     pub fn is_read_only(&self) -> bool {
@@ -333,6 +361,15 @@ impl BrowseSession {
     #[doc(hidden)]
     pub fn set_active_database_type_for_test(&mut self, database_type: Option<DatabaseType>) {
         self.active_database_type = database_type;
+        self.active_db_capabilities = database_type
+            .map(DbCapabilities::for_database_type)
+            .unwrap_or_else(DbCapabilities::postgres_like);
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_active_db_capabilities_for_test(&mut self, capabilities: DbCapabilities) {
+        self.active_db_capabilities = capabilities;
     }
 }
 

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -365,12 +365,6 @@ impl BrowseSession {
             .map(DbCapabilities::for_database_type)
             .unwrap_or_else(DbCapabilities::disconnected);
     }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_active_db_capabilities_for_test(&mut self, capabilities: DbCapabilities) {
-        self.active_db_capabilities = capabilities;
-    }
 }
 
 #[cfg(test)]

--- a/src/app/model/shared/db_capabilities.rs
+++ b/src/app/model/shared/db_capabilities.rs
@@ -1,3 +1,4 @@
+use crate::domain::connection::DatabaseType;
 use crate::model::shared::inspector_tab::InspectorTab;
 use crate::model::sql_editor::modal::SqlModalTab;
 use crate::ports::outbound::{DatabaseCapabilities, InspectorFeature};
@@ -23,6 +24,26 @@ impl DbCapabilities {
             ],
         )
         .into()
+    }
+
+    pub fn sqlite_like() -> Self {
+        DatabaseCapabilities::new(
+            false,
+            vec![
+                InspectorFeature::Info,
+                InspectorFeature::Columns,
+                InspectorFeature::Indexes,
+                InspectorFeature::ForeignKeys,
+            ],
+        )
+        .into()
+    }
+
+    pub fn for_database_type(database_type: DatabaseType) -> Self {
+        match database_type {
+            DatabaseType::PostgreSQL => Self::postgres_like(),
+            DatabaseType::SQLite => Self::sqlite_like(),
+        }
     }
 
     pub fn supports_explain(&self) -> bool {

--- a/src/app/model/shared/db_capabilities.rs
+++ b/src/app/model/shared/db_capabilities.rs
@@ -161,22 +161,40 @@ mod tests {
 
     #[test]
     fn postgres_supports_all_inspector_tabs() {
-        let caps = DbCapabilities::new(
-            true,
-            vec![
-                InspectorTab::Info,
-                InspectorTab::Columns,
-                InspectorTab::Indexes,
-                InspectorTab::ForeignKeys,
-                InspectorTab::Rls,
-                InspectorTab::Triggers,
-                InspectorTab::Ddl,
-            ],
-        );
+        let caps = DbCapabilities::postgres_like();
 
         assert!(caps.supports_explain());
         assert!(caps.supports_inspector_tab(InspectorTab::Ddl));
         assert_eq!(caps.supported_inspector_tabs().len(), 7);
+    }
+
+    #[test]
+    fn sqlite_supports_metadata_only_inspector_tabs() {
+        let caps = DbCapabilities::sqlite_like();
+
+        assert!(!caps.supports_explain());
+        assert_eq!(
+            caps.supported_inspector_tabs(),
+            &[
+                InspectorTab::Info,
+                InspectorTab::Columns,
+                InspectorTab::Indexes,
+                InspectorTab::ForeignKeys
+            ]
+        );
+        assert_eq!(caps.supported_sql_modal_tabs(), &[SqlModalTab::Sql]);
+    }
+
+    #[test]
+    fn for_database_type_uses_database_specific_capabilities() {
+        assert_eq!(
+            DbCapabilities::for_database_type(DatabaseType::PostgreSQL),
+            DbCapabilities::postgres_like()
+        );
+        assert_eq!(
+            DbCapabilities::for_database_type(DatabaseType::SQLite),
+            DbCapabilities::sqlite_like()
+        );
     }
 
     #[test]

--- a/src/app/model/shared/db_capabilities.rs
+++ b/src/app/model/shared/db_capabilities.rs
@@ -10,6 +10,10 @@ pub struct DbCapabilities {
 }
 
 impl DbCapabilities {
+    pub fn disconnected() -> Self {
+        Self::new(false, vec![InspectorTab::Info])
+    }
+
     pub fn postgres_like() -> Self {
         DatabaseCapabilities::new(
             true,
@@ -208,5 +212,14 @@ mod tests {
     #[should_panic(expected = "DbCapabilities requires at least one supported inspector tab")]
     fn rejects_empty_supported_inspector_tabs() {
         let _ = DbCapabilities::new(false, vec![]);
+    }
+
+    #[test]
+    fn disconnected_disables_database_specific_tabs() {
+        let caps = DbCapabilities::disconnected();
+
+        assert!(!caps.supports_explain());
+        assert_eq!(caps.supported_inspector_tabs(), &[InspectorTab::Info]);
+        assert_eq!(caps.supported_sql_modal_tabs(), &[SqlModalTab::Sql]);
     }
 }

--- a/src/app/ports/outbound/db_capabilities.rs
+++ b/src/app/ports/outbound/db_capabilities.rs
@@ -38,7 +38,3 @@ impl DatabaseCapabilities {
         &self.supported_inspector_features
     }
 }
-
-pub trait DatabaseCapabilityProvider {
-    fn capabilities(&self) -> DatabaseCapabilities;
-}

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -23,6 +23,8 @@ pub enum DbOperationError {
     ObjectMissing(String),
     #[error("Query failed")]
     QueryFailed(String),
+    #[error("Unsupported operation")]
+    UnsupportedOperation(String),
     #[error("Metadata parse failed")]
     MetadataParseFailed(String),
     #[error("Invalid JSON")]
@@ -52,6 +54,7 @@ impl DbOperationError {
             Self::LockTimeout(_) => "Operation blocked by lock or timeout",
             Self::ObjectMissing(_) => "Database object not found",
             Self::QueryFailed(_) => "Query failed",
+            Self::UnsupportedOperation(_) => "Unsupported operation",
             Self::MetadataParseFailed(_) => "Failed to parse database metadata output",
             Self::InvalidJson(_) => "Failed to parse database JSON output",
             Self::EmptyResponse(_) => "Database returned an empty response",
@@ -77,6 +80,7 @@ impl DbOperationError {
             }
             Self::ObjectMissing(_) => "Check the table, column, or connected database",
             Self::QueryFailed(_) => "Review the database error details and SQL",
+            Self::UnsupportedOperation(_) => "Use a supported operation for this database",
             Self::MetadataParseFailed(_) => {
                 "Check whether the metadata output format changed unexpectedly"
             }
@@ -100,6 +104,7 @@ impl DbOperationError {
             | Self::LockTimeout(details)
             | Self::ObjectMissing(details)
             | Self::QueryFailed(details)
+            | Self::UnsupportedOperation(details)
             | Self::MetadataParseFailed(details)
             | Self::EmptyResponse(details)
             | Self::CommandTagParseFailed(details)
@@ -185,6 +190,7 @@ mod tests {
         #[case(DbOperationError::LockTimeout("boom".to_string()))]
         #[case(DbOperationError::ObjectMissing("boom".to_string()))]
         #[case(DbOperationError::QueryFailed("boom".to_string()))]
+        #[case(DbOperationError::UnsupportedOperation("boom".to_string()))]
         #[case(DbOperationError::MetadataParseFailed("boom".to_string()))]
         #[case(DbOperationError::InvalidJson(Arc::new(serde_json::from_str::<i32>("x").unwrap_err())))]
         #[case(DbOperationError::EmptyResponse("boom".to_string()))]

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -25,7 +25,7 @@ pub mod sql_dialect;
 pub use clipboard::{ClipboardError, ClipboardWriter};
 pub use config_writer::{ConfigWriter, ConfigWriterError};
 pub use connection_store::{ConnectionStore, ConnectionStoreError};
-pub use db_capabilities::{DatabaseCapabilities, DatabaseCapabilityProvider, InspectorFeature};
+pub use db_capabilities::{DatabaseCapabilities, InspectorFeature};
 pub use db_operation_error::DbOperationError;
 pub use ddl_generator::DdlGenerator;
 pub use dsn_builder::DsnBuilder;

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -1,12 +1,10 @@
 use std::sync::Arc;
 
 use super::ports::outbound::{DdlGenerator, SqlDialect};
-use crate::model::shared::db_capabilities::DbCapabilities;
 
 pub struct AppServices {
     pub ddl_generator: Arc<dyn DdlGenerator>,
     pub sql_dialect: Arc<dyn SqlDialect>,
-    pub db_capabilities: DbCapabilities,
 }
 
 impl AppServices {
@@ -73,7 +71,6 @@ impl AppServices {
         Self {
             ddl_generator: Arc::new(StubDdlGenerator),
             sql_dialect: Arc::new(StubSqlDialect),
-            db_capabilities: DbCapabilities::postgres_like(),
         }
     }
 }

--- a/src/app/update/browse/navigation/focus.rs
+++ b/src/app/update/browse/navigation/focus.rs
@@ -11,7 +11,7 @@ use crate::update::action::Action;
 pub fn reduce(
     state: &mut AppState,
     action: &Action,
-    services: &AppServices,
+    _services: &AppServices,
     _now: Instant,
 ) -> Option<Vec<Effect>> {
     match action {
@@ -48,16 +48,18 @@ pub fn reduce(
         }
         Action::InspectorNextTab => {
             state.ui.set_inspector_tab(
-                services
-                    .db_capabilities
+                state
+                    .session
+                    .active_db_capabilities()
                     .next_inspector_tab(state.ui.inspector_tab()),
             );
             Some(vec![])
         }
         Action::InspectorPrevTab => {
             state.ui.set_inspector_tab(
-                services
-                    .db_capabilities
+                state
+                    .session
+                    .active_db_capabilities()
                     .prev_inspector_tab(state.ui.inspector_tab()),
             );
             Some(vec![])
@@ -119,15 +121,22 @@ mod tests {
         use super::*;
 
         fn services_with_two_tabs() -> AppServices {
-            let mut services = AppServices::stub();
-            services.db_capabilities =
-                DbCapabilities::new(true, vec![InspectorTab::Info, InspectorTab::Columns]);
-            services
+            AppServices::stub()
+        }
+
+        fn use_two_tabs(state: &mut AppState) {
+            state
+                .session
+                .set_active_db_capabilities_for_test(DbCapabilities::new(
+                    true,
+                    vec![InspectorTab::Info, InspectorTab::Columns],
+                ));
         }
 
         #[test]
         fn next_tab_wraps_between_supported_tabs() {
             let mut state = AppState::new("test".to_string());
+            use_two_tabs(&mut state);
             state.ui.set_inspector_tab(InspectorTab::Info);
 
             reduce_navigation(
@@ -143,6 +152,7 @@ mod tests {
         #[test]
         fn prev_tab_wraps_between_supported_tabs() {
             let mut state = AppState::new("test".to_string());
+            use_two_tabs(&mut state);
             state.ui.set_inspector_tab(InspectorTab::Info);
 
             reduce_navigation(

--- a/src/app/update/browse/navigation/focus.rs
+++ b/src/app/update/browse/navigation/focus.rs
@@ -120,10 +120,6 @@ mod tests {
     mod inspector_tabs {
         use super::*;
 
-        fn services_with_two_tabs() -> AppServices {
-            AppServices::stub()
-        }
-
         fn use_two_tabs(state: &mut AppState) {
             state
                 .session
@@ -142,7 +138,7 @@ mod tests {
             reduce_navigation(
                 &mut state,
                 &Action::InspectorNextTab,
-                &services_with_two_tabs(),
+                &AppServices::stub(),
                 Instant::now(),
             );
 
@@ -158,7 +154,7 @@ mod tests {
             reduce_navigation(
                 &mut state,
                 &Action::InspectorPrevTab,
-                &services_with_two_tabs(),
+                &AppServices::stub(),
                 Instant::now(),
             );
 

--- a/src/app/update/browse/navigation/focus.rs
+++ b/src/app/update/browse/navigation/focus.rs
@@ -1,19 +1,11 @@
-use std::time::Instant;
-
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
-use crate::services::AppServices;
 use crate::update::action::Action;
 
-pub fn reduce(
-    state: &mut AppState,
-    action: &Action,
-    _services: &AppServices,
-    _now: Instant,
-) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
     match action {
         Action::SetFocusedPane(pane) => {
             if *pane != FocusedPane::Result {
@@ -72,10 +64,11 @@ pub fn reduce(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::shared::db_capabilities::DbCapabilities;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::shared::inspector_tab::InspectorTab;
     use crate::services::AppServices;
     use crate::update::browse::navigation::reduce_navigation;
+    use std::time::Instant;
 
     mod toggle_read_only {
         use super::*;
@@ -120,19 +113,19 @@ mod tests {
     mod inspector_tabs {
         use super::*;
 
-        fn use_two_tabs(state: &mut AppState) {
-            state
-                .session
-                .set_active_db_capabilities_for_test(DbCapabilities::new(
-                    true,
-                    vec![InspectorTab::Info, InspectorTab::Columns],
-                ));
+        fn use_sqlite_tabs(state: &mut AppState) {
+            state.session.set_active_connection(
+                &ConnectionId::new(),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite://test.db",
+            );
         }
 
         #[test]
-        fn next_tab_wraps_between_supported_tabs() {
+        fn next_tab_moves_to_next_supported_tab() {
             let mut state = AppState::new("test".to_string());
-            use_two_tabs(&mut state);
+            use_sqlite_tabs(&mut state);
             state.ui.set_inspector_tab(InspectorTab::Info);
 
             reduce_navigation(
@@ -146,9 +139,9 @@ mod tests {
         }
 
         #[test]
-        fn prev_tab_wraps_between_supported_tabs() {
+        fn prev_tab_wraps_to_last_supported_tab() {
             let mut state = AppState::new("test".to_string());
-            use_two_tabs(&mut state);
+            use_sqlite_tabs(&mut state);
             state.ui.set_inspector_tab(InspectorTab::Info);
 
             reduce_navigation(
@@ -158,7 +151,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.inspector_tab(), InspectorTab::Columns);
+            assert_eq!(state.ui.inspector_tab(), InspectorTab::ForeignKeys);
         }
     }
 }

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -278,11 +278,7 @@ mod tests {
             assert_eq!(state.ui.inspector_scroll_offset(), 0);
         }
 
-        fn services_without_ddl() -> AppServices {
-            AppServices::stub()
-        }
-
-        fn use_services_without_ddl(state: &mut AppState) {
+        fn disable_ddl_for_test(state: &mut AppState) {
             state
                 .session
                 .set_active_db_capabilities_for_test(DbCapabilities::new(
@@ -294,8 +290,7 @@ mod tests {
         #[test]
         fn inspector_half_page_scroll_normalizes_unsupported_ddl_tab() {
             let mut state = state_with_table_detail(20);
-            use_services_without_ddl(&mut state);
-            let services = services_without_ddl();
+            disable_ddl_for_test(&mut state);
             state.ui.set_inspector_pane_height(7);
             state.ui.set_inspector_tab(InspectorTab::Ddl);
             state.ui.set_inspector_scroll_offset(1);
@@ -310,7 +305,7 @@ mod tests {
                     direction: ScrollDirection::Down,
                     amount: ScrollAmount::HalfPage,
                 },
-                &services,
+                &AppServices::stub(),
                 Instant::now(),
             );
 
@@ -321,8 +316,7 @@ mod tests {
         #[test]
         fn inspector_full_page_scroll_normalizes_unsupported_ddl_tab() {
             let mut state = state_with_table_detail(20);
-            use_services_without_ddl(&mut state);
-            let services = services_without_ddl();
+            disable_ddl_for_test(&mut state);
             state.ui.set_inspector_pane_height(7);
             state.ui.set_inspector_tab(InspectorTab::Ddl);
             state.ui.set_inspector_scroll_offset(1);
@@ -334,7 +328,7 @@ mod tests {
                     direction: ScrollDirection::Down,
                     amount: ScrollAmount::FullPage,
                 },
-                &services,
+                &AppServices::stub(),
                 Instant::now(),
             );
 

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -7,11 +7,7 @@ use crate::update::action::{Action, ScrollAmount, ScrollDirection, ScrollTarget}
 
 use super::inspector_max_scroll;
 
-fn inspector_page_scroll_delta(
-    state: &AppState,
-    _services: &AppServices,
-    amount: ScrollAmount,
-) -> Option<usize> {
+fn inspector_page_scroll_delta(state: &AppState, amount: ScrollAmount) -> Option<usize> {
     let visible = match state
         .session
         .active_db_capabilities()
@@ -68,7 +64,7 @@ pub fn reduce(
             direction,
             amount: amount @ (ScrollAmount::HalfPage | ScrollAmount::FullPage),
         } => {
-            if let Some(delta) = inspector_page_scroll_delta(state, services, *amount) {
+            if let Some(delta) = inspector_page_scroll_delta(state, *amount) {
                 let max = inspector_max_scroll(state, services);
                 state
                     .ui
@@ -116,8 +112,7 @@ pub fn reduce(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{Column, ColumnAttributes, Table};
-    use crate::model::shared::db_capabilities::DbCapabilities;
+    use crate::domain::{Column, ColumnAttributes, ConnectionId, DatabaseType, Table};
     use crate::update::browse::navigation::reduce_navigation;
     use std::time::Instant;
 
@@ -128,9 +123,12 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.ui.set_inspector_pane_height(10);
             state.ui.set_inspector_tab(InspectorTab::Columns);
-            state
-                .session
-                .set_active_db_capabilities_for_test(DbCapabilities::postgres_like());
+            state.session.set_active_connection(
+                &ConnectionId::new(),
+                "postgres",
+                DatabaseType::PostgreSQL,
+                "postgres://test",
+            );
             let cols: Vec<Column> = (0..columns)
                 .map(|i| Column {
                     name: format!("col_{i}"),
@@ -279,12 +277,12 @@ mod tests {
         }
 
         fn disable_ddl_for_test(state: &mut AppState) {
-            state
-                .session
-                .set_active_db_capabilities_for_test(DbCapabilities::new(
-                    true,
-                    vec![InspectorTab::Info, InspectorTab::Columns],
-                ));
+            state.session.set_active_connection(
+                &ConnectionId::new(),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite://test.db",
+            );
         }
 
         #[test]

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -128,6 +128,9 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.ui.set_inspector_pane_height(10);
             state.ui.set_inspector_tab(InspectorTab::Columns);
+            state
+                .session
+                .set_active_db_capabilities_for_test(DbCapabilities::postgres_like());
             let cols: Vec<Column> = (0..columns)
                 .map(|i| Column {
                     name: format!("col_{i}"),

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -9,11 +9,12 @@ use super::inspector_max_scroll;
 
 fn inspector_page_scroll_delta(
     state: &AppState,
-    services: &AppServices,
+    _services: &AppServices,
     amount: ScrollAmount,
 ) -> Option<usize> {
-    let visible = match services
-        .db_capabilities
+    let visible = match state
+        .session
+        .active_db_capabilities()
         .normalize_inspector_tab(state.ui.inspector_tab())
     {
         InspectorTab::Ddl => state.inspector_ddl_visible_rows(),
@@ -275,15 +276,22 @@ mod tests {
         }
 
         fn services_without_ddl() -> AppServices {
-            let mut services = AppServices::stub();
-            services.db_capabilities =
-                DbCapabilities::new(true, vec![InspectorTab::Info, InspectorTab::Columns]);
-            services
+            AppServices::stub()
+        }
+
+        fn use_services_without_ddl(state: &mut AppState) {
+            state
+                .session
+                .set_active_db_capabilities_for_test(DbCapabilities::new(
+                    true,
+                    vec![InspectorTab::Info, InspectorTab::Columns],
+                ));
         }
 
         #[test]
         fn inspector_half_page_scroll_normalizes_unsupported_ddl_tab() {
             let mut state = state_with_table_detail(20);
+            use_services_without_ddl(&mut state);
             let services = services_without_ddl();
             state.ui.set_inspector_pane_height(7);
             state.ui.set_inspector_tab(InspectorTab::Ddl);
@@ -310,6 +318,7 @@ mod tests {
         #[test]
         fn inspector_full_page_scroll_normalizes_unsupported_ddl_tab() {
             let mut state = state_with_table_detail(20);
+            use_services_without_ddl(&mut state);
             let services = services_without_ddl();
             state.ui.set_inspector_pane_height(7);
             state.ui.set_inspector_tab(InspectorTab::Ddl);

--- a/src/app/update/browse/navigation/mod.rs
+++ b/src/app/update/browse/navigation/mod.rs
@@ -65,7 +65,7 @@ pub fn reduce_navigation(
     services: &AppServices,
     now: Instant,
 ) -> Option<Vec<Effect>> {
-    focus::reduce(state, action, services, now)
+    focus::reduce(state, action)
         .or_else(|| input::reduce(state, action))
         .or_else(|| explorer::reduce(state, action))
         .or_else(|| inspector::reduce(state, action, services))

--- a/src/app/update/browse/navigation/mod.rs
+++ b/src/app/update/browse/navigation/mod.rs
@@ -13,8 +13,9 @@ use crate::services::AppServices;
 use crate::update::action::Action;
 
 fn inspector_total_items(state: &AppState, services: &AppServices) -> usize {
-    let active_tab = services
-        .db_capabilities
+    let active_tab = state
+        .session
+        .active_db_capabilities()
         .normalize_inspector_tab(state.ui.inspector_tab());
     state
         .session
@@ -43,8 +44,9 @@ fn inspector_total_items(state: &AppState, services: &AppServices) -> usize {
 }
 
 pub(super) fn inspector_max_scroll(state: &AppState, services: &AppServices) -> usize {
-    let visible = match services
-        .db_capabilities
+    let visible = match state
+        .session
+        .active_db_capabilities()
         .normalize_inspector_tab(state.ui.inspector_tab())
     {
         InspectorTab::Ddl => state.inspector_ddl_visible_rows(),

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -7,6 +7,7 @@ use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{PREVIEW_PAGE_SIZE, PostDeleteRowSelection};
 use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::AdhocSuccessSnapshot;
+#[cfg(test)]
 use crate::services::AppServices;
 use crate::update::action::{Action, ModalKind, TableTarget};
 use crate::update::input::command::{command_to_action, parse_command};
@@ -51,12 +52,7 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult) -> Vec<Effect> 
     effects
 }
 
-pub fn reduce(
-    state: &mut AppState,
-    action: &Action,
-    now: Instant,
-    _services: &AppServices,
-) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
     match action {
         Action::QueryCompleted {
             result,

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -15,9 +15,9 @@ pub fn reduce_query(
     now: Instant,
     services: &AppServices,
 ) -> Option<Vec<Effect>> {
-    execution::reduce(state, action, now, services)
+    execution::reduce(state, action, now)
         .or_else(|| write::reduce(state, action, now, services))
-        .or_else(|| pagination::reduce(state, action, now, services))
+        .or_else(|| pagination::reduce(state, action, now))
 }
 
 #[cfg(test)]

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -6,15 +6,11 @@ use crate::domain::QuerySource;
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::PREVIEW_PAGE_SIZE;
 use crate::model::shared::input_mode::InputMode;
+#[cfg(test)]
 use crate::services::AppServices;
 use crate::update::action::Action;
 
-pub fn reduce(
-    state: &mut AppState,
-    action: &Action,
-    now: Instant,
-    _services: &AppServices,
-) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
     match action {
         Action::RequestCsvExport => {
             if !state.can_request_csv_export() {

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -18,7 +18,6 @@ pub(super) fn restore_cache(
     name: &str,
     database_type: DatabaseType,
     dsn: &str,
-    _services: &crate::services::AppServices,
 ) {
     state.session.restore_from_cache_for_connection(
         cache,

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -1,7 +1,6 @@
 use crate::domain::connection::{ConnectionId, DatabaseType};
 use crate::model::app_state::AppState;
 use crate::model::connection::cache::ConnectionCache;
-use crate::services::AppServices;
 
 pub(super) fn save_current_cache(state: &AppState) -> ConnectionCache {
     state.session.to_cache(
@@ -19,7 +18,7 @@ pub(super) fn restore_cache(
     name: &str,
     database_type: DatabaseType,
     dsn: &str,
-    services: &AppServices,
+    _services: &crate::services::AppServices,
 ) {
     state.session.restore_from_cache_for_connection(
         cache,
@@ -31,8 +30,9 @@ pub(super) fn restore_cache(
     );
     state.ui.set_explorer_selected_raw(cache.explorer_selected);
     state.ui.set_inspector_tab(
-        services
-            .db_capabilities
+        state
+            .session
+            .active_db_capabilities()
             .normalize_inspector_tab(cache.inspector_tab),
     );
     state

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use crate::cmd::effect::Effect;
 use crate::domain::connection::{ConnectionId, DatabaseType};
 use crate::model::app_state::AppState;
@@ -24,7 +22,7 @@ fn reset_for_new_connection(
     state.session.disable_read_only();
 }
 
-pub fn reduce(state: &mut AppState, action: &Action, _now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
     match action {
         Action::TryConnect => {
             if state.session.connection_state().is_not_connected()
@@ -100,7 +98,7 @@ mod tests {
         state.ui.set_inspector_tab(InspectorTab::Indexes);
 
         let action = create_switch_action(&new_id, "new_db");
-        reduce(&mut state, &action, Instant::now());
+        reduce(&mut state, &action);
 
         let saved = state.connection_caches.get(&current_id).unwrap();
         assert_eq!(saved.explorer_selected, 5);
@@ -120,7 +118,7 @@ mod tests {
         state.connection_caches.save(&target_id, cached);
 
         let action = create_switch_action(&target_id, "cached_db");
-        reduce(&mut state, &action, Instant::now());
+        reduce(&mut state, &action);
 
         assert_eq!(state.ui.explorer_selected(), 42);
         assert_eq!(state.ui.inspector_tab(), InspectorTab::ForeignKeys);
@@ -147,7 +145,7 @@ mod tests {
             name: "app.db".to_string(),
             database_type: DatabaseType::SQLite,
         });
-        reduce(&mut state, &action, Instant::now());
+        reduce(&mut state, &action);
 
         assert_eq!(state.ui.inspector_tab(), InspectorTab::Info);
     }
@@ -158,7 +156,7 @@ mod tests {
         let new_id = ConnectionId::new();
 
         let action = create_switch_action(&new_id, "fresh_db");
-        let effects = reduce(&mut state, &action, Instant::now()).unwrap();
+        let effects = reduce(&mut state, &action).unwrap();
 
         assert!(
             effects
@@ -182,7 +180,7 @@ mod tests {
             name: "app.db".to_string(),
             database_type: DatabaseType::SQLite,
         });
-        let effects = reduce(&mut state, &action, Instant::now()).unwrap();
+        let effects = reduce(&mut state, &action).unwrap();
 
         assert!(
             effects
@@ -219,7 +217,7 @@ mod tests {
             name: "app.db".to_string(),
             database_type: DatabaseType::SQLite,
         });
-        let effects = reduce(&mut state, &action, Instant::now()).unwrap();
+        let effects = reduce(&mut state, &action).unwrap();
 
         assert!(
             !effects
@@ -246,7 +244,7 @@ mod tests {
             .session
             .set_connection_state(ConnectionState::NotConnected);
 
-        let effects = reduce(&mut state, &Action::TryConnect, Instant::now()).unwrap();
+        let effects = reduce(&mut state, &Action::TryConnect).unwrap();
 
         assert!(
             effects
@@ -265,7 +263,7 @@ mod tests {
         let new_id = ConnectionId::new();
 
         let action = create_switch_action(&new_id, "target_db");
-        reduce(&mut state, &action, Instant::now());
+        reduce(&mut state, &action);
 
         assert_eq!(state.session.active_connection_id(), Some(&new_id));
         assert_eq!(state.session.dsn(), Some("postgres://localhost/target_db"));
@@ -286,7 +284,7 @@ mod tests {
             .save(&target_id, ConnectionCache::default());
 
         let action = create_switch_action(&target_id, "cached_db");
-        reduce(&mut state, &action, Instant::now());
+        reduce(&mut state, &action);
 
         assert_eq!(state.session.connection_state(), ConnectionState::Connected);
     }
@@ -302,7 +300,7 @@ mod tests {
         state.result_interaction.activate_cell(3, 2);
 
         let action = create_switch_action(&target_id, "cached_db");
-        reduce(&mut state, &action, Instant::now());
+        reduce(&mut state, &action);
 
         assert_eq!(
             state.result_interaction.selection().mode(),
@@ -318,7 +316,7 @@ mod tests {
         state.result_interaction.activate_cell(5, 0);
 
         let action = create_switch_action(&new_id, "fresh_db");
-        reduce(&mut state, &action, Instant::now());
+        reduce(&mut state, &action);
 
         assert_eq!(
             state.result_interaction.selection().mode(),
@@ -333,7 +331,7 @@ mod tests {
         state.session.enable_read_only();
 
         let action = create_switch_action(&new_id, "fresh_db");
-        reduce(&mut state, &action, Instant::now());
+        reduce(&mut state, &action);
 
         assert!(!state.session.is_read_only());
     }
@@ -344,7 +342,7 @@ mod tests {
         let new_id = ConnectionId::new();
 
         let action = create_switch_action(&new_id, "any_db");
-        let effects = reduce(&mut state, &action, Instant::now()).unwrap();
+        let effects = reduce(&mut state, &action).unwrap();
 
         assert!(
             effects

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -36,9 +36,6 @@ pub fn reduce(
             if state.session.connection_state().is_not_connected()
                 && state.modal.active_mode() == InputMode::Normal
             {
-                if state.session.active_database_type() == Some(DatabaseType::SQLite) {
-                    return Some(vec![]);
-                }
                 if let Some(dsn) = state.session.dsn().map(str::to_string) {
                     state.session.begin_connecting(&dsn);
                     Some(vec![Effect::FetchMetadata { dsn }])
@@ -61,12 +58,7 @@ pub fn reduce(
                 state.connection_caches.save(&current_id, cache);
             }
 
-            if *database_type == DatabaseType::SQLite {
-                state.connection_caches.remove(id);
-                reset_for_new_connection(state, id, dsn, name, *database_type);
-                state.session.mark_disconnected();
-                Some(vec![Effect::ClearCompletionEngineCache])
-            } else if let Some(cached) = state.connection_caches.get(id).cloned() {
+            if let Some(cached) = state.connection_caches.get(id).cloned() {
                 restore_cache(state, &cached, id, name, *database_type, dsn, services);
                 Some(vec![Effect::ClearCompletionEngineCache])
             } else {
@@ -150,12 +142,7 @@ mod tests {
     fn normalizes_cached_inspector_tab_when_capability_is_missing() {
         let mut state = AppState::new("test".to_string());
         let target_id = ConnectionId::new();
-        let mut services = AppServices::stub();
-        services.db_capabilities = crate::model::shared::db_capabilities::DbCapabilities::new(
-            true,
-            vec![InspectorTab::Info],
-        );
-
+        let services = AppServices::stub();
         let cached = ConnectionCache {
             explorer_selected: 42,
             inspector_tab: InspectorTab::Ddl,
@@ -163,7 +150,12 @@ mod tests {
         };
         state.connection_caches.save(&target_id, cached);
 
-        let action = create_switch_action(&target_id, "cached_db");
+        let action = Action::SwitchConnection(ConnectionTarget {
+            id: target_id,
+            dsn: "sqlite:///tmp/app.db".to_string(),
+            name: "app.db".to_string(),
+            database_type: DatabaseType::SQLite,
+        });
         reduce(&mut state, &action, Instant::now(), &services);
 
         assert_eq!(state.ui.inspector_tab(), InspectorTab::Info);
@@ -190,7 +182,7 @@ mod tests {
     }
 
     #[test]
-    fn sqlite_switch_without_cache_does_not_fetch_metadata() {
+    fn sqlite_switch_without_cache_fetches_metadata() {
         let mut state = AppState::new("test".to_string());
         let new_id = ConnectionId::new();
         let services = AppServices::stub();
@@ -204,11 +196,14 @@ mod tests {
         let effects = reduce(&mut state, &action, Instant::now(), &services).unwrap();
 
         assert!(
-            !effects
+            effects
                 .iter()
                 .any(|e| matches!(e, Effect::FetchMetadata { .. }))
         );
-        assert!(state.session.connection_state().is_not_connected());
+        assert_eq!(
+            state.session.connection_state(),
+            ConnectionState::Connecting
+        );
         assert_eq!(
             state.session.active_database_type(),
             Some(DatabaseType::SQLite)
@@ -216,7 +211,7 @@ mod tests {
     }
 
     #[test]
-    fn sqlite_switch_ignores_stale_cache() {
+    fn sqlite_switch_restores_cache() {
         let mut state = AppState::new("test".to_string());
         let target_id = ConnectionId::new();
         let services = AppServices::stub();
@@ -243,17 +238,17 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, Effect::FetchMetadata { .. }))
         );
-        assert!(state.connection_caches.get(&target_id).is_none());
-        assert_eq!(state.ui.explorer_selected(), 0);
+        assert!(state.connection_caches.get(&target_id).is_some());
+        assert_eq!(state.ui.explorer_selected(), 42);
         assert_eq!(
             state.session.active_database_type(),
             Some(DatabaseType::SQLite)
         );
-        assert!(state.session.connection_state().is_not_connected());
+        assert_eq!(state.session.connection_state(), ConnectionState::Connected);
     }
 
     #[test]
-    fn sqlite_try_connect_does_not_fetch_metadata() {
+    fn sqlite_try_connect_fetches_metadata() {
         let mut state = AppState::new("test".to_string());
         let services = AppServices::stub();
         state.session.set_dsn_for_test("sqlite:///tmp/app.db");
@@ -266,8 +261,15 @@ mod tests {
 
         let effects = reduce(&mut state, &Action::TryConnect, Instant::now(), &services).unwrap();
 
-        assert!(effects.is_empty());
-        assert!(state.session.connection_state().is_not_connected());
+        assert!(
+            effects
+                .iter()
+                .any(|e| matches!(e, Effect::FetchMetadata { .. }))
+        );
+        assert_eq!(
+            state.session.connection_state(),
+            ConnectionState::Connecting
+        );
     }
 
     #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -4,7 +4,6 @@ use crate::cmd::effect::Effect;
 use crate::domain::connection::{ConnectionId, DatabaseType};
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
-use crate::services::AppServices;
 use crate::update::action::{Action, ConnectionTarget};
 
 use super::helpers::{restore_cache, save_current_cache};
@@ -25,12 +24,7 @@ fn reset_for_new_connection(
     state.session.disable_read_only();
 }
 
-pub fn reduce(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-    services: &AppServices,
-) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action, _now: Instant) -> Option<Vec<Effect>> {
     match action {
         Action::TryConnect => {
             if state.session.connection_state().is_not_connected()
@@ -59,7 +53,7 @@ pub fn reduce(
             }
 
             if let Some(cached) = state.connection_caches.get(id).cloned() {
-                restore_cache(state, &cached, id, name, *database_type, dsn, services);
+                restore_cache(state, &cached, id, name, *database_type, dsn);
                 Some(vec![Effect::ClearCompletionEngineCache])
             } else {
                 // No cache: reset and fetch metadata
@@ -98,7 +92,6 @@ mod tests {
         let mut state = AppState::new("test".to_string());
         let current_id = ConnectionId::new();
         let new_id = ConnectionId::new();
-        let services = AppServices::stub();
 
         state
             .session
@@ -107,7 +100,7 @@ mod tests {
         state.ui.set_inspector_tab(InspectorTab::Indexes);
 
         let action = create_switch_action(&new_id, "new_db");
-        reduce(&mut state, &action, Instant::now(), &services);
+        reduce(&mut state, &action, Instant::now());
 
         let saved = state.connection_caches.get(&current_id).unwrap();
         assert_eq!(saved.explorer_selected, 5);
@@ -118,7 +111,6 @@ mod tests {
     fn restores_cached_state_when_available() {
         let mut state = AppState::new("test".to_string());
         let target_id = ConnectionId::new();
-        let services = AppServices::stub();
 
         let cached = ConnectionCache {
             explorer_selected: 42,
@@ -128,7 +120,7 @@ mod tests {
         state.connection_caches.save(&target_id, cached);
 
         let action = create_switch_action(&target_id, "cached_db");
-        reduce(&mut state, &action, Instant::now(), &services);
+        reduce(&mut state, &action, Instant::now());
 
         assert_eq!(state.ui.explorer_selected(), 42);
         assert_eq!(state.ui.inspector_tab(), InspectorTab::ForeignKeys);
@@ -142,7 +134,6 @@ mod tests {
     fn normalizes_cached_inspector_tab_when_capability_is_missing() {
         let mut state = AppState::new("test".to_string());
         let target_id = ConnectionId::new();
-        let services = AppServices::stub();
         let cached = ConnectionCache {
             explorer_selected: 42,
             inspector_tab: InspectorTab::Ddl,
@@ -156,7 +147,7 @@ mod tests {
             name: "app.db".to_string(),
             database_type: DatabaseType::SQLite,
         });
-        reduce(&mut state, &action, Instant::now(), &services);
+        reduce(&mut state, &action, Instant::now());
 
         assert_eq!(state.ui.inspector_tab(), InspectorTab::Info);
     }
@@ -165,10 +156,9 @@ mod tests {
     fn fetches_metadata_when_no_cache_exists() {
         let mut state = AppState::new("test".to_string());
         let new_id = ConnectionId::new();
-        let services = AppServices::stub();
 
         let action = create_switch_action(&new_id, "fresh_db");
-        let effects = reduce(&mut state, &action, Instant::now(), &services).unwrap();
+        let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
         assert!(
             effects
@@ -185,7 +175,6 @@ mod tests {
     fn sqlite_switch_without_cache_fetches_metadata() {
         let mut state = AppState::new("test".to_string());
         let new_id = ConnectionId::new();
-        let services = AppServices::stub();
 
         let action = Action::SwitchConnection(ConnectionTarget {
             id: new_id,
@@ -193,7 +182,7 @@ mod tests {
             name: "app.db".to_string(),
             database_type: DatabaseType::SQLite,
         });
-        let effects = reduce(&mut state, &action, Instant::now(), &services).unwrap();
+        let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
         assert!(
             effects
@@ -214,7 +203,6 @@ mod tests {
     fn sqlite_switch_restores_cache() {
         let mut state = AppState::new("test".to_string());
         let target_id = ConnectionId::new();
-        let services = AppServices::stub();
         state.ui.set_explorer_selected_raw(7);
         state.connection_caches.save(
             &target_id,
@@ -231,7 +219,7 @@ mod tests {
             name: "app.db".to_string(),
             database_type: DatabaseType::SQLite,
         });
-        let effects = reduce(&mut state, &action, Instant::now(), &services).unwrap();
+        let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
         assert!(
             !effects
@@ -250,7 +238,6 @@ mod tests {
     #[test]
     fn sqlite_try_connect_fetches_metadata() {
         let mut state = AppState::new("test".to_string());
-        let services = AppServices::stub();
         state.session.set_dsn_for_test("sqlite:///tmp/app.db");
         state
             .session
@@ -259,7 +246,7 @@ mod tests {
             .session
             .set_connection_state(ConnectionState::NotConnected);
 
-        let effects = reduce(&mut state, &Action::TryConnect, Instant::now(), &services).unwrap();
+        let effects = reduce(&mut state, &Action::TryConnect, Instant::now()).unwrap();
 
         assert!(
             effects
@@ -276,10 +263,9 @@ mod tests {
     fn updates_active_connection_fields() {
         let mut state = AppState::new("test".to_string());
         let new_id = ConnectionId::new();
-        let services = AppServices::stub();
 
         let action = create_switch_action(&new_id, "target_db");
-        reduce(&mut state, &action, Instant::now(), &services);
+        reduce(&mut state, &action, Instant::now());
 
         assert_eq!(state.session.active_connection_id(), Some(&new_id));
         assert_eq!(state.session.dsn(), Some("postgres://localhost/target_db"));
@@ -294,14 +280,13 @@ mod tests {
     fn sets_connected_state_when_cache_exists() {
         let mut state = AppState::new("test".to_string());
         let target_id = ConnectionId::new();
-        let services = AppServices::stub();
 
         state
             .connection_caches
             .save(&target_id, ConnectionCache::default());
 
         let action = create_switch_action(&target_id, "cached_db");
-        reduce(&mut state, &action, Instant::now(), &services);
+        reduce(&mut state, &action, Instant::now());
 
         assert_eq!(state.session.connection_state(), ConnectionState::Connected);
     }
@@ -310,7 +295,6 @@ mod tests {
     fn resets_result_selection_when_restoring_cache() {
         let mut state = AppState::new("test".to_string());
         let target_id = ConnectionId::new();
-        let services = AppServices::stub();
 
         state
             .connection_caches
@@ -318,7 +302,7 @@ mod tests {
         state.result_interaction.activate_cell(3, 2);
 
         let action = create_switch_action(&target_id, "cached_db");
-        reduce(&mut state, &action, Instant::now(), &services);
+        reduce(&mut state, &action, Instant::now());
 
         assert_eq!(
             state.result_interaction.selection().mode(),
@@ -330,12 +314,11 @@ mod tests {
     fn resets_result_selection_when_no_cache() {
         let mut state = AppState::new("test".to_string());
         let new_id = ConnectionId::new();
-        let services = AppServices::stub();
 
         state.result_interaction.activate_cell(5, 0);
 
         let action = create_switch_action(&new_id, "fresh_db");
-        reduce(&mut state, &action, Instant::now(), &services);
+        reduce(&mut state, &action, Instant::now());
 
         assert_eq!(
             state.result_interaction.selection().mode(),
@@ -347,11 +330,10 @@ mod tests {
     fn resets_read_only_on_switch() {
         let mut state = AppState::new("test".to_string());
         let new_id = ConnectionId::new();
-        let services = AppServices::stub();
         state.session.enable_read_only();
 
         let action = create_switch_action(&new_id, "fresh_db");
-        reduce(&mut state, &action, Instant::now(), &services);
+        reduce(&mut state, &action, Instant::now());
 
         assert!(!state.session.is_read_only());
     }
@@ -360,10 +342,9 @@ mod tests {
     fn clears_completion_cache_on_switch() {
         let mut state = AppState::new("test".to_string());
         let new_id = ConnectionId::new();
-        let services = AppServices::stub();
 
         let action = create_switch_action(&new_id, "any_db");
-        let effects = reduce(&mut state, &action, Instant::now(), &services).unwrap();
+        let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
         assert!(
             effects

--- a/src/app/update/connection/mod.rs
+++ b/src/app/update/connection/mod.rs
@@ -15,7 +15,7 @@ pub fn reduce_connection(
     action: &Action,
     now: Instant,
 ) -> Option<Vec<Effect>> {
-    lifecycle::reduce(state, action, now)
+    lifecycle::reduce(state, action)
         .or_else(|| setup::reduce(state, action, now))
         .or_else(|| error::reduce(state, action, now))
         .or_else(|| selector::reduce(state, action, now))

--- a/src/app/update/connection/mod.rs
+++ b/src/app/update/connection/mod.rs
@@ -8,16 +8,14 @@ use std::time::Instant;
 
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
-use crate::services::AppServices;
 use crate::update::action::Action;
 
 pub fn reduce_connection(
     state: &mut AppState,
     action: &Action,
     now: Instant,
-    services: &AppServices,
 ) -> Option<Vec<Effect>> {
-    lifecycle::reduce(state, action, now, services)
+    lifecycle::reduce(state, action, now)
         .or_else(|| setup::reduce(state, action, now))
         .or_else(|| error::reduce(state, action, now))
         .or_else(|| selector::reduce(state, action, now))
@@ -37,7 +35,6 @@ mod tests {
             &mut state,
             &Action::Paste("hello".to_string()),
             Instant::now(),
-            &AppServices::stub(),
         );
 
         assert!(result.is_some());
@@ -52,7 +49,6 @@ mod tests {
             &mut state,
             &Action::Paste("hello".to_string()),
             Instant::now(),
-            &AppServices::stub(),
         );
 
         assert!(result.is_none());
@@ -62,12 +58,7 @@ mod tests {
     fn unknown_action_returns_none() {
         let mut state = AppState::new("test".to_string());
 
-        let result = reduce_connection(
-            &mut state,
-            &Action::Quit,
-            Instant::now(),
-            &AppServices::stub(),
-        );
+        let result = reduce_connection(&mut state, &Action::Quit, Instant::now());
 
         assert!(result.is_none());
     }

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -1,7 +1,6 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::connection::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::connection::setup::{
     CONNECTION_INPUT_VISIBLE_WIDTH, ConnectionField, ConnectionSetupState,
@@ -155,9 +154,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                         return Some(vec![]);
                     }
                 };
-                if config.database_type() != DatabaseType::SQLite {
-                    state.session.mark_connecting();
-                }
+                state.session.mark_connecting();
                 Some(vec![Effect::SaveAndConnect {
                     id: setup.editing_id().cloned(),
                     name: setup
@@ -197,10 +194,6 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 .session
                 .set_active_connection(id, name, *database_type, dsn);
             state.session.disable_read_only();
-            if *database_type == DatabaseType::SQLite {
-                state.session.mark_disconnected();
-                return Some(vec![]);
-            }
             state.session.begin_connecting(dsn);
             Some(vec![Effect::FetchMetadata { dsn: dsn.clone() }])
         }
@@ -404,6 +397,7 @@ mod tests {
 
     mod connection_save {
         use super::*;
+        use crate::domain::DatabaseType;
         use crate::domain::MetadataState;
         use crate::model::connection::state::ConnectionState;
         use crate::update::action::ConnectionTarget;
@@ -456,7 +450,7 @@ mod tests {
         }
 
         #[test]
-        fn sqlite_save_does_not_enter_connecting_state() {
+        fn sqlite_save_enters_connecting_state() {
             let mut state = AppState::new("test".to_string());
             state
                 .connection_setup
@@ -477,9 +471,9 @@ mod tests {
 
             assert_eq!(
                 state.session.connection_state(),
-                ConnectionState::NotConnected
+                ConnectionState::Connecting
             );
-            assert_eq!(state.session.metadata_state(), &MetadataState::NotLoaded);
+            assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
             assert!(matches!(
                 effects.as_slice(),
                 [Effect::SaveAndConnect { .. }]
@@ -503,7 +497,7 @@ mod tests {
         }
 
         #[test]
-        fn sqlite_save_completed_does_not_fetch_metadata() {
+        fn sqlite_save_completed_fetches_metadata() {
             let mut state = AppState::new("test".to_string());
 
             let action = Action::ConnectionSaveCompleted(ConnectionTarget {
@@ -514,13 +508,20 @@ mod tests {
             });
             let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
-            assert!(effects.is_empty());
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
             assert_eq!(state.session.dsn(), Some("sqlite:///tmp/app.db"));
             assert_eq!(
                 state.session.active_database_type(),
                 Some(DatabaseType::SQLite)
             );
-            assert!(state.session.connection_state().is_not_connected());
+            assert_eq!(
+                state.session.connection_state(),
+                ConnectionState::Connecting
+            );
         }
     }
 

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -14,12 +14,13 @@ fn is_multi_statement(content: &str) -> bool {
     split_statements(content).len() > 1
 }
 
-fn mark_explain_unavailable(state: &mut AppState, services: &AppServices) {
+fn mark_explain_unavailable(state: &mut AppState) {
     state
         .explain
         .set_error("EXPLAIN is unavailable for this database".to_string());
-    let tab = services
-        .db_capabilities
+    let tab = state
+        .session
+        .active_db_capabilities()
         .normalize_sql_modal_tab(state.sql_modal.active_tab());
     state.sql_modal.set_active_tab(tab);
 }
@@ -58,12 +59,12 @@ fn finish_explain_error(state: &mut AppState, error: impl Into<String>) {
     state.query.mark_idle();
 }
 
-fn reject_unsupported_explain(state: &mut AppState, services: &AppServices) -> bool {
-    if services.db_capabilities.supports_explain() {
+fn reject_unsupported_explain(state: &mut AppState) -> bool {
+    if state.session.active_db_capabilities().supports_explain() {
         return false;
     }
 
-    mark_explain_unavailable(state, services);
+    mark_explain_unavailable(state);
     true
 }
 
@@ -75,7 +76,7 @@ pub fn reduce_explain_with_services(
 ) -> Option<Vec<Effect>> {
     match action {
         Action::ExplainRequest => {
-            if reject_unsupported_explain(state, services) {
+            if reject_unsupported_explain(state) {
                 return Some(vec![]);
             }
             let content = state.sql_modal.editor().content().trim().to_string();
@@ -94,7 +95,7 @@ pub fn reduce_explain_with_services(
             }
 
             let Some(query) = services.sql_dialect.build_explain_sql(&content) else {
-                mark_explain_unavailable(state, services);
+                mark_explain_unavailable(state);
                 return Some(vec![]);
             };
             begin_explain_running(state, now);
@@ -108,7 +109,7 @@ pub fn reduce_explain_with_services(
         }
 
         Action::ExplainAnalyzeRequest => {
-            if reject_unsupported_explain(state, services) {
+            if reject_unsupported_explain(state) {
                 return Some(vec![]);
             }
             let content = state.sql_modal.editor().content().trim().to_string();
@@ -153,7 +154,7 @@ pub fn reduce_explain_with_services(
                     let Some(explain_query) =
                         services.sql_dialect.build_explain_analyze_sql(&content)
                     else {
-                        mark_explain_unavailable(state, services);
+                        mark_explain_unavailable(state);
                         return Some(vec![]);
                     };
                     begin_explain_running(state, now);
@@ -170,7 +171,7 @@ pub fn reduce_explain_with_services(
         }
 
         Action::ExplainAnalyzeConfirm => {
-            if reject_unsupported_explain(state, services) {
+            if reject_unsupported_explain(state) {
                 return Some(vec![]);
             }
             let query = match state.sql_modal.status() {
@@ -189,7 +190,7 @@ pub fn reduce_explain_with_services(
             {
                 let Some(explain_query) = services.sql_dialect.build_explain_analyze_sql(&query)
                 else {
-                    mark_explain_unavailable(state, services);
+                    mark_explain_unavailable(state);
                     return Some(vec![]);
                 };
                 begin_explain_running(state, now);
@@ -286,16 +287,18 @@ pub fn reduce_explain_with_services(
         }
 
         Action::SqlModalNextTab => {
-            let tab = services
-                .db_capabilities
+            let tab = state
+                .session
+                .active_db_capabilities()
                 .next_sql_modal_tab(state.sql_modal.active_tab());
             state.sql_modal.set_active_tab(tab);
             Some(vec![])
         }
 
         Action::SqlModalPrevTab => {
-            let tab = services
-                .db_capabilities
+            let tab = state
+                .session
+                .active_db_capabilities()
                 .prev_sql_modal_tab(state.sql_modal.active_tab());
             state.sql_modal.set_active_tab(tab);
             Some(vec![])
@@ -327,9 +330,16 @@ mod tests {
     }
 
     fn services_without_explain() -> AppServices {
-        let mut services = AppServices::stub();
-        services.db_capabilities = DbCapabilities::new(false, vec![InspectorTab::Info]);
-        services
+        AppServices::stub()
+    }
+
+    fn disable_explain_for_test(state: &mut AppState) {
+        state
+            .session
+            .set_active_db_capabilities_for_test(DbCapabilities::new(
+                false,
+                vec![InspectorTab::Info],
+            ));
     }
 
     mod explain_request {
@@ -372,6 +382,7 @@ mod tests {
                 .editor_mut_for_input()
                 .set_content("SELECT 1".to_string());
             state.session.set_dsn_for_test("dsn://test");
+            disable_explain_for_test(&mut state);
             state.sql_modal.begin_adhoc_running();
 
             let effects =
@@ -388,6 +399,7 @@ mod tests {
                 .editor_mut_for_input()
                 .set_content("SELECT 1".to_string());
             state.session.set_dsn_for_test("dsn://test");
+            disable_explain_for_test(&mut state);
 
             let effects = reduce_explain_with_services(
                 &mut state,
@@ -510,6 +522,7 @@ mod tests {
                 .editor_mut_for_input()
                 .set_content("SELECT 1".to_string());
             state.session.set_dsn_for_test("dsn://test");
+            disable_explain_for_test(&mut state);
 
             let effects = reduce_explain_with_services(
                 &mut state,
@@ -1133,6 +1146,7 @@ mod tests {
         fn next_tab_stays_on_sql_when_explain_is_unsupported() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
+            disable_explain_for_test(&mut state);
 
             reduce_explain_with_services(
                 &mut state,
@@ -1148,6 +1162,7 @@ mod tests {
         fn next_tab_normalizes_stale_plan_to_sql_when_explain_is_unsupported() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
+            disable_explain_for_test(&mut state);
 
             reduce_explain_with_services(
                 &mut state,
@@ -1193,6 +1208,7 @@ mod tests {
         fn prev_tab_stays_on_sql_when_explain_is_unsupported() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
+            disable_explain_for_test(&mut state);
 
             reduce_explain_with_services(
                 &mut state,
@@ -1208,6 +1224,7 @@ mod tests {
         fn prev_tab_normalizes_stale_compare_to_sql_when_explain_is_unsupported() {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
+            disable_explain_for_test(&mut state);
 
             reduce_explain_with_services(
                 &mut state,

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -332,10 +332,6 @@ mod tests {
         state
     }
 
-    fn services_without_explain() -> AppServices {
-        AppServices::stub()
-    }
-
     fn disable_explain_for_test(state: &mut AppState) {
         state
             .session
@@ -408,7 +404,7 @@ mod tests {
                 &mut state,
                 &Action::ExplainRequest,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             )
             .unwrap();
 
@@ -531,7 +527,7 @@ mod tests {
                 &mut state,
                 &Action::ExplainAnalyzeRequest,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             )
             .unwrap();
 
@@ -1155,7 +1151,7 @@ mod tests {
                 &mut state,
                 &Action::SqlModalNextTab,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             );
 
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
@@ -1171,7 +1167,7 @@ mod tests {
                 &mut state,
                 &Action::SqlModalNextTab,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             );
 
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
@@ -1217,7 +1213,7 @@ mod tests {
                 &mut state,
                 &Action::SqlModalPrevTab,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             );
 
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
@@ -1233,7 +1229,7 @@ mod tests {
                 &mut state,
                 &Action::SqlModalPrevTab,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             );
 
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -327,6 +327,9 @@ mod tests {
         let mut state = AppState::new("test".to_string());
         state.modal.set_mode(InputMode::SqlModal);
         state
+            .session
+            .set_active_db_capabilities_for_test(DbCapabilities::postgres_like());
+        state
     }
 
     fn services_without_explain() -> AppServices {

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -316,9 +316,8 @@ pub fn reduce_explain(state: &mut AppState, action: &Action, now: Instant) -> Op
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::shared::db_capabilities::DbCapabilities;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::shared::input_mode::InputMode;
-    use crate::model::shared::inspector_tab::InspectorTab;
     use crate::services::AppServices;
     use crate::update::action::ScrollDirection;
     use std::time::Instant;
@@ -326,19 +325,22 @@ mod tests {
     fn sql_modal_state() -> AppState {
         let mut state = AppState::new("test".to_string());
         state.modal.set_mode(InputMode::SqlModal);
-        state
-            .session
-            .set_active_db_capabilities_for_test(DbCapabilities::postgres_like());
+        state.session.set_active_connection(
+            &ConnectionId::new(),
+            "postgres",
+            DatabaseType::PostgreSQL,
+            "postgres://test",
+        );
         state
     }
 
     fn disable_explain_for_test(state: &mut AppState) {
-        state
-            .session
-            .set_active_db_capabilities_for_test(DbCapabilities::new(
-                false,
-                vec![InspectorTab::Info],
-            ));
+        state.session.set_active_connection(
+            &ConnectionId::new(),
+            "sqlite",
+            DatabaseType::SQLite,
+            "sqlite://test.db",
+        );
     }
 
     mod explain_request {
@@ -366,6 +368,7 @@ mod tests {
                 .sql_modal
                 .editor_mut_for_input()
                 .set_content("SELECT 1".to_string());
+            state.session.clear_dsn_for_test();
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainRequest, Instant::now()).unwrap();

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -9,14 +9,13 @@ mod sql_modal;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::ports::inbound::{InputEvent, KeyCombo};
-use crate::services::AppServices;
 use crate::update::action::Action;
 
-pub fn handle_event(event: InputEvent, state: &AppState, services: &AppServices) -> Action {
+pub fn handle_event(event: InputEvent, state: &AppState) -> Action {
     match event {
         InputEvent::Init => Action::Render,
         InputEvent::Resize(w, h) => Action::Resize(w, h),
-        InputEvent::Key(combo) => handle_key_event(combo, state, services),
+        InputEvent::Key(combo) => handle_key_event(combo, state),
         InputEvent::Paste(text) => handle_paste_event(text, state),
     }
 }
@@ -36,7 +35,7 @@ fn handle_paste_event(text: String, state: &AppState) -> Action {
     }
 }
 
-fn handle_key_event(combo: KeyCombo, state: &AppState, _services: &AppServices) -> Action {
+fn handle_key_event(combo: KeyCombo, state: &AppState) -> Action {
     match state.input_mode() {
         InputMode::Normal => normal::handle_normal_mode(combo, state),
         InputMode::CommandLine => editors::handle_command_line_mode(combo),
@@ -98,10 +97,9 @@ mod tests {
         #[test]
         fn normal_mode_routes_to_normal_handler() {
             let state = make_state(InputMode::Normal);
-            let services = AppServices::stub();
 
             // 'q' in Normal mode should quit
-            let result = handle_key_event(combo(Key::Char('q')), &state, &services);
+            let result = handle_key_event(combo(Key::Char('q')), &state);
 
             assert!(matches!(result, Action::Quit));
         }
@@ -109,10 +107,9 @@ mod tests {
         #[test]
         fn sql_modal_mode_routes_to_sql_modal_handler() {
             let state = make_state(InputMode::SqlModal);
-            let services = AppServices::stub();
 
             // Esc in SqlModal (Normal mode, the default) should close modal
-            let result = handle_key_event(combo(Key::Esc), &state, &services);
+            let result = handle_key_event(combo(Key::Esc), &state);
 
             assert!(matches!(result, Action::CloseModal(ModalKind::SqlModal)));
         }
@@ -124,12 +121,11 @@ mod tests {
                 .sql_modal
                 .set_active_tab(crate::model::sql_editor::modal::SqlModalTab::Plan);
 
-            let services = AppServices::stub();
             state
                 .session
                 .set_active_database_type_for_test(Some(crate::domain::DatabaseType::SQLite));
 
-            let result = handle_key_event(combo(Key::Char('i')), &state, &services);
+            let result = handle_key_event(combo(Key::Char('i')), &state);
 
             assert!(matches!(result, Action::SqlModalEnterInsert));
         }
@@ -205,9 +201,8 @@ mod tests {
         #[test]
         fn init_maps_to_render() {
             let state = AppState::new("test".to_string());
-            let services = AppServices::stub();
 
-            let result = handle_event(InputEvent::Init, &state, &services);
+            let result = handle_event(InputEvent::Init, &state);
 
             assert!(matches!(result, Action::Render));
         }
@@ -215,9 +210,8 @@ mod tests {
         #[test]
         fn resize_maps_to_resize() {
             let state = AppState::new("test".to_string());
-            let services = AppServices::stub();
 
-            let result = handle_event(InputEvent::Resize(80, 24), &state, &services);
+            let result = handle_event(InputEvent::Resize(80, 24), &state);
 
             assert!(matches!(result, Action::Resize(80, 24)));
         }

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -36,7 +36,7 @@ fn handle_paste_event(text: String, state: &AppState) -> Action {
     }
 }
 
-fn handle_key_event(combo: KeyCombo, state: &AppState, services: &AppServices) -> Action {
+fn handle_key_event(combo: KeyCombo, state: &AppState, _services: &AppServices) -> Action {
     match state.input_mode() {
         InputMode::Normal => normal::handle_normal_mode(combo, state),
         InputMode::CommandLine => editors::handle_command_line_mode(combo),
@@ -51,8 +51,9 @@ fn handle_key_event(combo: KeyCombo, state: &AppState, services: &AppServices) -
                 combo,
                 completion_visible,
                 state.sql_modal.status(),
-                services
-                    .db_capabilities
+                state
+                    .session
+                    .active_db_capabilities()
                     .normalize_sql_modal_tab(state.sql_modal.active_tab()),
                 state.ui.key_sequence().pending_prefix(),
             )
@@ -123,11 +124,10 @@ mod tests {
                 .sql_modal
                 .set_active_tab(crate::model::sql_editor::modal::SqlModalTab::Plan);
 
-            let mut services = AppServices::stub();
-            services.db_capabilities = crate::model::shared::db_capabilities::DbCapabilities::new(
-                false,
-                vec![crate::model::shared::inspector_tab::InspectorTab::Info],
-            );
+            let services = AppServices::stub();
+            state
+                .session
+                .set_active_database_type_for_test(Some(crate::domain::DatabaseType::SQLite));
 
             let result = handle_key_event(combo(Key::Char('i')), &state, &services);
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -47,11 +47,11 @@ fn reduce_inner(
 
     // reduce_result must precede reduce_query: passthrough actions (e.g. ResultNextPage)
     // reset view state here and return None, relying on reduce_query for the actual page change.
-    if let Some(effects) = reduce_connection(state, &action, now, services)
+    if let Some(effects) = reduce_connection(state, &action, now)
         .or_else(|| reduce_modal(state, &action, now))
         .or_else(|| reduce_result(state, &action, services, now))
         .or_else(|| reduce_navigation(state, &action, services, now))
-        .or_else(|| reduce_sql_modal(state, &action, now, services))
+        .or_else(|| reduce_sql_modal(state, &action, now))
         .or_else(|| reduce_explain_with_services(state, &action, now, services))
         .or_else(|| reduce_metadata(state, &action, now))
         .or_else(|| reduce_er(state, &action, now))

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -24,7 +24,7 @@ pub fn reduce_sql_modal(
     state: &mut AppState,
     action: &Action,
     now: Instant,
-    services: &crate::services::AppServices,
+    _services: &crate::services::AppServices,
 ) -> Option<Vec<Effect>> {
     match action {
         // Completion navigation
@@ -363,8 +363,9 @@ pub fn reduce_sql_modal(
             Some(vec![])
         }
         Action::SqlModalYank => {
-            let active_tab = services
-                .db_capabilities
+            let active_tab = state
+                .session
+                .active_db_capabilities()
                 .normalize_sql_modal_tab(state.sql_modal.active_tab());
             let content = match active_tab {
                 SqlModalTab::Plan => state.explain.plan_text().map(str::to_string),

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -471,6 +471,7 @@ fn adhoc_effects(state: &AppState, query: String) -> Vec<Effect> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::shared::db_capabilities::DbCapabilities;
     use std::time::Instant;
 
     fn reduce_sql_modal(
@@ -484,6 +485,9 @@ mod tests {
     fn sql_modal_state() -> AppState {
         let mut state = AppState::new("test".to_string());
         state.modal.set_mode(InputMode::SqlModal);
+        state
+            .session
+            .set_active_db_capabilities_for_test(DbCapabilities::postgres_like());
         state
     }
 

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -24,7 +24,6 @@ pub fn reduce_sql_modal(
     state: &mut AppState,
     action: &Action,
     now: Instant,
-    _services: &crate::services::AppServices,
 ) -> Option<Vec<Effect>> {
     match action {
         // Completion navigation
@@ -471,7 +470,7 @@ fn adhoc_effects(state: &AppState, query: String) -> Vec<Effect> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::shared::db_capabilities::DbCapabilities;
+    use crate::domain::{ConnectionId, DatabaseType};
     use std::time::Instant;
 
     fn reduce_sql_modal(
@@ -479,15 +478,18 @@ mod tests {
         action: &Action,
         now: Instant,
     ) -> Option<Vec<Effect>> {
-        super::reduce_sql_modal(state, action, now, &crate::services::AppServices::stub())
+        super::reduce_sql_modal(state, action, now)
     }
 
     fn sql_modal_state() -> AppState {
         let mut state = AppState::new("test".to_string());
         state.modal.set_mode(InputMode::SqlModal);
-        state
-            .session
-            .set_active_db_capabilities_for_test(DbCapabilities::postgres_like());
+        state.session.set_active_connection(
+            &ConnectionId::new(),
+            "postgres",
+            DatabaseType::PostgreSQL,
+            "postgres://test",
+        );
         state
     }
 

--- a/src/infra/adapters/mod.rs
+++ b/src/infra/adapters/mod.rs
@@ -8,6 +8,7 @@ pub mod pg_service;
 pub mod postgres;
 pub mod query_history;
 pub mod registry;
+pub mod sqlite;
 
 pub use clipboard::ArboardClipboard;
 pub use config_writer::FileConfigWriter;
@@ -18,3 +19,4 @@ pub use pg_service::PgServiceFileReader;
 pub use postgres::PostgresAdapter;
 pub use query_history::FileQueryHistoryStore;
 pub use registry::DbAdapterRegistry;
+pub use sqlite::SqliteAdapter;

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
 
 use crate::app::ports::outbound::{
-    DatabaseCapabilities, DatabaseCapabilityProvider, DbOperationError, DdlGenerator, DsnBuilder,
-    InspectorFeature, MetadataProvider, QueryExecutor, SqlDialect,
+    DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor, SqlDialect,
 };
 use crate::domain::connection::ConnectionProfile;
 use crate::domain::{DatabaseMetadata, QueryResult, Table, TableSignature, WriteExecutionResult};
@@ -12,20 +11,6 @@ pub struct MySqlAdapter;
 impl MySqlAdapter {
     pub fn new() -> Self {
         Self
-    }
-}
-
-impl DatabaseCapabilityProvider for MySqlAdapter {
-    fn capabilities(&self) -> DatabaseCapabilities {
-        DatabaseCapabilities::new(
-            false,
-            vec![
-                InspectorFeature::Info,
-                InspectorFeature::Columns,
-                InspectorFeature::Indexes,
-                InspectorFeature::ForeignKeys,
-            ],
-        )
     }
 }
 

--- a/src/infra/adapters/postgres/mod.rs
+++ b/src/infra/adapters/postgres/mod.rs
@@ -1,9 +1,6 @@
 use async_trait::async_trait;
 
-use crate::app::ports::outbound::{
-    DatabaseCapabilities, DatabaseCapabilityProvider, DbOperationError, InspectorFeature,
-    MetadataProvider, QueryExecutor,
-};
+use crate::app::ports::outbound::{DbOperationError, MetadataProvider, QueryExecutor};
 use crate::domain::{
     Column, DatabaseMetadata, QueryResult, QuerySource, Table, TableSignature, WriteExecutionResult,
 };
@@ -35,23 +32,6 @@ impl PostgresAdapter {
         } else {
             Some(pk_cols)
         }
-    }
-}
-
-impl DatabaseCapabilityProvider for PostgresAdapter {
-    fn capabilities(&self) -> DatabaseCapabilities {
-        DatabaseCapabilities::new(
-            true,
-            vec![
-                InspectorFeature::Info,
-                InspectorFeature::Columns,
-                InspectorFeature::Indexes,
-                InspectorFeature::ForeignKeys,
-                InspectorFeature::Rls,
-                InspectorFeature::Triggers,
-                InspectorFeature::Ddl,
-            ],
-        )
     }
 }
 

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -183,8 +183,7 @@ impl QueryExecutor for DbAdapterRegistry {
     }
 }
 
-// SAB-204 only introduces connection groundwork. SQLite DDL/dialect dispatch
-// belongs with the SQLite adapter skeleton.
+// SQLite query and DDL support is intentionally out of scope for SAB-235.
 impl DdlGenerator for DbAdapterRegistry {
     fn generate_ddl(&self, table: &Table) -> String {
         self.postgres.generate_ddl(table)

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -37,7 +37,9 @@ impl DbAdapterRegistry {
     }
 
     fn sqlite_query_not_implemented() -> DbOperationError {
-        DbOperationError::QueryFailed("SQLite query execution is not implemented yet".to_string())
+        DbOperationError::UnsupportedOperation(
+            "SQLite query execution is not implemented yet".to_string(),
+        )
     }
 }
 
@@ -296,5 +298,44 @@ mod tests {
         let signatures = registry.fetch_table_signatures(&dsn).await.unwrap();
 
         assert_eq!(signatures[0].qualified_name(), "main.users");
+    }
+
+    #[tokio::test]
+    async fn sqlite_table_detail_is_dispatched_to_sqlite_adapter() {
+        let (_dir, dsn) = make_sqlite_dsn("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+
+        let detail = registry
+            .fetch_table_detail(&dsn, "main", "users")
+            .await
+            .unwrap();
+
+        assert_eq!(detail.schema, "main");
+        assert_eq!(detail.name, "users");
+        assert_eq!(detail.primary_key, Some(vec!["id".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn sqlite_columns_and_fks_are_dispatched_to_sqlite_adapter() {
+        let (_dir, dsn) = make_sqlite_dsn(
+            r#"
+            CREATE TABLE orgs(id INTEGER PRIMARY KEY);
+            CREATE TABLE users(
+                id INTEGER PRIMARY KEY,
+                org_id INTEGER REFERENCES orgs(id)
+            );
+            "#,
+        );
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+
+        let detail = registry
+            .fetch_table_columns_and_fks(&dsn, "main", "users")
+            .await
+            .unwrap();
+
+        assert_eq!(detail.schema, "main");
+        assert!(detail.indexes.is_empty());
+        assert!(detail.columns.iter().any(|column| column.name == "org_id"));
+        assert_eq!(detail.foreign_keys[0].to_table, "orgs");
     }
 }

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -2,8 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use app::ports::outbound::{
-    DatabaseCapabilities, DatabaseCapabilityProvider, DbOperationError, DdlGenerator, DsnBuilder,
-    MetadataProvider, QueryExecutor, SqlDialect,
+    DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor, SqlDialect,
 };
 use async_trait::async_trait;
 use domain::connection::{ConnectionProfile, DatabaseType};
@@ -38,9 +37,7 @@ impl DbAdapterRegistry {
     }
 
     fn sqlite_query_not_implemented() -> DbOperationError {
-        DbOperationError::ConnectionFailed(
-            "SQLite query execution is not implemented yet".to_string(),
-        )
+        DbOperationError::QueryFailed("SQLite query execution is not implemented yet".to_string())
     }
 }
 
@@ -56,14 +53,6 @@ impl DsnBuilder for DbAdapterRegistry {
                 format!("sqlite://{path}")
             }
         }
-    }
-}
-
-impl DatabaseCapabilityProvider for DbAdapterRegistry {
-    fn capabilities(&self) -> DatabaseCapabilities {
-        // SAB-204 keeps capabilities startup-wide. Per-connection capability
-        // dispatch belongs with the SQLite adapter skeleton.
-        self.postgres.capabilities()
     }
 }
 

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -10,14 +10,19 @@ use domain::connection::{ConnectionProfile, DatabaseType};
 use domain::{DatabaseMetadata, QueryResult, Table, TableSignature, WriteExecutionResult};
 
 use super::postgres::PostgresAdapter;
+use super::sqlite::SqliteAdapter;
 
 pub struct DbAdapterRegistry {
     postgres: Arc<PostgresAdapter>,
+    sqlite: Arc<SqliteAdapter>,
 }
 
 impl DbAdapterRegistry {
     pub fn new(postgres: Arc<PostgresAdapter>) -> Self {
-        Self { postgres }
+        Self {
+            postgres,
+            sqlite: Arc::new(SqliteAdapter::new()),
+        }
     }
 
     fn db_type_from_dsn(dsn: &str) -> Result<DatabaseType, DbOperationError> {
@@ -32,10 +37,9 @@ impl DbAdapterRegistry {
         )))
     }
 
-    fn sqlite_not_implemented() -> DbOperationError {
+    fn sqlite_query_not_implemented() -> DbOperationError {
         DbOperationError::ConnectionFailed(
-            "SQLite adapter is not implemented yet; SAB-204 only adds connection groundwork"
-                .to_string(),
+            "SQLite query execution is not implemented yet".to_string(),
         )
     }
 }
@@ -68,7 +72,7 @@ impl MetadataProvider for DbAdapterRegistry {
     async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.fetch_metadata(dsn).await,
-            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+            DatabaseType::SQLite => self.sqlite.fetch_metadata(dsn).await,
         }
     }
 
@@ -80,7 +84,7 @@ impl MetadataProvider for DbAdapterRegistry {
     ) -> Result<Table, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.fetch_table_detail(dsn, schema, table).await,
-            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+            DatabaseType::SQLite => self.sqlite.fetch_table_detail(dsn, schema, table).await,
         }
     }
 
@@ -96,7 +100,11 @@ impl MetadataProvider for DbAdapterRegistry {
                     .fetch_table_columns_and_fks(dsn, schema, table)
                     .await
             }
-            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+            DatabaseType::SQLite => {
+                self.sqlite
+                    .fetch_table_columns_and_fks(dsn, schema, table)
+                    .await
+            }
         }
     }
 
@@ -106,7 +114,7 @@ impl MetadataProvider for DbAdapterRegistry {
     ) -> Result<Vec<TableSignature>, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.fetch_table_signatures(dsn).await,
-            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+            DatabaseType::SQLite => self.sqlite.fetch_table_signatures(dsn).await,
         }
     }
 }
@@ -128,7 +136,7 @@ impl QueryExecutor for DbAdapterRegistry {
                     .execute_preview(dsn, schema, table, limit, offset, read_only)
                     .await
             }
-            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+            DatabaseType::SQLite => Err(Self::sqlite_query_not_implemented()),
         }
     }
 
@@ -140,7 +148,7 @@ impl QueryExecutor for DbAdapterRegistry {
     ) -> Result<QueryResult, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.execute_adhoc(dsn, query, read_only).await,
-            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+            DatabaseType::SQLite => Err(Self::sqlite_query_not_implemented()),
         }
     }
 
@@ -152,7 +160,7 @@ impl QueryExecutor for DbAdapterRegistry {
     ) -> Result<WriteExecutionResult, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.execute_write(dsn, query, read_only).await,
-            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+            DatabaseType::SQLite => Err(Self::sqlite_query_not_implemented()),
         }
     }
 
@@ -164,7 +172,7 @@ impl QueryExecutor for DbAdapterRegistry {
     ) -> Result<usize, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.count_query_rows(dsn, query, read_only).await,
-            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+            DatabaseType::SQLite => Err(Self::sqlite_query_not_implemented()),
         }
     }
 
@@ -181,7 +189,7 @@ impl QueryExecutor for DbAdapterRegistry {
                     .export_to_csv(dsn, query, path, read_only)
                     .await
             }
-            DatabaseType::SQLite => Err(Self::sqlite_not_implemented()),
+            DatabaseType::SQLite => Err(Self::sqlite_query_not_implemented()),
         }
     }
 }
@@ -230,6 +238,19 @@ impl SqlDialect for DbAdapterRegistry {
 mod tests {
     use super::*;
     use domain::connection::SslMode;
+    use std::process::Command;
+
+    fn make_sqlite_dsn(sql: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("app.db");
+        let status = Command::new("sqlite3")
+            .arg(&path)
+            .arg(sql)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        (dir, format!("sqlite://{}", path.display()))
+    }
 
     #[test]
     fn builds_postgres_dsn_from_postgres_profile() {
@@ -267,5 +288,25 @@ mod tests {
         let result = registry.fetch_metadata("mysql://localhost/db").await;
 
         assert!(matches!(result, Err(DbOperationError::ConnectionFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn sqlite_metadata_is_dispatched_to_sqlite_adapter() {
+        let (_dir, dsn) = make_sqlite_dsn("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+
+        let metadata = registry.fetch_metadata(&dsn).await.unwrap();
+
+        assert_eq!(metadata.table_summaries[0].qualified_name(), "main.users");
+    }
+
+    #[tokio::test]
+    async fn sqlite_table_signatures_are_dispatched_to_sqlite_adapter() {
+        let (_dir, dsn) = make_sqlite_dsn("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+
+        let signatures = registry.fetch_table_signatures(&dsn).await.unwrap();
+
+        assert_eq!(signatures[0].qualified_name(), "main.users");
     }
 }

--- a/src/infra/adapters/sqlite/cli.rs
+++ b/src/infra/adapters/sqlite/cli.rs
@@ -1,0 +1,97 @@
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
+
+use serde::de::DeserializeOwned;
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use crate::app::ports::outbound::DbOperationError;
+
+#[derive(Debug, Clone)]
+pub(super) struct SqliteCli {
+    timeout_secs: u64,
+}
+
+struct SqliteOutput {
+    status: ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+impl SqliteCli {
+    pub(super) fn new() -> Self {
+        Self { timeout_secs: 30 }
+    }
+
+    pub(super) async fn execute_json<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        sql: &str,
+    ) -> Result<T, DbOperationError> {
+        let output = self.run(path, sql).await?;
+        if !output.status.success() {
+            return Err(DbOperationError::QueryFailed(output.stderr));
+        }
+        let stdout = match output.stdout.trim() {
+            "" => "[]",
+            stdout => stdout,
+        };
+        serde_json::from_str(stdout).map_err(DbOperationError::from)
+    }
+
+    async fn run(&self, path: &str, sql: &str) -> Result<SqliteOutput, DbOperationError> {
+        let mut cmd = Command::new("sqlite3");
+        cmd.arg("-json").arg(path).arg(sql);
+        Self::collect_output(&mut cmd, self.timeout_secs).await
+    }
+
+    async fn collect_output(
+        cmd: &mut Command,
+        timeout_secs: u64,
+    ) -> Result<SqliteOutput, DbOperationError> {
+        let mut child = cmd
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|error| DbOperationError::CommandNotFound(error.to_string()))?;
+
+        let mut stdout_handle = child.stdout.take();
+        let mut stderr_handle = child.stderr.take();
+
+        let result = timeout(Duration::from_secs(timeout_secs), async {
+            let (stdout_result, stderr_result) = tokio::join!(
+                async {
+                    let mut buf = Vec::new();
+                    if let Some(ref mut stdout) = stdout_handle {
+                        stdout.read_to_end(&mut buf).await?;
+                    }
+                    Ok::<_, std::io::Error>(String::from_utf8_lossy(&buf).into_owned())
+                },
+                async {
+                    let mut buf = Vec::new();
+                    if let Some(ref mut stderr) = stderr_handle {
+                        stderr.read_to_end(&mut buf).await?;
+                    }
+                    Ok::<_, std::io::Error>(String::from_utf8_lossy(&buf).into_owned())
+                }
+            );
+
+            let stdout = stdout_result?;
+            let stderr = stderr_result?;
+            let status = child.wait().await?;
+            Ok::<_, std::io::Error>((status, stdout, stderr))
+        })
+        .await
+        .map_err(|error| DbOperationError::Timeout(error.to_string()))?
+        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+
+        let (status, stdout, stderr) = result;
+        Ok(SqliteOutput {
+            status,
+            stdout,
+            stderr,
+        })
+    }
+}

--- a/src/infra/adapters/sqlite/cli.rs
+++ b/src/infra/adapters/sqlite/cli.rs
@@ -42,7 +42,7 @@ impl SqliteCli {
 
     async fn run(&self, path: &str, sql: &str) -> Result<SqliteOutput, DbOperationError> {
         let mut cmd = Command::new("sqlite3");
-        cmd.arg("-json").arg(path).arg(sql);
+        cmd.arg("-readonly").arg("-json").arg(path).arg(sql);
         Self::collect_output(&mut cmd, self.timeout_secs).await
     }
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -2,10 +2,7 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 
-use crate::app::ports::outbound::{
-    DatabaseCapabilities, DatabaseCapabilityProvider, DbOperationError, InspectorFeature,
-    MetadataProvider,
-};
+use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
 use crate::domain::{
     Column, ColumnAttributes, DatabaseMetadata, FkAction, ForeignKey, Index, IndexAttributes,
     IndexType, Schema, Table, TableSignature, TableSummary,
@@ -341,20 +338,6 @@ fn parse_fk_action(action: &str) -> Result<FkAction, DbOperationError> {
 impl Default for SqliteAdapter {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl DatabaseCapabilityProvider for SqliteAdapter {
-    fn capabilities(&self) -> DatabaseCapabilities {
-        DatabaseCapabilities::new(
-            false,
-            vec![
-                InspectorFeature::Info,
-                InspectorFeature::Columns,
-                InspectorFeature::Indexes,
-                InspectorFeature::ForeignKeys,
-            ],
-        )
     }
 }
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
+use serde::Deserialize;
 
 use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
 use crate::domain::{
@@ -20,13 +21,13 @@ pub struct SqliteAdapter {
     cli: SqliteCli,
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct RawTable {
     name: String,
     sql: Option<String>,
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct RawColumn {
     cid: i32,
     name: String,
@@ -37,20 +38,20 @@ struct RawColumn {
     pk: i64,
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct RawIndex {
     name: String,
     unique: i64,
     origin: String,
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct RawIndexColumn {
     seqno: i64,
     name: Option<String>,
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct RawForeignKey {
     id: i64,
     seq: i64,
@@ -61,7 +62,7 @@ struct RawForeignKey {
     on_delete: String,
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct RawRowCount {
     count: i64,
 }

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1,0 +1,484 @@
+use async_trait::async_trait;
+
+use crate::app::ports::outbound::{
+    DatabaseCapabilities, DatabaseCapabilityProvider, DbOperationError, InspectorFeature,
+    MetadataProvider,
+};
+use crate::domain::{
+    Column, ColumnAttributes, DatabaseMetadata, FkAction, ForeignKey, Index, IndexAttributes,
+    IndexType, Schema, Table, TableSignature, TableSummary,
+};
+
+mod cli;
+mod sql;
+
+use cli::SqliteCli;
+
+const MAIN_SCHEMA: &str = "main";
+
+#[derive(Debug, Clone)]
+pub struct SqliteAdapter {
+    cli: SqliteCli,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct RawTable {
+    name: String,
+    sql: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct RawColumn {
+    cid: i32,
+    name: String,
+    #[serde(rename = "type")]
+    data_type: String,
+    notnull: i64,
+    dflt_value: Option<String>,
+    pk: i64,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct RawIndex {
+    name: String,
+    unique: i64,
+    origin: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct RawIndexColumn {
+    seqno: i64,
+    name: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct RawForeignKey {
+    id: i64,
+    seq: i64,
+    table: String,
+    from: String,
+    to: Option<String>,
+    on_update: String,
+    on_delete: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct RawRowCount {
+    count: i64,
+}
+
+impl SqliteAdapter {
+    pub fn new() -> Self {
+        Self {
+            cli: SqliteCli::new(),
+        }
+    }
+
+    fn path_from_dsn(dsn: &str) -> Result<&str, DbOperationError> {
+        dsn.strip_prefix("sqlite://")
+            .filter(|path| !path.is_empty())
+            .ok_or_else(|| DbOperationError::ConnectionFailed(format!("Invalid SQLite DSN: {dsn}")))
+    }
+
+    fn database_name(path: &str) -> String {
+        std::path::Path::new(path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .unwrap_or(path)
+            .to_string()
+    }
+
+    async fn list_tables(&self, path: &str) -> Result<Vec<RawTable>, DbOperationError> {
+        self.cli.execute_json(path, sql::user_tables_query()).await
+    }
+
+    async fn row_count(&self, path: &str, table: &str) -> Option<i64> {
+        let rows: Result<Vec<RawRowCount>, DbOperationError> = self
+            .cli
+            .execute_json(path, &sql::row_count_query(table))
+            .await;
+        rows.ok()
+            .and_then(|rows| rows.into_iter().next())
+            .map(|row| row.count)
+    }
+
+    async fn columns(&self, path: &str, table: &str) -> Result<Vec<RawColumn>, DbOperationError> {
+        match self
+            .cli
+            .execute_json(path, &sql::table_xinfo_query(table))
+            .await
+        {
+            Ok(columns) => Ok(columns),
+            Err(_) => {
+                self.cli
+                    .execute_json(path, &sql::table_info_query(table))
+                    .await
+            }
+        }
+    }
+
+    async fn indexes(&self, path: &str, table: &str) -> Result<Vec<Index>, DbOperationError> {
+        let raw_indexes: Vec<RawIndex> = self
+            .cli
+            .execute_json(path, &sql::index_list_query(table))
+            .await?;
+        let mut indexes = Vec::new();
+
+        for raw in raw_indexes {
+            let mut columns: Vec<RawIndexColumn> = self
+                .cli
+                .execute_json(path, &sql::index_info_query(&raw.name))
+                .await?;
+            columns.sort_by_key(|col| col.seqno);
+            let columns: Vec<String> = columns.into_iter().filter_map(|col| col.name).collect();
+
+            indexes.push(Index {
+                name: raw.name,
+                columns,
+                attributes: IndexAttributes::from_parts(raw.unique != 0, raw.origin == "pk"),
+                index_type: IndexType::Other("sqlite".to_string()),
+                definition: None,
+            });
+        }
+
+        indexes.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(indexes)
+    }
+
+    async fn foreign_keys(
+        &self,
+        path: &str,
+        table: &str,
+    ) -> Result<Vec<ForeignKey>, DbOperationError> {
+        let mut raw: Vec<RawForeignKey> = self
+            .cli
+            .execute_json(path, &sql::foreign_key_list_query(table))
+            .await?;
+        raw.sort_by_key(|fk| (fk.id, fk.seq));
+
+        let mut grouped = Vec::new();
+        let mut current: Option<ForeignKey> = None;
+        let mut current_id = None;
+
+        for fk in raw {
+            if current_id != Some(fk.id) {
+                if let Some(fk) = current.take() {
+                    grouped.push(fk);
+                }
+                current_id = Some(fk.id);
+                current = Some(ForeignKey {
+                    name: format!("fk_{table}_{}", fk.id),
+                    from_schema: MAIN_SCHEMA.to_string(),
+                    from_table: table.to_string(),
+                    from_columns: Vec::new(),
+                    to_schema: MAIN_SCHEMA.to_string(),
+                    to_table: fk.table.clone(),
+                    to_columns: Vec::new(),
+                    on_delete: parse_fk_action(&fk.on_delete)?,
+                    on_update: parse_fk_action(&fk.on_update)?,
+                });
+            }
+
+            if let Some(current) = &mut current {
+                current.from_columns.push(fk.from);
+                current.to_columns.push(fk.to.unwrap_or_default());
+            }
+        }
+
+        if let Some(fk) = current {
+            grouped.push(fk);
+        }
+
+        Ok(grouped)
+    }
+
+    async fn table_detail_with_mode(
+        &self,
+        path: &str,
+        table: &str,
+        include_indexes: bool,
+    ) -> Result<Table, DbOperationError> {
+        let indexes = if include_indexes {
+            self.indexes(path, table).await?
+        } else {
+            Vec::new()
+        };
+        let unique_single_columns = indexes
+            .iter()
+            .filter(|index| index.is_unique() && index.columns.len() == 1)
+            .map(|index| index.columns[0].as_str())
+            .collect::<std::collections::HashSet<_>>();
+
+        let mut raw_columns = self.columns(path, table).await?;
+        raw_columns.sort_by_key(|column| column.cid);
+        let mut primary_key: Vec<(i64, String)> = raw_columns
+            .iter()
+            .filter(|column| column.pk > 0)
+            .map(|column| (column.pk, column.name.clone()))
+            .collect();
+        let columns: Vec<Column> = raw_columns
+            .into_iter()
+            .map(|column| {
+                let is_pk = column.pk > 0;
+                Column {
+                    name: column.name.clone(),
+                    data_type: column.data_type,
+                    default: column.dflt_value,
+                    attributes: ColumnAttributes::from_parts(
+                        column.notnull == 0 && !is_pk,
+                        is_pk,
+                        unique_single_columns.contains(column.name.as_str()),
+                    ),
+                    comment: None,
+                    ordinal_position: column.cid + 1,
+                }
+            })
+            .collect();
+        primary_key.sort_by_key(|(pk, _)| *pk);
+        let primary_key = (!primary_key.is_empty())
+            .then(|| primary_key.into_iter().map(|(_, name)| name).collect());
+
+        Ok(Table {
+            schema: MAIN_SCHEMA.to_string(),
+            name: table.to_string(),
+            owner: None,
+            columns,
+            primary_key,
+            foreign_keys: self.foreign_keys(path, table).await?,
+            indexes,
+            rls: None,
+            triggers: Vec::new(),
+            row_count_estimate: self.row_count(path, table).await,
+            comment: None,
+        })
+    }
+
+    async fn signature_for_table(
+        &self,
+        path: &str,
+        table: &RawTable,
+    ) -> Result<TableSignature, DbOperationError> {
+        let detail = self.table_detail_with_mode(path, &table.name, true).await?;
+        let mut parts = vec![format!("sql={}", table.sql.clone().unwrap_or_default())];
+        parts.extend(detail.columns.iter().map(|column| {
+            format!(
+                "col={}:{}:{}:{}",
+                column.name,
+                column.data_type,
+                column.is_nullable(),
+                column.default.clone().unwrap_or_default()
+            )
+        }));
+        parts.extend(detail.indexes.iter().map(|index| {
+            format!(
+                "idx={}:{}:{}:{}",
+                index.name,
+                index.columns.join(","),
+                index.is_unique(),
+                index.is_primary()
+            )
+        }));
+        parts.extend(detail.foreign_keys.iter().map(|fk| {
+            format!(
+                "fk={}:{}:{}:{}:{}",
+                fk.name,
+                fk.from_columns.join(","),
+                fk.to_table,
+                fk.to_columns.join(","),
+                fk.on_delete
+            )
+        }));
+
+        Ok(TableSignature {
+            schema: MAIN_SCHEMA.to_string(),
+            name: table.name.clone(),
+            signature: parts.join("|"),
+        })
+    }
+}
+
+fn parse_fk_action(action: &str) -> Result<FkAction, DbOperationError> {
+    action
+        .parse::<FkAction>()
+        .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))
+}
+
+impl Default for SqliteAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DatabaseCapabilityProvider for SqliteAdapter {
+    fn capabilities(&self) -> DatabaseCapabilities {
+        DatabaseCapabilities::new(
+            false,
+            vec![
+                InspectorFeature::Info,
+                InspectorFeature::Columns,
+                InspectorFeature::Indexes,
+                InspectorFeature::ForeignKeys,
+            ],
+        )
+    }
+}
+
+#[async_trait]
+impl MetadataProvider for SqliteAdapter {
+    async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
+        let path = Self::path_from_dsn(dsn)?;
+        let tables = self.list_tables(path).await?;
+        let mut metadata = DatabaseMetadata::new(Self::database_name(path));
+        metadata.schemas = vec![Schema::new(MAIN_SCHEMA)];
+        for table in &tables {
+            metadata.table_summaries.push(TableSummary::new(
+                MAIN_SCHEMA.to_string(),
+                table.name.clone(),
+                self.row_count(path, &table.name).await,
+                false,
+            ));
+        }
+        Ok(metadata)
+    }
+
+    async fn fetch_table_detail(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Table, DbOperationError> {
+        if schema != MAIN_SCHEMA {
+            return Err(DbOperationError::ObjectMissing(format!(
+                "SQLite schema not found: {schema}"
+            )));
+        }
+        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, true)
+            .await
+    }
+
+    async fn fetch_table_columns_and_fks(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Table, DbOperationError> {
+        if schema != MAIN_SCHEMA {
+            return Err(DbOperationError::ObjectMissing(format!(
+                "SQLite schema not found: {schema}"
+            )));
+        }
+        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, false)
+            .await
+    }
+
+    async fn fetch_table_signatures(
+        &self,
+        dsn: &str,
+    ) -> Result<Vec<TableSignature>, DbOperationError> {
+        let path = Self::path_from_dsn(dsn)?;
+        let tables = self.list_tables(path).await?;
+        let mut signatures = Vec::new();
+        for table in &tables {
+            signatures.push(self.signature_for_table(path, table).await?);
+        }
+        Ok(signatures)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use crate::app::ports::outbound::MetadataProvider;
+
+    use super::*;
+
+    fn make_db(sql: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("app.db");
+        let status = Command::new("sqlite3")
+            .arg(&path)
+            .arg(sql)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        (dir, format!("sqlite://{}", path.display()))
+    }
+
+    #[tokio::test]
+    async fn metadata_lists_user_tables_in_main_schema() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE users(id INTEGER PRIMARY KEY AUTOINCREMENT);
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
+
+        assert_eq!(metadata.schemas, vec![Schema::new("main")]);
+        assert_eq!(metadata.table_summaries.len(), 1);
+        assert_eq!(metadata.table_summaries[0].qualified_name(), "main.users");
+        assert_eq!(metadata.table_summaries[0].row_count_estimate, Some(0));
+    }
+
+    #[tokio::test]
+    async fn table_detail_loads_columns_indexes_and_foreign_keys() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE orgs(id INTEGER PRIMARY KEY);
+            CREATE TABLE users(
+                id INTEGER PRIMARY KEY,
+                email TEXT UNIQUE NOT NULL,
+                org_id INTEGER REFERENCES orgs(id) ON DELETE CASCADE
+            );
+            CREATE INDEX idx_users_org_id ON users(org_id);
+            INSERT INTO orgs(id) VALUES (1);
+            INSERT INTO users(id, email, org_id) VALUES (1, 'a@example.com', 1);
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let detail = adapter
+            .fetch_table_detail(&dsn, "main", "users")
+            .await
+            .unwrap();
+
+        assert_eq!(detail.primary_key, Some(vec!["id".to_string()]));
+        assert_eq!(detail.row_count_estimate, Some(1));
+        assert!(detail.columns.iter().any(|column| {
+            column.name == "email" && !column.is_nullable() && column.is_unique()
+        }));
+        assert!(
+            detail
+                .indexes
+                .iter()
+                .any(|index| index.name == "idx_users_org_id"
+                    && index.columns == vec!["org_id".to_string()])
+        );
+        let fk = detail
+            .foreign_keys
+            .iter()
+            .find(|fk| fk.to_table == "orgs")
+            .unwrap();
+        assert_eq!(fk.from_columns, vec!["org_id".to_string()]);
+        assert_eq!(fk.to_columns, vec!["id".to_string()]);
+        assert_eq!(fk.on_delete, FkAction::Cascade);
+        assert!(detail.rls.is_none());
+        assert!(detail.triggers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn table_signatures_change_with_table_shape() {
+        let (_dir, dsn) = make_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let adapter = SqliteAdapter::new();
+
+        let signatures = adapter.fetch_table_signatures(&dsn).await.unwrap();
+
+        assert_eq!(signatures.len(), 1);
+        assert_eq!(signatures[0].qualified_name(), "main.users");
+        assert!(signatures[0].signature.contains("CREATE TABLE users"));
+        assert!(signatures[0].signature.contains("col=id:INTEGER"));
+    }
+}

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -242,16 +242,17 @@ impl SqliteAdapter {
         table: &str,
         include_indexes: bool,
     ) -> Result<Table, DbOperationError> {
+        let all_indexes = self.indexes(path, table).await?;
+        let unique_single_columns = all_indexes
+            .iter()
+            .filter(|index| index.is_unique() && index.columns.len() == 1)
+            .map(|index| index.columns[0].clone())
+            .collect::<std::collections::HashSet<_>>();
         let indexes = if include_indexes {
-            self.indexes(path, table).await?
+            all_indexes
         } else {
             Vec::new()
         };
-        let unique_single_columns = indexes
-            .iter()
-            .filter(|index| index.is_unique() && index.columns.len() == 1)
-            .map(|index| index.columns[0].as_str())
-            .collect::<std::collections::HashSet<_>>();
 
         let mut raw_columns = self.columns(path, table).await?;
         if raw_columns.is_empty() {
@@ -520,6 +521,25 @@ mod tests {
 
         assert_eq!(detail.primary_key, None);
         assert_eq!(detail.columns.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn columns_and_fks_preserves_unique_column_attributes_without_returning_indexes() {
+        let (_dir, dsn) = make_db("CREATE TABLE users(email TEXT UNIQUE NOT NULL);");
+        let adapter = SqliteAdapter::new();
+
+        let detail = adapter
+            .fetch_table_columns_and_fks(&dsn, "main", "users")
+            .await
+            .unwrap();
+
+        assert!(detail.indexes.is_empty());
+        assert!(
+            detail
+                .columns
+                .iter()
+                .any(|column| column.name == "email" && column.is_unique())
+        );
     }
 
     #[tokio::test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 
 use crate::app::ports::outbound::{
@@ -118,6 +120,22 @@ impl SqliteAdapter {
         }
     }
 
+    async fn primary_key_columns(
+        &self,
+        path: &str,
+        table: &str,
+    ) -> Result<Vec<String>, DbOperationError> {
+        let mut primary_key: Vec<(i64, String)> = self
+            .columns(path, table)
+            .await?
+            .into_iter()
+            .filter(|column| column.pk > 0)
+            .map(|column| (column.pk, column.name))
+            .collect();
+        primary_key.sort_by_key(|(pk, _)| *pk);
+        Ok(primary_key.into_iter().map(|(_, name)| name).collect())
+    }
+
     async fn indexes(&self, path: &str, table: &str) -> Result<Vec<Index>, DbOperationError> {
         let raw_indexes: Vec<RawIndex> = self
             .cli
@@ -160,8 +178,24 @@ impl SqliteAdapter {
         let mut grouped = Vec::new();
         let mut current: Option<ForeignKey> = None;
         let mut current_id = None;
+        let mut referenced_primary_keys = HashMap::new();
 
         for fk in raw {
+            let to_column = match fk.to {
+                Some(to) => to,
+                None => {
+                    if !referenced_primary_keys.contains_key(&fk.table) {
+                        let primary_key = self.primary_key_columns(path, &fk.table).await?;
+                        referenced_primary_keys.insert(fk.table.clone(), primary_key);
+                    }
+                    referenced_primary_keys
+                        .get(&fk.table)
+                        .and_then(|primary_key| primary_key.get(fk.seq as usize))
+                        .cloned()
+                        .unwrap_or_default()
+                }
+            };
+
             if current_id != Some(fk.id) {
                 if let Some(fk) = current.take() {
                     grouped.push(fk);
@@ -182,7 +216,7 @@ impl SqliteAdapter {
 
             if let Some(current) = &mut current {
                 current.from_columns.push(fk.from);
-                current.to_columns.push(fk.to.unwrap_or_default());
+                current.to_columns.push(to_column);
             }
         }
 
@@ -467,6 +501,101 @@ mod tests {
         assert_eq!(fk.on_delete, FkAction::Cascade);
         assert!(detail.rls.is_none());
         assert!(detail.triggers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn composite_foreign_key_groups_columns_in_sequence_order() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE parent(a INTEGER, b INTEGER, PRIMARY KEY(a, b));
+            CREATE TABLE child(
+                x INTEGER,
+                y INTEGER,
+                FOREIGN KEY(x, y) REFERENCES parent(a, b)
+            );
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let detail = adapter
+            .fetch_table_detail(&dsn, "main", "child")
+            .await
+            .unwrap();
+
+        assert_eq!(detail.foreign_keys.len(), 1);
+        assert_eq!(
+            detail.foreign_keys[0].from_columns,
+            vec!["x".to_string(), "y".to_string()]
+        );
+        assert_eq!(
+            detail.foreign_keys[0].to_columns,
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn foreign_key_without_target_columns_resolves_parent_primary_key() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE parent(a INTEGER, b INTEGER, PRIMARY KEY(a, b));
+            CREATE TABLE child(
+                x INTEGER,
+                y INTEGER,
+                FOREIGN KEY(x, y) REFERENCES parent
+            );
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let detail = adapter
+            .fetch_table_detail(&dsn, "main", "child")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            detail.foreign_keys[0].to_columns,
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_dsn_returns_connection_error() {
+        let adapter = SqliteAdapter::new();
+
+        let postgres_result = adapter.fetch_metadata("postgres://localhost").await;
+        let empty_result = adapter.fetch_metadata("sqlite://").await;
+
+        assert!(matches!(
+            postgres_result,
+            Err(DbOperationError::ConnectionFailed(_))
+        ));
+        assert!(matches!(
+            empty_result,
+            Err(DbOperationError::ConnectionFailed(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn missing_database_file_returns_error_without_creating_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("missing.db");
+        let dsn = format!("sqlite://{}", path.display());
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter.fetch_metadata(&dsn).await;
+
+        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn non_main_schema_returns_object_missing() {
+        let (_dir, dsn) = make_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter.fetch_table_detail(&dsn, "other", "users").await;
+
+        assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
     }
 
     #[tokio::test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -117,20 +117,23 @@ impl SqliteAdapter {
         }
     }
 
+    fn extract_primary_key(columns: &[RawColumn]) -> Vec<String> {
+        let mut primary_key: Vec<(i64, String)> = columns
+            .iter()
+            .filter(|column| column.pk > 0)
+            .map(|column| (column.pk, column.name.clone()))
+            .collect();
+        primary_key.sort_by_key(|(pk, _)| *pk);
+        primary_key.into_iter().map(|(_, name)| name).collect()
+    }
+
     async fn primary_key_columns(
         &self,
         path: &str,
         table: &str,
     ) -> Result<Vec<String>, DbOperationError> {
-        let mut primary_key: Vec<(i64, String)> = self
-            .columns(path, table)
-            .await?
-            .into_iter()
-            .filter(|column| column.pk > 0)
-            .map(|column| (column.pk, column.name))
-            .collect();
-        primary_key.sort_by_key(|(pk, _)| *pk);
-        Ok(primary_key.into_iter().map(|(_, name)| name).collect())
+        let columns = self.columns(path, table).await?;
+        Ok(Self::extract_primary_key(&columns))
     }
 
     async fn indexes(&self, path: &str, table: &str) -> Result<Vec<Index>, DbOperationError> {
@@ -187,9 +190,18 @@ impl SqliteAdapter {
                     }
                     referenced_primary_keys
                         .get(&fk.table)
-                        .and_then(|primary_key| primary_key.get(fk.seq as usize))
+                        .and_then(|primary_key| {
+                            usize::try_from(fk.seq)
+                                .ok()
+                                .and_then(|idx| primary_key.get(idx))
+                        })
                         .cloned()
-                        .unwrap_or_default()
+                        .ok_or_else(|| {
+                            DbOperationError::MetadataParseFailed(format!(
+                                "SQLite foreign key references missing primary key column: {}.{}",
+                                fk.table, fk.seq
+                            ))
+                        })?
                 }
             };
 
@@ -242,12 +254,13 @@ impl SqliteAdapter {
             .collect::<std::collections::HashSet<_>>();
 
         let mut raw_columns = self.columns(path, table).await?;
+        if raw_columns.is_empty() {
+            return Err(DbOperationError::ObjectMissing(format!(
+                "SQLite table not found: {table}"
+            )));
+        }
         raw_columns.sort_by_key(|column| column.cid);
-        let mut primary_key: Vec<(i64, String)> = raw_columns
-            .iter()
-            .filter(|column| column.pk > 0)
-            .map(|column| (column.pk, column.name.clone()))
-            .collect();
+        let primary_key = Self::extract_primary_key(&raw_columns);
         let columns: Vec<Column> = raw_columns
             .into_iter()
             .map(|column| {
@@ -266,9 +279,7 @@ impl SqliteAdapter {
                 }
             })
             .collect();
-        primary_key.sort_by_key(|(pk, _)| *pk);
-        let primary_key = (!primary_key.is_empty())
-            .then(|| primary_key.into_iter().map(|(_, name)| name).collect());
+        let primary_key = (!primary_key.is_empty()).then_some(primary_key);
 
         Ok(Table {
             schema: MAIN_SCHEMA.to_string(),
@@ -441,6 +452,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn metadata_for_empty_database_returns_no_tables() {
+        let (_dir, dsn) = make_db("");
+        let adapter = SqliteAdapter::new();
+
+        let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
+
+        assert_eq!(metadata.schemas, vec![Schema::new("main")]);
+        assert!(metadata.table_summaries.is_empty());
+    }
+
+    #[tokio::test]
     async fn table_detail_loads_columns_indexes_and_foreign_keys() {
         let (_dir, dsn) = make_db(
             r#"
@@ -484,6 +506,20 @@ mod tests {
         assert_eq!(fk.on_delete, FkAction::Cascade);
         assert!(detail.rls.is_none());
         assert!(detail.triggers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn table_detail_without_primary_key_sets_primary_key_none() {
+        let (_dir, dsn) = make_db("CREATE TABLE logs(message TEXT);");
+        let adapter = SqliteAdapter::new();
+
+        let detail = adapter
+            .fetch_table_detail(&dsn, "main", "logs")
+            .await
+            .unwrap();
+
+        assert_eq!(detail.primary_key, None);
+        assert_eq!(detail.columns.len(), 1);
     }
 
     #[tokio::test]
@@ -577,6 +613,16 @@ mod tests {
         let adapter = SqliteAdapter::new();
 
         let result = adapter.fetch_table_detail(&dsn, "other", "users").await;
+
+        assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+    }
+
+    #[tokio::test]
+    async fn missing_table_returns_object_missing() {
+        let (_dir, dsn) = make_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter.fetch_table_detail(&dsn, "main", "missing").await;
 
         assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
     }

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -324,12 +324,13 @@ impl SqliteAdapter {
         }));
         parts.extend(detail.foreign_keys.iter().map(|fk| {
             format!(
-                "fk={}:{}:{}:{}:{}",
+                "fk={}:{}:{}:{}:{}:{}",
                 fk.name,
                 fk.from_columns.join(","),
                 fk.to_table,
                 fk.to_columns.join(","),
-                fk.on_delete
+                fk.on_delete,
+                fk.on_update
             )
         }));
 
@@ -658,5 +659,32 @@ mod tests {
         assert_eq!(signatures[0].qualified_name(), "main.users");
         assert!(signatures[0].signature.contains("CREATE TABLE users"));
         assert!(signatures[0].signature.contains("col=id:INTEGER"));
+    }
+
+    #[tokio::test]
+    async fn table_signatures_include_foreign_key_update_action() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE orgs(id INTEGER PRIMARY KEY);
+            CREATE TABLE users(
+                org_id INTEGER REFERENCES orgs(id)
+                    ON DELETE CASCADE
+                    ON UPDATE SET NULL
+            );
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let signatures = adapter.fetch_table_signatures(&dsn).await.unwrap();
+        let signature = signatures
+            .iter()
+            .find(|signature| signature.name == "users")
+            .unwrap();
+
+        assert!(
+            signature
+                .signature
+                .contains("fk=fk_users_0:org_id:orgs:id:CASCADE:SET NULL")
+        );
     }
 }

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -44,4 +44,36 @@ mod tests {
     fn quote_ident_escapes_embedded_quotes() {
         assert_eq!(quote_ident(r#"my"table"#), r#""my""table""#);
     }
+
+    #[test]
+    fn row_count_query_quotes_table_name() {
+        assert_eq!(
+            row_count_query(r#"my"table"#),
+            r#"SELECT COUNT(*) AS count FROM "my""table""#
+        );
+    }
+
+    #[test]
+    fn pragma_queries_quote_identifiers() {
+        assert_eq!(
+            table_xinfo_query(r#"my"table"#),
+            r#"PRAGMA table_xinfo("my""table")"#
+        );
+        assert_eq!(
+            table_info_query(r#"my"table"#),
+            r#"PRAGMA table_info("my""table")"#
+        );
+        assert_eq!(
+            index_list_query(r#"my"table"#),
+            r#"PRAGMA index_list("my""table")"#
+        );
+        assert_eq!(
+            foreign_key_list_query(r#"my"table"#),
+            r#"PRAGMA foreign_key_list("my""table")"#
+        );
+        assert_eq!(
+            index_info_query(r#"my"index"#),
+            r#"PRAGMA index_info("my""index")"#
+        );
+    }
 }

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -5,7 +5,7 @@ fn quote_ident(value: &str) -> String {
 pub(super) fn user_tables_query() -> &'static str {
     r"
     SELECT name, sql
-    FROM sqlite_schema
+    FROM sqlite_master
     WHERE type = 'table'
       AND name NOT LIKE 'sqlite_%'
     ORDER BY name
@@ -43,6 +43,12 @@ mod tests {
     #[test]
     fn quote_ident_escapes_embedded_quotes() {
         assert_eq!(quote_ident(r#"my"table"#), r#""my""table""#);
+    }
+
+    #[test]
+    fn user_tables_query_uses_compatible_schema_table() {
+        assert!(user_tables_query().contains("FROM sqlite_master"));
+        assert!(user_tables_query().contains("name NOT LIKE 'sqlite_%'"));
     }
 
     #[test]

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -1,0 +1,47 @@
+fn quote_ident(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+pub(super) fn user_tables_query() -> &'static str {
+    r"
+    SELECT name, sql
+    FROM sqlite_schema
+    WHERE type = 'table'
+      AND name NOT LIKE 'sqlite_%'
+    ORDER BY name
+    "
+}
+
+pub(super) fn row_count_query(table: &str) -> String {
+    format!("SELECT COUNT(*) AS count FROM {}", quote_ident(table))
+}
+
+pub(super) fn table_xinfo_query(table: &str) -> String {
+    format!("PRAGMA table_xinfo({})", quote_ident(table))
+}
+
+pub(super) fn table_info_query(table: &str) -> String {
+    format!("PRAGMA table_info({})", quote_ident(table))
+}
+
+pub(super) fn index_list_query(table: &str) -> String {
+    format!("PRAGMA index_list({})", quote_ident(table))
+}
+
+pub(super) fn index_info_query(index: &str) -> String {
+    format!("PRAGMA index_info({})", quote_ident(index))
+}
+
+pub(super) fn foreign_key_list_query(table: &str) -> String {
+    format!("PRAGMA foreign_key_list({})", quote_ident(table))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quote_ident_escapes_embedded_quotes() {
+        assert_eq!(quote_ident(r#"my"table"#), r#""my""table""#);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ async fn main() -> Result<()> {
 
         tokio::select! {
             Some(event) = tui.next_event() => {
-                let action = handle_event(event, &state, &services);
+                let action = handle_event(event, &state);
                 if !action.is_none() {
                     drain_and_process_terminal_events(action, &mut state, &mut tui, &effect_runner, &completion_engine, &services).await?;
                 }
@@ -376,7 +376,7 @@ async fn drain_and_process_terminal_events(
             break;
         };
         drained += 1;
-        let action = handle_event(event, state, services);
+        let action = handle_event(event, state);
         if action.is_none() {
             continue;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,11 +22,9 @@ use app::cmd::effect::Effect;
 use app::cmd::render_schedule::next_animation_deadline;
 use app::cmd::runner::EffectRunner;
 use app::model::app_state::AppState;
-use app::model::shared::db_capabilities::DbCapabilities;
 use app::model::shared::input_mode::InputMode;
 use app::ports::outbound::{
-    ConnectionStore, ConnectionStoreError, DatabaseCapabilityProvider, PgServiceEntryReader,
-    ServiceFileError,
+    ConnectionStore, ConnectionStoreError, PgServiceEntryReader, ServiceFileError,
 };
 use app::services::AppServices;
 use app::update::action::Action;
@@ -94,7 +92,6 @@ async fn main() -> Result<()> {
     let all_profiles = connection_store.load_all();
     let connection_store = Arc::new(connection_store);
 
-    let db_capabilities: DbCapabilities = adapter_registry.capabilities().into();
     let pg_service_entry_reader: Arc<dyn PgServiceEntryReader> =
         Arc::new(PgServiceFileReader::new());
 
@@ -117,7 +114,6 @@ async fn main() -> Result<()> {
     let services = AppServices {
         ddl_generator: Arc::clone(&adapter_registry) as _,
         sql_dialect: Arc::clone(&adapter_registry) as _,
-        db_capabilities,
     };
 
     let mut state = AppState::new(project_name);

--- a/src/tests/harness/mod.rs
+++ b/src/tests/harness/mod.rs
@@ -11,9 +11,9 @@ use ratatui::layout::Position;
 
 use app::model::app_state::AppState;
 use app::model::connection::setup::ConnectionField;
-use app::model::shared::db_capabilities::DbCapabilities;
 use app::model::shared::text_input::TextInputState;
 use app::services::AppServices;
+use domain::DatabaseType;
 use ui::shell::layout::MainLayout;
 use ui::theme::{ThemePalette, palette_for};
 
@@ -31,7 +31,7 @@ pub fn create_test_state() -> AppState {
         .set_active_connection_name_for_test(Some("localhost:5432/test".to_string()));
     state
         .session
-        .set_active_db_capabilities_for_test(DbCapabilities::postgres_like());
+        .set_active_database_type_for_test(Some(DatabaseType::PostgreSQL));
     state
 }
 

--- a/src/tests/harness/mod.rs
+++ b/src/tests/harness/mod.rs
@@ -11,6 +11,7 @@ use ratatui::layout::Position;
 
 use app::model::app_state::AppState;
 use app::model::connection::setup::ConnectionField;
+use app::model::shared::db_capabilities::DbCapabilities;
 use app::model::shared::text_input::TextInputState;
 use app::services::AppServices;
 use ui::shell::layout::MainLayout;
@@ -28,6 +29,9 @@ pub fn create_test_state() -> AppState {
     state
         .session
         .set_active_connection_name_for_test(Some("localhost:5432/test".to_string()));
+    state
+        .session
+        .set_active_db_capabilities_for_test(DbCapabilities::postgres_like());
     state
 }
 

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -34,11 +34,12 @@ impl Inspector {
         let is_focused = state.ui.focused_pane() == FocusedPane::Inspector;
         let [tab_area, content_area] =
             Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).areas(area);
-        let active_tab = services
-            .db_capabilities
+        let active_tab = state
+            .session
+            .active_db_capabilities()
             .normalize_inspector_tab(state.ui.inspector_tab());
 
-        Self::render_tab_bar(frame, tab_area, active_tab, services, theme);
+        Self::render_tab_bar(frame, tab_area, active_tab, state, theme);
         Self::render_content(
             frame,
             content_area,
@@ -55,11 +56,12 @@ impl Inspector {
         frame: &mut Frame,
         area: Rect,
         active_tab: InspectorTab,
-        services: &AppServices,
+        state: &AppState,
         theme: &ThemePalette,
     ) {
-        let tabs: Vec<Span> = services
-            .db_capabilities
+        let tabs: Vec<Span> = state
+            .session
+            .active_db_capabilities()
             .supported_inspector_tabs()
             .iter()
             .enumerate()

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -17,11 +17,11 @@ pub fn render(
     frame: &mut Frame,
     area: Rect,
     state: &AppState,
-    services: &AppServices,
+    _services: &AppServices,
     now: Instant,
     theme: &ThemePalette,
 ) -> u16 {
-    if !services.db_capabilities.supports_explain() {
+    if !state.session.active_db_capabilities().supports_explain() {
         let placeholder = Line::from(Span::styled(
             " EXPLAIN is unavailable for this database",
             Style::default().fg(theme.semantic.text.placeholder),

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -9,7 +9,6 @@ use ratatui::widgets::{Paragraph, Wrap};
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::sql_editor::modal::{HIGH_RISK_INPUT_VISIBLE_WIDTH, SqlModalStatus};
-use crate::app::services::AppServices;
 use crate::primitives::atoms::text_cursor_spans;
 use crate::theme::ThemePalette;
 
@@ -17,7 +16,6 @@ pub fn render(
     frame: &mut Frame,
     area: Rect,
     state: &AppState,
-    _services: &AppServices,
     now: Instant,
     theme: &ThemePalette,
 ) -> u16 {

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -15,7 +15,6 @@ use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::db_capabilities::DbCapabilities;
 use crate::app::model::sql_editor::modal::{SQL_MODAL_HEIGHT_PERCENT, SqlModalStatus, SqlModalTab};
-use crate::app::services::AppServices;
 use crate::app::update::input::keybindings::{
     SQL_MODAL_COMPARE_KEYS, SQL_MODAL_KEYS, SQL_MODAL_NORMAL_KEYS, SQL_MODAL_PLAN_KEYS, idx,
 };
@@ -33,7 +32,6 @@ impl SqlModal {
     pub fn render(
         frame: &mut Frame,
         state: &AppState,
-        services: &AppServices,
         now: Instant,
         theme: &ThemePalette,
     ) -> Option<u16> {
@@ -140,8 +138,7 @@ impl SqlModal {
                 completion::render_completion_popup(frame, area, main_area, state, theme);
             }
         } else if active_tab == SqlModalTab::Plan {
-            let plan_viewport_height =
-                explain::render(frame, main_area, state, services, now, theme);
+            let plan_viewport_height = explain::render(frame, main_area, state, now, theme);
             status::render_status(frame, status_area, state, theme);
             return Some(plan_viewport_height);
         } else {

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -13,6 +13,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
 
 use crate::app::model::app_state::AppState;
+use crate::app::model::shared::db_capabilities::DbCapabilities;
 use crate::app::model::sql_editor::modal::{SQL_MODAL_HEIGHT_PERCENT, SqlModalStatus, SqlModalTab};
 use crate::app::services::AppServices;
 use crate::app::update::input::keybindings::{
@@ -40,9 +41,8 @@ impl SqlModal {
             state.sql_modal.status(),
             SqlModalStatus::ConfirmingHigh { .. }
         );
-        let active_tab = services
-            .db_capabilities
-            .normalize_sql_modal_tab(state.sql_modal.active_tab());
+        let db_capabilities = state.session.active_db_capabilities();
+        let active_tab = db_capabilities.normalize_sql_modal_tab(state.sql_modal.active_tab());
 
         let (area, inner) = if is_confirming {
             match state.sql_modal.status() {
@@ -77,7 +77,7 @@ impl SqlModal {
             }
         } else {
             let hint: &str = match state.sql_modal.status() {
-                SqlModalStatus::Editing => Self::editing_hint(services),
+                SqlModalStatus::Editing => Self::editing_hint(db_capabilities),
                 SqlModalStatus::Running => " Running\u{2026} ",
                 SqlModalStatus::ConfirmingAnalyzeHigh {
                     input, target_name, ..
@@ -93,10 +93,10 @@ impl SqlModal {
                 }
                 _ => {
                     let compare_can_yank = state.explain.can_yank_compare();
-                    Self::border_hint(active_tab, compare_can_yank, services)
+                    Self::border_hint(active_tab, compare_can_yank, db_capabilities)
                 }
             };
-            Self::render_modal_with_tabs(frame, active_tab, hint, services, theme)
+            Self::render_modal_with_tabs(frame, active_tab, hint, db_capabilities, theme)
         };
 
         // Add 1-char horizontal padding for breathing room inside the modal
@@ -157,7 +157,7 @@ impl SqlModal {
         frame: &mut Frame,
         active_tab: SqlModalTab,
         hint: &str,
-        services: &AppServices,
+        db_capabilities: &DbCapabilities,
         theme: &ThemePalette,
     ) -> (Rect, Rect) {
         let area = centered_rect(
@@ -168,7 +168,7 @@ impl SqlModal {
         render_scrim(frame, theme);
         frame.render_widget(Clear, area);
 
-        let title = Self::build_title_with_tabs(active_tab, services, theme);
+        let title = Self::build_title_with_tabs(active_tab, db_capabilities, theme);
         let block = Block::default()
             .title(title)
             .title_bottom(Line::styled(hint.to_string(), theme.modal_hint_style()))
@@ -184,7 +184,7 @@ impl SqlModal {
 
     fn build_title_with_tabs(
         active_tab: SqlModalTab,
-        services: &AppServices,
+        db_capabilities: &DbCapabilities,
         theme: &ThemePalette,
     ) -> Line<'static> {
         let title_style = theme.modal_title_style();
@@ -200,7 +200,7 @@ impl SqlModal {
                 inactive_style
             }
         };
-        let supported_tabs = services.db_capabilities.supported_sql_modal_tabs();
+        let supported_tabs = db_capabilities.supported_sql_modal_tabs();
 
         if supported_tabs.len() == 1 {
             return Line::from(vec![Span::styled(" SQL Editor ", title_style)]);
@@ -225,7 +225,7 @@ impl SqlModal {
     fn border_hint(
         tab: SqlModalTab,
         compare_can_yank: bool,
-        services: &AppServices,
+        db_capabilities: &DbCapabilities,
     ) -> &'static str {
         static PLAN: LazyLock<String> = LazyLock::new(|| {
             SqlModal::join_hint_pairs(&[
@@ -281,7 +281,7 @@ impl SqlModal {
             ])
         });
         match tab {
-            SqlModalTab::Sql if services.db_capabilities.supported_sql_modal_tabs().len() == 1 => {
+            SqlModalTab::Sql if db_capabilities.supported_sql_modal_tabs().len() == 1 => {
                 &SQL_NO_TABS
             }
             SqlModalTab::Plan => &PLAN,
@@ -291,7 +291,7 @@ impl SqlModal {
         }
     }
 
-    fn editing_hint(services: &AppServices) -> &'static str {
+    fn editing_hint(db_capabilities: &DbCapabilities) -> &'static str {
         static HINT: LazyLock<String> = LazyLock::new(|| {
             SqlModal::join_hint_pairs(&[
                 SQL_MODAL_KEYS[idx::sql_modal::RUN].as_hint(),
@@ -309,7 +309,7 @@ impl SqlModal {
                 SQL_MODAL_KEYS[idx::sql_modal::ESC_NORMAL].as_hint(),
             ])
         });
-        if services.db_capabilities.supports_explain() {
+        if db_capabilities.supports_explain() {
             &HINT
         } else {
             &HINT_NO_EXPLAIN

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -77,7 +77,7 @@ impl Footer {
     // Hint ordering: Actions → Navigation → Help → Close/Cancel → Quit
     fn get_context_hints(
         state: &AppState,
-        services: &AppServices,
+        _services: &AppServices,
     ) -> Vec<(&'static str, &'static str)> {
         use crate::app::model::shared::focused_pane::FocusedPane;
 
@@ -144,8 +144,9 @@ impl Footer {
                     list
                 } else {
                     // Actions → Navigation → Help → Close/Cancel → Quit
-                    let active_inspector_tab = services
-                        .db_capabilities
+                    let active_inspector_tab = state
+                        .session
+                        .active_db_capabilities()
                         .normalize_inspector_tab(state.ui.inspector_tab());
                     let mut list = vec![
                         GLOBAL_KEYS[idx::global::RELOAD].as_hint(),
@@ -189,7 +190,12 @@ impl Footer {
                         }
                     }
                     if state.ui.focused_pane() == FocusedPane::Inspector
-                        && services.db_capabilities.supported_inspector_tabs().len() > 1
+                        && state
+                            .session
+                            .active_db_capabilities()
+                            .supported_inspector_tabs()
+                            .len()
+                            > 1
                     {
                         list.push(GLOBAL_KEYS[idx::global::INSPECTOR_TABS].as_hint());
                     }
@@ -245,7 +251,7 @@ impl Footer {
                         SQL_MODAL_KEYS[idx::sql_modal::MOVE].as_hint(),
                         SQL_MODAL_KEYS[idx::sql_modal::ESC_NORMAL].as_hint(),
                     ];
-                    if services.db_capabilities.supports_explain()
+                    if state.session.active_db_capabilities().supports_explain()
                         && state.sql_modal.status() == &SqlModalStatus::Editing
                     {
                         hints.insert(
@@ -384,9 +390,11 @@ mod tests {
         #[case] db_capabilities: DbCapabilities,
         #[case] expected_visible: bool,
     ) {
-        let state = inspector_state();
-        let mut services = AppServices::stub();
-        services.db_capabilities = db_capabilities;
+        let mut state = inspector_state();
+        let services = AppServices::stub();
+        state
+            .session
+            .set_active_db_capabilities_for_test(db_capabilities);
 
         let hints = Footer::get_context_hints(&state, &services);
 

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -9,7 +9,6 @@ use crate::app::model::er_state::ErStatus;
 use crate::app::model::shared::input_mode::InputMode;
 use crate::app::model::shared::ui_state::ResultNavMode;
 use crate::app::model::sql_editor::modal::SqlModalStatus;
-use crate::app::services::AppServices;
 use crate::app::update::input::keybindings::{
     CELL_EDIT_KEYS, COMMAND_PALETTE_ROWS, CONNECTION_ERROR_ROWS, CONNECTION_SELECTOR_ROWS,
     CONNECTION_SETUP_KEYS, ER_PICKER_ROWS, FOOTER_NAV_KEYS, GLOBAL_KEYS, HELP_ROWS, HISTORY_KEYS,
@@ -29,7 +28,6 @@ impl Footer {
         frame: &mut Frame,
         area: Rect,
         state: &AppState,
-        services: &AppServices,
         time_ms: Option<u128>,
         theme: &ThemePalette,
     ) {
@@ -42,7 +40,7 @@ impl Footer {
             frame.render_widget(Paragraph::new(line).style(base_style), area);
         } else {
             // Show hints with optional inline success message
-            let hints = Self::get_context_hints(state, services);
+            let hints = Self::get_context_hints(state);
             let line =
                 Self::build_hint_line_with_success(&hints, state.messages.last_success(), theme);
             frame.render_widget(Paragraph::new(line).style(base_style), area);
@@ -75,10 +73,7 @@ impl Footer {
     }
 
     // Hint ordering: Actions → Navigation → Help → Close/Cancel → Quit
-    fn get_context_hints(
-        state: &AppState,
-        _services: &AppServices,
-    ) -> Vec<(&'static str, &'static str)> {
+    fn get_context_hints(state: &AppState) -> Vec<(&'static str, &'static str)> {
         use crate::app::model::shared::focused_pane::FocusedPane;
 
         match state.input_mode() {
@@ -364,12 +359,10 @@ impl Footer {
 #[cfg(test)]
 mod tests {
     use super::Footer;
+    use crate::app::domain::{ConnectionId, DatabaseType};
     use crate::app::model::app_state::AppState;
-    use crate::app::model::shared::db_capabilities::DbCapabilities;
     use crate::app::model::shared::focused_pane::FocusedPane;
     use crate::app::model::shared::input_mode::InputMode;
-    use crate::app::model::shared::inspector_tab::InspectorTab;
-    use crate::app::services::AppServices;
     use crate::app::update::input::keybindings::{GLOBAL_KEYS, idx};
     use rstest::rstest;
 
@@ -381,22 +374,23 @@ mod tests {
     }
 
     #[rstest]
-    #[case(DbCapabilities::new(true, vec![InspectorTab::Info]), false)]
-    #[case(
-        DbCapabilities::new(true, vec![InspectorTab::Info, InspectorTab::Columns]),
-        true
-    )]
+    #[case(None, false)]
+    #[case(Some(DatabaseType::SQLite), true)]
     fn inspector_tabs_hint_visibility_tracks_supported_tab_count(
-        #[case] db_capabilities: DbCapabilities,
+        #[case] database_type: Option<DatabaseType>,
         #[case] expected_visible: bool,
     ) {
         let mut state = inspector_state();
-        let services = AppServices::stub();
-        state
-            .session
-            .set_active_db_capabilities_for_test(db_capabilities);
+        if let Some(database_type) = database_type {
+            state.session.set_active_connection(
+                &ConnectionId::new(),
+                "database",
+                database_type,
+                "sqlite://test.db",
+            );
+        }
 
-        let hints = Footer::get_context_hints(&state, &services);
+        let hints = Footer::get_context_hints(&state);
 
         assert_eq!(
             hints.contains(&GLOBAL_KEYS[idx::global::INSPECTOR_TABS].as_hint()),

--- a/src/ui/shell/layout.rs
+++ b/src/ui/shell/layout.rs
@@ -85,7 +85,7 @@ impl MainLayout {
         Header::render(frame, header_area, state, theme);
         let output = Self::render_browse_mode(frame, main_area, state, services, now, theme);
 
-        Footer::render(frame, footer_area, state, services, time_ms, theme);
+        Footer::render(frame, footer_area, state, time_ms, theme);
         let command_line_visible_width = CommandLine::render(frame, cmdline_area, state, theme);
         let connection_list_pane_height = match state.input_mode() {
             InputMode::ConnectionSelector => Some(ConnectionSelector::render(frame, state, theme)),
@@ -144,7 +144,7 @@ impl MainLayout {
         };
 
         let explain_compare_viewport_height = if matches!(state.input_mode(), InputMode::SqlModal) {
-            SqlModal::render(frame, state, services, now, theme)
+            SqlModal::render(frame, state, now, theme)
         } else {
             None
         };


### PR DESCRIPTION
## Problem
SQLite connections can be saved and selected, but they do not load metadata, so the browse experience cannot inspect SQLite schemas yet.

## Background
SAB-235 extends the existing driverless adapter model to SQLite metadata only. Query execution, writes, previews, CSV export, and SQLite-specific DDL remain out of scope.

## Approach
Scope: add SQLite metadata discovery on top of the `sqlite3` CLI, route SQLite metadata requests through the registry, and derive UI capabilities from the active database type.

SQLite is treated as metadata-only: inspector tabs are narrowed to supported features, EXPLAIN is disabled, and unsupported query paths fail as unsupported query operations instead of connection failures.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * SQLiteデータベースのサポートを強化し、メタデータ取得とスキーマ検査機能を追加しました。

* **Refactor**
  * データベース機能の追跡をセッションレベルで統一し、接続時の機能管理を改善しました。SQLite接続フローをPostgreSQLと同じ標準フローに統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->