### PR TITLE
fix: add f5 sql editor run shortcut

### DIFF
--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -39,7 +39,8 @@ pub fn handle_sql_modal_keys_with_prefix(
     ) {
         let ctrl = combo.modifiers.contains(Modifiers::CTRL);
         let alt = combo.modifiers.contains(Modifiers::ALT);
-        let plain = !ctrl && !alt;
+        let shift = combo.modifiers.contains(Modifiers::SHIFT);
+        let plain = !ctrl && !alt && !shift;
 
         if let Some(prefix) = pending_prefix {
             if ctrl || alt {
@@ -137,6 +138,7 @@ pub fn handle_sql_modal_keys_with_prefix(
 
         return match combo.key {
             Key::Enter if alt => Action::SqlModalSubmit,
+            Key::F(5) if plain => Action::SqlModalSubmit,
             Key::Up => Action::TextMoveCursor {
                 target: InputTarget::SqlModal,
                 direction: CursorMove::Up,
@@ -236,7 +238,9 @@ pub fn handle_sql_modal_keys_with_prefix(
     let shift = combo.modifiers.contains(Modifiers::SHIFT);
     let ctrl_only = ctrl && !alt && !shift;
 
-    if alt && combo.key == Key::Enter {
+    let plain = !ctrl && !alt && !shift;
+
+    if (alt && combo.key == Key::Enter) || (plain && combo.key == Key::F(5)) {
         return Action::SqlModalSubmit;
     }
 
@@ -599,6 +603,18 @@ mod tests {
         }
 
         #[test]
+        fn f5_submits_query() {
+            let result = handle_sql_modal_keys(
+                combo(Key::F(5)),
+                false,
+                &SqlModalStatus::Editing,
+                SqlModalTab::Sql,
+            );
+
+            assert_action(result, Expected::SqlModalSubmit);
+        }
+
+        #[test]
         fn ctrl_o_opens_query_history_picker() {
             let result = handle_sql_modal_keys(
                 combo_ctrl(Key::Char('o')),
@@ -924,6 +940,18 @@ mod tests {
         fn alt_enter_submits() {
             let result = handle_sql_modal_keys(
                 combo_alt(Key::Enter),
+                false,
+                &SqlModalStatus::Normal,
+                SqlModalTab::Sql,
+            );
+
+            assert_action(result, Expected::SqlModalSubmit);
+        }
+
+        #[test]
+        fn f5_submits() {
+            let result = handle_sql_modal_keys(
+                combo(Key::F(5)),
                 false,
                 &SqlModalStatus::Normal,
                 SqlModalTab::Sql,

--- a/src/app/update/input/keybindings/editors.rs
+++ b/src/app/update/input/keybindings/editors.rs
@@ -8,12 +8,12 @@ use crate::update::action::{Action, ModalKind};
 
 pub const SQL_MODAL_NORMAL_KEYS: &[KeyBinding] = &[
     KeyBinding {
-        key_short: "⌥Enter",
-        key: "Alt+Enter",
+        key_short: "⌥Enter/F5",
+        key: "Alt+Enter / F5",
         desc_short: "Run",
         description: "Execute query",
         action: Action::SqlModalSubmit,
-        combos: &[KeyCombo::alt(Key::Enter)],
+        combos: &[KeyCombo::alt(Key::Enter), KeyCombo::plain(Key::F(5))],
     },
     KeyBinding {
         key_short: "y",
@@ -229,12 +229,12 @@ pub const SQL_MODAL_COMPARE_KEYS: &[KeyBinding] = &[
 
 pub const SQL_MODAL_KEYS: &[KeyBinding] = &[
     KeyBinding {
-        key_short: "⌥Enter",
-        key: "Alt+Enter",
+        key_short: "⌥Enter/F5",
+        key: "Alt+Enter / F5",
         desc_short: "Run",
         description: "Execute query",
         action: Action::SqlModalSubmit,
-        combos: &[KeyCombo::alt(Key::Enter)],
+        combos: &[KeyCombo::alt(Key::Enter), KeyCombo::plain(Key::F(5))],
     },
     KeyBinding {
         key_short: "Esc",

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_completion_popup_with_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_completion_popup_with_scroll.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                       
@@ -20,8 +20,8 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │       │        │ COUNT       keyword                       │         │       │
 │       │ ───────└───────────────────────────────────────────┘──────── │       │
 │       │  [INSERT]                                             Ready  │       │
-│       ╰ ⌥Enter: Run │ ^E: Explain │ ^L: Clear │ ^O: History │ Esc: No╯       │
+│       ╰ ⌥Enter/F5: Run │ ^E: Explain │ ^L: Clear │ ^O: History │ Esc:╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-⌥Enter:Run  ^E:Explain  ↑↓←→:Move  Esc:Normal
+⌥Enter/F5:Run  ^E:Explain  ↑↓←→:Move  Esc:Normal

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_head.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -20,8 +20,8 @@ test_project | - | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │ ──────────────────────────────────────────────────────────── │       │
 │       │  [INSERT]                                             Ready  │       │
-│       ╰ ⌥Enter: Run │ ^E: Explain │ ^L: Clear │ ^O: History │ Esc: No╯       │
+│       ╰ ⌥Enter/F5: Run │ ^E: Explain │ ^L: Clear │ ^O: History │ Esc:╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-⌥Enter:Run  ^E:Explain  ↑↓←→:Move  Esc:Normal
+⌥Enter/F5:Run  ^E:Explain  ↑↓←→:Move  Esc:Normal

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_middle.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -20,8 +20,8 @@ test_project | - | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │ ──────────────────────────────────────────────────────────── │       │
 │       │  [INSERT]                                             Ready  │       │
-│       ╰ ⌥Enter: Run │ ^E: Explain │ ^L: Clear │ ^O: History │ Esc: No╯       │
+│       ╰ ⌥Enter/F5: Run │ ^E: Explain │ ^L: Clear │ ^O: History │ Esc:╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-⌥Enter:Run  ^E:Explain  ↑↓←→:Move  Esc:Normal
+⌥Enter/F5:Run  ^E:Explain  ↑↓←→:Move  Esc:Normal

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_tail.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -20,8 +20,8 @@ test_project | - | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │ ──────────────────────────────────────────────────────────── │       │
 │       │  [INSERT]                                             Ready  │       │
-│       ╰ ⌥Enter: Run │ ^E: Explain │ ^L: Clear │ ^O: History │ Esc: No╯       │
+│       ╰ ⌥Enter/F5: Run │ ^E: Explain │ ^L: Clear │ ^O: History │ Esc:╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-⌥Enter:Run  ^E:Explain  ↑↓←→:Move  Esc:Normal
+⌥Enter/F5:Run  ^E:Explain  ↑↓←→:Move  Esc:Normal

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_error_with_message.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_error_with_message.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -20,7 +20,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │ ──────────────────────────────────────────────────────────── │       │
 │       │  [NORMAL]          ✗ ERROR:  syntax error at or near "FORM"  │       │
-│       ╰ ⌥Enter: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ─────╯       │
+│       ╰ ⌥Enter/F5: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ──╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_cursor_at_tail.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -20,7 +20,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │ ──────────────────────────────────────────────────────────── │       │
 │       │  [NORMAL]                                             Ready  │       │
-│       ╰ ⌥Enter: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ─────╯       │
+│       ╰ ⌥Enter/F5: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ──╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_initial.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_initial.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -20,7 +20,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │ ──────────────────────────────────────────────────────────── │       │
 │       │  [NORMAL]                                             Ready  │       │
-│       ╰ ⌥Enter: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ─────╯       │
+│       ╰ ⌥Enter/F5: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ──╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_ddl_create_table.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_ddl_create_table.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -20,7 +20,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │ ──────────────────────────────────────────────────────────── │       │
 │       │  [NORMAL]                           ✓ table created (0.04s)  │       │
-│       ╰ ⌥Enter: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ─────╯       │
+│       ╰ ⌥Enter/F5: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ──╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_dml_with_command_tag.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_dml_with_command_tag.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -20,7 +20,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │ ──────────────────────────────────────────────────────────── │       │
 │       │  [NORMAL]                          ✓ 3 rows deleted (0.01s)  │       │
-│       ╰ ⌥Enter: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ─────╯       │
+│       ╰ ⌥Enter/F5: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ──╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_select.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_select.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                             
@@ -20,7 +20,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │ ──────────────────────────────────────────────────────────── │       │
 │       │  [NORMAL]                                  ✓ 2 rows (0.01s)  │       │
-│       ╰ ⌥Enter: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ─────╯       │
+│       ╰ ⌥Enter/F5: Run │ i: Insert │ Tab/⇧Tab: Switch │ Esc: Close ──╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_with_completion.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_with_completion.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                       
@@ -20,8 +20,8 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │       │                                                              │       │
 │       │ ──────────────────────────────────────────────────────────── │       │
 │       │  [INSERT]                                             Ready  │       │
-│       ╰ ⌥Enter: Run │ ^E: Explain │ ^L: Clear │ ^O: History │ Esc: No╯       │
+│       ╰ ⌥Enter/F5: Run │ ^E: Explain │ ^L: Clear │ ^O: History │ Esc:╯       │
 │                  ││                                                          │
 │                  ││                                                          │
 └──────────────────┘└──────────────────────────────────────────────────────────┘
-⌥Enter:Run  ^E:Explain  ↑↓←→:Move  Esc:Normal
+⌥Enter/F5:Run  ^E:Explain  ↑↓←→:Move  Esc:Normal


### PR DESCRIPTION
## Problem
The SQL editor only exposed Alt+Enter for running queries, but that key chord can be intercepted by some terminals or desktop environments before it reaches the TUI.

## Background
This came from GitHub issue #353. The goal is to keep the existing shortcut while adding a more reliable fallback for terminals where Alt+Enter is unavailable.

## Approach
Scope is limited to the SQL tab run action. Alt+Enter remains supported, and F5 is added as an additional run shortcut without changing Plan/Compare, confirmation, completion, or plain Enter behavior.

## Screenshots
Not applicable. Render snapshots were updated for the footer/help hint text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * SQLモーダルにF5キーによるクエリ実行機能を追加。Alt+Enterに加えて、F5でもクエリを送信できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->