### PR TITLE
Fix help modal key column overflow

### DIFF
--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -32,6 +32,14 @@ pub const HELP_VERTICAL_SCROLLBAR_WIDTH: usize = 1;
 pub const DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HelpViewportLayout {
+    pub visible_rows: usize,
+    pub visible_columns: usize,
+    pub has_horizontal_scrollbar: bool,
+    pub has_vertical_scrollbar: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResultNavMode {
     Scroll,
     CellActive,
@@ -239,9 +247,7 @@ impl UiState {
     }
 
     pub fn help_visible_rows(&self) -> usize {
-        (self.terminal_height as usize * HELP_MODAL_HEIGHT_PERCENT as usize / 100)
-            .saturating_sub(MODAL_VERTICAL_BORDER_OVERHEAD)
-            .saturating_sub(HELP_HORIZONTAL_SCROLLBAR_HEIGHT)
+        self.help_viewport_layout().visible_rows
     }
 
     pub fn help_max_scroll(&self) -> usize {
@@ -249,9 +255,7 @@ impl UiState {
     }
 
     pub fn help_visible_columns(&self) -> usize {
-        (self.terminal_width as usize * HELP_MODAL_WIDTH_PERCENT as usize / 100)
-            .saturating_sub(MODAL_HORIZONTAL_BORDER_OVERHEAD)
-            .saturating_sub(HELP_VERTICAL_SCROLLBAR_WIDTH)
+        self.help_viewport_layout().visible_columns
     }
 
     pub fn help_max_horizontal_scroll(&self) -> usize {
@@ -263,6 +267,20 @@ impl UiState {
         self.help_horizontal_offset = self
             .help_horizontal_offset
             .min(self.help_max_horizontal_scroll());
+    }
+
+    pub fn help_viewport_layout(&self) -> HelpViewportLayout {
+        let base_rows = (self.terminal_height as usize * HELP_MODAL_HEIGHT_PERCENT as usize / 100)
+            .saturating_sub(MODAL_VERTICAL_BORDER_OVERHEAD);
+        let base_columns = (self.terminal_width as usize * HELP_MODAL_WIDTH_PERCENT as usize / 100)
+            .saturating_sub(MODAL_HORIZONTAL_BORDER_OVERHEAD);
+
+        help_viewport_layout_for(
+            base_rows,
+            base_columns,
+            help_content_line_count(),
+            help_content_width(),
+        )
     }
 
     pub fn toggle_focus(&mut self) -> bool {
@@ -302,6 +320,53 @@ impl UiState {
             self.connection_list_selected = 0;
             self.connection_list_scroll_offset = 0;
         }
+    }
+}
+
+pub fn help_viewport_layout_for(
+    base_rows: usize,
+    base_columns: usize,
+    total_lines: usize,
+    content_width: usize,
+) -> HelpViewportLayout {
+    let mut has_horizontal_scrollbar = content_width > base_columns;
+    let mut has_vertical_scrollbar = total_lines > base_rows;
+
+    for _ in 0..2 {
+        let visible_rows = base_rows.saturating_sub(if has_horizontal_scrollbar {
+            HELP_HORIZONTAL_SCROLLBAR_HEIGHT
+        } else {
+            0
+        });
+        let visible_columns = base_columns.saturating_sub(if has_vertical_scrollbar {
+            HELP_VERTICAL_SCROLLBAR_WIDTH
+        } else {
+            0
+        });
+        let next_horizontal = content_width > visible_columns;
+        let next_vertical = total_lines > visible_rows;
+
+        if next_horizontal == has_horizontal_scrollbar && next_vertical == has_vertical_scrollbar {
+            break;
+        }
+
+        has_horizontal_scrollbar = next_horizontal;
+        has_vertical_scrollbar = next_vertical;
+    }
+
+    HelpViewportLayout {
+        visible_rows: base_rows.saturating_sub(if has_horizontal_scrollbar {
+            HELP_HORIZONTAL_SCROLLBAR_HEIGHT
+        } else {
+            0
+        }),
+        visible_columns: base_columns.saturating_sub(if has_vertical_scrollbar {
+            HELP_VERTICAL_SCROLLBAR_WIDTH
+        } else {
+            0
+        }),
+        has_horizontal_scrollbar,
+        has_vertical_scrollbar,
     }
 }
 
@@ -625,6 +690,51 @@ mod tests {
             assert_eq!(
                 state.help_max_horizontal_scroll(),
                 help_content_width().saturating_sub(53)
+            );
+        }
+
+        #[test]
+        fn help_viewport_layout_does_not_reserve_scrollbars_when_content_fits() {
+            let layout = help_viewport_layout_for(10, 20, 10, 20);
+
+            assert_eq!(
+                layout,
+                HelpViewportLayout {
+                    visible_rows: 10,
+                    visible_columns: 20,
+                    has_horizontal_scrollbar: false,
+                    has_vertical_scrollbar: false,
+                }
+            );
+        }
+
+        #[test]
+        fn help_viewport_layout_accounts_for_vertical_scrollbar_triggering_horizontal_overflow() {
+            let layout = help_viewport_layout_for(10, 20, 11, 20);
+
+            assert_eq!(
+                layout,
+                HelpViewportLayout {
+                    visible_rows: 9,
+                    visible_columns: 19,
+                    has_horizontal_scrollbar: true,
+                    has_vertical_scrollbar: true,
+                }
+            );
+        }
+
+        #[test]
+        fn help_viewport_layout_accounts_for_horizontal_scrollbar_triggering_vertical_overflow() {
+            let layout = help_viewport_layout_for(10, 20, 10, 21);
+
+            assert_eq!(
+                layout,
+                HelpViewportLayout {
+                    visible_rows: 9,
+                    visible_columns: 19,
+                    has_horizontal_scrollbar: true,
+                    has_vertical_scrollbar: true,
+                }
             );
         }
     }

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -27,7 +27,8 @@ pub const HELP_MODAL_HEIGHT_PERCENT: u16 = 80;
 // Top and bottom modal border rows subtracted from the inner visible area.
 pub const MODAL_VERTICAL_BORDER_OVERHEAD: usize = 2;
 pub const MODAL_HORIZONTAL_BORDER_OVERHEAD: usize = 2;
-pub const HELP_HORIZONTAL_SCROLLBAR_OVERHEAD: usize = 1;
+pub const HELP_HORIZONTAL_SCROLLBAR_HEIGHT: usize = 1;
+pub const HELP_VERTICAL_SCROLLBAR_WIDTH: usize = 1;
 pub const DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -240,7 +241,7 @@ impl UiState {
     pub fn help_visible_rows(&self) -> usize {
         (self.terminal_height as usize * HELP_MODAL_HEIGHT_PERCENT as usize / 100)
             .saturating_sub(MODAL_VERTICAL_BORDER_OVERHEAD)
-            .saturating_sub(HELP_HORIZONTAL_SCROLLBAR_OVERHEAD)
+            .saturating_sub(HELP_HORIZONTAL_SCROLLBAR_HEIGHT)
     }
 
     pub fn help_max_scroll(&self) -> usize {
@@ -250,7 +251,7 @@ impl UiState {
     pub fn help_visible_columns(&self) -> usize {
         (self.terminal_width as usize * HELP_MODAL_WIDTH_PERCENT as usize / 100)
             .saturating_sub(MODAL_HORIZONTAL_BORDER_OVERHEAD)
-            .saturating_sub(1)
+            .saturating_sub(HELP_VERTICAL_SCROLLBAR_WIDTH)
     }
 
     pub fn help_max_horizontal_scroll(&self) -> usize {

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -8,7 +8,7 @@ use super::key_sequence::KeySequenceState;
 use super::picker::PickerState;
 use super::theme_id::ThemeId;
 use super::viewport::{ColumnWidthsCache, ViewportPlan};
-use crate::update::input::keybindings::help_content_line_count;
+use crate::update::input::keybindings::{help_content_line_count, help_content_width};
 use unicode_width::UnicodeWidthStr;
 
 pub use super::picker::clamp_scroll_offset;
@@ -22,9 +22,12 @@ pub const EXPLORER_PANEL_BORDER_WIDTH: u16 = 2;
 pub const EXPLORER_HIGHLIGHT_SYMBOL_WIDTH: u16 = 2;
 pub const EXPLORER_SCROLLBAR_RESERVED_WIDTH: u16 = 1;
 // Help modal height as a percent of the available terminal height.
+pub const HELP_MODAL_WIDTH_PERCENT: u16 = 70;
 pub const HELP_MODAL_HEIGHT_PERCENT: u16 = 80;
 // Top and bottom modal border rows subtracted from the inner visible area.
 pub const MODAL_VERTICAL_BORDER_OVERHEAD: usize = 2;
+pub const MODAL_HORIZONTAL_BORDER_OVERHEAD: usize = 2;
+pub const HELP_HORIZONTAL_SCROLLBAR_OVERHEAD: usize = 1;
 pub const DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS: usize = 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -184,7 +187,9 @@ pub struct UiState {
     pub jsonb_detail_editor_visible_rows: usize,
 
     pub help_scroll_offset: usize,
+    pub help_horizontal_offset: usize,
 
+    pub terminal_width: u16,
     pub terminal_height: u16,
 
     pub key_sequence: KeySequenceState,
@@ -193,6 +198,7 @@ pub struct UiState {
 impl UiState {
     pub fn new() -> Self {
         Self {
+            terminal_width: 80,
             terminal_height: 24,
             jsonb_detail_editor_visible_rows: DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS,
             ..Default::default()
@@ -234,10 +240,28 @@ impl UiState {
     pub fn help_visible_rows(&self) -> usize {
         (self.terminal_height as usize * HELP_MODAL_HEIGHT_PERCENT as usize / 100)
             .saturating_sub(MODAL_VERTICAL_BORDER_OVERHEAD)
+            .saturating_sub(HELP_HORIZONTAL_SCROLLBAR_OVERHEAD)
     }
 
     pub fn help_max_scroll(&self) -> usize {
         help_content_line_count().saturating_sub(self.help_visible_rows())
+    }
+
+    pub fn help_visible_columns(&self) -> usize {
+        (self.terminal_width as usize * HELP_MODAL_WIDTH_PERCENT as usize / 100)
+            .saturating_sub(MODAL_HORIZONTAL_BORDER_OVERHEAD)
+            .saturating_sub(1)
+    }
+
+    pub fn help_max_horizontal_scroll(&self) -> usize {
+        help_content_width().saturating_sub(self.help_visible_columns())
+    }
+
+    pub fn clamp_help_offsets(&mut self) {
+        self.help_scroll_offset = self.help_scroll_offset.min(self.help_max_scroll());
+        self.help_horizontal_offset = self
+            .help_horizontal_offset
+            .min(self.help_max_horizontal_scroll());
     }
 
     pub fn toggle_focus(&mut self) -> bool {
@@ -323,6 +347,7 @@ mod tests {
         fn new_sets_terminal_height() {
             let state = UiState::new();
 
+            assert_eq!(state.terminal_width, 80);
             assert_eq!(state.terminal_height, 24);
         }
     }
@@ -586,7 +611,20 @@ mod tests {
                 ..Default::default()
             };
 
-            assert_eq!(state.help_visible_rows(), 17);
+            assert_eq!(state.help_visible_rows(), 16);
+        }
+
+        #[test]
+        fn help_max_horizontal_scroll_uses_modal_width() {
+            let state = UiState {
+                terminal_width: 80,
+                ..Default::default()
+            };
+
+            assert_eq!(
+                state.help_max_horizontal_scroll(),
+                help_content_width().saturating_sub(53)
+            );
         }
     }
 

--- a/src/app/update/input/handlers/overlays.rs
+++ b/src/app/update/input/handlers/overlays.rs
@@ -94,6 +94,10 @@ mod tests {
             ScrollAmount::FullPage
         )]
         #[case(combo(Key::PageUp), ScrollDirection::Up, ScrollAmount::FullPage)]
+        #[case(combo(Key::Char('h')), ScrollDirection::Left, ScrollAmount::Line)]
+        #[case(combo(Key::Left), ScrollDirection::Left, ScrollAmount::Line)]
+        #[case(combo(Key::Char('l')), ScrollDirection::Right, ScrollAmount::Line)]
+        #[case(combo(Key::Right), ScrollDirection::Right, ScrollAmount::Line)]
         fn supported_help_scroll_keys_map_to_expected_action(
             #[case] combo: KeyCombo,
             #[case] direction: ScrollDirection,
@@ -108,8 +112,6 @@ mod tests {
         #[case(Key::Char('H'))]
         #[case(Key::Char('M'))]
         #[case(Key::Char('L'))]
-        #[case(Key::Char('h'))]
-        #[case(Key::Char('l'))]
         #[case(Key::Char('z'))]
         fn issue_non_goals_remain_unbound_in_help_mode(#[case] code: Key) {
             let result = handle_help_keys(combo(code));

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -322,7 +322,7 @@ pub mod idx {
 // =============================================================================
 
 pub const HELP_KEY_INDENT_WIDTH: usize = 2;
-pub const HELP_KEY_MIN_COLUMN_WIDTH: usize = 20;
+pub const HELP_KEY_COLUMN_WIDTH: usize = 20;
 pub const HELP_KEY_DESC_GAP: usize = 2;
 
 // Must match the section order in `HelpOverlay::render()`.
@@ -365,26 +365,16 @@ pub const fn help_content_line_count() -> usize {
 }
 
 pub fn help_content_width() -> usize {
-    let key_column_width = help_key_column_width();
-
     help_section_titles()
         .map(|title| UnicodeWidthStr::width("▸ ") + UnicodeWidthStr::width(title))
         .chain(help_row_entries().map(|(key, desc)| {
             HELP_KEY_INDENT_WIDTH
-                + key_column_width.max(UnicodeWidthStr::width(key))
+                + UnicodeWidthStr::width(key).max(HELP_KEY_COLUMN_WIDTH)
                 + HELP_KEY_DESC_GAP
                 + UnicodeWidthStr::width(desc)
         }))
         .max()
         .unwrap_or(0)
-}
-
-pub fn help_key_column_width() -> usize {
-    help_row_entries()
-        .map(|(key, _)| UnicodeWidthStr::width(key))
-        .max()
-        .unwrap_or(0)
-        .max(HELP_KEY_MIN_COLUMN_WIDTH)
 }
 
 fn help_section_titles() -> impl Iterator<Item = &'static str> {

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -365,16 +365,26 @@ pub const fn help_content_line_count() -> usize {
 }
 
 pub fn help_content_width() -> usize {
+    let key_column_width = help_key_column_width();
+
     help_section_titles()
         .map(|title| UnicodeWidthStr::width("▸ ") + UnicodeWidthStr::width(title))
         .chain(help_row_entries().map(|(key, desc)| {
             HELP_KEY_INDENT_WIDTH
-                + UnicodeWidthStr::width(key).max(HELP_KEY_MIN_COLUMN_WIDTH)
+                + key_column_width.max(UnicodeWidthStr::width(key))
                 + HELP_KEY_DESC_GAP
                 + UnicodeWidthStr::width(desc)
         }))
         .max()
         .unwrap_or(0)
+}
+
+pub fn help_key_column_width() -> usize {
+    help_row_entries()
+        .map(|(key, _)| UnicodeWidthStr::width(key))
+        .max()
+        .unwrap_or(0)
+        .max(HELP_KEY_MIN_COLUMN_WIDTH)
 }
 
 fn help_section_titles() -> impl Iterator<Item = &'static str> {

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -368,9 +368,13 @@ pub fn help_content_width() -> usize {
     help_section_titles()
         .map(|title| UnicodeWidthStr::width("▸ ") + UnicodeWidthStr::width(title))
         .chain(help_row_entries().map(|(key, desc)| {
+            let key_width = UnicodeWidthStr::width(key);
             HELP_KEY_INDENT_WIDTH
-                + UnicodeWidthStr::width(key).max(HELP_KEY_COLUMN_WIDTH)
-                + HELP_KEY_DESC_GAP
+                + if key_width > HELP_KEY_COLUMN_WIDTH {
+                    key_width + HELP_KEY_DESC_GAP
+                } else {
+                    HELP_KEY_COLUMN_WIDTH
+                }
                 + UnicodeWidthStr::width(desc)
         }))
         .max()

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -9,6 +9,7 @@ pub use connections::*;
 pub use editors::*;
 pub use normal::*;
 pub use overlays::*;
+use unicode_width::UnicodeWidthStr;
 
 #[derive(Clone)]
 pub struct KeyBinding {
@@ -246,7 +247,8 @@ pub mod idx {
         pub const TOP_BOTTOM: usize = 1;
         pub const HALF_PAGE: usize = 2;
         pub const FULL_PAGE: usize = 3;
-        pub const CLOSE: usize = 4;
+        pub const H_SCROLL: usize = 4;
+        pub const CLOSE: usize = 5;
     }
 
     pub mod result_active {
@@ -319,6 +321,10 @@ pub mod idx {
 // Help Overlay Layout
 // =============================================================================
 
+pub const HELP_KEY_INDENT_WIDTH: usize = 2;
+pub const HELP_KEY_MIN_COLUMN_WIDTH: usize = 20;
+pub const HELP_KEY_DESC_GAP: usize = 2;
+
 // Must match the section order in `HelpOverlay::render()`.
 pub const fn help_content_line_count() -> usize {
     // Dedup pairs collapsed into one line by HelpOverlay::push_dedup:
@@ -356,6 +362,148 @@ pub const fn help_content_line_count() -> usize {
         + JSONB_DETAIL_ROWS.len()
         + JSONB_EDIT_ROWS.len()
         + JSONB_SEARCH_KEYS.len()
+}
+
+pub fn help_content_width() -> usize {
+    help_section_titles()
+        .map(|title| UnicodeWidthStr::width("▸ ") + UnicodeWidthStr::width(title))
+        .chain(help_row_entries().map(|(key, desc)| {
+            HELP_KEY_INDENT_WIDTH
+                + UnicodeWidthStr::width(key).max(HELP_KEY_MIN_COLUMN_WIDTH)
+                + HELP_KEY_DESC_GAP
+                + UnicodeWidthStr::width(desc)
+        }))
+        .max()
+        .unwrap_or(0)
+}
+
+fn help_section_titles() -> impl Iterator<Item = &'static str> {
+    [
+        "Global Keys",
+        "Navigation",
+        "Result History",
+        "Result Pane",
+        "Inspector Pane (DDL tab)",
+        "Cell Edit",
+        "SQL Editor (Normal)",
+        "SQL Editor (Insert)",
+        "SQL Editor (Plan)",
+        "SQL Editor (Compare)",
+        "SQL Editor (Confirm)",
+        "Overlays",
+        "Command Line",
+        "Connection Setup",
+        "Connection Error",
+        "Connection Selector",
+        "ER Diagram Picker",
+        "Query History Picker",
+        "Table Picker",
+        "Command Palette",
+        "Help Overlay",
+        "Confirm Dialog",
+        "JSONB Detail",
+        "JSONB Edit",
+        "JSONB Search",
+    ]
+    .into_iter()
+}
+
+fn help_row_entries() -> impl Iterator<Item = (&'static str, &'static str)> {
+    HELP_ROWS
+        .iter()
+        .map(|row| (row.key, row.description))
+        .chain(
+            GLOBAL_KEYS
+                .iter()
+                .map(|row| (row.key, row.description))
+                .chain(NAVIGATION_KEYS.iter().map(|row| (row.key, row.description)))
+                .chain(HISTORY_KEYS.iter().map(|row| (row.key, row.description)))
+                .chain(
+                    RESULT_ACTIVE_KEYS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(
+                    INSPECTOR_DDL_KEYS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(CELL_EDIT_KEYS.iter().map(|row| (row.key, row.description)))
+                .chain(
+                    SQL_MODAL_NORMAL_KEYS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(SQL_MODAL_KEYS.iter().map(|row| (row.key, row.description)))
+                .chain(
+                    SQL_MODAL_PLAN_KEYS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(
+                    SQL_MODAL_COMPARE_KEYS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(
+                    SQL_MODAL_CONFIRMING_KEYS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(OVERLAY_KEYS.iter().map(|row| (row.key, row.description)))
+                .chain(
+                    COMMAND_LINE_KEYS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(
+                    CONNECTION_SETUP_KEYS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(
+                    CONNECTION_ERROR_ROWS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(
+                    CONNECTION_SELECTOR_ROWS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(ER_PICKER_ROWS.iter().map(|row| (row.key, row.description)))
+                .chain(
+                    QUERY_HISTORY_PICKER_ROWS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(
+                    TABLE_PICKER_ROWS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(
+                    COMMAND_PALETTE_ROWS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(
+                    CONFIRM_DIALOG_KEYS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(
+                    JSONB_DETAIL_ROWS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                )
+                .chain(JSONB_EDIT_ROWS.iter().map(|row| (row.key, row.description)))
+                .chain(
+                    JSONB_SEARCH_KEYS
+                        .iter()
+                        .map(|row| (row.key, row.description)),
+                ),
+        )
 }
 
 pub fn is_quit(combo: &KeyCombo) -> bool {
@@ -531,6 +679,7 @@ mod tests {
             assert!(idx::help::TOP_BOTTOM < HELP_ROWS.len());
             assert!(idx::help::HALF_PAGE < HELP_ROWS.len());
             assert!(idx::help::FULL_PAGE < HELP_ROWS.len());
+            assert!(idx::help::H_SCROLL < HELP_ROWS.len());
             assert!(idx::help::CLOSE < HELP_ROWS.len());
 
             // RESULT_ACTIVE_KEYS

--- a/src/app/update/input/keybindings/overlays.rs
+++ b/src/app/update/input/keybindings/overlays.rs
@@ -181,6 +181,30 @@ pub const HELP_ROWS: &[ModeRow] = &[
         ],
     },
     ModeRow {
+        key_short: "h/l / ←→",
+        key: "h / l / ← / →",
+        desc_short: "H-Scroll",
+        description: "Scroll left / right",
+        bindings: &[
+            ExecBinding {
+                action: Action::Scroll {
+                    target: ScrollTarget::Help,
+                    direction: ScrollDirection::Left,
+                    amount: ScrollAmount::Line,
+                },
+                combos: &[KeyCombo::plain(Key::Char('h')), KeyCombo::plain(Key::Left)],
+            },
+            ExecBinding {
+                action: Action::Scroll {
+                    target: ScrollTarget::Help,
+                    direction: ScrollDirection::Right,
+                    amount: ScrollAmount::Line,
+                },
+                combos: &[KeyCombo::plain(Key::Char('l')), KeyCombo::plain(Key::Right)],
+            },
+        ],
+    },
+    ModeRow {
         key_short: "?/Esc",
         key: "? / Esc",
         desc_short: "Close",

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -16,6 +16,24 @@ fn scroll_help_by(state: &mut AppState, direction: ScrollDirection, delta: usize
         direction.clamp_vertical_offset(state.ui.help_scroll_offset, max_scroll, delta);
 }
 
+fn scroll_help_horizontally(state: &mut AppState, direction: ScrollDirection) {
+    match direction {
+        ScrollDirection::Left => {
+            state.ui.help_horizontal_offset = state.ui.help_horizontal_offset.saturating_sub(1);
+        }
+        ScrollDirection::Right => {
+            state.ui.help_horizontal_offset =
+                (state.ui.help_horizontal_offset + 1).min(state.ui.help_max_horizontal_scroll());
+        }
+        ScrollDirection::Up | ScrollDirection::Down => {}
+    }
+}
+
+fn reset_help_offsets(state: &mut AppState) {
+    state.ui.help_scroll_offset = 0;
+    state.ui.help_horizontal_offset = 0;
+}
+
 pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
     match action {
         Action::OpenModal(ModalKind::TablePicker) => {
@@ -38,7 +56,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
         Action::ToggleModal(ModalKind::Help) => {
             if state.modal.active_mode() == InputMode::Help {
                 state.modal.set_mode(InputMode::Normal);
-                state.ui.help_scroll_offset = 0;
+                reset_help_offsets(state);
             } else {
                 state.modal.set_mode(InputMode::Help);
             }
@@ -46,7 +64,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
         }
         Action::CloseModal(ModalKind::Help) => {
             state.modal.set_mode(InputMode::Normal);
-            state.ui.help_scroll_offset = 0;
+            reset_help_offsets(state);
             Some(vec![])
         }
         Action::Scroll {
@@ -55,9 +73,26 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             amount,
         } => {
             match amount {
+                ScrollAmount::Line
+                    if matches!(direction, ScrollDirection::Left | ScrollDirection::Right) =>
+                {
+                    scroll_help_horizontally(state, *direction);
+                }
                 ScrollAmount::Line => scroll_help_by(state, *direction, 1),
-                ScrollAmount::ToStart => state.ui.help_scroll_offset = 0,
-                ScrollAmount::ToEnd => state.ui.help_scroll_offset = state.ui.help_max_scroll(),
+                ScrollAmount::ToStart => {
+                    if matches!(direction, ScrollDirection::Left | ScrollDirection::Right) {
+                        state.ui.help_horizontal_offset = 0;
+                    } else {
+                        state.ui.help_scroll_offset = 0;
+                    }
+                }
+                ScrollAmount::ToEnd => {
+                    if matches!(direction, ScrollDirection::Left | ScrollDirection::Right) {
+                        state.ui.help_horizontal_offset = state.ui.help_max_horizontal_scroll();
+                    } else {
+                        state.ui.help_scroll_offset = state.ui.help_max_scroll();
+                    }
+                }
                 ScrollAmount::HalfPage | ScrollAmount::FullPage => {
                     if let Some(delta) = amount.page_delta(state.ui.help_visible_rows()) {
                         scroll_help_by(state, *direction, delta);

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -73,8 +73,10 @@ fn reduce_inner(
             state.should_quit = true;
             vec![]
         }
-        Action::Resize(_w, h) => {
+        Action::Resize(w, h) => {
+            state.ui.terminal_width = w;
             state.ui.terminal_height = h;
+            state.ui.clamp_help_offsets();
             vec![]
         }
         Action::Render => {
@@ -208,8 +210,12 @@ mod tests {
         }
 
         #[test]
-        fn resize_updates_terminal_height() {
+        fn resize_updates_terminal_size_and_clamps_help_offsets() {
             let mut state = create_test_state();
+            state.ui.terminal_width = 20;
+            state.ui.terminal_height = 10;
+            state.ui.help_scroll_offset = usize::MAX;
+            state.ui.help_horizontal_offset = usize::MAX;
             let now = Instant::now();
 
             let effects = reduce(
@@ -219,7 +225,13 @@ mod tests {
                 &AppServices::stub(),
             );
 
+            assert_eq!(state.ui.terminal_width, 100);
             assert_eq!(state.ui.terminal_height, 50);
+            assert_eq!(state.ui.help_scroll_offset, state.ui.help_max_scroll());
+            assert_eq!(
+                state.ui.help_horizontal_offset,
+                state.ui.help_max_horizontal_scroll()
+            );
             assert!(effects.is_empty());
         }
 
@@ -463,7 +475,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.ui.help_scroll_offset, 19);
+            assert_eq!(state.ui.help_scroll_offset, 18);
             assert!(effects.is_empty());
         }
 
@@ -509,6 +521,65 @@ mod tests {
             );
 
             assert_eq!(state.ui.help_scroll_offset, 0);
+        }
+
+        #[test]
+        fn help_horizontal_scroll_saturates_at_bounds() {
+            let mut state = create_test_state();
+            state.ui.terminal_width = 40;
+            state.ui.help_horizontal_offset = state.ui.help_max_horizontal_scroll();
+            let now = Instant::now();
+
+            reduce(
+                &mut state,
+                Action::Scroll {
+                    target: ScrollTarget::Help,
+                    direction: ScrollDirection::Right,
+                    amount: ScrollAmount::Line,
+                },
+                now,
+                &AppServices::stub(),
+            );
+
+            assert_eq!(
+                state.ui.help_horizontal_offset,
+                state.ui.help_max_horizontal_scroll()
+            );
+
+            reduce(
+                &mut state,
+                Action::Scroll {
+                    target: ScrollTarget::Help,
+                    direction: ScrollDirection::Left,
+                    amount: ScrollAmount::Line,
+                },
+                now,
+                &AppServices::stub(),
+            );
+
+            assert_eq!(
+                state.ui.help_horizontal_offset,
+                state.ui.help_max_horizontal_scroll().saturating_sub(1)
+            );
+        }
+
+        #[test]
+        fn help_close_resets_vertical_and_horizontal_offsets() {
+            let mut state = create_test_state();
+            state.modal.set_mode(InputMode::Help);
+            state.ui.help_scroll_offset = 3;
+            state.ui.help_horizontal_offset = 4;
+            let now = Instant::now();
+
+            reduce(
+                &mut state,
+                Action::CloseModal(ModalKind::Help),
+                now,
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.ui.help_scroll_offset, 0);
+            assert_eq!(state.ui.help_horizontal_offset, 0);
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,7 @@ async fn main() -> Result<()> {
     tui.enter()?;
 
     let initial_size = tui.terminal().size()?;
+    state.ui.terminal_width = initial_size.width;
     state.ui.terminal_height = initial_size.height;
 
     if state.session.dsn.is_some() && state.input_mode() == InputMode::Normal {

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -394,6 +394,20 @@ fn help_overlay_narrow_horizontal_scroll() {
 }
 
 #[test]
+fn help_overlay_omits_scrollbars_when_content_fits() {
+    let (mut state, _now) = connected_state();
+    let mut terminal = create_test_terminal_sized(180, 300);
+
+    state.modal.set_mode(InputMode::Help);
+    state.ui.terminal_width = 180;
+    state.ui.terminal_height = 300;
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn command_palette_overlay() {
     let (mut state, _now) = connected_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -365,6 +365,35 @@ fn help_overlay() {
 }
 
 #[test]
+fn help_overlay_long_key_rows() {
+    let (mut state, _now) = connected_state();
+    let mut terminal = create_test_terminal();
+
+    state.modal.set_mode(InputMode::Help);
+    state.ui.help_scroll_offset = 58;
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn help_overlay_narrow_horizontal_scroll() {
+    let (mut state, _now) = connected_state();
+    let mut terminal = create_test_terminal_sized(50, 24);
+
+    state.modal.set_mode(InputMode::Help);
+    state.ui.terminal_width = 50;
+    state.ui.terminal_height = 24;
+    state.ui.help_scroll_offset = 58;
+    state.ui.help_horizontal_offset = 18;
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn command_palette_overlay() {
     let (mut state, _now) = connected_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
@@ -6,22 +6,22 @@ test_project | test_db | - | no dsn | localhost:5432/test
 ┌ [1] Explorer ────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                 
 │> public.us╭ Help ────────────────────────────────────────────────╮───────────┐
 │  public.po│▸ Global Keys                                        ▲│           │
-│  public.co│  q                                    Quit applicati┃│           │
-│           │  ?                                    Toggle help   ││           │
-│           │  Ctrl+P                               Open Table Pic││           │
-│           │  Ctrl+K                               Open Command P││           │
-│           │  :                                    Enter command ││           │
-│           │  f                                    Toggle Focus  ││           │
-│           │  1/2/3                                Switch pane fo││           │
-│           │  Tab/⇧Tab                             Inspector prev││───────────┘
-│           │  r                                    Reload metadat││───────────┐
-│           │  s                                    Open SQL Edito││           │
-│           │  e                                    Open ER Diagra││           │
-│           │  c                                    Open Connectio││           │
-│           │  Ctrl+E                               Export result ││           │
-│           │  Ctrl+R                               Toggle Read-On││           │
-│           │  Ctrl+O                               Open Query His││           │
+│  public.co│  q                     Quit application             ┃│           │
+│           │  ?                     Toggle help                  ││           │
+│           │  Ctrl+P                Open Table Picker            ││           │
+│           │  Ctrl+K                Open Command Palette         ││           │
+│           │  :                     Enter command line           ││           │
+│           │  f                     Toggle Focus                 ││           │
+│           │  1/2/3                 Switch pane focus            ││           │
+│           │  Tab/⇧Tab              Inspector prev/next tab      ││───────────┘
+│           │  r                     Reload metadata              ││───────────┐
+│           │  s                     Open SQL Editor              ││           │
+│           │  e                     Open ER Diagram              ││           │
+│           │  c                     Open Connection Selector     ││           │
+│           │  Ctrl+E                Export result to CSV         ││           │
+│           │  Ctrl+R                Toggle Read-Only             ││           │
+│           │  Ctrl+O                Open Query History           ││           │
 │           │                                                     ▼│           │
-│           │ col   0% ◀︎═════════════════────────────────────────▶︎ │           │
+│           │ col   0% ◀︎════════════════════─────────────────────▶︎ │           │
 └───────────╰ ?/Esc Close ─────────────────────────────────────────╯───────────┘
 h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
@@ -1,27 +1,27 @@
 ---
-source: tests/render_snapshots/overlays.rs
+source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                       
 ┌ [1] Explorer ────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                 
 │> public.us╭ Help ────────────────────────────────────────────────╮───────────┐
 │  public.po│▸ Global Keys                                        ▲│           │
-│  public.co│  q                   Quit application               ┃│           │
-│           │  ?                   Toggle help                    ││           │
-│           │  Ctrl+P              Open Table Picker              ││           │
-│           │  Ctrl+K              Open Command Palette           ││           │
-│           │  :                   Enter command line             ││           │
-│           │  f                   Toggle Focus                   ││           │
-│           │  1/2/3               Switch pane focus              ││           │
-│           │  Tab/⇧Tab            Inspector prev/next tab        ││───────────┘
-│           │  r                   Reload metadata                ││───────────┐
-│           │  s                   Open SQL Editor                ││           │
-│           │  e                   Open ER Diagram                ││           │
-│           │  c                   Open Connection Selector       ││           │
-│           │  Ctrl+E              Export result to CSV           ││           │
-│           │  Ctrl+R              Toggle Read-Only               ││           │
-│           │  Ctrl+O              Open Query History             ││           │
-│           │                                                     ││           │
-│           │▸ Navigation                                         ▼│           │
+│  public.co│  q                     Quit application             ┃│           │
+│           │  ?                     Toggle help                  ││           │
+│           │  Ctrl+P                Open Table Picker            ││           │
+│           │  Ctrl+K                Open Command Palette         ││           │
+│           │  :                     Enter command line           ││           │
+│           │  f                     Toggle Focus                 ││           │
+│           │  1/2/3                 Switch pane focus            ││           │
+│           │  Tab/⇧Tab              Inspector prev/next tab      ││───────────┘
+│           │  r                     Reload metadata              ││───────────┐
+│           │  s                     Open SQL Editor              ││           │
+│           │  e                     Open ER Diagram              ││           │
+│           │  c                     Open Connection Selector     ││           │
+│           │  Ctrl+E                Export result to CSV         ││           │
+│           │  Ctrl+R                Toggle Read-Only             ││           │
+│           │  Ctrl+O                Open Query History           ││           │
+│           │                                                     ▼│           │
+│           │ col   0% ◀︎════════════════════─────────────────────▶︎ │           │
 └───────────╰ ?/Esc Close ─────────────────────────────────────────╯───────────┘
-?/Esc:Close
+h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
@@ -6,21 +6,21 @@ test_project | test_db | - | no dsn | localhost:5432/test
 ┌ [1] Explorer ────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                 
 │> public.us╭ Help ────────────────────────────────────────────────╮───────────┐
 │  public.po│▸ Global Keys                                        ▲│           │
-│  public.co│  q                     Quit application             ┃│           │
-│           │  ?                     Toggle help                  ││           │
-│           │  Ctrl+P                Open Table Picker            ││           │
-│           │  Ctrl+K                Open Command Palette         ││           │
-│           │  :                     Enter command line           ││           │
-│           │  f                     Toggle Focus                 ││           │
-│           │  1/2/3                 Switch pane focus            ││           │
-│           │  Tab/⇧Tab              Inspector prev/next tab      ││───────────┘
-│           │  r                     Reload metadata              ││───────────┐
-│           │  s                     Open SQL Editor              ││           │
-│           │  e                     Open ER Diagram              ││           │
-│           │  c                     Open Connection Selector     ││           │
-│           │  Ctrl+E                Export result to CSV         ││           │
-│           │  Ctrl+R                Toggle Read-Only             ││           │
-│           │  Ctrl+O                Open Query History           ││           │
+│  public.co│  q                   Quit application               ┃│           │
+│           │  ?                   Toggle help                    ││           │
+│           │  Ctrl+P              Open Table Picker              ││           │
+│           │  Ctrl+K              Open Command Palette           ││           │
+│           │  :                   Enter command line             ││           │
+│           │  f                   Toggle Focus                   ││           │
+│           │  1/2/3               Switch pane focus              ││           │
+│           │  Tab/⇧Tab            Inspector prev/next tab        ││───────────┘
+│           │  r                   Reload metadata                ││───────────┐
+│           │  s                   Open SQL Editor                ││           │
+│           │  e                   Open ER Diagram                ││           │
+│           │  c                   Open Connection Selector       ││           │
+│           │  Ctrl+E              Export result to CSV           ││           │
+│           │  Ctrl+R              Toggle Read-Only               ││           │
+│           │  Ctrl+O              Open Query History             ││           │
 │           │                                                     ▼│           │
 │           │ col   0% ◀︎════════════════════─────────────────────▶︎ │           │
 └───────────╰ ?/Esc Close ─────────────────────────────────────────╯───────────┘

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
@@ -6,22 +6,22 @@ test_project | test_db | - | no dsn | localhost:5432/test
 ┌ [1] Explorer ────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                 
 │> public.us╭ Help ────────────────────────────────────────────────╮───────────┐
 │  public.po│▸ Global Keys                                        ▲│           │
-│  public.co│  q                     Quit application             ┃│           │
-│           │  ?                     Toggle help                  ││           │
-│           │  Ctrl+P                Open Table Picker            ││           │
-│           │  Ctrl+K                Open Command Palette         ││           │
-│           │  :                     Enter command line           ││           │
-│           │  f                     Toggle Focus                 ││           │
-│           │  1/2/3                 Switch pane focus            ││           │
-│           │  Tab/⇧Tab              Inspector prev/next tab      ││───────────┘
-│           │  r                     Reload metadata              ││───────────┐
-│           │  s                     Open SQL Editor              ││           │
-│           │  e                     Open ER Diagram              ││           │
-│           │  c                     Open Connection Selector     ││           │
-│           │  Ctrl+E                Export result to CSV         ││           │
-│           │  Ctrl+R                Toggle Read-Only             ││           │
-│           │  Ctrl+O                Open Query History           ││           │
+│  public.co│  q                                    Quit applicati┃│           │
+│           │  ?                                    Toggle help   ││           │
+│           │  Ctrl+P                               Open Table Pic││           │
+│           │  Ctrl+K                               Open Command P││           │
+│           │  :                                    Enter command ││           │
+│           │  f                                    Toggle Focus  ││           │
+│           │  1/2/3                                Switch pane fo││           │
+│           │  Tab/⇧Tab                             Inspector prev││───────────┘
+│           │  r                                    Reload metadat││───────────┐
+│           │  s                                    Open SQL Edito││           │
+│           │  e                                    Open ER Diagra││           │
+│           │  c                                    Open Connectio││           │
+│           │  Ctrl+E                               Export result ││           │
+│           │  Ctrl+R                               Toggle Read-On││           │
+│           │  Ctrl+O                               Open Query His││           │
 │           │                                                     ▼│           │
-│           │ col   0% ◀︎════════════════════─────────────────────▶︎ │           │
+│           │ col   0% ◀︎═════════════════────────────────────────▶︎ │           │
 └───────────╰ ?/Esc Close ─────────────────────────────────────────╯───────────┘
 h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
@@ -5,23 +5,23 @@ expression: output
 test_project | test_db | - | no dsn | localhost:5432/test                       
 ┌ [1] Explorer ────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                 
 │> public.us╭ Help ────────────────────────────────────────────────╮───────────┐
-│  public.po│  :                                    Open command l▲│           │
-│  public.co│  Esc                                  Exit to Cell A││           │
+│  public.po│  :                     Open command line            ▲│           │
+│  public.co│  Esc                   Exit to Cell Active (draft pr││           │
 │           │                                                     ││           │
 │           │▸ SQL Editor (Normal)                                ││           │
-│           │  Alt+Enter / F5                       Execute query ││           │
-│           │  y                                    Copy query to ┃│           │
-│           │  i                                    Enter Insert m││           │
-│           │  A                                    Append at line││           │
-│           │  h / j / k / l / ↑↓←→                 Move cursor   ││───────────┘
-│           │  0 / $ / w / b / Home / End           Move by word o││───────────┐
-│           │  gg / G / H / M / L                   Jump by buffer││           │
-│           │  Esc                                  Close editor  ││           │
-│           │  Ctrl+L                               Clear editor  ││           │
-│           │  Ctrl+O                               Open Query His││           │
+│           │  Alt+Enter / F5        Execute query                ││           │
+│           │  y                     Copy query to clipboard      ┃│           │
+│           │  i                     Enter Insert mode            ││           │
+│           │  A                     Append at line end           ││           │
+│           │  h / j / k / l / ↑↓←→  Move cursor                  ││───────────┘
+│           │  0 / $ / w / b / Home / End  Move by word or line bo││───────────┐
+│           │  gg / G / H / M / L    Jump by buffer or viewport   ││           │
+│           │  Esc                   Close editor                 ││           │
+│           │  Ctrl+L                Clear editor                 ││           │
+│           │  Ctrl+O                Open Query History           ││           │
 │           │                                                     ││           │
 │           │▸ SQL Editor (Insert)                                ││           │
-│           │  Alt+Enter / F5                       Execute query ▼│           │
-│           │ col   0% ◀︎═════════════════────────────────────────▶︎ │           │
+│           │  Alt+Enter / F5        Execute query                ▼│           │
+│           │ col   0% ◀︎════════════════════─────────────────────▶︎ │           │
 └───────────╰ ?/Esc Close ─────────────────────────────────────────╯───────────┘
 h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
@@ -5,23 +5,23 @@ expression: output
 test_project | test_db | - | no dsn | localhost:5432/test                       
 ┌ [1] Explorer ────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                 
 │> public.us╭ Help ────────────────────────────────────────────────╮───────────┐
-│  public.po│  :                     Open command line            ▲│           │
-│  public.co│  Esc                   Exit to Cell Active (draft pr││           │
+│  public.po│  :                                    Open command l▲│           │
+│  public.co│  Esc                                  Exit to Cell A││           │
 │           │                                                     ││           │
 │           │▸ SQL Editor (Normal)                                ││           │
-│           │  Alt+Enter             Execute query                ││           │
-│           │  y                     Copy query to clipboard      ┃│           │
-│           │  i                     Enter Insert mode            ││           │
-│           │  A                     Append at line end           ││           │
-│           │  h / j / k / l / ↑↓←→  Move cursor                  ││───────────┘
-│           │  0 / $ / w / b / Home / End  Move by word or line bo││───────────┐
-│           │  gg / G / H / M / L    Jump by buffer or viewport   ││           │
-│           │  Esc                   Close editor                 ││           │
-│           │  Ctrl+L                Clear editor                 ││           │
-│           │  Ctrl+O                Open Query History           ││           │
+│           │  Alt+Enter / F5                       Execute query ││           │
+│           │  y                                    Copy query to ┃│           │
+│           │  i                                    Enter Insert m││           │
+│           │  A                                    Append at line││           │
+│           │  h / j / k / l / ↑↓←→                 Move cursor   ││───────────┘
+│           │  0 / $ / w / b / Home / End           Move by word o││───────────┐
+│           │  gg / G / H / M / L                   Jump by buffer││           │
+│           │  Esc                                  Close editor  ││           │
+│           │  Ctrl+L                               Clear editor  ││           │
+│           │  Ctrl+O                               Open Query His││           │
 │           │                                                     ││           │
 │           │▸ SQL Editor (Insert)                                ││           │
-│           │  Alt+Enter             Execute query                ▼│           │
-│           │ col   0% ◀︎════════════════════─────────────────────▶︎ │           │
+│           │  Alt+Enter / F5                       Execute query ▼│           │
+│           │ col   0% ◀︎═════════════════────────────────────────▶︎ │           │
 └───────────╰ ?/Esc Close ─────────────────────────────────────────╯───────────┘
 h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
@@ -1,0 +1,27 @@
+---
+source: src/tests/render_snapshots/overlays.rs
+expression: output
+---
+test_project | test_db | - | no dsn | localhost:5432/test                       
+┌ [1] Explorer ────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                 
+│> public.us╭ Help ────────────────────────────────────────────────╮───────────┐
+│  public.po│  :                     Open command line            ▲│           │
+│  public.co│  Esc                   Exit to Cell Active (draft pr││           │
+│           │                                                     ││           │
+│           │▸ SQL Editor (Normal)                                ││           │
+│           │  Alt+Enter             Execute query                ││           │
+│           │  y                     Copy query to clipboard      ┃│           │
+│           │  i                     Enter Insert mode            ││           │
+│           │  A                     Append at line end           ││           │
+│           │  h / j / k / l / ↑↓←→  Move cursor                  ││───────────┘
+│           │  0 / $ / w / b / Home / End  Move by word or line bo││───────────┐
+│           │  gg / G / H / M / L    Jump by buffer or viewport   ││           │
+│           │  Esc                   Close editor                 ││           │
+│           │  Ctrl+L                Clear editor                 ││           │
+│           │  Ctrl+O                Open Query History           ││           │
+│           │                                                     ││           │
+│           │▸ SQL Editor (Insert)                                ││           │
+│           │  Alt+Enter             Execute query                ▼│           │
+│           │ col   0% ◀︎════════════════════─────────────────────▶︎ │           │
+└───────────╰ ?/Esc Close ─────────────────────────────────────────╯───────────┘
+h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
@@ -5,23 +5,23 @@ expression: output
 test_project | test_db | - | no dsn | localhost:5432/test                       
 ┌ [1] Explorer ────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                 
 │> public.us╭ Help ────────────────────────────────────────────────╮───────────┐
-│  public.po│  :                     Open command line            ▲│           │
-│  public.co│  Esc                   Exit to Cell Active (draft pr││           │
+│  public.po│  :                   Open command line              ▲│           │
+│  public.co│  Esc                 Exit to Cell Active (draft pres││           │
 │           │                                                     ││           │
 │           │▸ SQL Editor (Normal)                                ││           │
-│           │  Alt+Enter / F5        Execute query                ││           │
-│           │  y                     Copy query to clipboard      ┃│           │
-│           │  i                     Enter Insert mode            ││           │
-│           │  A                     Append at line end           ││           │
-│           │  h / j / k / l / ↑↓←→  Move cursor                  ││───────────┘
+│           │  Alt+Enter / F5      Execute query                  ││           │
+│           │  y                   Copy query to clipboard        ┃│           │
+│           │  i                   Enter Insert mode              ││           │
+│           │  A                   Append at line end             ││           │
+│           │  h / j / k / l / ↑↓←→Move cursor                    ││───────────┘
 │           │  0 / $ / w / b / Home / End  Move by word or line bo││───────────┐
-│           │  gg / G / H / M / L    Jump by buffer or viewport   ││           │
-│           │  Esc                   Close editor                 ││           │
-│           │  Ctrl+L                Clear editor                 ││           │
-│           │  Ctrl+O                Open Query History           ││           │
+│           │  gg / G / H / M / L  Jump by buffer or viewport     ││           │
+│           │  Esc                 Close editor                   ││           │
+│           │  Ctrl+L              Clear editor                   ││           │
+│           │  Ctrl+O              Open Query History             ││           │
 │           │                                                     ││           │
 │           │▸ SQL Editor (Insert)                                ││           │
-│           │  Alt+Enter / F5        Execute query                ▼│           │
+│           │  Alt+Enter / F5      Execute query                  ▼│           │
 │           │ col   0% ◀︎════════════════════─────────────────────▶︎ │           │
 └───────────╰ ?/Esc Close ─────────────────────────────────────────╯───────────┘
 h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
@@ -1,0 +1,27 @@
+---
+source: src/tests/render_snapshots/overlays.rs
+expression: output
+---
+test_project | test_db | - | no dsn | localhost:54
+┌ [1] Explor┐[Info] [Cols] [Idx] [FK] [RLS] [Trig]
+│> publi╭ Help ───────────────────────────╮──────┐
+│  publi│      Open command line         ▲│      │
+│  publi│      Exit to Cell Active (draft││      │
+│       │                                ││      │
+│       │al)                             ││      │
+│       │      Execute query             ││      │
+│       │      Copy query to clipboard   ┃│      │
+│       │      Enter Insert mode         ││      │
+│       │      Append at line end        ││      │
+│       │↑↓←→  Move cursor               ││──────┘
+│       │Home / End  Move by word or line││──────┐
+│       │ L    Jump by buffer or viewport││      │
+│       │      Close editor              ││      │
+│       │      Clear editor              ││      │
+│       │      Open Query History        ││      │
+│       │                                ││      │
+│       │rt)                             ││      │
+│       │      Execute query             ▼│      │
+│       │ col  26% ◀︎────═════───────────▶︎ │      │
+└───────╰ ?/Esc Close ────────────────────╯──────┘
+h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
@@ -5,23 +5,23 @@ expression: output
 test_project | test_db | - | no dsn | localhost:54
 ┌ [1] Explor┐[Info] [Cols] [Idx] [FK] [RLS] [Trig]
 │> publi╭ Help ───────────────────────────╮──────┐
-│  publi│      Open command line         ▲│      │
-│  publi│      Exit to Cell Active (draft││      │
+│  publi│                     Open comman▲│      │
+│  publi│                     Exit to Cel││      │
 │       │                                ││      │
 │       │al)                             ││      │
-│       │      Execute query             ││      │
-│       │      Copy query to clipboard   ┃│      │
-│       │      Enter Insert mode         ││      │
-│       │      Append at line end        ││      │
-│       │↑↓←→  Move cursor               ││──────┘
-│       │Home / End  Move by word or line││──────┐
-│       │ L    Jump by buffer or viewport││      │
-│       │      Close editor              ││      │
-│       │      Clear editor              ││      │
-│       │      Open Query History        ││      │
+│       │                     Execute que││      │
+│       │                     Copy query ┃│      │
+│       │                     Enter Inser││      │
+│       │                     Append at l││      │
+│       │↑↓←→                 Move cursor││──────┘
+│       │Home / End           Move by wor││──────┐
+│       │ L                   Jump by buf││      │
+│       │                     Close edito││      │
+│       │                     Clear edito││      │
+│       │                     Open Query ││      │
 │       │                                ││      │
 │       │rt)                             ││      │
-│       │      Execute query             ▼│      │
-│       │ col  26% ◀︎────═════───────────▶︎ │      │
+│       │                     Execute que▼│      │
+│       │ col  21% ◀︎───═════────────────▶︎ │      │
 └───────╰ ?/Esc Close ────────────────────╯──────┘
 h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
@@ -5,23 +5,23 @@ expression: output
 test_project | test_db | - | no dsn | localhost:54
 ┌ [1] Explor┐[Info] [Cols] [Idx] [FK] [RLS] [Trig]
 │> publi╭ Help ───────────────────────────╮──────┐
-│  publi│      Open command line         ▲│      │
-│  publi│      Exit to Cell Active (draft││      │
+│  publi│    Open command line           ▲│      │
+│  publi│    Exit to Cell Active (draft p││      │
 │       │                                ││      │
 │       │al)                             ││      │
-│       │      Execute query             ││      │
-│       │      Copy query to clipboard   ┃│      │
-│       │      Enter Insert mode         ││      │
-│       │      Append at line end        ││      │
-│       │↑↓←→  Move cursor               ││──────┘
+│       │    Execute query               ││      │
+│       │    Copy query to clipboard     ┃│      │
+│       │    Enter Insert mode           ││      │
+│       │    Append at line end          ││      │
+│       │↑↓←→Move cursor                 ││──────┘
 │       │Home / End  Move by word or line││──────┐
-│       │ L    Jump by buffer or viewport││      │
-│       │      Close editor              ││      │
-│       │      Clear editor              ││      │
-│       │      Open Query History        ││      │
+│       │ L  Jump by buffer or viewport  ││      │
+│       │    Close editor                ││      │
+│       │    Clear editor                ││      │
+│       │    Open Query History          ││      │
 │       │                                ││      │
 │       │rt)                             ││      │
-│       │      Execute query             ▼│      │
+│       │    Execute query               ▼│      │
 │       │ col  26% ◀︎────═════───────────▶︎ │      │
 └───────╰ ?/Esc Close ────────────────────╯──────┘
 h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
@@ -5,23 +5,23 @@ expression: output
 test_project | test_db | - | no dsn | localhost:54
 ┌ [1] Explor┐[Info] [Cols] [Idx] [FK] [RLS] [Trig]
 │> publi╭ Help ───────────────────────────╮──────┐
-│  publi│                     Open comman▲│      │
-│  publi│                     Exit to Cel││      │
+│  publi│      Open command line         ▲│      │
+│  publi│      Exit to Cell Active (draft││      │
 │       │                                ││      │
 │       │al)                             ││      │
-│       │                     Execute que││      │
-│       │                     Copy query ┃│      │
-│       │                     Enter Inser││      │
-│       │                     Append at l││      │
-│       │↑↓←→                 Move cursor││──────┘
-│       │Home / End           Move by wor││──────┐
-│       │ L                   Jump by buf││      │
-│       │                     Close edito││      │
-│       │                     Clear edito││      │
-│       │                     Open Query ││      │
+│       │      Execute query             ││      │
+│       │      Copy query to clipboard   ┃│      │
+│       │      Enter Insert mode         ││      │
+│       │      Append at line end        ││      │
+│       │↑↓←→  Move cursor               ││──────┘
+│       │Home / End  Move by word or line││──────┐
+│       │ L    Jump by buffer or viewport││      │
+│       │      Close editor              ││      │
+│       │      Clear editor              ││      │
+│       │      Open Query History        ││      │
 │       │                                ││      │
 │       │rt)                             ││      │
-│       │                     Execute que▼│      │
-│       │ col  21% ◀︎───═════────────────▶︎ │      │
+│       │      Execute query             ▼│      │
+│       │ col  26% ◀︎────═════───────────▶︎ │      │
 └───────╰ ?/Esc Close ────────────────────╯──────┘
 h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_omits_scrollbars_when_content_fits.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_omits_scrollbars_when_content_fits.snap
@@ -1,0 +1,303 @@
+---
+source: src/tests/render_snapshots/overlays.rs
+expression: output
+---
+test_project | test_db | - | no dsn | localhost:5432/test                                                                                                                           
+┌ [1] Explorer ─────────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                            
+│> public.users                             │┌ [2] Inspector ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  public.posts                             ││(select a table)                                                                                                                     │
+│  public.comments                          ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                          ╭ Help ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮                          │
+│                          │▸ Global Keys                                                                                                               │                          │
+│                          │  q                     Quit application                                                                                    │                          │
+│                          │  ?                     Toggle help                                                                                         │                          │
+│                          │  Ctrl+P                Open Table Picker                                                                                   │                          │
+│                          │  Ctrl+K                Open Command Palette                                                                                │                          │
+│                          │  :                     Enter command line                                                                                  │                          │
+│                          │  f                     Toggle Focus                                                                                        │                          │
+│                          │  1/2/3                 Switch pane focus                                                                                   │                          │
+│                          │  Tab/⇧Tab              Inspector prev/next tab                                                                             │                          │
+│                          │  r                     Reload metadata                                                                                     │                          │
+│                          │  s                     Open SQL Editor                                                                                     │                          │
+│                          │  e                     Open ER Diagram                                                                                     │                          │
+│                          │  c                     Open Connection Selector                                                                            │                          │
+│                          │  Ctrl+E                Export result to CSV                                                                                │                          │
+│                          │  Ctrl+R                Toggle Read-Only                                                                                    │                          │
+│                          │  Ctrl+O                Open Query History                                                                                  │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Navigation                                                                                                                │                          │
+│                          │  j / ↓                 Move down / scroll                                                                                  │                          │
+│                          │  k / ↑                 Move up / scroll                                                                                    │                          │
+│                          │  g / Home              First item / top                                                                                    │                          │
+│                          │  G / End               Last item / bottom                                                                                  │                          │
+│                          │  H                     First visible item                                                                                  │                          │
+│                          │  M                     Middle of visible items                                                                             │                          │
+│                          │  L                     Last visible item                                                                                   │                          │
+│                          │  zz / zt / zb          Scroll cursor to center/top/bottom                                                                  │                          │
+│                          │  Ctrl+D / Ctrl+U       Scroll half page down/up                                                                            │                          │
+│                          │  Ctrl+F/B / PgDn/Up    Scroll full page down/up                                                                            │                          │
+│                          │  h / l                 Scroll left/right                                                                                   │                          │
+│                          │  ]                     Next page (Preview)                                                                                 │                          │
+│                          │  [                     Previous page (Preview)                                                                             │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Result History                                                                                                            │                          │
+│                          │  Ctrl+H                Toggle Result History                                                                               │                          │
+│                          │  ] / [                 Navigate history newer/older                                                                        │                          │
+│                          │  Ctrl+H                Exit history (back to latest)                                                                       │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Result Pane                                                                                                               │                          │
+│                          │  Enter                 Enter cell selection at the current viewport anchor                                                 │                          │
+│                          │  Y                     Copy the active cell value to clipboard                                                             │                          │
+│                          │  d, d                  Stage the active row for deletion (red highlight; :w to commit)                                     │                          │
+│                          │  u                     Unstage the last staged row deletion                                                                │                          │
+│                          │  h / l                 Move cell left/right                                                                                │                          │
+│                          │  j / k                 Move the active row up/down                                                                         │                          │
+│                          │  g / G / H / M / L     Jump the active row to first/last or viewport top/mid/bot                                           │                          │
+│                          │  Esc                   Exit cell selection and return to scroll mode without clearing staged deletes                       │                          │
+│                          │  i                     Edit active cell                                                                                    │                          │
+│                          │  Esc                   Discard the pending draft and stay in cell selection                                                │                          │
+│                          │  y, y                  Copy the active row values to clipboard (TSV)                                                       │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Inspector Pane (DDL tab)                                                                                                  │                          │
+│                          │  y                     Copy DDL to clipboard                                                                               │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Cell Edit                                                                                                                 │                          │
+│                          │  :w                    Preview and confirm UPDATE                                                                          │                          │
+│                          │  type                  Edit cell value                                                                                     │                          │
+│                          │  ←→                    Move cursor                                                                                         │                          │
+│                          │  Home/End              Jump to start/end                                                                                   │                          │
+│                          │  :                     Open command line                                                                                   │                          │
+│                          │  Esc                   Exit to Cell Active (draft preserved)                                                               │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ SQL Editor (Normal)                                                                                                       │                          │
+│                          │  Alt+Enter / F5        Execute query                                                                                       │                          │
+│                          │  y                     Copy query to clipboard                                                                             │                          │
+│                          │  i                     Enter Insert mode                                                                                   │                          │
+│                          │  A                     Append at line end                                                                                  │                          │
+│                          │  h / j / k / l / ↑↓←→  Move cursor                                                                                         │                          │
+│                          │  0 / $ / w / b / Home / End  Move by word or line boundary                                                                 │                          │
+│                          │  gg / G / H / M / L    Jump by buffer or viewport                                                                          │                          │
+│                          │  Esc                   Close editor                                                                                        │                          │
+│                          │  Ctrl+L                Clear editor                                                                                        │                          │
+│                          │  Ctrl+O                Open Query History                                                                                  │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ SQL Editor (Insert)                                                                                                       │                          │
+│                          │  Alt+Enter / F5        Execute query                                                                                       │                          │
+│                          │  Esc                   Return to Normal mode                                                                               │                          │
+│                          │  ↑↓←→                  Move cursor                                                                                         │                          │
+│                          │  Home/End              Line start/end                                                                                      │                          │
+│                          │  Tab                   Insert tab / Accept completion                                                                      │                          │
+│                          │  Ctrl+Space            Trigger completion                                                                                  │                          │
+│                          │  Ctrl+L                Clear editor                                                                                        │                          │
+│                          │  Ctrl+O                Open Query History                                                                                  │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ SQL Editor (Plan)                                                                                                         │                          │
+│                          │  Ctrl+E                Run EXPLAIN on current query                                                                        │                          │
+│                          │  Alt+E                 Run EXPLAIN ANALYZE on current query                                                                │                          │
+│                          │  y                     Copy to clipboard                                                                                   │                          │
+│                          │  Ctrl+N / Ctrl+P / ↑↓ / j / k  Scroll plan text                                                                            │                          │
+│                          │  Tab                   Switch tab                                                                                          │                          │
+│                          │  Shift+Tab             Previous tab                                                                                        │                          │
+│                          │  Esc                   Close editor                                                                                        │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ SQL Editor (Compare)                                                                                                      │                          │
+│                          │  Ctrl+E                Run EXPLAIN on current query                                                                        │                          │
+│                          │  Alt+E                 Run EXPLAIN ANALYZE on current query                                                                │                          │
+│                          │  e                     Edit query in SQL tab                                                                               │                          │
+│                          │  y                     Copy to clipboard                                                                                   │                          │
+│                          │  Ctrl+N / Ctrl+P / ↑↓ / j / k  Scroll comparison text                                                                      │                          │
+│                          │  Tab                   Switch tab                                                                                          │                          │
+│                          │  Shift+Tab             Previous tab                                                                                        │                          │
+│                          │  Esc                   Close editor                                                                                        │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ SQL Editor (Confirm)                                                                                                      │                          │
+│                          │  Esc                   Cancel and return to editor                                                                         │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Overlays                                                                                                                  │                          │
+│                          │  Esc                   Close overlay / Cancel                                                                              │                          │
+│                          │  Esc                   Close overlay                                                                                       │                          │
+│                          │  Enter                 Execute command                                                                                     │                          │
+│                          │  Enter                 Confirm selection                                                                                   │                          │
+│                          │  j / k / Ctrl+N / Ctrl+P / ↑ / ↓  Navigate items                                                                           │                          │
+│                          │  type                  Type to filter                                                                                      │                          │
+│                          │  Enter                 View error details                                                                                  │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Command Line                                                                                                              │                          │
+│                          │  :quit                 Quit application                                                                                    │                          │
+│                          │  :help                 Show help                                                                                           │                          │
+│                          │  :sql                  Open SQL Editor                                                                                     │                          │
+│                          │  :erd                  Open ER Diagram                                                                                     │──────────────────────────┘
+│                          │  ←→                    Move cursor                                                                                         │──────────────────────────┐
+│                          │  Home/End              Jump to start/end                                                                                   │                          │
+│                          │  Enter                 Submit command                                                                                      │                          │
+│                          │  Esc                   Exit command line                                                                                   │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Connection Setup                                                                                                          │                          │
+│                          │  Tab/⇧Tab              Next/Previous field                                                                                 │                          │
+│                          │  Tab                   Next field                                                                                          │                          │
+│                          │  ⇧Tab                  Previous field                                                                                      │                          │
+│                          │  Ctrl+S                Save and connect                                                                                    │                          │
+│                          │  Esc                   Cancel                                                                                              │                          │
+│                          │  Enter                 Toggle dropdown (SSL field)                                                                         │                          │
+│                          │  Ctrl+N / Ctrl+P / ↑ / ↓  Dropdown navigation                                                                              │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Connection Error                                                                                                          │                          │
+│                          │  e                     Edit connection settings                                                                            │                          │
+│                          │  s                     Switch to another connection                                                                        │                          │
+│                          │  d                     Toggle error details                                                                                │                          │
+│                          │  y                     Copy error to clipboard                                                                             │                          │
+│                          │  j / k / Ctrl+N / Ctrl+P / ↑ / ↓  Scroll error                                                                             │                          │
+│                          │  Esc                   Close                                                                                               │                          │
+│                          │  r                     Retry service connection                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Connection Selector                                                                                                       │                          │
+│                          │  Enter                 Confirm selection                                                                                   │                          │
+│                          │  Ctrl+N / Ctrl+P / ↑ / ↓ / j / k  Select connection                                                                        │                          │
+│                          │  n                     New connection                                                                                      │                          │
+│                          │  e                     Edit connection                                                                                     │                          │
+│                          │  d                     Delete connection                                                                                   │                          │
+│                          │  Esc                   Close selector                                                                                      │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ ER Diagram Picker                                                                                                         │                          │
+│                          │  Enter                 Generate ER diagram                                                                                 │                          │
+│                          │  Space                 Toggle table selection                                                                              │                          │
+│                          │  Ctrl+A                Select/deselect all tables                                                                          │                          │
+│                          │  Ctrl+N / Ctrl+P / ↑ / ↓  Navigate                                                                                         │                          │
+│                          │  type                  Type to filter                                                                                      │                          │
+│                          │  Esc                   Close                                                                                               │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Query History Picker                                                                                                      │                          │
+│                          │  Enter                 Select query                                                                                        │                          │
+│                          │  Ctrl+N / Ctrl+P / ↑ / ↓  Navigate                                                                                         │                          │
+│                          │  type                  Type to filter                                                                                      │                          │
+│                          │  Esc                   Close                                                                                               │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Table Picker                                                                                                              │                          │
+│                          │  Enter                 Select table                                                                                        │                          │
+│                          │  Ctrl+N / Ctrl+P / ↑ / ↓  Navigate                                                                                         │                          │
+│                          │  type                  Type to filter                                                                                      │                          │
+│                          │  Esc                   Close                                                                                               │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Command Palette                                                                                                           │                          │
+│                          │  Enter                 Execute command                                                                                     │                          │
+│                          │  j / k / Ctrl+N / Ctrl+P / ↑ / ↓  Navigate                                                                                 │                          │
+│                          │  Esc                   Close                                                                                               │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Help Overlay                                                                                                              │                          │
+│                          │  j / k / Ctrl+N / Ctrl+P / ↑ / ↓  Scroll down / up                                                                         │                          │
+│                          │  g / Home / G / End    Jump to top / bottom                                                                                │                          │
+│                          │  Ctrl+D / Ctrl+U       Scroll half page down / up                                                                          │                          │
+│                          │  Ctrl+F / Ctrl+B / PageDown / PageUp  Scroll full page down / up                                                           │                          │
+│                          │  h / l / ← / →         Scroll left / right                                                                                 │                          │
+│                          │  ? / Esc               Close help                                                                                          │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ Confirm Dialog                                                                                                            │                          │
+│                          │  Enter                 Confirm                                                                                             │                          │
+│                          │  Ctrl+N / j / ↓        Scroll down                                                                                         │                          │
+│                          │  Ctrl+P / k / ↑        Scroll up                                                                                           │                          │
+│                          │  Esc                   Cancel                                                                                              │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ JSONB Detail                                                                                                              │                          │
+│                          │  y                     Copy full JSON                                                                                      │                          │
+│                          │  i / A                 Enter Insert mode / append at line end                                                              │                          │
+│                          │  /                     Search JSON text                                                                                    │                          │
+│                          │  n / N                 Jump to next / previous search result                                                               │                          │
+│                          │  h / j / k / l / ↑↓←→  Move cursor                                                                                         │                          │
+│                          │  0 / $ / w / b / Home / End  Move by word or line boundary                                                                 │                          │
+│                          │  gg / G / H / M / L    Jump by buffer or viewport                                                                          │                          │
+│                          │  Esc / q               Close JSONB detail                                                                                  │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ JSONB Edit                                                                                                                │                          │
+│                          │  Esc                   Return to Normal mode                                                                               │                          │
+│                          │  ↑↓←→                  Move cursor                                                                                         │                          │
+│                          │  Home / End            Line start/end                                                                                      │                          │
+│                          │                                                                                                                            │                          │
+│                          │▸ JSONB Search                                                                                                              │                          │
+│                          │  type                  Type to search                                                                                      │                          │
+│                          │  Enter                 Confirm search                                                                                      │                          │
+│                          │  Esc                   Cancel search                                                                                       │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          │                                                                                                                            │                          │
+│                          ╰ ?/Esc Close ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╯                          │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+│                                           ││                                                                                                                                     │
+└───────────────────────────────────────────┘└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_omits_scrollbars_when_content_fits.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_omits_scrollbars_when_content_fits.snap
@@ -34,213 +34,213 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                           ││                                                                                                                                     │
 │                          ╭ Help ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮                          │
 │                          │▸ Global Keys                                                                                                               │                          │
-│                          │  q                     Quit application                                                                                    │                          │
-│                          │  ?                     Toggle help                                                                                         │                          │
-│                          │  Ctrl+P                Open Table Picker                                                                                   │                          │
-│                          │  Ctrl+K                Open Command Palette                                                                                │                          │
-│                          │  :                     Enter command line                                                                                  │                          │
-│                          │  f                     Toggle Focus                                                                                        │                          │
-│                          │  1/2/3                 Switch pane focus                                                                                   │                          │
-│                          │  Tab/⇧Tab              Inspector prev/next tab                                                                             │                          │
-│                          │  r                     Reload metadata                                                                                     │                          │
-│                          │  s                     Open SQL Editor                                                                                     │                          │
-│                          │  e                     Open ER Diagram                                                                                     │                          │
-│                          │  c                     Open Connection Selector                                                                            │                          │
-│                          │  Ctrl+E                Export result to CSV                                                                                │                          │
-│                          │  Ctrl+R                Toggle Read-Only                                                                                    │                          │
-│                          │  Ctrl+O                Open Query History                                                                                  │                          │
+│                          │  q                   Quit application                                                                                      │                          │
+│                          │  ?                   Toggle help                                                                                           │                          │
+│                          │  Ctrl+P              Open Table Picker                                                                                     │                          │
+│                          │  Ctrl+K              Open Command Palette                                                                                  │                          │
+│                          │  :                   Enter command line                                                                                    │                          │
+│                          │  f                   Toggle Focus                                                                                          │                          │
+│                          │  1/2/3               Switch pane focus                                                                                     │                          │
+│                          │  Tab/⇧Tab            Inspector prev/next tab                                                                               │                          │
+│                          │  r                   Reload metadata                                                                                       │                          │
+│                          │  s                   Open SQL Editor                                                                                       │                          │
+│                          │  e                   Open ER Diagram                                                                                       │                          │
+│                          │  c                   Open Connection Selector                                                                              │                          │
+│                          │  Ctrl+E              Export result to CSV                                                                                  │                          │
+│                          │  Ctrl+R              Toggle Read-Only                                                                                      │                          │
+│                          │  Ctrl+O              Open Query History                                                                                    │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Navigation                                                                                                                │                          │
-│                          │  j / ↓                 Move down / scroll                                                                                  │                          │
-│                          │  k / ↑                 Move up / scroll                                                                                    │                          │
-│                          │  g / Home              First item / top                                                                                    │                          │
-│                          │  G / End               Last item / bottom                                                                                  │                          │
-│                          │  H                     First visible item                                                                                  │                          │
-│                          │  M                     Middle of visible items                                                                             │                          │
-│                          │  L                     Last visible item                                                                                   │                          │
-│                          │  zz / zt / zb          Scroll cursor to center/top/bottom                                                                  │                          │
-│                          │  Ctrl+D / Ctrl+U       Scroll half page down/up                                                                            │                          │
-│                          │  Ctrl+F/B / PgDn/Up    Scroll full page down/up                                                                            │                          │
-│                          │  h / l                 Scroll left/right                                                                                   │                          │
-│                          │  ]                     Next page (Preview)                                                                                 │                          │
-│                          │  [                     Previous page (Preview)                                                                             │                          │
+│                          │  j / ↓               Move down / scroll                                                                                    │                          │
+│                          │  k / ↑               Move up / scroll                                                                                      │                          │
+│                          │  g / Home            First item / top                                                                                      │                          │
+│                          │  G / End             Last item / bottom                                                                                    │                          │
+│                          │  H                   First visible item                                                                                    │                          │
+│                          │  M                   Middle of visible items                                                                               │                          │
+│                          │  L                   Last visible item                                                                                     │                          │
+│                          │  zz / zt / zb        Scroll cursor to center/top/bottom                                                                    │                          │
+│                          │  Ctrl+D / Ctrl+U     Scroll half page down/up                                                                              │                          │
+│                          │  Ctrl+F/B / PgDn/Up  Scroll full page down/up                                                                              │                          │
+│                          │  h / l               Scroll left/right                                                                                     │                          │
+│                          │  ]                   Next page (Preview)                                                                                   │                          │
+│                          │  [                   Previous page (Preview)                                                                               │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Result History                                                                                                            │                          │
-│                          │  Ctrl+H                Toggle Result History                                                                               │                          │
-│                          │  ] / [                 Navigate history newer/older                                                                        │                          │
-│                          │  Ctrl+H                Exit history (back to latest)                                                                       │                          │
+│                          │  Ctrl+H              Toggle Result History                                                                                 │                          │
+│                          │  ] / [               Navigate history newer/older                                                                          │                          │
+│                          │  Ctrl+H              Exit history (back to latest)                                                                         │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Result Pane                                                                                                               │                          │
-│                          │  Enter                 Enter cell selection at the current viewport anchor                                                 │                          │
-│                          │  Y                     Copy the active cell value to clipboard                                                             │                          │
-│                          │  d, d                  Stage the active row for deletion (red highlight; :w to commit)                                     │                          │
-│                          │  u                     Unstage the last staged row deletion                                                                │                          │
-│                          │  h / l                 Move cell left/right                                                                                │                          │
-│                          │  j / k                 Move the active row up/down                                                                         │                          │
-│                          │  g / G / H / M / L     Jump the active row to first/last or viewport top/mid/bot                                           │                          │
-│                          │  Esc                   Exit cell selection and return to scroll mode without clearing staged deletes                       │                          │
-│                          │  i                     Edit active cell                                                                                    │                          │
-│                          │  Esc                   Discard the pending draft and stay in cell selection                                                │                          │
-│                          │  y, y                  Copy the active row values to clipboard (TSV)                                                       │                          │
+│                          │  Enter               Enter cell selection at the current viewport anchor                                                   │                          │
+│                          │  Y                   Copy the active cell value to clipboard                                                               │                          │
+│                          │  d, d                Stage the active row for deletion (red highlight; :w to commit)                                       │                          │
+│                          │  u                   Unstage the last staged row deletion                                                                  │                          │
+│                          │  h / l               Move cell left/right                                                                                  │                          │
+│                          │  j / k               Move the active row up/down                                                                           │                          │
+│                          │  g / G / H / M / L   Jump the active row to first/last or viewport top/mid/bot                                             │                          │
+│                          │  Esc                 Exit cell selection and return to scroll mode without clearing staged deletes                         │                          │
+│                          │  i                   Edit active cell                                                                                      │                          │
+│                          │  Esc                 Discard the pending draft and stay in cell selection                                                  │                          │
+│                          │  y, y                Copy the active row values to clipboard (TSV)                                                         │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Inspector Pane (DDL tab)                                                                                                  │                          │
-│                          │  y                     Copy DDL to clipboard                                                                               │                          │
+│                          │  y                   Copy DDL to clipboard                                                                                 │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Cell Edit                                                                                                                 │                          │
-│                          │  :w                    Preview and confirm UPDATE                                                                          │                          │
-│                          │  type                  Edit cell value                                                                                     │                          │
-│                          │  ←→                    Move cursor                                                                                         │                          │
-│                          │  Home/End              Jump to start/end                                                                                   │                          │
-│                          │  :                     Open command line                                                                                   │                          │
-│                          │  Esc                   Exit to Cell Active (draft preserved)                                                               │                          │
+│                          │  :w                  Preview and confirm UPDATE                                                                            │                          │
+│                          │  type                Edit cell value                                                                                       │                          │
+│                          │  ←→                  Move cursor                                                                                           │                          │
+│                          │  Home/End            Jump to start/end                                                                                     │                          │
+│                          │  :                   Open command line                                                                                     │                          │
+│                          │  Esc                 Exit to Cell Active (draft preserved)                                                                 │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ SQL Editor (Normal)                                                                                                       │                          │
-│                          │  Alt+Enter / F5        Execute query                                                                                       │                          │
-│                          │  y                     Copy query to clipboard                                                                             │                          │
-│                          │  i                     Enter Insert mode                                                                                   │                          │
-│                          │  A                     Append at line end                                                                                  │                          │
-│                          │  h / j / k / l / ↑↓←→  Move cursor                                                                                         │                          │
+│                          │  Alt+Enter / F5      Execute query                                                                                         │                          │
+│                          │  y                   Copy query to clipboard                                                                               │                          │
+│                          │  i                   Enter Insert mode                                                                                     │                          │
+│                          │  A                   Append at line end                                                                                    │                          │
+│                          │  h / j / k / l / ↑↓←→Move cursor                                                                                           │                          │
 │                          │  0 / $ / w / b / Home / End  Move by word or line boundary                                                                 │                          │
-│                          │  gg / G / H / M / L    Jump by buffer or viewport                                                                          │                          │
-│                          │  Esc                   Close editor                                                                                        │                          │
-│                          │  Ctrl+L                Clear editor                                                                                        │                          │
-│                          │  Ctrl+O                Open Query History                                                                                  │                          │
+│                          │  gg / G / H / M / L  Jump by buffer or viewport                                                                            │                          │
+│                          │  Esc                 Close editor                                                                                          │                          │
+│                          │  Ctrl+L              Clear editor                                                                                          │                          │
+│                          │  Ctrl+O              Open Query History                                                                                    │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ SQL Editor (Insert)                                                                                                       │                          │
-│                          │  Alt+Enter / F5        Execute query                                                                                       │                          │
-│                          │  Esc                   Return to Normal mode                                                                               │                          │
-│                          │  ↑↓←→                  Move cursor                                                                                         │                          │
-│                          │  Home/End              Line start/end                                                                                      │                          │
-│                          │  Tab                   Insert tab / Accept completion                                                                      │                          │
-│                          │  Ctrl+Space            Trigger completion                                                                                  │                          │
-│                          │  Ctrl+L                Clear editor                                                                                        │                          │
-│                          │  Ctrl+O                Open Query History                                                                                  │                          │
+│                          │  Alt+Enter / F5      Execute query                                                                                         │                          │
+│                          │  Esc                 Return to Normal mode                                                                                 │                          │
+│                          │  ↑↓←→                Move cursor                                                                                           │                          │
+│                          │  Home/End            Line start/end                                                                                        │                          │
+│                          │  Tab                 Insert tab / Accept completion                                                                        │                          │
+│                          │  Ctrl+Space          Trigger completion                                                                                    │                          │
+│                          │  Ctrl+L              Clear editor                                                                                          │                          │
+│                          │  Ctrl+O              Open Query History                                                                                    │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ SQL Editor (Plan)                                                                                                         │                          │
-│                          │  Ctrl+E                Run EXPLAIN on current query                                                                        │                          │
-│                          │  Alt+E                 Run EXPLAIN ANALYZE on current query                                                                │                          │
-│                          │  y                     Copy to clipboard                                                                                   │                          │
+│                          │  Ctrl+E              Run EXPLAIN on current query                                                                          │                          │
+│                          │  Alt+E               Run EXPLAIN ANALYZE on current query                                                                  │                          │
+│                          │  y                   Copy to clipboard                                                                                     │                          │
 │                          │  Ctrl+N / Ctrl+P / ↑↓ / j / k  Scroll plan text                                                                            │                          │
-│                          │  Tab                   Switch tab                                                                                          │                          │
-│                          │  Shift+Tab             Previous tab                                                                                        │                          │
-│                          │  Esc                   Close editor                                                                                        │                          │
+│                          │  Tab                 Switch tab                                                                                            │                          │
+│                          │  Shift+Tab           Previous tab                                                                                          │                          │
+│                          │  Esc                 Close editor                                                                                          │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ SQL Editor (Compare)                                                                                                      │                          │
-│                          │  Ctrl+E                Run EXPLAIN on current query                                                                        │                          │
-│                          │  Alt+E                 Run EXPLAIN ANALYZE on current query                                                                │                          │
-│                          │  e                     Edit query in SQL tab                                                                               │                          │
-│                          │  y                     Copy to clipboard                                                                                   │                          │
+│                          │  Ctrl+E              Run EXPLAIN on current query                                                                          │                          │
+│                          │  Alt+E               Run EXPLAIN ANALYZE on current query                                                                  │                          │
+│                          │  e                   Edit query in SQL tab                                                                                 │                          │
+│                          │  y                   Copy to clipboard                                                                                     │                          │
 │                          │  Ctrl+N / Ctrl+P / ↑↓ / j / k  Scroll comparison text                                                                      │                          │
-│                          │  Tab                   Switch tab                                                                                          │                          │
-│                          │  Shift+Tab             Previous tab                                                                                        │                          │
-│                          │  Esc                   Close editor                                                                                        │                          │
+│                          │  Tab                 Switch tab                                                                                            │                          │
+│                          │  Shift+Tab           Previous tab                                                                                          │                          │
+│                          │  Esc                 Close editor                                                                                          │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ SQL Editor (Confirm)                                                                                                      │                          │
-│                          │  Esc                   Cancel and return to editor                                                                         │                          │
+│                          │  Esc                 Cancel and return to editor                                                                           │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Overlays                                                                                                                  │                          │
-│                          │  Esc                   Close overlay / Cancel                                                                              │                          │
-│                          │  Esc                   Close overlay                                                                                       │                          │
-│                          │  Enter                 Execute command                                                                                     │                          │
-│                          │  Enter                 Confirm selection                                                                                   │                          │
+│                          │  Esc                 Close overlay / Cancel                                                                                │                          │
+│                          │  Esc                 Close overlay                                                                                         │                          │
+│                          │  Enter               Execute command                                                                                       │                          │
+│                          │  Enter               Confirm selection                                                                                     │                          │
 │                          │  j / k / Ctrl+N / Ctrl+P / ↑ / ↓  Navigate items                                                                           │                          │
-│                          │  type                  Type to filter                                                                                      │                          │
-│                          │  Enter                 View error details                                                                                  │                          │
+│                          │  type                Type to filter                                                                                        │                          │
+│                          │  Enter               View error details                                                                                    │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Command Line                                                                                                              │                          │
-│                          │  :quit                 Quit application                                                                                    │                          │
-│                          │  :help                 Show help                                                                                           │                          │
-│                          │  :sql                  Open SQL Editor                                                                                     │                          │
-│                          │  :erd                  Open ER Diagram                                                                                     │──────────────────────────┘
-│                          │  ←→                    Move cursor                                                                                         │──────────────────────────┐
-│                          │  Home/End              Jump to start/end                                                                                   │                          │
-│                          │  Enter                 Submit command                                                                                      │                          │
-│                          │  Esc                   Exit command line                                                                                   │                          │
+│                          │  :quit               Quit application                                                                                      │                          │
+│                          │  :help               Show help                                                                                             │                          │
+│                          │  :sql                Open SQL Editor                                                                                       │                          │
+│                          │  :erd                Open ER Diagram                                                                                       │──────────────────────────┘
+│                          │  ←→                  Move cursor                                                                                           │──────────────────────────┐
+│                          │  Home/End            Jump to start/end                                                                                     │                          │
+│                          │  Enter               Submit command                                                                                        │                          │
+│                          │  Esc                 Exit command line                                                                                     │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Connection Setup                                                                                                          │                          │
-│                          │  Tab/⇧Tab              Next/Previous field                                                                                 │                          │
-│                          │  Tab                   Next field                                                                                          │                          │
-│                          │  ⇧Tab                  Previous field                                                                                      │                          │
-│                          │  Ctrl+S                Save and connect                                                                                    │                          │
-│                          │  Esc                   Cancel                                                                                              │                          │
-│                          │  Enter                 Toggle dropdown (SSL field)                                                                         │                          │
+│                          │  Tab/⇧Tab            Next/Previous field                                                                                   │                          │
+│                          │  Tab                 Next field                                                                                            │                          │
+│                          │  ⇧Tab                Previous field                                                                                        │                          │
+│                          │  Ctrl+S              Save and connect                                                                                      │                          │
+│                          │  Esc                 Cancel                                                                                                │                          │
+│                          │  Enter               Toggle dropdown (SSL field)                                                                           │                          │
 │                          │  Ctrl+N / Ctrl+P / ↑ / ↓  Dropdown navigation                                                                              │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Connection Error                                                                                                          │                          │
-│                          │  e                     Edit connection settings                                                                            │                          │
-│                          │  s                     Switch to another connection                                                                        │                          │
-│                          │  d                     Toggle error details                                                                                │                          │
-│                          │  y                     Copy error to clipboard                                                                             │                          │
+│                          │  e                   Edit connection settings                                                                              │                          │
+│                          │  s                   Switch to another connection                                                                          │                          │
+│                          │  d                   Toggle error details                                                                                  │                          │
+│                          │  y                   Copy error to clipboard                                                                               │                          │
 │                          │  j / k / Ctrl+N / Ctrl+P / ↑ / ↓  Scroll error                                                                             │                          │
-│                          │  Esc                   Close                                                                                               │                          │
-│                          │  r                     Retry service connection                                                                            │                          │
+│                          │  Esc                 Close                                                                                                 │                          │
+│                          │  r                   Retry service connection                                                                              │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Connection Selector                                                                                                       │                          │
-│                          │  Enter                 Confirm selection                                                                                   │                          │
+│                          │  Enter               Confirm selection                                                                                     │                          │
 │                          │  Ctrl+N / Ctrl+P / ↑ / ↓ / j / k  Select connection                                                                        │                          │
-│                          │  n                     New connection                                                                                      │                          │
-│                          │  e                     Edit connection                                                                                     │                          │
-│                          │  d                     Delete connection                                                                                   │                          │
-│                          │  Esc                   Close selector                                                                                      │                          │
+│                          │  n                   New connection                                                                                        │                          │
+│                          │  e                   Edit connection                                                                                       │                          │
+│                          │  d                   Delete connection                                                                                     │                          │
+│                          │  Esc                 Close selector                                                                                        │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ ER Diagram Picker                                                                                                         │                          │
-│                          │  Enter                 Generate ER diagram                                                                                 │                          │
-│                          │  Space                 Toggle table selection                                                                              │                          │
-│                          │  Ctrl+A                Select/deselect all tables                                                                          │                          │
+│                          │  Enter               Generate ER diagram                                                                                   │                          │
+│                          │  Space               Toggle table selection                                                                                │                          │
+│                          │  Ctrl+A              Select/deselect all tables                                                                            │                          │
 │                          │  Ctrl+N / Ctrl+P / ↑ / ↓  Navigate                                                                                         │                          │
-│                          │  type                  Type to filter                                                                                      │                          │
-│                          │  Esc                   Close                                                                                               │                          │
+│                          │  type                Type to filter                                                                                        │                          │
+│                          │  Esc                 Close                                                                                                 │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Query History Picker                                                                                                      │                          │
-│                          │  Enter                 Select query                                                                                        │                          │
+│                          │  Enter               Select query                                                                                          │                          │
 │                          │  Ctrl+N / Ctrl+P / ↑ / ↓  Navigate                                                                                         │                          │
-│                          │  type                  Type to filter                                                                                      │                          │
-│                          │  Esc                   Close                                                                                               │                          │
+│                          │  type                Type to filter                                                                                        │                          │
+│                          │  Esc                 Close                                                                                                 │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Table Picker                                                                                                              │                          │
-│                          │  Enter                 Select table                                                                                        │                          │
+│                          │  Enter               Select table                                                                                          │                          │
 │                          │  Ctrl+N / Ctrl+P / ↑ / ↓  Navigate                                                                                         │                          │
-│                          │  type                  Type to filter                                                                                      │                          │
-│                          │  Esc                   Close                                                                                               │                          │
+│                          │  type                Type to filter                                                                                        │                          │
+│                          │  Esc                 Close                                                                                                 │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Command Palette                                                                                                           │                          │
-│                          │  Enter                 Execute command                                                                                     │                          │
+│                          │  Enter               Execute command                                                                                       │                          │
 │                          │  j / k / Ctrl+N / Ctrl+P / ↑ / ↓  Navigate                                                                                 │                          │
-│                          │  Esc                   Close                                                                                               │                          │
+│                          │  Esc                 Close                                                                                                 │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Help Overlay                                                                                                              │                          │
 │                          │  j / k / Ctrl+N / Ctrl+P / ↑ / ↓  Scroll down / up                                                                         │                          │
-│                          │  g / Home / G / End    Jump to top / bottom                                                                                │                          │
-│                          │  Ctrl+D / Ctrl+U       Scroll half page down / up                                                                          │                          │
+│                          │  g / Home / G / End  Jump to top / bottom                                                                                  │                          │
+│                          │  Ctrl+D / Ctrl+U     Scroll half page down / up                                                                            │                          │
 │                          │  Ctrl+F / Ctrl+B / PageDown / PageUp  Scroll full page down / up                                                           │                          │
-│                          │  h / l / ← / →         Scroll left / right                                                                                 │                          │
-│                          │  ? / Esc               Close help                                                                                          │                          │
+│                          │  h / l / ← / →       Scroll left / right                                                                                   │                          │
+│                          │  ? / Esc             Close help                                                                                            │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ Confirm Dialog                                                                                                            │                          │
-│                          │  Enter                 Confirm                                                                                             │                          │
-│                          │  Ctrl+N / j / ↓        Scroll down                                                                                         │                          │
-│                          │  Ctrl+P / k / ↑        Scroll up                                                                                           │                          │
-│                          │  Esc                   Cancel                                                                                              │                          │
+│                          │  Enter               Confirm                                                                                               │                          │
+│                          │  Ctrl+N / j / ↓      Scroll down                                                                                           │                          │
+│                          │  Ctrl+P / k / ↑      Scroll up                                                                                             │                          │
+│                          │  Esc                 Cancel                                                                                                │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ JSONB Detail                                                                                                              │                          │
-│                          │  y                     Copy full JSON                                                                                      │                          │
-│                          │  i / A                 Enter Insert mode / append at line end                                                              │                          │
-│                          │  /                     Search JSON text                                                                                    │                          │
-│                          │  n / N                 Jump to next / previous search result                                                               │                          │
-│                          │  h / j / k / l / ↑↓←→  Move cursor                                                                                         │                          │
+│                          │  y                   Copy full JSON                                                                                        │                          │
+│                          │  i / A               Enter Insert mode / append at line end                                                                │                          │
+│                          │  /                   Search JSON text                                                                                      │                          │
+│                          │  n / N               Jump to next / previous search result                                                                 │                          │
+│                          │  h / j / k / l / ↑↓←→Move cursor                                                                                           │                          │
 │                          │  0 / $ / w / b / Home / End  Move by word or line boundary                                                                 │                          │
-│                          │  gg / G / H / M / L    Jump by buffer or viewport                                                                          │                          │
-│                          │  Esc / q               Close JSONB detail                                                                                  │                          │
+│                          │  gg / G / H / M / L  Jump by buffer or viewport                                                                            │                          │
+│                          │  Esc / q             Close JSONB detail                                                                                    │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ JSONB Edit                                                                                                                │                          │
-│                          │  Esc                   Return to Normal mode                                                                               │                          │
-│                          │  ↑↓←→                  Move cursor                                                                                         │                          │
-│                          │  Home / End            Line start/end                                                                                      │                          │
+│                          │  Esc                 Return to Normal mode                                                                                 │                          │
+│                          │  ↑↓←→                Move cursor                                                                                           │                          │
+│                          │  Home / End          Line start/end                                                                                        │                          │
 │                          │                                                                                                                            │                          │
 │                          │▸ JSONB Search                                                                                                              │                          │
-│                          │  type                  Type to search                                                                                      │                          │
-│                          │  Enter                 Confirm search                                                                                      │                          │
-│                          │  Esc                   Cancel search                                                                                       │                          │
+│                          │  type                Type to search                                                                                        │                          │
+│                          │  Enter               Confirm search                                                                                        │                          │
+│                          │  Esc                 Cancel search                                                                                         │                          │
 │                          │                                                                                                                            │                          │
 │                          │                                                                                                                            │                          │
 │                          │                                                                                                                            │                          │

--- a/src/ui/features/overlays/help.rs
+++ b/src/ui/features/overlays/help.rs
@@ -8,15 +8,18 @@ use unicode_width::UnicodeWidthStr;
 use crate::theme::ThemePalette;
 
 use crate::app::model::app_state::AppState;
-use crate::app::model::shared::ui_state::{HELP_MODAL_HEIGHT_PERCENT, HELP_MODAL_WIDTH_PERCENT};
+use crate::app::model::shared::ui_state::{
+    HELP_HORIZONTAL_SCROLLBAR_HEIGHT, HELP_MODAL_HEIGHT_PERCENT, HELP_MODAL_WIDTH_PERCENT,
+    HELP_VERTICAL_SCROLLBAR_WIDTH,
+};
 use crate::app::update::input::keybindings::{
     CELL_EDIT_KEYS, COMMAND_LINE_KEYS, COMMAND_PALETTE_ROWS, CONFIRM_DIALOG_KEYS,
     CONNECTION_ERROR_ROWS, CONNECTION_SELECTOR_ROWS, CONNECTION_SETUP_KEYS, ER_PICKER_ROWS,
-    GLOBAL_KEYS, HELP_KEY_DESC_GAP, HELP_KEY_INDENT_WIDTH, HELP_KEY_MIN_COLUMN_WIDTH, HELP_ROWS,
-    HISTORY_KEYS, INSPECTOR_DDL_KEYS, JSONB_DETAIL_ROWS, JSONB_EDIT_ROWS, JSONB_SEARCH_KEYS,
-    KeyBinding, NAVIGATION_KEYS, OVERLAY_KEYS, QUERY_HISTORY_PICKER_ROWS, RESULT_ACTIVE_KEYS,
+    GLOBAL_KEYS, HELP_KEY_DESC_GAP, HELP_KEY_INDENT_WIDTH, HELP_ROWS, HISTORY_KEYS,
+    INSPECTOR_DDL_KEYS, JSONB_DETAIL_ROWS, JSONB_EDIT_ROWS, JSONB_SEARCH_KEYS, KeyBinding,
+    NAVIGATION_KEYS, OVERLAY_KEYS, QUERY_HISTORY_PICKER_ROWS, RESULT_ACTIVE_KEYS,
     SQL_MODAL_COMPARE_KEYS, SQL_MODAL_CONFIRMING_KEYS, SQL_MODAL_KEYS, SQL_MODAL_NORMAL_KEYS,
-    SQL_MODAL_PLAN_KEYS, TABLE_PICKER_ROWS, help_content_width,
+    SQL_MODAL_PLAN_KEYS, TABLE_PICKER_ROWS, help_content_width, help_key_column_width,
 };
 
 use crate::primitives::atoms::scroll_indicator::{
@@ -38,7 +41,7 @@ impl HelpOverlay {
             theme,
         );
 
-        let key_column_width = HELP_KEY_MIN_COLUMN_WIDTH;
+        let key_column_width = help_key_column_width();
         let mut help_lines = vec![Self::section("Global Keys", theme)];
         Self::push_dedup(&mut help_lines, GLOBAL_KEYS, key_column_width, theme);
 
@@ -300,7 +303,7 @@ impl HelpOverlay {
         }
 
         let total_lines = help_lines.len();
-        let content_area = Self::content_area(inner);
+        let content_area = Self::content_area_excluding_scrollbars(inner);
         let viewport_height = content_area.height as usize;
         let scroll_offset =
             clamp_scroll_offset(state.ui.help_scroll_offset, viewport_height, total_lines);
@@ -342,10 +345,14 @@ impl HelpOverlay {
         );
     }
 
-    fn content_area(inner: Rect) -> Rect {
+    fn content_area_excluding_scrollbars(inner: Rect) -> Rect {
         Rect {
-            height: inner.height.saturating_sub(1),
-            width: inner.width.saturating_sub(1),
+            height: inner
+                .height
+                .saturating_sub(HELP_HORIZONTAL_SCROLLBAR_HEIGHT as u16),
+            width: inner
+                .width
+                .saturating_sub(HELP_VERTICAL_SCROLLBAR_WIDTH as u16),
             ..inner
         }
     }

--- a/src/ui/features/overlays/help.rs
+++ b/src/ui/features/overlays/help.rs
@@ -15,11 +15,11 @@ use crate::app::model::shared::ui_state::{
 use crate::app::update::input::keybindings::{
     CELL_EDIT_KEYS, COMMAND_LINE_KEYS, COMMAND_PALETTE_ROWS, CONFIRM_DIALOG_KEYS,
     CONNECTION_ERROR_ROWS, CONNECTION_SELECTOR_ROWS, CONNECTION_SETUP_KEYS, ER_PICKER_ROWS,
-    GLOBAL_KEYS, HELP_KEY_DESC_GAP, HELP_KEY_INDENT_WIDTH, HELP_ROWS, HISTORY_KEYS,
-    INSPECTOR_DDL_KEYS, JSONB_DETAIL_ROWS, JSONB_EDIT_ROWS, JSONB_SEARCH_KEYS, KeyBinding,
-    NAVIGATION_KEYS, OVERLAY_KEYS, QUERY_HISTORY_PICKER_ROWS, RESULT_ACTIVE_KEYS,
+    GLOBAL_KEYS, HELP_KEY_COLUMN_WIDTH, HELP_KEY_DESC_GAP, HELP_KEY_INDENT_WIDTH, HELP_ROWS,
+    HISTORY_KEYS, INSPECTOR_DDL_KEYS, JSONB_DETAIL_ROWS, JSONB_EDIT_ROWS, JSONB_SEARCH_KEYS,
+    KeyBinding, NAVIGATION_KEYS, OVERLAY_KEYS, QUERY_HISTORY_PICKER_ROWS, RESULT_ACTIVE_KEYS,
     SQL_MODAL_COMPARE_KEYS, SQL_MODAL_CONFIRMING_KEYS, SQL_MODAL_KEYS, SQL_MODAL_NORMAL_KEYS,
-    SQL_MODAL_PLAN_KEYS, TABLE_PICKER_ROWS, help_content_width, help_key_column_width,
+    SQL_MODAL_PLAN_KEYS, TABLE_PICKER_ROWS, help_content_width,
 };
 
 use crate::primitives::atoms::scroll_indicator::{
@@ -41,265 +41,149 @@ impl HelpOverlay {
             theme,
         );
 
-        let key_column_width = help_key_column_width();
         let mut help_lines = vec![Self::section("Global Keys", theme)];
-        Self::push_dedup(&mut help_lines, GLOBAL_KEYS, key_column_width, theme);
+        Self::push_dedup(&mut help_lines, GLOBAL_KEYS, theme);
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Navigation", theme));
         for entry in NAVIGATION_KEYS {
-            help_lines.push(Self::key_line(
-                entry.key,
-                entry.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(entry.key, entry.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Result History", theme));
-        Self::push_dedup(&mut help_lines, HISTORY_KEYS, key_column_width, theme);
+        Self::push_dedup(&mut help_lines, HISTORY_KEYS, theme);
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Result Pane", theme));
         for kb in RESULT_ACTIVE_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Inspector Pane (DDL tab)", theme));
         for kb in INSPECTOR_DDL_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Cell Edit", theme));
         for kb in CELL_EDIT_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("SQL Editor (Normal)", theme));
         for kb in SQL_MODAL_NORMAL_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("SQL Editor (Insert)", theme));
         for kb in SQL_MODAL_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("SQL Editor (Plan)", theme));
         for kb in SQL_MODAL_PLAN_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("SQL Editor (Compare)", theme));
         for kb in SQL_MODAL_COMPARE_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("SQL Editor (Confirm)", theme));
         for kb in SQL_MODAL_CONFIRMING_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Overlays", theme));
         for kb in OVERLAY_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Command Line", theme));
         for kb in COMMAND_LINE_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Connection Setup", theme));
         for kb in CONNECTION_SETUP_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Connection Error", theme));
         for row in CONNECTION_ERROR_ROWS {
-            help_lines.push(Self::key_line(
-                row.key,
-                row.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(row.key, row.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Connection Selector", theme));
         for row in CONNECTION_SELECTOR_ROWS {
-            help_lines.push(Self::key_line(
-                row.key,
-                row.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(row.key, row.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("ER Diagram Picker", theme));
         for row in ER_PICKER_ROWS {
-            help_lines.push(Self::key_line(
-                row.key,
-                row.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(row.key, row.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Query History Picker", theme));
         for row in QUERY_HISTORY_PICKER_ROWS {
-            help_lines.push(Self::key_line(
-                row.key,
-                row.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(row.key, row.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Table Picker", theme));
         for row in TABLE_PICKER_ROWS {
-            help_lines.push(Self::key_line(
-                row.key,
-                row.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(row.key, row.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Command Palette", theme));
         for row in COMMAND_PALETTE_ROWS {
-            help_lines.push(Self::key_line(
-                row.key,
-                row.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(row.key, row.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Help Overlay", theme));
         for row in HELP_ROWS {
-            help_lines.push(Self::key_line(
-                row.key,
-                row.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(row.key, row.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Confirm Dialog", theme));
         for kb in CONFIRM_DIALOG_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("JSONB Detail", theme));
         for row in JSONB_DETAIL_ROWS {
-            help_lines.push(Self::key_line(
-                row.key,
-                row.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(row.key, row.description, theme));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("JSONB Edit", theme));
         for row in JSONB_EDIT_ROWS {
-            help_lines.push(Self::key_line(
-                row.key,
-                row.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(row.key, row.description, theme));
         }
 
         help_lines.push(Line::raw(""));
         help_lines.push(Self::section("JSONB Search", theme));
         for kb in JSONB_SEARCH_KEYS {
-            help_lines.push(Self::key_line(
-                kb.key,
-                kb.description,
-                key_column_width,
-                theme,
-            ));
+            help_lines.push(Self::key_line(kb.key, kb.description, theme));
         }
 
         let total_lines = help_lines.len();
@@ -372,28 +256,17 @@ impl HelpOverlay {
         ])
     }
 
-    fn push_dedup(
-        lines: &mut Vec<Line<'static>>,
-        bindings: &[KeyBinding],
-        key_column_width: usize,
-        theme: &ThemePalette,
-    ) {
+    fn push_dedup(lines: &mut Vec<Line<'static>>, bindings: &[KeyBinding], theme: &ThemePalette) {
         let mut i = 0;
         while i < bindings.len() {
             if i + 1 < bindings.len() && bindings[i].key == bindings[i + 1].key {
                 let toggle_desc = format!("Toggle {}", bindings[i].desc_short);
-                lines.push(Self::key_line(
-                    bindings[i].key,
-                    &toggle_desc,
-                    key_column_width,
-                    theme,
-                ));
+                lines.push(Self::key_line(bindings[i].key, &toggle_desc, theme));
                 i += 2;
             } else {
                 lines.push(Self::key_line(
                     bindings[i].key,
                     bindings[i].description,
-                    key_column_width,
                     theme,
                 ));
                 i += 1;
@@ -401,14 +274,9 @@ impl HelpOverlay {
         }
     }
 
-    fn key_line(
-        key: &str,
-        desc: &str,
-        key_column_width: usize,
-        theme: &ThemePalette,
-    ) -> Line<'static> {
+    fn key_line(key: &str, desc: &str, theme: &ThemePalette) -> Line<'static> {
         let key_width = UnicodeWidthStr::width(key);
-        let padding = key_column_width.saturating_sub(key_width) + HELP_KEY_DESC_GAP;
+        let padding = HELP_KEY_COLUMN_WIDTH.saturating_sub(key_width) + HELP_KEY_DESC_GAP;
 
         Line::from(vec![
             Span::styled(

--- a/src/ui/features/overlays/help.rs
+++ b/src/ui/features/overlays/help.rs
@@ -9,8 +9,8 @@ use crate::theme::ThemePalette;
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::ui_state::{
-    HELP_HORIZONTAL_SCROLLBAR_HEIGHT, HELP_MODAL_HEIGHT_PERCENT, HELP_MODAL_WIDTH_PERCENT,
-    HELP_VERTICAL_SCROLLBAR_WIDTH,
+    HELP_MODAL_HEIGHT_PERCENT, HELP_MODAL_WIDTH_PERCENT, HelpViewportLayout,
+    help_viewport_layout_for,
 };
 use crate::app::update::input::keybindings::{
     CELL_EDIT_KEYS, COMMAND_LINE_KEYS, COMMAND_PALETTE_ROWS, CONFIRM_DIALOG_KEYS,
@@ -187,12 +187,18 @@ impl HelpOverlay {
         }
 
         let total_lines = help_lines.len();
-        let content_area = Self::content_area_excluding_scrollbars(inner);
+        let content_width = help_content_width();
+        let viewport = help_viewport_layout_for(
+            inner.height as usize,
+            inner.width as usize,
+            total_lines,
+            content_width,
+        );
+        let content_area = Self::content_area(inner, viewport);
         let viewport_height = content_area.height as usize;
         let scroll_offset =
             clamp_scroll_offset(state.ui.help_scroll_offset, viewport_height, total_lines);
         let viewport_width = content_area.width as usize;
-        let content_width = help_content_width();
         let horizontal_offset = clamp_scroll_offset(
             state.ui.help_horizontal_offset,
             viewport_width,
@@ -205,38 +211,38 @@ impl HelpOverlay {
 
         frame.render_widget(help, content_area);
 
-        render_horizontal_scroll_indicator(
-            frame,
-            inner,
-            HorizontalScrollParams {
-                position: horizontal_offset,
-                viewport_size: viewport_width,
-                total_items: content_width,
-            },
-            theme,
-        );
+        if viewport.has_horizontal_scrollbar {
+            render_horizontal_scroll_indicator(
+                frame,
+                inner,
+                HorizontalScrollParams {
+                    position: horizontal_offset,
+                    viewport_size: viewport_width,
+                    total_items: content_width,
+                },
+                theme,
+            );
+        }
 
-        render_vertical_scroll_indicator_bar(
-            frame,
-            inner,
-            VerticalScrollParams {
-                position: scroll_offset,
-                viewport_size: viewport_height,
-                total_items: total_lines,
-                has_horizontal_scrollbar: true,
-            },
-            theme,
-        );
+        if viewport.has_vertical_scrollbar {
+            render_vertical_scroll_indicator_bar(
+                frame,
+                inner,
+                VerticalScrollParams {
+                    position: scroll_offset,
+                    viewport_size: viewport_height,
+                    total_items: total_lines,
+                    has_horizontal_scrollbar: viewport.has_horizontal_scrollbar,
+                },
+                theme,
+            );
+        }
     }
 
-    fn content_area_excluding_scrollbars(inner: Rect) -> Rect {
+    fn content_area(inner: Rect, viewport: HelpViewportLayout) -> Rect {
         Rect {
-            height: inner
-                .height
-                .saturating_sub(HELP_HORIZONTAL_SCROLLBAR_HEIGHT as u16),
-            width: inner
-                .width
-                .saturating_sub(HELP_VERTICAL_SCROLLBAR_WIDTH as u16),
+            height: viewport.visible_rows as u16,
+            width: viewport.visible_columns as u16,
             ..inner
         }
     }

--- a/src/ui/features/overlays/help.rs
+++ b/src/ui/features/overlays/help.rs
@@ -1,24 +1,27 @@
 use ratatui::Frame;
-use ratatui::layout::Constraint;
+use ratatui::layout::{Constraint, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Paragraph, Wrap};
+use ratatui::widgets::Paragraph;
+use unicode_width::UnicodeWidthStr;
 
 use crate::theme::ThemePalette;
 
 use crate::app::model::app_state::AppState;
-use crate::app::model::shared::ui_state::HELP_MODAL_HEIGHT_PERCENT;
+use crate::app::model::shared::ui_state::{HELP_MODAL_HEIGHT_PERCENT, HELP_MODAL_WIDTH_PERCENT};
 use crate::app::update::input::keybindings::{
     CELL_EDIT_KEYS, COMMAND_LINE_KEYS, COMMAND_PALETTE_ROWS, CONFIRM_DIALOG_KEYS,
     CONNECTION_ERROR_ROWS, CONNECTION_SELECTOR_ROWS, CONNECTION_SETUP_KEYS, ER_PICKER_ROWS,
-    GLOBAL_KEYS, HELP_ROWS, HISTORY_KEYS, INSPECTOR_DDL_KEYS, JSONB_DETAIL_ROWS, JSONB_EDIT_ROWS,
-    JSONB_SEARCH_KEYS, KeyBinding, NAVIGATION_KEYS, OVERLAY_KEYS, QUERY_HISTORY_PICKER_ROWS,
-    RESULT_ACTIVE_KEYS, SQL_MODAL_COMPARE_KEYS, SQL_MODAL_CONFIRMING_KEYS, SQL_MODAL_KEYS,
-    SQL_MODAL_NORMAL_KEYS, SQL_MODAL_PLAN_KEYS, TABLE_PICKER_ROWS,
+    GLOBAL_KEYS, HELP_KEY_DESC_GAP, HELP_KEY_INDENT_WIDTH, HELP_KEY_MIN_COLUMN_WIDTH, HELP_ROWS,
+    HISTORY_KEYS, INSPECTOR_DDL_KEYS, JSONB_DETAIL_ROWS, JSONB_EDIT_ROWS, JSONB_SEARCH_KEYS,
+    KeyBinding, NAVIGATION_KEYS, OVERLAY_KEYS, QUERY_HISTORY_PICKER_ROWS, RESULT_ACTIVE_KEYS,
+    SQL_MODAL_COMPARE_KEYS, SQL_MODAL_CONFIRMING_KEYS, SQL_MODAL_KEYS, SQL_MODAL_NORMAL_KEYS,
+    SQL_MODAL_PLAN_KEYS, TABLE_PICKER_ROWS, help_content_width,
 };
 
 use crate::primitives::atoms::scroll_indicator::{
-    VerticalScrollParams, clamp_scroll_offset, render_vertical_scroll_indicator_bar,
+    HorizontalScrollParams, VerticalScrollParams, clamp_scroll_offset,
+    render_horizontal_scroll_indicator, render_vertical_scroll_indicator_bar,
 };
 use crate::primitives::molecules::render_modal;
 
@@ -28,169 +31,303 @@ impl HelpOverlay {
     pub fn render(frame: &mut Frame, state: &AppState, theme: &ThemePalette) {
         let (_, inner) = render_modal(
             frame,
-            Constraint::Percentage(70),
+            Constraint::Percentage(HELP_MODAL_WIDTH_PERCENT),
             Constraint::Percentage(HELP_MODAL_HEIGHT_PERCENT),
             " Help ",
             " ?/Esc Close ",
             theme,
         );
 
+        let key_column_width = HELP_KEY_MIN_COLUMN_WIDTH;
         let mut help_lines = vec![Self::section("Global Keys", theme)];
-        Self::push_dedup(&mut help_lines, GLOBAL_KEYS, theme);
+        Self::push_dedup(&mut help_lines, GLOBAL_KEYS, key_column_width, theme);
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Navigation", theme));
         for entry in NAVIGATION_KEYS {
-            help_lines.push(Self::key_line(entry.key, entry.description, theme));
+            help_lines.push(Self::key_line(
+                entry.key,
+                entry.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Result History", theme));
-        Self::push_dedup(&mut help_lines, HISTORY_KEYS, theme);
+        Self::push_dedup(&mut help_lines, HISTORY_KEYS, key_column_width, theme);
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Result Pane", theme));
         for kb in RESULT_ACTIVE_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Inspector Pane (DDL tab)", theme));
         for kb in INSPECTOR_DDL_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Cell Edit", theme));
         for kb in CELL_EDIT_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("SQL Editor (Normal)", theme));
         for kb in SQL_MODAL_NORMAL_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("SQL Editor (Insert)", theme));
         for kb in SQL_MODAL_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("SQL Editor (Plan)", theme));
         for kb in SQL_MODAL_PLAN_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("SQL Editor (Compare)", theme));
         for kb in SQL_MODAL_COMPARE_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("SQL Editor (Confirm)", theme));
         for kb in SQL_MODAL_CONFIRMING_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Overlays", theme));
         for kb in OVERLAY_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Command Line", theme));
         for kb in COMMAND_LINE_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Connection Setup", theme));
         for kb in CONNECTION_SETUP_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Connection Error", theme));
         for row in CONNECTION_ERROR_ROWS {
-            help_lines.push(Self::key_line(row.key, row.description, theme));
+            help_lines.push(Self::key_line(
+                row.key,
+                row.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Connection Selector", theme));
         for row in CONNECTION_SELECTOR_ROWS {
-            help_lines.push(Self::key_line(row.key, row.description, theme));
+            help_lines.push(Self::key_line(
+                row.key,
+                row.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("ER Diagram Picker", theme));
         for row in ER_PICKER_ROWS {
-            help_lines.push(Self::key_line(row.key, row.description, theme));
+            help_lines.push(Self::key_line(
+                row.key,
+                row.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Query History Picker", theme));
         for row in QUERY_HISTORY_PICKER_ROWS {
-            help_lines.push(Self::key_line(row.key, row.description, theme));
+            help_lines.push(Self::key_line(
+                row.key,
+                row.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Table Picker", theme));
         for row in TABLE_PICKER_ROWS {
-            help_lines.push(Self::key_line(row.key, row.description, theme));
+            help_lines.push(Self::key_line(
+                row.key,
+                row.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Command Palette", theme));
         for row in COMMAND_PALETTE_ROWS {
-            help_lines.push(Self::key_line(row.key, row.description, theme));
+            help_lines.push(Self::key_line(
+                row.key,
+                row.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Help Overlay", theme));
         for row in HELP_ROWS {
-            help_lines.push(Self::key_line(row.key, row.description, theme));
+            help_lines.push(Self::key_line(
+                row.key,
+                row.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("Confirm Dialog", theme));
         for kb in CONFIRM_DIALOG_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("JSONB Detail", theme));
         for row in JSONB_DETAIL_ROWS {
-            help_lines.push(Self::key_line(row.key, row.description, theme));
+            help_lines.push(Self::key_line(
+                row.key,
+                row.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::from(""));
         help_lines.push(Self::section("JSONB Edit", theme));
         for row in JSONB_EDIT_ROWS {
-            help_lines.push(Self::key_line(row.key, row.description, theme));
+            help_lines.push(Self::key_line(
+                row.key,
+                row.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         help_lines.push(Line::raw(""));
         help_lines.push(Self::section("JSONB Search", theme));
         for kb in JSONB_SEARCH_KEYS {
-            help_lines.push(Self::key_line(kb.key, kb.description, theme));
+            help_lines.push(Self::key_line(
+                kb.key,
+                kb.description,
+                key_column_width,
+                theme,
+            ));
         }
 
         let total_lines = help_lines.len();
-        let viewport_height = inner.height as usize;
+        let content_area = Self::content_area(inner);
+        let viewport_height = content_area.height as usize;
         let scroll_offset =
             clamp_scroll_offset(state.ui.help_scroll_offset, viewport_height, total_lines);
+        let viewport_width = content_area.width as usize;
+        let content_width = help_content_width();
+        let horizontal_offset = clamp_scroll_offset(
+            state.ui.help_horizontal_offset,
+            viewport_width,
+            content_width,
+        );
 
         let help = Paragraph::new(help_lines)
-            .wrap(Wrap { trim: false })
             .style(Style::default())
-            .scroll((scroll_offset as u16, 0));
+            .scroll((scroll_offset as u16, horizontal_offset as u16));
 
-        frame.render_widget(help, inner);
+        frame.render_widget(help, content_area);
+
+        render_horizontal_scroll_indicator(
+            frame,
+            inner,
+            HorizontalScrollParams {
+                position: horizontal_offset,
+                viewport_size: viewport_width,
+                total_items: content_width,
+            },
+            theme,
+        );
 
         render_vertical_scroll_indicator_bar(
             frame,
@@ -199,10 +336,18 @@ impl HelpOverlay {
                 position: scroll_offset,
                 viewport_size: viewport_height,
                 total_items: total_lines,
-                has_horizontal_scrollbar: false,
+                has_horizontal_scrollbar: true,
             },
             theme,
         );
+    }
+
+    fn content_area(inner: Rect) -> Rect {
+        Rect {
+            height: inner.height.saturating_sub(1),
+            width: inner.width.saturating_sub(1),
+            ..inner
+        }
     }
 
     fn section(title: &str, theme: &ThemePalette) -> Line<'static> {
@@ -220,17 +365,28 @@ impl HelpOverlay {
         ])
     }
 
-    fn push_dedup(lines: &mut Vec<Line<'static>>, bindings: &[KeyBinding], theme: &ThemePalette) {
+    fn push_dedup(
+        lines: &mut Vec<Line<'static>>,
+        bindings: &[KeyBinding],
+        key_column_width: usize,
+        theme: &ThemePalette,
+    ) {
         let mut i = 0;
         while i < bindings.len() {
             if i + 1 < bindings.len() && bindings[i].key == bindings[i + 1].key {
                 let toggle_desc = format!("Toggle {}", bindings[i].desc_short);
-                lines.push(Self::key_line(bindings[i].key, &toggle_desc, theme));
+                lines.push(Self::key_line(
+                    bindings[i].key,
+                    &toggle_desc,
+                    key_column_width,
+                    theme,
+                ));
                 i += 2;
             } else {
                 lines.push(Self::key_line(
                     bindings[i].key,
                     bindings[i].description,
+                    key_column_width,
                     theme,
                 ));
                 i += 1;
@@ -238,10 +394,22 @@ impl HelpOverlay {
         }
     }
 
-    fn key_line(key: &str, desc: &str, theme: &ThemePalette) -> Line<'static> {
+    fn key_line(
+        key: &str,
+        desc: &str,
+        key_column_width: usize,
+        theme: &ThemePalette,
+    ) -> Line<'static> {
+        let key_width = UnicodeWidthStr::width(key);
+        let padding = key_column_width.saturating_sub(key_width) + HELP_KEY_DESC_GAP;
+
         Line::from(vec![
             Span::styled(
-                format!("  {key:<20}"),
+                format!(
+                    "{}{key}{}",
+                    " ".repeat(HELP_KEY_INDENT_WIDTH),
+                    " ".repeat(padding)
+                ),
                 Style::default()
                     .fg(theme.semantic.text.accent)
                     .add_modifier(Modifier::BOLD),

--- a/src/ui/features/overlays/help.rs
+++ b/src/ui/features/overlays/help.rs
@@ -282,7 +282,11 @@ impl HelpOverlay {
 
     fn key_line(key: &str, desc: &str, theme: &ThemePalette) -> Line<'static> {
         let key_width = UnicodeWidthStr::width(key);
-        let padding = HELP_KEY_COLUMN_WIDTH.saturating_sub(key_width) + HELP_KEY_DESC_GAP;
+        let padding = if key_width > HELP_KEY_COLUMN_WIDTH {
+            HELP_KEY_DESC_GAP
+        } else {
+            HELP_KEY_COLUMN_WIDTH.saturating_sub(key_width)
+        };
 
         Line::from(vec![
             Span::styled(

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -225,7 +225,10 @@ impl Footer {
                     COMMAND_PALETTE_ROWS[idx::cmd_palette::ESC_CLOSE].as_hint(),
                 ]
             }
-            InputMode::Help => vec![HELP_ROWS[idx::help::CLOSE].as_hint()],
+            InputMode::Help => vec![
+                HELP_ROWS[idx::help::H_SCROLL].as_hint(),
+                HELP_ROWS[idx::help::CLOSE].as_hint(),
+            ],
             InputMode::ConfirmDialog => vec![],
             InputMode::SqlModal => {
                 if matches!(


### PR DESCRIPTION
## Problem
Help modal key labels can run into descriptions when a row has many key alternatives, and narrow terminals cannot reveal the full row content.

## Background
The help overlay used a fixed key column and only supported vertical scrolling, so long key labels and narrow layouts had no readable fallback.

## Approach
Keep keybinding metadata as the source of truth, render help rows without wrapping, preserve a minimum key column gap, and add Help-only horizontal scrolling with visible hints and snapshots.

## Screenshots
Not included. Covered by render snapshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* ヘルプモーダルで水平スクロール機能が利用可能になりました。h/lキーおよび左右矢印キーでスクロール可能です。
* スクロール可能な状態を示す視覚的なインジケーターをヘルプオーバーレイに追加しました。
* フッターにヘルプモード時の水平スクロール操作ヒントを表示するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->