### PR TITLE
SAB-240 Clarify custom browser choice

### DIFF
--- a/src/app/model/shared/settings.rs
+++ b/src/app/model/shared/settings.rs
@@ -65,7 +65,7 @@ impl ErBrowserChoice {
             Self::Safari => "Safari",
             Self::MicrosoftEdge => "Microsoft Edge",
             Self::Brave => "Brave",
-            Self::Custom => "Custom",
+            Self::Custom => "Other",
         }
     }
 
@@ -81,21 +81,26 @@ impl ErBrowserChoice {
     }
 
     pub fn from_browser_name(browser: Option<&str>) -> Self {
-        match browser.map(str::trim).filter(|value| !value.is_empty()) {
+        match browser
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_ascii_lowercase())
+            .as_deref()
+        {
             None => Self::SystemDefault,
             Some(
-                "Google Chrome"
+                "google chrome"
                 | "google-chrome"
                 | "google-chrome-stable"
                 | "chromium"
                 | "chromium-browser",
             ) => Self::GoogleChrome,
-            Some("Firefox" | "firefox") => Self::Firefox,
-            Some("Safari") => Self::Safari,
-            Some("Microsoft Edge" | "microsoft-edge" | "microsoft-edge-stable") => {
+            Some("firefox") => Self::Firefox,
+            Some("safari") => Self::Safari,
+            Some("microsoft edge" | "microsoft-edge" | "microsoft-edge-stable") => {
                 Self::MicrosoftEdge
             }
-            Some("Brave" | "brave" | "brave-browser") => Self::Brave,
+            Some("brave" | "brave-browser") => Self::Brave,
             Some(_) => Self::Custom,
         }
     }
@@ -390,6 +395,30 @@ mod tests {
         );
         assert_eq!(
             ErBrowserChoice::from_browser_name(Some("brave-browser")),
+            ErBrowserChoice::Brave
+        );
+    }
+
+    #[test]
+    fn browser_choice_ignores_case() {
+        assert_eq!(
+            ErBrowserChoice::from_browser_name(Some("google chrome")),
+            ErBrowserChoice::GoogleChrome
+        );
+        assert_eq!(
+            ErBrowserChoice::from_browser_name(Some("FIREFOX")),
+            ErBrowserChoice::Firefox
+        );
+        assert_eq!(
+            ErBrowserChoice::from_browser_name(Some("safari")),
+            ErBrowserChoice::Safari
+        );
+        assert_eq!(
+            ErBrowserChoice::from_browser_name(Some("MICROSOFT EDGE")),
+            ErBrowserChoice::MicrosoftEdge
+        );
+        assert_eq!(
+            ErBrowserChoice::from_browser_name(Some("BRAVE")),
             ErBrowserChoice::Brave
         );
     }

--- a/src/infra/export/dot.rs
+++ b/src/infra/export/dot.rs
@@ -158,18 +158,21 @@ fn open_with_browser(path: &Path, browser: &str) -> Result<(), ViewerError> {
 
 #[cfg(any(target_os = "freebsd", target_os = "linux", test))]
 fn browser_command_candidates(browser: &str) -> Vec<&str> {
-    match browser {
-        "Google Chrome" => vec![
+    match browser.trim().to_ascii_lowercase().as_str() {
+        "google chrome" | "google-chrome" | "google-chrome-stable" => vec![
             "google-chrome",
             "google-chrome-stable",
             "chromium",
             "chromium-browser",
             "chrome",
         ],
-        "Firefox" => vec!["firefox"],
-        "Safari" => vec![],
-        "Microsoft Edge" => vec!["microsoft-edge", "microsoft-edge-stable"],
-        "Brave" => vec!["brave-browser", "brave"],
+        "firefox" => vec!["firefox"],
+        "safari" => vec![],
+        "microsoft edge" | "microsoft-edge" | "microsoft-edge-stable" => {
+            vec!["microsoft-edge", "microsoft-edge-stable"]
+        }
+        "brave" | "brave-browser" => vec!["brave-browser", "brave"],
+        "arc" => vec!["arc", "Arc"],
         _ => vec![browser],
     }
 }
@@ -550,13 +553,14 @@ mod tests {
         #[test]
         fn browser_command_candidates_include_common_presets() {
             assert_eq!(
-                browser_command_candidates("Microsoft Edge"),
+                browser_command_candidates("microsoft edge"),
                 vec!["microsoft-edge", "microsoft-edge-stable"]
             );
             assert_eq!(
-                browser_command_candidates("Brave"),
+                browser_command_candidates("BRAVE"),
                 vec!["brave-browser", "brave"]
             );
+            assert_eq!(browser_command_candidates("arc"), vec!["arc", "Arc"]);
             assert_eq!(
                 browser_command_candidates("CustomBrowser"),
                 vec!["CustomBrowser"]

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram.snap
@@ -28,7 +28,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                │                  │    Microsoft Edge                                                            │                                │
 │                                │                  │    Brave                                                                     │────────────────────────────────┘
 │                                │                  │                                                                              │────────────────────────────────┐
-│                                │                  │Custom command                                                                │                                │
+│                                │                  │Other                                                                         │                                │
 │                                │                  │    []                                                                        │                                │
 │                                │                  │                                                                              │                                │
 │                                │                  │                                                                              │                                │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram_custom_browser.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram_custom_browser.snap
@@ -28,7 +28,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                │                  │    Microsoft Edge                                                            │                                │
 │                                │                  │    Brave                                                                     │────────────────────────────────┘
 │                                │                  │                                                                              │────────────────────────────────┐
-│                                │                  │Custom command                                                                │                                │
+│                                │                  │Other                                                                         │                                │
 │                                │                  │  > [Brave Browser] saved                                                     │                                │
 │                                │                  │                                                                              │                                │
 │                                │                  │                                                                              │                                │

--- a/src/ui/features/overlays/settings.rs
+++ b/src/ui/features/overlays/settings.rs
@@ -148,7 +148,7 @@ impl SettingsOverlay {
 
         lines.push(Line::raw(""));
         lines.push(Line::from(Span::styled(
-            "Custom command",
+            "Other",
             Style::default().fg(theme.semantic.text.primary),
         )));
         let custom_selected =


### PR DESCRIPTION
## Problem
The ER diagram browser setting exposed "Custom command" even though the field is used as a browser choice. That wording makes the setting look like a free-form shell command and makes values such as `Arc` feel less like a normal browser option.

The settings modal border also read as warm/orange next to the footer hints, which made a normal settings dialog look closer to an active or warning state than a neutral container.

## Approach
Scope: ER diagram browser setting copy, browser-name normalization, Linux/BSD browser command candidates, and neutral modal border tokens.

- Rename the non-preset browser option from "Custom command"/"Custom" to "Other" so the UI describes the choice, not the implementation.
- Normalize known browser names case-insensitively when loading settings, so `Arc`/`arc`-style casing differences do not change how preset browsers are interpreted.
- Apply the same normalization to Linux/BSD launch candidate lookup and include `arc` candidates for typed Arc values.
- Shift default and light theme modal borders from warm brown/red-gray to neutral gray, while leaving focused input, warning, and error borders unchanged.

## Screenshots
Not attached.