### PR TITLE
feat: add F1 command palette shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Built in Rust for minimal memory footprint and near-zero idle CPU. A full-featur
 - **Fuzzy Search** (`/`) — Incremental table filtering
 - **Focus Mode** (`f`) — Expand any pane to full screen
 - **Settings** (`Ctrl+K`) — Theme and ER diagram preferences
-- **Command Palette** (`:palette`) — Searchable command list
+- **Command Palette** (`F1`, `:palette`) — Searchable command list
 
 ## Installation
 

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -102,6 +102,9 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
     if kb::is_command_line(&combo) {
         return Action::EnterCommandLine;
     }
+    if kb::is_command_palette(&combo) {
+        return Action::OpenModal(ModalKind::CommandPalette);
+    }
     if kb::is_reload(&combo) {
         return Action::ReloadMetadata;
     }
@@ -273,6 +276,18 @@ mod tests {
                 let result = handle_normal_mode(combo(Key::Char(':')), &state);
 
                 assert!(matches!(result, Action::EnterCommandLine));
+            }
+
+            #[test]
+            fn f1_opens_command_palette() {
+                let state = browse_state();
+
+                let result = handle_normal_mode(combo(Key::F(1)), &state);
+
+                assert!(matches!(
+                    result,
+                    Action::OpenModal(ModalKind::CommandPalette)
+                ));
             }
 
             #[test]
@@ -1204,6 +1219,7 @@ mod tests {
                 #[case(Key::Char('f'))]
                 #[case(Key::Char('r'))]
                 #[case(Key::Char(':'))]
+                #[case(Key::F(1))]
                 #[case(Key::Enter)]
                 #[case(Key::Esc)]
                 fn are_noop(#[case] key: Key) {

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -109,18 +109,19 @@ pub mod idx {
         pub const TABLE_PICKER: usize = 2;
         pub const SETTINGS: usize = 3;
         pub const COMMAND_LINE: usize = 4;
-        pub const FOCUS: usize = 5;
-        pub const EXIT_FOCUS: usize = 6;
-        pub const PANE_SWITCH: usize = 7;
-        pub const INSPECTOR_TABS: usize = 8;
-        pub const RELOAD: usize = 9;
-        pub const SQL: usize = 10;
-        pub const ER_DIAGRAM: usize = 11;
-        pub const CONNECTIONS: usize = 12;
-        pub const CSV_EXPORT: usize = 13;
-        pub const READ_ONLY: usize = 14;
-        pub const EXIT_READ_ONLY: usize = 15;
-        pub const QUERY_HISTORY: usize = 16;
+        pub const COMMAND_PALETTE: usize = 5;
+        pub const FOCUS: usize = 6;
+        pub const EXIT_FOCUS: usize = 7;
+        pub const PANE_SWITCH: usize = 8;
+        pub const INSPECTOR_TABS: usize = 9;
+        pub const RELOAD: usize = 10;
+        pub const SQL: usize = 11;
+        pub const ER_DIAGRAM: usize = 12;
+        pub const CONNECTIONS: usize = 13;
+        pub const CSV_EXPORT: usize = 14;
+        pub const READ_ONLY: usize = 15;
+        pub const EXIT_READ_ONLY: usize = 16;
+        pub const QUERY_HISTORY: usize = 17;
     }
 
     pub mod footer_nav {
@@ -539,6 +540,12 @@ pub fn is_command_line(combo: &KeyCombo) -> bool {
         .contains(combo)
 }
 
+pub fn is_command_palette(combo: &KeyCombo) -> bool {
+    GLOBAL_KEYS[idx::global::COMMAND_PALETTE]
+        .combos
+        .contains(combo)
+}
+
 pub fn is_settings(combo: &KeyCombo) -> bool {
     GLOBAL_KEYS[idx::global::SETTINGS].combos.contains(combo)
 }
@@ -576,6 +583,7 @@ mod tests {
             assert!(idx::global::TABLE_PICKER < GLOBAL_KEYS.len());
             assert!(idx::global::SETTINGS < GLOBAL_KEYS.len());
             assert!(idx::global::COMMAND_LINE < GLOBAL_KEYS.len());
+            assert!(idx::global::COMMAND_PALETTE < GLOBAL_KEYS.len());
             assert!(idx::global::FOCUS < GLOBAL_KEYS.len());
             assert!(idx::global::EXIT_FOCUS < GLOBAL_KEYS.len());
             assert!(idx::global::PANE_SWITCH < GLOBAL_KEYS.len());
@@ -823,6 +831,10 @@ mod tests {
             #[case(idx::global::TABLE_PICKER, Action::OpenModal(ModalKind::TablePicker))]
             #[case(idx::global::SETTINGS, Action::OpenModal(ModalKind::Settings))]
             #[case(idx::global::COMMAND_LINE, Action::EnterCommandLine)]
+            #[case(
+                idx::global::COMMAND_PALETTE,
+                Action::OpenModal(ModalKind::CommandPalette)
+            )]
             #[case(idx::global::RELOAD, Action::ReloadMetadata)]
             #[case(idx::global::SQL, Action::OpenModal(ModalKind::SqlModal))]
             #[case(idx::global::ER_DIAGRAM, Action::OpenModal(ModalKind::ErTablePicker))]

--- a/src/app/update/input/keybindings/normal.rs
+++ b/src/app/update/input/keybindings/normal.rs
@@ -47,6 +47,14 @@ pub const GLOBAL_KEYS: &[KeyBinding] = &[
         action: Action::EnterCommandLine,
         combos: &[KeyCombo::plain(Key::Char(':'))],
     },
+    KeyBinding {
+        key_short: "F1",
+        key: "F1",
+        desc_short: "Palette",
+        description: "Open Command Palette",
+        action: Action::OpenModal(ModalKind::CommandPalette),
+        combos: &[KeyCombo::plain(Key::F(1))],
+    },
     // for the same Action::ToggleFocus. Two entries exist because the footer
     // shows different labels depending on whether focus mode is active.
     KeyBinding {

--- a/src/app/update/input/palette.rs
+++ b/src/app/update/input/palette.rs
@@ -7,6 +7,7 @@ use crate::update::action::Action;
 // - INSPECTOR_TABS: Action::None — not executable
 const EXCLUDED_GLOBAL_INDICES: &[usize] = &[
     idx::global::COMMAND_LINE,
+    idx::global::COMMAND_PALETTE,
     idx::global::EXIT_FOCUS,
     idx::global::PANE_SWITCH,
     idx::global::INSPECTOR_TABS,

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__footer_shows_success_message.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__footer_shows_success_message.snap
@@ -51,4 +51,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-✓ Reconnected!  r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  ^K:Settings  q:Quit
+✓ Reconnected!  r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__explorer_shows_not_connected_when_no_active_connection.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__explorer_shows_not_connected_when_no_active_connection.snap
@@ -51,4 +51,4 @@ test_project | - | - | no dsn | -
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__initial_state_no_metadata.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__initial_state_no_metadata.snap
@@ -51,4 +51,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_with_data.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_shows_owner_and_comment.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_shows_owner_and_comment.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_with_no_metadata.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_with_no_metadata.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_empty.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_empty.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_with_data.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
@@ -14,8 +14,9 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                        │  Ctrl+P              Open Table Picker                                                                         ┃│                        │
 │                        │  Ctrl+K              Open Settings                                                                             ┃│                        │
 │                        │  :                   Enter command line                                                                        ┃│                        │
+│                        │  F1                  Open Command Palette                                                                      ┃│                        │
 │                        │  f                   Toggle Focus                                                                              ┃│                        │
-│                        │  1/2/3               Switch pane focus                                                                         ┃│                        │
+│                        │  1/2/3               Switch pane focus                                                                         ││                        │
 │                        │  Tab/⇧Tab            Inspector prev/next tab                                                                   ││                        │
 │                        │  r                   Reload metadata                                                                           ││                        │
 │                        │  s                   Open SQL Editor                                                                           ││                        │
@@ -25,9 +26,9 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                        │  Ctrl+R              Toggle Read-Only                                                                          ││                        │
 │                        │  Ctrl+O              Open Query History                                                                        ││                        │
 │                        │                                                                                                                ││                        │
-│                        │▸ Navigation                                                                                                    ││                        │
-│                        │  j / ↓               Move down / scroll                                                                        ││────────────────────────┘
-│                        │  k / ↑               Move up / scroll                                                                          ││────────────────────────┐
+│                        │▸ Navigation                                                                                                    ││────────────────────────┘
+│                        │  j / ↓               Move down / scroll                                                                        ││────────────────────────┐
+│                        │  k / ↑               Move up / scroll                                                                          ││                        │
 │                        │  g / Home            First item / top                                                                          ││                        │
 │                        │  G / End             Last item / bottom                                                                        ││                        │
 │                        │  H                   First visible item                                                                        ││                        │
@@ -45,8 +46,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                        │  ] / [               Navigate history newer/older                                                              ││                        │
 │                        │  Ctrl+H              Exit history (back to latest)                                                             ││                        │
 │                        │                                                                                                                ││                        │
-│                        │▸ Result Pane                                                                                                   ││                        │
-│                        │  Enter               Enter cell selection at the current viewport anchor                                       ▼│                        │
+│                        │▸ Result Pane                                                                                                   ▼│                        │
 │                        ╰ ?/Esc: Close ───────────────────────────────────────────────────────────────────────────────────────────────────╯                        │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
@@ -8,7 +8,8 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │  public.posts                         ││(select a table)                                                                                                          │
 │  public.comments                      ││                                                                                                                          │
 │                        ╭ Help ───────────────────────────────────────────────────────────────────────────────────────────────────────────╮                        │
-│                        │  :                   Open command line                                                                         ▲│                        │
+│                        │  Home/End            Jump to start/end                                                                         ▲│                        │
+│                        │  :                   Open command line                                                                         ││                        │
 │                        │  Esc                 Exit to Cell Active (draft preserved)                                                     ││                        │
 │                        │                                                                                                                ││                        │
 │                        │▸ SQL Editor (Normal)                                                                                           ││                        │
@@ -18,16 +19,16 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                        │  A                   Append at line end                                                                        ││                        │
 │                        │  h / j / k / l / ↑↓←→Move cursor                                                                               ││                        │
 │                        │  0 / $ / w / b / Home / End  Move by word or line boundary                                                     ││                        │
-│                        │  gg / G / H / M / L  Jump by buffer or viewport                                                                ││                        │
+│                        │  gg / G / H / M / L  Jump by buffer or viewport                                                                ┃│                        │
 │                        │  Esc                 Close editor                                                                              ┃│                        │
 │                        │  Ctrl+L              Clear editor                                                                              ┃│                        │
 │                        │  Ctrl+O              Open Query History                                                                        ┃│                        │
 │                        │                                                                                                                ┃│                        │
 │                        │▸ SQL Editor (Insert)                                                                                           ┃│                        │
-│                        │  Alt+Enter / F5      Execute query                                                                             ┃│                        │
-│                        │  Esc                 Return to Normal mode                                                                     ┃│                        │
-│                        │  ↑↓←→                Move cursor                                                                               ││────────────────────────┘
-│                        │  Home/End            Line start/end                                                                            ││────────────────────────┐
+│                        │  Alt+Enter / F5      Execute query                                                                             ││                        │
+│                        │  Esc                 Return to Normal mode                                                                     ││────────────────────────┘
+│                        │  ↑↓←→                Move cursor                                                                               ││────────────────────────┐
+│                        │  Home/End            Line start/end                                                                            ││                        │
 │                        │  Tab                 Insert tab / Accept completion                                                            ││                        │
 │                        │  Ctrl+Space          Trigger completion                                                                        ││                        │
 │                        │  Ctrl+L              Clear editor                                                                              ││                        │
@@ -45,8 +46,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                        │▸ SQL Editor (Compare)                                                                                          ││                        │
 │                        │  Ctrl+E              Run EXPLAIN on current query                                                              ││                        │
 │                        │  Alt+E               Run EXPLAIN ANALYZE on current query                                                      ││                        │
-│                        │  e                   Edit query in SQL tab                                                                     ││                        │
-│                        │  y                   Copy to clipboard                                                                         ▼│                        │
+│                        │  e                   Edit query in SQL tab                                                                     ▼│                        │
 │                        ╰ ?/Esc: Close ───────────────────────────────────────────────────────────────────────────────────────────────────╯                        │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
@@ -5,23 +5,23 @@ expression: output
 test_project | test_db | - | no dsn | localhost:54
 ┌ [1] Explor┐[Info] [Cols] [Idx] [FK] [RLS] [Trig]
 │> publi╭ Help ───────────────────────────╮──────┐
-│  publi│    Open command line           ▲│      │
-│  publi│    Exit to Cell Active (draft p││      │
+│  publi│    Jump to start/end           ▲│      │
+│  publi│    Open command line           ││      │
+│       │    Exit to Cell Active (draft p││      │
 │       │                                ││      │
 │       │al)                             ││      │
-│       │    Execute query               ││      │
-│       │    Copy query to clipboard     ┃│      │
+│       │    Execute query               ┃│      │
+│       │    Copy query to clipboard     ││      │
 │       │    Enter Insert mode           ││      │
-│       │    Append at line end          ││      │
-│       │↑↓←→Move cursor                 ││──────┘
-│       │Home / End  Move by word or line││──────┐
+│       │    Append at line end          ││──────┘
+│       │↑↓←→Move cursor                 ││──────┐
+│       │Home / End  Move by word or line││      │
 │       │ L  Jump by buffer or viewport  ││      │
 │       │    Close editor                ││      │
 │       │    Clear editor                ││      │
 │       │    Open Query History          ││      │
 │       │                                ││      │
-│       │rt)                             ││      │
-│       │    Execute query               ▼│      │
+│       │rt)                             ▼│      │
 │       │ col  26% ◀︎────═════───────────▶︎ │      │
 └───────╰ ?/Esc: Close ───────────────────╯──────┘
 h/l / ←→:H-Scroll  ?/Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_omits_scrollbars_when_content_fits.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_omits_scrollbars_when_content_fits.snap
@@ -39,6 +39,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                          │  Ctrl+P              Open Table Picker                                                                                     │                          │
 │                          │  Ctrl+K              Open Settings                                                                                         │                          │
 │                          │  :                   Enter command line                                                                                    │                          │
+│                          │  F1                  Open Command Palette                                                                                  │                          │
 │                          │  f                   Toggle Focus                                                                                          │                          │
 │                          │  1/2/3               Switch pane focus                                                                                     │                          │
 │                          │  Tab/⇧Tab            Inspector prev/next tab                                                                               │                          │
@@ -150,9 +151,9 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                          │▸ Command Line                                                                                                              │                          │
 │                          │  :quit               Quit application                                                                                      │                          │
 │                          │  :help               Show help                                                                                             │                          │
-│                          │  :sql                Open SQL Editor                                                                                       │                          │
-│                          │  :erd                Open ER Diagram                                                                                       │──────────────────────────┘
-│                          │  :settings           Open Settings                                                                                         │──────────────────────────┐
+│                          │  :sql                Open SQL Editor                                                                                       │──────────────────────────┘
+│                          │  :erd                Open ER Diagram                                                                                       │──────────────────────────┐
+│                          │  :settings           Open Settings                                                                                         │                          │
 │                          │  :theme              Open Theme Settings                                                                                   │                          │
 │                          │  :palette            Open Command Palette                                                                                  │                          │
 │                          │  ←→                  Move cursor                                                                                           │                          │
@@ -251,7 +252,6 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                          │  type                Type to search                                                                                        │                          │
 │                          │  Enter               Confirm search                                                                                        │                          │
 │                          │  Esc                 Cancel search                                                                                         │                          │
-│                          │                                                                                                                            │                          │
 │                          │                                                                                                                            │                          │
 │                          │                                                                                                                            │                          │
 │                          │                                                                                                                            │                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_history__preview_with_history_hint.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_history__preview_with_history_hint.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_history__result_query_with_history_hint.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_history__result_query_with_history_hint.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__empty_query_result.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__empty_query_result.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_on_result_pane.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_on_result_pane.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__table_selection_with_preview.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__table_selection_with_preview.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  ?:Help  ^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -200,6 +200,7 @@ impl Footer {
                         list.push(GLOBAL_KEYS[idx::global::INSPECTOR_TABS].as_hint());
                     }
                     list.push(GLOBAL_KEYS[idx::global::HELP].as_hint());
+                    list.push(GLOBAL_KEYS[idx::global::COMMAND_PALETTE].as_hint());
                     list.push(GLOBAL_KEYS[idx::global::SETTINGS].as_hint());
                     list.push(GLOBAL_KEYS[idx::global::QUIT].as_hint());
                     list


### PR DESCRIPTION
## Problem
The command palette existed but was hard to discover unless users already knew the command-line entry.

## Background
F1 is a familiar command palette entry point in editor workflows and is more terminal-friendly than Cmd or Ctrl+Shift combinations.

## Approach
Add F1 as the normal-mode entry point, surface it in hints and docs, and keep :palette available as the command-line path.

## Screenshots
N/A