### PR TITLE
Refactor: Introduce DispatchResult for reducers

### DIFF
--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -125,7 +125,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                 state.ui.pending_er_picker = false;
             }
 
-            DispatchResult::effects(effects)
+            DispatchResult::handled_with(effects)
         }
         Action::MetadataFailed(error) => {
             let error_info = ConnectionErrorInfo::from_db_operation_error(error);
@@ -138,27 +138,27 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             if state.er_preparation.status == ErStatus::Waiting {
                 state.er_preparation.status = ErStatus::Idle;
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TableDetailLoaded(detail, generation) => {
             if state.session.set_table_detail(*detail.clone(), *generation) {
                 state.ui.inspector_scroll_offset = 0;
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TableDetailFailed(error, generation) => {
             if *generation == state.session.selection_generation() {
                 state.set_error(error.user_message());
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::LoadMetadata => {
             if let Some(dsn) = state.session.dsn.clone() {
                 state.session.begin_metadata_refresh();
-                DispatchResult::effects(vec![Effect::FetchMetadata { dsn }])
+                DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn }])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
         Action::LoadTableDetail(TableTarget {
@@ -167,14 +167,14 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             generation,
         }) => {
             if let Some(dsn) = &state.session.dsn {
-                DispatchResult::effects(vec![Effect::FetchTableDetail {
+                DispatchResult::handled_with(vec![Effect::FetchTableDetail {
                     dsn: dsn.clone(),
                     schema: schema.clone(),
                     table: table.clone(),
                     generation: *generation,
                 }])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 
@@ -189,13 +189,13 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                 state.messages.last_success = None;
                 state.messages.expires_at = None;
 
-                DispatchResult::effects(vec![Effect::Sequence(vec![
+                DispatchResult::handled_with(vec![Effect::Sequence(vec![
                     Effect::CacheInvalidate { dsn: dsn.clone() },
                     Effect::ClearCompletionEngineCache,
                     Effect::FetchMetadata { dsn },
                 ])])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 
@@ -221,20 +221,20 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                         .push_back(qualified_name.clone());
                     state.er_preparation.pending_tables.insert(qualified_name);
                 }
-                DispatchResult::effects(vec![
+                DispatchResult::handled_with(vec![
                     Effect::ResizeCompletionCache {
                         capacity: resize_capacity,
                     },
                     Effect::ProcessPrefetchQueue,
                 ])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 
         Action::StartPrefetchScoped { tables } => {
             if state.sql_modal.is_prefetch_started() {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             } else {
                 state.sql_modal.begin_prefetch();
                 state.er_preparation.pending_tables.clear();
@@ -254,13 +254,13 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                         .pending_tables
                         .insert(qualified_name.clone());
                 }
-                DispatchResult::effects(vec![Effect::ProcessPrefetchQueue])
+                DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue])
             }
         }
 
         Action::ExpandPrefetchWithFkNeighbors => {
             let seed_tables = state.er_preparation.seed_tables.clone();
-            DispatchResult::effects(vec![Effect::ExtractFkNeighbors { seed_tables }])
+            DispatchResult::handled_with(vec![Effect::ExtractFkNeighbors { seed_tables }])
         }
 
         Action::FkNeighborsDiscovered { tables } => {
@@ -268,7 +268,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
             if tables.is_empty() {
                 // No new neighbors — proceed to generate with what we have
-                return DispatchResult::effects(check_er_completion(state));
+                return DispatchResult::handled_with(check_er_completion(state));
             }
 
             for qualified_name in tables {
@@ -281,7 +281,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     .prefetch_queue
                     .push_back(qualified_name.clone());
             }
-            DispatchResult::effects(vec![Effect::ProcessPrefetchQueue])
+            DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue])
         }
 
         Action::ProcessPrefetchQueue => {
@@ -302,9 +302,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             }
 
             if actions.is_empty() {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             } else {
-                DispatchResult::effects(vec![Effect::DispatchActions(actions)])
+                DispatchResult::handled_with(vec![Effect::DispatchActions(actions)])
             }
         }
 
@@ -312,7 +312,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             let qualified_name = format!("{schema}.{table}");
 
             if state.sql_modal.prefetching_tables.contains(&qualified_name) {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             if let Some(entry) = state.sql_modal.failed_prefetch_tables.get(&qualified_name) {
@@ -327,7 +327,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     if effects.is_empty() && state.er_preparation.status == ErStatus::Waiting {
                         effects.push(Effect::ProcessPrefetchQueue);
                     }
-                    return DispatchResult::effects(effects);
+                    return DispatchResult::handled_with(effects);
                 }
 
                 let backoff_secs =
@@ -338,9 +338,11 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     // to avoid busy-looping while waiting for the backoff to expire.
                     let remaining = backoff_secs - elapsed;
                     state.sql_modal.prefetch_queue.push_back(qualified_name);
-                    return DispatchResult::effects(vec![Effect::DelayedProcessPrefetchQueue {
-                        delay_secs: remaining,
-                    }]);
+                    return DispatchResult::handled_with(vec![
+                        Effect::DelayedProcessPrefetchQueue {
+                            delay_secs: remaining,
+                        },
+                    ]);
                 }
             }
 
@@ -355,13 +357,13 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                 .insert(qualified_name.clone());
 
             if let Some(dsn) = &state.session.dsn {
-                DispatchResult::effects(vec![Effect::PrefetchTableDetail {
+                DispatchResult::handled_with(vec![Effect::PrefetchTableDetail {
                     dsn: dsn.clone(),
                     schema: schema.clone(),
                     table: table.clone(),
                 }])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 
@@ -389,7 +391,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
             effects.extend(check_er_completion(state));
 
-            DispatchResult::effects(effects)
+            DispatchResult::handled_with(effects)
         }
 
         Action::TableDetailCacheFailed {
@@ -425,7 +427,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
             effects.extend(check_er_completion(state));
 
-            DispatchResult::effects(effects)
+            DispatchResult::handled_with(effects)
         }
 
         Action::TableDetailAlreadyCached { schema, table } => {
@@ -445,7 +447,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
             effects.extend(check_er_completion(state));
 
-            DispatchResult::effects(effects)
+            DispatchResult::handled_with(effects)
         }
 
         _ => DispatchResult::pass(),

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -9,6 +9,7 @@ use crate::model::er_state::ErStatus;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::FailedPrefetchEntry;
 use crate::update::action::{Action, ModalKind, TableTarget};
+use crate::update::dispatch_result::DispatchResult;
 
 const BASE_BACKOFF_SECS: u64 = 1;
 const MAX_BACKOFF_SECS: u64 = 4;
@@ -46,7 +47,7 @@ fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
     }]
 }
 
-pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::MetadataLoaded(metadata) => {
             let has_tables = !metadata.table_summaries.is_empty();
@@ -124,7 +125,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 state.ui.pending_er_picker = false;
             }
 
-            Some(effects)
+            DispatchResult::effects(effects)
         }
         Action::MetadataFailed(error) => {
             let error_info = ConnectionErrorInfo::from_db_operation_error(error);
@@ -137,27 +138,27 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
             if state.er_preparation.status == ErStatus::Waiting {
                 state.er_preparation.status = ErStatus::Idle;
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TableDetailLoaded(detail, generation) => {
             if state.session.set_table_detail(*detail.clone(), *generation) {
                 state.ui.inspector_scroll_offset = 0;
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TableDetailFailed(error, generation) => {
             if *generation == state.session.selection_generation() {
                 state.set_error(error.user_message());
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::LoadMetadata => {
             if let Some(dsn) = state.session.dsn.clone() {
                 state.session.begin_metadata_refresh();
-                Some(vec![Effect::FetchMetadata { dsn }])
+                DispatchResult::effects(vec![Effect::FetchMetadata { dsn }])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
         Action::LoadTableDetail(TableTarget {
@@ -166,14 +167,14 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
             generation,
         }) => {
             if let Some(dsn) = &state.session.dsn {
-                Some(vec![Effect::FetchTableDetail {
+                DispatchResult::effects(vec![Effect::FetchTableDetail {
                     dsn: dsn.clone(),
                     schema: schema.clone(),
                     table: table.clone(),
                     generation: *generation,
                 }])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
@@ -188,13 +189,13 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 state.messages.last_success = None;
                 state.messages.expires_at = None;
 
-                Some(vec![Effect::Sequence(vec![
+                DispatchResult::effects(vec![Effect::Sequence(vec![
                     Effect::CacheInvalidate { dsn: dsn.clone() },
                     Effect::ClearCompletionEngineCache,
                     Effect::FetchMetadata { dsn },
                 ])])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
@@ -220,20 +221,20 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                         .push_back(qualified_name.clone());
                     state.er_preparation.pending_tables.insert(qualified_name);
                 }
-                Some(vec![
+                DispatchResult::effects(vec![
                     Effect::ResizeCompletionCache {
                         capacity: resize_capacity,
                     },
                     Effect::ProcessPrefetchQueue,
                 ])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
         Action::StartPrefetchScoped { tables } => {
             if state.sql_modal.is_prefetch_started() {
-                Some(vec![])
+                DispatchResult::no_effects()
             } else {
                 state.sql_modal.begin_prefetch();
                 state.er_preparation.pending_tables.clear();
@@ -253,13 +254,13 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                         .pending_tables
                         .insert(qualified_name.clone());
                 }
-                Some(vec![Effect::ProcessPrefetchQueue])
+                DispatchResult::effects(vec![Effect::ProcessPrefetchQueue])
             }
         }
 
         Action::ExpandPrefetchWithFkNeighbors => {
             let seed_tables = state.er_preparation.seed_tables.clone();
-            Some(vec![Effect::ExtractFkNeighbors { seed_tables }])
+            DispatchResult::effects(vec![Effect::ExtractFkNeighbors { seed_tables }])
         }
 
         Action::FkNeighborsDiscovered { tables } => {
@@ -267,7 +268,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
             if tables.is_empty() {
                 // No new neighbors — proceed to generate with what we have
-                return Some(check_er_completion(state));
+                return DispatchResult::effects(check_er_completion(state));
             }
 
             for qualified_name in tables {
@@ -280,7 +281,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                     .prefetch_queue
                     .push_back(qualified_name.clone());
             }
-            Some(vec![Effect::ProcessPrefetchQueue])
+            DispatchResult::effects(vec![Effect::ProcessPrefetchQueue])
         }
 
         Action::ProcessPrefetchQueue => {
@@ -301,9 +302,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
             }
 
             if actions.is_empty() {
-                Some(vec![])
+                DispatchResult::no_effects()
             } else {
-                Some(vec![Effect::DispatchActions(actions)])
+                DispatchResult::effects(vec![Effect::DispatchActions(actions)])
             }
         }
 
@@ -311,7 +312,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
             let qualified_name = format!("{schema}.{table}");
 
             if state.sql_modal.prefetching_tables.contains(&qualified_name) {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             if let Some(entry) = state.sql_modal.failed_prefetch_tables.get(&qualified_name) {
@@ -326,7 +327,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                     if effects.is_empty() && state.er_preparation.status == ErStatus::Waiting {
                         effects.push(Effect::ProcessPrefetchQueue);
                     }
-                    return Some(effects);
+                    return DispatchResult::effects(effects);
                 }
 
                 let backoff_secs =
@@ -337,7 +338,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                     // to avoid busy-looping while waiting for the backoff to expire.
                     let remaining = backoff_secs - elapsed;
                     state.sql_modal.prefetch_queue.push_back(qualified_name);
-                    return Some(vec![Effect::DelayedProcessPrefetchQueue {
+                    return DispatchResult::effects(vec![Effect::DelayedProcessPrefetchQueue {
                         delay_secs: remaining,
                     }]);
                 }
@@ -354,13 +355,13 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
                 .insert(qualified_name.clone());
 
             if let Some(dsn) = &state.session.dsn {
-                Some(vec![Effect::PrefetchTableDetail {
+                DispatchResult::effects(vec![Effect::PrefetchTableDetail {
                     dsn: dsn.clone(),
                     schema: schema.clone(),
                     table: table.clone(),
                 }])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
@@ -388,7 +389,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
             effects.extend(check_er_completion(state));
 
-            Some(effects)
+            DispatchResult::effects(effects)
         }
 
         Action::TableDetailCacheFailed {
@@ -424,7 +425,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
             effects.extend(check_er_completion(state));
 
-            Some(effects)
+            DispatchResult::effects(effects)
         }
 
         Action::TableDetailAlreadyCached { schema, table } => {
@@ -444,10 +445,10 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> O
 
             effects.extend(check_er_completion(state));
 
-            Some(effects)
+            DispatchResult::effects(effects)
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -866,8 +867,9 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(530)));
 
-            let effects =
-                reduce_metadata(&mut state, &Action::StartPrefetchAll, Instant::now()).unwrap();
+            let effects = reduce_metadata(&mut state, &Action::StartPrefetchAll, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(
                 effects
@@ -881,8 +883,9 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(50)));
 
-            let effects =
-                reduce_metadata(&mut state, &Action::StartPrefetchAll, Instant::now()).unwrap();
+            let effects = reduce_metadata(&mut state, &Action::StartPrefetchAll, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(
                 effects

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -4,8 +4,9 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ConnectionsLoadedPayload, ListMotion, ListTarget};
+use crate::update::dispatch_result::DispatchResult;
 
-pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::ListSelect {
             target: ListTarget::ConnectionList,
@@ -16,7 +17,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             if next < len {
                 state.ui.set_connection_list_selection(Some(next));
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ListSelect {
             target: ListTarget::ConnectionList,
@@ -27,7 +28,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                     .ui
                     .set_connection_list_selection(Some(state.ui.connection_list_selected - 1));
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConnectionsLoaded(ConnectionsLoadedPayload {
             profiles,
@@ -67,7 +68,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                     .ui
                     .set_connection_list_selection(Some(state.ui.connection_list_selected));
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConfirmConnectionSelection => {
             use crate::model::connection::list::ConnectionListItem;
@@ -90,12 +91,12 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             state.modal.set_mode(InputMode::Normal);
 
             match effect {
-                Some(e) => Some(vec![e]),
-                None => Some(vec![]),
+                Some(e) => DispatchResult::effects(vec![e]),
+                None => DispatchResult::no_effects(),
             }
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -17,7 +17,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             if next < len {
                 state.ui.set_connection_list_selection(Some(next));
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ListSelect {
             target: ListTarget::ConnectionList,
@@ -28,7 +28,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                     .ui
                     .set_connection_list_selection(Some(state.ui.connection_list_selected - 1));
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConnectionsLoaded(ConnectionsLoadedPayload {
             profiles,
@@ -68,7 +68,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                     .ui
                     .set_connection_list_selection(Some(state.ui.connection_list_selected));
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConfirmConnectionSelection => {
             use crate::model::connection::list::ConnectionListItem;
@@ -91,8 +91,8 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             state.modal.set_mode(InputMode::Normal);
 
             match effect {
-                Some(e) => DispatchResult::effects(vec![e]),
-                None => DispatchResult::no_effects(),
+                Some(e) => DispatchResult::handled_with(vec![e]),
+                None => DispatchResult::handled(),
             }
         }
 

--- a/src/app/update/browse/navigation/explorer.rs
+++ b/src/app/update/browse/navigation/explorer.rs
@@ -21,20 +21,20 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                         .set_explorer_selection(Some(state.ui.explorer_selected + 1));
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Select(SelectMotion::Previous) => {
             if state.ui.focused_pane == FocusedPane::Explorer && !state.tables().is_empty() {
                 let new_idx = state.ui.explorer_selected.saturating_sub(1);
                 state.ui.set_explorer_selection(Some(new_idx));
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Select(SelectMotion::First) => {
             if state.ui.focused_pane == FocusedPane::Explorer && !state.tables().is_empty() {
                 state.ui.set_explorer_selection(Some(0));
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Select(SelectMotion::Last) => {
             if state.ui.focused_pane == FocusedPane::Explorer {
@@ -43,7 +43,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     state.ui.set_explorer_selection(Some(len - 1));
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Select(SelectMotion::ViewportMiddle) => {
             if state.ui.focused_pane == FocusedPane::Explorer {
@@ -56,7 +56,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     state.ui.set_explorer_selection(Some(target));
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Select(SelectMotion::ViewportTop) => {
             if state.ui.focused_pane == FocusedPane::Explorer {
@@ -66,7 +66,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     state.ui.set_explorer_selection(Some(target));
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Select(SelectMotion::ViewportBottom) => {
             if state.ui.focused_pane == FocusedPane::Explorer {
@@ -79,7 +79,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     state.ui.set_explorer_selection(Some(target));
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::ScrollToCursor {
@@ -95,7 +95,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                 state.ui.explorer_scroll_offset =
                     selected.saturating_sub(visible / 2).min(max_offset);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ScrollToCursor {
             target: ScrollToCursorTarget::Explorer,
@@ -109,7 +109,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                 let max_offset = len.saturating_sub(visible);
                 state.ui.explorer_scroll_offset = selected.min(max_offset);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ScrollToCursor {
             target: ScrollToCursorTarget::Explorer,
@@ -125,17 +125,17 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     .saturating_sub(visible.saturating_sub(1))
                     .min(max_offset);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::Select(motion @ (SelectMotion::HalfPageDown | SelectMotion::FullPageDown)) => {
             let len = explorer_item_count(state);
             if len == 0 {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let visible = state.ui.explorer_visible_items();
             if visible == 0 {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let delta = match motion {
                 SelectMotion::HalfPageDown => (visible / 2).max(1),
@@ -146,16 +146,16 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
             state.ui.explorer_selected = (state.ui.explorer_selected + delta).min(max_idx);
             state.ui.explorer_scroll_offset =
                 (state.ui.explorer_scroll_offset + delta).min(max_offset);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Select(motion @ (SelectMotion::HalfPageUp | SelectMotion::FullPageUp)) => {
             let len = explorer_item_count(state);
             if len == 0 {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let visible = state.ui.explorer_visible_items();
             if visible == 0 {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let delta = match motion {
                 SelectMotion::HalfPageUp => (visible / 2).max(1),
@@ -163,7 +163,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
             };
             state.ui.explorer_selected = state.ui.explorer_selected.saturating_sub(delta);
             state.ui.explorer_scroll_offset = state.ui.explorer_scroll_offset.saturating_sub(delta);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::Scroll {
@@ -173,7 +173,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
         } => {
             state.ui.explorer_horizontal_offset =
                 state.ui.explorer_horizontal_offset.saturating_sub(1);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Explorer,
@@ -190,7 +190,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
             if state.ui.explorer_horizontal_offset < max_offset {
                 state.ui.explorer_horizontal_offset += 1;
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         _ => DispatchResult::pass(),

--- a/src/app/update/browse/navigation/explorer.rs
+++ b/src/app/update/browse/navigation/explorer.rs
@@ -1,4 +1,3 @@
-use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::key_sequence::KeySequenceState;
@@ -7,10 +6,11 @@ use crate::update::action::{
     Action, CursorPosition, ScrollAmount, ScrollDirection, ScrollTarget, ScrollToCursorTarget,
     SelectMotion,
 };
+use crate::update::dispatch_result::DispatchResult;
 
 use super::explorer_item_count;
 
-pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::Select(SelectMotion::Next) => {
             if state.ui.focused_pane == FocusedPane::Explorer {
@@ -21,20 +21,20 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                         .set_explorer_selection(Some(state.ui.explorer_selected + 1));
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Select(SelectMotion::Previous) => {
             if state.ui.focused_pane == FocusedPane::Explorer && !state.tables().is_empty() {
                 let new_idx = state.ui.explorer_selected.saturating_sub(1);
                 state.ui.set_explorer_selection(Some(new_idx));
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Select(SelectMotion::First) => {
             if state.ui.focused_pane == FocusedPane::Explorer && !state.tables().is_empty() {
                 state.ui.set_explorer_selection(Some(0));
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Select(SelectMotion::Last) => {
             if state.ui.focused_pane == FocusedPane::Explorer {
@@ -43,7 +43,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     state.ui.set_explorer_selection(Some(len - 1));
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Select(SelectMotion::ViewportMiddle) => {
             if state.ui.focused_pane == FocusedPane::Explorer {
@@ -56,7 +56,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     state.ui.set_explorer_selection(Some(target));
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Select(SelectMotion::ViewportTop) => {
             if state.ui.focused_pane == FocusedPane::Explorer {
@@ -66,7 +66,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     state.ui.set_explorer_selection(Some(target));
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Select(SelectMotion::ViewportBottom) => {
             if state.ui.focused_pane == FocusedPane::Explorer {
@@ -79,7 +79,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     state.ui.set_explorer_selection(Some(target));
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::ScrollToCursor {
@@ -95,7 +95,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 state.ui.explorer_scroll_offset =
                     selected.saturating_sub(visible / 2).min(max_offset);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ScrollToCursor {
             target: ScrollToCursorTarget::Explorer,
@@ -109,7 +109,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 let max_offset = len.saturating_sub(visible);
                 state.ui.explorer_scroll_offset = selected.min(max_offset);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ScrollToCursor {
             target: ScrollToCursorTarget::Explorer,
@@ -125,17 +125,17 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     .saturating_sub(visible.saturating_sub(1))
                     .min(max_offset);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::Select(motion @ (SelectMotion::HalfPageDown | SelectMotion::FullPageDown)) => {
             let len = explorer_item_count(state);
             if len == 0 {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let visible = state.ui.explorer_visible_items();
             if visible == 0 {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let delta = match motion {
                 SelectMotion::HalfPageDown => (visible / 2).max(1),
@@ -146,16 +146,16 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
             state.ui.explorer_selected = (state.ui.explorer_selected + delta).min(max_idx);
             state.ui.explorer_scroll_offset =
                 (state.ui.explorer_scroll_offset + delta).min(max_offset);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Select(motion @ (SelectMotion::HalfPageUp | SelectMotion::FullPageUp)) => {
             let len = explorer_item_count(state);
             if len == 0 {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let visible = state.ui.explorer_visible_items();
             if visible == 0 {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let delta = match motion {
                 SelectMotion::HalfPageUp => (visible / 2).max(1),
@@ -163,7 +163,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
             };
             state.ui.explorer_selected = state.ui.explorer_selected.saturating_sub(delta);
             state.ui.explorer_scroll_offset = state.ui.explorer_scroll_offset.saturating_sub(delta);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::Scroll {
@@ -173,7 +173,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
         } => {
             state.ui.explorer_horizontal_offset =
                 state.ui.explorer_horizontal_offset.saturating_sub(1);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Explorer,
@@ -190,10 +190,10 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
             if state.ui.explorer_horizontal_offset < max_offset {
                 state.ui.explorer_horizontal_offset += 1;
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -315,7 +315,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.ui.explorer_selected, 0);
         }
 

--- a/src/app/update/browse/navigation/focus.rs
+++ b/src/app/update/browse/navigation/focus.rs
@@ -1,19 +1,19 @@
 use std::time::Instant;
 
-use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
+use crate::update::dispatch_result::DispatchResult;
 
 pub fn reduce(
     state: &mut AppState,
     action: &Action,
     services: &AppServices,
     _now: Instant,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     match action {
         Action::SetFocusedPane(pane) => {
             if *pane != FocusedPane::Result {
@@ -23,7 +23,7 @@ pub fn reduce(
                 }
             }
             state.ui.focused_pane = *pane;
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ToggleFocus => {
             let was_focus = state.ui.is_focus_mode();
@@ -31,7 +31,7 @@ pub fn reduce(
             if was_focus {
                 state.result_interaction.reset_interaction();
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ToggleReadOnly => {
             if state.session.read_only {
@@ -44,22 +44,22 @@ pub fn reduce(
             } else {
                 state.session.read_only = true;
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::InspectorNextTab => {
             state.ui.inspector_tab = services
                 .db_capabilities
                 .next_inspector_tab(state.ui.inspector_tab);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::InspectorPrevTab => {
             state.ui.inspector_tab = services
                 .db_capabilities
                 .prev_inspector_tab(state.ui.inspector_tab);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 

--- a/src/app/update/browse/navigation/focus.rs
+++ b/src/app/update/browse/navigation/focus.rs
@@ -23,7 +23,7 @@ pub fn reduce(
                 }
             }
             state.ui.focused_pane = *pane;
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ToggleFocus => {
             let was_focus = state.ui.is_focus_mode();
@@ -31,7 +31,7 @@ pub fn reduce(
             if was_focus {
                 state.result_interaction.reset_interaction();
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ToggleReadOnly => {
             if state.session.read_only {
@@ -44,19 +44,19 @@ pub fn reduce(
             } else {
                 state.session.read_only = true;
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::InspectorNextTab => {
             state.ui.inspector_tab = services
                 .db_capabilities
                 .next_inspector_tab(state.ui.inspector_tab);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::InspectorPrevTab => {
             state.ui.inspector_tab = services
                 .db_capabilities
                 .prev_inspector_tab(state.ui.inspector_tab);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         _ => DispatchResult::pass(),

--- a/src/app/update/browse/navigation/input.rs
+++ b/src/app/update/browse/navigation/input.rs
@@ -1,19 +1,19 @@
-use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, InputTarget, ListMotion, ListTarget};
+use crate::update::dispatch_result::DispatchResult;
 use crate::update::input::palette::palette_command_count;
 
-pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::Paste(text) => match state.modal.active_mode() {
             InputMode::TablePicker => {
                 state.ui.table_picker.insert_filter_str(text);
-                Some(vec![])
+                DispatchResult::no_effects()
             }
             InputMode::ErTablePicker => {
                 state.ui.er_picker.insert_filter_str(text);
-                Some(vec![])
+                DispatchResult::no_effects()
             }
             InputMode::CommandLine => {
                 let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
@@ -21,7 +21,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 state
                     .command_line_input
                     .update_viewport(state.command_line_visible_width);
-                Some(vec![])
+                DispatchResult::no_effects()
             }
             InputMode::CellEdit => {
                 let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
@@ -29,13 +29,13 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     .result_interaction
                     .cell_edit_input_mut()
                     .insert_str(&clean);
-                Some(vec![])
+                DispatchResult::no_effects()
             }
             InputMode::QueryHistoryPicker => {
                 state.query_history_picker.insert_filter_str(text);
-                Some(vec![])
+                DispatchResult::no_effects()
             }
-            _ => None,
+            _ => DispatchResult::pass(),
         },
 
         Action::TextInput {
@@ -43,30 +43,30 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
             ch: c,
         } => {
             state.ui.table_picker.insert_filter_char(*c);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextBackspace {
             target: InputTarget::Filter,
         } => {
             state.ui.table_picker.backspace_filter();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextMoveCursor {
             target: InputTarget::Filter,
             direction: movement,
         } => {
             state.ui.table_picker.move_filter_cursor(*movement);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::EnterCommandLine => {
             state.modal.push_mode(InputMode::CommandLine);
             state.command_line_input.clear();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ExitCommandLine => {
             state.modal.pop_mode();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextInput {
             target: InputTarget::CommandLine,
@@ -76,7 +76,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
             state
                 .command_line_input
                 .update_viewport(state.command_line_visible_width);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextBackspace {
             target: InputTarget::CommandLine,
@@ -85,7 +85,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
             state
                 .command_line_input
                 .update_viewport(state.command_line_visible_width);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextMoveCursor {
             target: InputTarget::CommandLine,
@@ -95,7 +95,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
             state
                 .command_line_input
                 .update_viewport(state.command_line_visible_width);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         // -----------------------------------------------------------------
@@ -112,7 +112,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     .table_picker
                     .set_selection(state.ui.table_picker.selected() + 1);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ListSelect {
             target: ListTarget::TablePicker | ListTarget::CommandPalette,
@@ -122,7 +122,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 .ui
                 .table_picker
                 .set_selection(state.ui.table_picker.selected().saturating_sub(1));
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ListSelect {
             target: ListTarget::ErTablePicker,
@@ -135,7 +135,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     .er_picker
                     .set_selection(state.ui.er_picker.selected() + 1);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ListSelect {
             target: ListTarget::ErTablePicker,
@@ -145,7 +145,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 .ui
                 .er_picker
                 .set_selection(state.ui.er_picker.selected().saturating_sub(1));
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ListSelect {
             target: ListTarget::CommandPalette,
@@ -158,10 +158,10 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     .table_picker
                     .set_selection(state.ui.table_picker.selected() + 1);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -187,7 +187,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.ui.table_picker.filter_input().content(), "hello");
         }
 
@@ -264,7 +264,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_none());
+            assert!(effects.is_pass());
         }
 
         #[test]
@@ -279,7 +279,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.ui.er_picker.filter_input().content(), "public.users");
             assert_eq!(state.ui.er_picker.selected(), 0);
         }
@@ -312,7 +312,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.query_history_picker.filter_input().content(), "users");
             assert_eq!(state.query_history_picker.selected(), 0);
         }

--- a/src/app/update/browse/navigation/input.rs
+++ b/src/app/update/browse/navigation/input.rs
@@ -9,11 +9,11 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
         Action::Paste(text) => match state.modal.active_mode() {
             InputMode::TablePicker => {
                 state.ui.table_picker.insert_filter_str(text);
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
             InputMode::ErTablePicker => {
                 state.ui.er_picker.insert_filter_str(text);
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
             InputMode::CommandLine => {
                 let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
@@ -21,7 +21,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                 state
                     .command_line_input
                     .update_viewport(state.command_line_visible_width);
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
             InputMode::CellEdit => {
                 let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
@@ -29,11 +29,11 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     .result_interaction
                     .cell_edit_input_mut()
                     .insert_str(&clean);
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
             InputMode::QueryHistoryPicker => {
                 state.query_history_picker.insert_filter_str(text);
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
             _ => DispatchResult::pass(),
         },
@@ -43,30 +43,30 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
             ch: c,
         } => {
             state.ui.table_picker.insert_filter_char(*c);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::Filter,
         } => {
             state.ui.table_picker.backspace_filter();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: InputTarget::Filter,
             direction: movement,
         } => {
             state.ui.table_picker.move_filter_cursor(*movement);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::EnterCommandLine => {
             state.modal.push_mode(InputMode::CommandLine);
             state.command_line_input.clear();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ExitCommandLine => {
             state.modal.pop_mode();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextInput {
             target: InputTarget::CommandLine,
@@ -76,7 +76,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
             state
                 .command_line_input
                 .update_viewport(state.command_line_visible_width);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::CommandLine,
@@ -85,7 +85,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
             state
                 .command_line_input
                 .update_viewport(state.command_line_visible_width);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: InputTarget::CommandLine,
@@ -95,7 +95,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
             state
                 .command_line_input
                 .update_viewport(state.command_line_visible_width);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         // -----------------------------------------------------------------
@@ -112,7 +112,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     .table_picker
                     .set_selection(state.ui.table_picker.selected() + 1);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ListSelect {
             target: ListTarget::TablePicker | ListTarget::CommandPalette,
@@ -122,7 +122,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                 .ui
                 .table_picker
                 .set_selection(state.ui.table_picker.selected().saturating_sub(1));
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ListSelect {
             target: ListTarget::ErTablePicker,
@@ -135,7 +135,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     .er_picker
                     .set_selection(state.ui.er_picker.selected() + 1);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ListSelect {
             target: ListTarget::ErTablePicker,
@@ -145,7 +145,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                 .ui
                 .er_picker
                 .set_selection(state.ui.er_picker.selected().saturating_sub(1));
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ListSelect {
             target: ListTarget::CommandPalette,
@@ -158,7 +158,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     .table_picker
                     .set_selection(state.ui.table_picker.selected() + 1);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         _ => DispatchResult::pass(),

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -1,9 +1,9 @@
-use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::inspector_tab::InspectorTab;
 use crate::model::shared::viewport::{calculate_next_column_offset, calculate_prev_column_offset};
 use crate::services::AppServices;
 use crate::update::action::{Action, ScrollAmount, ScrollDirection, ScrollTarget};
+use crate::update::dispatch_result::DispatchResult;
 
 use super::inspector_max_scroll;
 
@@ -23,11 +23,7 @@ fn inspector_page_scroll_delta(
     amount.page_delta(visible)
 }
 
-pub fn reduce(
-    state: &mut AppState,
-    action: &Action,
-    services: &AppServices,
-) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action, services: &AppServices) -> DispatchResult {
     match action {
         Action::Scroll {
             target: ScrollTarget::Inspector,
@@ -37,7 +33,7 @@ pub fn reduce(
             let max = inspector_max_scroll(state, services);
             state.ui.inspector_scroll_offset =
                 direction.clamp_vertical_offset(state.ui.inspector_scroll_offset, max, 1);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Inspector,
@@ -45,7 +41,7 @@ pub fn reduce(
             amount: ScrollAmount::ToStart,
         } => {
             state.ui.inspector_scroll_offset = 0;
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Inspector,
@@ -53,7 +49,7 @@ pub fn reduce(
             amount: ScrollAmount::ToEnd,
         } => {
             state.ui.inspector_scroll_offset = inspector_max_scroll(state, services);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Inspector,
@@ -65,7 +61,7 @@ pub fn reduce(
                 state.ui.inspector_scroll_offset =
                     direction.clamp_vertical_offset(state.ui.inspector_scroll_offset, max, delta);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Inspector,
@@ -74,7 +70,7 @@ pub fn reduce(
         } => {
             state.ui.inspector_horizontal_offset =
                 calculate_prev_column_offset(state.ui.inspector_horizontal_offset);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Inspector,
@@ -88,10 +84,10 @@ pub fn reduce(
                 state.ui.inspector_horizontal_offset,
                 plan.column_count,
             );
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -152,7 +148,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.ui.inspector_scroll_offset, 0);
         }
 
@@ -174,7 +170,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.ui.inspector_scroll_offset, expected_max);
         }
 
@@ -194,7 +190,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.ui.inspector_scroll_offset, 0);
         }
 
@@ -214,7 +210,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.ui.inspector_scroll_offset, 3);
         }
 
@@ -234,7 +230,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.ui.inspector_scroll_offset, 15);
         }
 
@@ -253,7 +249,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.ui.inspector_scroll_offset, 0);
         }
 
@@ -286,7 +282,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.ui.inspector_scroll_offset, 1 + expected_delta);
         }
 
@@ -309,7 +305,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(effects.is_some());
+            assert!(effects.is_handled());
             assert_eq!(state.ui.inspector_scroll_offset, 3);
         }
     }

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -33,7 +33,7 @@ pub fn reduce(state: &mut AppState, action: &Action, services: &AppServices) -> 
             let max = inspector_max_scroll(state, services);
             state.ui.inspector_scroll_offset =
                 direction.clamp_vertical_offset(state.ui.inspector_scroll_offset, max, 1);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Inspector,
@@ -41,7 +41,7 @@ pub fn reduce(state: &mut AppState, action: &Action, services: &AppServices) -> 
             amount: ScrollAmount::ToStart,
         } => {
             state.ui.inspector_scroll_offset = 0;
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Inspector,
@@ -49,7 +49,7 @@ pub fn reduce(state: &mut AppState, action: &Action, services: &AppServices) -> 
             amount: ScrollAmount::ToEnd,
         } => {
             state.ui.inspector_scroll_offset = inspector_max_scroll(state, services);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Inspector,
@@ -61,7 +61,7 @@ pub fn reduce(state: &mut AppState, action: &Action, services: &AppServices) -> 
                 state.ui.inspector_scroll_offset =
                     direction.clamp_vertical_offset(state.ui.inspector_scroll_offset, max, delta);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Inspector,
@@ -70,7 +70,7 @@ pub fn reduce(state: &mut AppState, action: &Action, services: &AppServices) -> 
         } => {
             state.ui.inspector_horizontal_offset =
                 calculate_prev_column_offset(state.ui.inspector_horizontal_offset);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Inspector,
@@ -84,7 +84,7 @@ pub fn reduce(state: &mut AppState, action: &Action, services: &AppServices) -> 
                 state.ui.inspector_horizontal_offset,
                 plan.column_count,
             );
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         _ => DispatchResult::pass(),

--- a/src/app/update/browse/navigation/mod.rs
+++ b/src/app/update/browse/navigation/mod.rs
@@ -6,11 +6,11 @@ mod inspector;
 
 use std::time::Instant;
 
-use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::inspector_tab::InspectorTab;
 use crate::services::AppServices;
 use crate::update::action::Action;
+use crate::update::dispatch_result::DispatchResult;
 
 fn inspector_total_items(state: &AppState, services: &AppServices) -> usize {
     let active_tab = services
@@ -62,7 +62,7 @@ pub fn reduce_navigation(
     action: &Action,
     services: &AppServices,
     now: Instant,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     focus::reduce(state, action, services, now)
         .or_else(|| input::reduce(state, action))
         .or_else(|| explorer::reduce(state, action))

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -10,6 +10,7 @@ use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::AdhocSuccessSnapshot;
 use crate::services::AppServices;
 use crate::update::action::{Action, ModalKind, TableTarget};
+use crate::update::dispatch_result::DispatchResult;
 use crate::update::input::command::{command_to_action, parse_command};
 
 fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult) -> Vec<Effect> {
@@ -57,7 +58,7 @@ pub fn reduce(
     action: &Action,
     now: Instant,
     _services: &AppServices,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     match action {
         Action::QueryCompleted {
             result,
@@ -136,9 +137,9 @@ pub fn reduce(
                         .set_post_delete_selection(PostDeleteRowSelection::Keep);
                 }
 
-                Some(try_adhoc_refresh(state, result))
+                DispatchResult::effects(try_adhoc_refresh(state, result))
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
         Action::QueryFailed {
@@ -174,7 +175,7 @@ pub fn reduce(
                     state.sql_modal.finish_adhoc_error(user_message);
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::CommandLineSubmit => {
@@ -183,7 +184,7 @@ pub fn reduce(
             state.modal.pop_mode();
             state.command_line_input.clear();
 
-            Some(match follow_up {
+            DispatchResult::effects(match follow_up {
                 Action::Quit => {
                     state.should_quit = true;
                     vec![]
@@ -248,7 +249,7 @@ pub fn reduce(
                     });
                 state.query.pagination.total_rows_estimate = row_estimate;
 
-                Some(vec![Effect::ExecutePreview {
+                DispatchResult::effects(vec![Effect::ExecutePreview {
                     dsn: dsn.clone(),
                     schema: schema.clone(),
                     table: table.clone(),
@@ -259,24 +260,24 @@ pub fn reduce(
                     read_only: state.session.read_only,
                 }])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
         Action::ExecuteAdhoc(query) => {
             if let Some(dsn) = &state.session.dsn {
                 state.query.begin_running(now);
-                Some(vec![Effect::ExecuteAdhoc {
+                DispatchResult::effects(vec![Effect::ExecuteAdhoc {
                     dsn: dsn.clone(),
                     query: query.clone(),
                     read_only: state.session.read_only,
                 }])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -137,9 +137,9 @@ pub fn reduce(
                         .set_post_delete_selection(PostDeleteRowSelection::Keep);
                 }
 
-                DispatchResult::effects(try_adhoc_refresh(state, result))
+                DispatchResult::handled_with(try_adhoc_refresh(state, result))
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
         Action::QueryFailed {
@@ -175,7 +175,7 @@ pub fn reduce(
                     state.sql_modal.finish_adhoc_error(user_message);
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::CommandLineSubmit => {
@@ -184,7 +184,7 @@ pub fn reduce(
             state.modal.pop_mode();
             state.command_line_input.clear();
 
-            DispatchResult::effects(match follow_up {
+            DispatchResult::handled_with(match follow_up {
                 Action::Quit => {
                     state.should_quit = true;
                     vec![]
@@ -249,7 +249,7 @@ pub fn reduce(
                     });
                 state.query.pagination.total_rows_estimate = row_estimate;
 
-                DispatchResult::effects(vec![Effect::ExecutePreview {
+                DispatchResult::handled_with(vec![Effect::ExecutePreview {
                     dsn: dsn.clone(),
                     schema: schema.clone(),
                     table: table.clone(),
@@ -260,20 +260,20 @@ pub fn reduce(
                     read_only: state.session.read_only,
                 }])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 
         Action::ExecuteAdhoc(query) => {
             if let Some(dsn) = &state.session.dsn {
                 state.query.begin_running(now);
-                DispatchResult::effects(vec![Effect::ExecuteAdhoc {
+                DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
                     dsn: dsn.clone(),
                     query: query.clone(),
                     read_only: state.session.read_only,
                 }])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -4,17 +4,17 @@ mod write;
 
 use std::time::Instant;
 
-use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::services::AppServices;
 use crate::update::action::Action;
+use crate::update::dispatch_result::DispatchResult;
 
 pub fn reduce_query(
     state: &mut AppState,
     action: &Action,
     now: Instant,
     services: &AppServices,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     execution::reduce(state, action, now, services)
         .or_else(|| write::reduce(state, action, now, services))
         .or_else(|| pagination::reduce(state, action, now, services))

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -8,24 +8,25 @@ use crate::model::browse::query_execution::PREVIEW_PAGE_SIZE;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
+use crate::update::dispatch_result::DispatchResult;
 
 pub fn reduce(
     state: &mut AppState,
     action: &Action,
     now: Instant,
     _services: &AppServices,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     match action {
         Action::RequestCsvExport => {
             if !state.can_request_csv_export() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let Some(result) = state.query.visible_result() else {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             };
             let dsn = match &state.session.dsn {
                 Some(d) => d.clone(),
-                None => return Some(vec![]),
+                None => return DispatchResult::no_effects(),
             };
 
             let export_query = result.query.clone();
@@ -49,7 +50,7 @@ pub fn reduce(
             let stripped = export_query.trim_end().trim_end_matches(';').to_string();
             let count_query = format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count");
 
-            Some(vec![Effect::CountRowsForExport {
+            DispatchResult::effects(vec![Effect::CountRowsForExport {
                 dsn,
                 count_query,
                 export_query,
@@ -85,13 +86,13 @@ pub fn reduce(
                     },
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
-                Some(vec![])
+                DispatchResult::no_effects()
             } else {
                 let dsn = match &state.session.dsn {
                     Some(d) => d.clone(),
-                    None => return Some(vec![]),
+                    None => return DispatchResult::no_effects(),
                 };
-                Some(vec![Effect::ExportCsv {
+                DispatchResult::effects(vec![Effect::ExportCsv {
                     dsn,
                     query: export_query.clone(),
                     file_name: file_name.clone(),
@@ -108,9 +109,9 @@ pub fn reduce(
         } => {
             let dsn = match &state.session.dsn {
                 Some(d) => d.clone(),
-                None => return Some(vec![]),
+                None => return DispatchResult::no_effects(),
             };
-            Some(vec![Effect::ExportCsv {
+            DispatchResult::effects(vec![Effect::ExportCsv {
                 dsn,
                 query: export_query.clone(),
                 file_name: file_name.clone(),
@@ -128,12 +129,12 @@ pub fn reduce(
             let folder = Path::new(path)
                 .parent()
                 .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
-            Some(vec![Effect::OpenFolder { path: folder }])
+            DispatchResult::effects(vec![Effect::OpenFolder { path: folder }])
         }
 
         Action::CsvExportFailed(error) => {
             state.messages.set_error_at(error.user_message(), now);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::OpenFolderFailed(error) => {
@@ -141,21 +142,21 @@ pub fn reduce(
                 .messages
                 .set_error_at(format!("Failed to open folder: {error}"), now);
 
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::ResultNextPage => {
             if state.query.is_running() || !state.query.can_paginate_visible_result() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if !state.query.pagination.can_next() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if let Some(dsn) = state.session.dsn.clone() {
                 let next_page = state.query.pagination.current_page + 1;
                 state.query.begin_running(now);
                 state.result_interaction.reset_view();
-                Some(vec![Effect::ExecutePreview {
+                DispatchResult::effects(vec![Effect::ExecutePreview {
                     dsn,
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
@@ -166,23 +167,23 @@ pub fn reduce(
                     read_only: state.session.read_only,
                 }])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
         Action::ResultPrevPage => {
             if state.query.is_running() || !state.query.can_paginate_visible_result() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if !state.query.pagination.can_prev() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if let Some(dsn) = state.session.dsn.clone() {
                 let prev_page = state.query.pagination.current_page - 1;
                 state.query.begin_running(now);
                 state.result_interaction.reset_view();
                 state.query.pagination.reached_end = false;
-                Some(vec![Effect::ExecutePreview {
+                DispatchResult::effects(vec![Effect::ExecutePreview {
                     dsn,
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
@@ -193,11 +194,11 @@ pub fn reduce(
                     read_only: state.session.read_only,
                 }])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -19,14 +19,14 @@ pub fn reduce(
     match action {
         Action::RequestCsvExport => {
             if !state.can_request_csv_export() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let Some(result) = state.query.visible_result() else {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             };
             let dsn = match &state.session.dsn {
                 Some(d) => d.clone(),
-                None => return DispatchResult::no_effects(),
+                None => return DispatchResult::handled(),
             };
 
             let export_query = result.query.clone();
@@ -50,7 +50,7 @@ pub fn reduce(
             let stripped = export_query.trim_end().trim_end_matches(';').to_string();
             let count_query = format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count");
 
-            DispatchResult::effects(vec![Effect::CountRowsForExport {
+            DispatchResult::handled_with(vec![Effect::CountRowsForExport {
                 dsn,
                 count_query,
                 export_query,
@@ -86,13 +86,13 @@ pub fn reduce(
                     },
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             } else {
                 let dsn = match &state.session.dsn {
                     Some(d) => d.clone(),
-                    None => return DispatchResult::no_effects(),
+                    None => return DispatchResult::handled(),
                 };
-                DispatchResult::effects(vec![Effect::ExportCsv {
+                DispatchResult::handled_with(vec![Effect::ExportCsv {
                     dsn,
                     query: export_query.clone(),
                     file_name: file_name.clone(),
@@ -109,9 +109,9 @@ pub fn reduce(
         } => {
             let dsn = match &state.session.dsn {
                 Some(d) => d.clone(),
-                None => return DispatchResult::no_effects(),
+                None => return DispatchResult::handled(),
             };
-            DispatchResult::effects(vec![Effect::ExportCsv {
+            DispatchResult::handled_with(vec![Effect::ExportCsv {
                 dsn,
                 query: export_query.clone(),
                 file_name: file_name.clone(),
@@ -129,12 +129,12 @@ pub fn reduce(
             let folder = Path::new(path)
                 .parent()
                 .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
-            DispatchResult::effects(vec![Effect::OpenFolder { path: folder }])
+            DispatchResult::handled_with(vec![Effect::OpenFolder { path: folder }])
         }
 
         Action::CsvExportFailed(error) => {
             state.messages.set_error_at(error.user_message(), now);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::OpenFolderFailed(error) => {
@@ -142,21 +142,21 @@ pub fn reduce(
                 .messages
                 .set_error_at(format!("Failed to open folder: {error}"), now);
 
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::ResultNextPage => {
             if state.query.is_running() || !state.query.can_paginate_visible_result() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if !state.query.pagination.can_next() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if let Some(dsn) = state.session.dsn.clone() {
                 let next_page = state.query.pagination.current_page + 1;
                 state.query.begin_running(now);
                 state.result_interaction.reset_view();
-                DispatchResult::effects(vec![Effect::ExecutePreview {
+                DispatchResult::handled_with(vec![Effect::ExecutePreview {
                     dsn,
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
@@ -167,23 +167,23 @@ pub fn reduce(
                     read_only: state.session.read_only,
                 }])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 
         Action::ResultPrevPage => {
             if state.query.is_running() || !state.query.can_paginate_visible_result() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if !state.query.pagination.can_prev() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if let Some(dsn) = state.session.dsn.clone() {
                 let prev_page = state.query.pagination.current_page - 1;
                 state.query.begin_running(now);
                 state.result_interaction.reset_view();
                 state.query.pagination.reached_end = false;
-                DispatchResult::effects(vec![Effect::ExecutePreview {
+                DispatchResult::handled_with(vec![Effect::ExecutePreview {
                     dsn,
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
@@ -194,7 +194,7 @@ pub fn reduce(
                     read_only: state.session.read_only,
                 }])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -15,6 +15,7 @@ use crate::policy::write::write_update::{
 };
 use crate::services::AppServices;
 use crate::update::action::Action;
+use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{
     EditGuardrailError, build_bulk_delete_preview, editable_preview_base,
 };
@@ -138,7 +139,7 @@ pub fn reduce(
     action: &Action,
     now: Instant,
     services: &AppServices,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     match action {
         Action::SubmitCellEditWrite => {
             if !state.result_interaction.staged_delete_rows().is_empty() {
@@ -150,13 +151,13 @@ pub fn reduce(
                             result.target_row,
                             staged_count,
                         );
-                        return Some(vec![Effect::DispatchActions(vec![
+                        return DispatchResult::effects(vec![Effect::DispatchActions(vec![
                             Action::OpenWritePreviewConfirm(Box::new(result.preview)),
                         ])]);
                     }
                     Err(err) => {
                         state.messages.set_error_at(err.to_string(), now);
-                        return Some(vec![]);
+                        return DispatchResult::no_effects();
                     }
                 }
             }
@@ -166,16 +167,16 @@ pub fn reduce(
                     EditGuardrailError::WriteUnavailableWhileQueryRunning.to_string(),
                     now,
                 );
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             match build_update_preview(state, services) {
-                Ok(preview) => Some(vec![Effect::DispatchActions(vec![
+                Ok(preview) => DispatchResult::effects(vec![Effect::DispatchActions(vec![
                     Action::OpenWritePreviewConfirm(Box::new(preview)),
                 ])]),
                 Err(err) => {
                     state.messages.set_error_at(err.to_string(), now);
-                    Some(vec![])
+                    DispatchResult::no_effects()
                 }
             }
         }
@@ -186,7 +187,7 @@ pub fn reduce(
                     "Read-only mode: write operations are disabled".to_string(),
                     now,
                 );
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             state
                 .result_interaction
@@ -224,7 +225,7 @@ pub fn reduce(
             }
             state.modal.push_mode(InputMode::ConfirmDialog);
 
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::ExecuteWrite(query) => {
@@ -233,11 +234,11 @@ pub fn reduce(
                     "Read-only mode: write operations are disabled".to_string(),
                     now,
                 );
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if let Some(dsn) = &state.session.dsn {
                 state.query.begin_running(now);
-                Some(vec![Effect::ExecuteWrite {
+                DispatchResult::effects(vec![Effect::ExecuteWrite {
                     dsn: dsn.clone(),
                     query: query.clone(),
                     read_only: state.session.read_only,
@@ -246,7 +247,7 @@ pub fn reduce(
                 state
                     .messages
                     .set_error_at("No active connection".to_string(), now);
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
@@ -265,7 +266,7 @@ pub fn reduce(
                             now,
                         );
                         state.modal.set_mode(InputMode::CellEdit);
-                        return Some(vec![]);
+                        return DispatchResult::no_effects();
                     }
 
                     state
@@ -277,7 +278,7 @@ pub fn reduce(
                     if let Some(dsn) = &state.session.dsn {
                         let page = state.query.pagination.current_page;
                         state.query.begin_running(now);
-                        Some(vec![Effect::ExecutePreview {
+                        DispatchResult::effects(vec![Effect::ExecutePreview {
                             dsn: dsn.clone(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
@@ -288,7 +289,7 @@ pub fn reduce(
                             read_only: state.session.read_only,
                         }])
                     } else {
-                        Some(vec![])
+                        DispatchResult::no_effects()
                     }
                 }
                 WriteOperation::Delete => {
@@ -335,7 +336,7 @@ pub fn reduce(
                     if let Some(dsn) = &state.session.dsn {
                         state.query.begin_running(now);
                         state.query.pagination.reached_end = false;
-                        Some(vec![Effect::ExecutePreview {
+                        DispatchResult::effects(vec![Effect::ExecutePreview {
                             dsn: dsn.clone(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
@@ -346,7 +347,7 @@ pub fn reduce(
                             read_only: state.session.read_only,
                         }])
                     } else {
-                        Some(vec![])
+                        DispatchResult::no_effects()
                     }
                 }
             }
@@ -365,10 +366,10 @@ pub fn reduce(
                 WriteOperation::Update => InputMode::CellEdit,
                 WriteOperation::Delete => InputMode::Normal,
             });
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -418,7 +419,12 @@ mod tests {
                 Instant::now(),
                 &AppServices::stub(),
             );
-            assert!(effects.unwrap().is_empty());
+            assert!(
+                effects
+                    .into_effects()
+                    .expect("reducer should handle action")
+                    .is_empty()
+            );
             assert_eq!(
                 state.messages.last_error.as_deref(),
                 Some("No active cell edit session")
@@ -436,7 +442,12 @@ mod tests {
                 Instant::now(),
                 &AppServices::stub(),
             );
-            assert!(effects.unwrap().is_empty());
+            assert!(
+                effects
+                    .into_effects()
+                    .expect("reducer should handle action")
+                    .is_empty()
+            );
             assert_eq!(
                 state.messages.last_error.as_deref(),
                 Some("Write is unavailable while query is running")
@@ -457,7 +468,12 @@ mod tests {
                 Instant::now(),
                 &AppServices::stub(),
             );
-            assert!(effects.unwrap().is_empty());
+            assert!(
+                effects
+                    .into_effects()
+                    .expect("reducer should handle action")
+                    .is_empty()
+            );
             assert_eq!(
                 state.messages.last_error.as_deref(),
                 Some("Table metadata does not match current preview target")

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -151,13 +151,13 @@ pub fn reduce(
                             result.target_row,
                             staged_count,
                         );
-                        return DispatchResult::effects(vec![Effect::DispatchActions(vec![
+                        return DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
                             Action::OpenWritePreviewConfirm(Box::new(result.preview)),
                         ])]);
                     }
                     Err(err) => {
                         state.messages.set_error_at(err.to_string(), now);
-                        return DispatchResult::no_effects();
+                        return DispatchResult::handled();
                     }
                 }
             }
@@ -167,16 +167,16 @@ pub fn reduce(
                     EditGuardrailError::WriteUnavailableWhileQueryRunning.to_string(),
                     now,
                 );
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             match build_update_preview(state, services) {
-                Ok(preview) => DispatchResult::effects(vec![Effect::DispatchActions(vec![
+                Ok(preview) => DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
                     Action::OpenWritePreviewConfirm(Box::new(preview)),
                 ])]),
                 Err(err) => {
                     state.messages.set_error_at(err.to_string(), now);
-                    DispatchResult::no_effects()
+                    DispatchResult::handled()
                 }
             }
         }
@@ -187,7 +187,7 @@ pub fn reduce(
                     "Read-only mode: write operations are disabled".to_string(),
                     now,
                 );
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             state
                 .result_interaction
@@ -225,7 +225,7 @@ pub fn reduce(
             }
             state.modal.push_mode(InputMode::ConfirmDialog);
 
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::ExecuteWrite(query) => {
@@ -234,11 +234,11 @@ pub fn reduce(
                     "Read-only mode: write operations are disabled".to_string(),
                     now,
                 );
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if let Some(dsn) = &state.session.dsn {
                 state.query.begin_running(now);
-                DispatchResult::effects(vec![Effect::ExecuteWrite {
+                DispatchResult::handled_with(vec![Effect::ExecuteWrite {
                     dsn: dsn.clone(),
                     query: query.clone(),
                     read_only: state.session.read_only,
@@ -247,7 +247,7 @@ pub fn reduce(
                 state
                     .messages
                     .set_error_at("No active connection".to_string(), now);
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 
@@ -266,7 +266,7 @@ pub fn reduce(
                             now,
                         );
                         state.modal.set_mode(InputMode::CellEdit);
-                        return DispatchResult::no_effects();
+                        return DispatchResult::handled();
                     }
 
                     state
@@ -278,7 +278,7 @@ pub fn reduce(
                     if let Some(dsn) = &state.session.dsn {
                         let page = state.query.pagination.current_page;
                         state.query.begin_running(now);
-                        DispatchResult::effects(vec![Effect::ExecutePreview {
+                        DispatchResult::handled_with(vec![Effect::ExecutePreview {
                             dsn: dsn.clone(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
@@ -289,7 +289,7 @@ pub fn reduce(
                             read_only: state.session.read_only,
                         }])
                     } else {
-                        DispatchResult::no_effects()
+                        DispatchResult::handled()
                     }
                 }
                 WriteOperation::Delete => {
@@ -336,7 +336,7 @@ pub fn reduce(
                     if let Some(dsn) = &state.session.dsn {
                         state.query.begin_running(now);
                         state.query.pagination.reached_end = false;
-                        DispatchResult::effects(vec![Effect::ExecutePreview {
+                        DispatchResult::handled_with(vec![Effect::ExecutePreview {
                             dsn: dsn.clone(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
@@ -347,7 +347,7 @@ pub fn reduce(
                             read_only: state.session.read_only,
                         }])
                     } else {
-                        DispatchResult::no_effects()
+                        DispatchResult::handled()
                     }
                 }
             }
@@ -366,7 +366,7 @@ pub fn reduce(
                 WriteOperation::Update => InputMode::CellEdit,
                 WriteOperation::Delete => InputMode::Normal,
             });
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         _ => DispatchResult::pass(),

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -72,12 +72,12 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 state
                     .messages
                     .set_error_at("Read-only mode: editing is disabled".to_string(), now);
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             // JSONB columns open the dedicated detail modal instead of inline edit
             if is_jsonb_cell(state) {
-                return DispatchResult::effects(vec![Effect::DispatchActions(vec![
+                return DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
                     Action::OpenModal(ModalKind::JsonbDetail),
                 ])]);
             }
@@ -93,11 +93,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                         state.result_interaction.clear_write_preview();
                     }
                     state.modal.set_mode(InputMode::CellEdit);
-                    DispatchResult::no_effects()
+                    DispatchResult::handled()
                 }
                 Err(reason) => {
                     state.messages.set_error_at(reason.to_string(), now);
-                    DispatchResult::no_effects()
+                    DispatchResult::handled()
                 }
             }
         }
@@ -108,12 +108,12 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 state.result_interaction.discard_cell_edit();
             }
             state.modal.set_mode(InputMode::Normal);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ResultDiscardCellEdit => {
             state.result_interaction.discard_cell_edit();
             state.modal.set_mode(InputMode::Normal);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextInput {
             target: InputTarget::ResultCellEdit,
@@ -123,19 +123,19 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 .result_interaction
                 .cell_edit_input_mut()
                 .insert_char(*c);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::ResultCellEdit,
         } => {
             state.result_interaction.cell_edit_input_mut().backspace();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextDelete {
             target: InputTarget::ResultCellEdit,
         } => {
             state.result_interaction.cell_edit_input_mut().delete();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: InputTarget::ResultCellEdit,
@@ -145,7 +145,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 .result_interaction
                 .cell_edit_input_mut()
                 .move_cursor(*m);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         _ => DispatchResult::pass(),
     }

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -7,6 +7,7 @@ use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::write::write_update::build_pk_pairs;
 use crate::update::action::{Action, InputTarget, ModalKind};
+use crate::update::dispatch_result::DispatchResult;
 
 use crate::update::helpers::{EditGuardrailError, editable_preview_base};
 
@@ -64,21 +65,21 @@ fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), Edi
     Ok((row_idx, col_idx, cell_value))
 }
 
-pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::ResultEnterCellEdit => {
             if state.session.read_only {
                 state
                     .messages
                     .set_error_at("Read-only mode: editing is disabled".to_string(), now);
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             // JSONB columns open the dedicated detail modal instead of inline edit
             if is_jsonb_cell(state) {
-                return Some(vec![Effect::DispatchActions(vec![Action::OpenModal(
-                    ModalKind::JsonbDetail,
-                )])]);
+                return DispatchResult::effects(vec![Effect::DispatchActions(vec![
+                    Action::OpenModal(ModalKind::JsonbDetail),
+                ])]);
             }
 
             match editable_cell_context(state) {
@@ -92,11 +93,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                         state.result_interaction.clear_write_preview();
                     }
                     state.modal.set_mode(InputMode::CellEdit);
-                    Some(vec![])
+                    DispatchResult::no_effects()
                 }
                 Err(reason) => {
                     state.messages.set_error_at(reason.to_string(), now);
-                    Some(vec![])
+                    DispatchResult::no_effects()
                 }
             }
         }
@@ -107,12 +108,12 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 state.result_interaction.discard_cell_edit();
             }
             state.modal.set_mode(InputMode::Normal);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ResultDiscardCellEdit => {
             state.result_interaction.discard_cell_edit();
             state.modal.set_mode(InputMode::Normal);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextInput {
             target: InputTarget::ResultCellEdit,
@@ -122,19 +123,19 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 .result_interaction
                 .cell_edit_input_mut()
                 .insert_char(*c);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextBackspace {
             target: InputTarget::ResultCellEdit,
         } => {
             state.result_interaction.cell_edit_input_mut().backspace();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextDelete {
             target: InputTarget::ResultCellEdit,
         } => {
             state.result_interaction.cell_edit_input_mut().delete();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextMoveCursor {
             target: InputTarget::ResultCellEdit,
@@ -144,9 +145,9 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 .result_interaction
                 .cell_edit_input_mut()
                 .move_cursor(*m);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -210,7 +211,9 @@ mod tests {
                 .set_content("modified".to_string());
             state.modal.set_mode(InputMode::Normal);
 
-            reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now()).unwrap();
+            reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(state.input_mode(), InputMode::CellEdit);
             assert_eq!(
@@ -233,7 +236,9 @@ mod tests {
                 .cell_edit_input_mut()
                 .set_content("stale-modified".to_string());
 
-            reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now()).unwrap();
+            reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(state.input_mode(), InputMode::CellEdit);
             assert_eq!(state.result_interaction.cell_edit().col, Some(1));
@@ -257,7 +262,9 @@ mod tests {
                 comment: None,
             }));
 
-            let effects = reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now()).unwrap();
+            let effects = reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::Normal);
@@ -277,7 +284,9 @@ mod tests {
                 .begin_cell_edit(0, 1, "alice".to_string());
             state.modal.set_mode(InputMode::CellEdit);
 
-            reduce(&mut state, &Action::ResultCancelCellEdit, Instant::now()).unwrap();
+            reduce(&mut state, &Action::ResultCancelCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(!state.result_interaction.cell_edit().is_active());
@@ -298,7 +307,9 @@ mod tests {
                 .set_content("bob".to_string());
             state.modal.set_mode(InputMode::CellEdit);
 
-            reduce(&mut state, &Action::ResultCancelCellEdit, Instant::now()).unwrap();
+            reduce(&mut state, &Action::ResultCancelCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(state.result_interaction.cell_edit().is_active());
@@ -339,7 +350,9 @@ mod tests {
         fn jsonb_cell_returns_dispatch_to_open_jsonb_detail() {
             let mut state = state_with_jsonb_column();
 
-            let effects = reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now()).unwrap();
+            let effects = reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
             assert!(matches!(
@@ -360,7 +373,9 @@ mod tests {
                 .set_table_detail_raw(Some(cell_edit_entry_guardrails::minimal_users_table()));
             state.session.read_only = true;
 
-            let effects = reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now()).unwrap();
+            let effects = reduce(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::Normal);

--- a/src/app/update/browse/result/history.rs
+++ b/src/app/update/browse/result/history.rs
@@ -1,17 +1,17 @@
-use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::update::action::Action;
+use crate::update::dispatch_result::DispatchResult;
 
-pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::OpenResultHistory => {
             let len = state.query.result_history().len();
             if len == 0 {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             state.query.enter_history(len - 1);
             state.result_interaction.reset_view();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::HistoryOlder => {
             if let Some(idx) = state.query.history_index()
@@ -20,7 +20,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 state.query.enter_history(idx - 1);
                 state.result_interaction.reset_view();
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::HistoryNewer => {
             if let Some(idx) = state.query.history_index() {
@@ -30,14 +30,14 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     state.result_interaction.reset_view();
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ExitResultHistory => {
             state.query.exit_history();
             state.result_interaction.reset_view();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 

--- a/src/app/update/browse/result/history.rs
+++ b/src/app/update/browse/result/history.rs
@@ -7,11 +7,11 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
         Action::OpenResultHistory => {
             let len = state.query.result_history().len();
             if len == 0 {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             state.query.enter_history(len - 1);
             state.result_interaction.reset_view();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::HistoryOlder => {
             if let Some(idx) = state.query.history_index()
@@ -20,7 +20,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                 state.query.enter_history(idx - 1);
                 state.result_interaction.reset_view();
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::HistoryNewer => {
             if let Some(idx) = state.query.history_index() {
@@ -30,12 +30,12 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     state.result_interaction.reset_view();
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ExitResultHistory => {
             state.query.exit_history();
             state.result_interaction.reset_view();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         _ => DispatchResult::pass(),
     }

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -14,17 +14,18 @@ use crate::model::shared::text_input::TextInputLike;
 use crate::model::shared::ui_state::DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS;
 use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
+use crate::update::dispatch_result::DispatchResult;
 
-pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::JsonbDetail) => {
             let result = match state.query.visible_result() {
                 Some(r) if r.source == QuerySource::Preview && !r.is_error() => r,
-                _ => return Some(vec![]),
+                _ => return DispatchResult::no_effects(),
             };
 
             if state.query.is_history_mode() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             let table_detail = match state.session.table_detail() {
@@ -34,24 +35,24 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 {
                     td
                 }
-                _ => return Some(vec![]),
+                _ => return DispatchResult::no_effects(),
             };
 
             let Some(row_idx) = state.result_interaction.selection().row() else {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             };
             let Some(col_idx) = state.result_interaction.selection().cell() else {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             };
 
             let column = match table_detail.columns.get(col_idx) {
                 Some(c) if c.data_type == "jsonb" => c,
-                _ => return Some(vec![]),
+                _ => return DispatchResult::no_effects(),
             };
 
             let cell_value = match result.rows.get(row_idx).and_then(|r| r.get(col_idx)) {
                 Some(v) if !v.is_empty() => v,
-                _ => return Some(vec![]),
+                _ => return DispatchResult::no_effects(),
             };
 
             let pretty_original = match serde_json::from_str::<serde_json::Value>(cell_value) {
@@ -62,7 +63,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                     state
                         .messages
                         .set_error_at(format!("Invalid JSON: {err}"), now);
-                    return Some(vec![]);
+                    return DispatchResult::no_effects();
                 }
             };
 
@@ -74,20 +75,20 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 pretty_original,
             );
             state.modal.push_mode(InputMode::JsonbDetail);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::CloseModal(ModalKind::JsonbDetail) => {
             apply_pending_edit_as_draft(state);
             state.jsonb_detail.close();
             state.modal.pop_mode();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::JsonbYankAll => {
             let json = state.jsonb_detail.current_json_for_yank();
             state.flash_timers.set(FlashId::JsonbDetail, now);
-            Some(vec![Effect::CopyToClipboard {
+            DispatchResult::effects(vec![Effect::CopyToClipboard {
                 content: json,
                 on_success: Some(Action::CellCopied),
                 on_failure: Some(Action::CopyFailed(ClipboardError::Unavailable(
@@ -101,11 +102,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 state
                     .messages
                     .set_error_at("Read-only mode: editing is disabled".to_string(), now);
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             state.jsonb_detail.enter_edit();
             state.modal.replace_mode(InputMode::JsonbEdit);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::JsonbAppendInsert => {
@@ -113,7 +114,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 state
                     .messages
                     .set_error_at("Read-only mode: editing is disabled".to_string(), now);
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             state
                 .jsonb_detail
@@ -122,13 +123,13 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             update_editor_scroll(state);
             state.jsonb_detail.enter_edit();
             state.modal.replace_mode(InputMode::JsonbEdit);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::JsonbExitEdit => {
             state.jsonb_detail.exit_edit();
             state.modal.replace_mode(InputMode::JsonbDetail);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::TextInput {
@@ -144,7 +145,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             }
             update_editor_scroll(state);
             validate_editor_inline(state);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::TextBackspace {
@@ -153,7 +154,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             state.jsonb_detail.editor_mut().backspace();
             update_editor_scroll(state);
             validate_editor_inline(state);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::TextDelete {
@@ -162,7 +163,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             state.jsonb_detail.editor_mut().delete();
             update_editor_scroll(state);
             validate_editor_inline(state);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::TextMoveCursor {
@@ -183,30 +184,30 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             }
             update_editor_scroll(state);
             state.ui.key_sequence = KeySequenceState::Idle;
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::Paste(text) if state.input_mode() == InputMode::JsonbEdit => {
             state.jsonb_detail.editor_mut().insert_str(text);
             update_editor_scroll(state);
             validate_editor_inline(state);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::JsonbEnterSearch => {
             state.jsonb_detail.enter_search();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::JsonbExitSearch => {
             state.jsonb_detail.exit_search();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::JsonbSearchSubmit => {
             state.jsonb_detail.exit_search();
             jump_to_current_match(state);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::JsonbSearchNext => {
@@ -216,7 +217,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 state.jsonb_detail.search_mut().current_match = next;
                 jump_to_current_match(state);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::JsonbSearchPrev => {
@@ -230,7 +231,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 state.jsonb_detail.search_mut().current_match = prev;
                 jump_to_current_match(state);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::TextInput {
@@ -239,7 +240,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         } => {
             state.jsonb_detail.search_mut().input.insert_char(*ch);
             update_search_matches(state);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::TextBackspace {
@@ -247,7 +248,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         } => {
             state.jsonb_detail.search_mut().input.backspace();
             update_search_matches(state);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::TextDelete {
@@ -255,7 +256,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
         } => {
             state.jsonb_detail.search_mut().input.delete();
             update_search_matches(state);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::Paste(text)
@@ -265,7 +266,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
             state.jsonb_detail.search_mut().input.insert_str(&clean);
             update_search_matches(state);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::TextMoveCursor {
@@ -277,10 +278,10 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 .search_mut()
                 .input
                 .move_cursor(*direction);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -857,7 +858,7 @@ mod tests {
 
             let effects = reduce(&mut state, &Action::JsonbYankAll, Instant::now());
 
-            let effects = effects.expect("should return effects");
+            let effects = effects.into_effects().expect("should return effects");
             assert_eq!(effects.len(), 1);
             assert!(
                 matches!(&effects[0], Effect::CopyToClipboard { content, .. } if content.contains("theme"))

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -21,11 +21,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
         Action::OpenModal(ModalKind::JsonbDetail) => {
             let result = match state.query.visible_result() {
                 Some(r) if r.source == QuerySource::Preview && !r.is_error() => r,
-                _ => return DispatchResult::no_effects(),
+                _ => return DispatchResult::handled(),
             };
 
             if state.query.is_history_mode() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             let table_detail = match state.session.table_detail() {
@@ -35,24 +35,24 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 {
                     td
                 }
-                _ => return DispatchResult::no_effects(),
+                _ => return DispatchResult::handled(),
             };
 
             let Some(row_idx) = state.result_interaction.selection().row() else {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             };
             let Some(col_idx) = state.result_interaction.selection().cell() else {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             };
 
             let column = match table_detail.columns.get(col_idx) {
                 Some(c) if c.data_type == "jsonb" => c,
-                _ => return DispatchResult::no_effects(),
+                _ => return DispatchResult::handled(),
             };
 
             let cell_value = match result.rows.get(row_idx).and_then(|r| r.get(col_idx)) {
                 Some(v) if !v.is_empty() => v,
-                _ => return DispatchResult::no_effects(),
+                _ => return DispatchResult::handled(),
             };
 
             let pretty_original = match serde_json::from_str::<serde_json::Value>(cell_value) {
@@ -63,7 +63,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                     state
                         .messages
                         .set_error_at(format!("Invalid JSON: {err}"), now);
-                    return DispatchResult::no_effects();
+                    return DispatchResult::handled();
                 }
             };
 
@@ -75,20 +75,20 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 pretty_original,
             );
             state.modal.push_mode(InputMode::JsonbDetail);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::CloseModal(ModalKind::JsonbDetail) => {
             apply_pending_edit_as_draft(state);
             state.jsonb_detail.close();
             state.modal.pop_mode();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::JsonbYankAll => {
             let json = state.jsonb_detail.current_json_for_yank();
             state.flash_timers.set(FlashId::JsonbDetail, now);
-            DispatchResult::effects(vec![Effect::CopyToClipboard {
+            DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                 content: json,
                 on_success: Some(Action::CellCopied),
                 on_failure: Some(Action::CopyFailed(ClipboardError::Unavailable(
@@ -102,11 +102,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 state
                     .messages
                     .set_error_at("Read-only mode: editing is disabled".to_string(), now);
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             state.jsonb_detail.enter_edit();
             state.modal.replace_mode(InputMode::JsonbEdit);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::JsonbAppendInsert => {
@@ -114,7 +114,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 state
                     .messages
                     .set_error_at("Read-only mode: editing is disabled".to_string(), now);
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             state
                 .jsonb_detail
@@ -123,13 +123,13 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             update_editor_scroll(state);
             state.jsonb_detail.enter_edit();
             state.modal.replace_mode(InputMode::JsonbEdit);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::JsonbExitEdit => {
             state.jsonb_detail.exit_edit();
             state.modal.replace_mode(InputMode::JsonbDetail);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::TextInput {
@@ -145,7 +145,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             }
             update_editor_scroll(state);
             validate_editor_inline(state);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::TextBackspace {
@@ -154,7 +154,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             state.jsonb_detail.editor_mut().backspace();
             update_editor_scroll(state);
             validate_editor_inline(state);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::TextDelete {
@@ -163,7 +163,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             state.jsonb_detail.editor_mut().delete();
             update_editor_scroll(state);
             validate_editor_inline(state);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::TextMoveCursor {
@@ -184,30 +184,30 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             }
             update_editor_scroll(state);
             state.ui.key_sequence = KeySequenceState::Idle;
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::Paste(text) if state.input_mode() == InputMode::JsonbEdit => {
             state.jsonb_detail.editor_mut().insert_str(text);
             update_editor_scroll(state);
             validate_editor_inline(state);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::JsonbEnterSearch => {
             state.jsonb_detail.enter_search();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::JsonbExitSearch => {
             state.jsonb_detail.exit_search();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::JsonbSearchSubmit => {
             state.jsonb_detail.exit_search();
             jump_to_current_match(state);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::JsonbSearchNext => {
@@ -217,7 +217,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 state.jsonb_detail.search_mut().current_match = next;
                 jump_to_current_match(state);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::JsonbSearchPrev => {
@@ -231,7 +231,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 state.jsonb_detail.search_mut().current_match = prev;
                 jump_to_current_match(state);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::TextInput {
@@ -240,7 +240,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
         } => {
             state.jsonb_detail.search_mut().input.insert_char(*ch);
             update_search_matches(state);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::TextBackspace {
@@ -248,7 +248,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
         } => {
             state.jsonb_detail.search_mut().input.backspace();
             update_search_matches(state);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::TextDelete {
@@ -256,7 +256,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
         } => {
             state.jsonb_detail.search_mut().input.delete();
             update_search_matches(state);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::Paste(text)
@@ -266,7 +266,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
             state.jsonb_detail.search_mut().input.insert_str(&clean);
             update_search_matches(state);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::TextMoveCursor {
@@ -278,7 +278,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 .search_mut()
                 .input
                 .move_cursor(*direction);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         _ => DispatchResult::pass(),

--- a/src/app/update/browse/result/mod.rs
+++ b/src/app/update/browse/result/mod.rs
@@ -7,17 +7,17 @@ mod yank;
 
 use std::time::Instant;
 
-use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::services::AppServices;
 use crate::update::action::Action;
+use crate::update::dispatch_result::DispatchResult;
 
 pub fn reduce_result(
     state: &mut AppState,
     action: &Action,
     services: &AppServices,
     now: Instant,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     scroll::reduce(state, action)
         .or_else(|| selection::reduce(state, action, now))
         .or_else(|| edit::reduce(state, action, now))

--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -85,7 +85,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                 }
                 _ => {} // row == 0, no-op
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -104,7 +104,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     s.result_interaction.scroll_offset += 1;
                 }
             });
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -112,7 +112,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
             amount: ScrollAmount::ToStart,
         } => {
             move_row_or_scroll(state, 0, |s| s.result_interaction.scroll_offset = 0);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -124,7 +124,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
             move_row_or_scroll(state, max_row, |s| {
                 s.result_interaction.scroll_offset = max_scroll;
             });
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -140,7 +140,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                 state.result_interaction.move_row(target_row);
                 ensure_row_visible(state);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -152,7 +152,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                 state.result_interaction.move_row(target);
                 ensure_row_visible(state);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -168,7 +168,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                 state.result_interaction.move_row(target);
                 ensure_row_visible(state);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -179,7 +179,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
             if delta > 0 {
                 move_result_row_and_scroll(state, *direction, delta);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         // Scroll-to-cursor (zz/zt/zb): only meaningful with an active cell
         Action::ScrollToCursor {
@@ -195,7 +195,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                         row.saturating_sub(visible / 2).min(max_scroll);
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ScrollToCursor {
             target: ScrollToCursorTarget::Result,
@@ -209,7 +209,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                     state.result_interaction.scroll_offset = row.min(max_scroll);
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ScrollToCursor {
             target: ScrollToCursorTarget::Result,
@@ -225,7 +225,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                         .min(max_scroll);
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -234,7 +234,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
         } => {
             state.result_interaction.horizontal_offset =
                 calculate_prev_column_offset(state.result_interaction.horizontal_offset);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -248,7 +248,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
                 state.result_interaction.horizontal_offset,
                 plan.column_count,
             );
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         _ => DispatchResult::pass(),
     }

--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -1,10 +1,10 @@
-use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::key_sequence::KeySequenceState;
 use crate::model::shared::viewport::{calculate_next_column_offset, calculate_prev_column_offset};
 use crate::update::action::{
     Action, CursorPosition, ScrollAmount, ScrollDirection, ScrollTarget, ScrollToCursorTarget,
 };
+use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn result_row_count(state: &AppState) -> usize {
     state.query.visible_result().map_or(0, |r| r.rows.len())
@@ -65,7 +65,7 @@ fn move_result_row_and_scroll(state: &mut AppState, direction: ScrollDirection, 
     scroll_result_by(state, direction, delta);
 }
 
-pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -85,7 +85,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 }
                 _ => {} // row == 0, no-op
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -104,7 +104,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     s.result_interaction.scroll_offset += 1;
                 }
             });
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -112,7 +112,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
             amount: ScrollAmount::ToStart,
         } => {
             move_row_or_scroll(state, 0, |s| s.result_interaction.scroll_offset = 0);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -124,7 +124,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
             move_row_or_scroll(state, max_row, |s| {
                 s.result_interaction.scroll_offset = max_scroll;
             });
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -140,7 +140,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 state.result_interaction.move_row(target_row);
                 ensure_row_visible(state);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -152,7 +152,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 state.result_interaction.move_row(target);
                 ensure_row_visible(state);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -168,7 +168,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 state.result_interaction.move_row(target);
                 ensure_row_visible(state);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -179,7 +179,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
             if delta > 0 {
                 move_result_row_and_scroll(state, *direction, delta);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         // Scroll-to-cursor (zz/zt/zb): only meaningful with an active cell
         Action::ScrollToCursor {
@@ -195,7 +195,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                         row.saturating_sub(visible / 2).min(max_scroll);
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ScrollToCursor {
             target: ScrollToCursorTarget::Result,
@@ -209,7 +209,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                     state.result_interaction.scroll_offset = row.min(max_scroll);
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ScrollToCursor {
             target: ScrollToCursorTarget::Result,
@@ -225,7 +225,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                         .min(max_scroll);
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -234,7 +234,7 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
         } => {
             state.result_interaction.horizontal_offset =
                 calculate_prev_column_offset(state.result_interaction.horizontal_offset);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Result,
@@ -248,9 +248,9 @@ pub fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
                 state.result_interaction.horizontal_offset,
                 plan.column_count,
             );
-            Some(vec![])
+            DispatchResult::no_effects()
         }
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -302,7 +302,7 @@ mod tests {
                     },
                 );
 
-                assert!(effects.is_some());
+                assert!(effects.is_handled());
                 assert_eq!(state.result_interaction.scroll_offset, 10);
             }
 

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -31,11 +31,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 let col = state.result_interaction.horizontal_offset.min(cols - 1);
                 state.result_interaction.activate_cell(row, col);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ResultExitToScroll => {
             state.result_interaction.exit_cell_to_scroll();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ResultCellLeft => {
             if let Some(c) = state.result_interaction.selection().cell()
@@ -44,7 +44,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 state.result_interaction.move_cell(c - 1);
                 ensure_cell_visible(state);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ResultCellRight => {
             if let Some(c) = state.result_interaction.selection().cell() {
@@ -54,11 +54,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                     ensure_cell_visible(state);
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ResultDeleteOperatorPending => {
             state.result_interaction.start_delete_operator();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::StageRowForDelete => {
             if state.session.read_only {
@@ -66,20 +66,20 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                     "Read-only mode: delete operations are disabled".to_string(),
                     now,
                 );
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if let Some(row_idx) = state.result_interaction.selection().row() {
                 state.result_interaction.stage_row(row_idx);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::UnstageLastStagedRow => {
             state.result_interaction.unstage_last_row();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ClearStagedDeletes => {
             state.result_interaction.clear_staged_deletes();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ResultNextPage | Action::ResultPrevPage => {
             DispatchResult::pass() // Handled entirely by the query reducer (reset only after transition confirmed)

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -1,10 +1,10 @@
 use std::time::Instant;
 
-use crate::cmd::effect::Effect;
 #[cfg(test)]
 use crate::domain::ColumnAttributes;
 use crate::model::app_state::AppState;
 use crate::update::action::Action;
+use crate::update::dispatch_result::DispatchResult;
 
 use super::scroll::{result_col_count, result_row_count};
 
@@ -21,7 +21,7 @@ fn ensure_cell_visible(state: &mut AppState) {
     }
 }
 
-pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::ResultActivateCell => {
             let rows = result_row_count(state);
@@ -31,11 +31,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 let col = state.result_interaction.horizontal_offset.min(cols - 1);
                 state.result_interaction.activate_cell(row, col);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ResultExitToScroll => {
             state.result_interaction.exit_cell_to_scroll();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ResultCellLeft => {
             if let Some(c) = state.result_interaction.selection().cell()
@@ -44,7 +44,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 state.result_interaction.move_cell(c - 1);
                 ensure_cell_visible(state);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ResultCellRight => {
             if let Some(c) = state.result_interaction.selection().cell() {
@@ -54,11 +54,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                     ensure_cell_visible(state);
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ResultDeleteOperatorPending => {
             state.result_interaction.start_delete_operator();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::StageRowForDelete => {
             if state.session.read_only {
@@ -66,25 +66,25 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                     "Read-only mode: delete operations are disabled".to_string(),
                     now,
                 );
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if let Some(row_idx) = state.result_interaction.selection().row() {
                 state.result_interaction.stage_row(row_idx);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::UnstageLastStagedRow => {
             state.result_interaction.unstage_last_row();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ClearStagedDeletes => {
             state.result_interaction.clear_staged_deletes();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ResultNextPage | Action::ResultPrevPage => {
-            None // Handled entirely by the query reducer (reset only after transition confirmed)
+            DispatchResult::pass() // Handled entirely by the query reducer (reset only after transition confirmed)
         }
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -229,7 +229,9 @@ mod tests {
             state.result_interaction.activate_cell(0, 0);
             state.session.read_only = true;
 
-            let effects = reduce(&mut state, &Action::StageRowForDelete, Instant::now()).unwrap();
+            let effects = reduce(&mut state, &Action::StageRowForDelete, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
             assert!(state.result_interaction.staged_delete_rows().is_empty());
@@ -248,7 +250,7 @@ mod tests {
 
             let result = reduce(&mut state, &Action::ResultNextPage, Instant::now());
 
-            assert!(result.is_none());
+            assert!(result.is_pass());
             assert_eq!(state.result_interaction.selection().row(), Some(0));
             assert!(state.result_interaction.staged_delete_rows().contains(&0));
         }
@@ -261,7 +263,7 @@ mod tests {
 
             let result = reduce(&mut state, &Action::ResultPrevPage, Instant::now());
 
-            assert!(result.is_none());
+            assert!(result.is_pass());
             assert_eq!(state.result_interaction.selection().row(), Some(0));
             assert!(state.result_interaction.staged_delete_rows().contains(&0));
         }

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -10,13 +10,14 @@ use crate::model::shared::ui_state::YankFlash;
 use crate::ports::outbound::ClipboardError;
 use crate::services::AppServices;
 use crate::update::action::Action;
+use crate::update::dispatch_result::DispatchResult;
 
 pub fn reduce(
     state: &mut AppState,
     action: &Action,
     services: &AppServices,
     now: Instant,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     match action {
         Action::ResultCellYank => {
             if let (Some(row_idx), Some(col_idx)) = (
@@ -35,7 +36,7 @@ pub fn reduce(
                         col: Some(col_idx),
                         until: now + Duration::from_millis(200),
                     });
-                    Some(vec![Effect::CopyToClipboard {
+                    DispatchResult::effects(vec![Effect::CopyToClipboard {
                         content: value,
                         on_success: Some(Action::CellCopied),
                         on_failure: Some(clipboard_unavailable()),
@@ -44,15 +45,15 @@ pub fn reduce(
                     state
                         .messages
                         .set_error_at("Cell index out of bounds".into(), now);
-                    Some(vec![])
+                    DispatchResult::no_effects()
                 }
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
         Action::ResultRowYankOperatorPending => {
             state.result_interaction.start_yank_operator();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::DdlYank => {
             if state.ui.inspector_tab == InspectorTab::Ddl
@@ -60,13 +61,13 @@ pub fn reduce(
             {
                 let ddl = services.ddl_generator.generate_ddl(table);
                 state.flash_timers.set(FlashId::Ddl, now);
-                return Some(vec![Effect::CopyToClipboard {
+                return DispatchResult::effects(vec![Effect::CopyToClipboard {
                     content: ddl,
                     on_success: Some(Action::CellCopied),
                     on_failure: Some(clipboard_unavailable()),
                 }]);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ResultRowYank => {
             if let Some(row_idx) = state.result_interaction.selection().row() {
@@ -90,7 +91,7 @@ pub fn reduce(
                         col: None,
                         until: now + Duration::from_millis(200),
                     });
-                    Some(vec![Effect::CopyToClipboard {
+                    DispatchResult::effects(vec![Effect::CopyToClipboard {
                         content: tsv,
                         on_success: Some(Action::CellCopied),
                         on_failure: Some(clipboard_unavailable()),
@@ -99,18 +100,18 @@ pub fn reduce(
                     state
                         .messages
                         .set_error_at("Row index out of bounds".into(), now);
-                    Some(vec![])
+                    DispatchResult::no_effects()
                 }
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
-        Action::CellCopied => Some(vec![]),
+        Action::CellCopied => DispatchResult::no_effects(),
         Action::CopyFailed(e) => {
             state.messages.set_error_at(e.to_string(), now);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -477,7 +478,7 @@ mod tests {
                 Instant::now(),
             );
 
-            let effects = effects.expect("should return Some");
+            let effects = effects.into_effects().expect("should return Some");
             assert_eq!(effects.len(), 1);
             assert!(
                 matches!(&effects[0], Effect::CopyToClipboard { content, .. } if content.contains("CREATE TABLE"))
@@ -506,7 +507,7 @@ mod tests {
                 Instant::now(),
             );
 
-            let effects = effects.expect("should return Some");
+            let effects = effects.into_effects().expect("should return Some");
             assert!(effects.is_empty());
         }
 
@@ -522,7 +523,7 @@ mod tests {
                 Instant::now(),
             );
 
-            let effects = effects.expect("should return Some");
+            let effects = effects.into_effects().expect("should return Some");
             assert!(effects.is_empty());
         }
     }

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -36,7 +36,7 @@ pub fn reduce(
                         col: Some(col_idx),
                         until: now + Duration::from_millis(200),
                     });
-                    DispatchResult::effects(vec![Effect::CopyToClipboard {
+                    DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: value,
                         on_success: Some(Action::CellCopied),
                         on_failure: Some(clipboard_unavailable()),
@@ -45,15 +45,15 @@ pub fn reduce(
                     state
                         .messages
                         .set_error_at("Cell index out of bounds".into(), now);
-                    DispatchResult::no_effects()
+                    DispatchResult::handled()
                 }
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
         Action::ResultRowYankOperatorPending => {
             state.result_interaction.start_yank_operator();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::DdlYank => {
             if state.ui.inspector_tab == InspectorTab::Ddl
@@ -61,13 +61,13 @@ pub fn reduce(
             {
                 let ddl = services.ddl_generator.generate_ddl(table);
                 state.flash_timers.set(FlashId::Ddl, now);
-                return DispatchResult::effects(vec![Effect::CopyToClipboard {
+                return DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                     content: ddl,
                     on_success: Some(Action::CellCopied),
                     on_failure: Some(clipboard_unavailable()),
                 }]);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ResultRowYank => {
             if let Some(row_idx) = state.result_interaction.selection().row() {
@@ -91,7 +91,7 @@ pub fn reduce(
                         col: None,
                         until: now + Duration::from_millis(200),
                     });
-                    DispatchResult::effects(vec![Effect::CopyToClipboard {
+                    DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: tsv,
                         on_success: Some(Action::CellCopied),
                         on_failure: Some(clipboard_unavailable()),
@@ -100,16 +100,16 @@ pub fn reduce(
                     state
                         .messages
                         .set_error_at("Row index out of bounds".into(), now);
-                    DispatchResult::no_effects()
+                    DispatchResult::handled()
                 }
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
-        Action::CellCopied => DispatchResult::no_effects(),
+        Action::CellCopied => DispatchResult::handled(),
         Action::CopyFailed(e) => {
             state.messages.set_error_at(e.to_string(), now);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         _ => DispatchResult::pass(),
     }

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -4,24 +4,25 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ScrollAmount, ScrollDirection, ScrollTarget};
+use crate::update::dispatch_result::DispatchResult;
 
-pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::ShowConnectionError(info) => {
             state.connection_error.set_error(info.clone());
             state.modal.replace_mode(InputMode::ConnectionError);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::CloseConnectionError => {
             state.connection_error.details_expanded = false;
             state.connection_error.scroll_offset = 0;
             state.connection_error.clear_copied_feedback();
             state.modal.set_mode(InputMode::Normal);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ToggleConnectionErrorDetails => {
             state.connection_error.toggle_details();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::ConnectionError,
@@ -29,7 +30,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             amount: ScrollAmount::Line,
         } => {
             state.connection_error.scroll_up();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::ConnectionError,
@@ -41,31 +42,31 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             // is not subtracted. Acceptable for typical short psql errors.
             let max_scroll = state.connection_error.detail_line_count().saturating_sub(1);
             state.connection_error.scroll_down(max_scroll);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::CopyConnectionError => {
             if let Some(content) = state.connection_error.masked_details() {
-                Some(vec![Effect::CopyToClipboard {
+                DispatchResult::effects(vec![Effect::CopyToClipboard {
                     content: content.to_string(),
                     on_success: Some(Action::ConnectionErrorCopied),
                     on_failure: None,
                 }])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
         Action::ConnectionErrorCopied => {
             state.connection_error.mark_copied_at(now);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ReenterConnectionSetup => {
             if state.session.is_service_connection() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             state.connection_error.clear();
             state.session.mark_disconnected();
             state.modal.replace_mode(InputMode::ConnectionSetup);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::RetryServiceConnection => {
             if let Some(dsn) = state.session.dsn.clone() {
@@ -73,13 +74,13 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 state.session.begin_connecting(&dsn);
                 state.session.read_only = false;
                 state.modal.set_mode(InputMode::Normal);
-                Some(vec![Effect::FetchMetadata { dsn }])
+                DispatchResult::effects(vec![Effect::FetchMetadata { dsn }])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -11,18 +11,18 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
         Action::ShowConnectionError(info) => {
             state.connection_error.set_error(info.clone());
             state.modal.replace_mode(InputMode::ConnectionError);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::CloseConnectionError => {
             state.connection_error.details_expanded = false;
             state.connection_error.scroll_offset = 0;
             state.connection_error.clear_copied_feedback();
             state.modal.set_mode(InputMode::Normal);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ToggleConnectionErrorDetails => {
             state.connection_error.toggle_details();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::ConnectionError,
@@ -30,7 +30,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             amount: ScrollAmount::Line,
         } => {
             state.connection_error.scroll_up();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::ConnectionError,
@@ -42,31 +42,31 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             // is not subtracted. Acceptable for typical short psql errors.
             let max_scroll = state.connection_error.detail_line_count().saturating_sub(1);
             state.connection_error.scroll_down(max_scroll);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::CopyConnectionError => {
             if let Some(content) = state.connection_error.masked_details() {
-                DispatchResult::effects(vec![Effect::CopyToClipboard {
+                DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                     content: content.to_string(),
                     on_success: Some(Action::ConnectionErrorCopied),
                     on_failure: None,
                 }])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
         Action::ConnectionErrorCopied => {
             state.connection_error.mark_copied_at(now);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ReenterConnectionSetup => {
             if state.session.is_service_connection() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             state.connection_error.clear();
             state.session.mark_disconnected();
             state.modal.replace_mode(InputMode::ConnectionSetup);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::RetryServiceConnection => {
             if let Some(dsn) = state.session.dsn.clone() {
@@ -74,9 +74,9 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 state.session.begin_connecting(&dsn);
                 state.session.read_only = false;
                 state.modal.set_mode(InputMode::Normal);
-                DispatchResult::effects(vec![Effect::FetchMetadata { dsn }])
+                DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn }])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -5,6 +5,7 @@ use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
 use crate::update::action::{Action, ConnectionTarget};
+use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::{restore_cache, save_current_cache};
 
@@ -13,7 +14,7 @@ pub fn reduce(
     action: &Action,
     _now: Instant,
     services: &AppServices,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     match action {
         Action::TryConnect => {
             if state.session.connection_state().is_not_connected()
@@ -21,12 +22,12 @@ pub fn reduce(
             {
                 if let Some(dsn) = state.session.dsn.clone() {
                     state.session.begin_connecting(&dsn);
-                    Some(vec![Effect::FetchMetadata { dsn }])
+                    DispatchResult::effects(vec![Effect::FetchMetadata { dsn }])
                 } else {
-                    Some(vec![])
+                    DispatchResult::no_effects()
                 }
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
@@ -43,7 +44,7 @@ pub fn reduce(
                 state.session.dsn = Some(dsn.clone());
                 state.session.active_connection_name = Some(name.clone());
                 state.session.read_only = false;
-                Some(vec![Effect::ClearCompletionEngineCache])
+                DispatchResult::effects(vec![Effect::ClearCompletionEngineCache])
             } else {
                 // No cache: reset and fetch metadata
                 state.session.reset(&mut state.query);
@@ -53,14 +54,14 @@ pub fn reduce(
                 state.session.active_connection_name = Some(name.clone());
                 state.session.read_only = false;
                 state.session.begin_connecting(dsn);
-                Some(vec![
+                DispatchResult::effects(vec![
                     Effect::ClearCompletionEngineCache,
                     Effect::FetchMetadata { dsn: dsn.clone() },
                 ])
             }
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -149,7 +150,9 @@ mod tests {
         let services = AppServices::stub();
 
         let action = create_switch_action(&new_id, "fresh_db");
-        let effects = reduce(&mut state, &action, Instant::now(), &services).unwrap();
+        let effects = reduce(&mut state, &action, Instant::now(), &services)
+            .into_effects()
+            .expect("reducer should handle action");
 
         assert!(
             effects
@@ -255,7 +258,9 @@ mod tests {
         let services = AppServices::stub();
 
         let action = create_switch_action(&new_id, "any_db");
-        let effects = reduce(&mut state, &action, Instant::now(), &services).unwrap();
+        let effects = reduce(&mut state, &action, Instant::now(), &services)
+            .into_effects()
+            .expect("reducer should handle action");
 
         assert!(
             effects

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -22,12 +22,12 @@ pub fn reduce(
             {
                 if let Some(dsn) = state.session.dsn.clone() {
                     state.session.begin_connecting(&dsn);
-                    DispatchResult::effects(vec![Effect::FetchMetadata { dsn }])
+                    DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn }])
                 } else {
-                    DispatchResult::no_effects()
+                    DispatchResult::handled()
                 }
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 
@@ -44,7 +44,7 @@ pub fn reduce(
                 state.session.dsn = Some(dsn.clone());
                 state.session.active_connection_name = Some(name.clone());
                 state.session.read_only = false;
-                DispatchResult::effects(vec![Effect::ClearCompletionEngineCache])
+                DispatchResult::handled_with(vec![Effect::ClearCompletionEngineCache])
             } else {
                 // No cache: reset and fetch metadata
                 state.session.reset(&mut state.query);
@@ -54,7 +54,7 @@ pub fn reduce(
                 state.session.active_connection_name = Some(name.clone());
                 state.session.read_only = false;
                 state.session.begin_connecting(dsn);
-                DispatchResult::effects(vec![
+                DispatchResult::handled_with(vec![
                     Effect::ClearCompletionEngineCache,
                     Effect::FetchMetadata { dsn: dsn.clone() },
                 ])

--- a/src/app/update/connection/mod.rs
+++ b/src/app/update/connection/mod.rs
@@ -6,17 +6,17 @@ mod setup;
 
 use std::time::Instant;
 
-use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::services::AppServices;
 use crate::update::action::Action;
+use crate::update::dispatch_result::DispatchResult;
 
 pub fn reduce_connection(
     state: &mut AppState,
     action: &Action,
     now: Instant,
     services: &AppServices,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     lifecycle::reduce(state, action, now, services)
         .or_else(|| setup::reduce(state, action, now))
         .or_else(|| error::reduce(state, action, now))
@@ -40,7 +40,7 @@ mod tests {
             &AppServices::stub(),
         );
 
-        assert!(result.is_some());
+        assert!(result.is_handled());
     }
 
     #[test]
@@ -55,7 +55,7 @@ mod tests {
             &AppServices::stub(),
         );
 
-        assert!(result.is_none());
+        assert!(result.is_pass());
     }
 
     #[test]
@@ -69,6 +69,6 @@ mod tests {
             &AppServices::stub(),
         );
 
-        assert!(result.is_none());
+        assert!(result.is_pass());
     }
 }

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -4,13 +4,14 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ModalKind};
+use crate::update::dispatch_result::DispatchResult;
 
-pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::ConnectionSelector) => {
             state.modal.set_mode(InputMode::ConnectionSelector);
             state.ui.set_connection_list_selection(Some(0));
-            Some(vec![Effect::LoadConnections])
+            DispatchResult::effects(vec![Effect::LoadConnections])
         }
 
         // ===== Connection Deletion =====
@@ -19,7 +20,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             let selected_idx = state.ui.connection_list_selected;
             let profile_idx = match state.connection_list_items().get(selected_idx) {
                 Some(ConnectionListItem::Profile(i)) => *i,
-                _ => return Some(vec![]),
+                _ => return DispatchResult::no_effects(),
             };
             if let Some(connection) = state.connections().get(profile_idx) {
                 let id = connection.id.clone();
@@ -40,9 +41,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
-        Action::DeleteConnection(id) => Some(vec![Effect::DeleteConnection { id: id.clone() }]),
+        Action::DeleteConnection(id) => {
+            DispatchResult::effects(vec![Effect::DeleteConnection { id: id.clone() }])
+        }
         Action::ConnectionDeleted(id) => {
             if state.session.active_connection_id.as_ref() == Some(id) {
                 state.session.reset(&mut state.query);
@@ -68,11 +71,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             state
                 .messages
                 .set_success_at("Connection deleted".to_string(), now);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConnectionDeleteFailed(e) => {
             state.messages.set_error_at(e.to_string(), now);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         // ===== Connection Edit =====
@@ -81,17 +84,17 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             let selected_idx = state.ui.connection_list_selected;
             let profile_idx = match state.connection_list_items().get(selected_idx) {
                 Some(ConnectionListItem::Profile(i)) => *i,
-                _ => return Some(vec![]),
+                _ => return DispatchResult::no_effects(),
             };
             if let Some(connection) = state.connections().get(profile_idx) {
                 let id = connection.id.clone();
-                Some(vec![Effect::LoadConnectionForEdit { id }])
+                DispatchResult::effects(vec![Effect::LoadConnectionForEdit { id }])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -128,7 +131,9 @@ mod tests {
             );
 
             assert_eq!(state.input_mode(), InputMode::ConnectionSelector);
-            let effects = effects.unwrap();
+            let effects = effects
+                .into_effects()
+                .expect("reducer should handle action");
             assert!(effects.iter().any(|e| matches!(e, Effect::LoadConnections)));
         }
 

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -11,7 +11,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
         Action::OpenModal(ModalKind::ConnectionSelector) => {
             state.modal.set_mode(InputMode::ConnectionSelector);
             state.ui.set_connection_list_selection(Some(0));
-            DispatchResult::effects(vec![Effect::LoadConnections])
+            DispatchResult::handled_with(vec![Effect::LoadConnections])
         }
 
         // ===== Connection Deletion =====
@@ -20,7 +20,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             let selected_idx = state.ui.connection_list_selected;
             let profile_idx = match state.connection_list_items().get(selected_idx) {
                 Some(ConnectionListItem::Profile(i)) => *i,
-                _ => return DispatchResult::no_effects(),
+                _ => return DispatchResult::handled(),
             };
             if let Some(connection) = state.connections().get(profile_idx) {
                 let id = connection.id.clone();
@@ -41,10 +41,10 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::DeleteConnection(id) => {
-            DispatchResult::effects(vec![Effect::DeleteConnection { id: id.clone() }])
+            DispatchResult::handled_with(vec![Effect::DeleteConnection { id: id.clone() }])
         }
         Action::ConnectionDeleted(id) => {
             if state.session.active_connection_id.as_ref() == Some(id) {
@@ -71,11 +71,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             state
                 .messages
                 .set_success_at("Connection deleted".to_string(), now);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConnectionDeleteFailed(e) => {
             state.messages.set_error_at(e.to_string(), now);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         // ===== Connection Edit =====
@@ -84,13 +84,13 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             let selected_idx = state.ui.connection_list_selected;
             let profile_idx = match state.connection_list_items().get(selected_idx) {
                 Some(ConnectionListItem::Profile(i)) => *i,
-                _ => return DispatchResult::no_effects(),
+                _ => return DispatchResult::handled(),
             };
             if let Some(connection) = state.connections().get(profile_idx) {
                 let id = connection.id.clone();
-                DispatchResult::effects(vec![Effect::LoadConnectionForEdit { id }])
+                DispatchResult::handled_with(vec![Effect::LoadConnectionForEdit { id }])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -8,9 +8,10 @@ use crate::model::connection::setup::{
 };
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ConnectionTarget, InputTarget, ModalKind};
+use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{validate_all, validate_field};
 
-pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::ConnectionSetup) => {
             state.connection_setup.reset();
@@ -18,23 +19,23 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 state.connection_setup.is_first_run = false;
             }
             state.modal.set_mode(InputMode::ConnectionSetup);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::StartEditConnection(id) => {
-            Some(vec![Effect::LoadConnectionForEdit { id: id.clone() }])
+            DispatchResult::effects(vec![Effect::LoadConnectionForEdit { id: id.clone() }])
         }
         Action::ConnectionEditLoaded(profile) => {
             state.connection_setup = ConnectionSetupState::from(&**profile);
             state.modal.set_mode(InputMode::ConnectionSetup);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConnectionEditLoadFailed(e) => {
             state.messages.set_error_at(e.to_string(), now);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::CloseModal(ModalKind::ConnectionSetup) => {
             state.modal.set_mode(InputMode::Normal);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         // ===== Clipboard Paste =====
@@ -63,7 +64,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                     }
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         // ===== Connection Setup Form =====
@@ -87,7 +88,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                     }
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextBackspace {
             target: InputTarget::ConnectionSetup,
@@ -97,7 +98,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 input.backspace();
                 input.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextMoveCursor {
             target: InputTarget::ConnectionSetup,
@@ -108,7 +109,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 input.move_cursor(*movement);
                 input.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConnectionSetupNextField => {
             let setup = &mut state.connection_setup;
@@ -116,7 +117,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             if let Some(next) = setup.focused_field.next() {
                 setup.focused_field = next;
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConnectionSetupPrevField => {
             let setup = &mut state.connection_setup;
@@ -124,7 +125,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             if let Some(prev) = setup.focused_field.prev() {
                 setup.focused_field = prev;
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConnectionSetupToggleDropdown => {
             let setup = &mut state.connection_setup;
@@ -137,7 +138,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                         .unwrap_or(2);
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConnectionSetupDropdownNext => {
             let setup = &mut state.connection_setup;
@@ -147,7 +148,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                     setup.ssl_dropdown.selected_index += 1;
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConnectionSetupDropdownPrev => {
             let setup = &mut state.connection_setup;
@@ -155,7 +156,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 setup.ssl_dropdown.selected_index =
                     setup.ssl_dropdown.selected_index.saturating_sub(1);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConnectionSetupDropdownConfirm => {
             let setup = &mut state.connection_setup;
@@ -165,11 +166,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                 }
                 setup.ssl_dropdown.is_open = false;
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConnectionSetupDropdownCancel => {
             state.connection_setup.ssl_dropdown.is_open = false;
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ConnectionSetupSave => {
             let setup = &mut state.connection_setup;
@@ -177,7 +178,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             if setup.validation_errors.is_empty() {
                 let port = setup.port.content().parse().unwrap_or(5432);
                 state.session.mark_connecting();
-                Some(vec![Effect::SaveAndConnect {
+                DispatchResult::effects(vec![Effect::SaveAndConnect {
                     id: setup.editing_id.clone(),
                     name: setup.name.content().to_string(),
                     host: setup.host.content().to_string(),
@@ -188,7 +189,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                     ssl_mode: setup.ssl_mode,
                 }])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
         Action::ConnectionSetupCancel => {
@@ -199,10 +200,10 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
                     crate::model::shared::confirm_dialog::ConfirmIntent::QuitNoConnection,
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
-                Some(vec![])
+                DispatchResult::no_effects()
             } else {
                 state.modal.set_mode(InputMode::Normal);
-                Some(vec![Effect::DispatchActions(vec![Action::TryConnect])])
+                DispatchResult::effects(vec![Effect::DispatchActions(vec![Action::TryConnect])])
             }
         }
         Action::ConnectionSaveCompleted(ConnectionTarget { id, dsn, name }) => {
@@ -212,17 +213,17 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec
             state.session.active_connection_name = Some(name.clone());
             state.session.read_only = false;
             state.session.begin_connecting(dsn);
-            Some(vec![Effect::FetchMetadata { dsn: dsn.clone() }])
+            DispatchResult::effects(vec![Effect::FetchMetadata { dsn: dsn.clone() }])
         }
         Action::ConnectionSaveFailed(e) => {
             if !state.session.connection_state().is_connected() {
                 state.session.mark_disconnected();
             }
             state.messages.set_error_at(e.to_string(), now);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -19,23 +19,23 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 state.connection_setup.is_first_run = false;
             }
             state.modal.set_mode(InputMode::ConnectionSetup);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::StartEditConnection(id) => {
-            DispatchResult::effects(vec![Effect::LoadConnectionForEdit { id: id.clone() }])
+            DispatchResult::handled_with(vec![Effect::LoadConnectionForEdit { id: id.clone() }])
         }
         Action::ConnectionEditLoaded(profile) => {
             state.connection_setup = ConnectionSetupState::from(&**profile);
             state.modal.set_mode(InputMode::ConnectionSetup);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConnectionEditLoadFailed(e) => {
             state.messages.set_error_at(e.to_string(), now);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::ConnectionSetup) => {
             state.modal.set_mode(InputMode::Normal);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         // ===== Clipboard Paste =====
@@ -64,7 +64,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                     }
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         // ===== Connection Setup Form =====
@@ -88,7 +88,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                     }
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::ConnectionSetup,
@@ -98,7 +98,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 input.backspace();
                 input.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: InputTarget::ConnectionSetup,
@@ -109,7 +109,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 input.move_cursor(*movement);
                 input.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConnectionSetupNextField => {
             let setup = &mut state.connection_setup;
@@ -117,7 +117,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             if let Some(next) = setup.focused_field.next() {
                 setup.focused_field = next;
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConnectionSetupPrevField => {
             let setup = &mut state.connection_setup;
@@ -125,7 +125,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             if let Some(prev) = setup.focused_field.prev() {
                 setup.focused_field = prev;
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConnectionSetupToggleDropdown => {
             let setup = &mut state.connection_setup;
@@ -138,7 +138,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                         .unwrap_or(2);
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConnectionSetupDropdownNext => {
             let setup = &mut state.connection_setup;
@@ -148,7 +148,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                     setup.ssl_dropdown.selected_index += 1;
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConnectionSetupDropdownPrev => {
             let setup = &mut state.connection_setup;
@@ -156,7 +156,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 setup.ssl_dropdown.selected_index =
                     setup.ssl_dropdown.selected_index.saturating_sub(1);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConnectionSetupDropdownConfirm => {
             let setup = &mut state.connection_setup;
@@ -166,11 +166,11 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                 }
                 setup.ssl_dropdown.is_open = false;
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConnectionSetupDropdownCancel => {
             state.connection_setup.ssl_dropdown.is_open = false;
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ConnectionSetupSave => {
             let setup = &mut state.connection_setup;
@@ -178,7 +178,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             if setup.validation_errors.is_empty() {
                 let port = setup.port.content().parse().unwrap_or(5432);
                 state.session.mark_connecting();
-                DispatchResult::effects(vec![Effect::SaveAndConnect {
+                DispatchResult::handled_with(vec![Effect::SaveAndConnect {
                     id: setup.editing_id.clone(),
                     name: setup.name.content().to_string(),
                     host: setup.host.content().to_string(),
@@ -189,7 +189,7 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                     ssl_mode: setup.ssl_mode,
                 }])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
         Action::ConnectionSetupCancel => {
@@ -200,10 +200,12 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
                     crate::model::shared::confirm_dialog::ConfirmIntent::QuitNoConnection,
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             } else {
                 state.modal.set_mode(InputMode::Normal);
-                DispatchResult::effects(vec![Effect::DispatchActions(vec![Action::TryConnect])])
+                DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
+                    Action::TryConnect,
+                ])])
             }
         }
         Action::ConnectionSaveCompleted(ConnectionTarget { id, dsn, name }) => {
@@ -213,14 +215,14 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             state.session.active_connection_name = Some(name.clone());
             state.session.read_only = false;
             state.session.begin_connecting(dsn);
-            DispatchResult::effects(vec![Effect::FetchMetadata { dsn: dsn.clone() }])
+            DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn: dsn.clone() }])
         }
         Action::ConnectionSaveFailed(e) => {
             if !state.session.connection_state().is_connected() {
                 state.session.mark_disconnected();
             }
             state.messages.set_error_at(e.to_string(), now);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         _ => DispatchResult::pass(),

--- a/src/app/update/dispatch_result.rs
+++ b/src/app/update/dispatch_result.rs
@@ -11,11 +11,11 @@ impl DispatchResult {
         Self::Pass
     }
 
-    pub fn no_effects() -> Self {
+    pub fn handled() -> Self {
         Self::Handled(vec![])
     }
 
-    pub fn effects(effects: Vec<Effect>) -> Self {
+    pub fn handled_with(effects: Vec<Effect>) -> Self {
         Self::Handled(effects)
     }
 

--- a/src/app/update/dispatch_result.rs
+++ b/src/app/update/dispatch_result.rs
@@ -1,8 +1,14 @@
 use crate::cmd::effect::Effect;
 
+/// Outcome of dispatching an action to a reducer.
+///
+/// `Pass` keeps the dispatcher chain moving. `Handled` stops the chain and
+/// returns the effects produced by the reducer, if any.
 #[derive(Debug, Clone)]
 pub enum DispatchResult {
+    /// The reducer did not handle the action.
     Pass,
+    /// The reducer handled the action and produced zero or more effects.
     Handled(Vec<Effect>),
 }
 
@@ -62,5 +68,42 @@ impl DispatchResult {
     #[cfg(test)]
     pub fn expect(self, msg: &str) -> Vec<Effect> {
         self.into_effects().expect(msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn or_else_keeps_handled_result() {
+        let result = DispatchResult::handled_with(vec![Effect::Render]);
+
+        let chained = result.or_else(DispatchResult::handled);
+
+        assert!(chained.is_handled_and(|effects| matches!(effects.as_slice(), [Effect::Render])));
+    }
+
+    #[test]
+    fn or_else_dispatches_next_on_pass() {
+        let result = DispatchResult::pass();
+
+        let chained = result.or_else(|| DispatchResult::handled_with(vec![Effect::Render]));
+
+        assert!(chained.is_handled_and(|effects| matches!(effects.as_slice(), [Effect::Render])));
+    }
+
+    #[test]
+    fn is_handled_and_checks_effects() {
+        let result = DispatchResult::handled();
+
+        assert!(result.is_handled_and(Vec::is_empty));
+    }
+
+    #[test]
+    fn is_handled_and_returns_false_on_pass() {
+        let result = DispatchResult::pass();
+
+        assert!(!result.is_handled_and(|_| true));
     }
 }

--- a/src/app/update/dispatch_result.rs
+++ b/src/app/update/dispatch_result.rs
@@ -1,0 +1,66 @@
+use crate::cmd::effect::Effect;
+
+#[derive(Debug, Clone)]
+pub enum DispatchResult {
+    Pass,
+    Handled(Vec<Effect>),
+}
+
+impl DispatchResult {
+    pub fn pass() -> Self {
+        Self::Pass
+    }
+
+    pub fn no_effects() -> Self {
+        Self::Handled(vec![])
+    }
+
+    pub fn effects(effects: Vec<Effect>) -> Self {
+        Self::Handled(effects)
+    }
+
+    pub fn into_effects(self) -> Option<Vec<Effect>> {
+        match self {
+            Self::Pass => None,
+            Self::Handled(effects) => Some(effects),
+        }
+    }
+
+    pub fn or_else<F>(self, f: F) -> Self
+    where
+        F: FnOnce() -> Self,
+    {
+        match self {
+            Self::Pass => f(),
+            Self::Handled(_) => self,
+        }
+    }
+
+    pub fn is_pass(&self) -> bool {
+        matches!(self, Self::Pass)
+    }
+
+    pub fn is_handled(&self) -> bool {
+        matches!(self, Self::Handled(_))
+    }
+
+    pub fn is_handled_and<F>(&self, f: F) -> bool
+    where
+        F: FnOnce(&Vec<Effect>) -> bool,
+    {
+        match self {
+            Self::Handled(effects) => f(effects),
+            Self::Pass => false,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn unwrap(self) -> Vec<Effect> {
+        self.into_effects().unwrap()
+    }
+
+    #[cfg(test)]
+    pub fn expect(self, msg: &str) -> Vec<Effect> {
+        self.into_effects().expect(msg)
+    }
+}

--- a/src/app/update/er.rs
+++ b/src/app/update/er.rs
@@ -20,32 +20,32 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Dispat
             state.set_success(format!(
                 "✓ Opened {path} ({table_count}/{total_tables} tables) — Stale? Press r to reload"
             ));
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ErDiagramFailed(error) => {
             state.er_preparation.status = ErStatus::Idle;
             state.set_error(error.to_string());
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ErLogWriteFailed(error) => {
             state.set_error(error.to_string());
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ErOpenDiagram => {
             if matches!(
                 state.er_preparation.status,
                 ErStatus::Rendering | ErStatus::Waiting
             ) {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             let Some(dsn) = state.session.dsn.clone() else {
                 state.set_error("No active connection".to_string());
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             };
             if state.session.metadata().is_none() {
                 state.set_error("Metadata not loaded yet".to_string());
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             state.sql_modal.invalidate_prefetch();
@@ -53,7 +53,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Dispat
             state.er_preparation.status = ErStatus::Waiting;
             state.set_success("Checking for schema changes...".to_string());
 
-            DispatchResult::effects(vec![Effect::SmartErRefresh {
+            DispatchResult::handled_with(vec![Effect::SmartErRefresh {
                 dsn,
                 run_id: state.er_preparation.run_id,
             }])
@@ -69,7 +69,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Dispat
             new_signatures,
         }) => {
             if *run_id != state.er_preparation.run_id {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             state.session.set_metadata(Some(Arc::clone(new_metadata)));
@@ -114,7 +114,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Dispat
                 }]));
             }
 
-            DispatchResult::effects(effects)
+            DispatchResult::handled_with(effects)
         }
 
         Action::SmartErRefreshFailed(SmartErRefreshError {
@@ -123,7 +123,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Dispat
             new_metadata,
         }) => {
             if *run_id != state.er_preparation.run_id {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             if let Some(md) = new_metadata {
@@ -133,7 +133,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Dispat
             let Some(metadata) = &state.session.metadata() else {
                 state.er_preparation.status = ErStatus::Idle;
                 state.set_error("Metadata not loaded yet".to_string());
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             };
             let total_table_count = metadata.table_summaries.len();
             let is_scoped = !state.er_preparation.target_tables.is_empty()
@@ -147,14 +147,14 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Dispat
 
             if is_scoped {
                 let scoped_tables = state.er_preparation.target_tables.clone();
-                DispatchResult::effects(vec![
+                DispatchResult::handled_with(vec![
                     Effect::ClearCompletionEngineCache,
                     Effect::DispatchActions(vec![Action::StartPrefetchScoped {
                         tables: scoped_tables,
                     }]),
                 ])
             } else {
-                DispatchResult::effects(vec![
+                DispatchResult::handled_with(vec![
                     Effect::ClearCompletionEngineCache,
                     Effect::DispatchActions(vec![Action::StartPrefetchAll]),
                 ])
@@ -166,7 +166,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Dispat
                 state.er_preparation.status,
                 ErStatus::Idle | ErStatus::Waiting
             ) {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             state.er_preparation.status = ErStatus::Rendering;
@@ -175,7 +175,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Dispat
                 .metadata()
                 .map_or(0, |m| m.table_summaries.len());
 
-            DispatchResult::effects(vec![Effect::GenerateErDiagramFromCache {
+            DispatchResult::handled_with(vec![Effect::GenerateErDiagramFromCache {
                 total_tables,
                 project_name: state.runtime.project_name.clone(),
                 target_tables: state.er_preparation.target_tables.clone(),

--- a/src/app/update/er.rs
+++ b/src/app/update/er.rs
@@ -5,8 +5,9 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::er_state::ErStatus;
 use crate::update::action::{Action, ErDiagramInfo, SmartErRefreshError, SmartErRefreshResult};
+use crate::update::dispatch_result::DispatchResult;
 
-pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
     match action {
         Action::ErDiagramOpened(ErDiagramInfo {
             path,
@@ -19,32 +20,32 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             state.set_success(format!(
                 "✓ Opened {path} ({table_count}/{total_tables} tables) — Stale? Press r to reload"
             ));
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ErDiagramFailed(error) => {
             state.er_preparation.status = ErStatus::Idle;
             state.set_error(error.to_string());
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ErLogWriteFailed(error) => {
             state.set_error(error.to_string());
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ErOpenDiagram => {
             if matches!(
                 state.er_preparation.status,
                 ErStatus::Rendering | ErStatus::Waiting
             ) {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             let Some(dsn) = state.session.dsn.clone() else {
                 state.set_error("No active connection".to_string());
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             };
             if state.session.metadata().is_none() {
                 state.set_error("Metadata not loaded yet".to_string());
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             state.sql_modal.invalidate_prefetch();
@@ -52,7 +53,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             state.er_preparation.status = ErStatus::Waiting;
             state.set_success("Checking for schema changes...".to_string());
 
-            Some(vec![Effect::SmartErRefresh {
+            DispatchResult::effects(vec![Effect::SmartErRefresh {
                 dsn,
                 run_id: state.er_preparation.run_id,
             }])
@@ -68,7 +69,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             new_signatures,
         }) => {
             if *run_id != state.er_preparation.run_id {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             state.session.set_metadata(Some(Arc::clone(new_metadata)));
@@ -113,7 +114,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
                 }]));
             }
 
-            Some(effects)
+            DispatchResult::effects(effects)
         }
 
         Action::SmartErRefreshFailed(SmartErRefreshError {
@@ -122,7 +123,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             new_metadata,
         }) => {
             if *run_id != state.er_preparation.run_id {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             if let Some(md) = new_metadata {
@@ -132,7 +133,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
             let Some(metadata) = &state.session.metadata() else {
                 state.er_preparation.status = ErStatus::Idle;
                 state.set_error("Metadata not loaded yet".to_string());
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             };
             let total_table_count = metadata.table_summaries.len();
             let is_scoped = !state.er_preparation.target_tables.is_empty()
@@ -146,14 +147,14 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
 
             if is_scoped {
                 let scoped_tables = state.er_preparation.target_tables.clone();
-                Some(vec![
+                DispatchResult::effects(vec![
                     Effect::ClearCompletionEngineCache,
                     Effect::DispatchActions(vec![Action::StartPrefetchScoped {
                         tables: scoped_tables,
                     }]),
                 ])
             } else {
-                Some(vec![
+                DispatchResult::effects(vec![
                     Effect::ClearCompletionEngineCache,
                     Effect::DispatchActions(vec![Action::StartPrefetchAll]),
                 ])
@@ -165,7 +166,7 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
                 state.er_preparation.status,
                 ErStatus::Idle | ErStatus::Waiting
             ) {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             state.er_preparation.status = ErStatus::Rendering;
@@ -174,14 +175,14 @@ pub fn reduce_er(state: &mut AppState, action: &Action, _now: Instant) -> Option
                 .metadata()
                 .map_or(0, |m| m.table_summaries.len());
 
-            Some(vec![Effect::GenerateErDiagramFromCache {
+            DispatchResult::effects(vec![Effect::GenerateErDiagramFromCache {
                 total_tables,
                 project_name: state.runtime.project_name.clone(),
                 target_tables: state.er_preparation.target_tables.clone(),
             }])
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -219,7 +220,9 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(0)));
 
-            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(state.er_preparation.status, ErStatus::Waiting);
             assert_eq!(state.er_preparation.run_id, 1);
@@ -236,7 +239,9 @@ mod tests {
             state.session.set_metadata(Some(make_metadata(5)));
             state.er_preparation.run_id = 3;
 
-            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(state.er_preparation.run_id, 4);
             assert!(matches!(
@@ -251,7 +256,9 @@ mod tests {
             state.sql_modal.begin_prefetch();
             state.session.set_metadata(Some(make_metadata(0)));
 
-            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(!state.sql_modal.is_prefetch_started());
             assert_eq!(state.er_preparation.status, ErStatus::Waiting);
@@ -264,7 +271,9 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.session.set_metadata(Some(make_metadata(5)));
 
-            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
             assert!(state.messages.last_error.is_some());
@@ -275,7 +284,9 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.er_preparation.status = ErStatus::Rendering;
 
-            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -285,7 +296,9 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.er_preparation.status = ErStatus::Waiting;
 
-            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -295,7 +308,9 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.sql_modal.begin_prefetch();
 
-            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
             assert!(state.messages.last_error.is_some());
@@ -318,8 +333,9 @@ mod tests {
             })));
             state.er_preparation.target_tables = vec!["public.users".to_string()];
 
-            let effects =
-                reduce_er(&mut state, &Action::ErGenerateFromCache, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &Action::ErGenerateFromCache, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
             assert!(matches!(
@@ -335,8 +351,9 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.er_preparation.status = ErStatus::Rendering;
 
-            let effects =
-                reduce_er(&mut state, &Action::ErGenerateFromCache, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &Action::ErGenerateFromCache, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -377,7 +394,9 @@ mod tests {
                 new_signatures: HashMap::new(),
             });
 
-            let effects = reduce_er(&mut state, &action, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &action, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.iter().any(|e| matches!(
                 e,
@@ -403,7 +422,9 @@ mod tests {
                 new_signatures: HashMap::new(),
             });
 
-            let effects = reduce_er(&mut state, &action, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &action, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(
                 effects
@@ -434,7 +455,9 @@ mod tests {
                 new_signatures: HashMap::new(),
             });
 
-            let effects = reduce_er(&mut state, &action, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &action, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.iter().any(|e| matches!(
                 e,
@@ -460,7 +483,9 @@ mod tests {
                 new_signatures: HashMap::new(),
             });
 
-            let effects = reduce_er(&mut state, &action, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &action, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.iter().any(|e| matches!(
                 e,
@@ -486,7 +511,9 @@ mod tests {
                 new_signatures: HashMap::new(),
             });
 
-            let effects = reduce_er(&mut state, &action, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &action, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.iter().any(|e| matches!(
                 e,
@@ -511,7 +538,9 @@ mod tests {
                 new_signatures: HashMap::new(),
             });
 
-            let effects = reduce_er(&mut state, &action, Instant::now()).unwrap();
+            let effects = reduce_er(&mut state, &action, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -9,6 +9,7 @@ use crate::policy::sql::statement_classifier::{self, StatementKind};
 use crate::policy::write::sql_risk::{ConfirmationType, evaluate_sql_risk, split_statements};
 use crate::services::AppServices;
 use crate::update::action::{Action, ScrollAmount, ScrollTarget};
+use crate::update::dispatch_result::DispatchResult;
 
 fn is_multi_statement(content: &str) -> bool {
     split_statements(content).len() > 1
@@ -72,34 +73,34 @@ pub fn reduce_explain_with_services(
     action: &Action,
     now: Instant,
     services: &AppServices,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     match action {
         Action::ExplainRequest => {
             if reject_unsupported_explain(state, services) {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let content = state.sql_modal.editor.content().trim().to_string();
             if content.is_empty() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let Some(dsn) = state.session.dsn.clone() else {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             };
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if is_multi_statement(&content) {
                 show_explain_error_on_plan(state, "EXPLAIN does not support multiple statements");
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             let Some(query) = services.sql_dialect.build_explain_sql(&content) else {
                 mark_explain_unavailable(state, services);
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             };
             begin_explain_running(state, now);
 
-            Some(vec![Effect::ExecuteExplain {
+            DispatchResult::effects(vec![Effect::ExecuteExplain {
                 dsn,
                 query,
                 is_analyze: false,
@@ -109,25 +110,25 @@ pub fn reduce_explain_with_services(
 
         Action::ExplainAnalyzeRequest => {
             if reject_unsupported_explain(state, services) {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let content = state.sql_modal.editor.content().trim().to_string();
             if content.is_empty() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let Some(dsn) = &state.session.dsn else {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             };
             let dsn = dsn.clone();
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if is_multi_statement(&content) {
                 show_explain_error_on_plan(
                     state,
                     "EXPLAIN ANALYZE does not support multiple statements",
                 );
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let kind = statement_classifier::classify(&content);
             let risk = evaluate_sql_risk(&kind, &content);
@@ -139,7 +140,7 @@ pub fn reduce_explain_with_services(
                     state,
                     "Read-only mode: EXPLAIN ANALYZE is blocked for DML statements.",
                 );
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             state.explain.confirm_scroll_offset = 0;
@@ -155,10 +156,10 @@ pub fn reduce_explain_with_services(
                         services.sql_dialect.build_explain_analyze_sql(&content)
                     else {
                         mark_explain_unavailable(state, services);
-                        return Some(vec![]);
+                        return DispatchResult::no_effects();
                     };
                     begin_explain_running(state, now);
-                    return Some(vec![Effect::ExecuteExplain {
+                    return DispatchResult::effects(vec![Effect::ExecuteExplain {
                         dsn,
                         query: explain_query,
                         is_analyze: true,
@@ -167,12 +168,12 @@ pub fn reduce_explain_with_services(
                 }
             }
 
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::ExplainAnalyzeConfirm => {
             if reject_unsupported_explain(state, services) {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let query = match state.sql_modal.status() {
                 SqlModalStatus::ConfirmingAnalyzeHigh {
@@ -191,17 +192,17 @@ pub fn reduce_explain_with_services(
                 let Some(explain_query) = services.sql_dialect.build_explain_analyze_sql(&query)
                 else {
                     mark_explain_unavailable(state, services);
-                    return Some(vec![]);
+                    return DispatchResult::no_effects();
                 };
                 begin_explain_running(state, now);
-                return Some(vec![Effect::ExecuteExplain {
+                return DispatchResult::effects(vec![Effect::ExecuteExplain {
                     dsn,
                     query: explain_query,
                     is_analyze: true,
                     read_only: state.session.read_only,
                 }]);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::ExplainAnalyzeCancel => {
@@ -211,7 +212,7 @@ pub fn reduce_explain_with_services(
             ) {
                 state.sql_modal.cancel_confirmation();
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::ExplainCompleted {
@@ -227,12 +228,12 @@ pub fn reduce_explain_with_services(
                 *execution_time_ms,
                 &query,
             );
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::ExplainFailed(error) => {
             finish_explain_error(state, error.user_message());
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::Scroll {
@@ -267,7 +268,7 @@ pub fn reduce_explain_with_services(
                 _ => unreachable!(),
             };
             *offset = direction.clamp_vertical_offset(*offset, max, 1);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::CompareEditQuery => {
@@ -275,7 +276,7 @@ pub fn reduce_explain_with_services(
                 let query = right.full_query.clone();
                 state.sql_modal.load_query_for_editing(query);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::SqlModalNextTab => {
@@ -283,7 +284,7 @@ pub fn reduce_explain_with_services(
                 .db_capabilities
                 .next_sql_modal_tab(state.sql_modal.active_tab());
             state.sql_modal.set_active_tab(tab);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::SqlModalPrevTab => {
@@ -291,15 +292,15 @@ pub fn reduce_explain_with_services(
                 .db_capabilities
                 .prev_sql_modal_tab(state.sql_modal.active_tab());
             state.sql_modal.set_active_tab(tab);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
 #[cfg(test)]
-pub fn reduce_explain(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce_explain(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     reduce_explain_with_services(state, action, now, &crate::services::AppServices::stub())
 }
 
@@ -334,8 +335,9 @@ mod tests {
             state.sql_modal.editor.set_content("  ".to_string());
             state.session.dsn = Some("dsn://test".to_string());
 
-            let effects =
-                reduce_explain(&mut state, &Action::ExplainRequest, Instant::now()).unwrap();
+            let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -345,8 +347,9 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
 
-            let effects =
-                reduce_explain(&mut state, &Action::ExplainRequest, Instant::now()).unwrap();
+            let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -358,8 +361,9 @@ mod tests {
             state.session.dsn = Some("dsn://test".to_string());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
-            let effects =
-                reduce_explain(&mut state, &Action::ExplainRequest, Instant::now()).unwrap();
+            let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -395,8 +399,9 @@ mod tests {
                 .set_content("SELECT 1; DELETE FROM users".to_string());
             state.session.dsn = Some("dsn://test".to_string());
 
-            let effects =
-                reduce_explain(&mut state, &Action::ExplainRequest, Instant::now()).unwrap();
+            let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
             assert_eq!(
@@ -424,8 +429,9 @@ mod tests {
             state.sql_modal.editor.set_content("SELECT 1".to_string());
             state.session.dsn = Some("dsn://test".to_string());
 
-            let effects =
-                reduce_explain(&mut state, &Action::ExplainRequest, Instant::now()).unwrap();
+            let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
             assert!(matches!(
@@ -451,7 +457,9 @@ mod tests {
             state.session.dsn = Some("dsn://test".to_string());
 
             let effects =
-                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
+                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -466,7 +474,9 @@ mod tests {
             state.session.dsn = Some("dsn://test".to_string());
 
             let effects =
-                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
+                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert!(effects.is_empty());
             assert_eq!(
@@ -506,7 +516,9 @@ mod tests {
             state.session.dsn = Some("dsn://test".to_string());
 
             let effects =
-                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
+                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
             assert!(matches!(
@@ -529,7 +541,9 @@ mod tests {
             state.session.dsn = Some("dsn://test".to_string());
 
             let effects =
-                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
+                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
             assert_eq!(effects.len(), 1);
@@ -552,7 +566,9 @@ mod tests {
             state.session.dsn = Some("dsn://test".to_string());
 
             let effects =
-                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
+                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
             assert_eq!(effects.len(), 1);
@@ -595,7 +611,9 @@ mod tests {
             state.session.dsn = Some("dsn://test".to_string());
 
             let effects =
-                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
+                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
             assert_eq!(effects.len(), 1);
@@ -688,7 +706,9 @@ mod tests {
             state.session.read_only = true;
 
             let effects =
-                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now()).unwrap();
+                reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert!(state.explain.error.is_none());
             assert_eq!(effects.len(), 1);
@@ -745,7 +765,9 @@ mod tests {
                 });
 
             let effects =
-                reduce_explain(&mut state, &Action::ExplainAnalyzeConfirm, Instant::now()).unwrap();
+                reduce_explain(&mut state, &Action::ExplainAnalyzeConfirm, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
@@ -766,7 +788,9 @@ mod tests {
                 });
 
             let effects =
-                reduce_explain(&mut state, &Action::ExplainAnalyzeConfirm, Instant::now()).unwrap();
+                reduce_explain(&mut state, &Action::ExplainAnalyzeConfirm, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
             assert!(effects.is_empty());
             assert!(matches!(

--- a/src/app/update/explain.rs
+++ b/src/app/update/explain.rs
@@ -77,30 +77,30 @@ pub fn reduce_explain_with_services(
     match action {
         Action::ExplainRequest => {
             if reject_unsupported_explain(state, services) {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let content = state.sql_modal.editor.content().trim().to_string();
             if content.is_empty() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let Some(dsn) = state.session.dsn.clone() else {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             };
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if is_multi_statement(&content) {
                 show_explain_error_on_plan(state, "EXPLAIN does not support multiple statements");
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             let Some(query) = services.sql_dialect.build_explain_sql(&content) else {
                 mark_explain_unavailable(state, services);
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             };
             begin_explain_running(state, now);
 
-            DispatchResult::effects(vec![Effect::ExecuteExplain {
+            DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                 dsn,
                 query,
                 is_analyze: false,
@@ -110,25 +110,25 @@ pub fn reduce_explain_with_services(
 
         Action::ExplainAnalyzeRequest => {
             if reject_unsupported_explain(state, services) {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let content = state.sql_modal.editor.content().trim().to_string();
             if content.is_empty() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let Some(dsn) = &state.session.dsn else {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             };
             let dsn = dsn.clone();
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if is_multi_statement(&content) {
                 show_explain_error_on_plan(
                     state,
                     "EXPLAIN ANALYZE does not support multiple statements",
                 );
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let kind = statement_classifier::classify(&content);
             let risk = evaluate_sql_risk(&kind, &content);
@@ -140,7 +140,7 @@ pub fn reduce_explain_with_services(
                     state,
                     "Read-only mode: EXPLAIN ANALYZE is blocked for DML statements.",
                 );
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             state.explain.confirm_scroll_offset = 0;
@@ -156,10 +156,10 @@ pub fn reduce_explain_with_services(
                         services.sql_dialect.build_explain_analyze_sql(&content)
                     else {
                         mark_explain_unavailable(state, services);
-                        return DispatchResult::no_effects();
+                        return DispatchResult::handled();
                     };
                     begin_explain_running(state, now);
-                    return DispatchResult::effects(vec![Effect::ExecuteExplain {
+                    return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                         dsn,
                         query: explain_query,
                         is_analyze: true,
@@ -168,12 +168,12 @@ pub fn reduce_explain_with_services(
                 }
             }
 
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::ExplainAnalyzeConfirm => {
             if reject_unsupported_explain(state, services) {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let query = match state.sql_modal.status() {
                 SqlModalStatus::ConfirmingAnalyzeHigh {
@@ -192,17 +192,17 @@ pub fn reduce_explain_with_services(
                 let Some(explain_query) = services.sql_dialect.build_explain_analyze_sql(&query)
                 else {
                     mark_explain_unavailable(state, services);
-                    return DispatchResult::no_effects();
+                    return DispatchResult::handled();
                 };
                 begin_explain_running(state, now);
-                return DispatchResult::effects(vec![Effect::ExecuteExplain {
+                return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                     dsn,
                     query: explain_query,
                     is_analyze: true,
                     read_only: state.session.read_only,
                 }]);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::ExplainAnalyzeCancel => {
@@ -212,7 +212,7 @@ pub fn reduce_explain_with_services(
             ) {
                 state.sql_modal.cancel_confirmation();
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::ExplainCompleted {
@@ -228,12 +228,12 @@ pub fn reduce_explain_with_services(
                 *execution_time_ms,
                 &query,
             );
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::ExplainFailed(error) => {
             finish_explain_error(state, error.user_message());
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::Scroll {
@@ -268,7 +268,7 @@ pub fn reduce_explain_with_services(
                 _ => unreachable!(),
             };
             *offset = direction.clamp_vertical_offset(*offset, max, 1);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::CompareEditQuery => {
@@ -276,7 +276,7 @@ pub fn reduce_explain_with_services(
                 let query = right.full_query.clone();
                 state.sql_modal.load_query_for_editing(query);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::SqlModalNextTab => {
@@ -284,7 +284,7 @@ pub fn reduce_explain_with_services(
                 .db_capabilities
                 .next_sql_modal_tab(state.sql_modal.active_tab());
             state.sql_modal.set_active_tab(tab);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::SqlModalPrevTab => {
@@ -292,7 +292,7 @@ pub fn reduce_explain_with_services(
                 .db_capabilities
                 .prev_sql_modal_tab(state.sql_modal.active_tab());
             state.sql_modal.set_active_tab(tab);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         _ => DispatchResult::pass(),

--- a/src/app/update/mod.rs
+++ b/src/app/update/mod.rs
@@ -1,6 +1,7 @@
 pub mod action;
 pub mod browse;
 pub mod connection;
+pub mod dispatch_result;
 pub mod er;
 pub mod explain;
 pub mod helpers;
@@ -15,6 +16,7 @@ pub use browse::navigation::reduce_navigation;
 pub use browse::query::reduce_query;
 pub use browse::result::reduce_result;
 pub use connection::reduce_connection;
+pub use dispatch_result::DispatchResult;
 pub use er::reduce_er;
 #[cfg(test)]
 pub use explain::reduce_explain;

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -58,74 +58,74 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
         Action::OpenModal(ModalKind::TablePicker) => {
             state.modal.set_mode(InputMode::TablePicker);
             state.ui.table_picker.clear_filter_and_reset();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::TablePicker)
         | Action::CloseModal(ModalKind::CommandPalette)
         | Action::Escape => {
             state.modal.set_mode(InputMode::Normal);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::OpenModal(ModalKind::CommandPalette) => {
             state.modal.set_mode(InputMode::CommandPalette);
             // Command palette currently reuses the generic picker selection state.
             state.ui.table_picker.reset();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::OpenModal(ModalKind::Settings) => {
             state.settings.open(state.ui.theme_id());
             state.modal.set_mode(InputMode::Settings);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SettingsSelectNext => {
             state.settings.select_next();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SettingsSelectPrevious => {
             state.settings.select_previous();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SettingsNextSection => {
             state.settings.switch_next_section();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SettingsPreviousSection => {
             state.settings.switch_previous_section();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SettingsStartCustomBrowserEdit => {
             state.settings.start_custom_browser_edit();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SettingsStopCustomBrowserEdit => {
             state.settings.stop_custom_browser_edit();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextInput {
             target: InputTarget::SettingsErBrowser,
             ch,
         } => {
             state.settings.input_custom_browser(*ch);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::SettingsErBrowser,
         } => {
             state.settings.backspace_custom_browser();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextDelete {
             target: InputTarget::SettingsErBrowser,
         } => {
             state.settings.delete_custom_browser();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: InputTarget::SettingsErBrowser,
             direction,
         } => {
             state.settings.move_custom_browser_cursor(*direction);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SettingsApply => {
             let theme_id = state.settings.selected_theme();
@@ -133,12 +133,12 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 theme_id,
                 er_browser: state.settings.selected_er_browser(),
             };
-            DispatchResult::effects(vec![Effect::SaveSettings { settings }])
+            DispatchResult::handled_with(vec![Effect::SaveSettings { settings }])
         }
         Action::SettingsCancel | Action::CloseModal(ModalKind::Settings) => {
             state.settings.discard_selection();
             state.modal.set_mode(InputMode::Normal);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SettingsSaved(settings) => {
             state.ui.set_theme(settings.theme_id);
@@ -146,11 +146,11 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 .settings
                 .commit_saved(settings.theme_id, settings.er_browser.clone());
             state.set_success("Settings saved".to_string());
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SettingsSaveFailed(error) => {
             state.set_error(format!("Failed to save settings: {error}"));
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ToggleModal(ModalKind::Help) => {
             if state.modal.active_mode() == InputMode::Help {
@@ -160,24 +160,24 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 state.ui.help.open(origin);
                 state.modal.push_mode(InputMode::Help);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::Help) => {
             close_help(state);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextInput {
             target: InputTarget::HelpFilter,
             ch,
         } => {
             state.ui.help.insert_filter_char(*ch);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::HelpFilter,
         } => {
             state.ui.help.backspace_filter();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::Help,
@@ -236,7 +236,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 | ScrollAmount::ViewportMiddle
                 | ScrollAmount::ViewportBottom => {}
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::Scroll {
             target: ScrollTarget::ConfirmDialog,
@@ -249,52 +249,52 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 max_scroll,
                 1,
             ) as u16;
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::SqlModal) => {
             state.modal.set_mode(InputMode::Normal);
             state.sql_modal.cleanup_on_close();
             state.flash_timers.clear(FlashId::SqlModal);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::OpenModal(ModalKind::ErTablePicker) => {
             if state.session.metadata().is_none() {
                 state.ui.pending_er_picker = true;
                 state.set_success("Waiting for metadata...".to_string());
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             state.ui.pending_er_picker = false;
             state.ui.er_selected_tables.clear();
             state.modal.set_mode(InputMode::ErTablePicker);
             state.ui.er_picker.clear_filter_and_reset();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::ErTablePicker) => {
             state.modal.set_mode(InputMode::Normal);
             state.ui.er_picker.clear_filter();
             state.ui.er_selected_tables.clear();
             state.ui.pending_er_picker = false;
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextInput {
             target: InputTarget::ErFilter,
             ch: c,
         } => {
             state.ui.er_picker.insert_filter_char(*c);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::ErFilter,
         } => {
             state.ui.er_picker.backspace_filter();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: InputTarget::ErFilter,
             direction: movement,
         } => {
             state.ui.er_picker.move_filter_cursor(*movement);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ErToggleSelection => {
             let filtered = state.er_filtered_tables();
@@ -304,7 +304,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                     state.ui.er_selected_tables.insert(name);
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ErSelectAll => {
             let all_tables: Vec<String> =
@@ -314,41 +314,41 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
             } else {
                 state.ui.er_selected_tables = all_tables.into_iter().collect();
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ErConfirmSelection => {
             if state.ui.er_selected_tables.is_empty() {
                 state.set_error("No tables selected".to_string());
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             state.er_preparation.target_tables =
                 state.ui.er_selected_tables.iter().cloned().collect();
             state.modal.set_mode(InputMode::Normal);
             state.ui.er_picker.clear_filter();
             state.ui.er_selected_tables.clear();
-            DispatchResult::effects(vec![Effect::DispatchActions(vec![Action::ErOpenDiagram])])
+            DispatchResult::handled_with(vec![Effect::DispatchActions(vec![Action::ErOpenDiagram])])
         }
         Action::OpenModal(ModalKind::QueryHistoryPicker) => {
             if state.session.active_connection_id.is_none() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if state.query.is_running() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if state.modal.active_mode() == InputMode::ConfirmDialog {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if state.sql_modal.completion().visible
                 && !state.sql_modal.completion().candidates.is_empty()
             {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
 
             state.query_history_picker.reset();
             state.modal.push_mode(InputMode::QueryHistoryPicker);
 
             let conn_id = state.session.active_connection_id.as_ref().unwrap();
-            DispatchResult::effects(vec![Effect::LoadQueryHistory {
+            DispatchResult::handled_with(vec![Effect::LoadQueryHistory {
                 project_name: state.runtime.project_name.clone(),
                 connection_id: conn_id.clone(),
             }])
@@ -356,52 +356,52 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
         Action::CloseModal(ModalKind::QueryHistoryPicker) => {
             state.modal.pop_mode();
             state.query_history_picker.reset();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::QueryHistoryLoaded(conn_id, entries) => {
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             if state.session.active_connection_id.as_ref() != Some(conn_id) {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             state.query_history_picker.replace_entries(entries);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::QueryHistoryLoadFailed(e) => {
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             state.messages.set_error_at(e.to_string(), now);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
-        Action::QueryHistoryAppendFailed(_) => DispatchResult::no_effects(),
+        Action::QueryHistoryAppendFailed(_) => DispatchResult::handled(),
         Action::TextInput {
             target: InputTarget::QueryHistoryFilter,
             ch: c,
         } => {
             state.query_history_picker.insert_filter_char(*c);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::QueryHistoryFilter,
         } => {
             state.query_history_picker.backspace_filter();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ListSelect {
             target: ListTarget::QueryHistory,
             motion: ListMotion::Next,
         } => {
             state.query_history_picker.select_next();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::ListSelect {
             target: ListTarget::QueryHistory,
             motion: ListMotion::Previous,
         } => {
             state.query_history_picker.select_previous();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::QueryHistoryConfirmSelection => {
             let grouped = state.query_history_picker.grouped_filtered_entries();
@@ -412,7 +412,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
             state.query_history_picker.reset();
 
             let Some(query) = query else {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             };
 
             match origin {
@@ -425,7 +425,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 }
                 _ => {}
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::ConfirmDialogConfirm => {
@@ -435,15 +435,15 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
             match intent {
                 Some(ConfirmIntent::QuitNoConnection) => {
                     state.should_quit = true;
-                    DispatchResult::no_effects()
+                    DispatchResult::handled()
                 }
                 Some(ConfirmIntent::DeleteConnection(id)) => {
-                    DispatchResult::effects(vec![Effect::DeleteConnection { id }])
+                    DispatchResult::handled_with(vec![Effect::DeleteConnection { id }])
                 }
                 Some(ConfirmIntent::ExecuteWrite { blocked: true, .. }) => {
                     state.result_interaction.clear_write_preview();
                     state.query.clear_delete_refresh_target();
-                    DispatchResult::no_effects()
+                    DispatchResult::handled()
                 }
                 Some(ConfirmIntent::ExecuteWrite {
                     sql,
@@ -451,7 +451,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 }) => {
                     if let Some(dsn) = &state.session.dsn {
                         state.query.begin_running(now);
-                        DispatchResult::effects(vec![Effect::ExecuteWrite {
+                        DispatchResult::handled_with(vec![Effect::ExecuteWrite {
                             dsn: dsn.clone(),
                             query: sql,
                             read_only: state.session.read_only,
@@ -462,12 +462,12 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                         state
                             .messages
                             .set_error_at("No active connection".to_string(), now);
-                        DispatchResult::no_effects()
+                        DispatchResult::handled()
                     }
                 }
                 Some(ConfirmIntent::DisableReadOnly) => {
                     state.session.read_only = false;
-                    DispatchResult::no_effects()
+                    DispatchResult::handled()
                 }
                 Some(ConfirmIntent::CsvExport {
                     export_query,
@@ -475,7 +475,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                     row_count,
                 }) => {
                     if let Some(dsn) = &state.session.dsn {
-                        DispatchResult::effects(vec![Effect::ExportCsv {
+                        DispatchResult::handled_with(vec![Effect::ExportCsv {
                             dsn: dsn.clone(),
                             query: export_query,
                             file_name,
@@ -483,10 +483,10 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                             read_only: state.session.read_only,
                         }])
                     } else {
-                        DispatchResult::no_effects()
+                        DispatchResult::handled()
                     }
                 }
-                None => DispatchResult::no_effects(),
+                None => DispatchResult::handled(),
             }
         }
         Action::ConfirmDialogCancel => {
@@ -500,10 +500,10 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Disp
                     state.connection_setup.is_first_run = false;
                 }
                 state.modal.pop_mode_override(InputMode::ConnectionSetup);
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             } else {
                 state.modal.pop_mode();
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
 

--- a/src/app/update/modal.rs
+++ b/src/app/update/modal.rs
@@ -12,6 +12,7 @@ use crate::update::action::{
     Action, InputTarget, ListMotion, ListTarget, ModalKind, ScrollAmount, ScrollDirection,
     ScrollTarget,
 };
+use crate::update::dispatch_result::DispatchResult;
 
 fn scroll_help_by(
     state: &mut AppState,
@@ -52,79 +53,79 @@ fn close_help(state: &mut AppState) {
     state.ui.help.close();
 }
 
-pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
+pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::TablePicker) => {
             state.modal.set_mode(InputMode::TablePicker);
             state.ui.table_picker.clear_filter_and_reset();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::CloseModal(ModalKind::TablePicker)
         | Action::CloseModal(ModalKind::CommandPalette)
         | Action::Escape => {
             state.modal.set_mode(InputMode::Normal);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::OpenModal(ModalKind::CommandPalette) => {
             state.modal.set_mode(InputMode::CommandPalette);
             // Command palette currently reuses the generic picker selection state.
             state.ui.table_picker.reset();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::OpenModal(ModalKind::Settings) => {
             state.settings.open(state.ui.theme_id());
             state.modal.set_mode(InputMode::Settings);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SettingsSelectNext => {
             state.settings.select_next();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SettingsSelectPrevious => {
             state.settings.select_previous();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SettingsNextSection => {
             state.settings.switch_next_section();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SettingsPreviousSection => {
             state.settings.switch_previous_section();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SettingsStartCustomBrowserEdit => {
             state.settings.start_custom_browser_edit();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SettingsStopCustomBrowserEdit => {
             state.settings.stop_custom_browser_edit();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextInput {
             target: InputTarget::SettingsErBrowser,
             ch,
         } => {
             state.settings.input_custom_browser(*ch);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextBackspace {
             target: InputTarget::SettingsErBrowser,
         } => {
             state.settings.backspace_custom_browser();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextDelete {
             target: InputTarget::SettingsErBrowser,
         } => {
             state.settings.delete_custom_browser();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextMoveCursor {
             target: InputTarget::SettingsErBrowser,
             direction,
         } => {
             state.settings.move_custom_browser_cursor(*direction);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SettingsApply => {
             let theme_id = state.settings.selected_theme();
@@ -132,12 +133,12 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                 theme_id,
                 er_browser: state.settings.selected_er_browser(),
             };
-            Some(vec![Effect::SaveSettings { settings }])
+            DispatchResult::effects(vec![Effect::SaveSettings { settings }])
         }
         Action::SettingsCancel | Action::CloseModal(ModalKind::Settings) => {
             state.settings.discard_selection();
             state.modal.set_mode(InputMode::Normal);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SettingsSaved(settings) => {
             state.ui.set_theme(settings.theme_id);
@@ -145,11 +146,11 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                 .settings
                 .commit_saved(settings.theme_id, settings.er_browser.clone());
             state.set_success("Settings saved".to_string());
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SettingsSaveFailed(error) => {
             state.set_error(format!("Failed to save settings: {error}"));
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ToggleModal(ModalKind::Help) => {
             if state.modal.active_mode() == InputMode::Help {
@@ -159,24 +160,24 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                 state.ui.help.open(origin);
                 state.modal.push_mode(InputMode::Help);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::CloseModal(ModalKind::Help) => {
             close_help(state);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextInput {
             target: InputTarget::HelpFilter,
             ch,
         } => {
             state.ui.help.insert_filter_char(*ch);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextBackspace {
             target: InputTarget::HelpFilter,
         } => {
             state.ui.help.backspace_filter();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::Help,
@@ -235,7 +236,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                 | ScrollAmount::ViewportMiddle
                 | ScrollAmount::ViewportBottom => {}
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::Scroll {
             target: ScrollTarget::ConfirmDialog,
@@ -248,52 +249,52 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                 max_scroll,
                 1,
             ) as u16;
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::CloseModal(ModalKind::SqlModal) => {
             state.modal.set_mode(InputMode::Normal);
             state.sql_modal.cleanup_on_close();
             state.flash_timers.clear(FlashId::SqlModal);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::OpenModal(ModalKind::ErTablePicker) => {
             if state.session.metadata().is_none() {
                 state.ui.pending_er_picker = true;
                 state.set_success("Waiting for metadata...".to_string());
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             state.ui.pending_er_picker = false;
             state.ui.er_selected_tables.clear();
             state.modal.set_mode(InputMode::ErTablePicker);
             state.ui.er_picker.clear_filter_and_reset();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::CloseModal(ModalKind::ErTablePicker) => {
             state.modal.set_mode(InputMode::Normal);
             state.ui.er_picker.clear_filter();
             state.ui.er_selected_tables.clear();
             state.ui.pending_er_picker = false;
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextInput {
             target: InputTarget::ErFilter,
             ch: c,
         } => {
             state.ui.er_picker.insert_filter_char(*c);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextBackspace {
             target: InputTarget::ErFilter,
         } => {
             state.ui.er_picker.backspace_filter();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextMoveCursor {
             target: InputTarget::ErFilter,
             direction: movement,
         } => {
             state.ui.er_picker.move_filter_cursor(*movement);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ErToggleSelection => {
             let filtered = state.er_filtered_tables();
@@ -303,7 +304,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                     state.ui.er_selected_tables.insert(name);
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ErSelectAll => {
             let all_tables: Vec<String> =
@@ -313,41 +314,41 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             } else {
                 state.ui.er_selected_tables = all_tables.into_iter().collect();
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ErConfirmSelection => {
             if state.ui.er_selected_tables.is_empty() {
                 state.set_error("No tables selected".to_string());
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             state.er_preparation.target_tables =
                 state.ui.er_selected_tables.iter().cloned().collect();
             state.modal.set_mode(InputMode::Normal);
             state.ui.er_picker.clear_filter();
             state.ui.er_selected_tables.clear();
-            Some(vec![Effect::DispatchActions(vec![Action::ErOpenDiagram])])
+            DispatchResult::effects(vec![Effect::DispatchActions(vec![Action::ErOpenDiagram])])
         }
         Action::OpenModal(ModalKind::QueryHistoryPicker) => {
             if state.session.active_connection_id.is_none() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if state.query.is_running() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if state.modal.active_mode() == InputMode::ConfirmDialog {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if state.sql_modal.completion().visible
                 && !state.sql_modal.completion().candidates.is_empty()
             {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
 
             state.query_history_picker.reset();
             state.modal.push_mode(InputMode::QueryHistoryPicker);
 
             let conn_id = state.session.active_connection_id.as_ref().unwrap();
-            Some(vec![Effect::LoadQueryHistory {
+            DispatchResult::effects(vec![Effect::LoadQueryHistory {
                 project_name: state.runtime.project_name.clone(),
                 connection_id: conn_id.clone(),
             }])
@@ -355,52 +356,52 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
         Action::CloseModal(ModalKind::QueryHistoryPicker) => {
             state.modal.pop_mode();
             state.query_history_picker.reset();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::QueryHistoryLoaded(conn_id, entries) => {
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             if state.session.active_connection_id.as_ref() != Some(conn_id) {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             state.query_history_picker.replace_entries(entries);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::QueryHistoryLoadFailed(e) => {
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             state.messages.set_error_at(e.to_string(), now);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
-        Action::QueryHistoryAppendFailed(_) => Some(vec![]),
+        Action::QueryHistoryAppendFailed(_) => DispatchResult::no_effects(),
         Action::TextInput {
             target: InputTarget::QueryHistoryFilter,
             ch: c,
         } => {
             state.query_history_picker.insert_filter_char(*c);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextBackspace {
             target: InputTarget::QueryHistoryFilter,
         } => {
             state.query_history_picker.backspace_filter();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ListSelect {
             target: ListTarget::QueryHistory,
             motion: ListMotion::Next,
         } => {
             state.query_history_picker.select_next();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::ListSelect {
             target: ListTarget::QueryHistory,
             motion: ListMotion::Previous,
         } => {
             state.query_history_picker.select_previous();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::QueryHistoryConfirmSelection => {
             let grouped = state.query_history_picker.grouped_filtered_entries();
@@ -411,7 +412,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             state.query_history_picker.reset();
 
             let Some(query) = query else {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             };
 
             match origin {
@@ -424,7 +425,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                 }
                 _ => {}
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::ConfirmDialogConfirm => {
@@ -434,15 +435,15 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
             match intent {
                 Some(ConfirmIntent::QuitNoConnection) => {
                     state.should_quit = true;
-                    Some(vec![])
+                    DispatchResult::no_effects()
                 }
                 Some(ConfirmIntent::DeleteConnection(id)) => {
-                    Some(vec![Effect::DeleteConnection { id }])
+                    DispatchResult::effects(vec![Effect::DeleteConnection { id }])
                 }
                 Some(ConfirmIntent::ExecuteWrite { blocked: true, .. }) => {
                     state.result_interaction.clear_write_preview();
                     state.query.clear_delete_refresh_target();
-                    Some(vec![])
+                    DispatchResult::no_effects()
                 }
                 Some(ConfirmIntent::ExecuteWrite {
                     sql,
@@ -450,7 +451,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                 }) => {
                     if let Some(dsn) = &state.session.dsn {
                         state.query.begin_running(now);
-                        Some(vec![Effect::ExecuteWrite {
+                        DispatchResult::effects(vec![Effect::ExecuteWrite {
                             dsn: dsn.clone(),
                             query: sql,
                             read_only: state.session.read_only,
@@ -461,12 +462,12 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                         state
                             .messages
                             .set_error_at("No active connection".to_string(), now);
-                        Some(vec![])
+                        DispatchResult::no_effects()
                     }
                 }
                 Some(ConfirmIntent::DisableReadOnly) => {
                     state.session.read_only = false;
-                    Some(vec![])
+                    DispatchResult::no_effects()
                 }
                 Some(ConfirmIntent::CsvExport {
                     export_query,
@@ -474,7 +475,7 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                     row_count,
                 }) => {
                     if let Some(dsn) = &state.session.dsn {
-                        Some(vec![Effect::ExportCsv {
+                        DispatchResult::effects(vec![Effect::ExportCsv {
                             dsn: dsn.clone(),
                             query: export_query,
                             file_name,
@@ -482,10 +483,10 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                             read_only: state.session.read_only,
                         }])
                     } else {
-                        Some(vec![])
+                        DispatchResult::no_effects()
                     }
                 }
-                None => Some(vec![]),
+                None => DispatchResult::no_effects(),
             }
         }
         Action::ConfirmDialogCancel => {
@@ -499,14 +500,14 @@ pub fn reduce_modal(state: &mut AppState, action: &Action, now: Instant) -> Opti
                     state.connection_setup.is_first_run = false;
                 }
                 state.modal.pop_mode_override(InputMode::ConnectionSetup);
-                Some(vec![])
+                DispatchResult::no_effects()
             } else {
                 state.modal.pop_mode();
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -652,7 +653,9 @@ mod tests {
                 );
                 reduce_modal(&mut state, &Action::SettingsSelectNext, Instant::now());
 
-                let effects = reduce_modal(&mut state, &action, Instant::now()).unwrap();
+                let effects = reduce_modal(&mut state, &action, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
                 assert_eq!(state.input_mode(), InputMode::Normal);
                 assert_eq!(state.settings.selected_theme(), ThemeId::Default);
@@ -670,8 +673,9 @@ mod tests {
                 );
                 reduce_modal(&mut state, &Action::SettingsSelectNext, Instant::now());
 
-                let effects =
-                    reduce_modal(&mut state, &Action::SettingsApply, Instant::now()).unwrap();
+                let effects = reduce_modal(&mut state, &Action::SettingsApply, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
                 assert_eq!(state.input_mode(), InputMode::Settings);
                 assert_eq!(state.ui.theme_id(), ThemeId::Default);
@@ -693,8 +697,9 @@ mod tests {
                 reduce_modal(&mut state, &Action::SettingsNextSection, Instant::now());
                 reduce_modal(&mut state, &Action::SettingsSelectNext, Instant::now());
 
-                let effects =
-                    reduce_modal(&mut state, &Action::SettingsApply, Instant::now()).unwrap();
+                let effects = reduce_modal(&mut state, &Action::SettingsApply, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
                 assert_eq!(state.input_mode(), InputMode::Settings);
                 assert_eq!(state.settings.saved_er_browser(), None);
@@ -728,8 +733,9 @@ mod tests {
                     Instant::now(),
                 );
 
-                let effects =
-                    reduce_modal(&mut state, &Action::SettingsApply, Instant::now()).unwrap();
+                let effects = reduce_modal(&mut state, &Action::SettingsApply, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
                 assert_eq!(state.input_mode(), InputMode::Settings);
                 assert!(matches!(
@@ -856,7 +862,9 @@ mod tests {
                 );
 
                 let now = Instant::now();
-                let effects = reduce_modal(&mut state, &Action::ConfirmDialogConfirm, now).unwrap();
+                let effects = reduce_modal(&mut state, &Action::ConfirmDialogConfirm, now)
+                    .into_effects()
+                    .expect("reducer should handle action");
 
                 assert_eq!(state.input_mode(), InputMode::CellEdit);
                 assert!(state.query.is_running());
@@ -943,7 +951,9 @@ mod tests {
                     },
                 );
 
-                reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now()).unwrap();
+                reduce_modal(&mut state, &Action::ConfirmDialogConfirm, Instant::now())
+                    .into_effects()
+                    .expect("reducer should handle action");
 
                 assert!(state.result_interaction.pending_write_preview().is_none());
                 assert!(state.query.pending_delete_refresh_target().is_none());
@@ -1125,7 +1135,9 @@ mod tests {
                     .open("", "", ConfirmIntent::QuitNoConnection);
 
                 let effects =
-                    reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now()).unwrap();
+                    reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now())
+                        .into_effects()
+                        .expect("reducer should handle action");
 
                 assert_eq!(state.input_mode(), InputMode::ConnectionSetup);
                 assert!(effects.is_empty());
@@ -1145,7 +1157,9 @@ mod tests {
                 );
 
                 let effects =
-                    reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now()).unwrap();
+                    reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now())
+                        .into_effects()
+                        .expect("reducer should handle action");
 
                 assert_eq!(state.input_mode(), InputMode::CellEdit);
                 assert!(effects.is_empty());
@@ -1158,7 +1172,9 @@ mod tests {
                 enter_confirm_dialog(&mut state, InputMode::Normal);
 
                 let effects =
-                    reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now()).unwrap();
+                    reduce_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now())
+                        .into_effects()
+                        .expect("reducer should handle action");
 
                 assert!(effects.is_empty());
             }

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -46,10 +46,10 @@ fn reduce_inner(
 ) -> Vec<Effect> {
     state.result_interaction.clear_operator_pending();
 
-    // reduce_result must precede reduce_query: passthrough actions (e.g. ResultNextPage)
-    // reset view state here and return None, relying on reduce_query for the actual page change.
     if let Some(effects) = reduce_connection(state, &action, now, services)
         .or_else(|| reduce_modal(state, &action, now))
+        // reduce_result must precede reduce_query: passthrough actions (e.g. ResultNextPage)
+        // reset view state here and return Pass, relying on reduce_query for the page change.
         .or_else(|| reduce_result(state, &action, services, now))
         .or_else(|| reduce_navigation(state, &action, services, now))
         .or_else(|| reduce_sql_modal(state, &action, now, services))
@@ -57,6 +57,7 @@ fn reduce_inner(
         .or_else(|| reduce_metadata(state, &action, now))
         .or_else(|| reduce_er(state, &action, now))
         .or_else(|| reduce_query(state, &action, now, services))
+        .into_effects()
     {
         return effects;
     }

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -19,32 +19,33 @@ use crate::policy::write::sql_risk::{
 use crate::policy::write::write_guardrails::{AdhocRiskDecision, RiskLevel, evaluate_sql_risk};
 use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
+use crate::update::dispatch_result::DispatchResult;
 
 pub fn reduce_sql_modal(
     state: &mut AppState,
     action: &Action,
     now: Instant,
     services: &crate::services::AppServices,
-) -> Option<Vec<Effect>> {
+) -> DispatchResult {
     match action {
         // Completion navigation
         Action::CompletionNext => {
             state.sql_modal.completion_next();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::CompletionPrev => {
             state.sql_modal.completion_prev();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::CompletionDismiss => {
             state.sql_modal.dismiss_completion();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         // Clipboard paste
         Action::Paste(text) if state.modal.active_mode() == InputMode::SqlModal => {
             if !matches!(state.sql_modal.status(), SqlModalStatus::Editing) {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
             state.sql_modal.editor.insert_str(&normalized);
@@ -56,7 +57,7 @@ pub fn reduce_sql_modal(
                 .sql_modal
                 .schedule_completion_after_dismiss(now + Duration::from_millis(100));
             state.sql_modal.enter_editing();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         // Text editing
@@ -73,7 +74,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextBackspace {
             target: InputTarget::SqlModal,
@@ -87,7 +88,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextDelete {
             target: InputTarget::SqlModal,
@@ -101,7 +102,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SqlModalNewLine => {
             state.sql_modal.enter_editing();
@@ -113,7 +114,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SqlModalTab => {
             state.sql_modal.enter_editing();
@@ -125,7 +126,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextMoveCursor {
             target: InputTarget::SqlModal,
@@ -147,13 +148,13 @@ pub fn reduce_sql_modal(
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
             state.ui.key_sequence = KeySequenceState::Idle;
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SqlModalClear => {
             state.sql_modal.editor.clear();
             state.sql_modal.reset_completion();
             state.ui.key_sequence = KeySequenceState::Idle;
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         // Modal open/submit
@@ -162,24 +163,24 @@ pub fn reduce_sql_modal(
             state.sql_modal.open_sql_tab();
             state.flash_timers.clear(FlashId::SqlModal);
             if !state.sql_modal.is_prefetch_started() && state.session.metadata().is_some() {
-                Some(vec![Effect::DispatchActions(vec![
+                DispatchResult::effects(vec![Effect::DispatchActions(vec![
                     Action::StartPrefetchAll,
                 ])])
             } else {
-                Some(vec![])
+                DispatchResult::no_effects()
             }
         }
         Action::SqlModalSubmit => {
             let query = state.sql_modal.editor.content().trim().to_string();
             if query.is_empty() {
-                return Some(vec![]);
+                return DispatchResult::no_effects();
             }
             state.sql_modal.dismiss_completion();
 
             match evaluate_multi_statement(&query) {
                 MultiStatementDecision::Block { reason } => {
                     state.sql_modal.finish_adhoc_error(reason);
-                    Some(vec![])
+                    DispatchResult::no_effects()
                 }
                 MultiStatementDecision::Allow {
                     risk,
@@ -199,18 +200,18 @@ pub fn reduce_sql_modal(
                         state.sql_modal.finish_adhoc_error(
                             "Read-only mode: write operations are disabled".to_string(),
                         );
-                        return Some(vec![]);
+                        return DispatchResult::no_effects();
                     }
                     match risk.confirmation {
                         ConfirmationType::Immediate => {
                             state.sql_modal.begin_adhoc_running();
-                            Some(adhoc_effects(state, query))
+                            DispatchResult::effects(adhoc_effects(state, query))
                         }
                         ConfirmationType::TableNameInput { target } => {
                             state
                                 .sql_modal
                                 .begin_confirming_high(decision, Some(target));
-                            Some(vec![])
+                            DispatchResult::no_effects()
                         }
                     }
                 }
@@ -223,9 +224,9 @@ pub fn reduce_sql_modal(
             ) {
                 state.sql_modal.cancel_confirmation();
                 state.ui.key_sequence = KeySequenceState::Idle;
-                Some(vec![])
+                DispatchResult::no_effects()
             } else {
-                None
+                DispatchResult::pass()
             }
         }
 
@@ -238,7 +239,7 @@ pub fn reduce_sql_modal(
                 input.insert_char(*c);
                 input.update_viewport(HIGH_RISK_INPUT_VISIBLE_WIDTH);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextBackspace {
             target: target @ (InputTarget::SqlModalHighRisk | InputTarget::SqlModalAnalyzeHighRisk),
@@ -247,7 +248,7 @@ pub fn reduce_sql_modal(
                 input.backspace();
                 input.update_viewport(HIGH_RISK_INPUT_VISIBLE_WIDTH);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::TextMoveCursor {
             target: target @ (InputTarget::SqlModalHighRisk | InputTarget::SqlModalAnalyzeHighRisk),
@@ -257,7 +258,7 @@ pub fn reduce_sql_modal(
                 input.move_cursor(*movement);
                 input.update_viewport(HIGH_RISK_INPUT_VISIBLE_WIDTH);
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::SqlModalHighRiskConfirmExecute => {
@@ -275,14 +276,14 @@ pub fn reduce_sql_modal(
                 let query = state.sql_modal.editor.content().trim().to_string();
                 state.sql_modal.begin_adhoc_running();
                 if let Some(dsn) = &state.session.dsn {
-                    return Some(vec![Effect::ExecuteAdhoc {
+                    return DispatchResult::effects(vec![Effect::ExecuteAdhoc {
                         dsn: dsn.clone(),
                         query,
                         read_only: state.session.read_only,
                     }]);
                 }
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         // Completion accept
@@ -292,7 +293,7 @@ pub fn reduce_sql_modal(
             {
                 if state.sql_modal.editor.cursor() < trigger_pos {
                     state.sql_modal.dismiss_completion();
-                    return Some(vec![]);
+                    return DispatchResult::no_effects();
                 }
 
                 let start_byte = state.sql_modal.editor.char_to_byte_index(trigger_pos);
@@ -317,11 +318,11 @@ pub fn reduce_sql_modal(
                     .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
                 state.sql_modal.dismiss_completion();
             }
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         // Completion trigger/update
-        Action::CompletionTrigger => Some(vec![Effect::TriggerCompletion]),
+        Action::CompletionTrigger => DispatchResult::effects(vec![Effect::TriggerCompletion]),
         Action::CompletionUpdated {
             candidates,
             trigger_position,
@@ -330,7 +331,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .apply_completion_update(candidates, *trigger_position, *visible);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
         Action::SqlModalAppendInsert => {
@@ -340,15 +341,15 @@ pub fn reduce_sql_modal(
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
             state.sql_modal.enter_editing();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SqlModalEnterInsert => {
             state.sql_modal.enter_editing();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SqlModalEnterNormal => {
             state.sql_modal.enter_normal();
-            Some(vec![])
+            DispatchResult::no_effects()
         }
         Action::SqlModalYank => {
             let active_tab = services
@@ -399,22 +400,24 @@ pub fn reduce_sql_modal(
                 }
             };
             match content {
-                Some(c) if !c.is_empty() => Some(vec![Effect::CopyToClipboard {
-                    content: c,
-                    on_success: Some(Action::SqlModalYankSuccess),
-                    on_failure: Some(Action::CopyFailed(ClipboardError::Unavailable(
-                        "Clipboard unavailable".into(),
-                    ))),
-                }]),
-                _ => Some(vec![]),
+                Some(c) if !c.is_empty() => {
+                    DispatchResult::effects(vec![Effect::CopyToClipboard {
+                        content: c,
+                        on_success: Some(Action::SqlModalYankSuccess),
+                        on_failure: Some(Action::CopyFailed(ClipboardError::Unavailable(
+                            "Clipboard unavailable".into(),
+                        ))),
+                    }])
+                }
+                _ => DispatchResult::no_effects(),
             }
         }
         Action::SqlModalYankSuccess => {
             state.flash_timers.set(FlashId::SqlModal, now);
-            Some(vec![])
+            DispatchResult::no_effects()
         }
 
-        _ => None,
+        _ => DispatchResult::pass(),
     }
 }
 
@@ -460,11 +463,7 @@ mod tests {
     use super::*;
     use std::time::Instant;
 
-    fn reduce_sql_modal(
-        state: &mut AppState,
-        action: &Action,
-        now: Instant,
-    ) -> Option<Vec<Effect>> {
+    fn reduce_sql_modal(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
         super::reduce_sql_modal(state, action, now, &crate::services::AppServices::stub())
     }
 
@@ -814,8 +813,9 @@ mod tests {
 
             assert!(matches!(state.sql_modal.status(), SqlModalStatus::Running));
             assert!(
-                effects
-                    .is_some_and(|e| e.iter().any(|ef| matches!(ef, Effect::ExecuteAdhoc { .. })))
+                effects.is_handled_and(|e| e
+                    .iter()
+                    .any(|ef| matches!(ef, Effect::ExecuteAdhoc { .. })))
             );
         }
 
@@ -999,8 +999,9 @@ mod tests {
 
             assert!(matches!(state.sql_modal.status(), SqlModalStatus::Running));
             assert!(
-                effects
-                    .is_some_and(|e| e.iter().any(|ef| matches!(ef, Effect::ExecuteAdhoc { .. })))
+                effects.is_handled_and(|e| e
+                    .iter()
+                    .any(|ef| matches!(ef, Effect::ExecuteAdhoc { .. })))
             );
         }
     }
@@ -1019,8 +1020,9 @@ mod tests {
             state.session.dsn = Some("postgres://localhost/test".to_string());
             state.session.read_only = true;
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Error);
@@ -1052,7 +1054,9 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id = 1".to_string());
-            reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now()).unwrap();
+            reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Error);
             assert!(state.sql_modal.last_adhoc_success().is_none());
@@ -1067,8 +1071,9 @@ mod tests {
             state.session.dsn = Some("postgres://localhost/test".to_string());
             state.session.read_only = true;
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(!effects.is_empty());
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
@@ -1091,8 +1096,9 @@ mod tests {
         fn submit_select_executes_immediately() {
             let mut state = modal_state_with_query("SELECT 1");
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
             assert!(
@@ -1106,8 +1112,9 @@ mod tests {
         fn submit_insert_executes_immediately() {
             let mut state = modal_state_with_query("INSERT INTO t VALUES (1)");
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
             assert!(
@@ -1215,8 +1222,9 @@ mod tests {
         fn yank_empty_content_is_noop() {
             let mut state = sql_modal_state();
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -1226,8 +1234,9 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
             assert!(
@@ -1314,8 +1323,9 @@ mod tests {
             state.sql_modal.editor.set_content("SELECT 1".to_string());
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
             assert!(
@@ -1329,8 +1339,9 @@ mod tests {
             state.sql_modal.editor.set_content(String::new());
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -1341,8 +1352,9 @@ mod tests {
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = Some("Seq Scan on users".to_string());
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
             assert!(
@@ -1356,8 +1368,9 @@ mod tests {
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = None;
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -1369,8 +1382,9 @@ mod tests {
             state.explain.plan_text = None;
             state.explain.error = Some("syntax error".to_string());
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -1382,8 +1396,9 @@ mod tests {
             state.explain.left = Some(make_slot("Seq Scan", false, 420, SlotSource::AutoPrevious));
             state.explain.right = Some(make_slot("Index Scan", true, 50, SlotSource::AutoLatest));
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
             if let Effect::CopyToClipboard { content, .. } = &effects[0] {
@@ -1406,8 +1421,9 @@ mod tests {
             state.explain.left = Some(make_slot("Seq Scan", false, 300, SlotSource::AutoPrevious));
             state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
             if let Effect::CopyToClipboard { content, .. } = &effects[0] {
@@ -1425,8 +1441,9 @@ mod tests {
             state.explain.left = None;
             state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -1438,8 +1455,9 @@ mod tests {
             state.explain.left = Some(make_slot("Seq Scan", false, 200, SlotSource::AutoPrevious));
             state.explain.right = None;
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -1451,8 +1469,9 @@ mod tests {
             state.explain.left = None;
             state.explain.right = None;
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert!(effects.is_empty());
         }
@@ -1490,8 +1509,9 @@ mod tests {
                 source: SlotSource::AutoLatest,
             });
 
-            let effects =
-                reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now()).unwrap();
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalYank, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
             if let Effect::CopyToClipboard { content, .. } = &effects[0] {

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -203,10 +203,7 @@ pub fn reduce_sql_modal(
                         return DispatchResult::handled();
                     }
                     match risk.confirmation {
-                        ConfirmationType::Immediate => {
-                            state.sql_modal.begin_adhoc_running();
-                            DispatchResult::handled_with(adhoc_effects(state, query))
-                        }
+                        ConfirmationType::Immediate => dispatch_adhoc_if_connected(state, query),
                         ConfirmationType::TableNameInput { target } => {
                             state
                                 .sql_modal
@@ -274,14 +271,7 @@ pub fn reduce_sql_modal(
             );
             if matched {
                 let query = state.sql_modal.editor.content().trim().to_string();
-                state.sql_modal.begin_adhoc_running();
-                if let Some(dsn) = &state.session.dsn {
-                    return DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
-                        dsn: dsn.clone(),
-                        query,
-                        read_only: state.session.read_only,
-                    }]);
-                }
+                return dispatch_adhoc_if_connected(state, query);
             }
             DispatchResult::handled()
         }
@@ -447,15 +437,20 @@ fn multi_statement_label(sql: &str) -> &'static str {
     worst_label
 }
 
-fn adhoc_effects(state: &AppState, query: String) -> Vec<Effect> {
-    match &state.session.dsn {
-        Some(dsn) => vec![Effect::ExecuteAdhoc {
-            dsn: dsn.clone(),
-            query,
-            read_only: state.session.read_only,
-        }],
-        None => vec![],
-    }
+fn dispatch_adhoc_if_connected(state: &mut AppState, query: String) -> DispatchResult {
+    let Some(dsn) = state.session.dsn.clone() else {
+        state
+            .sql_modal
+            .finish_adhoc_error("No active connection".to_string());
+        return DispatchResult::handled();
+    };
+
+    state.sql_modal.begin_adhoc_running();
+    DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
+        dsn,
+        query,
+        read_only: state.session.read_only,
+    }])
 }
 
 #[cfg(test)]
@@ -736,6 +731,24 @@ mod tests {
         }
 
         #[test]
+        fn submit_medium_risk_without_dsn_sets_error() {
+            let mut state = sql_modal_state();
+            state
+                .sql_modal
+                .editor
+                .set_content("UPDATE users SET x=1 WHERE id=1".to_string());
+
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
+
+            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error));
+            assert_eq!(
+                state.sql_modal.last_adhoc_error(),
+                Some("No active connection")
+            );
+            assert!(effects.is_handled_and(Vec::is_empty));
+        }
+
+        #[test]
         fn high_risk_input_appends_char() {
             let mut state = confirming_high_state("DROP TABLE users", Some("users"));
 
@@ -817,6 +830,34 @@ mod tests {
                     .iter()
                     .any(|ef| matches!(ef, Effect::ExecuteAdhoc { .. })))
             );
+        }
+
+        #[test]
+        fn high_risk_confirm_without_dsn_sets_error() {
+            let mut state = confirming_high_state("DROP TABLE users", Some("users"));
+            for c in "users".chars() {
+                reduce_sql_modal(
+                    &mut state,
+                    &Action::TextInput {
+                        target: InputTarget::SqlModalHighRisk,
+                        ch: c,
+                    },
+                    Instant::now(),
+                );
+            }
+
+            let effects = reduce_sql_modal(
+                &mut state,
+                &Action::SqlModalHighRiskConfirmExecute,
+                Instant::now(),
+            );
+
+            assert!(matches!(state.sql_modal.status(), SqlModalStatus::Error));
+            assert_eq!(
+                state.sql_modal.last_adhoc_error(),
+                Some("No active connection")
+            );
+            assert!(effects.is_handled_and(Vec::is_empty));
         }
 
         #[test]

--- a/src/app/update/sql_editor.rs
+++ b/src/app/update/sql_editor.rs
@@ -31,21 +31,21 @@ pub fn reduce_sql_modal(
         // Completion navigation
         Action::CompletionNext => {
             state.sql_modal.completion_next();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::CompletionPrev => {
             state.sql_modal.completion_prev();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::CompletionDismiss => {
             state.sql_modal.dismiss_completion();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         // Clipboard paste
         Action::Paste(text) if state.modal.active_mode() == InputMode::SqlModal => {
             if !matches!(state.sql_modal.status(), SqlModalStatus::Editing) {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
             state.sql_modal.editor.insert_str(&normalized);
@@ -57,7 +57,7 @@ pub fn reduce_sql_modal(
                 .sql_modal
                 .schedule_completion_after_dismiss(now + Duration::from_millis(100));
             state.sql_modal.enter_editing();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         // Text editing
@@ -74,7 +74,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::SqlModal,
@@ -88,7 +88,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextDelete {
             target: InputTarget::SqlModal,
@@ -102,7 +102,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SqlModalNewLine => {
             state.sql_modal.enter_editing();
@@ -114,7 +114,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SqlModalTab => {
             state.sql_modal.enter_editing();
@@ -126,7 +126,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: InputTarget::SqlModal,
@@ -148,13 +148,13 @@ pub fn reduce_sql_modal(
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
             state.ui.key_sequence = KeySequenceState::Idle;
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SqlModalClear => {
             state.sql_modal.editor.clear();
             state.sql_modal.reset_completion();
             state.ui.key_sequence = KeySequenceState::Idle;
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         // Modal open/submit
@@ -163,24 +163,24 @@ pub fn reduce_sql_modal(
             state.sql_modal.open_sql_tab();
             state.flash_timers.clear(FlashId::SqlModal);
             if !state.sql_modal.is_prefetch_started() && state.session.metadata().is_some() {
-                DispatchResult::effects(vec![Effect::DispatchActions(vec![
+                DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
                     Action::StartPrefetchAll,
                 ])])
             } else {
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             }
         }
         Action::SqlModalSubmit => {
             let query = state.sql_modal.editor.content().trim().to_string();
             if query.is_empty() {
-                return DispatchResult::no_effects();
+                return DispatchResult::handled();
             }
             state.sql_modal.dismiss_completion();
 
             match evaluate_multi_statement(&query) {
                 MultiStatementDecision::Block { reason } => {
                     state.sql_modal.finish_adhoc_error(reason);
-                    DispatchResult::no_effects()
+                    DispatchResult::handled()
                 }
                 MultiStatementDecision::Allow {
                     risk,
@@ -200,18 +200,18 @@ pub fn reduce_sql_modal(
                         state.sql_modal.finish_adhoc_error(
                             "Read-only mode: write operations are disabled".to_string(),
                         );
-                        return DispatchResult::no_effects();
+                        return DispatchResult::handled();
                     }
                     match risk.confirmation {
                         ConfirmationType::Immediate => {
                             state.sql_modal.begin_adhoc_running();
-                            DispatchResult::effects(adhoc_effects(state, query))
+                            DispatchResult::handled_with(adhoc_effects(state, query))
                         }
                         ConfirmationType::TableNameInput { target } => {
                             state
                                 .sql_modal
                                 .begin_confirming_high(decision, Some(target));
-                            DispatchResult::no_effects()
+                            DispatchResult::handled()
                         }
                     }
                 }
@@ -224,7 +224,7 @@ pub fn reduce_sql_modal(
             ) {
                 state.sql_modal.cancel_confirmation();
                 state.ui.key_sequence = KeySequenceState::Idle;
-                DispatchResult::no_effects()
+                DispatchResult::handled()
             } else {
                 DispatchResult::pass()
             }
@@ -239,7 +239,7 @@ pub fn reduce_sql_modal(
                 input.insert_char(*c);
                 input.update_viewport(HIGH_RISK_INPUT_VISIBLE_WIDTH);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextBackspace {
             target: target @ (InputTarget::SqlModalHighRisk | InputTarget::SqlModalAnalyzeHighRisk),
@@ -248,7 +248,7 @@ pub fn reduce_sql_modal(
                 input.backspace();
                 input.update_viewport(HIGH_RISK_INPUT_VISIBLE_WIDTH);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: target @ (InputTarget::SqlModalHighRisk | InputTarget::SqlModalAnalyzeHighRisk),
@@ -258,7 +258,7 @@ pub fn reduce_sql_modal(
                 input.move_cursor(*movement);
                 input.update_viewport(HIGH_RISK_INPUT_VISIBLE_WIDTH);
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::SqlModalHighRiskConfirmExecute => {
@@ -276,14 +276,14 @@ pub fn reduce_sql_modal(
                 let query = state.sql_modal.editor.content().trim().to_string();
                 state.sql_modal.begin_adhoc_running();
                 if let Some(dsn) = &state.session.dsn {
-                    return DispatchResult::effects(vec![Effect::ExecuteAdhoc {
+                    return DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
                         dsn: dsn.clone(),
                         query,
                         read_only: state.session.read_only,
                     }]);
                 }
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         // Completion accept
@@ -293,7 +293,7 @@ pub fn reduce_sql_modal(
             {
                 if state.sql_modal.editor.cursor() < trigger_pos {
                     state.sql_modal.dismiss_completion();
-                    return DispatchResult::no_effects();
+                    return DispatchResult::handled();
                 }
 
                 let start_byte = state.sql_modal.editor.char_to_byte_index(trigger_pos);
@@ -318,11 +318,11 @@ pub fn reduce_sql_modal(
                     .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
                 state.sql_modal.dismiss_completion();
             }
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         // Completion trigger/update
-        Action::CompletionTrigger => DispatchResult::effects(vec![Effect::TriggerCompletion]),
+        Action::CompletionTrigger => DispatchResult::handled_with(vec![Effect::TriggerCompletion]),
         Action::CompletionUpdated {
             candidates,
             trigger_position,
@@ -331,7 +331,7 @@ pub fn reduce_sql_modal(
             state
                 .sql_modal
                 .apply_completion_update(candidates, *trigger_position, *visible);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         Action::SqlModalAppendInsert => {
@@ -341,15 +341,15 @@ pub fn reduce_sql_modal(
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
             state.sql_modal.enter_editing();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SqlModalEnterInsert => {
             state.sql_modal.enter_editing();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SqlModalEnterNormal => {
             state.sql_modal.enter_normal();
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
         Action::SqlModalYank => {
             let active_tab = services
@@ -401,7 +401,7 @@ pub fn reduce_sql_modal(
             };
             match content {
                 Some(c) if !c.is_empty() => {
-                    DispatchResult::effects(vec![Effect::CopyToClipboard {
+                    DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: c,
                         on_success: Some(Action::SqlModalYankSuccess),
                         on_failure: Some(Action::CopyFailed(ClipboardError::Unavailable(
@@ -409,12 +409,12 @@ pub fn reduce_sql_modal(
                         ))),
                     }])
                 }
-                _ => DispatchResult::no_effects(),
+                _ => DispatchResult::handled(),
             }
         }
         Action::SqlModalYankSuccess => {
             state.flash_timers.set(FlashId::SqlModal, now);
-            DispatchResult::no_effects()
+            DispatchResult::handled()
         }
 
         _ => DispatchResult::pass(),


### PR DESCRIPTION
## Problem
Sub reducers encode dispatch semantics with `Option<Vec<Effect>>`, so handled no-effect actions and pass-through actions are easy to confuse.

## Background
This is the first step of the reducer hierarchy cleanup. The current contract relies on readers knowing that `None` means pass-through while `Some(vec![])` means handled.

## Approach
Scope: app update reducer contract only.

Introduce `DispatchResult` to name the reducer dispatch result explicitly, then migrate sub reducers to return `Pass` or `Handled`. Result page passthrough actions remain `Pass` so the query reducer still owns the page-change effect.

## Screenshots
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

このリリースは、内部的なコード構造の改善に焦点を当てた技術的なアップデートです。エンドユーザーに対する新機能や変更はありません。

* **リファクタリング**
  * 内部的な処理フローの管理メカニズムを改善し、コードの保守性と信頼性を向上させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/riii111/sabiql/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->