### PR TITLE
chore: guard db async completions

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -21,38 +21,68 @@ pub async fn run(
     completion_engine: &RefCell<CompletionEngine>,
 ) -> Result<()> {
     match effect {
-        Effect::FetchMetadata { dsn } => {
-            fetch_metadata(action_tx, metadata_provider, metadata_cache, dsn).await
+        Effect::FetchMetadata { dsn, request_id } => {
+            fetch_metadata(
+                action_tx,
+                metadata_provider,
+                metadata_cache,
+                dsn,
+                request_id,
+            )
+            .await
         }
         Effect::FetchTableDetail {
             dsn,
             schema,
             table,
             generation,
+            request_id,
         } => {
-            fetch_table_detail(action_tx, metadata_provider, dsn, schema, table, generation);
+            fetch_table_detail(
+                action_tx,
+                metadata_provider,
+                dsn,
+                schema,
+                table,
+                generation,
+                request_id,
+            );
             Ok(())
         }
-        Effect::PrefetchTableDetail { dsn, schema, table } => {
+        Effect::PrefetchTableDetail {
+            dsn,
+            batch_id,
+            schema,
+            table,
+        } => {
             prefetch_table_detail(
                 action_tx,
                 metadata_provider,
                 completion_engine,
                 dsn,
+                batch_id,
                 schema,
                 table,
             )
             .await
         }
-        Effect::ProcessPrefetchQueue => {
-            action_tx.send(Action::ProcessPrefetchQueue).await.ok();
+        Effect::ProcessPrefetchQueue { batch_id } => {
+            action_tx
+                .send(Action::ProcessPrefetchQueue { batch_id })
+                .await
+                .ok();
             Ok(())
         }
-        Effect::DelayedProcessPrefetchQueue { delay_secs } => {
+        Effect::DelayedProcessPrefetchQueue {
+            batch_id,
+            delay_secs,
+        } => {
             let tx = action_tx.clone();
             tokio::spawn(async move {
                 tokio::time::sleep(tokio::time::Duration::from_secs(delay_secs)).await;
-                tx.send(Action::ProcessPrefetchQueue).await.ok();
+                tx.send(Action::ProcessPrefetchQueue { batch_id })
+                    .await
+                    .ok();
             });
             Ok(())
         }
@@ -70,9 +100,17 @@ async fn fetch_metadata(
     metadata_provider: &Arc<dyn MetadataProvider>,
     metadata_cache: &TtlCache<String, Arc<DatabaseMetadata>>,
     dsn: String,
+    request_id: u64,
 ) -> Result<()> {
     if let Some(cached) = metadata_cache.get(&dsn).await {
-        action_tx.send(Action::MetadataLoaded(cached)).await.ok();
+        action_tx
+            .send(Action::MetadataLoaded {
+                dsn,
+                request_id,
+                metadata: cached,
+            })
+            .await
+            .ok();
         return Ok(());
     }
 
@@ -84,11 +122,23 @@ async fn fetch_metadata(
         match provider.fetch_metadata(&dsn).await {
             Ok(metadata) => {
                 let metadata = Arc::new(metadata);
-                cache.set(dsn, Arc::clone(&metadata)).await;
-                tx.send(Action::MetadataLoaded(metadata)).await.ok();
+                cache.set(dsn.clone(), Arc::clone(&metadata)).await;
+                tx.send(Action::MetadataLoaded {
+                    dsn,
+                    request_id,
+                    metadata,
+                })
+                .await
+                .ok();
             }
             Err(e) => {
-                tx.send(Action::MetadataFailed(e)).await.ok();
+                tx.send(Action::MetadataFailed {
+                    dsn,
+                    request_id,
+                    error: e,
+                })
+                .await
+                .ok();
             }
         }
     });
@@ -103,6 +153,7 @@ fn fetch_table_detail(
     schema: String,
     table: String,
     generation: u64,
+    request_id: u64,
 ) {
     let provider = Arc::clone(metadata_provider);
     let tx = action_tx.clone();
@@ -110,12 +161,24 @@ fn fetch_table_detail(
     tokio::spawn(async move {
         match provider.fetch_table_detail(&dsn, &schema, &table).await {
             Ok(detail) => {
-                tx.send(Action::TableDetailLoaded(Box::new(detail), generation))
-                    .await
-                    .ok();
+                tx.send(Action::TableDetailLoaded {
+                    dsn,
+                    request_id,
+                    detail: Box::new(detail),
+                    generation,
+                })
+                .await
+                .ok();
             }
             Err(e) => {
-                tx.send(Action::TableDetailFailed(e, generation)).await.ok();
+                tx.send(Action::TableDetailFailed {
+                    dsn,
+                    request_id,
+                    error: e,
+                    generation,
+                })
+                .await
+                .ok();
             }
         }
     });
@@ -126,6 +189,7 @@ async fn prefetch_table_detail(
     metadata_provider: &Arc<dyn MetadataProvider>,
     completion_engine: &RefCell<CompletionEngine>,
     dsn: String,
+    batch_id: u64,
     schema: String,
     table: String,
 ) -> Result<()> {
@@ -134,7 +198,12 @@ async fn prefetch_table_detail(
 
     if already_cached {
         action_tx
-            .send(Action::TableDetailAlreadyCached { schema, table })
+            .send(Action::TableDetailAlreadyCached {
+                dsn,
+                batch_id,
+                schema,
+                table,
+            })
             .await
             .ok();
         return Ok(());
@@ -152,6 +221,8 @@ async fn prefetch_table_detail(
         match result {
             Ok(Ok(detail)) => {
                 tx.send(Action::TableDetailCached {
+                    dsn,
+                    batch_id,
                     schema,
                     table,
                     detail: Box::new(detail),
@@ -161,6 +232,8 @@ async fn prefetch_table_detail(
             }
             Ok(Err(e)) => {
                 tx.send(Action::TableDetailCacheFailed {
+                    dsn,
+                    batch_id,
                     schema,
                     table,
                     error: e,
@@ -170,6 +243,8 @@ async fn prefetch_table_detail(
             }
             Err(_) => {
                 tx.send(Action::TableDetailCacheFailed {
+                    dsn,
+                    batch_id,
                     schema,
                     table,
                     error: DbOperationError::Timeout("timed out".to_string()),
@@ -247,6 +322,7 @@ mod tests {
                 .run(
                     vec![Effect::FetchMetadata {
                         dsn: "dsn://test".to_string(),
+                        request_id: 7,
                     }],
                     &mut renderer,
                     state,
@@ -261,7 +337,14 @@ mod tests {
                 .expect("action timeout")
                 .expect("channel closed");
             assert!(
-                matches!(action, Action::MetadataLoaded(_)),
+                matches!(
+                    action,
+                    Action::MetadataLoaded {
+                        ref dsn,
+                        request_id: 7,
+                        ..
+                    } if dsn == "dsn://test"
+                ),
                 "expected MetadataLoaded, got {action:?}"
             );
         }
@@ -292,6 +375,7 @@ mod tests {
                 .run(
                     vec![Effect::FetchMetadata {
                         dsn: "dsn://miss".to_string(),
+                        request_id: 7,
                     }],
                     &mut renderer,
                     state,
@@ -306,7 +390,14 @@ mod tests {
                 .expect("action timeout")
                 .expect("channel closed");
             assert!(
-                matches!(action, Action::MetadataLoaded(_)),
+                matches!(
+                    action,
+                    Action::MetadataLoaded {
+                        ref dsn,
+                        request_id: 7,
+                        ..
+                    } if dsn == "dsn://miss"
+                ),
                 "expected MetadataLoaded, got {action:?}"
             );
         }
@@ -337,6 +428,7 @@ mod tests {
                 .run(
                     vec![Effect::FetchMetadata {
                         dsn: "dsn://err".to_string(),
+                        request_id: 7,
                     }],
                     &mut renderer,
                     state,
@@ -351,7 +443,14 @@ mod tests {
                 .expect("action timeout")
                 .expect("channel closed");
             assert!(
-                matches!(action, Action::MetadataFailed(_)),
+                matches!(
+                    action,
+                    Action::MetadataFailed {
+                        ref dsn,
+                        request_id: 7,
+                        ..
+                    } if dsn == "dsn://err"
+                ),
                 "expected MetadataFailed, got {action:?}"
             );
         }
@@ -407,6 +506,7 @@ mod tests {
                         schema: "public".to_string(),
                         table: "users".to_string(),
                         generation: 1,
+                        request_id: 9,
                     }],
                     &mut renderer,
                     state,
@@ -421,7 +521,15 @@ mod tests {
                 .expect("action timeout")
                 .expect("channel closed");
             assert!(
-                matches!(action, Action::TableDetailLoaded(_, 1)),
+                matches!(
+                    action,
+                    Action::TableDetailLoaded {
+                        ref dsn,
+                        request_id: 9,
+                        generation: 1,
+                        ..
+                    } if dsn == "dsn://test"
+                ),
                 "expected TableDetailLoaded, got {action:?}"
             );
         }
@@ -453,6 +561,7 @@ mod tests {
                 .run(
                     vec![Effect::PrefetchTableDetail {
                         dsn: "dsn://test".to_string(),
+                        batch_id: 3,
                         schema: "public".to_string(),
                         table: "users".to_string(),
                     }],

--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -21,22 +21,15 @@ pub async fn run(
     completion_engine: &RefCell<CompletionEngine>,
 ) -> Result<()> {
     match effect {
-        Effect::FetchMetadata { dsn, request_id } => {
-            fetch_metadata(
-                action_tx,
-                metadata_provider,
-                metadata_cache,
-                dsn,
-                request_id,
-            )
-            .await
+        Effect::FetchMetadata { dsn, run_id } => {
+            fetch_metadata(action_tx, metadata_provider, metadata_cache, dsn, run_id).await
         }
         Effect::FetchTableDetail {
             dsn,
             schema,
             table,
             generation,
-            request_id,
+            run_id,
         } => {
             fetch_table_detail(
                 action_tx,
@@ -45,13 +38,13 @@ pub async fn run(
                 schema,
                 table,
                 generation,
-                request_id,
+                run_id,
             );
             Ok(())
         }
         Effect::PrefetchTableDetail {
             dsn,
-            batch_id,
+            run_id,
             schema,
             table,
         } => {
@@ -60,29 +53,24 @@ pub async fn run(
                 metadata_provider,
                 completion_engine,
                 dsn,
-                batch_id,
+                run_id,
                 schema,
                 table,
             )
             .await
         }
-        Effect::ProcessPrefetchQueue { batch_id } => {
+        Effect::ProcessPrefetchQueue { run_id } => {
             action_tx
-                .send(Action::ProcessPrefetchQueue { batch_id })
+                .send(Action::ProcessPrefetchQueue { run_id })
                 .await
                 .ok();
             Ok(())
         }
-        Effect::DelayedProcessPrefetchQueue {
-            batch_id,
-            delay_secs,
-        } => {
+        Effect::DelayedProcessPrefetchQueue { run_id, delay_secs } => {
             let tx = action_tx.clone();
             tokio::spawn(async move {
                 tokio::time::sleep(tokio::time::Duration::from_secs(delay_secs)).await;
-                tx.send(Action::ProcessPrefetchQueue { batch_id })
-                    .await
-                    .ok();
+                tx.send(Action::ProcessPrefetchQueue { run_id }).await.ok();
             });
             Ok(())
         }
@@ -100,13 +88,13 @@ async fn fetch_metadata(
     metadata_provider: &Arc<dyn MetadataProvider>,
     metadata_cache: &TtlCache<String, Arc<DatabaseMetadata>>,
     dsn: String,
-    request_id: u64,
+    run_id: u64,
 ) -> Result<()> {
     if let Some(cached) = metadata_cache.get(&dsn).await {
         action_tx
             .send(Action::MetadataLoaded {
                 dsn,
-                request_id,
+                run_id,
                 metadata: cached,
             })
             .await
@@ -125,7 +113,7 @@ async fn fetch_metadata(
                 cache.set(dsn.clone(), Arc::clone(&metadata)).await;
                 tx.send(Action::MetadataLoaded {
                     dsn,
-                    request_id,
+                    run_id,
                     metadata,
                 })
                 .await
@@ -134,7 +122,7 @@ async fn fetch_metadata(
             Err(e) => {
                 tx.send(Action::MetadataFailed {
                     dsn,
-                    request_id,
+                    run_id,
                     error: e,
                 })
                 .await
@@ -153,7 +141,7 @@ fn fetch_table_detail(
     schema: String,
     table: String,
     generation: u64,
-    request_id: u64,
+    run_id: u64,
 ) {
     let provider = Arc::clone(metadata_provider);
     let tx = action_tx.clone();
@@ -163,7 +151,7 @@ fn fetch_table_detail(
             Ok(detail) => {
                 tx.send(Action::TableDetailLoaded {
                     dsn,
-                    request_id,
+                    run_id,
                     detail: Box::new(detail),
                     generation,
                 })
@@ -173,7 +161,7 @@ fn fetch_table_detail(
             Err(e) => {
                 tx.send(Action::TableDetailFailed {
                     dsn,
-                    request_id,
+                    run_id,
                     error: e,
                     generation,
                 })
@@ -189,7 +177,7 @@ async fn prefetch_table_detail(
     metadata_provider: &Arc<dyn MetadataProvider>,
     completion_engine: &RefCell<CompletionEngine>,
     dsn: String,
-    batch_id: u64,
+    run_id: u64,
     schema: String,
     table: String,
 ) -> Result<()> {
@@ -200,7 +188,7 @@ async fn prefetch_table_detail(
         action_tx
             .send(Action::TableDetailAlreadyCached {
                 dsn,
-                batch_id,
+                run_id,
                 schema,
                 table,
             })
@@ -222,7 +210,7 @@ async fn prefetch_table_detail(
             Ok(Ok(detail)) => {
                 tx.send(Action::TableDetailCached {
                     dsn,
-                    batch_id,
+                    run_id,
                     schema,
                     table,
                     detail: Box::new(detail),
@@ -233,7 +221,7 @@ async fn prefetch_table_detail(
             Ok(Err(e)) => {
                 tx.send(Action::TableDetailCacheFailed {
                     dsn,
-                    batch_id,
+                    run_id,
                     schema,
                     table,
                     error: e,
@@ -244,7 +232,7 @@ async fn prefetch_table_detail(
             Err(_) => {
                 tx.send(Action::TableDetailCacheFailed {
                     dsn,
-                    batch_id,
+                    run_id,
                     schema,
                     table,
                     error: DbOperationError::Timeout("timed out".to_string()),
@@ -322,7 +310,7 @@ mod tests {
                 .run(
                     vec![Effect::FetchMetadata {
                         dsn: "dsn://test".to_string(),
-                        request_id: 7,
+                        run_id: 7,
                     }],
                     &mut renderer,
                     state,
@@ -341,7 +329,7 @@ mod tests {
                     action,
                     Action::MetadataLoaded {
                         ref dsn,
-                        request_id: 7,
+                        run_id: 7,
                         ..
                     } if dsn == "dsn://test"
                 ),
@@ -375,7 +363,7 @@ mod tests {
                 .run(
                     vec![Effect::FetchMetadata {
                         dsn: "dsn://miss".to_string(),
-                        request_id: 7,
+                        run_id: 7,
                     }],
                     &mut renderer,
                     state,
@@ -394,7 +382,7 @@ mod tests {
                     action,
                     Action::MetadataLoaded {
                         ref dsn,
-                        request_id: 7,
+                        run_id: 7,
                         ..
                     } if dsn == "dsn://miss"
                 ),
@@ -428,7 +416,7 @@ mod tests {
                 .run(
                     vec![Effect::FetchMetadata {
                         dsn: "dsn://err".to_string(),
-                        request_id: 7,
+                        run_id: 7,
                     }],
                     &mut renderer,
                     state,
@@ -447,7 +435,7 @@ mod tests {
                     action,
                     Action::MetadataFailed {
                         ref dsn,
-                        request_id: 7,
+                        run_id: 7,
                         ..
                     } if dsn == "dsn://err"
                 ),
@@ -506,7 +494,7 @@ mod tests {
                         schema: "public".to_string(),
                         table: "users".to_string(),
                         generation: 1,
-                        request_id: 9,
+                        run_id: 9,
                     }],
                     &mut renderer,
                     state,
@@ -525,7 +513,7 @@ mod tests {
                     action,
                     Action::TableDetailLoaded {
                         ref dsn,
-                        request_id: 9,
+                        run_id: 9,
                         generation: 1,
                         ..
                     } if dsn == "dsn://test"
@@ -561,7 +549,7 @@ mod tests {
                 .run(
                     vec![Effect::PrefetchTableDetail {
                         dsn: "dsn://test".to_string(),
-                        batch_id: 3,
+                        run_id: 3,
                         schema: "public".to_string(),
                         table: "users".to_string(),
                     }],

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -106,7 +106,7 @@ pub async fn run(
             schema,
             table,
             generation,
-            request_id,
+            run_id,
             limit,
             offset,
             target_page,
@@ -123,7 +123,7 @@ pub async fn run(
                     Ok(result) => {
                         tx.send(Action::QueryCompleted {
                             dsn,
-                            request_id,
+                            run_id,
                             result: Arc::new(result),
                             generation,
                             target_page: Some(target_page),
@@ -134,7 +134,7 @@ pub async fn run(
                     Err(e) => {
                         tx.send(Action::QueryFailed {
                             dsn,
-                            request_id,
+                            run_id,
                             error: e,
                             generation,
                             source: QuerySource::Preview,
@@ -149,7 +149,7 @@ pub async fn run(
 
         Effect::ExecuteExplain {
             dsn,
-            request_id,
+            run_id,
             query,
             source_query,
             is_analyze,
@@ -170,7 +170,7 @@ pub async fn run(
                             .join("\n");
                         tx.send(Action::ExplainCompleted {
                             dsn,
-                            request_id,
+                            run_id,
                             query: source_query,
                             plan_text,
                             is_analyze,
@@ -182,7 +182,7 @@ pub async fn run(
                     Err(e) => {
                         tx.send(Action::ExplainFailed {
                             dsn,
-                            request_id,
+                            run_id,
                             error: e,
                         })
                         .await
@@ -195,7 +195,7 @@ pub async fn run(
 
         Effect::ExecuteAdhoc {
             dsn,
-            request_id,
+            run_id,
             query,
             read_only,
         } => {
@@ -227,7 +227,7 @@ pub async fn run(
                         }
                         tx.send(Action::QueryCompleted {
                             dsn,
-                            request_id,
+                            run_id,
                             result: Arc::new(result),
                             generation: 0,
                             target_page: None,
@@ -249,7 +249,7 @@ pub async fn run(
                         }
                         tx.send(Action::QueryFailed {
                             dsn,
-                            request_id,
+                            run_id,
                             error: e,
                             generation: 0,
                             source: QuerySource::Adhoc,
@@ -264,7 +264,7 @@ pub async fn run(
 
         Effect::ExecuteWrite {
             dsn,
-            request_id,
+            run_id,
             query,
             read_only,
         } => {
@@ -292,7 +292,7 @@ pub async fn run(
                         }
                         tx.send(Action::ExecuteWriteSucceeded {
                             dsn,
-                            request_id,
+                            run_id,
                             affected_rows: result.affected_rows,
                         })
                         .await
@@ -312,7 +312,7 @@ pub async fn run(
                         }
                         tx.send(Action::ExecuteWriteFailed {
                             dsn,
-                            request_id,
+                            run_id,
                             error: e,
                         })
                         .await
@@ -325,7 +325,7 @@ pub async fn run(
 
         Effect::CountRowsForExport {
             dsn,
-            request_id,
+            run_id,
             count_query,
             export_query,
             file_name,
@@ -341,7 +341,7 @@ pub async fn run(
                     .ok();
                 tx.send(Action::CsvExportRowsCounted {
                     dsn,
-                    request_id,
+                    run_id,
                     row_count,
                     export_query,
                     file_name,
@@ -354,7 +354,7 @@ pub async fn run(
 
         Effect::ExportCsv {
             dsn,
-            request_id,
+            run_id,
             query,
             file_name,
             row_count,
@@ -369,7 +369,7 @@ pub async fn run(
                     Ok(_) => {
                         tx.send(Action::CsvExportSucceeded {
                             dsn,
-                            request_id,
+                            run_id,
                             path: path.display().to_string(),
                             row_count,
                         })
@@ -379,7 +379,7 @@ pub async fn run(
                     Err(e) => {
                         tx.send(Action::CsvExportFailed {
                             dsn,
-                            request_id,
+                            run_id,
                             error: e,
                         })
                         .await
@@ -508,7 +508,7 @@ mod tests {
                         schema: "public".to_string(),
                         table: "users".to_string(),
                         generation: 1,
-                        request_id: 8,
+                        run_id: 8,
                         limit: 100,
                         offset: 0,
                         target_page: 0,
@@ -563,7 +563,7 @@ mod tests {
                         schema: "public".to_string(),
                         table: "users".to_string(),
                         generation: 1,
-                        request_id: 8,
+                        run_id: 8,
                         limit: 100,
                         offset: 0,
                         target_page: 0,

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -106,6 +106,7 @@ pub async fn run(
             schema,
             table,
             generation,
+            request_id,
             limit,
             offset,
             target_page,
@@ -121,6 +122,8 @@ pub async fn run(
                 {
                     Ok(result) => {
                         tx.send(Action::QueryCompleted {
+                            dsn,
+                            request_id,
                             result: Arc::new(result),
                             generation,
                             target_page: Some(target_page),
@@ -130,6 +133,8 @@ pub async fn run(
                     }
                     Err(e) => {
                         tx.send(Action::QueryFailed {
+                            dsn,
+                            request_id,
                             error: e,
                             generation,
                             source: QuerySource::Preview,
@@ -144,7 +149,9 @@ pub async fn run(
 
         Effect::ExecuteExplain {
             dsn,
+            request_id,
             query,
+            source_query,
             is_analyze,
             read_only,
         } => {
@@ -162,6 +169,9 @@ pub async fn run(
                             .collect::<Vec<_>>()
                             .join("\n");
                         tx.send(Action::ExplainCompleted {
+                            dsn,
+                            request_id,
+                            query: source_query,
                             plan_text,
                             is_analyze,
                             execution_time_ms: result.execution_time_ms,
@@ -170,7 +180,13 @@ pub async fn run(
                         .ok();
                     }
                     Err(e) => {
-                        tx.send(Action::ExplainFailed(e)).await.ok();
+                        tx.send(Action::ExplainFailed {
+                            dsn,
+                            request_id,
+                            error: e,
+                        })
+                        .await
+                        .ok();
                     }
                 }
             });
@@ -179,6 +195,7 @@ pub async fn run(
 
         Effect::ExecuteAdhoc {
             dsn,
+            request_id,
             query,
             read_only,
         } => {
@@ -209,6 +226,8 @@ pub async fn run(
                             );
                         }
                         tx.send(Action::QueryCompleted {
+                            dsn,
+                            request_id,
                             result: Arc::new(result),
                             generation: 0,
                             target_page: None,
@@ -229,6 +248,8 @@ pub async fn run(
                             );
                         }
                         tx.send(Action::QueryFailed {
+                            dsn,
+                            request_id,
                             error: e,
                             generation: 0,
                             source: QuerySource::Adhoc,
@@ -243,6 +264,7 @@ pub async fn run(
 
         Effect::ExecuteWrite {
             dsn,
+            request_id,
             query,
             read_only,
         } => {
@@ -269,6 +291,8 @@ pub async fn run(
                             );
                         }
                         tx.send(Action::ExecuteWriteSucceeded {
+                            dsn,
+                            request_id,
                             affected_rows: result.affected_rows,
                         })
                         .await
@@ -286,7 +310,13 @@ pub async fn run(
                                 None,
                             );
                         }
-                        tx.send(Action::ExecuteWriteFailed(e)).await.ok();
+                        tx.send(Action::ExecuteWriteFailed {
+                            dsn,
+                            request_id,
+                            error: e,
+                        })
+                        .await
+                        .ok();
                     }
                 }
             });
@@ -295,6 +325,7 @@ pub async fn run(
 
         Effect::CountRowsForExport {
             dsn,
+            request_id,
             count_query,
             export_query,
             file_name,
@@ -309,6 +340,8 @@ pub async fn run(
                     .await
                     .ok();
                 tx.send(Action::CsvExportRowsCounted {
+                    dsn,
+                    request_id,
                     row_count,
                     export_query,
                     file_name,
@@ -321,6 +354,7 @@ pub async fn run(
 
         Effect::ExportCsv {
             dsn,
+            request_id,
             query,
             file_name,
             row_count,
@@ -334,6 +368,8 @@ pub async fn run(
                 match executor.export_to_csv(&dsn, &query, &path, read_only).await {
                     Ok(_) => {
                         tx.send(Action::CsvExportSucceeded {
+                            dsn,
+                            request_id,
                             path: path.display().to_string(),
                             row_count,
                         })
@@ -341,7 +377,13 @@ pub async fn run(
                         .ok();
                     }
                     Err(e) => {
-                        tx.send(Action::CsvExportFailed(e)).await.ok();
+                        tx.send(Action::CsvExportFailed {
+                            dsn,
+                            request_id,
+                            error: e,
+                        })
+                        .await
+                        .ok();
                     }
                 }
             });
@@ -466,6 +508,7 @@ mod tests {
                         schema: "public".to_string(),
                         table: "users".to_string(),
                         generation: 1,
+                        request_id: 8,
                         limit: 100,
                         offset: 0,
                         target_page: 0,
@@ -520,6 +563,7 @@ mod tests {
                         schema: "public".to_string(),
                         table: "users".to_string(),
                         generation: 1,
+                        request_id: 8,
                         limit: 100,
                         offset: 0,
                         target_page: 0,

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -99,7 +99,7 @@ pub(crate) async fn run(
                         }
                     }
                     Err(e) => {
-                        tx.send(Action::MetadataFailed(e)).await.ok();
+                        tx.send(Action::ConnectionSaveFailed(e.into())).await.ok();
                     }
                 }
             });

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -30,6 +30,7 @@ pub enum Effect {
     },
     FetchMetadata {
         dsn: String,
+        request_id: u64,
     },
     // Updates state.table_detail on completion
     FetchTableDetail {
@@ -37,15 +38,20 @@ pub enum Effect {
         schema: String,
         table: String,
         generation: u64,
+        request_id: u64,
     },
     // Only caches in completion_engine, does NOT update state.table_detail
     PrefetchTableDetail {
         dsn: String,
+        batch_id: u64,
         schema: String,
         table: String,
     },
-    ProcessPrefetchQueue,
+    ProcessPrefetchQueue {
+        batch_id: u64,
+    },
     DelayedProcessPrefetchQueue {
+        batch_id: u64,
         delay_secs: u64,
     },
 
@@ -54,6 +60,7 @@ pub enum Effect {
         schema: String,
         table: String,
         generation: u64,
+        request_id: u64,
         limit: usize,
         offset: usize,
         target_page: usize,
@@ -61,22 +68,27 @@ pub enum Effect {
     },
     ExecuteAdhoc {
         dsn: String,
+        request_id: u64,
         query: String,
         read_only: bool,
     },
     ExecuteExplain {
         dsn: String,
+        request_id: u64,
         query: String,
+        source_query: String,
         is_analyze: bool,
         read_only: bool,
     },
     ExecuteWrite {
         dsn: String,
+        request_id: u64,
         query: String,
         read_only: bool,
     },
     CountRowsForExport {
         dsn: String,
+        request_id: u64,
         count_query: String,
         export_query: String,
         file_name: String,
@@ -84,6 +96,7 @@ pub enum Effect {
     },
     ExportCsv {
         dsn: String,
+        request_id: u64,
         query: String,
         file_name: String,
         row_count: Option<usize>,
@@ -121,8 +134,8 @@ pub enum Effect {
 
     CopyToClipboard {
         content: String,
-        on_success: Option<Action>,
-        on_failure: Option<Action>,
+        on_success: Option<Box<Action>>,
+        on_failure: Option<Box<Action>>,
     },
     OpenFolder {
         path: std::path::PathBuf,

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -30,7 +30,7 @@ pub enum Effect {
     },
     FetchMetadata {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
     },
     // Updates state.table_detail on completion
     FetchTableDetail {
@@ -38,20 +38,20 @@ pub enum Effect {
         schema: String,
         table: String,
         generation: u64,
-        request_id: u64,
+        run_id: u64,
     },
     // Only caches in completion_engine, does NOT update state.table_detail
     PrefetchTableDetail {
         dsn: String,
-        batch_id: u64,
+        run_id: u64,
         schema: String,
         table: String,
     },
     ProcessPrefetchQueue {
-        batch_id: u64,
+        run_id: u64,
     },
     DelayedProcessPrefetchQueue {
-        batch_id: u64,
+        run_id: u64,
         delay_secs: u64,
     },
 
@@ -60,7 +60,7 @@ pub enum Effect {
         schema: String,
         table: String,
         generation: u64,
-        request_id: u64,
+        run_id: u64,
         limit: usize,
         offset: usize,
         target_page: usize,
@@ -68,13 +68,13 @@ pub enum Effect {
     },
     ExecuteAdhoc {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         query: String,
         read_only: bool,
     },
     ExecuteExplain {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         query: String,
         source_query: String,
         is_analyze: bool,
@@ -82,13 +82,13 @@ pub enum Effect {
     },
     ExecuteWrite {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         query: String,
         read_only: bool,
     },
     CountRowsForExport {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         count_query: String,
         export_query: String,
         file_name: String,
@@ -96,7 +96,7 @@ pub enum Effect {
     },
     ExportCsv {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         query: String,
         file_name: String,
         row_count: Option<usize>,

--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -181,12 +181,14 @@ fn handle_smart_refresh(
     let tx = action_tx.clone();
     let old_signatures = state.er_preparation.last_signatures.clone();
     let cached_tables = collect_cached_table_names(completion_engine);
+    let request_dsn = dsn.clone();
 
     tokio::spawn(async move {
         let new_metadata = match provider.fetch_metadata(&dsn).await {
             Ok(m) => m,
             Err(e) => {
                 tx.send(Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn,
                     run_id,
                     error: e,
                     new_metadata: None,
@@ -202,6 +204,7 @@ fn handle_smart_refresh(
             Err(e) => {
                 let new_metadata = Arc::new(new_metadata);
                 tx.send(Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn,
                     run_id,
                     error: e,
                     new_metadata: Some(Arc::clone(&new_metadata)),
@@ -246,6 +249,7 @@ fn handle_smart_refresh(
             .collect();
 
         tx.send(Action::SmartErRefreshCompleted(SmartErRefreshResult {
+            dsn: request_dsn,
             run_id,
             new_metadata: Arc::new(new_metadata),
             stale_tables,

--- a/src/app/cmd/render_schedule.rs
+++ b/src/app/cmd/render_schedule.rs
@@ -88,7 +88,7 @@ mod tests {
         fn query_running_returns_spinner_interval() {
             let mut state = create_test_state();
             let now = Instant::now();
-            state.query.begin_running(now);
+            let _ = state.query.begin_running(now);
 
             let deadline = next_animation_deadline(&state, now);
 
@@ -178,7 +178,7 @@ mod tests {
             let mut state = create_test_state();
             state.modal.set_mode(InputMode::SqlModal);
             let now = Instant::now();
-            state.query.begin_running(now);
+            let _ = state.query.begin_running(now);
 
             let deadline = next_animation_deadline(&state, now);
 
@@ -191,7 +191,7 @@ mod tests {
         fn earlier_message_timeout_takes_priority() {
             let mut state = create_test_state();
             let now = Instant::now();
-            state.query.begin_running(now);
+            let _ = state.query.begin_running(now);
             // Message expires before spinner would update
             let expires_at = now + Duration::from_millis(50);
             state.messages.expires_at = Some(expires_at);
@@ -206,7 +206,7 @@ mod tests {
             let mut state = create_test_state();
             let now = Instant::now();
 
-            state.query.begin_running(now);
+            let _ = state.query.begin_running(now);
             state.messages.expires_at = Some(now + Duration::from_secs(2));
             state
                 .query
@@ -246,7 +246,7 @@ mod tests {
         #[test]
         fn running_query_returns_true() {
             let mut state = create_test_state();
-            state.query.begin_running(Instant::now());
+            let _ = state.query.begin_running(Instant::now());
 
             assert!(has_active_spinner(&state));
         }

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -623,8 +623,8 @@ mod tests {
             let result = runner
                 .run(
                     vec![Effect::DispatchActions(vec![
-                        Action::ProcessPrefetchQueue { batch_id: 1 },
-                        Action::ProcessPrefetchQueue { batch_id: 1 },
+                        Action::ProcessPrefetchQueue { run_id: 1 },
+                        Action::ProcessPrefetchQueue { run_id: 1 },
                     ])],
                     &mut renderer,
                     state,
@@ -637,11 +637,11 @@ mod tests {
             assert_eq!(result.len(), 2);
             assert!(matches!(
                 result[0],
-                Action::ProcessPrefetchQueue { batch_id: 1 }
+                Action::ProcessPrefetchQueue { run_id: 1 }
             ));
             assert!(matches!(
                 result[1],
-                Action::ProcessPrefetchQueue { batch_id: 1 }
+                Action::ProcessPrefetchQueue { run_id: 1 }
             ));
         }
     }

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -351,7 +351,7 @@ impl EffectRunner {
             e @ (Effect::FetchMetadata { .. }
             | Effect::FetchTableDetail { .. }
             | Effect::PrefetchTableDetail { .. }
-            | Effect::ProcessPrefetchQueue
+            | Effect::ProcessPrefetchQueue { .. }
             | Effect::DelayedProcessPrefetchQueue { .. }
             | Effect::CacheInvalidate { .. }) => {
                 cmd_browse::metadata::run(
@@ -623,8 +623,8 @@ mod tests {
             let result = runner
                 .run(
                     vec![Effect::DispatchActions(vec![
-                        Action::ProcessPrefetchQueue,
-                        Action::ProcessPrefetchQueue,
+                        Action::ProcessPrefetchQueue { batch_id: 1 },
+                        Action::ProcessPrefetchQueue { batch_id: 1 },
                     ])],
                     &mut renderer,
                     state,
@@ -635,8 +635,14 @@ mod tests {
                 .unwrap();
 
             assert_eq!(result.len(), 2);
-            assert!(matches!(result[0], Action::ProcessPrefetchQueue));
-            assert!(matches!(result[1], Action::ProcessPrefetchQueue));
+            assert!(matches!(
+                result[0],
+                Action::ProcessPrefetchQueue { batch_id: 1 }
+            ));
+            assert!(matches!(
+                result[1],
+                Action::ProcessPrefetchQueue { batch_id: 1 }
+            ));
         }
     }
 }

--- a/src/app/cmd/sql_editor/completion.rs
+++ b/src/app/cmd/sql_editor/completion.rs
@@ -55,14 +55,14 @@ pub async fn run(
 
             let prefetch_actions: Vec<Action> = state
                 .sql_modal
-                .active_prefetch_batch_id()
-                .map(|batch_id| {
+                .active_prefetch_run_id()
+                .map(|run_id| {
                     missing
                         .into_iter()
                         .filter_map(|qualified_name| {
                             qualified_name.split_once('.').map(|(schema, table)| {
                                 Action::PrefetchTableDetail {
-                                    batch_id,
+                                    run_id,
                                     schema: schema.to_string(),
                                     table: table.to_string(),
                                 }

--- a/src/app/cmd/sql_editor/completion.rs
+++ b/src/app/cmd/sql_editor/completion.rs
@@ -53,17 +53,24 @@ pub async fn run(
                 (prep, missing)
             };
 
-            let prefetch_actions: Vec<Action> = missing
-                .into_iter()
-                .filter_map(|qualified_name| {
-                    qualified_name.split_once('.').map(|(schema, table)| {
-                        Action::PrefetchTableDetail {
-                            schema: schema.to_string(),
-                            table: table.to_string(),
-                        }
-                    })
+            let prefetch_actions: Vec<Action> = state
+                .sql_modal
+                .active_prefetch_batch_id()
+                .map(|batch_id| {
+                    missing
+                        .into_iter()
+                        .filter_map(|qualified_name| {
+                            qualified_name.split_once('.').map(|(schema, table)| {
+                                Action::PrefetchTableDetail {
+                                    batch_id,
+                                    schema: schema.to_string(),
+                                    table: table.to_string(),
+                                }
+                            })
+                        })
+                        .collect()
                 })
-                .collect();
+                .unwrap_or_default();
 
             for action in prefetch_actions {
                 action_tx.try_send(action).ok();

--- a/src/app/cmd/sql_editor/query_history.rs
+++ b/src/app/cmd/sql_editor/query_history.rs
@@ -28,7 +28,9 @@ pub fn run(
                             .ok();
                     }
                     Err(e) => {
-                        tx.send(Action::QueryHistoryLoadFailed(e)).await.ok();
+                        tx.send(Action::QueryHistoryLoadFailed(conn_id, e))
+                            .await
+                            .ok();
                     }
                 }
             });

--- a/src/app/cmd/utility.rs
+++ b/src/app/cmd/utility.rs
@@ -24,12 +24,12 @@ pub(crate) async fn run(
             tokio::task::spawn_blocking(move || match clipboard.copy_text(&content) {
                 Ok(()) => {
                     if let Some(action) = on_success {
-                        tx.blocking_send(action).ok();
+                        tx.blocking_send(*action).ok();
                     }
                 }
                 Err(e) => {
                     if let Some(action) = on_failure {
-                        tx.blocking_send(action).ok();
+                        tx.blocking_send(*action).ok();
                     } else {
                         tx.blocking_send(Action::CopyFailed(e)).ok();
                     }
@@ -107,7 +107,7 @@ mod tests {
             run(
                 Effect::CopyToClipboard {
                     content: "hello".to_string(),
-                    on_success: Some(Action::Render),
+                    on_success: Some(Box::new(Action::Render)),
                     on_failure: None,
                 },
                 &tx,
@@ -136,7 +136,7 @@ mod tests {
                 Effect::CopyToClipboard {
                     content: "hello".to_string(),
                     on_success: None,
-                    on_failure: Some(Action::Render),
+                    on_failure: Some(Box::new(Action::Render)),
                 },
                 &tx,
                 &clipboard,

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -530,8 +530,8 @@ mod tests {
 
         fn prepare_state_for_reload() -> AppState {
             let mut state = make_state();
-            state.session.begin_connecting("postgres://localhost/test");
-            state.sql_modal.begin_prefetch();
+            let _ = state.session.begin_connecting("postgres://localhost/test");
+            let _ = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
                 .prefetch_queue
@@ -681,11 +681,18 @@ mod tests {
                     .session
                     .select_table("public", "users", &mut state.query.pagination);
                 let generation = state.session.selection_generation();
+                state.session.dsn = Some("dsn://test".to_string());
+                let request_id = state.session.begin_table_detail_request();
                 state.ui.inspector_scroll_offset = 42;
 
                 reduce_metadata(
                     &mut state,
-                    &Action::TableDetailLoaded(Box::new(make_table_detail()), generation),
+                    &Action::TableDetailLoaded {
+                        dsn: "dsn://test".to_string(),
+                        request_id,
+                        detail: Box::new(make_table_detail()),
+                        generation,
+                    },
                     Instant::now(),
                 );
 

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -682,14 +682,14 @@ mod tests {
                     .select_table("public", "users", &mut state.query.pagination);
                 let generation = state.session.selection_generation();
                 state.session.dsn = Some("dsn://test".to_string());
-                let request_id = state.session.begin_table_detail_request();
+                let run_id = state.session.begin_table_detail_run();
                 state.ui.inspector_scroll_offset = 42;
 
                 reduce_metadata(
                     &mut state,
                     &Action::TableDetailLoaded {
                         dsn: "dsn://test".to_string(),
-                        request_id,
+                        run_id,
                         detail: Box::new(make_table_detail()),
                         generation,
                     },

--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 
 use crate::domain::{QueryResult, QuerySource};
 use crate::model::browse::result_history::ResultHistory;
+use crate::model::shared::async_run::AsyncRun;
 
 pub const PREVIEW_PAGE_SIZE: usize = 500;
 
@@ -86,8 +87,7 @@ pub struct QueryExecution {
     pub pagination: PaginationState,
     pending_delete_refresh_target: Option<DeleteRefreshTarget>,
     post_delete_row_selection: PostDeleteRowSelection,
-    request_id: u64,
-    active_request_id: Option<u64>,
+    run: AsyncRun,
 }
 
 impl QueryExecution {
@@ -97,19 +97,17 @@ impl QueryExecution {
     pub fn begin_running(&mut self, now: Instant) -> u64 {
         self.status = QueryStatus::Running;
         self.start_time = Some(now);
-        self.request_id += 1;
-        self.active_request_id = Some(self.request_id);
-        self.request_id
+        self.run.begin()
     }
 
     pub fn mark_idle(&mut self) {
         self.status = QueryStatus::Idle;
         self.start_time = None;
-        self.active_request_id = None;
+        self.run.clear_active();
     }
 
-    pub fn is_current_request(&self, request_id: u64) -> bool {
-        self.active_request_id == Some(request_id)
+    pub fn is_current_run(&self, run_id: u64) -> bool {
+        self.run.is_current(run_id)
     }
 
     pub fn status(&self) -> QueryStatus {

--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -86,19 +86,30 @@ pub struct QueryExecution {
     pub pagination: PaginationState,
     pending_delete_refresh_target: Option<DeleteRefreshTarget>,
     post_delete_row_selection: PostDeleteRowSelection,
+    request_id: u64,
+    active_request_id: Option<u64>,
 }
 
 impl QueryExecution {
     // ── Status / timing ────────────────────────────────────────────
 
-    pub fn begin_running(&mut self, now: Instant) {
+    #[must_use]
+    pub fn begin_running(&mut self, now: Instant) -> u64 {
         self.status = QueryStatus::Running;
         self.start_time = Some(now);
+        self.request_id += 1;
+        self.active_request_id = Some(self.request_id);
+        self.request_id
     }
 
     pub fn mark_idle(&mut self) {
         self.status = QueryStatus::Idle;
         self.start_time = None;
+        self.active_request_id = None;
+    }
+
+    pub fn is_current_request(&self, request_id: u64) -> bool {
+        self.active_request_id == Some(request_id)
     }
 
     pub fn status(&self) -> QueryStatus {

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -35,6 +35,10 @@ pub struct BrowseSession {
 
     // -- lifecycle-gated --
     metadata: Option<Arc<DatabaseMetadata>>,
+    metadata_request_id: u64,
+    active_metadata_request_id: Option<u64>,
+    table_detail_request_id: u64,
+    active_table_detail_request_id: Option<u64>,
 
     // -- public / independent --
     pub dsn: Option<String>,
@@ -77,7 +81,19 @@ impl BrowseSession {
         self.selected_table_key = None;
         self.table_detail = None;
         self.selection_generation += 1;
+        self.active_table_detail_request_id = None;
         pagination.reset();
+    }
+
+    #[must_use]
+    pub fn begin_table_detail_request(&mut self) -> u64 {
+        self.table_detail_request_id += 1;
+        self.active_table_detail_request_id = Some(self.table_detail_request_id);
+        self.table_detail_request_id
+    }
+
+    pub fn is_current_table_detail_request(&self, request_id: u64) -> bool {
+        self.active_table_detail_request_id == Some(request_id)
     }
 
     // ── Connection lifecycle ─────────────────────────────────────────
@@ -87,15 +103,18 @@ impl BrowseSession {
         self.metadata_state = MetadataState::Loading;
     }
 
-    pub fn begin_connecting(&mut self, dsn: &str) {
+    #[must_use]
+    pub fn begin_connecting(&mut self, dsn: &str) -> u64 {
         self.dsn = Some(dsn.to_string());
         self.mark_connecting();
+        self.begin_metadata_request()
     }
 
     pub fn mark_connected(&mut self, metadata: Arc<DatabaseMetadata>) {
         self.connection_state = ConnectionState::Connected;
         self.metadata_state = MetadataState::Loaded;
         self.metadata = Some(metadata);
+        self.active_metadata_request_id = None;
     }
 
     // On reload failure (already Connected), keeps Connected to preserve
@@ -103,27 +122,45 @@ impl BrowseSession {
     pub fn mark_connection_failed(&mut self, error: String) {
         self.metadata_state = MetadataState::Error(error);
         self.is_reloading = false;
+        self.active_metadata_request_id = None;
         if !self.connection_state.is_connected() {
             self.connection_state = ConnectionState::Failed;
         }
     }
 
-    pub fn begin_metadata_refresh(&mut self) {
+    #[must_use]
+    pub fn begin_metadata_refresh(&mut self) -> u64 {
         self.metadata_state = MetadataState::Loading;
+        self.begin_metadata_request()
     }
 
     pub fn mark_disconnected(&mut self) {
         self.connection_state = ConnectionState::NotConnected;
         self.metadata_state = MetadataState::NotLoaded;
         self.is_reloading = false;
+        self.active_metadata_request_id = None;
+        self.active_table_detail_request_id = None;
     }
 
-    pub fn begin_reload(&mut self) {
+    #[must_use]
+    pub fn begin_reload(&mut self) -> u64 {
         self.is_reloading = true;
+        self.begin_metadata_request()
     }
 
     pub fn finish_reload(&mut self) {
         self.is_reloading = false;
+    }
+
+    #[must_use]
+    fn begin_metadata_request(&mut self) -> u64 {
+        self.metadata_request_id += 1;
+        self.active_metadata_request_id = Some(self.metadata_request_id);
+        self.metadata_request_id
+    }
+
+    pub fn is_current_metadata_request(&self, request_id: u64) -> bool {
+        self.active_metadata_request_id == Some(request_id)
     }
 
     // ── Cache operations ─────────────────────────────────────────────
@@ -156,6 +193,8 @@ impl BrowseSession {
         self.metadata_state = MetadataState::Loaded;
         self.selection_generation = 0;
         self.is_reloading = false;
+        self.active_metadata_request_id = None;
+        self.active_table_detail_request_id = None;
         match &cache.query_result {
             Some(r) => query.set_current_result(r.clone()),
             None => query.clear_current_result(),
@@ -172,6 +211,8 @@ impl BrowseSession {
         self.selection_generation = 0;
         self.connection_state = ConnectionState::default();
         self.metadata_state = MetadataState::default();
+        self.active_metadata_request_id = None;
+        self.active_table_detail_request_id = None;
         self.dsn = None;
         self.active_connection_id = None;
         self.active_connection_name = None;
@@ -424,7 +465,7 @@ mod tests {
         fn begin_connecting_sets_pair() {
             let mut session = BrowseSession::default();
 
-            session.begin_connecting("postgres://localhost/test");
+            let _ = session.begin_connecting("postgres://localhost/test");
 
             assert!(session.connection_state().is_connecting());
             assert_eq!(session.metadata_state(), &MetadataState::Loading);
@@ -494,7 +535,7 @@ mod tests {
             let mut session = BrowseSession::default();
             session.mark_connected(make_metadata("db"));
 
-            session.begin_metadata_refresh();
+            let _ = session.begin_metadata_refresh();
 
             assert!(session.connection_state().is_connected());
             assert_eq!(session.metadata_state(), &MetadataState::Loading);
@@ -503,8 +544,8 @@ mod tests {
         #[test]
         fn mark_disconnected_resets_connection_pair() {
             let mut session = BrowseSession::default();
-            session.begin_connecting("postgres://localhost/test");
-            session.begin_reload();
+            let _ = session.begin_connecting("postgres://localhost/test");
+            let _ = session.begin_reload();
 
             session.mark_disconnected();
 
@@ -517,7 +558,7 @@ mod tests {
         fn begin_reload_and_finish_reload() {
             let mut session = BrowseSession::default();
 
-            session.begin_reload();
+            let _ = session.begin_reload();
             assert!(session.is_reloading);
 
             session.finish_reload();
@@ -598,7 +639,7 @@ mod tests {
             let mut restored = BrowseSession::default();
             let mut query = QueryExecution::default();
             restored.restore_from_cache(&cache, &mut query);
-            restored.begin_reload();
+            let _ = restored.begin_reload();
 
             assert_eq!(restored.selected_table_key(), Some("public.users"));
             assert!(restored.table_detail().is_some());

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -7,6 +7,7 @@ use crate::model::browse::query_execution::{PaginationState, QueryExecution};
 use crate::model::browse::result_history::ResultHistory;
 use crate::model::connection::cache::ConnectionCache;
 use crate::model::connection::state::ConnectionState;
+use crate::model::shared::async_run::AsyncRun;
 use crate::model::shared::inspector_tab::InspectorTab;
 
 // # Invariants
@@ -35,10 +36,8 @@ pub struct BrowseSession {
 
     // -- lifecycle-gated --
     metadata: Option<Arc<DatabaseMetadata>>,
-    metadata_request_id: u64,
-    active_metadata_request_id: Option<u64>,
-    table_detail_request_id: u64,
-    active_table_detail_request_id: Option<u64>,
+    metadata_run: AsyncRun,
+    table_detail_run: AsyncRun,
 
     // -- public / independent --
     pub dsn: Option<String>,
@@ -81,19 +80,17 @@ impl BrowseSession {
         self.selected_table_key = None;
         self.table_detail = None;
         self.selection_generation += 1;
-        self.active_table_detail_request_id = None;
+        self.table_detail_run.clear_active();
         pagination.reset();
     }
 
     #[must_use]
-    pub fn begin_table_detail_request(&mut self) -> u64 {
-        self.table_detail_request_id += 1;
-        self.active_table_detail_request_id = Some(self.table_detail_request_id);
-        self.table_detail_request_id
+    pub fn begin_table_detail_run(&mut self) -> u64 {
+        self.table_detail_run.begin()
     }
 
-    pub fn is_current_table_detail_request(&self, request_id: u64) -> bool {
-        self.active_table_detail_request_id == Some(request_id)
+    pub fn is_current_table_detail_run(&self, run_id: u64) -> bool {
+        self.table_detail_run.is_current(run_id)
     }
 
     // ── Connection lifecycle ─────────────────────────────────────────
@@ -107,14 +104,14 @@ impl BrowseSession {
     pub fn begin_connecting(&mut self, dsn: &str) -> u64 {
         self.dsn = Some(dsn.to_string());
         self.mark_connecting();
-        self.begin_metadata_request()
+        self.begin_metadata_run()
     }
 
     pub fn mark_connected(&mut self, metadata: Arc<DatabaseMetadata>) {
         self.connection_state = ConnectionState::Connected;
         self.metadata_state = MetadataState::Loaded;
         self.metadata = Some(metadata);
-        self.active_metadata_request_id = None;
+        self.metadata_run.clear_active();
     }
 
     // On reload failure (already Connected), keeps Connected to preserve
@@ -122,7 +119,7 @@ impl BrowseSession {
     pub fn mark_connection_failed(&mut self, error: String) {
         self.metadata_state = MetadataState::Error(error);
         self.is_reloading = false;
-        self.active_metadata_request_id = None;
+        self.metadata_run.clear_active();
         if !self.connection_state.is_connected() {
             self.connection_state = ConnectionState::Failed;
         }
@@ -131,21 +128,21 @@ impl BrowseSession {
     #[must_use]
     pub fn begin_metadata_refresh(&mut self) -> u64 {
         self.metadata_state = MetadataState::Loading;
-        self.begin_metadata_request()
+        self.begin_metadata_run()
     }
 
     pub fn mark_disconnected(&mut self) {
         self.connection_state = ConnectionState::NotConnected;
         self.metadata_state = MetadataState::NotLoaded;
         self.is_reloading = false;
-        self.active_metadata_request_id = None;
-        self.active_table_detail_request_id = None;
+        self.metadata_run.clear_active();
+        self.table_detail_run.clear_active();
     }
 
     #[must_use]
     pub fn begin_reload(&mut self) -> u64 {
         self.is_reloading = true;
-        self.begin_metadata_request()
+        self.begin_metadata_run()
     }
 
     pub fn finish_reload(&mut self) {
@@ -153,14 +150,12 @@ impl BrowseSession {
     }
 
     #[must_use]
-    fn begin_metadata_request(&mut self) -> u64 {
-        self.metadata_request_id += 1;
-        self.active_metadata_request_id = Some(self.metadata_request_id);
-        self.metadata_request_id
+    fn begin_metadata_run(&mut self) -> u64 {
+        self.metadata_run.begin()
     }
 
-    pub fn is_current_metadata_request(&self, request_id: u64) -> bool {
-        self.active_metadata_request_id == Some(request_id)
+    pub fn is_current_metadata_run(&self, run_id: u64) -> bool {
+        self.metadata_run.is_current(run_id)
     }
 
     // ── Cache operations ─────────────────────────────────────────────
@@ -193,8 +188,8 @@ impl BrowseSession {
         self.metadata_state = MetadataState::Loaded;
         self.selection_generation = 0;
         self.is_reloading = false;
-        self.active_metadata_request_id = None;
-        self.active_table_detail_request_id = None;
+        self.metadata_run.clear_active();
+        self.table_detail_run.clear_active();
         match &cache.query_result {
             Some(r) => query.set_current_result(r.clone()),
             None => query.clear_current_result(),
@@ -211,8 +206,8 @@ impl BrowseSession {
         self.selection_generation = 0;
         self.connection_state = ConnectionState::default();
         self.metadata_state = MetadataState::default();
-        self.active_metadata_request_id = None;
-        self.active_table_detail_request_id = None;
+        self.metadata_run.clear_active();
+        self.table_detail_run.clear_active();
         self.dsn = None;
         self.active_connection_id = None;
         self.active_connection_name = None;

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
+use crate::model::shared::async_run::AsyncRun;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ErStatus {
     #[default]
@@ -19,7 +21,7 @@ pub struct ErPreparationState {
     pub seed_tables: Vec<String>,
     pub fk_expanded: bool,
     pub last_signatures: HashMap<String, String>,
-    pub run_id: u64,
+    run: AsyncRun,
 }
 
 impl ErPreparationState {
@@ -56,9 +58,17 @@ impl ErPreparationState {
     }
 
     pub fn begin_smart_refresh(&mut self) -> u64 {
-        self.run_id += 1;
+        let run_id = self.run.begin();
         self.status = ErStatus::Waiting;
-        self.run_id
+        run_id
+    }
+
+    pub fn is_current_run(&self, run_id: u64) -> bool {
+        self.run.is_current(run_id)
+    }
+
+    pub fn run_id(&self) -> u64 {
+        self.run.last_id()
     }
 
     pub fn can_generate_from_cache(&self) -> bool {
@@ -70,9 +80,21 @@ impl ErPreparationState {
     }
 
     pub fn reset(&mut self) {
-        let run_id = self.run_id;
-        *self = Self::default();
-        self.run_id = run_id;
+        self.pending_tables.clear();
+        self.fetching_tables.clear();
+        self.failed_tables.clear();
+        self.status = ErStatus::Idle;
+        self.total_tables = 0;
+        self.target_tables.clear();
+        self.seed_tables.clear();
+        self.fk_expanded = false;
+        self.last_signatures.clear();
+        self.run.clear_active();
+    }
+
+    #[cfg(test)]
+    pub fn set_run_id_for_test(&mut self, run_id: u64) {
+        self.run.set_last_id_for_test(run_id);
     }
 }
 
@@ -174,12 +196,12 @@ mod tests {
                 failed_tables: HashMap::from([("c".to_string(), "err".to_string())]),
                 status: ErStatus::Waiting,
                 total_tables: 3,
-                target_tables: vec![],
                 seed_tables: vec!["a".to_string()],
                 fk_expanded: true,
                 last_signatures: HashMap::from([("a".to_string(), "sig".to_string())]),
-                run_id: 5,
+                ..Default::default()
             };
+            state.set_run_id_for_test(5);
 
             state.reset();
 
@@ -191,7 +213,7 @@ mod tests {
             assert!(state.seed_tables.is_empty());
             assert!(!state.fk_expanded);
             assert!(state.last_signatures.is_empty());
-            assert_eq!(state.run_id, 5);
+            assert_eq!(state.run_id(), 5);
         }
     }
 

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -70,7 +70,9 @@ impl ErPreparationState {
     }
 
     pub fn reset(&mut self) {
+        let run_id = self.run_id;
         *self = Self::default();
+        self.run_id = run_id;
     }
 }
 
@@ -189,7 +191,7 @@ mod tests {
             assert!(state.seed_tables.is_empty());
             assert!(!state.fk_expanded);
             assert!(state.last_signatures.is_empty());
-            assert_eq!(state.run_id, 0);
+            assert_eq!(state.run_id, 5);
         }
     }
 

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -91,16 +91,18 @@ impl ErPreparationState {
         self.last_signatures.clear();
         self.run.clear_active();
     }
-
-    #[cfg(test)]
-    pub fn set_run_id_for_test(&mut self, run_id: u64) {
-        self.run.set_last_id_for_test(run_id);
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn set_active_run_id(state: &mut ErPreparationState, run_id: u64) {
+        for _ in 0..run_id {
+            state.begin_smart_refresh();
+        }
+        state.mark_idle();
+    }
 
     mod is_complete {
         use super::*;
@@ -201,7 +203,7 @@ mod tests {
                 last_signatures: HashMap::from([("a".to_string(), "sig".to_string())]),
                 ..Default::default()
             };
-            state.set_run_id_for_test(5);
+            set_active_run_id(&mut state, 5);
 
             state.reset();
 

--- a/src/app/model/shared/async_run.rs
+++ b/src/app/model/shared/async_run.rs
@@ -1,0 +1,41 @@
+/// Monotonic async run tracker for aggregate-owned freshness guards.
+#[derive(Debug, Clone, Default)]
+pub struct AsyncRun {
+    run_id: u64,
+    active_run_id: Option<u64>,
+}
+
+impl AsyncRun {
+    /// Starts a new active run and returns its id.
+    #[must_use]
+    pub fn begin(&mut self) -> u64 {
+        self.run_id += 1;
+        self.active_run_id = Some(self.run_id);
+        self.run_id
+    }
+
+    pub fn clear_active(&mut self) {
+        self.active_run_id = None;
+    }
+
+    /// Returns the active run id, if this aggregate has an in-flight run.
+    pub fn active_id(&self) -> Option<u64> {
+        self.active_run_id
+    }
+
+    /// Returns the most recently allocated run id without reactivating it.
+    pub fn last_id(&self) -> u64 {
+        self.run_id
+    }
+
+    /// Checks whether a completion belongs to the currently active run.
+    pub fn is_current(&self, run_id: u64) -> bool {
+        self.active_run_id == Some(run_id)
+    }
+
+    #[cfg(test)]
+    pub fn set_last_id_for_test(&mut self, run_id: u64) {
+        self.run_id = run_id;
+        self.active_run_id = Some(run_id);
+    }
+}

--- a/src/app/model/shared/async_run.rs
+++ b/src/app/model/shared/async_run.rs
@@ -32,10 +32,4 @@ impl AsyncRun {
     pub fn is_current(&self, run_id: u64) -> bool {
         self.active_run_id == Some(run_id)
     }
-
-    #[cfg(test)]
-    pub fn set_last_id_for_test(&mut self, run_id: u64) {
-        self.run_id = run_id;
-        self.active_run_id = Some(run_id);
-    }
 }

--- a/src/app/model/shared/confirm_dialog.rs
+++ b/src/app/model/shared/confirm_dialog.rs
@@ -10,7 +10,7 @@ pub enum ConfirmIntent {
     },
     CsvExport {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         export_query: String,
         file_name: String,
         row_count: Option<usize>,

--- a/src/app/model/shared/confirm_dialog.rs
+++ b/src/app/model/shared/confirm_dialog.rs
@@ -9,6 +9,8 @@ pub enum ConfirmIntent {
         blocked: bool,
     },
     CsvExport {
+        dsn: String,
+        request_id: u64,
         export_query: String,
         file_name: String,
         row_count: Option<usize>,

--- a/src/app/model/shared/mod.rs
+++ b/src/app/model/shared/mod.rs
@@ -1,3 +1,4 @@
+pub mod async_run;
 pub mod confirm_dialog;
 pub mod db_capabilities;
 pub mod flash_timer;

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::Instant;
 
 use crate::domain::CommandTag;
+use crate::model::shared::async_run::AsyncRun;
 use crate::model::shared::multi_line_input::MultiLineInputState;
 use crate::model::shared::text_input::{TextInputLike, TextInputState};
 use crate::policy::write::write_guardrails::AdhocRiskDecision;
@@ -80,8 +81,7 @@ pub struct SqlModalContext {
     pub prefetching_tables: HashSet<String>,
     pub failed_prefetch_tables: HashMap<String, FailedPrefetchEntry>,
     prefetch_started: bool,
-    prefetch_batch_id: u64,
-    active_prefetch_batch_id: Option<u64>,
+    prefetch_run: AsyncRun,
     active_tab: SqlModalTab,
 }
 
@@ -93,35 +93,34 @@ impl SqlModalContext {
         self.prefetch_queue.clear();
         self.prefetching_tables.clear();
         self.failed_prefetch_tables.clear();
-        self.active_prefetch_batch_id = None;
+        self.prefetch_run.clear_active();
     }
 
     // Preserves `prefetching_tables` so in-flight requests drain naturally.
     #[must_use]
     pub fn begin_prefetch(&mut self) -> u64 {
         self.prefetch_started = true;
-        self.prefetch_batch_id += 1;
-        self.active_prefetch_batch_id = Some(self.prefetch_batch_id);
         self.prefetch_queue.clear();
         self.failed_prefetch_tables.clear();
-        self.prefetch_batch_id
+        self.prefetch_run.begin()
     }
 
     pub fn invalidate_prefetch(&mut self) {
         self.prefetch_started = false;
-        self.active_prefetch_batch_id = None;
+        self.prefetching_tables.clear();
+        self.prefetch_run.clear_active();
     }
 
     pub fn is_prefetch_started(&self) -> bool {
         self.prefetch_started
     }
 
-    pub fn active_prefetch_batch_id(&self) -> Option<u64> {
-        self.active_prefetch_batch_id
+    pub fn active_prefetch_run_id(&self) -> Option<u64> {
+        self.prefetch_run.active_id()
     }
 
-    pub fn is_current_prefetch_batch(&self, batch_id: u64) -> bool {
-        self.active_prefetch_batch_id == Some(batch_id)
+    pub fn is_current_prefetch_run(&self, run_id: u64) -> bool {
+        self.prefetch_run.is_current(run_id)
     }
 
     // ── Adhoc status ────────────────────────────────────────────────

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -80,6 +80,8 @@ pub struct SqlModalContext {
     pub prefetching_tables: HashSet<String>,
     pub failed_prefetch_tables: HashMap<String, FailedPrefetchEntry>,
     prefetch_started: bool,
+    prefetch_batch_id: u64,
+    active_prefetch_batch_id: Option<u64>,
     active_tab: SqlModalTab,
 }
 
@@ -91,21 +93,35 @@ impl SqlModalContext {
         self.prefetch_queue.clear();
         self.prefetching_tables.clear();
         self.failed_prefetch_tables.clear();
+        self.active_prefetch_batch_id = None;
     }
 
     // Preserves `prefetching_tables` so in-flight requests drain naturally.
-    pub fn begin_prefetch(&mut self) {
+    #[must_use]
+    pub fn begin_prefetch(&mut self) -> u64 {
         self.prefetch_started = true;
+        self.prefetch_batch_id += 1;
+        self.active_prefetch_batch_id = Some(self.prefetch_batch_id);
         self.prefetch_queue.clear();
         self.failed_prefetch_tables.clear();
+        self.prefetch_batch_id
     }
 
     pub fn invalidate_prefetch(&mut self) {
         self.prefetch_started = false;
+        self.active_prefetch_batch_id = None;
     }
 
     pub fn is_prefetch_started(&self) -> bool {
         self.prefetch_started
+    }
+
+    pub fn active_prefetch_batch_id(&self) -> Option<u64> {
+        self.active_prefetch_batch_id
+    }
+
+    pub fn is_current_prefetch_batch(&self, batch_id: u64) -> bool {
+        self.active_prefetch_batch_id == Some(batch_id)
     }
 
     // ── Adhoc status ────────────────────────────────────────────────
@@ -414,7 +430,7 @@ mod tests {
         #[test]
         fn reset_clears_all_state() {
             let mut ctx = SqlModalContext::default();
-            ctx.begin_prefetch();
+            let _ = ctx.begin_prefetch();
             ctx.prefetch_queue.push_back("public.users".to_string());
             ctx.prefetching_tables.insert("public.posts".to_string());
             ctx.failed_prefetch_tables.insert(

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -375,12 +375,12 @@ pub enum Action {
     ReloadMetadata,
     MetadataLoaded {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         metadata: Arc<DatabaseMetadata>,
     },
     MetadataFailed {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         error: DbOperationError,
     },
 
@@ -388,40 +388,40 @@ pub enum Action {
     LoadTableDetail(TableTarget),
     TableDetailLoaded {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         detail: Box<Table>,
         generation: u64,
     },
     TableDetailFailed {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         error: DbOperationError,
         generation: u64,
     },
 
     // Completion prefetch (does NOT update state.table_detail)
     PrefetchTableDetail {
-        batch_id: u64,
+        run_id: u64,
         schema: String,
         table: String,
     },
     TableDetailCached {
         dsn: String,
-        batch_id: u64,
+        run_id: u64,
         schema: String,
         table: String,
         detail: Box<Table>,
     },
     TableDetailCacheFailed {
         dsn: String,
-        batch_id: u64,
+        run_id: u64,
         schema: String,
         table: String,
         error: DbOperationError,
     },
     TableDetailAlreadyCached {
         dsn: String,
-        batch_id: u64,
+        run_id: u64,
         schema: String,
         table: String,
     },
@@ -436,7 +436,7 @@ pub enum Action {
         tables: Vec<String>,
     },
     ProcessPrefetchQueue {
-        batch_id: u64,
+        run_id: u64,
     },
 
     // Inspector sub-tabs
@@ -470,7 +470,7 @@ pub enum Action {
     ExplainAnalyzeCancel,
     ExplainCompleted {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         query: String,
         plan_text: String,
         is_analyze: bool,
@@ -478,7 +478,7 @@ pub enum Action {
     },
     ExplainFailed {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         error: DbOperationError,
     },
     CompareEditQuery,
@@ -501,26 +501,26 @@ pub enum Action {
     ExecuteWrite(String),
     QueryCompleted {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         result: Arc<QueryResult>,
         generation: u64,
         target_page: Option<usize>,
     },
     QueryFailed {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         error: DbOperationError,
         generation: u64,
         source: QuerySource,
     },
     ExecuteWriteSucceeded {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         affected_rows: usize,
     },
     ExecuteWriteFailed {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         error: DbOperationError,
     },
 
@@ -585,27 +585,27 @@ pub enum Action {
     RequestCsvExport,
     CsvExportRowsCounted {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         row_count: Option<usize>,
         export_query: String,
         file_name: String,
     },
     ExecuteCsvExport {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         export_query: String,
         file_name: String,
         row_count: Option<usize>,
     },
     CsvExportSucceeded {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         path: String,
         row_count: Option<usize>,
     },
     CsvExportFailed {
         dsn: String,
-        request_id: u64,
+        run_id: u64,
         error: DbOperationError,
     },
 

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -22,6 +22,8 @@ pub enum ConnectionSaveError {
     Validation(#[from] ConnectionNameError),
     #[error("{0}")]
     Store(#[from] ConnectionStoreError),
+    #[error("{0}")]
+    Metadata(#[from] DbOperationError),
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -206,6 +208,7 @@ pub enum ModalKind {
 
 #[derive(Debug, Clone)]
 pub struct SmartErRefreshResult {
+    pub dsn: String,
     pub run_id: u64,
     pub new_metadata: Arc<DatabaseMetadata>,
     pub stale_tables: Vec<String>,
@@ -217,6 +220,7 @@ pub struct SmartErRefreshResult {
 
 #[derive(Debug, Clone)]
 pub struct SmartErRefreshError {
+    pub dsn: String,
     pub run_id: u64,
     pub error: DbOperationError,
     pub new_metadata: Option<Arc<DatabaseMetadata>>,
@@ -369,30 +373,55 @@ pub enum Action {
     // Metadata loading
     LoadMetadata,
     ReloadMetadata,
-    MetadataLoaded(Arc<DatabaseMetadata>),
-    MetadataFailed(DbOperationError),
+    MetadataLoaded {
+        dsn: String,
+        request_id: u64,
+        metadata: Arc<DatabaseMetadata>,
+    },
+    MetadataFailed {
+        dsn: String,
+        request_id: u64,
+        error: DbOperationError,
+    },
 
     // Table detail loading
     LoadTableDetail(TableTarget),
-    TableDetailLoaded(Box<Table>, u64),
-    TableDetailFailed(DbOperationError, u64),
+    TableDetailLoaded {
+        dsn: String,
+        request_id: u64,
+        detail: Box<Table>,
+        generation: u64,
+    },
+    TableDetailFailed {
+        dsn: String,
+        request_id: u64,
+        error: DbOperationError,
+        generation: u64,
+    },
 
     // Completion prefetch (does NOT update state.table_detail)
     PrefetchTableDetail {
+        batch_id: u64,
         schema: String,
         table: String,
     },
     TableDetailCached {
+        dsn: String,
+        batch_id: u64,
         schema: String,
         table: String,
         detail: Box<Table>,
     },
     TableDetailCacheFailed {
+        dsn: String,
+        batch_id: u64,
         schema: String,
         table: String,
         error: DbOperationError,
     },
     TableDetailAlreadyCached {
+        dsn: String,
+        batch_id: u64,
         schema: String,
         table: String,
     },
@@ -406,7 +435,9 @@ pub enum Action {
     FkNeighborsDiscovered {
         tables: Vec<String>,
     },
-    ProcessPrefetchQueue,
+    ProcessPrefetchQueue {
+        batch_id: u64,
+    },
 
     // Inspector sub-tabs
     InspectorNextTab,
@@ -438,11 +469,18 @@ pub enum Action {
     ExplainAnalyzeConfirm,
     ExplainAnalyzeCancel,
     ExplainCompleted {
+        dsn: String,
+        request_id: u64,
+        query: String,
         plan_text: String,
         is_analyze: bool,
         execution_time_ms: u64,
     },
-    ExplainFailed(DbOperationError),
+    ExplainFailed {
+        dsn: String,
+        request_id: u64,
+        error: DbOperationError,
+    },
     CompareEditQuery,
 
     // SQL Modal completion
@@ -462,19 +500,29 @@ pub enum Action {
     ExecuteAdhoc(String),
     ExecuteWrite(String),
     QueryCompleted {
+        dsn: String,
+        request_id: u64,
         result: Arc<QueryResult>,
         generation: u64,
         target_page: Option<usize>,
     },
     QueryFailed {
+        dsn: String,
+        request_id: u64,
         error: DbOperationError,
         generation: u64,
         source: QuerySource,
     },
     ExecuteWriteSucceeded {
+        dsn: String,
+        request_id: u64,
         affected_rows: usize,
     },
-    ExecuteWriteFailed(DbOperationError),
+    ExecuteWriteFailed {
+        dsn: String,
+        request_id: u64,
+        error: DbOperationError,
+    },
 
     // Result pane
     ResultNextPage,
@@ -529,27 +577,37 @@ pub enum Action {
         crate::domain::ConnectionId,
         Vec<crate::domain::query_history::QueryHistoryEntry>,
     ),
-    QueryHistoryLoadFailed(QueryHistoryError),
+    QueryHistoryLoadFailed(crate::domain::ConnectionId, QueryHistoryError),
     QueryHistoryAppendFailed(QueryHistoryError),
     QueryHistoryConfirmSelection,
 
     // CSV Export
     RequestCsvExport,
     CsvExportRowsCounted {
+        dsn: String,
+        request_id: u64,
         row_count: Option<usize>,
         export_query: String,
         file_name: String,
     },
     ExecuteCsvExport {
+        dsn: String,
+        request_id: u64,
         export_query: String,
         file_name: String,
         row_count: Option<usize>,
     },
     CsvExportSucceeded {
+        dsn: String,
+        request_id: u64,
         path: String,
         row_count: Option<usize>,
     },
-    CsvExportFailed(DbOperationError),
+    CsvExportFailed {
+        dsn: String,
+        request_id: u64,
+        error: DbOperationError,
+    },
 
     // JSONB Detail View
     JsonbYankAll,

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -51,11 +51,11 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
     match action {
         Action::MetadataLoaded {
             dsn,
-            request_id,
+            run_id,
             metadata,
         } => {
             if state.session.dsn.as_ref() != Some(dsn)
-                || !state.session.is_current_metadata_request(*request_id)
+                || !state.session.is_current_metadata_run(*run_id)
             {
                 return DispatchResult::handled();
             }
@@ -83,14 +83,14 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     if let Some(dsn) = state.session.dsn.clone() {
                         let page = state.query.pagination.current_page;
                         let generation = state.session.selection_generation();
-                        let query_request_id = state.query.begin_running(now);
-                        let detail_request_id = state.session.begin_table_detail_request();
+                        let query_run_id = state.query.begin_running(now);
+                        let detail_run_id = state.session.begin_table_detail_run();
                         effects.push(Effect::ExecutePreview {
                             dsn: dsn.clone(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation,
-                            request_id: query_request_id,
+                            run_id: query_run_id,
                             limit: PREVIEW_PAGE_SIZE,
                             offset: page * PREVIEW_PAGE_SIZE,
                             target_page: page,
@@ -101,7 +101,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation,
-                            request_id: detail_request_id,
+                            run_id: detail_run_id,
                         });
                     }
                 } else {
@@ -141,13 +141,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
             DispatchResult::handled_with(effects)
         }
-        Action::MetadataFailed {
-            dsn,
-            request_id,
-            error,
-        } => {
+        Action::MetadataFailed { dsn, run_id, error } => {
             if state.session.dsn.as_ref() != Some(dsn)
-                || !state.session.is_current_metadata_request(*request_id)
+                || !state.session.is_current_metadata_run(*run_id)
             {
                 return DispatchResult::handled();
             }
@@ -166,12 +162,12 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
         }
         Action::TableDetailLoaded {
             dsn,
-            request_id,
+            run_id,
             detail,
             generation,
         } => {
             if state.session.dsn.as_ref() != Some(dsn)
-                || !state.session.is_current_table_detail_request(*request_id)
+                || !state.session.is_current_table_detail_run(*run_id)
             {
                 return DispatchResult::handled();
             }
@@ -183,12 +179,12 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
         }
         Action::TableDetailFailed {
             dsn,
-            request_id,
+            run_id,
             error,
             generation,
         } => {
             if state.session.dsn.as_ref() != Some(dsn)
-                || !state.session.is_current_table_detail_request(*request_id)
+                || !state.session.is_current_table_detail_run(*run_id)
             {
                 return DispatchResult::handled();
             }
@@ -201,8 +197,8 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
         Action::LoadMetadata => {
             if let Some(dsn) = state.session.dsn.clone() {
-                let request_id = state.session.begin_metadata_refresh();
-                DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, request_id }])
+                let run_id = state.session.begin_metadata_refresh();
+                DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
             } else {
                 DispatchResult::handled()
             }
@@ -213,13 +209,13 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             generation,
         }) => {
             if let Some(dsn) = state.session.dsn.clone() {
-                let request_id = state.session.begin_table_detail_request();
+                let run_id = state.session.begin_table_detail_run();
                 DispatchResult::handled_with(vec![Effect::FetchTableDetail {
                     dsn,
                     schema: schema.clone(),
                     table: table.clone(),
                     generation: *generation,
-                    request_id,
+                    run_id,
                 }])
             } else {
                 DispatchResult::handled()
@@ -228,7 +224,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
         Action::ReloadMetadata => {
             if let Some(dsn) = state.session.dsn.clone() {
-                let request_id = state.session.begin_reload();
+                let run_id = state.session.begin_reload();
                 state.sql_modal.reset_prefetch();
                 state.er_preparation.reset();
                 state.ui.er_selected_tables.clear();
@@ -240,7 +236,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                 DispatchResult::handled_with(vec![Effect::Sequence(vec![
                     Effect::CacheInvalidate { dsn: dsn.clone() },
                     Effect::ClearCompletionEngineCache,
-                    Effect::FetchMetadata { dsn, request_id },
+                    Effect::FetchMetadata { dsn, run_id },
                 ])])
             } else {
                 DispatchResult::handled()
@@ -251,7 +247,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             if !state.sql_modal.is_prefetch_started()
                 && let Some(metadata) = state.session.metadata()
             {
-                let batch_id = state.sql_modal.begin_prefetch();
+                let run_id = state.sql_modal.begin_prefetch();
                 state.er_preparation.pending_tables.clear();
                 state.er_preparation.fetching_tables.clear();
                 state.er_preparation.failed_tables.clear();
@@ -273,7 +269,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     Effect::ResizeCompletionCache {
                         capacity: resize_capacity,
                     },
-                    Effect::ProcessPrefetchQueue { batch_id },
+                    Effect::ProcessPrefetchQueue { run_id },
                 ])
             } else {
                 DispatchResult::handled()
@@ -284,7 +280,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             if state.sql_modal.is_prefetch_started() {
                 DispatchResult::handled()
             } else {
-                let batch_id = state.sql_modal.begin_prefetch();
+                let run_id = state.sql_modal.begin_prefetch();
                 state.er_preparation.pending_tables.clear();
                 state.er_preparation.fetching_tables.clear();
                 state.er_preparation.failed_tables.clear();
@@ -302,7 +298,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                         .pending_tables
                         .insert(qualified_name.clone());
                 }
-                DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue { batch_id }])
+                DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue { run_id }])
             }
         }
 
@@ -329,14 +325,14 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     .prefetch_queue
                     .push_back(qualified_name.clone());
             }
-            let Some(batch_id) = state.sql_modal.active_prefetch_batch_id() else {
+            let Some(run_id) = state.sql_modal.active_prefetch_run_id() else {
                 return DispatchResult::handled();
             };
-            DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue { batch_id }])
+            DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue { run_id }])
         }
 
-        Action::ProcessPrefetchQueue { batch_id } => {
-            if !state.sql_modal.is_current_prefetch_batch(*batch_id) {
+        Action::ProcessPrefetchQueue { run_id } => {
+            if !state.sql_modal.is_current_prefetch_run(*run_id) {
                 return DispatchResult::handled();
             }
             const MAX_CONCURRENT_PREFETCH: usize = 4;
@@ -349,7 +345,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     && let Some((schema, table)) = qualified_name.split_once('.')
                 {
                     actions.push(Action::PrefetchTableDetail {
-                        batch_id: *batch_id,
+                        run_id: *run_id,
                         schema: schema.to_string(),
                         table: table.to_string(),
                     });
@@ -364,11 +360,11 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
         }
 
         Action::PrefetchTableDetail {
-            batch_id,
+            run_id,
             schema,
             table,
         } => {
-            if !state.sql_modal.is_current_prefetch_batch(*batch_id) {
+            if !state.sql_modal.is_current_prefetch_run(*run_id) {
                 return DispatchResult::handled();
             }
             let qualified_name = format!("{schema}.{table}");
@@ -387,9 +383,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     let mut effects = check_er_completion(state);
                     // No fetch started → no completion event to re-drive the queue.
                     if effects.is_empty() && state.er_preparation.status == ErStatus::Waiting {
-                        effects.push(Effect::ProcessPrefetchQueue {
-                            batch_id: *batch_id,
-                        });
+                        effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
                     }
                     return DispatchResult::handled_with(effects);
                 }
@@ -404,7 +398,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     state.sql_modal.prefetch_queue.push_back(qualified_name);
                     return DispatchResult::handled_with(vec![
                         Effect::DelayedProcessPrefetchQueue {
-                            batch_id: *batch_id,
+                            run_id: *run_id,
                             delay_secs: remaining,
                         },
                     ]);
@@ -424,7 +418,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             if let Some(dsn) = &state.session.dsn {
                 DispatchResult::handled_with(vec![Effect::PrefetchTableDetail {
                     dsn: dsn.clone(),
-                    batch_id: *batch_id,
+                    run_id: *run_id,
                     schema: schema.clone(),
                     table: table.clone(),
                 }])
@@ -435,13 +429,13 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
         Action::TableDetailCached {
             dsn,
-            batch_id,
+            run_id,
             schema,
             table,
             detail,
         } => {
             if state.session.dsn.as_ref() != Some(dsn)
-                || !state.sql_modal.is_current_prefetch_batch(*batch_id)
+                || !state.sql_modal.is_current_prefetch_run(*run_id)
             {
                 return DispatchResult::handled();
             }
@@ -459,9 +453,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             }];
 
             if !state.sql_modal.prefetch_queue.is_empty() {
-                effects.push(Effect::ProcessPrefetchQueue {
-                    batch_id: *batch_id,
-                });
+                effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
             }
 
             effects.extend(check_er_completion(state));
@@ -471,13 +463,13 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
         Action::TableDetailCacheFailed {
             dsn,
-            batch_id,
+            run_id,
             schema,
             table,
             error,
         } => {
             if state.session.dsn.as_ref() != Some(dsn)
-                || !state.sql_modal.is_current_prefetch_batch(*batch_id)
+                || !state.sql_modal.is_current_prefetch_run(*run_id)
             {
                 return DispatchResult::handled();
             }
@@ -504,9 +496,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             let mut effects = Vec::new();
 
             if !state.sql_modal.prefetch_queue.is_empty() {
-                effects.push(Effect::ProcessPrefetchQueue {
-                    batch_id: *batch_id,
-                });
+                effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
             }
 
             effects.extend(check_er_completion(state));
@@ -516,12 +506,12 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
         Action::TableDetailAlreadyCached {
             dsn,
-            batch_id,
+            run_id,
             schema,
             table,
         } => {
             if state.session.dsn.as_ref() != Some(dsn)
-                || !state.sql_modal.is_current_prefetch_batch(*batch_id)
+                || !state.sql_modal.is_current_prefetch_run(*run_id)
             {
                 return DispatchResult::handled();
             }
@@ -536,9 +526,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             let mut effects = Vec::new();
 
             if !state.sql_modal.prefetch_queue.is_empty() {
-                effects.push(Effect::ProcessPrefetchQueue {
-                    batch_id: *batch_id,
-                });
+                effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
             }
 
             effects.extend(check_er_completion(state));
@@ -600,13 +588,13 @@ mod tests {
         #[test]
         fn stale_metadata_loaded_does_not_replace_current_state() {
             let mut state = state_with_dsn("postgres://localhost/new");
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
 
             let effects = reduce_metadata(
                 &mut state,
                 &Action::MetadataLoaded {
                     dsn: "postgres://localhost/old".to_string(),
-                    request_id,
+                    run_id,
                     metadata: metadata_with_users(),
                 },
                 Instant::now(),
@@ -620,15 +608,15 @@ mod tests {
         #[test]
         fn stale_table_detail_loaded_does_not_replace_current_detail() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let request_id = state.session.begin_table_detail_request();
+            let run_id = state.session.begin_table_detail_run();
             let current_generation = state.session.selection_generation();
-            let _ = state.session.begin_table_detail_request();
+            let _ = state.session.begin_table_detail_run();
 
             reduce_metadata(
                 &mut state,
                 &Action::TableDetailLoaded {
                     dsn: "postgres://localhost/test".to_string(),
-                    request_id,
+                    run_id,
                     detail: empty_table("public", "users"),
                     generation: current_generation,
                 },
@@ -639,9 +627,9 @@ mod tests {
         }
 
         #[test]
-        fn stale_prefetch_batch_does_not_advance_queue() {
+        fn stale_prefetch_run_does_not_advance_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let old_batch_id = state.sql_modal.begin_prefetch();
+            let old_run_id = state.sql_modal.begin_prefetch();
             let _ = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
@@ -650,9 +638,7 @@ mod tests {
 
             let effects = reduce_metadata(
                 &mut state,
-                &Action::ProcessPrefetchQueue {
-                    batch_id: old_batch_id,
-                },
+                &Action::ProcessPrefetchQueue { run_id: old_run_id },
                 Instant::now(),
             )
             .unwrap();
@@ -670,7 +656,7 @@ mod tests {
         #[test]
         fn backoff_table_requeued_at_tail_with_process_effect() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             // Insert a recently failed entry (retry_count=1, just failed)
             state.sql_modal.failed_prefetch_tables.insert(
@@ -685,7 +671,7 @@ mod tests {
             let effects = reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -706,7 +692,7 @@ mod tests {
         #[test]
         fn retry_limit_exceeded_gives_up_and_calls_on_table_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             state
                 .er_preparation
@@ -724,7 +710,7 @@ mod tests {
             reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -739,7 +725,7 @@ mod tests {
         #[test]
         fn retry_limit_exceeded_as_last_table_triggers_er_completion() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.status = ErStatus::Waiting;
             state.er_preparation.fk_expanded = true;
             let qualified = "public.users".to_string();
@@ -760,7 +746,7 @@ mod tests {
             let effects = reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -779,7 +765,7 @@ mod tests {
         #[test]
         fn retry_limit_exceeded_with_queue_remaining_redrives_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.status = ErStatus::Waiting;
             state.er_preparation.fk_expanded = true;
             let failed = "public.users".to_string();
@@ -803,7 +789,7 @@ mod tests {
             let effects = reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -822,7 +808,7 @@ mod tests {
         #[test]
         fn expired_backoff_proceeds_normally() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             // Failed 10 seconds ago with retry_count=1 (backoff = 2s, already expired)
             state.sql_modal.failed_prefetch_tables.insert(
@@ -837,7 +823,7 @@ mod tests {
             let effects = reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -862,7 +848,7 @@ mod tests {
         #[test]
         fn increments_retry_count() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             state.sql_modal.prefetching_tables.insert(qualified.clone());
             state.sql_modal.failed_prefetch_tables.insert(
@@ -879,7 +865,7 @@ mod tests {
                 &mut state,
                 &Action::TableDetailCacheFailed {
                     dsn: "postgres://localhost/test".to_string(),
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                     error: DbOperationError::QueryFailed("new error".to_string()),
@@ -902,7 +888,7 @@ mod tests {
         #[test]
         fn first_failure_sets_retry_count_1() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             state.sql_modal.prefetching_tables.insert(qualified.clone());
 
@@ -911,7 +897,7 @@ mod tests {
                 &mut state,
                 &Action::TableDetailCacheFailed {
                     dsn: "postgres://localhost/test".to_string(),
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                     error: DbOperationError::Timeout("timed out".to_string()),
@@ -963,10 +949,10 @@ mod tests {
         }
 
         fn metadata_loaded_action(state: &mut AppState, metadata: Arc<DatabaseMetadata>) -> Action {
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
-                request_id,
+                run_id,
                 metadata,
             }
         }
@@ -1257,7 +1243,7 @@ mod tests {
         fn phase2_table_retry_limit_triggers_completion() {
             // All Phase 2 tables fail → completion must still fire
             let mut state = state_with_dsn("postgres://localhost/test");
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.status = ErStatus::Waiting;
             state.er_preparation.fk_expanded = true;
             let neighbor = "public.posts".to_string();
@@ -1274,7 +1260,7 @@ mod tests {
             let effects = reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "posts".to_string(),
                 },

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -49,7 +49,17 @@ fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
 
 pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
-        Action::MetadataLoaded(metadata) => {
+        Action::MetadataLoaded {
+            dsn,
+            request_id,
+            metadata,
+        } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.session.is_current_metadata_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
             let has_tables = !metadata.table_summaries.is_empty();
             state.session.mark_connected(Arc::clone(metadata));
 
@@ -70,14 +80,17 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     state.ui.set_explorer_selection(Some(idx));
                     // Refresh preview and detail: DDL or reload may have changed
                     // data/schema even though the table still exists.
-                    if let Some(dsn) = &state.session.dsn {
+                    if let Some(dsn) = state.session.dsn.clone() {
                         let page = state.query.pagination.current_page;
                         let generation = state.session.selection_generation();
+                        let query_request_id = state.query.begin_running(now);
+                        let detail_request_id = state.session.begin_table_detail_request();
                         effects.push(Effect::ExecutePreview {
                             dsn: dsn.clone(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation,
+                            request_id: query_request_id,
                             limit: PREVIEW_PAGE_SIZE,
                             offset: page * PREVIEW_PAGE_SIZE,
                             target_page: page,
@@ -88,6 +101,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation,
+                            request_id: detail_request_id,
                         });
                     }
                 } else {
@@ -127,7 +141,17 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
             DispatchResult::handled_with(effects)
         }
-        Action::MetadataFailed(error) => {
+        Action::MetadataFailed {
+            dsn,
+            request_id,
+            error,
+        } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.session.is_current_metadata_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
             let error_info = ConnectionErrorInfo::from_db_operation_error(error);
             state.connection_error.set_error(error_info);
             let was_connected = state.session.connection_state().is_connected();
@@ -140,13 +164,35 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             }
             DispatchResult::handled()
         }
-        Action::TableDetailLoaded(detail, generation) => {
+        Action::TableDetailLoaded {
+            dsn,
+            request_id,
+            detail,
+            generation,
+        } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.session.is_current_table_detail_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
             if state.session.set_table_detail(*detail.clone(), *generation) {
                 state.ui.inspector_scroll_offset = 0;
             }
             DispatchResult::handled()
         }
-        Action::TableDetailFailed(error, generation) => {
+        Action::TableDetailFailed {
+            dsn,
+            request_id,
+            error,
+            generation,
+        } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.session.is_current_table_detail_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
             if *generation == state.session.selection_generation() {
                 state.set_error(error.user_message());
             }
@@ -155,8 +201,8 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
         Action::LoadMetadata => {
             if let Some(dsn) = state.session.dsn.clone() {
-                state.session.begin_metadata_refresh();
-                DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn }])
+                let request_id = state.session.begin_metadata_refresh();
+                DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, request_id }])
             } else {
                 DispatchResult::handled()
             }
@@ -166,12 +212,14 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             table,
             generation,
         }) => {
-            if let Some(dsn) = &state.session.dsn {
+            if let Some(dsn) = state.session.dsn.clone() {
+                let request_id = state.session.begin_table_detail_request();
                 DispatchResult::handled_with(vec![Effect::FetchTableDetail {
-                    dsn: dsn.clone(),
+                    dsn,
                     schema: schema.clone(),
                     table: table.clone(),
                     generation: *generation,
+                    request_id,
                 }])
             } else {
                 DispatchResult::handled()
@@ -180,7 +228,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
 
         Action::ReloadMetadata => {
             if let Some(dsn) = state.session.dsn.clone() {
-                state.session.begin_reload();
+                let request_id = state.session.begin_reload();
                 state.sql_modal.reset_prefetch();
                 state.er_preparation.reset();
                 state.ui.er_selected_tables.clear();
@@ -192,7 +240,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                 DispatchResult::handled_with(vec![Effect::Sequence(vec![
                     Effect::CacheInvalidate { dsn: dsn.clone() },
                     Effect::ClearCompletionEngineCache,
-                    Effect::FetchMetadata { dsn },
+                    Effect::FetchMetadata { dsn, request_id },
                 ])])
             } else {
                 DispatchResult::handled()
@@ -203,7 +251,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             if !state.sql_modal.is_prefetch_started()
                 && let Some(metadata) = state.session.metadata()
             {
-                state.sql_modal.begin_prefetch();
+                let batch_id = state.sql_modal.begin_prefetch();
                 state.er_preparation.pending_tables.clear();
                 state.er_preparation.fetching_tables.clear();
                 state.er_preparation.failed_tables.clear();
@@ -225,7 +273,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     Effect::ResizeCompletionCache {
                         capacity: resize_capacity,
                     },
-                    Effect::ProcessPrefetchQueue,
+                    Effect::ProcessPrefetchQueue { batch_id },
                 ])
             } else {
                 DispatchResult::handled()
@@ -236,7 +284,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             if state.sql_modal.is_prefetch_started() {
                 DispatchResult::handled()
             } else {
-                state.sql_modal.begin_prefetch();
+                let batch_id = state.sql_modal.begin_prefetch();
                 state.er_preparation.pending_tables.clear();
                 state.er_preparation.fetching_tables.clear();
                 state.er_preparation.failed_tables.clear();
@@ -254,7 +302,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                         .pending_tables
                         .insert(qualified_name.clone());
                 }
-                DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue])
+                DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue { batch_id }])
             }
         }
 
@@ -281,10 +329,16 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     .prefetch_queue
                     .push_back(qualified_name.clone());
             }
-            DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue])
+            let Some(batch_id) = state.sql_modal.active_prefetch_batch_id() else {
+                return DispatchResult::handled();
+            };
+            DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue { batch_id }])
         }
 
-        Action::ProcessPrefetchQueue => {
+        Action::ProcessPrefetchQueue { batch_id } => {
+            if !state.sql_modal.is_current_prefetch_batch(*batch_id) {
+                return DispatchResult::handled();
+            }
             const MAX_CONCURRENT_PREFETCH: usize = 4;
             let current_in_flight = state.sql_modal.prefetching_tables.len();
             let available_slots = MAX_CONCURRENT_PREFETCH.saturating_sub(current_in_flight);
@@ -295,6 +349,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     && let Some((schema, table)) = qualified_name.split_once('.')
                 {
                     actions.push(Action::PrefetchTableDetail {
+                        batch_id: *batch_id,
                         schema: schema.to_string(),
                         table: table.to_string(),
                     });
@@ -308,7 +363,14 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             }
         }
 
-        Action::PrefetchTableDetail { schema, table } => {
+        Action::PrefetchTableDetail {
+            batch_id,
+            schema,
+            table,
+        } => {
+            if !state.sql_modal.is_current_prefetch_batch(*batch_id) {
+                return DispatchResult::handled();
+            }
             let qualified_name = format!("{schema}.{table}");
 
             if state.sql_modal.prefetching_tables.contains(&qualified_name) {
@@ -325,7 +387,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     let mut effects = check_er_completion(state);
                     // No fetch started → no completion event to re-drive the queue.
                     if effects.is_empty() && state.er_preparation.status == ErStatus::Waiting {
-                        effects.push(Effect::ProcessPrefetchQueue);
+                        effects.push(Effect::ProcessPrefetchQueue {
+                            batch_id: *batch_id,
+                        });
                     }
                     return DispatchResult::handled_with(effects);
                 }
@@ -340,6 +404,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     state.sql_modal.prefetch_queue.push_back(qualified_name);
                     return DispatchResult::handled_with(vec![
                         Effect::DelayedProcessPrefetchQueue {
+                            batch_id: *batch_id,
                             delay_secs: remaining,
                         },
                     ]);
@@ -359,6 +424,7 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             if let Some(dsn) = &state.session.dsn {
                 DispatchResult::handled_with(vec![Effect::PrefetchTableDetail {
                     dsn: dsn.clone(),
+                    batch_id: *batch_id,
                     schema: schema.clone(),
                     table: table.clone(),
                 }])
@@ -368,10 +434,17 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
         }
 
         Action::TableDetailCached {
+            dsn,
+            batch_id,
             schema,
             table,
             detail,
         } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.sql_modal.is_current_prefetch_batch(*batch_id)
+            {
+                return DispatchResult::handled();
+            }
             let qualified_name = format!("{schema}.{table}");
             state.sql_modal.prefetching_tables.remove(&qualified_name);
             state
@@ -386,7 +459,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             }];
 
             if !state.sql_modal.prefetch_queue.is_empty() {
-                effects.push(Effect::ProcessPrefetchQueue);
+                effects.push(Effect::ProcessPrefetchQueue {
+                    batch_id: *batch_id,
+                });
             }
 
             effects.extend(check_er_completion(state));
@@ -395,10 +470,17 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
         }
 
         Action::TableDetailCacheFailed {
+            dsn,
+            batch_id,
             schema,
             table,
             error,
         } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.sql_modal.is_current_prefetch_batch(*batch_id)
+            {
+                return DispatchResult::handled();
+            }
             let qualified_name = format!("{schema}.{table}");
             state.sql_modal.prefetching_tables.remove(&qualified_name);
 
@@ -422,7 +504,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             let mut effects = Vec::new();
 
             if !state.sql_modal.prefetch_queue.is_empty() {
-                effects.push(Effect::ProcessPrefetchQueue);
+                effects.push(Effect::ProcessPrefetchQueue {
+                    batch_id: *batch_id,
+                });
             }
 
             effects.extend(check_er_completion(state));
@@ -430,7 +514,17 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             DispatchResult::handled_with(effects)
         }
 
-        Action::TableDetailAlreadyCached { schema, table } => {
+        Action::TableDetailAlreadyCached {
+            dsn,
+            batch_id,
+            schema,
+            table,
+        } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.sql_modal.is_current_prefetch_batch(*batch_id)
+            {
+                return DispatchResult::handled();
+            }
             let qualified_name = format!("{schema}.{table}");
             state.sql_modal.prefetching_tables.remove(&qualified_name);
             state
@@ -442,7 +536,9 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
             let mut effects = Vec::new();
 
             if !state.sql_modal.prefetch_queue.is_empty() {
-                effects.push(Effect::ProcessPrefetchQueue);
+                effects.push(Effect::ProcessPrefetchQueue {
+                    batch_id: *batch_id,
+                });
             }
 
             effects.extend(check_er_completion(state));
@@ -467,6 +563,106 @@ mod tests {
         state
     }
 
+    fn empty_table(schema: &str, name: &str) -> Box<crate::domain::Table> {
+        Box::new(crate::domain::Table {
+            schema: schema.to_string(),
+            name: name.to_string(),
+            owner: None,
+            columns: vec![],
+            primary_key: None,
+            indexes: vec![],
+            foreign_keys: vec![],
+            rls: None,
+            triggers: vec![],
+            row_count_estimate: None,
+            comment: None,
+        })
+    }
+
+    mod freshness_guards {
+        use super::*;
+        use crate::domain::{DatabaseMetadata, TableSummary};
+
+        fn metadata_with_users() -> Arc<DatabaseMetadata> {
+            Arc::new(DatabaseMetadata {
+                database_name: "test".to_string(),
+                schemas: vec![],
+                table_summaries: vec![TableSummary::new(
+                    "public".to_string(),
+                    "users".to_string(),
+                    None,
+                    false,
+                )],
+                fetched_at: Instant::now(),
+            })
+        }
+
+        #[test]
+        fn stale_metadata_loaded_does_not_replace_current_state() {
+            let mut state = state_with_dsn("postgres://localhost/new");
+            let request_id = state.session.begin_metadata_refresh();
+
+            let effects = reduce_metadata(
+                &mut state,
+                &Action::MetadataLoaded {
+                    dsn: "postgres://localhost/old".to_string(),
+                    request_id,
+                    metadata: metadata_with_users(),
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert!(state.session.metadata().is_none());
+        }
+
+        #[test]
+        fn stale_table_detail_loaded_does_not_replace_current_detail() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let request_id = state.session.begin_table_detail_request();
+            let current_generation = state.session.selection_generation();
+            let _ = state.session.begin_table_detail_request();
+
+            reduce_metadata(
+                &mut state,
+                &Action::TableDetailLoaded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    request_id,
+                    detail: empty_table("public", "users"),
+                    generation: current_generation,
+                },
+                Instant::now(),
+            );
+
+            assert!(state.session.table_detail().is_none());
+        }
+
+        #[test]
+        fn stale_prefetch_batch_does_not_advance_queue() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let old_batch_id = state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_prefetch();
+            state
+                .sql_modal
+                .prefetch_queue
+                .push_back("public.users".to_string());
+
+            let effects = reduce_metadata(
+                &mut state,
+                &Action::ProcessPrefetchQueue {
+                    batch_id: old_batch_id,
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(state.sql_modal.prefetch_queue.len(), 1);
+            assert!(state.sql_modal.prefetching_tables.is_empty());
+        }
+    }
+
     mod prefetch_table_detail {
         use super::*;
         use crate::model::er_state::ErStatus;
@@ -474,7 +670,7 @@ mod tests {
         #[test]
         fn backoff_table_requeued_at_tail_with_process_effect() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.sql_modal.begin_prefetch();
+            let batch_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             // Insert a recently failed entry (retry_count=1, just failed)
             state.sql_modal.failed_prefetch_tables.insert(
@@ -489,6 +685,7 @@ mod tests {
             let effects = reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
+                    batch_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -509,7 +706,7 @@ mod tests {
         #[test]
         fn retry_limit_exceeded_gives_up_and_calls_on_table_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.sql_modal.begin_prefetch();
+            let batch_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             state
                 .er_preparation
@@ -527,6 +724,7 @@ mod tests {
             reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
+                    batch_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -541,7 +739,7 @@ mod tests {
         #[test]
         fn retry_limit_exceeded_as_last_table_triggers_er_completion() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.sql_modal.begin_prefetch();
+            let batch_id = state.sql_modal.begin_prefetch();
             state.er_preparation.status = ErStatus::Waiting;
             state.er_preparation.fk_expanded = true;
             let qualified = "public.users".to_string();
@@ -562,6 +760,7 @@ mod tests {
             let effects = reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
+                    batch_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -580,7 +779,7 @@ mod tests {
         #[test]
         fn retry_limit_exceeded_with_queue_remaining_redrives_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.sql_modal.begin_prefetch();
+            let batch_id = state.sql_modal.begin_prefetch();
             state.er_preparation.status = ErStatus::Waiting;
             state.er_preparation.fk_expanded = true;
             let failed = "public.users".to_string();
@@ -604,6 +803,7 @@ mod tests {
             let effects = reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
+                    batch_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -614,7 +814,7 @@ mod tests {
             assert!(
                 effects
                     .iter()
-                    .any(|e| matches!(e, Effect::ProcessPrefetchQueue))
+                    .any(|e| matches!(e, Effect::ProcessPrefetchQueue { .. }))
             );
             assert_eq!(state.er_preparation.status, ErStatus::Waiting);
         }
@@ -622,7 +822,7 @@ mod tests {
         #[test]
         fn expired_backoff_proceeds_normally() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.sql_modal.begin_prefetch();
+            let batch_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             // Failed 10 seconds ago with retry_count=1 (backoff = 2s, already expired)
             state.sql_modal.failed_prefetch_tables.insert(
@@ -637,6 +837,7 @@ mod tests {
             let effects = reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
+                    batch_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -661,6 +862,7 @@ mod tests {
         #[test]
         fn increments_retry_count() {
             let mut state = state_with_dsn("postgres://localhost/test");
+            let batch_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             state.sql_modal.prefetching_tables.insert(qualified.clone());
             state.sql_modal.failed_prefetch_tables.insert(
@@ -676,6 +878,8 @@ mod tests {
             reduce_metadata(
                 &mut state,
                 &Action::TableDetailCacheFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    batch_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                     error: DbOperationError::QueryFailed("new error".to_string()),
@@ -698,6 +902,7 @@ mod tests {
         #[test]
         fn first_failure_sets_retry_count_1() {
             let mut state = state_with_dsn("postgres://localhost/test");
+            let batch_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             state.sql_modal.prefetching_tables.insert(qualified.clone());
 
@@ -705,6 +910,8 @@ mod tests {
             reduce_metadata(
                 &mut state,
                 &Action::TableDetailCacheFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    batch_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                     error: DbOperationError::Timeout("timed out".to_string()),
@@ -755,6 +962,15 @@ mod tests {
             })
         }
 
+        fn metadata_loaded_action(state: &mut AppState, metadata: Arc<DatabaseMetadata>) -> Action {
+            let request_id = state.session.begin_metadata_refresh();
+            Action::MetadataLoaded {
+                dsn: "postgres://localhost/test".to_string(),
+                request_id,
+                metadata,
+            }
+        }
+
         #[test]
         fn table_disappeared_clears_pagination_and_result() {
             let mut state = state_with_dsn("postgres://localhost/test");
@@ -763,11 +979,8 @@ mod tests {
                 .select_table("public", "users", &mut state.query.pagination);
 
             let metadata = make_metadata(vec![("public", "orders")]);
-            reduce_metadata(
-                &mut state,
-                &Action::MetadataLoaded(metadata),
-                Instant::now(),
-            );
+            let action = metadata_loaded_action(&mut state, metadata);
+            reduce_metadata(&mut state, &action, Instant::now());
 
             assert!(state.query.pagination.table.is_empty());
             assert!(state.query.current_result().is_none());
@@ -784,12 +997,8 @@ mod tests {
 
             // "orders" comes before "users" alphabetically, so "users" → index 1
             let metadata = make_metadata(vec![("public", "orders"), ("public", "users")]);
-            let effects = reduce_metadata(
-                &mut state,
-                &Action::MetadataLoaded(metadata),
-                Instant::now(),
-            )
-            .unwrap();
+            let action = metadata_loaded_action(&mut state, metadata);
+            let effects = reduce_metadata(&mut state, &action, Instant::now()).unwrap();
 
             assert_eq!(state.query.pagination.table, "users");
             assert_eq!(state.ui.explorer_selected, 1);
@@ -810,11 +1019,8 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
 
             let metadata = make_metadata(vec![("public", "orders"), ("public", "users")]);
-            reduce_metadata(
-                &mut state,
-                &Action::MetadataLoaded(metadata),
-                Instant::now(),
-            );
+            let action = metadata_loaded_action(&mut state, metadata);
+            reduce_metadata(&mut state, &action, Instant::now());
 
             assert_eq!(state.ui.explorer_selected, 0);
         }
@@ -827,12 +1033,8 @@ mod tests {
 
             // New DB happens to have a table named "users" too
             let metadata = make_metadata(vec![("public", "users")]);
-            let effects = reduce_metadata(
-                &mut state,
-                &Action::MetadataLoaded(metadata),
-                Instant::now(),
-            )
-            .unwrap();
+            let action = metadata_loaded_action(&mut state, metadata);
+            let effects = reduce_metadata(&mut state, &action, Instant::now()).unwrap();
 
             // No table was selected on this connection, so no auto-preview should fire
             assert!(
@@ -913,7 +1115,7 @@ mod tests {
         #[test]
         fn second_call_while_running_is_ignored() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_prefetch();
             state
                 .er_preparation
                 .pending_tables
@@ -960,7 +1162,7 @@ mod tests {
             assert!(
                 effects
                     .iter()
-                    .any(|e| matches!(e, Effect::ProcessPrefetchQueue))
+                    .any(|e| matches!(e, Effect::ProcessPrefetchQueue { .. }))
             );
         }
     }
@@ -1028,6 +1230,7 @@ mod tests {
         #[test]
         fn non_empty_neighbors_adds_to_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
+            let _ = state.sql_modal.begin_prefetch();
             state.er_preparation.status = ErStatus::Waiting;
 
             let effects = reduce_metadata(
@@ -1046,7 +1249,7 @@ mod tests {
             assert!(
                 effects
                     .iter()
-                    .any(|e| matches!(e, Effect::ProcessPrefetchQueue))
+                    .any(|e| matches!(e, Effect::ProcessPrefetchQueue { .. }))
             );
         }
 
@@ -1054,7 +1257,7 @@ mod tests {
         fn phase2_table_retry_limit_triggers_completion() {
             // All Phase 2 tables fail → completion must still fire
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.sql_modal.begin_prefetch();
+            let batch_id = state.sql_modal.begin_prefetch();
             state.er_preparation.status = ErStatus::Waiting;
             state.er_preparation.fk_expanded = true;
             let neighbor = "public.posts".to_string();
@@ -1071,6 +1274,7 @@ mod tests {
             let effects = reduce_metadata(
                 &mut state,
                 &Action::PrefetchTableDetail {
+                    batch_id,
                     schema: "public".to_string(),
                     table: "posts".to_string(),
                 },

--- a/src/app/update/browse/metadata.rs
+++ b/src/app/update/browse/metadata.rs
@@ -80,30 +80,29 @@ pub fn reduce_metadata(state: &mut AppState, action: &Action, now: Instant) -> D
                     state.ui.set_explorer_selection(Some(idx));
                     // Refresh preview and detail: DDL or reload may have changed
                     // data/schema even though the table still exists.
-                    if let Some(dsn) = state.session.dsn.clone() {
-                        let page = state.query.pagination.current_page;
-                        let generation = state.session.selection_generation();
-                        let query_run_id = state.query.begin_running(now);
-                        let detail_run_id = state.session.begin_table_detail_run();
-                        effects.push(Effect::ExecutePreview {
-                            dsn: dsn.clone(),
-                            schema: state.query.pagination.schema.clone(),
-                            table: state.query.pagination.table.clone(),
-                            generation,
-                            run_id: query_run_id,
-                            limit: PREVIEW_PAGE_SIZE,
-                            offset: page * PREVIEW_PAGE_SIZE,
-                            target_page: page,
-                            read_only: state.session.read_only,
-                        });
-                        effects.push(Effect::FetchTableDetail {
-                            dsn: dsn.clone(),
-                            schema: state.query.pagination.schema.clone(),
-                            table: state.query.pagination.table.clone(),
-                            generation,
-                            run_id: detail_run_id,
-                        });
-                    }
+                    let dsn = dsn.clone();
+                    let page = state.query.pagination.current_page;
+                    let generation = state.session.selection_generation();
+                    let query_run_id = state.query.begin_running(now);
+                    let detail_run_id = state.session.begin_table_detail_run();
+                    effects.push(Effect::ExecutePreview {
+                        dsn: dsn.clone(),
+                        schema: state.query.pagination.schema.clone(),
+                        table: state.query.pagination.table.clone(),
+                        generation,
+                        run_id: query_run_id,
+                        limit: PREVIEW_PAGE_SIZE,
+                        offset: page * PREVIEW_PAGE_SIZE,
+                        target_page: page,
+                        read_only: state.session.read_only,
+                    });
+                    effects.push(Effect::FetchTableDetail {
+                        dsn,
+                        schema: state.query.pagination.schema.clone(),
+                        table: state.query.pagination.table.clone(),
+                        generation,
+                        run_id: detail_run_id,
+                    });
                 } else {
                     // The previously selected table was removed (e.g. via DROP TABLE).
                     // Clear all selection state to avoid stale references.

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -32,20 +32,20 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -
     if tag.is_schema_modifying() {
         state.sql_modal.reset_prefetch();
         state.session.set_table_detail_raw(None);
-        let request_id = state.session.begin_metadata_refresh();
+        let run_id = state.session.begin_metadata_refresh();
 
         effects.push(Effect::CacheInvalidate { dsn: dsn.clone() });
         effects.push(Effect::ClearCompletionEngineCache);
-        effects.push(Effect::FetchMetadata { dsn, request_id });
+        effects.push(Effect::FetchMetadata { dsn, run_id });
     } else if !state.query.pagination.table.is_empty() {
         let page = state.query.pagination.current_page;
-        let request_id = state.query.begin_running(now);
+        let run_id = state.query.begin_running(now);
         effects.push(Effect::ExecutePreview {
             dsn,
             schema: state.query.pagination.schema.clone(),
             table: state.query.pagination.table.clone(),
             generation: state.session.selection_generation(),
-            request_id,
+            run_id,
             limit: PREVIEW_PAGE_SIZE,
             offset: page * PREVIEW_PAGE_SIZE,
             target_page: page,
@@ -65,14 +65,12 @@ pub fn reduce(
     match action {
         Action::QueryCompleted {
             dsn,
-            request_id,
+            run_id,
             result,
             generation,
             target_page,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.query.is_current_request(*request_id)
-            {
+            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -155,14 +153,12 @@ pub fn reduce(
         }
         Action::QueryFailed {
             dsn,
-            request_id,
+            run_id,
             error,
             generation,
             source,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.query.is_current_request(*request_id)
-            {
+            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -247,7 +243,7 @@ pub fn reduce(
             generation,
         }) => {
             if let Some(dsn) = &state.session.dsn {
-                let request_id = state.query.begin_running(now);
+                let run_id = state.query.begin_running(now);
 
                 state.query.pagination.reset();
                 state.query.pagination.schema.clone_from(schema);
@@ -273,7 +269,7 @@ pub fn reduce(
                     schema: schema.clone(),
                     table: table.clone(),
                     generation: *generation,
-                    request_id,
+                    run_id,
                     limit: PREVIEW_PAGE_SIZE,
                     offset: 0,
                     target_page: 0,
@@ -286,10 +282,10 @@ pub fn reduce(
 
         Action::ExecuteAdhoc(query) => {
             if let Some(dsn) = &state.session.dsn {
-                let request_id = state.query.begin_running(now);
+                let run_id = state.query.begin_running(now);
                 DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
                     dsn: dsn.clone(),
-                    request_id,
+                    run_id,
                     query: query.clone(),
                     read_only: state.session.read_only,
                 }])
@@ -310,7 +306,7 @@ mod tests {
     use crate::update::browse::query::reduce_query;
     use crate::update::browse::query::tests::*;
 
-    fn begin_query_request(state: &mut AppState) -> u64 {
+    fn begin_query_run(state: &mut AppState) -> u64 {
         state.query.begin_running(Instant::now())
     }
 
@@ -320,10 +316,10 @@ mod tests {
         generation: u64,
         target_page: Option<usize>,
     ) -> Action {
-        let request_id = begin_query_request(state);
+        let run_id = begin_query_run(state);
         Action::QueryCompleted {
             dsn: "postgres://localhost/test".to_string(),
-            request_id,
+            run_id,
             result,
             generation,
             target_page,
@@ -336,10 +332,10 @@ mod tests {
         generation: u64,
         source: QuerySource,
     ) -> Action {
-        let request_id = begin_query_request(state);
+        let run_id = begin_query_run(state);
         Action::QueryFailed {
             dsn: "postgres://localhost/test".to_string(),
-            request_id,
+            run_id,
             error,
             generation,
             source,
@@ -665,16 +661,16 @@ mod tests {
         }
 
         #[test]
-        fn stale_request_does_not_replace_current_result() {
+        fn stale_run_does_not_replace_current_result() {
             let mut state = create_test_state();
-            let old_request_id = begin_query_request(&mut state);
-            let _ = begin_query_request(&mut state);
+            let old_run_id = begin_query_run(&mut state);
+            let _ = begin_query_run(&mut state);
 
             reduce_query(
                 &mut state,
                 &Action::QueryCompleted {
                     dsn: "postgres://localhost/test".to_string(),
-                    request_id: old_request_id,
+                    run_id: old_run_id,
                     result: adhoc_result(),
                     generation: 0,
                     target_page: None,
@@ -999,10 +995,10 @@ mod tests {
             );
 
             let metadata = make_metadata(vec![("public", "orders"), ("public", "users")]);
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
             let action = Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
-                request_id,
+                run_id,
                 metadata,
             };
             let meta_effects = reduce_metadata(&mut state, &action, Instant::now()).unwrap();
@@ -1037,10 +1033,10 @@ mod tests {
             );
 
             let metadata = make_metadata(vec![("public", "orders")]);
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
             let action = Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
-                request_id,
+                run_id,
                 metadata,
             };
             reduce_metadata(&mut state, &action, Instant::now());

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -13,7 +13,7 @@ use crate::update::action::{Action, ModalKind, TableTarget};
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::input::command::{command_to_action, parse_command};
 
-fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult) -> Vec<Effect> {
+fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -> Vec<Effect> {
     if result.source != QuerySource::Adhoc || result.is_error() {
         return vec![];
     }
@@ -32,17 +32,20 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult) -> Vec<Effect> 
     if tag.is_schema_modifying() {
         state.sql_modal.reset_prefetch();
         state.session.set_table_detail_raw(None);
+        let request_id = state.session.begin_metadata_refresh();
 
         effects.push(Effect::CacheInvalidate { dsn: dsn.clone() });
         effects.push(Effect::ClearCompletionEngineCache);
-        effects.push(Effect::FetchMetadata { dsn });
+        effects.push(Effect::FetchMetadata { dsn, request_id });
     } else if !state.query.pagination.table.is_empty() {
         let page = state.query.pagination.current_page;
+        let request_id = state.query.begin_running(now);
         effects.push(Effect::ExecutePreview {
             dsn,
             schema: state.query.pagination.schema.clone(),
             table: state.query.pagination.table.clone(),
             generation: state.session.selection_generation(),
+            request_id,
             limit: PREVIEW_PAGE_SIZE,
             offset: page * PREVIEW_PAGE_SIZE,
             target_page: page,
@@ -61,10 +64,18 @@ pub fn reduce(
 ) -> DispatchResult {
     match action {
         Action::QueryCompleted {
+            dsn,
+            request_id,
             result,
             generation,
             target_page,
         } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.query.is_current_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
             if *generation == 0 || *generation == state.session.selection_generation() {
                 state.query.mark_idle();
                 let preserved_result_col = state.result_interaction.selection().cell();
@@ -137,16 +148,24 @@ pub fn reduce(
                         .set_post_delete_selection(PostDeleteRowSelection::Keep);
                 }
 
-                DispatchResult::handled_with(try_adhoc_refresh(state, result))
+                DispatchResult::handled_with(try_adhoc_refresh(state, result, now))
             } else {
                 DispatchResult::handled()
             }
         }
         Action::QueryFailed {
+            dsn,
+            request_id,
             error,
             generation,
             source,
         } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.query.is_current_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
             if *generation == 0 || *generation == state.session.selection_generation() {
                 state.query.mark_idle();
                 if *source == QuerySource::Preview {
@@ -228,7 +247,7 @@ pub fn reduce(
             generation,
         }) => {
             if let Some(dsn) = &state.session.dsn {
-                state.query.begin_running(now);
+                let request_id = state.query.begin_running(now);
 
                 state.query.pagination.reset();
                 state.query.pagination.schema.clone_from(schema);
@@ -254,6 +273,7 @@ pub fn reduce(
                     schema: schema.clone(),
                     table: table.clone(),
                     generation: *generation,
+                    request_id,
                     limit: PREVIEW_PAGE_SIZE,
                     offset: 0,
                     target_page: 0,
@@ -266,9 +286,10 @@ pub fn reduce(
 
         Action::ExecuteAdhoc(query) => {
             if let Some(dsn) = &state.session.dsn {
-                state.query.begin_running(now);
+                let request_id = state.query.begin_running(now);
                 DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
                     dsn: dsn.clone(),
+                    request_id,
                     query: query.clone(),
                     read_only: state.session.read_only,
                 }])
@@ -285,8 +306,45 @@ pub fn reduce(
 mod tests {
     use super::*;
     use crate::model::browse::query_execution::PaginationState;
+    use crate::ports::outbound::DbOperationError;
     use crate::update::browse::query::reduce_query;
     use crate::update::browse::query::tests::*;
+
+    fn begin_query_request(state: &mut AppState) -> u64 {
+        state.query.begin_running(Instant::now())
+    }
+
+    fn query_completed_action(
+        state: &mut AppState,
+        result: Arc<QueryResult>,
+        generation: u64,
+        target_page: Option<usize>,
+    ) -> Action {
+        let request_id = begin_query_request(state);
+        Action::QueryCompleted {
+            dsn: "postgres://localhost/test".to_string(),
+            request_id,
+            result,
+            generation,
+            target_page,
+        }
+    }
+
+    fn query_failed_action(
+        state: &mut AppState,
+        error: DbOperationError,
+        generation: u64,
+        source: QuerySource,
+    ) -> Action {
+        let request_id = begin_query_request(state);
+        Action::QueryFailed {
+            dsn: "postgres://localhost/test".to_string(),
+            request_id,
+            error,
+            generation,
+            source,
+        }
+    }
 
     mod command_line_submit {
         use super::*;
@@ -452,17 +510,9 @@ mod tests {
             state.session.set_selection_generation(1);
             let result = preview_result(100);
             let now = Instant::now();
+            let action = query_completed_action(&mut state, result, 1, Some(2));
 
-            reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result,
-                    generation: 1,
-                    target_page: Some(2),
-                },
-                now,
-                &AppServices::stub(),
-            );
+            reduce_query(&mut state, &action, now, &AppServices::stub());
 
             assert_eq!(state.query.pagination.current_page, 2);
             assert!(state.query.pagination.reached_end);
@@ -474,17 +524,9 @@ mod tests {
             state.session.set_selection_generation(1);
             let result = preview_result(PREVIEW_PAGE_SIZE);
             let now = Instant::now();
+            let action = query_completed_action(&mut state, result, 1, Some(0));
 
-            reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result,
-                    generation: 1,
-                    target_page: Some(0),
-                },
-                now,
-                &AppServices::stub(),
-            );
+            reduce_query(&mut state, &action, now, &AppServices::stub());
 
             assert_eq!(state.query.pagination.current_page, 0);
             assert!(!state.query.pagination.reached_end);
@@ -496,17 +538,9 @@ mod tests {
             state.query.pagination.current_page = 3;
             let result = adhoc_result();
             let now = Instant::now();
+            let action = query_completed_action(&mut state, result, 0, None);
 
-            reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result,
-                    generation: 0,
-                    target_page: None,
-                },
-                now,
-                &AppServices::stub(),
-            );
+            reduce_query(&mut state, &action, now, &AppServices::stub());
 
             assert_eq!(state.query.pagination.current_page, 3);
         }
@@ -520,17 +554,9 @@ mod tests {
             state.result_interaction.stage_row(0);
             state.result_interaction.stage_row(2);
             let result = adhoc_result();
+            let action = query_completed_action(&mut state, result, 0, None);
 
-            reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result,
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             assert_eq!(state.query.result_history().len(), 1);
             assert_eq!(state.query.history_index(), None);
@@ -553,17 +579,9 @@ mod tests {
             state.result_interaction.horizontal_offset = 5;
             state.result_interaction.activate_cell(3, 0);
             let result = adhoc_error_result();
+            let action = query_completed_action(&mut state, result, 0, None);
 
-            reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result,
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             assert!(state.query.result_history().is_empty());
             assert_eq!(state.query.history_index(), None);
@@ -582,17 +600,9 @@ mod tests {
             state.session.set_selection_generation(1);
             state.query.push_history(adhoc_result());
             state.query.enter_history(0);
+            let action = query_completed_action(&mut state, preview_result(5), 1, Some(0));
 
-            reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result: preview_result(5),
-                    generation: 1,
-                    target_page: Some(0),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             assert_eq!(state.query.history_index(), None);
             assert!(state.query.current_result().is_some());
@@ -629,17 +639,9 @@ mod tests {
             state.result_interaction.horizontal_offset = 1;
             state.result_interaction.activate_cell(3, 2);
             state.query.set_current_result(Arc::clone(&result));
+            let action = query_completed_action(&mut state, result, 0, Some(0));
 
-            reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result,
-                    generation: 0,
-                    target_page: Some(0),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             assert_eq!(state.result_interaction.selection().row(), Some(1));
             assert_eq!(state.result_interaction.selection().cell(), Some(2));
@@ -654,20 +656,35 @@ mod tests {
                 .set_post_delete_selection(PostDeleteRowSelection::Clear);
             state.result_interaction.activate_cell(0, 0);
             state.result_interaction.stage_row(0);
+            let action = query_completed_action(&mut state, preview_result(1), 0, Some(0));
+
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
+
+            assert_eq!(state.result_interaction.selection().row(), None);
+            assert!(state.result_interaction.staged_delete_rows().is_empty());
+        }
+
+        #[test]
+        fn stale_request_does_not_replace_current_result() {
+            let mut state = create_test_state();
+            let old_request_id = begin_query_request(&mut state);
+            let _ = begin_query_request(&mut state);
 
             reduce_query(
                 &mut state,
                 &Action::QueryCompleted {
-                    result: preview_result(1),
+                    dsn: "postgres://localhost/test".to_string(),
+                    request_id: old_request_id,
+                    result: adhoc_result(),
                     generation: 0,
-                    target_page: Some(0),
+                    target_page: None,
                 },
                 Instant::now(),
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.result_interaction.selection().row(), None);
-            assert!(state.result_interaction.staged_delete_rows().is_empty());
+            assert!(state.query.current_result().is_none());
+            assert!(state.query.is_running());
         }
     }
 
@@ -683,17 +700,14 @@ mod tests {
             state.result_interaction.activate_cell(5, 2);
             state.result_interaction.scroll_offset = 10;
             state.result_interaction.horizontal_offset = 3;
-
-            reduce_query(
+            let action = query_failed_action(
                 &mut state,
-                &Action::QueryFailed {
-                    error: DbOperationError::QueryFailed("error".to_string()),
-                    generation: 1,
-                    source: QuerySource::Preview,
-                },
-                Instant::now(),
-                &AppServices::stub(),
+                DbOperationError::QueryFailed("error".to_string()),
+                1,
+                QuerySource::Preview,
             );
+
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             assert_eq!(
                 state.result_interaction.selection().mode(),
@@ -707,17 +721,14 @@ mod tests {
         fn preview_failure_sets_error_result() {
             let mut state = state_with_table("public", "users");
             state.session.set_selection_generation(1);
-
-            reduce_query(
+            let action = query_failed_action(
                 &mut state,
-                &Action::QueryFailed {
-                    error: DbOperationError::PermissionDenied("forbidden".to_string()),
-                    generation: 1,
-                    source: QuerySource::Preview,
-                },
-                Instant::now(),
-                &AppServices::stub(),
+                DbOperationError::PermissionDenied("forbidden".to_string()),
+                1,
+                QuerySource::Preview,
             );
+
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             let result = state.query.current_result().expect("result");
             assert!(result.is_error());
@@ -740,17 +751,14 @@ mod tests {
             state
                 .sql_modal
                 .finish_adhoc_error("previous adhoc error".to_string());
-
-            reduce_query(
+            let action = query_failed_action(
                 &mut state,
-                &Action::QueryFailed {
-                    error: DbOperationError::PermissionDenied("forbidden".to_string()),
-                    generation: 1,
-                    source: QuerySource::Preview,
-                },
-                Instant::now(),
-                &AppServices::stub(),
+                DbOperationError::PermissionDenied("forbidden".to_string()),
+                1,
+                QuerySource::Preview,
             );
+
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             assert_eq!(
                 state.sql_modal.last_adhoc_error(),
@@ -769,18 +777,15 @@ mod tests {
         #[test]
         fn dml_with_table_selected_emits_execute_preview() {
             let mut state = state_with_table("public", "users");
-
-            let effects = reduce_query(
+            let action = query_completed_action(
                 &mut state,
-                &Action::QueryCompleted {
-                    result: adhoc_result_with_tag(CommandTag::Update(3)),
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+                adhoc_result_with_tag(CommandTag::Update(3)),
+                0,
+                None,
+            );
+
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert_eq!(effects.len(), 1);
             assert!(
@@ -791,18 +796,15 @@ mod tests {
         #[test]
         fn dml_without_table_selected_emits_no_effects() {
             let mut state = create_test_state();
-
-            let effects = reduce_query(
+            let action = query_completed_action(
                 &mut state,
-                &Action::QueryCompleted {
-                    result: adhoc_result_with_tag(CommandTag::Insert(1)),
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+                adhoc_result_with_tag(CommandTag::Insert(1)),
+                0,
+                None,
+            );
+
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(effects.is_empty());
         }
@@ -810,18 +812,15 @@ mod tests {
         #[test]
         fn ddl_emits_cache_invalidate_and_fetch_metadata() {
             let mut state = state_with_table("public", "users");
-
-            let effects = reduce_query(
+            let action = query_completed_action(
                 &mut state,
-                &Action::QueryCompleted {
-                    result: adhoc_result_with_tag(CommandTag::Create("TABLE".to_string())),
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+                adhoc_result_with_tag(CommandTag::Create("TABLE".to_string())),
+                0,
+                None,
+            );
+
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(
                 effects
@@ -848,7 +847,7 @@ mod tests {
         #[test]
         fn ddl_resets_prefetch_state_and_clears_table_detail() {
             let mut state = state_with_table("public", "users");
-            state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
                 .prefetch_queue
@@ -856,17 +855,14 @@ mod tests {
             state
                 .session
                 .set_table_detail_raw(Some(users_table_detail()));
-
-            reduce_query(
+            let action = query_completed_action(
                 &mut state,
-                &Action::QueryCompleted {
-                    result: adhoc_result_with_tag(CommandTag::Drop("TABLE".to_string())),
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
+                adhoc_result_with_tag(CommandTag::Drop("TABLE".to_string())),
+                0,
+                None,
             );
+
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             assert!(!state.sql_modal.is_prefetch_started());
             assert!(state.sql_modal.prefetch_queue.is_empty());
@@ -877,18 +873,12 @@ mod tests {
         fn tcl_emits_no_effects() {
             for tag in [CommandTag::Begin, CommandTag::Commit, CommandTag::Rollback] {
                 let mut state = state_with_table("public", "users");
+                let action =
+                    query_completed_action(&mut state, adhoc_result_with_tag(tag), 0, None);
 
-                let effects = reduce_query(
-                    &mut state,
-                    &Action::QueryCompleted {
-                        result: adhoc_result_with_tag(tag),
-                        generation: 0,
-                        target_page: None,
-                    },
-                    Instant::now(),
-                    &AppServices::stub(),
-                )
-                .unwrap();
+                let effects =
+                    reduce_query(&mut state, &action, Instant::now(), &AppServices::stub())
+                        .unwrap();
 
                 assert!(effects.is_empty());
             }
@@ -897,18 +887,15 @@ mod tests {
         #[test]
         fn select_emits_no_effects() {
             let mut state = state_with_table("public", "users");
-
-            let effects = reduce_query(
+            let action = query_completed_action(
                 &mut state,
-                &Action::QueryCompleted {
-                    result: adhoc_result_with_tag(CommandTag::Select(5)),
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+                adhoc_result_with_tag(CommandTag::Select(5)),
+                0,
+                None,
+            );
+
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(effects.is_empty());
         }
@@ -916,18 +903,10 @@ mod tests {
         #[test]
         fn adhoc_error_emits_no_effects() {
             let mut state = state_with_table("public", "users");
+            let action = query_completed_action(&mut state, adhoc_error_result(), 0, None);
 
-            let effects = reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result: adhoc_error_result(),
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(effects.is_empty());
         }
@@ -946,18 +925,10 @@ mod tests {
                 error: None,
                 command_tag: None,
             });
+            let action = query_completed_action(&mut state, result, 0, None);
 
-            let effects = reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result,
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(effects.is_empty());
         }
@@ -985,33 +956,22 @@ mod tests {
         #[test]
         fn dml_then_preview_updates_current_result() {
             let mut state = state_with_table("public", "users");
-
-            let effects = reduce_query(
+            let action = query_completed_action(
                 &mut state,
-                &Action::QueryCompleted {
-                    result: adhoc_result_with_tag(CommandTag::Update(3)),
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+                adhoc_result_with_tag(CommandTag::Update(3)),
+                0,
+                None,
+            );
+
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::ExecutePreview { .. }));
 
             let new_preview = preview_result(5);
-            reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result: Arc::clone(&new_preview),
-                    generation: 0,
-                    target_page: Some(0),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
+            let action = query_completed_action(&mut state, Arc::clone(&new_preview), 0, Some(0));
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             let stored = state.query.current_result().unwrap();
             assert_eq!(stored.source, QuerySource::Preview);
@@ -1021,18 +981,15 @@ mod tests {
         #[test]
         fn ddl_create_then_metadata_loaded_preserves_explorer_selection() {
             let mut state = state_with_table("public", "users");
-
-            let effects = reduce_query(
+            let action = query_completed_action(
                 &mut state,
-                &Action::QueryCompleted {
-                    result: adhoc_result_with_tag(CommandTag::Create("TABLE".to_string())),
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+                adhoc_result_with_tag(CommandTag::Create("TABLE".to_string())),
+                0,
+                None,
+            );
+
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(!state.sql_modal.is_prefetch_started());
             assert!(
@@ -1042,12 +999,13 @@ mod tests {
             );
 
             let metadata = make_metadata(vec![("public", "orders"), ("public", "users")]);
-            let meta_effects = reduce_metadata(
-                &mut state,
-                &Action::MetadataLoaded(metadata),
-                Instant::now(),
-            )
-            .unwrap();
+            let request_id = state.session.begin_metadata_refresh();
+            let action = Action::MetadataLoaded {
+                dsn: "postgres://localhost/test".to_string(),
+                request_id,
+                metadata,
+            };
+            let meta_effects = reduce_metadata(&mut state, &action, Instant::now()).unwrap();
 
             assert_eq!(state.ui.explorer_selected, 1);
             assert_eq!(state.query.pagination.table, "users");
@@ -1062,18 +1020,15 @@ mod tests {
         fn ddl_drop_then_metadata_loaded_without_table_clears_selection() {
             let mut state = state_with_table("public", "users");
             state.query.set_current_result(preview_result(3));
-
-            let effects = reduce_query(
+            let action = query_completed_action(
                 &mut state,
-                &Action::QueryCompleted {
-                    result: adhoc_result_with_tag(CommandTag::Drop("TABLE".to_string())),
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+                adhoc_result_with_tag(CommandTag::Drop("TABLE".to_string())),
+                0,
+                None,
+            );
+
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(
                 effects
@@ -1082,11 +1037,13 @@ mod tests {
             );
 
             let metadata = make_metadata(vec![("public", "orders")]);
-            reduce_metadata(
-                &mut state,
-                &Action::MetadataLoaded(metadata),
-                Instant::now(),
-            );
+            let request_id = state.session.begin_metadata_refresh();
+            let action = Action::MetadataLoaded {
+                dsn: "postgres://localhost/test".to_string(),
+                request_id,
+                metadata,
+            };
+            reduce_metadata(&mut state, &action, Instant::now());
 
             assert!(state.query.pagination.table.is_empty());
             assert!(state.query.current_result().is_none());
@@ -1097,18 +1054,15 @@ mod tests {
         #[test]
         fn ddl_does_not_emit_execute_preview_so_modal_status_stays_success() {
             let mut state = state_with_table("public", "users");
-
-            let effects = reduce_query(
+            let action = query_completed_action(
                 &mut state,
-                &Action::QueryCompleted {
-                    result: adhoc_result_with_tag(CommandTag::Drop("TABLE".to_string())),
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+                adhoc_result_with_tag(CommandTag::Drop("TABLE".to_string())),
+                0,
+                None,
+            );
+
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(
                 !effects
@@ -1124,17 +1078,14 @@ mod tests {
         #[test]
         fn success_snapshot_not_overwritten_by_subsequent_preview_result() {
             let mut state = state_with_table("public", "users");
-
-            reduce_query(
+            let action = query_completed_action(
                 &mut state,
-                &Action::QueryCompleted {
-                    result: adhoc_result_with_tag(CommandTag::Alter("TABLE".to_string())),
-                    generation: 0,
-                    target_page: None,
-                },
-                Instant::now(),
-                &AppServices::stub(),
+                adhoc_result_with_tag(CommandTag::Alter("TABLE".to_string())),
+                0,
+                None,
             );
+
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             let saved_tag = state
                 .sql_modal
@@ -1142,16 +1093,8 @@ mod tests {
                 .and_then(|s| s.command_tag.clone());
             assert!(matches!(saved_tag, Some(CommandTag::Alter(_))));
 
-            reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result: preview_result(5),
-                    generation: 0,
-                    target_page: Some(0),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
+            let action = query_completed_action(&mut state, preview_result(5), 0, Some(0));
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             let tag_after = state
                 .sql_modal

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -49,9 +49,11 @@ pub fn reduce(
 
             let stripped = export_query.trim_end().trim_end_matches(';').to_string();
             let count_query = format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count");
+            let request_id = state.query.begin_running(now);
 
             DispatchResult::handled_with(vec![Effect::CountRowsForExport {
                 dsn,
+                request_id,
                 count_query,
                 export_query,
                 file_name,
@@ -60,10 +62,18 @@ pub fn reduce(
         }
 
         Action::CsvExportRowsCounted {
+            dsn,
+            request_id,
             row_count,
             export_query,
             file_name,
         } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.query.is_current_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
             const LARGE_EXPORT_THRESHOLD: usize = 100_000;
 
             let needs_confirm = match row_count {
@@ -80,6 +90,8 @@ pub fn reduce(
                     "Confirm CSV Export",
                     msg,
                     crate::model::shared::confirm_dialog::ConfirmIntent::CsvExport {
+                        dsn: dsn.clone(),
+                        request_id: *request_id,
                         export_query: export_query.clone(),
                         file_name: file_name.clone(),
                         row_count: *row_count,
@@ -88,12 +100,9 @@ pub fn reduce(
                 state.modal.push_mode(InputMode::ConfirmDialog);
                 DispatchResult::handled()
             } else {
-                let dsn = match &state.session.dsn {
-                    Some(d) => d.clone(),
-                    None => return DispatchResult::handled(),
-                };
                 DispatchResult::handled_with(vec![Effect::ExportCsv {
-                    dsn,
+                    dsn: dsn.clone(),
+                    request_id: *request_id,
                     query: export_query.clone(),
                     file_name: file_name.clone(),
                     row_count: *row_count,
@@ -103,16 +112,21 @@ pub fn reduce(
         }
 
         Action::ExecuteCsvExport {
+            dsn,
+            request_id,
             export_query,
             file_name,
             row_count,
         } => {
-            let dsn = match &state.session.dsn {
-                Some(d) => d.clone(),
-                None => return DispatchResult::handled(),
-            };
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.query.is_current_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
             DispatchResult::handled_with(vec![Effect::ExportCsv {
-                dsn,
+                dsn: dsn.clone(),
+                request_id: *request_id,
                 query: export_query.clone(),
                 file_name: file_name.clone(),
                 row_count: *row_count,
@@ -120,7 +134,19 @@ pub fn reduce(
             }])
         }
 
-        Action::CsvExportSucceeded { path, row_count } => {
+        Action::CsvExportSucceeded {
+            dsn,
+            request_id,
+            path,
+            row_count,
+        } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.query.is_current_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
+            state.query.mark_idle();
             let msg = match row_count {
                 Some(n) => format!("Exported {n} rows → {path}"),
                 None => format!("Exported → {path}"),
@@ -132,7 +158,18 @@ pub fn reduce(
             DispatchResult::handled_with(vec![Effect::OpenFolder { path: folder }])
         }
 
-        Action::CsvExportFailed(error) => {
+        Action::CsvExportFailed {
+            dsn,
+            request_id,
+            error,
+        } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.query.is_current_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
+            state.query.mark_idle();
             state.messages.set_error_at(error.user_message(), now);
             DispatchResult::handled()
         }
@@ -154,13 +191,14 @@ pub fn reduce(
             }
             if let Some(dsn) = state.session.dsn.clone() {
                 let next_page = state.query.pagination.current_page + 1;
-                state.query.begin_running(now);
+                let request_id = state.query.begin_running(now);
                 state.result_interaction.reset_view();
                 DispatchResult::handled_with(vec![Effect::ExecutePreview {
                     dsn,
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
                     generation: state.session.selection_generation(),
+                    request_id,
                     limit: PREVIEW_PAGE_SIZE,
                     offset: next_page * PREVIEW_PAGE_SIZE,
                     target_page: next_page,
@@ -180,7 +218,7 @@ pub fn reduce(
             }
             if let Some(dsn) = state.session.dsn.clone() {
                 let prev_page = state.query.pagination.current_page - 1;
-                state.query.begin_running(now);
+                let request_id = state.query.begin_running(now);
                 state.result_interaction.reset_view();
                 state.query.pagination.reached_end = false;
                 DispatchResult::handled_with(vec![Effect::ExecutePreview {
@@ -188,6 +226,7 @@ pub fn reduce(
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
                     generation: state.session.selection_generation(),
+                    request_id,
                     limit: PREVIEW_PAGE_SIZE,
                     offset: prev_page * PREVIEW_PAGE_SIZE,
                     target_page: prev_page,
@@ -206,11 +245,51 @@ pub fn reduce(
 mod tests {
     use super::*;
     use crate::domain::{QueryResult, QuerySource};
+    use crate::ports::outbound::DbOperationError;
     use std::sync::Arc;
 
     use crate::model::browse::query_execution::PaginationState;
     use crate::update::browse::query::reduce_query;
     use crate::update::browse::query::tests::*;
+
+    fn begin_query_request(state: &mut AppState) -> u64 {
+        state.query.begin_running(Instant::now())
+    }
+
+    fn csv_rows_counted_action(
+        state: &mut AppState,
+        row_count: Option<usize>,
+        export_query: &str,
+        file_name: &str,
+    ) -> Action {
+        let request_id = begin_query_request(state);
+        Action::CsvExportRowsCounted {
+            dsn: "postgres://localhost/test".to_string(),
+            request_id,
+            row_count,
+            export_query: export_query.to_string(),
+            file_name: file_name.to_string(),
+        }
+    }
+
+    fn csv_succeeded_action(state: &mut AppState, path: &str, row_count: Option<usize>) -> Action {
+        let request_id = begin_query_request(state);
+        Action::CsvExportSucceeded {
+            dsn: "postgres://localhost/test".to_string(),
+            request_id,
+            path: path.to_string(),
+            row_count,
+        }
+    }
+
+    fn csv_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
+        let request_id = begin_query_request(state);
+        Action::CsvExportFailed {
+            dsn: "postgres://localhost/test".to_string(),
+            request_id,
+            error,
+        }
+    }
 
     fn preview_result_with_two_columns(row_count: usize) -> Arc<QueryResult> {
         let rows: Vec<Vec<String>> = (0..row_count)
@@ -310,7 +389,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.begin_running(Instant::now());
+            let _ = state.query.begin_running(Instant::now());
             let now = Instant::now();
 
             let effects = reduce_query(
@@ -545,18 +624,10 @@ mod tests {
         #[test]
         fn rows_counted_below_threshold_emits_export_effect() {
             let mut state = create_test_state();
+            let action = csv_rows_counted_action(&mut state, Some(500), "SELECT 1", "test");
 
-            let effects = reduce_query(
-                &mut state,
-                &Action::CsvExportRowsCounted {
-                    row_count: Some(500),
-                    export_query: "SELECT 1".to_string(),
-                    file_name: "test".to_string(),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::ExportCsv { .. }));
@@ -565,18 +636,10 @@ mod tests {
         #[test]
         fn rows_counted_above_threshold_opens_confirm_dialog() {
             let mut state = create_test_state();
+            let action = csv_rows_counted_action(&mut state, Some(200_000), "SELECT 1", "test");
 
-            let effects = reduce_query(
-                &mut state,
-                &Action::CsvExportRowsCounted {
-                    row_count: Some(200_000),
-                    export_query: "SELECT 1".to_string(),
-                    file_name: "test".to_string(),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
@@ -586,18 +649,10 @@ mod tests {
         #[test]
         fn rows_counted_none_opens_confirm_dialog() {
             let mut state = create_test_state();
+            let action = csv_rows_counted_action(&mut state, None, "SELECT 1", "test");
 
-            let effects = reduce_query(
-                &mut state,
-                &Action::CsvExportRowsCounted {
-                    row_count: None,
-                    export_query: "SELECT 1".to_string(),
-                    file_name: "test".to_string(),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
@@ -607,17 +662,10 @@ mod tests {
         #[test]
         fn export_succeeded_sets_success_message() {
             let mut state = create_test_state();
+            let action = csv_succeeded_action(&mut state, "/tmp/export.csv", Some(42));
 
-            let effects = reduce_query(
-                &mut state,
-                &Action::CsvExportSucceeded {
-                    path: "/tmp/export.csv".to_string(),
-                    row_count: Some(42),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::OpenFolder { .. }));
@@ -642,20 +690,44 @@ mod tests {
         #[test]
         fn export_failed_sets_error_message() {
             let mut state = create_test_state();
-
-            let effects = reduce_query(
+            let action = csv_failed_action(
                 &mut state,
-                &Action::CsvExportFailed(DbOperationError::QueryFailed("psql error".to_string())),
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+                DbOperationError::QueryFailed("psql error".to_string()),
+            );
+
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(effects.is_empty());
             assert_eq!(
                 state.messages.last_error.as_deref(),
                 Some("Query failed: psql error. Review the database error details and SQL.")
             );
+        }
+
+        #[test]
+        fn stale_rows_counted_does_not_open_confirm_or_export() {
+            let mut state = create_test_state();
+            let old_request_id = begin_query_request(&mut state);
+            let _ = begin_query_request(&mut state);
+
+            let effects = reduce_query(
+                &mut state,
+                &Action::CsvExportRowsCounted {
+                    dsn: "postgres://localhost/test".to_string(),
+                    request_id: old_request_id,
+                    row_count: Some(200_000),
+                    export_query: "SELECT 1".to_string(),
+                    file_name: "test".to_string(),
+                },
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_ne!(state.input_mode(), InputMode::ConfirmDialog);
+            assert!(state.query.is_running());
         }
 
         #[test]

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -49,11 +49,11 @@ pub fn reduce(
 
             let stripped = export_query.trim_end().trim_end_matches(';').to_string();
             let count_query = format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count");
-            let request_id = state.query.begin_running(now);
+            let run_id = state.query.begin_running(now);
 
             DispatchResult::handled_with(vec![Effect::CountRowsForExport {
                 dsn,
-                request_id,
+                run_id,
                 count_query,
                 export_query,
                 file_name,
@@ -63,14 +63,12 @@ pub fn reduce(
 
         Action::CsvExportRowsCounted {
             dsn,
-            request_id,
+            run_id,
             row_count,
             export_query,
             file_name,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.query.is_current_request(*request_id)
-            {
+            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -91,7 +89,7 @@ pub fn reduce(
                     msg,
                     crate::model::shared::confirm_dialog::ConfirmIntent::CsvExport {
                         dsn: dsn.clone(),
-                        request_id: *request_id,
+                        run_id: *run_id,
                         export_query: export_query.clone(),
                         file_name: file_name.clone(),
                         row_count: *row_count,
@@ -102,7 +100,7 @@ pub fn reduce(
             } else {
                 DispatchResult::handled_with(vec![Effect::ExportCsv {
                     dsn: dsn.clone(),
-                    request_id: *request_id,
+                    run_id: *run_id,
                     query: export_query.clone(),
                     file_name: file_name.clone(),
                     row_count: *row_count,
@@ -113,20 +111,18 @@ pub fn reduce(
 
         Action::ExecuteCsvExport {
             dsn,
-            request_id,
+            run_id,
             export_query,
             file_name,
             row_count,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.query.is_current_request(*request_id)
-            {
+            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
             DispatchResult::handled_with(vec![Effect::ExportCsv {
                 dsn: dsn.clone(),
-                request_id: *request_id,
+                run_id: *run_id,
                 query: export_query.clone(),
                 file_name: file_name.clone(),
                 row_count: *row_count,
@@ -136,13 +132,11 @@ pub fn reduce(
 
         Action::CsvExportSucceeded {
             dsn,
-            request_id,
+            run_id,
             path,
             row_count,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.query.is_current_request(*request_id)
-            {
+            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -158,14 +152,8 @@ pub fn reduce(
             DispatchResult::handled_with(vec![Effect::OpenFolder { path: folder }])
         }
 
-        Action::CsvExportFailed {
-            dsn,
-            request_id,
-            error,
-        } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.query.is_current_request(*request_id)
-            {
+        Action::CsvExportFailed { dsn, run_id, error } => {
+            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -191,14 +179,14 @@ pub fn reduce(
             }
             if let Some(dsn) = state.session.dsn.clone() {
                 let next_page = state.query.pagination.current_page + 1;
-                let request_id = state.query.begin_running(now);
+                let run_id = state.query.begin_running(now);
                 state.result_interaction.reset_view();
                 DispatchResult::handled_with(vec![Effect::ExecutePreview {
                     dsn,
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
                     generation: state.session.selection_generation(),
-                    request_id,
+                    run_id,
                     limit: PREVIEW_PAGE_SIZE,
                     offset: next_page * PREVIEW_PAGE_SIZE,
                     target_page: next_page,
@@ -218,7 +206,7 @@ pub fn reduce(
             }
             if let Some(dsn) = state.session.dsn.clone() {
                 let prev_page = state.query.pagination.current_page - 1;
-                let request_id = state.query.begin_running(now);
+                let run_id = state.query.begin_running(now);
                 state.result_interaction.reset_view();
                 state.query.pagination.reached_end = false;
                 DispatchResult::handled_with(vec![Effect::ExecutePreview {
@@ -226,7 +214,7 @@ pub fn reduce(
                     schema: state.query.pagination.schema.clone(),
                     table: state.query.pagination.table.clone(),
                     generation: state.session.selection_generation(),
-                    request_id,
+                    run_id,
                     limit: PREVIEW_PAGE_SIZE,
                     offset: prev_page * PREVIEW_PAGE_SIZE,
                     target_page: prev_page,
@@ -252,7 +240,7 @@ mod tests {
     use crate::update::browse::query::reduce_query;
     use crate::update::browse::query::tests::*;
 
-    fn begin_query_request(state: &mut AppState) -> u64 {
+    fn begin_query_run(state: &mut AppState) -> u64 {
         state.query.begin_running(Instant::now())
     }
 
@@ -262,10 +250,10 @@ mod tests {
         export_query: &str,
         file_name: &str,
     ) -> Action {
-        let request_id = begin_query_request(state);
+        let run_id = begin_query_run(state);
         Action::CsvExportRowsCounted {
             dsn: "postgres://localhost/test".to_string(),
-            request_id,
+            run_id,
             row_count,
             export_query: export_query.to_string(),
             file_name: file_name.to_string(),
@@ -273,20 +261,20 @@ mod tests {
     }
 
     fn csv_succeeded_action(state: &mut AppState, path: &str, row_count: Option<usize>) -> Action {
-        let request_id = begin_query_request(state);
+        let run_id = begin_query_run(state);
         Action::CsvExportSucceeded {
             dsn: "postgres://localhost/test".to_string(),
-            request_id,
+            run_id,
             path: path.to_string(),
             row_count,
         }
     }
 
     fn csv_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
-        let request_id = begin_query_request(state);
+        let run_id = begin_query_run(state);
         Action::CsvExportFailed {
             dsn: "postgres://localhost/test".to_string(),
-            request_id,
+            run_id,
             error,
         }
     }
@@ -708,14 +696,14 @@ mod tests {
         #[test]
         fn stale_rows_counted_does_not_open_confirm_or_export() {
             let mut state = create_test_state();
-            let old_request_id = begin_query_request(&mut state);
-            let _ = begin_query_request(&mut state);
+            let old_run_id = begin_query_run(&mut state);
+            let _ = begin_query_run(&mut state);
 
             let effects = reduce_query(
                 &mut state,
                 &Action::CsvExportRowsCounted {
                     dsn: "postgres://localhost/test".to_string(),
-                    request_id: old_request_id,
+                    run_id: old_run_id,
                     row_count: Some(200_000),
                     export_query: "SELECT 1".to_string(),
                     file_name: "test".to_string(),

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -237,10 +237,10 @@ pub fn reduce(
                 return DispatchResult::handled();
             }
             if let Some(dsn) = &state.session.dsn {
-                let request_id = state.query.begin_running(now);
+                let run_id = state.query.begin_running(now);
                 DispatchResult::handled_with(vec![Effect::ExecuteWrite {
                     dsn: dsn.clone(),
-                    request_id,
+                    run_id,
                     query: query.clone(),
                     read_only: state.session.read_only,
                 }])
@@ -254,12 +254,10 @@ pub fn reduce(
 
         Action::ExecuteWriteSucceeded {
             dsn,
-            request_id,
+            run_id,
             affected_rows,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.query.is_current_request(*request_id)
-            {
+            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -288,13 +286,13 @@ pub fn reduce(
 
                     if let Some(dsn) = &state.session.dsn {
                         let page = state.query.pagination.current_page;
-                        let request_id = state.query.begin_running(now);
+                        let run_id = state.query.begin_running(now);
                         DispatchResult::handled_with(vec![Effect::ExecutePreview {
                             dsn: dsn.clone(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation: state.session.selection_generation(),
-                            request_id,
+                            run_id,
                             limit: PREVIEW_PAGE_SIZE,
                             offset: page * PREVIEW_PAGE_SIZE,
                             target_page: page,
@@ -346,14 +344,14 @@ pub fn reduce(
                     ));
 
                     if let Some(dsn) = &state.session.dsn {
-                        let request_id = state.query.begin_running(now);
+                        let run_id = state.query.begin_running(now);
                         state.query.pagination.reached_end = false;
                         DispatchResult::handled_with(vec![Effect::ExecutePreview {
                             dsn: dsn.clone(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation: state.session.selection_generation(),
-                            request_id,
+                            run_id,
                             limit: PREVIEW_PAGE_SIZE,
                             offset: target_page * PREVIEW_PAGE_SIZE,
                             target_page,
@@ -366,14 +364,8 @@ pub fn reduce(
             }
         }
 
-        Action::ExecuteWriteFailed {
-            dsn,
-            request_id,
-            error,
-        } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.query.is_current_request(*request_id)
-            {
+        Action::ExecuteWriteFailed { dsn, run_id, error } => {
+            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -412,24 +404,24 @@ mod tests {
     use crate::update::browse::query::reduce_query;
     use crate::update::browse::query::tests::*;
 
-    fn begin_query_request(state: &mut AppState) -> u64 {
+    fn begin_query_run(state: &mut AppState) -> u64 {
         state.query.begin_running(Instant::now())
     }
 
     fn write_succeeded_action(state: &mut AppState, affected_rows: usize) -> Action {
-        let request_id = begin_query_request(state);
+        let run_id = begin_query_run(state);
         Action::ExecuteWriteSucceeded {
             dsn: "postgres://localhost/test".to_string(),
-            request_id,
+            run_id,
             affected_rows,
         }
     }
 
     fn write_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
-        let request_id = begin_query_request(state);
+        let run_id = begin_query_run(state);
         Action::ExecuteWriteFailed {
             dsn: "postgres://localhost/test".to_string(),
-            request_id,
+            run_id,
             error,
         }
     }
@@ -440,10 +432,10 @@ mod tests {
         generation: u64,
         target_page: Option<usize>,
     ) -> Action {
-        let request_id = begin_query_request(state);
+        let run_id = begin_query_run(state);
         Action::QueryCompleted {
             dsn: "postgres://localhost/test".to_string(),
-            request_id,
+            run_id,
             result,
             generation,
             target_page,
@@ -742,14 +734,14 @@ mod tests {
         #[test]
         fn stale_write_success_does_not_refresh_or_set_message() {
             let mut state = editable_state();
-            let old_request_id = begin_query_request(&mut state);
-            let _ = begin_query_request(&mut state);
+            let old_run_id = begin_query_run(&mut state);
+            let _ = begin_query_run(&mut state);
 
             let effects = reduce_query(
                 &mut state,
                 &Action::ExecuteWriteSucceeded {
                     dsn: "postgres://localhost/test".to_string(),
-                    request_id: old_request_id,
+                    run_id: old_run_id,
                     affected_rows: 1,
                 },
                 Instant::now(),

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -237,9 +237,10 @@ pub fn reduce(
                 return DispatchResult::handled();
             }
             if let Some(dsn) = &state.session.dsn {
-                state.query.begin_running(now);
+                let request_id = state.query.begin_running(now);
                 DispatchResult::handled_with(vec![Effect::ExecuteWrite {
                     dsn: dsn.clone(),
+                    request_id,
                     query: query.clone(),
                     read_only: state.session.read_only,
                 }])
@@ -251,7 +252,17 @@ pub fn reduce(
             }
         }
 
-        Action::ExecuteWriteSucceeded { affected_rows } => {
+        Action::ExecuteWriteSucceeded {
+            dsn,
+            request_id,
+            affected_rows,
+        } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.query.is_current_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
             state.query.mark_idle();
             let operation = state
                 .result_interaction
@@ -277,12 +288,13 @@ pub fn reduce(
 
                     if let Some(dsn) = &state.session.dsn {
                         let page = state.query.pagination.current_page;
-                        state.query.begin_running(now);
+                        let request_id = state.query.begin_running(now);
                         DispatchResult::handled_with(vec![Effect::ExecutePreview {
                             dsn: dsn.clone(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation: state.session.selection_generation(),
+                            request_id,
                             limit: PREVIEW_PAGE_SIZE,
                             offset: page * PREVIEW_PAGE_SIZE,
                             target_page: page,
@@ -334,13 +346,14 @@ pub fn reduce(
                     ));
 
                     if let Some(dsn) = &state.session.dsn {
-                        state.query.begin_running(now);
+                        let request_id = state.query.begin_running(now);
                         state.query.pagination.reached_end = false;
                         DispatchResult::handled_with(vec![Effect::ExecutePreview {
                             dsn: dsn.clone(),
                             schema: state.query.pagination.schema.clone(),
                             table: state.query.pagination.table.clone(),
                             generation: state.session.selection_generation(),
+                            request_id,
                             limit: PREVIEW_PAGE_SIZE,
                             offset: target_page * PREVIEW_PAGE_SIZE,
                             target_page,
@@ -353,7 +366,17 @@ pub fn reduce(
             }
         }
 
-        Action::ExecuteWriteFailed(error) => {
+        Action::ExecuteWriteFailed {
+            dsn,
+            request_id,
+            error,
+        } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.query.is_current_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
+
             state.query.mark_idle();
             let operation = state
                 .result_interaction
@@ -376,14 +399,56 @@ pub fn reduce(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    use crate::domain::QueryResult;
     use crate::model::browse::query_execution::{
         DeleteRefreshTarget, PostDeleteRowSelection, QueryStatus,
     };
     use crate::policy::write::write_guardrails::{
         GuardrailDecision, RiskLevel, TargetSummary, WriteOperation, WritePreview,
     };
+    use crate::ports::outbound::DbOperationError;
     use crate::update::browse::query::reduce_query;
     use crate::update::browse::query::tests::*;
+
+    fn begin_query_request(state: &mut AppState) -> u64 {
+        state.query.begin_running(Instant::now())
+    }
+
+    fn write_succeeded_action(state: &mut AppState, affected_rows: usize) -> Action {
+        let request_id = begin_query_request(state);
+        Action::ExecuteWriteSucceeded {
+            dsn: "postgres://localhost/test".to_string(),
+            request_id,
+            affected_rows,
+        }
+    }
+
+    fn write_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
+        let request_id = begin_query_request(state);
+        Action::ExecuteWriteFailed {
+            dsn: "postgres://localhost/test".to_string(),
+            request_id,
+            error,
+        }
+    }
+
+    fn query_completed_action(
+        state: &mut AppState,
+        result: Arc<QueryResult>,
+        generation: u64,
+        target_page: Option<usize>,
+    ) -> Action {
+        let request_id = begin_query_request(state);
+        Action::QueryCompleted {
+            dsn: "postgres://localhost/test".to_string(),
+            request_id,
+            result,
+            generation,
+            target_page,
+        }
+    }
 
     mod write_flow {
         use super::*;
@@ -434,7 +499,7 @@ mod tests {
         #[test]
         fn write_requires_idle_query_status() {
             let mut state = editable_state();
-            state.query.begin_running(Instant::now());
+            let _ = state.query.begin_running(Instant::now());
 
             let effects = reduce_query(
                 &mut state,
@@ -636,14 +701,10 @@ mod tests {
         fn execute_write_success_refreshes_preview_page() {
             let mut state = editable_state();
             state.query.pagination.current_page = 2;
+            let action = write_succeeded_action(&mut state, 1);
 
-            let effects = reduce_query(
-                &mut state,
-                &Action::ExecuteWriteSucceeded { affected_rows: 1 },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert_eq!(state.query.status(), QueryStatus::Running);
@@ -665,14 +726,10 @@ mod tests {
         #[test]
         fn execute_write_with_non_one_row_sets_error() {
             let mut state = editable_state();
+            let action = write_succeeded_action(&mut state, 0);
 
-            let effects = reduce_query(
-                &mut state,
-                &Action::ExecuteWriteSucceeded { affected_rows: 0 },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::CellEdit);
@@ -680,6 +737,29 @@ mod tests {
                 state.messages.last_error.as_deref(),
                 Some("UPDATE expected 1 row, but affected 0 rows")
             );
+        }
+
+        #[test]
+        fn stale_write_success_does_not_refresh_or_set_message() {
+            let mut state = editable_state();
+            let old_request_id = begin_query_request(&mut state);
+            let _ = begin_query_request(&mut state);
+
+            let effects = reduce_query(
+                &mut state,
+                &Action::ExecuteWriteSucceeded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    request_id: old_request_id,
+                    affected_rows: 1,
+                },
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert!(state.messages.last_success.is_none());
+            assert!(state.query.is_running());
         }
     }
 
@@ -766,14 +846,10 @@ mod tests {
             state.query.pagination.table = "users".to_string();
             state.query.set_delete_refresh_target(1, Some(499), 1);
             state.result_interaction.set_write_preview(delete_preview());
+            let action = write_succeeded_action(&mut state, 1);
 
-            let effects = reduce_query(
-                &mut state,
-                &Action::ExecuteWriteSucceeded { affected_rows: 1 },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert_eq!(
@@ -804,14 +880,10 @@ mod tests {
             state.query.pagination.schema = "public".to_string();
             state.query.pagination.table = "users".to_string();
             state.result_interaction.set_write_preview(delete_preview());
+            let action = write_succeeded_action(&mut state, 0);
 
-            let effects = reduce_query(
-                &mut state,
-                &Action::ExecuteWriteSucceeded { affected_rows: 0 },
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert_eq!(
@@ -825,14 +897,13 @@ mod tests {
         fn execute_write_failed_for_delete_returns_to_normal_mode() {
             let mut state = create_test_state();
             state.result_interaction.set_write_preview(delete_preview());
-
-            let effects = reduce_query(
+            let action = write_failed_action(
                 &mut state,
-                &Action::ExecuteWriteFailed(DbOperationError::QueryFailed("boom".to_string())),
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+                DbOperationError::QueryFailed("boom".to_string()),
+            );
+
+            let effects =
+                reduce_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::Normal);
@@ -849,17 +920,9 @@ mod tests {
             state
                 .query
                 .set_post_delete_selection(PostDeleteRowSelection::Select(1000));
+            let action = query_completed_action(&mut state, preview_result(3), 1, Some(0));
 
-            reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result: preview_result(3),
-                    generation: 1,
-                    target_page: Some(0),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             assert_eq!(state.result_interaction.selection().row(), Some(2));
             assert_eq!(
@@ -876,17 +939,9 @@ mod tests {
             state
                 .query
                 .set_post_delete_selection(PostDeleteRowSelection::Clear);
+            let action = query_completed_action(&mut state, preview_result(2), 1, Some(0));
 
-            reduce_query(
-                &mut state,
-                &Action::QueryCompleted {
-                    result: preview_result(2),
-                    generation: 1,
-                    target_page: Some(0),
-                },
-                Instant::now(),
-                &AppServices::stub(),
-            );
+            reduce_query(&mut state, &action, Instant::now(), &AppServices::stub());
 
             assert_eq!(state.result_interaction.selection().row(), None);
             assert_eq!(

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -90,10 +90,10 @@ pub fn reduce(state: &mut AppState, action: &Action, now: Instant) -> DispatchRe
             state.flash_timers.set(FlashId::JsonbDetail, now);
             DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                 content: json,
-                on_success: Some(Action::CellCopied),
-                on_failure: Some(Action::CopyFailed(ClipboardError::Unavailable(
+                on_success: Some(Box::new(Action::CellCopied)),
+                on_failure: Some(Box::new(Action::CopyFailed(ClipboardError::Unavailable(
                     "Clipboard unavailable".into(),
-                ))),
+                )))),
             }])
         }
 

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -38,8 +38,8 @@ pub fn reduce(
                     });
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: value,
-                        on_success: Some(Action::CellCopied),
-                        on_failure: Some(clipboard_unavailable()),
+                        on_success: Some(Box::new(Action::CellCopied)),
+                        on_failure: Some(Box::new(clipboard_unavailable())),
                     }])
                 } else {
                     state
@@ -63,8 +63,8 @@ pub fn reduce(
                 state.flash_timers.set(FlashId::Ddl, now);
                 return DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                     content: ddl,
-                    on_success: Some(Action::CellCopied),
-                    on_failure: Some(clipboard_unavailable()),
+                    on_success: Some(Box::new(Action::CellCopied)),
+                    on_failure: Some(Box::new(clipboard_unavailable())),
                 }]);
             }
             DispatchResult::handled()
@@ -93,8 +93,8 @@ pub fn reduce(
                     });
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: tsv,
-                        on_success: Some(Action::CellCopied),
-                        on_failure: Some(clipboard_unavailable()),
+                        on_success: Some(Box::new(Action::CellCopied)),
+                        on_failure: Some(Box::new(clipboard_unavailable())),
                     }])
                 } else {
                     state

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -75,10 +75,10 @@ pub(super) fn reduce_connection_error(
         Action::RetryServiceConnection => {
             if let Some(dsn) = state.session.dsn.clone() {
                 state.connection_error.clear();
-                let request_id = state.session.begin_connecting(&dsn);
+                let run_id = state.session.begin_connecting(&dsn);
                 state.session.read_only = false;
                 state.modal.set_mode(InputMode::Normal);
-                DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, request_id }])
+                DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
             } else {
                 DispatchResult::handled()
             }

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -52,7 +52,7 @@ pub(super) fn reduce_connection_error(
             if let Some(content) = state.connection_error.masked_details() {
                 DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                     content: content.to_string(),
-                    on_success: Some(Action::ConnectionErrorCopied),
+                    on_success: Some(Box::new(Action::ConnectionErrorCopied)),
                     on_failure: None,
                 }])
             } else {
@@ -75,10 +75,10 @@ pub(super) fn reduce_connection_error(
         Action::RetryServiceConnection => {
             if let Some(dsn) = state.session.dsn.clone() {
                 state.connection_error.clear();
-                state.session.begin_connecting(&dsn);
+                let request_id = state.session.begin_connecting(&dsn);
                 state.session.read_only = false;
                 state.modal.set_mode(InputMode::Normal);
-                DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn }])
+                DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, request_id }])
             } else {
                 DispatchResult::handled()
             }

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -21,8 +21,8 @@ pub(super) fn reduce_connection_lifecycle(
                 && state.modal.active_mode() == InputMode::Normal
             {
                 if let Some(dsn) = state.session.dsn.clone() {
-                    state.session.begin_connecting(&dsn);
-                    DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn }])
+                    let request_id = state.session.begin_connecting(&dsn);
+                    DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, request_id }])
                 } else {
                     DispatchResult::handled()
                 }
@@ -53,10 +53,13 @@ pub(super) fn reduce_connection_lifecycle(
                 state.session.active_connection_id = Some(id.clone());
                 state.session.active_connection_name = Some(name.clone());
                 state.session.read_only = false;
-                state.session.begin_connecting(dsn);
+                let request_id = state.session.begin_connecting(dsn);
                 DispatchResult::handled_with(vec![
                     Effect::ClearCompletionEngineCache,
-                    Effect::FetchMetadata { dsn: dsn.clone() },
+                    Effect::FetchMetadata {
+                        dsn: dsn.clone(),
+                        request_id,
+                    },
                 ])
             }
         }

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -21,8 +21,8 @@ pub(super) fn reduce_connection_lifecycle(
                 && state.modal.active_mode() == InputMode::Normal
             {
                 if let Some(dsn) = state.session.dsn.clone() {
-                    let request_id = state.session.begin_connecting(&dsn);
-                    DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, request_id }])
+                    let run_id = state.session.begin_connecting(&dsn);
+                    DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
                 } else {
                     DispatchResult::handled()
                 }
@@ -53,12 +53,12 @@ pub(super) fn reduce_connection_lifecycle(
                 state.session.active_connection_id = Some(id.clone());
                 state.session.active_connection_name = Some(name.clone());
                 state.session.read_only = false;
-                let request_id = state.session.begin_connecting(dsn);
+                let run_id = state.session.begin_connecting(dsn);
                 DispatchResult::handled_with(vec![
                     Effect::ClearCompletionEngineCache,
                     Effect::FetchMetadata {
                         dsn: dsn.clone(),
-                        request_id,
+                        run_id,
                     },
                 ])
             }

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -218,10 +218,10 @@ pub(super) fn reduce_connection_setup(
             state.session.active_connection_id = Some(id.clone());
             state.session.active_connection_name = Some(name.clone());
             state.session.read_only = false;
-            let request_id = state.session.begin_connecting(dsn);
+            let run_id = state.session.begin_connecting(dsn);
             DispatchResult::handled_with(vec![Effect::FetchMetadata {
                 dsn: dsn.clone(),
-                request_id,
+                run_id,
             }])
         }
         Action::ConnectionSaveFailed(e) => {

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -218,8 +218,11 @@ pub(super) fn reduce_connection_setup(
             state.session.active_connection_id = Some(id.clone());
             state.session.active_connection_name = Some(name.clone());
             state.session.read_only = false;
-            state.session.begin_connecting(dsn);
-            DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn: dsn.clone() }])
+            let request_id = state.session.begin_connecting(dsn);
+            DispatchResult::handled_with(vec![Effect::FetchMetadata {
+                dsn: dsn.clone(),
+                request_id,
+            }])
         }
         Action::ConnectionSaveFailed(e) => {
             if !state.session.connection_state().is_connected() {

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -61,7 +61,7 @@ mod tests {
                 .expect("reducer should handle action");
 
             assert_eq!(state.er_preparation.status, ErStatus::Waiting);
-            assert_eq!(state.er_preparation.run_id, 1);
+            assert_eq!(state.er_preparation.run_id(), 1);
             assert_eq!(effects.len(), 1);
             assert!(matches!(
                 &effects[0],
@@ -73,13 +73,13 @@ mod tests {
         fn increments_run_id_on_each_call() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(5)));
-            state.er_preparation.run_id = 3;
+            state.er_preparation.set_run_id_for_test(3);
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
                 .into_effects()
                 .expect("reducer should handle action");
 
-            assert_eq!(state.er_preparation.run_id, 4);
+            assert_eq!(state.er_preparation.run_id(), 4);
             assert!(matches!(
                 &effects[0],
                 Effect::SmartErRefresh { run_id: 4, .. }
@@ -216,7 +216,7 @@ mod tests {
         #[test]
         fn no_changes_dispatches_generate_from_cache() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
+            state.er_preparation.set_run_id_for_test(1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -245,7 +245,7 @@ mod tests {
         #[test]
         fn stale_tables_trigger_evict_and_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
+            state.er_preparation.set_run_id_for_test(1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -279,7 +279,7 @@ mod tests {
         #[test]
         fn added_tables_trigger_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
+            state.er_preparation.set_run_id_for_test(1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -308,7 +308,7 @@ mod tests {
         #[test]
         fn removed_tables_trigger_evict() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
+            state.er_preparation.set_run_id_for_test(1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -337,7 +337,7 @@ mod tests {
         #[test]
         fn missing_in_cache_triggers_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
+            state.er_preparation.set_run_id_for_test(1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -366,7 +366,7 @@ mod tests {
         #[test]
         fn mismatched_run_id_returns_empty_for_completed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 5;
+            state.er_preparation.set_run_id_for_test(5);
             state.er_preparation.status = ErStatus::Waiting;
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -390,7 +390,7 @@ mod tests {
         #[test]
         fn updates_metadata_and_signatures() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
+            state.er_preparation.set_run_id_for_test(1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -444,7 +444,7 @@ mod tests {
         #[test]
         fn falls_back_to_full_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
+            state.er_preparation.set_run_id_for_test(1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(5)));
             state
@@ -488,7 +488,7 @@ mod tests {
         #[test]
         fn falls_back_to_scoped_prefetch_when_targets_set() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
+            state.er_preparation.set_run_id_for_test(1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(10)));
             state.er_preparation.target_tables = vec!["public.t0".to_string()];
@@ -528,7 +528,7 @@ mod tests {
         #[test]
         fn mismatched_run_id_returns_empty_for_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 5;
+            state.er_preparation.set_run_id_for_test(5);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(5)));
 
@@ -550,7 +550,7 @@ mod tests {
         #[test]
         fn no_metadata_sets_idle_and_error() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
+            state.er_preparation.set_run_id_for_test(1);
             state.er_preparation.status = ErStatus::Waiting;
 
             let effects = reduce_er(
@@ -573,7 +573,7 @@ mod tests {
         #[test]
         fn new_metadata_applied_before_fallback() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.run_id = 1;
+            state.er_preparation.set_run_id_for_test(1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(3)));
 

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -35,6 +35,13 @@ mod tests {
         state
     }
 
+    fn set_active_run_id(state: &mut AppState, run_id: u64) {
+        for _ in 0..run_id {
+            state.er_preparation.begin_smart_refresh();
+        }
+        state.er_preparation.mark_idle();
+    }
+
     mod er_open_diagram {
         use super::*;
         use crate::domain::{DatabaseMetadata, TableSummary};
@@ -73,7 +80,7 @@ mod tests {
         fn increments_run_id_on_each_call() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(5)));
-            state.er_preparation.set_run_id_for_test(3);
+            set_active_run_id(&mut state, 3);
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
                 .into_effects()
@@ -216,7 +223,7 @@ mod tests {
         #[test]
         fn no_changes_dispatches_generate_from_cache() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(1);
+            set_active_run_id(&mut state, 1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -245,7 +252,7 @@ mod tests {
         #[test]
         fn stale_tables_trigger_evict_and_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(1);
+            set_active_run_id(&mut state, 1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -279,7 +286,7 @@ mod tests {
         #[test]
         fn added_tables_trigger_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(1);
+            set_active_run_id(&mut state, 1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -308,7 +315,7 @@ mod tests {
         #[test]
         fn removed_tables_trigger_evict() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(1);
+            set_active_run_id(&mut state, 1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -337,7 +344,7 @@ mod tests {
         #[test]
         fn missing_in_cache_triggers_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(1);
+            set_active_run_id(&mut state, 1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -366,7 +373,7 @@ mod tests {
         #[test]
         fn mismatched_run_id_returns_empty_for_completed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(5);
+            set_active_run_id(&mut state, 5);
             state.er_preparation.status = ErStatus::Waiting;
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -390,7 +397,7 @@ mod tests {
         #[test]
         fn updates_metadata_and_signatures() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(1);
+            set_active_run_id(&mut state, 1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(0)));
 
@@ -444,7 +451,7 @@ mod tests {
         #[test]
         fn falls_back_to_full_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(1);
+            set_active_run_id(&mut state, 1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(5)));
             state
@@ -488,7 +495,7 @@ mod tests {
         #[test]
         fn falls_back_to_scoped_prefetch_when_targets_set() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(1);
+            set_active_run_id(&mut state, 1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(10)));
             state.er_preparation.target_tables = vec!["public.t0".to_string()];
@@ -528,7 +535,7 @@ mod tests {
         #[test]
         fn mismatched_run_id_returns_empty_for_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(5);
+            set_active_run_id(&mut state, 5);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(5)));
 
@@ -550,7 +557,7 @@ mod tests {
         #[test]
         fn mismatched_dsn_returns_empty_for_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(1);
+            set_active_run_id(&mut state, 1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(5)));
 
@@ -575,7 +582,7 @@ mod tests {
         #[test]
         fn no_metadata_sets_idle_and_error() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(1);
+            set_active_run_id(&mut state, 1);
             state.er_preparation.status = ErStatus::Waiting;
 
             let effects = reduce_er(
@@ -598,7 +605,7 @@ mod tests {
         #[test]
         fn new_metadata_applied_before_fallback() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.set_run_id_for_test(1);
+            set_active_run_id(&mut state, 1);
             state.er_preparation.status = ErStatus::Waiting;
             state.session.set_metadata(Some(make_metadata(3)));
 

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -548,6 +548,31 @@ mod tests {
         }
 
         #[test]
+        fn mismatched_dsn_returns_empty_for_failed() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            state.er_preparation.set_run_id_for_test(1);
+            state.er_preparation.status = ErStatus::Waiting;
+            state.session.set_metadata(Some(make_metadata(5)));
+
+            let effects = reduce_er(
+                &mut state,
+                &Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn: "postgres://other/test".to_string(),
+                    run_id: 1,
+                    error: DbOperationError::Timeout("timed out".to_string()),
+                    new_metadata: None,
+                }),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(state.session.metadata().unwrap().table_summaries.len(), 5);
+            assert!(state.messages.last_error.is_none());
+        }
+
+        #[test]
         fn no_metadata_sets_idle_and_error() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.er_preparation.set_run_id_for_test(1);

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -89,7 +89,7 @@ mod tests {
         #[test]
         fn prefetch_started_true_still_resets_and_emits_smart_refresh() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_prefetch();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
@@ -142,7 +142,7 @@ mod tests {
         #[test]
         fn no_metadata_returns_error() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_prefetch();
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
                 .into_effects()
@@ -221,6 +221,7 @@ mod tests {
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
+                dsn: "postgres://localhost/test".to_string(),
                 run_id: 1,
                 new_metadata: make_metadata(2),
                 stale_tables: vec![],
@@ -249,6 +250,7 @@ mod tests {
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
+                dsn: "postgres://localhost/test".to_string(),
                 run_id: 1,
                 new_metadata: make_metadata(2),
                 stale_tables: vec!["public.users".to_string()],
@@ -282,6 +284,7 @@ mod tests {
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
+                dsn: "postgres://localhost/test".to_string(),
                 run_id: 1,
                 new_metadata: make_metadata(3),
                 stale_tables: vec![],
@@ -310,6 +313,7 @@ mod tests {
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
+                dsn: "postgres://localhost/test".to_string(),
                 run_id: 1,
                 new_metadata: make_metadata(1),
                 stale_tables: vec![],
@@ -338,6 +342,7 @@ mod tests {
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
+                dsn: "postgres://localhost/test".to_string(),
                 run_id: 1,
                 new_metadata: make_metadata(2),
                 stale_tables: vec![],
@@ -365,6 +370,7 @@ mod tests {
             state.er_preparation.status = ErStatus::Waiting;
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
+                dsn: "postgres://localhost/test".to_string(),
                 run_id: 3,
                 new_metadata: make_metadata(0),
                 stale_tables: vec![],
@@ -392,6 +398,7 @@ mod tests {
                 std::iter::once(("public.users".to_string(), "abc123".to_string())).collect();
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
+                dsn: "postgres://localhost/test".to_string(),
                 run_id: 1,
                 new_metadata: make_metadata(5),
                 stale_tables: vec![],
@@ -448,6 +455,7 @@ mod tests {
             let effects = reduce_er(
                 &mut state,
                 &Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn: "postgres://localhost/test".to_string(),
                     run_id: 1,
                     error: DbOperationError::Timeout("timed out".to_string()),
                     new_metadata: None,
@@ -488,6 +496,7 @@ mod tests {
             let effects = reduce_er(
                 &mut state,
                 &Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn: "postgres://localhost/test".to_string(),
                     run_id: 1,
                     error: DbOperationError::Timeout("timed out".to_string()),
                     new_metadata: None,
@@ -526,6 +535,7 @@ mod tests {
             let effects = reduce_er(
                 &mut state,
                 &Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn: "postgres://localhost/test".to_string(),
                     run_id: 3,
                     error: DbOperationError::Timeout("timed out".to_string()),
                     new_metadata: None,
@@ -546,6 +556,7 @@ mod tests {
             let effects = reduce_er(
                 &mut state,
                 &Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn: "postgres://localhost/test".to_string(),
                     run_id: 1,
                     error: DbOperationError::Timeout("timed out".to_string()),
                     new_metadata: None,
@@ -569,6 +580,7 @@ mod tests {
             let effects = reduce_er(
                 &mut state,
                 &Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn: "postgres://localhost/test".to_string(),
                     run_id: 1,
                     error: DbOperationError::QueryFailed("sig fetch failed".to_string()),
                     new_metadata: Some(make_metadata(20)),

--- a/src/app/update/er/smart_refresh_completed.rs
+++ b/src/app/update/er/smart_refresh_completed.rs
@@ -13,6 +13,7 @@ pub(super) fn reduce_smart_refresh_completed(
 ) -> DispatchResult {
     match action {
         Action::SmartErRefreshCompleted(SmartErRefreshResult {
+            dsn,
             run_id,
             new_metadata,
             stale_tables,
@@ -21,7 +22,7 @@ pub(super) fn reduce_smart_refresh_completed(
             missing_in_cache,
             new_signatures,
         }) => {
-            if *run_id != state.er_preparation.run_id {
+            if state.session.dsn.as_ref() != Some(dsn) || *run_id != state.er_preparation.run_id {
                 return DispatchResult::handled();
             }
 

--- a/src/app/update/er/smart_refresh_completed.rs
+++ b/src/app/update/er/smart_refresh_completed.rs
@@ -22,7 +22,9 @@ pub(super) fn reduce_smart_refresh_completed(
             missing_in_cache,
             new_signatures,
         }) => {
-            if state.session.dsn.as_ref() != Some(dsn) || *run_id != state.er_preparation.run_id {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.er_preparation.is_current_run(*run_id)
+            {
                 return DispatchResult::handled();
             }
 

--- a/src/app/update/er/smart_refresh_failed.rs
+++ b/src/app/update/er/smart_refresh_failed.rs
@@ -13,11 +13,12 @@ pub(super) fn reduce_smart_refresh_failed(
 ) -> DispatchResult {
     match action {
         Action::SmartErRefreshFailed(SmartErRefreshError {
+            dsn,
             run_id,
             error,
             new_metadata,
         }) => {
-            if *run_id != state.er_preparation.run_id {
+            if state.session.dsn.as_ref() != Some(dsn) || *run_id != state.er_preparation.run_id {
                 return DispatchResult::handled();
             }
 

--- a/src/app/update/er/smart_refresh_failed.rs
+++ b/src/app/update/er/smart_refresh_failed.rs
@@ -18,7 +18,9 @@ pub(super) fn reduce_smart_refresh_failed(
             error,
             new_metadata,
         }) => {
-            if state.session.dsn.as_ref() != Some(dsn) || *run_id != state.er_preparation.run_id {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.er_preparation.is_current_run(*run_id)
+            {
                 return DispatchResult::handled();
             }
 

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -72,10 +72,10 @@ pub(super) fn reduce_analyze(
                         mark_explain_unavailable(state, services);
                         return DispatchResult::handled();
                     };
-                    let request_id = begin_explain_running(state, now);
+                    let run_id = begin_explain_running(state, now);
                     return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                         dsn,
-                        request_id,
+                        run_id,
                         query: explain_query,
                         source_query: content,
                         is_analyze: true,
@@ -110,10 +110,10 @@ pub(super) fn reduce_analyze(
                     mark_explain_unavailable(state, services);
                     return DispatchResult::handled();
                 };
-                let request_id = begin_explain_running(state, now);
+                let run_id = begin_explain_running(state, now);
                 return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                     dsn,
-                    request_id,
+                    run_id,
                     query: explain_query,
                     source_query: query,
                     is_analyze: true,

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -72,10 +72,12 @@ pub(super) fn reduce_analyze(
                         mark_explain_unavailable(state, services);
                         return DispatchResult::handled();
                     };
-                    begin_explain_running(state, now);
+                    let request_id = begin_explain_running(state, now);
                     return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                         dsn,
+                        request_id,
                         query: explain_query,
+                        source_query: content,
                         is_analyze: true,
                         read_only: state.session.read_only,
                     }]);
@@ -108,10 +110,12 @@ pub(super) fn reduce_analyze(
                     mark_explain_unavailable(state, services);
                     return DispatchResult::handled();
                 };
-                begin_explain_running(state, now);
+                let request_id = begin_explain_running(state, now);
                 return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                     dsn,
+                    request_id,
                     query: explain_query,
+                    source_query: query,
                     is_analyze: true,
                     read_only: state.session.read_only,
                 }]);

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -24,11 +24,11 @@ pub(super) fn show_explain_error_on_plan(state: &mut AppState, message: impl Int
     state.sql_modal.set_active_tab(SqlModalTab::Plan);
 }
 
-pub(super) fn begin_explain_running(state: &mut AppState, now: Instant) {
+pub(super) fn begin_explain_running(state: &mut AppState, now: Instant) -> u64 {
     state.sql_modal.begin_adhoc_running();
     state.sql_modal.set_active_tab(SqlModalTab::Plan);
     state.explain.reset();
-    state.query.begin_running(now);
+    state.query.begin_running(now)
 }
 
 pub(super) fn finish_explain_success(

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -568,7 +568,7 @@ mod tests {
                 &mut state,
                 &Action::ExplainCompleted {
                     dsn: "dsn://test".to_string(),
-                    request_id: 1,
+                    run_id: 1,
                     query: "SELECT 1".to_string(),
                     plan_text: "Seq Scan".to_string(),
                     is_analyze: false,
@@ -599,7 +599,7 @@ mod tests {
                 &mut state,
                 &Action::ExplainFailed {
                     dsn: "dsn://test".to_string(),
-                    request_id: 1,
+                    run_id: 1,
                     error: DbOperationError::QueryFailed("syntax error".to_string()),
                 },
                 Instant::now(),
@@ -631,7 +631,7 @@ mod tests {
                 &mut state,
                 &Action::ExplainCompleted {
                     dsn: "dsn://test".to_string(),
-                    request_id: 1,
+                    run_id: 1,
                     query: "SELECT 1".to_string(),
                     plan_text: "Seq Scan  (cost=0.00..100.00 rows=10 width=32)".to_string(),
                     is_analyze: false,
@@ -649,7 +649,7 @@ mod tests {
                 &mut state,
                 &Action::ExplainCompleted {
                     dsn: "dsn://test".to_string(),
-                    request_id: 2,
+                    run_id: 2,
                     query: "SELECT 2".to_string(),
                     plan_text: "Index Scan  (cost=0.00..5.00 rows=1 width=32)".to_string(),
                     is_analyze: false,

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -560,11 +560,16 @@ mod tests {
         #[test]
         fn sets_plan_and_switches_to_plan_tab() {
             let mut state = sql_modal_state();
+            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
+                    dsn: "dsn://test".to_string(),
+                    request_id: 1,
+                    query: "SELECT 1".to_string(),
                     plan_text: "Seq Scan".to_string(),
                     is_analyze: false,
                     execution_time_ms: 42,
@@ -586,11 +591,17 @@ mod tests {
         #[test]
         fn sets_error_and_switches_to_plan_tab() {
             let mut state = sql_modal_state();
+            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
             reduce_explain(
                 &mut state,
-                &Action::ExplainFailed(DbOperationError::QueryFailed("syntax error".to_string())),
+                &Action::ExplainFailed {
+                    dsn: "dsn://test".to_string(),
+                    request_id: 1,
+                    error: DbOperationError::QueryFailed("syntax error".to_string()),
+                },
                 Instant::now(),
             );
 
@@ -619,6 +630,9 @@ mod tests {
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
+                    dsn: "dsn://test".to_string(),
+                    request_id: 1,
+                    query: "SELECT 1".to_string(),
                     plan_text: "Seq Scan  (cost=0.00..100.00 rows=10 width=32)".to_string(),
                     is_analyze: false,
                     execution_time_ms: 42,
@@ -634,6 +648,9 @@ mod tests {
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
+                    dsn: "dsn://test".to_string(),
+                    request_id: 2,
+                    query: "SELECT 2".to_string(),
                     plan_text: "Index Scan  (cost=0.00..5.00 rows=1 width=32)".to_string(),
                     is_analyze: false,
                     execution_time_ms: 5,

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -582,6 +582,37 @@ mod tests {
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
             assert!(!state.query.is_running());
         }
+
+        #[test]
+        fn mismatched_dsn_does_not_replace_plan() {
+            let mut state = sql_modal_state();
+            state.session.dsn = Some("dsn://current".to_string());
+            let _ = state.query.begin_running(Instant::now());
+            state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            state
+                .explain
+                .set_plan("Original".to_string(), false, 10, "SELECT old");
+
+            reduce_explain(
+                &mut state,
+                &Action::ExplainCompleted {
+                    dsn: "dsn://stale".to_string(),
+                    run_id: 1,
+                    query: "SELECT stale".to_string(),
+                    plan_text: "Stale".to_string(),
+                    is_analyze: false,
+                    execution_time_ms: 42,
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(state.explain.plan_text.as_deref(), Some("Original"));
+            assert_eq!(
+                state.explain.plan_query_snippet.as_deref(),
+                Some("SELECT old")
+            );
+            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
+        }
     }
 
     mod explain_failed {
@@ -612,6 +643,31 @@ mod tests {
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Normal);
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
             assert!(!state.query.is_running());
+        }
+
+        #[test]
+        fn mismatched_dsn_does_not_replace_plan_with_error() {
+            let mut state = sql_modal_state();
+            state.session.dsn = Some("dsn://current".to_string());
+            let _ = state.query.begin_running(Instant::now());
+            state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            state
+                .explain
+                .set_plan("Original".to_string(), false, 10, "SELECT old");
+
+            reduce_explain(
+                &mut state,
+                &Action::ExplainFailed {
+                    dsn: "dsn://stale".to_string(),
+                    run_id: 1,
+                    error: DbOperationError::QueryFailed("syntax error".to_string()),
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(state.explain.plan_text.as_deref(), Some("Original"));
+            assert_eq!(state.explain.error, None);
+            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
         }
     }
 

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -43,11 +43,11 @@ pub(super) fn reduce_request(
                 mark_explain_unavailable(state, services);
                 return DispatchResult::handled();
             };
-            let request_id = begin_explain_running(state, now);
+            let run_id = begin_explain_running(state, now);
 
             DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                 dsn,
-                request_id,
+                run_id,
                 query,
                 source_query: content,
                 is_analyze: false,

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -43,11 +43,13 @@ pub(super) fn reduce_request(
                 mark_explain_unavailable(state, services);
                 return DispatchResult::handled();
             };
-            begin_explain_running(state, now);
+            let request_id = begin_explain_running(state, now);
 
             DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                 dsn,
+                request_id,
                 query,
+                source_query: content,
                 is_analyze: false,
                 read_only: true,
             }])

--- a/src/app/update/explain/result.rs
+++ b/src/app/update/explain/result.rs
@@ -14,15 +14,13 @@ pub(super) fn reduce_result(
     match action {
         Action::ExplainCompleted {
             dsn,
-            request_id,
+            run_id,
             query,
             plan_text,
             is_analyze,
             execution_time_ms,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.query.is_current_request(*request_id)
-            {
+            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_success(
@@ -35,14 +33,8 @@ pub(super) fn reduce_result(
             DispatchResult::handled()
         }
 
-        Action::ExplainFailed {
-            dsn,
-            request_id,
-            error,
-        } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.query.is_current_request(*request_id)
-            {
+        Action::ExplainFailed { dsn, run_id, error } => {
+            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_error(state, error.user_message());

--- a/src/app/update/explain/result.rs
+++ b/src/app/update/explain/result.rs
@@ -1,7 +1,6 @@
 use std::time::Instant;
 
 use crate::model::app_state::AppState;
-use crate::model::shared::text_input::TextInputLike;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
@@ -14,22 +13,38 @@ pub(super) fn reduce_result(
 ) -> DispatchResult {
     match action {
         Action::ExplainCompleted {
+            dsn,
+            request_id,
+            query,
             plan_text,
             is_analyze,
             execution_time_ms,
         } => {
-            let query = state.sql_modal.editor.content().to_string();
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.query.is_current_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
             finish_explain_success(
                 state,
                 plan_text.clone(),
                 *is_analyze,
                 *execution_time_ms,
-                &query,
+                query,
             );
             DispatchResult::handled()
         }
 
-        Action::ExplainFailed(error) => {
+        Action::ExplainFailed {
+            dsn,
+            request_id,
+            error,
+        } => {
+            if state.session.dsn.as_ref() != Some(dsn)
+                || !state.query.is_current_request(*request_id)
+            {
+                return DispatchResult::handled();
+            }
             finish_explain_error(state, error.user_message());
             DispatchResult::handled()
         }

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -48,9 +48,10 @@ pub(super) fn reduce_confirm_dialog(
                     blocked: false,
                 }) => {
                     if let Some(dsn) = &state.session.dsn {
-                        state.query.begin_running(now);
+                        let request_id = state.query.begin_running(now);
                         DispatchResult::handled_with(vec![Effect::ExecuteWrite {
                             dsn: dsn.clone(),
+                            request_id,
                             query: sql,
                             read_only: state.session.read_only,
                         }])
@@ -68,13 +69,18 @@ pub(super) fn reduce_confirm_dialog(
                     DispatchResult::handled()
                 }
                 Some(ConfirmIntent::CsvExport {
+                    dsn,
+                    request_id,
                     export_query,
                     file_name,
                     row_count,
                 }) => {
-                    if let Some(dsn) = &state.session.dsn {
+                    if state.session.dsn.as_ref() == Some(&dsn)
+                        && state.query.is_current_request(request_id)
+                    {
                         DispatchResult::handled_with(vec![Effect::ExportCsv {
-                            dsn: dsn.clone(),
+                            dsn,
+                            request_id,
                             query: export_query,
                             file_name,
                             row_count,

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -48,10 +48,10 @@ pub(super) fn reduce_confirm_dialog(
                     blocked: false,
                 }) => {
                     if let Some(dsn) = &state.session.dsn {
-                        let request_id = state.query.begin_running(now);
+                        let run_id = state.query.begin_running(now);
                         DispatchResult::handled_with(vec![Effect::ExecuteWrite {
                             dsn: dsn.clone(),
-                            request_id,
+                            run_id,
                             query: sql,
                             read_only: state.session.read_only,
                         }])
@@ -70,17 +70,17 @@ pub(super) fn reduce_confirm_dialog(
                 }
                 Some(ConfirmIntent::CsvExport {
                     dsn,
-                    request_id,
+                    run_id,
                     export_query,
                     file_name,
                     row_count,
                 }) => {
                     if state.session.dsn.as_ref() == Some(&dsn)
-                        && state.query.is_current_request(request_id)
+                        && state.query.is_current_run(run_id)
                     {
                         DispatchResult::handled_with(vec![Effect::ExportCsv {
                             dsn,
-                            request_id,
+                            run_id,
                             query: export_query,
                             file_name,
                             row_count,

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -521,10 +521,13 @@ mod tests {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
                 state.session.dsn = Some("postgres://localhost/test".to_string());
+                let _ = state.query.begin_running(Instant::now());
                 state.confirm_dialog.open(
                     "",
                     "",
                     ConfirmIntent::CsvExport {
+                        dsn: "postgres://localhost/test".to_string(),
+                        request_id: 1,
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
@@ -798,7 +801,7 @@ mod tests {
             #[test]
             fn open_when_running_is_noop() {
                 let mut state = connected_state();
-                state.query.begin_running(Instant::now());
+                let _ = state.query.begin_running(Instant::now());
 
                 let effects = super::dispatch_modal(
                     &mut state,
@@ -929,9 +932,10 @@ mod tests {
 
                 super::dispatch_modal(
                     &mut state,
-                    &Action::QueryHistoryLoadFailed(QueryHistoryError::Io(Arc::new(
-                        std::io::Error::other("disk error"),
-                    ))),
+                    &Action::QueryHistoryLoadFailed(
+                        crate::domain::ConnectionId::from_string("test-conn"),
+                        QueryHistoryError::Io(Arc::new(std::io::Error::other("disk error"))),
+                    ),
                     now,
                 )
                 .unwrap();
@@ -950,9 +954,10 @@ mod tests {
 
                 super::dispatch_modal(
                     &mut state,
-                    &Action::QueryHistoryLoadFailed(QueryHistoryError::Io(Arc::new(
-                        std::io::Error::other("stale error"),
-                    ))),
+                    &Action::QueryHistoryLoadFailed(
+                        crate::domain::ConnectionId::from_string("test-conn"),
+                        QueryHistoryError::Io(Arc::new(std::io::Error::other("stale error"))),
+                    ),
                     now,
                 )
                 .unwrap();

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -527,7 +527,7 @@ mod tests {
                     "",
                     ConfirmIntent::CsvExport {
                         dsn: "postgres://localhost/test".to_string(),
-                        request_id: 1,
+                        run_id: 1,
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -546,6 +546,62 @@ mod tests {
             }
 
             #[test]
+            fn csv_export_ignores_mismatched_dsn() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                state.session.dsn = Some("postgres://localhost/current".to_string());
+                let _ = state.query.begin_running(Instant::now());
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::CsvExport {
+                        dsn: "postgres://localhost/stale".to_string(),
+                        run_id: 1,
+                        export_query: "SELECT 1".to_string(),
+                        file_name: "test.csv".to_string(),
+                        row_count: Some(200_000),
+                    },
+                );
+
+                let effects = super::dispatch_modal(
+                    &mut state,
+                    &Action::ConfirmDialogConfirm,
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert!(effects.is_empty());
+            }
+
+            #[test]
+            fn csv_export_ignores_mismatched_run_id() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                state.session.dsn = Some("postgres://localhost/test".to_string());
+                let _ = state.query.begin_running(Instant::now());
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::CsvExport {
+                        dsn: "postgres://localhost/test".to_string(),
+                        run_id: 2,
+                        export_query: "SELECT 1".to_string(),
+                        file_name: "test.csv".to_string(),
+                        row_count: Some(200_000),
+                    },
+                );
+
+                let effects = super::dispatch_modal(
+                    &mut state,
+                    &Action::ConfirmDialogConfirm,
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert!(effects.is_empty());
+            }
+
+            #[test]
             fn disable_read_only_confirm_sets_read_only_false() {
                 let mut state = create_test_state();
                 state.session.read_only = true;
@@ -956,6 +1012,25 @@ mod tests {
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
                         crate::domain::ConnectionId::from_string("test-conn"),
+                        QueryHistoryError::Io(Arc::new(std::io::Error::other("stale error"))),
+                    ),
+                    now,
+                )
+                .unwrap();
+
+                assert!(state.messages.last_error.is_none());
+            }
+
+            #[test]
+            fn load_failed_ignored_when_connection_mismatches() {
+                let mut state = connected_state();
+                state.modal.set_mode(InputMode::QueryHistoryPicker);
+                let now = Instant::now();
+
+                super::dispatch_modal(
+                    &mut state,
+                    &Action::QueryHistoryLoadFailed(
+                        ConnectionId::from_string("old-conn"),
                         QueryHistoryError::Io(Arc::new(std::io::Error::other("stale error"))),
                     ),
                     now,

--- a/src/app/update/modal/query_history.rs
+++ b/src/app/update/modal/query_history.rs
@@ -55,8 +55,11 @@ pub(super) fn reduce_query_history_picker(
             state.query_history_picker.replace_entries(entries);
             DispatchResult::handled()
         }
-        Action::QueryHistoryLoadFailed(e) => {
+        Action::QueryHistoryLoadFailed(conn_id, e) => {
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
+                return DispatchResult::handled();
+            }
+            if state.session.active_connection_id.as_ref() != Some(conn_id) {
                 return DispatchResult::handled();
             }
             state.messages.set_error_at(e.to_string(), now);

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -156,13 +156,13 @@ fn select_table(state: &mut AppState, table: &TableSummary) -> Vec<Effect> {
 
     let mut effects = Vec::new();
     if let Some(dsn) = state.session.dsn.clone() {
-        let request_id = state.session.begin_table_detail_request();
+        let run_id = state.session.begin_table_detail_run();
         effects.push(Effect::FetchTableDetail {
             dsn,
             schema: schema.clone(),
             table: table_name.clone(),
             generation,
-            request_id,
+            run_id,
         });
     }
     effects.push(Effect::DispatchActions(vec![Action::ExecutePreview(
@@ -905,20 +905,20 @@ mod tests {
 
         fn metadata_loaded_action(state: &mut AppState, metadata: DatabaseMetadata) -> Action {
             state.session.dsn = Some("postgres://localhost/test".to_string());
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
-                request_id,
+                run_id,
                 metadata: Arc::new(metadata),
             }
         }
 
         fn metadata_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
             state.session.dsn = Some("postgres://localhost/test".to_string());
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
             Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
-                request_id,
+                run_id,
                 error,
             }
         }
@@ -1319,7 +1319,7 @@ mod tests {
             };
             let action = Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
-                request_id: 1,
+                run_id: 1,
                 metadata: Arc::new(metadata),
             };
             reduce(&mut state, action, now, &AppServices::stub());
@@ -1445,10 +1445,10 @@ mod tests {
             state.er_preparation.status = ErStatus::Waiting;
             let now = Instant::now();
             state.session.dsn = Some("postgres://localhost/test".to_string());
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
             let action = Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
-                request_id,
+                run_id,
                 error: DbOperationError::ConnectionFailed("connection refused".to_string()),
             };
 
@@ -1482,7 +1482,7 @@ mod tests {
         fn emits_cache_effect() {
             let mut state = create_test_state();
             state.session.dsn = Some("postgres://localhost/test".to_string());
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
                 .prefetching_tables
@@ -1493,7 +1493,7 @@ mod tests {
                 &mut state,
                 Action::TableDetailCached {
                     dsn: "postgres://localhost/test".to_string(),
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                     detail: make_test_table(),
@@ -1514,7 +1514,7 @@ mod tests {
         fn with_queue_returns_process_effect() {
             let mut state = create_test_state();
             state.session.dsn = Some("postgres://localhost/test".to_string());
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
                 .prefetch_queue
@@ -1525,7 +1525,7 @@ mod tests {
                 &mut state,
                 Action::TableDetailCached {
                     dsn: "postgres://localhost/test".to_string(),
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                     detail: make_test_table(),
@@ -1866,7 +1866,7 @@ mod tests {
                 &mut state,
                 Action::ExecuteWriteSucceeded {
                     dsn: "postgres://localhost/test".to_string(),
-                    request_id: 1,
+                    run_id: 1,
                     affected_rows: 1,
                 },
                 now,
@@ -1935,7 +1935,7 @@ mod tests {
                 &mut state,
                 Action::ExecuteWriteFailed {
                     dsn: "postgres://localhost/test".to_string(),
-                    request_id: 1,
+                    run_id: 1,
                     error: DbOperationError::QueryFailed("connection lost".to_string()),
                 },
                 now,
@@ -2044,7 +2044,7 @@ mod tests {
                 .session
                 .set_connection_state(ConnectionState::Connecting);
             state.session.dsn = Some("postgres://localhost/test".to_string());
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
             let metadata = DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -2057,7 +2057,7 @@ mod tests {
                 &mut state,
                 Action::MetadataLoaded {
                     dsn: "postgres://localhost/test".to_string(),
-                    request_id,
+                    run_id,
                     metadata: Arc::new(metadata),
                 },
                 now,
@@ -2078,14 +2078,14 @@ mod tests {
                 .session
                 .set_connection_state(ConnectionState::Connecting);
             state.session.dsn = Some("postgres://localhost/test".to_string());
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
             let now = Instant::now();
 
             reduce(
                 &mut state,
                 Action::MetadataFailed {
                     dsn: "postgres://localhost/test".to_string(),
-                    request_id,
+                    run_id,
                     error: DbOperationError::ConnectionFailed("connection refused".to_string()),
                 },
                 now,
@@ -2109,14 +2109,14 @@ mod tests {
                 .set_connection_state(ConnectionState::Connected);
             state.session.dsn = Some("postgres://localhost/test".to_string());
             state.session.set_metadata_state(MetadataState::Loaded);
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
             let now = Instant::now();
 
             reduce(
                 &mut state,
                 Action::MetadataFailed {
                     dsn: "postgres://localhost/test".to_string(),
-                    request_id,
+                    run_id,
                     error: DbOperationError::QueryFailed("permission denied".to_string()),
                 },
                 now,
@@ -2384,10 +2384,10 @@ mod tests {
 
         fn metadata_loaded_action(state: &mut AppState) -> Action {
             state.session.dsn = Some("postgres://localhost/test".to_string());
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
-                request_id,
+                run_id,
                 metadata: sample_metadata(),
             }
         }
@@ -2529,7 +2529,7 @@ mod tests {
 
             let mut state = state_with_metadata();
             state.session.dsn = Some("postgres://localhost/test".to_string());
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.status = ErStatus::Waiting;
             state.er_preparation.total_tables = 1;
             state.er_preparation.fk_expanded = true;
@@ -2543,7 +2543,7 @@ mod tests {
                 &mut state,
                 Action::TableDetailAlreadyCached {
                     dsn: "postgres://localhost/test".to_string(),
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -2564,7 +2564,7 @@ mod tests {
 
             let mut state = state_with_metadata();
             state.session.dsn = Some("postgres://localhost/test".to_string());
-            let batch_id = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.status = ErStatus::Waiting;
             state.er_preparation.total_tables = 2;
             state.er_preparation.fk_expanded = true;
@@ -2582,7 +2582,7 @@ mod tests {
                 &mut state,
                 Action::TableDetailAlreadyCached {
                     dsn: "postgres://localhost/test".to_string(),
-                    batch_id,
+                    run_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -2622,12 +2622,12 @@ mod tests {
                 )],
                 fetched_at: now,
             };
-            let request_id = state.session.begin_metadata_refresh();
+            let run_id = state.session.begin_metadata_refresh();
             reduce(
                 &mut state,
                 Action::MetadataLoaded {
                     dsn: "postgres://localhost/test".to_string(),
-                    request_id,
+                    run_id,
                     metadata: Arc::new(metadata),
                 },
                 now,
@@ -2671,12 +2671,12 @@ mod tests {
                 error: None,
                 command_tag: None,
             });
-            let request_id = state.query.begin_running(now);
+            let run_id = state.query.begin_running(now);
             reduce(
                 &mut state,
                 Action::QueryCompleted {
                     dsn: "postgres://localhost/test".to_string(),
-                    request_id,
+                    run_id,
                     result,
                     generation: current_gen,
                     target_page: Some(0),

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -155,12 +155,14 @@ fn select_table(state: &mut AppState, table: &TableSummary) -> Vec<Effect> {
     let table_name = table.name.clone();
 
     let mut effects = Vec::new();
-    if let Some(dsn) = &state.session.dsn {
+    if let Some(dsn) = state.session.dsn.clone() {
+        let request_id = state.session.begin_table_detail_request();
         effects.push(Effect::FetchTableDetail {
-            dsn: dsn.clone(),
+            dsn,
             schema: schema.clone(),
             table: table_name.clone(),
             generation,
+            request_id,
         });
     }
     effects.push(Effect::DispatchActions(vec![Action::ExecutePreview(
@@ -901,6 +903,26 @@ mod tests {
         use crate::domain::{DatabaseMetadata, MetadataState, TableSummary};
         use crate::model::connection::error::ConnectionErrorInfo;
 
+        fn metadata_loaded_action(state: &mut AppState, metadata: DatabaseMetadata) -> Action {
+            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let request_id = state.session.begin_metadata_refresh();
+            Action::MetadataLoaded {
+                dsn: "postgres://localhost/test".to_string(),
+                request_id,
+                metadata: Arc::new(metadata),
+            }
+        }
+
+        fn metadata_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
+            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let request_id = state.session.begin_metadata_refresh();
+            Action::MetadataFailed {
+                dsn: "postgres://localhost/test".to_string(),
+                request_id,
+                error,
+            }
+        }
+
         #[test]
         fn metadata_loaded_with_empty_tables_selects_none() {
             let mut state = create_test_state();
@@ -912,13 +934,9 @@ mod tests {
                 fetched_at: Instant::now(),
             };
             let now = Instant::now();
+            let action = metadata_loaded_action(&mut state, metadata);
 
-            reduce(
-                &mut state,
-                Action::MetadataLoaded(Arc::new(metadata)),
-                now,
-                &AppServices::stub(),
-            );
+            reduce(&mut state, action, now, &AppServices::stub());
 
             assert!(state.session.metadata().is_some());
             assert_eq!(state.ui.explorer_selected, 0);
@@ -940,13 +958,9 @@ mod tests {
                 fetched_at: Instant::now(),
             };
             let now = Instant::now();
+            let action = metadata_loaded_action(&mut state, metadata);
 
-            reduce(
-                &mut state,
-                Action::MetadataLoaded(Arc::new(metadata)),
-                now,
-                &AppServices::stub(),
-            );
+            reduce(&mut state, action, now, &AppServices::stub());
 
             assert!(state.session.metadata().is_some());
             assert_eq!(state.ui.explorer_selected, 0);
@@ -956,15 +970,12 @@ mod tests {
         fn metadata_failed_opens_error_modal_automatically() {
             let mut state = create_test_state();
             let now = Instant::now();
-
-            let effects = reduce(
+            let action = metadata_failed_action(
                 &mut state,
-                Action::MetadataFailed(DbOperationError::ConnectionFailed(
-                    "psql: error: connection refused".to_string(),
-                )),
-                now,
-                &AppServices::stub(),
+                DbOperationError::ConnectionFailed("psql: error: connection refused".to_string()),
             );
+
+            let effects = reduce(&mut state, action, now, &AppServices::stub());
 
             assert!(matches!(
                 state.session.metadata_state(),
@@ -1306,12 +1317,12 @@ mod tests {
                 table_summaries: vec![],
                 fetched_at: now,
             };
-            reduce(
-                &mut state,
-                Action::MetadataLoaded(Arc::new(metadata)),
-                now,
-                &AppServices::stub(),
-            );
+            let action = Action::MetadataLoaded {
+                dsn: "postgres://localhost/test".to_string(),
+                request_id: 1,
+                metadata: Arc::new(metadata),
+            };
+            reduce(&mut state, action, now, &AppServices::stub());
 
             // Check reloading flag is cleared and message is shown
             assert!(!state.session.is_reloading);
@@ -1362,7 +1373,7 @@ mod tests {
                 table_summaries: vec![],
                 fetched_at: Instant::now(),
             })));
-            state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_prefetch();
             state
                 .er_preparation
                 .pending_tables
@@ -1387,7 +1398,7 @@ mod tests {
                 table_summaries: vec![],
                 fetched_at: Instant::now(),
             })));
-            state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_prefetch();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
@@ -1419,7 +1430,7 @@ mod tests {
         #[test]
         fn no_metadata_returns_error() {
             let mut state = create_test_state();
-            state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_prefetch();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
@@ -1433,15 +1444,15 @@ mod tests {
             let mut state = create_test_state();
             state.er_preparation.status = ErStatus::Waiting;
             let now = Instant::now();
+            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let request_id = state.session.begin_metadata_refresh();
+            let action = Action::MetadataFailed {
+                dsn: "postgres://localhost/test".to_string(),
+                request_id,
+                error: DbOperationError::ConnectionFailed("connection refused".to_string()),
+            };
 
-            reduce(
-                &mut state,
-                Action::MetadataFailed(DbOperationError::ConnectionFailed(
-                    "connection refused".to_string(),
-                )),
-                now,
-                &AppServices::stub(),
-            );
+            reduce(&mut state, action, now, &AppServices::stub());
 
             assert_eq!(state.er_preparation.status, ErStatus::Idle);
         }
@@ -1470,6 +1481,8 @@ mod tests {
         #[test]
         fn emits_cache_effect() {
             let mut state = create_test_state();
+            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let batch_id = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
                 .prefetching_tables
@@ -1479,6 +1492,8 @@ mod tests {
             let effects = reduce(
                 &mut state,
                 Action::TableDetailCached {
+                    dsn: "postgres://localhost/test".to_string(),
+                    batch_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                     detail: make_test_table(),
@@ -1498,6 +1513,8 @@ mod tests {
         #[test]
         fn with_queue_returns_process_effect() {
             let mut state = create_test_state();
+            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let batch_id = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
                 .prefetch_queue
@@ -1507,6 +1524,8 @@ mod tests {
             let effects = reduce(
                 &mut state,
                 Action::TableDetailCached {
+                    dsn: "postgres://localhost/test".to_string(),
+                    batch_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                     detail: make_test_table(),
@@ -1518,7 +1537,7 @@ mod tests {
             assert!(
                 effects
                     .iter()
-                    .any(|e| matches!(e, Effect::ProcessPrefetchQueue))
+                    .any(|e| matches!(e, Effect::ProcessPrefetchQueue { .. }))
             );
         }
     }
@@ -1845,7 +1864,11 @@ mod tests {
             // Simulate success
             let effects = reduce(
                 &mut state,
-                Action::ExecuteWriteSucceeded { affected_rows: 1 },
+                Action::ExecuteWriteSucceeded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    request_id: 1,
+                    affected_rows: 1,
+                },
                 now,
                 &AppServices::stub(),
             );
@@ -1910,9 +1933,11 @@ mod tests {
             // Simulate failure — must detect Delete and return to Normal (not CellEdit)
             reduce(
                 &mut state,
-                Action::ExecuteWriteFailed(DbOperationError::QueryFailed(
-                    "connection lost".to_string(),
-                )),
+                Action::ExecuteWriteFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    request_id: 1,
+                    error: DbOperationError::QueryFailed("connection lost".to_string()),
+                },
                 now,
                 &AppServices::stub(),
             );
@@ -2018,6 +2043,8 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
+            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let request_id = state.session.begin_metadata_refresh();
             let metadata = DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -2028,7 +2055,11 @@ mod tests {
 
             reduce(
                 &mut state,
-                Action::MetadataLoaded(Arc::new(metadata)),
+                Action::MetadataLoaded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    request_id,
+                    metadata: Arc::new(metadata),
+                },
                 now,
                 &AppServices::stub(),
             );
@@ -2046,13 +2077,17 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
+            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let request_id = state.session.begin_metadata_refresh();
             let now = Instant::now();
 
             reduce(
                 &mut state,
-                Action::MetadataFailed(DbOperationError::ConnectionFailed(
-                    "connection refused".to_string(),
-                )),
+                Action::MetadataFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    request_id,
+                    error: DbOperationError::ConnectionFailed("connection refused".to_string()),
+                },
                 now,
                 &AppServices::stub(),
             );
@@ -2072,14 +2107,18 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
+            state.session.dsn = Some("postgres://localhost/test".to_string());
             state.session.set_metadata_state(MetadataState::Loaded);
+            let request_id = state.session.begin_metadata_refresh();
             let now = Instant::now();
 
             reduce(
                 &mut state,
-                Action::MetadataFailed(DbOperationError::QueryFailed(
-                    "permission denied".to_string(),
-                )),
+                Action::MetadataFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    request_id,
+                    error: DbOperationError::QueryFailed("permission denied".to_string()),
+                },
                 now,
                 &AppServices::stub(),
             );
@@ -2343,6 +2382,16 @@ mod tests {
             })
         }
 
+        fn metadata_loaded_action(state: &mut AppState) -> Action {
+            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let request_id = state.session.begin_metadata_refresh();
+            Action::MetadataLoaded {
+                dsn: "postgres://localhost/test".to_string(),
+                request_id,
+                metadata: sample_metadata(),
+            }
+        }
+
         fn has_open_er_dispatch(effects: &[Effect]) -> bool {
             effects.iter().any(|e| {
                 matches!(e, Effect::DispatchActions(actions)
@@ -2356,13 +2405,9 @@ mod tests {
             state.ui.pending_er_picker = true;
             state.modal.set_mode(InputMode::Normal);
             let now = Instant::now();
+            let action = metadata_loaded_action(&mut state);
 
-            let effects = reduce(
-                &mut state,
-                Action::MetadataLoaded(sample_metadata()),
-                now,
-                &AppServices::stub(),
-            );
+            let effects = reduce(&mut state, action, now, &AppServices::stub());
 
             assert!(!state.ui.pending_er_picker);
             assert!(has_open_er_dispatch(&effects));
@@ -2373,13 +2418,9 @@ mod tests {
             let mut state = create_test_state();
             state.ui.pending_er_picker = false;
             let now = Instant::now();
+            let action = metadata_loaded_action(&mut state);
 
-            let effects = reduce(
-                &mut state,
-                Action::MetadataLoaded(sample_metadata()),
-                now,
-                &AppServices::stub(),
-            );
+            let effects = reduce(&mut state, action, now, &AppServices::stub());
 
             assert!(!has_open_er_dispatch(&effects));
         }
@@ -2390,13 +2431,9 @@ mod tests {
             state.ui.pending_er_picker = true;
             state.modal.set_mode(InputMode::SqlModal);
             let now = Instant::now();
+            let action = metadata_loaded_action(&mut state);
 
-            let effects = reduce(
-                &mut state,
-                Action::MetadataLoaded(sample_metadata()),
-                now,
-                &AppServices::stub(),
-            );
+            let effects = reduce(&mut state, action, now, &AppServices::stub());
 
             assert!(!state.ui.pending_er_picker);
             assert!(!has_open_er_dispatch(&effects));
@@ -2472,7 +2509,7 @@ mod tests {
         fn target_tables_survive_er_open() {
             let mut state = state_with_metadata();
             state.session.dsn = Some("postgres://localhost/test".to_string());
-            state.sql_modal.begin_prefetch();
+            let _ = state.sql_modal.begin_prefetch();
             state.er_preparation.target_tables = vec!["public.users".to_string()];
             let now = Instant::now();
 
@@ -2491,7 +2528,8 @@ mod tests {
             use crate::model::er_state::ErStatus;
 
             let mut state = state_with_metadata();
-            state.sql_modal.begin_prefetch();
+            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let batch_id = state.sql_modal.begin_prefetch();
             state.er_preparation.status = ErStatus::Waiting;
             state.er_preparation.total_tables = 1;
             state.er_preparation.fk_expanded = true;
@@ -2504,6 +2542,8 @@ mod tests {
             let effects = reduce(
                 &mut state,
                 Action::TableDetailAlreadyCached {
+                    dsn: "postgres://localhost/test".to_string(),
+                    batch_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -2523,7 +2563,8 @@ mod tests {
             use crate::model::er_state::ErStatus;
 
             let mut state = state_with_metadata();
-            state.sql_modal.begin_prefetch();
+            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let batch_id = state.sql_modal.begin_prefetch();
             state.er_preparation.status = ErStatus::Waiting;
             state.er_preparation.total_tables = 2;
             state.er_preparation.fk_expanded = true;
@@ -2540,6 +2581,8 @@ mod tests {
             let effects = reduce(
                 &mut state,
                 Action::TableDetailAlreadyCached {
+                    dsn: "postgres://localhost/test".to_string(),
+                    batch_id,
                     schema: "public".to_string(),
                     table: "users".to_string(),
                 },
@@ -2579,9 +2622,14 @@ mod tests {
                 )],
                 fetched_at: now,
             };
+            let request_id = state.session.begin_metadata_refresh();
             reduce(
                 &mut state,
-                Action::MetadataLoaded(Arc::new(metadata)),
+                Action::MetadataLoaded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    request_id,
+                    metadata: Arc::new(metadata),
+                },
                 now,
                 &AppServices::stub(),
             );
@@ -2623,9 +2671,12 @@ mod tests {
                 error: None,
                 command_tag: None,
             });
+            let request_id = state.query.begin_running(now);
             reduce(
                 &mut state,
                 Action::QueryCompleted {
+                    dsn: "postgres://localhost/test".to_string(),
+                    request_id,
                     result,
                     generation: current_gen,
                     target_page: Some(0),

--- a/src/app/update/sql_editor/helpers.rs
+++ b/src/app/update/sql_editor/helpers.rs
@@ -16,11 +16,11 @@ pub(super) fn start_adhoc_if_connected(
         return DispatchResult::handled();
     };
 
-    let request_id = state.query.begin_running(now);
+    let run_id = state.query.begin_running(now);
     state.sql_modal.begin_adhoc_running();
     DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
         dsn,
-        request_id,
+        run_id,
         query,
         read_only: state.session.read_only,
     }])

--- a/src/app/update/sql_editor/helpers.rs
+++ b/src/app/update/sql_editor/helpers.rs
@@ -1,8 +1,14 @@
+use std::time::Instant;
+
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn start_adhoc_if_connected(state: &mut AppState, query: String) -> DispatchResult {
+pub(super) fn start_adhoc_if_connected(
+    state: &mut AppState,
+    query: String,
+    now: Instant,
+) -> DispatchResult {
     let Some(dsn) = state.session.dsn.clone() else {
         state
             .sql_modal
@@ -10,9 +16,11 @@ pub(super) fn start_adhoc_if_connected(state: &mut AppState, query: String) -> D
         return DispatchResult::handled();
     };
 
+    let request_id = state.query.begin_running(now);
     state.sql_modal.begin_adhoc_running();
     DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
         dsn,
+        request_id,
         query,
         read_only: state.session.read_only,
     }])

--- a/src/app/update/sql_editor/high_risk.rs
+++ b/src/app/update/sql_editor/high_risk.rs
@@ -25,7 +25,7 @@ fn high_risk_input_mut(
 pub(super) fn reduce_high_risk_confirmation(
     state: &mut AppState,
     action: &Action,
-    _now: Instant,
+    now: Instant,
 ) -> DispatchResult {
     match action {
         Action::SqlModalCancelConfirm => {
@@ -85,7 +85,7 @@ pub(super) fn reduce_high_risk_confirmation(
             );
             if matched {
                 let query = state.sql_modal.editor.content().trim().to_string();
-                return start_adhoc_if_connected(state, query);
+                return start_adhoc_if_connected(state, query, now);
             }
             DispatchResult::handled()
         }

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -406,11 +406,14 @@ mod tests {
             );
 
             assert!(matches!(state.sql_modal.status(), SqlModalStatus::Running));
-            assert!(
-                effects.is_handled_and(|e| e
-                    .iter()
-                    .any(|ef| matches!(ef, Effect::ExecuteAdhoc { .. })))
-            );
+            assert!(state.query.is_running());
+            let effects = effects
+                .into_effects()
+                .expect("reducer should handle action");
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::ExecuteAdhoc { run_id: 1, .. }]
+            ));
         }
 
         #[test]
@@ -723,11 +726,11 @@ mod tests {
                 .expect("reducer should handle action");
 
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
-            assert!(
-                effects
-                    .iter()
-                    .any(|e| matches!(e, Effect::ExecuteAdhoc { .. }))
-            );
+            assert!(state.query.is_running());
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::ExecuteAdhoc { run_id: 1, .. }]
+            ));
         }
 
         #[test]

--- a/src/app/update/sql_editor/submit.rs
+++ b/src/app/update/sql_editor/submit.rs
@@ -26,11 +26,7 @@ fn multi_statement_label(sql: &str) -> &'static str {
     }
     worst_label
 }
-pub(super) fn reduce_submit(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-) -> DispatchResult {
+pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::SqlModalSubmit => {
             let query = state.sql_modal.editor.content().trim().to_string();
@@ -65,7 +61,7 @@ pub(super) fn reduce_submit(
                         return DispatchResult::handled();
                     }
                     match risk.confirmation {
-                        ConfirmationType::Immediate => start_adhoc_if_connected(state, query),
+                        ConfirmationType::Immediate => start_adhoc_if_connected(state, query, now),
                         ConfirmationType::TableNameInput { target } => {
                             state
                                 .sql_modal

--- a/src/app/update/sql_editor/yank.rs
+++ b/src/app/update/sql_editor/yank.rs
@@ -71,9 +71,9 @@ pub(super) fn reduce_yank(
                 Some(c) if !c.is_empty() => {
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: c,
-                        on_success: Some(Action::SqlModalYankSuccess),
-                        on_failure: Some(Action::CopyFailed(ClipboardError::Unavailable(
-                            "Clipboard unavailable".into(),
+                        on_success: Some(Box::new(Action::SqlModalYankSuccess)),
+                        on_failure: Some(Box::new(Action::CopyFailed(
+                            ClipboardError::Unavailable("Clipboard unavailable".into()),
                         ))),
                     }])
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ use sabiql_app::model::app_state::AppState;
 use sabiql_app::model::shared::db_capabilities::DbCapabilities;
 use sabiql_app::model::shared::input_mode::InputMode;
 use sabiql_app::ports::outbound::{
-    ConnectionStore, ConnectionStoreError, DatabaseCapabilityProvider, PgServiceEntryReader,
-    ServiceFileError, SettingsStore,
+    ConnectionStore, ConnectionStoreError, DatabaseCapabilityProvider, DdlGenerator,
+    PgServiceEntryReader, ServiceFileError, SettingsStore, SqlDialect,
 };
 use sabiql_app::services::AppServices;
 use sabiql_app::update::action::Action;
@@ -117,9 +117,11 @@ async fn main() -> Result<()> {
         .action_tx(action_tx.clone())
         .build();
 
+    let ddl_generator: Arc<dyn DdlGenerator> = adapter.clone();
+    let sql_dialect: Arc<dyn SqlDialect> = adapter.clone();
     let services = AppServices {
-        ddl_generator: Arc::clone(&adapter) as _,
-        sql_dialect: Arc::clone(&adapter) as _,
+        ddl_generator,
+        sql_dialect,
         db_capabilities,
     };
 

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -294,7 +294,7 @@ fn header_status_uses_success_warning_and_error_colors() {
 
     let now = test_instant();
     let mut connected = create_test_state();
-    connected
+    let _ = connected
         .session
         .begin_connecting("postgres://localhost/test");
     connected
@@ -308,7 +308,7 @@ fn header_status_uses_success_warning_and_error_colors() {
     );
 
     let mut loading = create_test_state();
-    loading
+    let _ = loading
         .session
         .begin_connecting("postgres://localhost/test");
     let loading_buffer = render_and_get_buffer_at(&mut terminal, &mut loading, now);


### PR DESCRIPTION
## Problem
DB-backed async completions can arrive after the active connection, selection, or request context has changed, allowing stale results to update current app state.

## Background
SAB-243 identified that existing freshness checks were inconsistent across metadata, table detail, prefetch, query execution, CSV export, explain, and ER refresh flows.

## Approach
Scope: app-layer DB async completion freshness for metadata, table detail, SQL modal prefetch, query/write/explain/CSV, and ER smart refresh.

Carry the issuing DB context and monotonic request identity through async payloads, then reject completions whose context no longer matches the active aggregate state. Existing generation/run guards remain where they protect narrower selection or ER lifecycles.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 非同期操作の実行トラッキング機能を追加し、古い実行結果が誤って反映される問題を修正。メタデータ取得、クエリ実行、テーブル詳細読み込み時に最新の実行結果のみが反映されるように改善。

* **Refactor**
  * 複数の非同期操作の整合性管理を強化。実行ライフサイクル管理システムを導入し、キャンセルされた操作の結果がステート更新に反映されないよう調整。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/riii111/sabiql/pull/377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->