### PR TITLE
refactor: classify action enum variants

### DIFF
--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -258,15 +258,23 @@ pub struct ConnectionTarget {
 
 // Do not derive PartialEq here: payload variants carry domain snapshots and
 // errors that are not all value-comparable.
+//
+// Classification rule:
+// Order actions by user-facing responsibility:
+// - Shared controls: common behavior used across features (e.g., Quit, Render, Scroll, TextInput).
+// - Product objects: group by the object in the action sentence, rather than by UI component or reducer (e.g., ConnectionSetupSave -> Connections).
+// Product object groups follow dependency order:
+// User setup -> DB structure -> Authored SQL -> Query results -> Result derivatives.
 #[derive(Debug, Clone)]
 pub enum Action {
+    // App shell
     None,
     Quit,
     Render,
     Resize(u16, u16),
     SetFocusedPane(FocusedPane),
 
-    // Parametric variants (consolidation targets)
+    // Input primitives
     Scroll {
         target: ScrollTarget,
         direction: ScrollDirection,
@@ -295,17 +303,29 @@ pub enum Action {
         target: ListTarget,
         motion: ListMotion,
     },
+    Paste(String),
+    BeginKeySequence(Prefix),
+    CancelKeySequence,
 
-    // Modal lifecycle
+    // Modal shell
     OpenModal(ModalKind),
     CloseModal(ModalKind),
     ToggleModal(ModalKind),
+    Escape,
+    ConfirmSelection,
+    ConfirmDialogConfirm,
+    ConfirmDialogCancel,
 
-    // Connection lifecycle
+    // Command line
+    EnterCommandLine,
+    ExitCommandLine,
+    CommandLineSubmit,
+
+    // Connections
     TryConnect,
     SwitchConnection(ConnectionTarget),
-
-    // Connection Setup
+    ConnectionsLoaded(ConnectionsLoadedPayload),
+    ConfirmConnectionSelection,
     StartEditConnection(ConnectionId),
     ConnectionSetupNextField,
     ConnectionSetupPrevField,
@@ -320,8 +340,6 @@ pub enum Action {
     ConnectionSaveFailed(ConnectionSaveError),
     ConnectionEditLoaded(Box<ConnectionProfile>),
     ConnectionEditLoadFailed(ConnectionStoreError),
-
-    // Connection Error
     ShowConnectionError(ConnectionErrorInfo),
     CloseConnectionError,
     ToggleConnectionErrorDetails,
@@ -329,24 +347,11 @@ pub enum Action {
     ConnectionErrorCopied,
     ReenterConnectionSetup,
     RetryServiceConnection,
-
-    // Confirm Dialog
-    ConfirmDialogConfirm,
-    ConfirmDialogCancel,
-
-    // Connection deletion
     RequestDeleteSelectedConnection,
     DeleteConnection(ConnectionId),
     ConnectionDeleted(ConnectionId),
     ConnectionDeleteFailed(ConnectionStoreError),
-
-    // Connection edit (from list)
     RequestEditSelectedConnection,
-
-    // Command line actions
-    EnterCommandLine,
-    ExitCommandLine,
-    CommandLineSubmit,
 
     // Settings
     SettingsSelectNext,
@@ -360,17 +365,7 @@ pub enum Action {
     SettingsSaved(AppSettings),
     SettingsSaveFailed(SettingsStoreError),
 
-    // Connection list navigation
-    ConnectionsLoaded(ConnectionsLoadedPayload),
-    ConfirmConnectionSelection,
-
-    // Selection
-    ConfirmSelection,
-
-    // Escape (context-dependent close)
-    Escape,
-
-    // Metadata loading
+    // Database structure
     LoadMetadata,
     ReloadMetadata,
     MetadataLoaded {
@@ -383,8 +378,6 @@ pub enum Action {
         run_id: u64,
         error: DbOperationError,
     },
-
-    // Table detail loading
     LoadTableDetail(TableTarget),
     TableDetailLoaded {
         dsn: String,
@@ -398,8 +391,6 @@ pub enum Action {
         error: DbOperationError,
         generation: u64,
     },
-
-    // Completion prefetch (does NOT update state.table_detail)
     PrefetchTableDetail {
         run_id: u64,
         schema: String,
@@ -425,8 +416,6 @@ pub enum Action {
         schema: String,
         table: String,
     },
-
-    // Prefetch all tables for completion
     StartPrefetchAll,
     StartPrefetchScoped {
         tables: Vec<String>,
@@ -438,15 +427,10 @@ pub enum Action {
     ProcessPrefetchQueue {
         run_id: u64,
     },
-
-    // Inspector sub-tabs
     InspectorNextTab,
     InspectorPrevTab,
 
-    // Clipboard paste (bracketed paste)
-    Paste(String),
-
-    // SQL Modal
+    // SQL editing
     SqlModalAppendInsert,
     SqlModalEnterInsert,
     SqlModalEnterNormal,
@@ -458,12 +442,20 @@ pub enum Action {
     SqlModalClear,
     SqlModalCancelConfirm,
     SqlModalHighRiskConfirmExecute,
-
-    // SQL Modal tabs
     SqlModalNextTab,
     SqlModalPrevTab,
+    CompletionTrigger,
+    CompletionUpdated {
+        candidates: Vec<CompletionCandidate>,
+        trigger_position: usize,
+        visible: bool,
+    },
+    CompletionAccept,
+    CompletionDismiss,
+    CompletionNext,
+    CompletionPrev,
 
-    // EXPLAIN
+    // Explain plans
     ExplainRequest,
     ExplainAnalyzeRequest,
     ExplainAnalyzeConfirm,
@@ -483,19 +475,7 @@ pub enum Action {
     },
     CompareEditQuery,
 
-    // SQL Modal completion
-    CompletionTrigger,
-    CompletionUpdated {
-        candidates: Vec<CompletionCandidate>,
-        trigger_position: usize,
-        visible: bool,
-    },
-    CompletionAccept,
-    CompletionDismiss,
-    CompletionNext,
-    CompletionPrev,
-
-    // Query execution
+    // Query results
     ExecutePreview(TableTarget),
     ExecuteAdhoc(String),
     ExecuteWrite(String),
@@ -523,12 +503,8 @@ pub enum Action {
         run_id: u64,
         error: DbOperationError,
     },
-
-    // Result pane
     ResultNextPage,
     ResultPrevPage,
-
-    // Result pane selection
     ResultActivateCell,
     ResultExitToScroll,
     ResultCellLeft,
@@ -550,29 +526,16 @@ pub enum Action {
     CellCopied,
     CopyFailed(ClipboardError),
     OpenFolderFailed(FolderOpenError),
+    ToggleFocus,
+    ToggleReadOnly,
 
-    // Result history navigation
+    // Result history
     OpenResultHistory,
     HistoryOlder,
     HistoryNewer,
     ExitResultHistory,
 
-    // Multi-key sequence FSM (zz, zt, zb)
-    BeginKeySequence(Prefix),
-    CancelKeySequence,
-
-    // Focus mode
-    ToggleFocus,
-
-    // Read-only mode
-    ToggleReadOnly,
-
-    // ER Table Picker
-    ErToggleSelection,
-    ErSelectAll,
-    ErConfirmSelection,
-
-    // Query History Picker
+    // Query history
     QueryHistoryLoaded(
         crate::domain::ConnectionId,
         Vec<crate::domain::query_history::QueryHistoryEntry>,
@@ -581,7 +544,7 @@ pub enum Action {
     QueryHistoryAppendFailed(QueryHistoryError),
     QueryHistoryConfirmSelection,
 
-    // CSV Export
+    // CSV export
     RequestCsvExport,
     CsvExportRowsCounted {
         dsn: String,
@@ -609,7 +572,7 @@ pub enum Action {
         error: DbOperationError,
     },
 
-    // JSONB Detail View
+    // JSONB detail
     JsonbYankAll,
     JsonbEnterEdit,
     JsonbAppendInsert,
@@ -620,7 +583,10 @@ pub enum Action {
     JsonbSearchPrev,
     JsonbSearchSubmit,
 
-    // ER Diagram (full or partial, depending on selected tables)
+    // ER diagrams
+    ErToggleSelection,
+    ErSelectAll,
+    ErConfirmSelection,
     ErOpenDiagram,
     ErGenerateFromCache,
     SmartErRefreshCompleted(SmartErRefreshResult),

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -256,15 +256,14 @@ pub struct ConnectionTarget {
     pub name: String,
 }
 
-// Do not derive PartialEq here: payload variants carry domain snapshots and
-// errors that are not all value-comparable.
+// Full Action equality is intentionally unavailable: some payloads carry
+// snapshots or errors that are not value-comparable.
 //
 // Classification rule:
-// Order actions by user-facing responsibility:
-// - Shared controls: common behavior used across features (e.g., Quit, Render, Scroll, TextInput).
-// - Product objects: group by the object in the action sentence, rather than by UI component or reducer (e.g., ConnectionSetupSave -> Connections).
-// Product object groups follow dependency order:
-// User setup -> DB structure -> Authored SQL -> Query results -> Result derivatives.
+// Order shared controls first, then product objects by dependency:
+// setup -> DB structure -> SQL -> query results -> result derivatives.
+// Product groups follow the object in the action sentence, not UI/reducer names
+// (e.g., MetadataLoaded -> Database structure, QueryCompleted -> Query results).
 #[derive(Debug, Clone)]
 pub enum Action {
     // App shell


### PR DESCRIPTION
## Problem
The central Action enum had mixed grouping rules, making it harder to decide where new variants belong.

## Background
SAB-246 calls for improving Action classification and naming guidance without changing reducer architecture or behavior.

## Approach
Scope: Action enum organization only.

Group shared controls first, then user-facing product objects in dependency order. Keep result/completion variants next to the product object they update, and document the classification rule in the enum itself.

## Screenshots
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 内部コードの構成を整理し、セクション分けとコメント記述を改善しました。公開APIへの変更はありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/riii111/sabiql/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->