### PR TITLE
refactor: encapsulate app aggregates

### DIFF
--- a/src/app/cmd/render_schedule.rs
+++ b/src/app/cmd/render_schedule.rs
@@ -102,7 +102,7 @@ mod tests {
         #[test]
         fn er_waiting_returns_spinner_interval() {
             let mut state = create_test_state();
-            state.er_preparation.start_waiting_run();
+            let _ = state.er_preparation.start_waiting_run();
             let now = Instant::now();
 
             let deadline = next_animation_deadline(&state, now);
@@ -268,7 +268,7 @@ mod tests {
         #[test]
         fn er_waiting_returns_true() {
             let mut state = create_test_state();
-            state.er_preparation.start_waiting_run();
+            let _ = state.er_preparation.start_waiting_run();
 
             assert!(has_active_spinner(&state));
         }

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -689,7 +689,7 @@ mod tests {
                     .session
                     .select_table("public", "users", &mut state.query.pagination);
                 let generation = state.session.selection_generation();
-                state.session.set_dsn_for_test("dsn://test");
+                let _ = state.session.begin_connecting("dsn://test");
                 let run_id = state.session.begin_table_detail_run();
                 state.ui.set_inspector_scroll_offset(42);
 

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -570,7 +570,7 @@ mod tests {
         #[test]
         fn resets_er_preparation() {
             let mut state = prepare_state_for_reload();
-            state.er_preparation.start_waiting_run();
+            let _ = state.er_preparation.start_waiting_run();
 
             dispatch_metadata(&mut state, &Action::ReloadMetadata, Instant::now());
 
@@ -670,7 +670,7 @@ mod tests {
                 match status {
                     ErStatus::Idle => state.er_preparation.mark_idle(),
                     ErStatus::Waiting => {
-                        state.er_preparation.start_waiting_run();
+                        let _ = state.er_preparation.start_waiting_run();
                     }
                     ErStatus::Rendering => state.er_preparation.mark_rendering(),
                 }

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -538,7 +538,7 @@ mod tests {
 
         fn prepare_state_for_reload() -> AppState {
             let mut state = make_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
             state.sql_modal.enqueue_prefetch("public.users".to_string());
             state
@@ -689,7 +689,7 @@ mod tests {
                     .session
                     .select_table("public", "users", &mut state.query.pagination);
                 let generation = state.session.selection_generation();
-                let _ = state.session.begin_connecting("dsn://test");
+                state.session.set_dsn_for_test("dsn://test");
                 let run_id = state.session.begin_table_detail_run();
                 state.ui.set_inspector_scroll_offset(42);
 

--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -99,16 +99,16 @@ impl PaginationState {
         self.table.clear();
     }
 
-    pub fn reset_for_table(&mut self, schema: impl AsRef<str>, table: impl AsRef<str>) {
+    pub fn reset_for_table(&mut self, schema: &str, table: &str) {
         self.reset();
-        self.schema = schema.as_ref().to_string();
-        self.table = table.as_ref().to_string();
+        self.schema = schema.to_string();
+        self.table = table.to_string();
     }
 
     pub fn reset_for_table_with_estimate(
         &mut self,
-        schema: impl AsRef<str>,
-        table: impl AsRef<str>,
+        schema: &str,
+        table: &str,
         estimate: Option<i64>,
     ) {
         self.reset_for_table(schema, table);

--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -127,6 +127,8 @@ impl PaginationState {
         self.current_page = page;
     }
 
+    // Applying a query result replaces both the page and end-of-data flag so
+    // stale pagination state cannot survive a completed fetch.
     pub fn set_page_result(&mut self, page: usize, reached_end: bool) {
         self.current_page = page;
         self.reached_end = reached_end;
@@ -796,7 +798,7 @@ mod tests {
         }
 
         #[test]
-        fn allow_next_page_after_refresh_clears_reached_end_only() {
+        fn clear_reached_end_only_clears_that_flag() {
             let mut p = PaginationState {
                 current_page: 3,
                 reached_end: true,

--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -24,11 +24,11 @@ pub enum QueryStatus {
 
 #[derive(Debug, Clone, Default)]
 pub struct PaginationState {
-    pub(crate) current_page: usize,
-    pub(crate) total_rows_estimate: Option<i64>,
-    pub(crate) reached_end: bool,
-    pub(crate) schema: String,
-    pub(crate) table: String,
+    current_page: usize,
+    total_rows_estimate: Option<i64>,
+    reached_end: bool,
+    schema: String,
+    table: String,
 }
 
 impl PaginationState {
@@ -56,8 +56,24 @@ impl PaginationState {
         !self.table.is_empty()
     }
 
+    pub fn preview_label(&self) -> String {
+        if self.schema.is_empty() {
+            self.table.clone()
+        } else {
+            format!("{}.{}", self.schema, self.table)
+        }
+    }
+
     pub fn offset(&self) -> usize {
         self.current_page * PREVIEW_PAGE_SIZE
+    }
+
+    pub fn next_page(&self) -> usize {
+        self.current_page + 1
+    }
+
+    pub fn prev_page(&self) -> usize {
+        self.current_page.saturating_sub(1)
     }
 
     pub fn total_pages_estimate(&self) -> Option<usize> {
@@ -83,16 +99,16 @@ impl PaginationState {
         self.table.clear();
     }
 
-    pub fn reset_for_table(&mut self, schema: &str, table: &str) {
+    pub fn reset_for_table(&mut self, schema: impl AsRef<str>, table: impl AsRef<str>) {
         self.reset();
-        self.schema = schema.to_string();
-        self.table = table.to_string();
+        self.schema = schema.as_ref().to_string();
+        self.table = table.as_ref().to_string();
     }
 
     pub fn reset_for_table_with_estimate(
         &mut self,
-        schema: &str,
-        table: &str,
+        schema: impl AsRef<str>,
+        table: impl AsRef<str>,
         estimate: Option<i64>,
     ) {
         self.reset_for_table(schema, table);
@@ -103,34 +119,13 @@ impl PaginationState {
         self.reached_end = false;
     }
 
-    pub fn set_page_result(&mut self, page: usize, reached_end: bool) {
-        self.current_page = page;
-        self.reached_end = reached_end;
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_table_for_test(&mut self, schema: &str, table: &str) {
-        self.schema = schema.to_string();
-        self.table = table.to_string();
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_page_for_test(&mut self, page: usize) {
-        self.current_page = page;
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_total_rows_estimate_for_test(&mut self, estimate: Option<i64>) {
+    pub fn set_total_rows_estimate(&mut self, estimate: Option<i64>) {
         self.total_rows_estimate = estimate;
     }
 
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn mark_reached_end_for_test(&mut self) {
-        self.reached_end = true;
+    pub fn set_page_result(&mut self, page: usize, reached_end: bool) {
+        self.current_page = page;
+        self.reached_end = reached_end;
     }
 }
 

--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -56,7 +56,7 @@ impl PaginationState {
         !self.table.is_empty()
     }
 
-    pub fn preview_label(&self) -> String {
+    pub fn qualified_name(&self) -> String {
         if self.schema.is_empty() {
             self.table.clone()
         } else {
@@ -115,12 +115,16 @@ impl PaginationState {
         self.total_rows_estimate = estimate;
     }
 
-    pub fn allow_next_page_after_refresh(&mut self) {
+    pub fn clear_reached_end(&mut self) {
         self.reached_end = false;
     }
 
     pub fn set_total_rows_estimate(&mut self, estimate: Option<i64>) {
         self.total_rows_estimate = estimate;
+    }
+
+    pub fn set_current_page(&mut self, page: usize) {
+        self.current_page = page;
     }
 
     pub fn set_page_result(&mut self, page: usize, reached_end: bool) {
@@ -799,7 +803,7 @@ mod tests {
                 ..Default::default()
             };
 
-            p.allow_next_page_after_refresh();
+            p.clear_reached_end();
 
             assert_eq!(p.current_page(), 3);
             assert!(!p.reached_end());

--- a/src/app/model/browse/query_execution.rs
+++ b/src/app/model/browse/query_execution.rs
@@ -123,6 +123,8 @@ impl PaginationState {
         self.total_rows_estimate = estimate;
     }
 
+    // Use when navigation changes only the page index and must preserve the
+    // current end-of-data flag.
     pub fn set_current_page(&mut self, page: usize) {
         self.current_page = page;
     }

--- a/src/app/model/browse/result_interaction.rs
+++ b/src/app/model/browse/result_interaction.rs
@@ -12,16 +12,16 @@ use crate::policy::write::write_guardrails::WritePreview;
 // - Callers must restore `input_mode` themselves when leaving `CellEdit`.
 #[derive(Debug, Clone, Default)]
 pub struct ResultInteraction {
-    pub(crate) scroll_offset: usize,
-    pub(crate) horizontal_offset: usize,
-    pub(crate) yank_flash: Option<YankFlash>,
+    scroll_offset: usize,
+    horizontal_offset: usize,
+    yank_flash: Option<YankFlash>,
 
-    pub(crate) delete_op_pending: bool,
-    pub(crate) yank_op_pending: bool,
-    pub(crate) selection: ResultSelection,
-    pub(crate) cell_edit: CellEditState,
-    pub(crate) staged_delete_rows: BTreeSet<usize>,
-    pub(crate) pending_write_preview: Option<WritePreview>,
+    delete_op_pending: bool,
+    yank_op_pending: bool,
+    selection: ResultSelection,
+    cell_edit: CellEditState,
+    staged_delete_rows: BTreeSet<usize>,
+    pending_write_preview: Option<WritePreview>,
 }
 
 impl ResultInteraction {

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -27,27 +27,27 @@ use crate::model::shared::inspector_tab::InspectorTab;
 #[derive(Debug, Clone)]
 pub struct BrowseSession {
     // -- co-dependent: connection lifecycle --
-    pub(crate) connection_state: ConnectionState,
-    pub(crate) metadata_state: MetadataState,
+    connection_state: ConnectionState,
+    metadata_state: MetadataState,
 
     // -- co-dependent: table selection --
-    pub(crate) selected_table_key: Option<String>,
-    pub(crate) table_detail: Option<Table>,
-    pub(crate) selection_generation: u64,
+    selected_table_key: Option<String>,
+    table_detail: Option<Table>,
+    selection_generation: u64,
 
     // -- lifecycle-gated --
-    pub(crate) metadata: Option<Arc<DatabaseMetadata>>,
-    pub(crate) metadata_run: AsyncRun,
-    pub(crate) table_detail_run: AsyncRun,
+    metadata: Option<Arc<DatabaseMetadata>>,
+    metadata_run: AsyncRun,
+    table_detail_run: AsyncRun,
 
     // -- co-dependent: connection identity / lifecycle --
-    pub(crate) dsn: Option<String>,
-    pub(crate) active_connection_id: Option<ConnectionId>,
-    pub(crate) active_connection_name: Option<String>,
-    pub(crate) active_database_type: Option<DatabaseType>,
-    pub(crate) active_db_capabilities: DbCapabilities,
-    pub(crate) read_only: bool,
-    pub(crate) is_reloading: bool,
+    dsn: Option<String>,
+    active_connection_id: Option<ConnectionId>,
+    active_connection_name: Option<String>,
+    active_database_type: Option<DatabaseType>,
+    active_db_capabilities: DbCapabilities,
+    read_only: bool,
+    is_reloading: bool,
 }
 
 impl Default for BrowseSession {
@@ -142,6 +142,31 @@ impl BrowseSession {
         self.active_database_type = Some(database_type);
         self.active_db_capabilities = DbCapabilities::for_database_type(database_type);
         self.dsn = Some(dsn.to_string());
+    }
+
+    pub fn set_active_connection_identity(
+        &mut self,
+        id: &ConnectionId,
+        name: &str,
+        database_type: DatabaseType,
+    ) {
+        self.active_connection_id = Some(id.clone());
+        self.active_connection_name = Some(name.to_string());
+        self.active_database_type = Some(database_type);
+        self.active_db_capabilities = DbCapabilities::for_database_type(database_type);
+    }
+
+    pub fn set_active_database_type(&mut self, database_type: DatabaseType) {
+        self.active_database_type = Some(database_type);
+        self.active_db_capabilities = DbCapabilities::for_database_type(database_type);
+    }
+
+    pub fn clear_connection(&mut self) {
+        self.dsn = None;
+        self.active_connection_id = None;
+        self.active_connection_name = None;
+        self.active_database_type = None;
+        self.active_db_capabilities = DbCapabilities::disconnected();
     }
 
     pub fn mark_connected(&mut self, metadata: Arc<DatabaseMetadata>) {
@@ -266,11 +291,7 @@ impl BrowseSession {
         self.metadata_state = MetadataState::default();
         self.metadata_run.clear_active();
         self.table_detail_run.clear_active();
-        self.dsn = None;
-        self.active_connection_id = None;
-        self.active_connection_name = None;
-        self.active_database_type = None;
-        self.active_db_capabilities = DbCapabilities::disconnected();
+        self.clear_connection();
         self.read_only = false;
         self.is_reloading = false;
         query.pagination.reset();
@@ -311,6 +332,14 @@ impl BrowseSession {
 
     pub fn dsn(&self) -> Option<&str> {
         self.dsn.as_deref()
+    }
+
+    pub fn dsn_owned(&self) -> Option<String> {
+        self.dsn.clone()
+    }
+
+    pub fn dsn_matches(&self, expected: &str) -> bool {
+        self.dsn() == Some(expected)
     }
 
     pub fn active_connection_id(&self) -> Option<&ConnectionId> {
@@ -373,39 +402,6 @@ impl BrowseSession {
     #[cfg(test)]
     pub(crate) fn set_selection_generation(&mut self, value: u64) {
         self.selection_generation = value;
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_dsn_for_test(&mut self, dsn: impl Into<String>) {
-        self.dsn = Some(dsn.into());
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn clear_dsn_for_test(&mut self) {
-        self.dsn = None;
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_active_connection_id_for_test(&mut self, id: Option<ConnectionId>) {
-        self.active_connection_id = id;
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_active_connection_name_for_test(&mut self, name: Option<String>) {
-        self.active_connection_name = name;
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_active_database_type_for_test(&mut self, database_type: Option<DatabaseType>) {
-        self.active_database_type = database_type;
-        self.active_db_capabilities = database_type
-            .map(DbCapabilities::for_database_type)
-            .unwrap_or_else(DbCapabilities::disconnected);
     }
 }
 
@@ -495,10 +491,10 @@ mod tests {
         fn resets_pagination() {
             let mut session = BrowseSession::default();
             let mut pagination = PaginationState::default();
-            pagination.set_page_for_test(5);
-            pagination.set_total_rows_estimate_for_test(Some(10000));
-            pagination.mark_reached_end_for_test();
-            pagination.set_table_for_test("old", "old");
+            pagination.set_page_result(5, pagination.reached_end());
+            pagination.set_total_rows_estimate(Some(10000));
+            pagination.set_page_result(pagination.current_page(), true);
+            pagination.reset_for_table("old", "old");
 
             let _ = session.select_table("public", "users", &mut pagination);
 
@@ -590,7 +586,7 @@ mod tests {
         #[test]
         fn mark_connecting_sets_pair_without_changing_dsn() {
             let mut session = BrowseSession::default();
-            session.set_dsn_for_test("postgres://localhost/test");
+            let _ = session.begin_connecting("postgres://localhost/test");
 
             session.mark_connecting();
 
@@ -770,20 +766,24 @@ mod tests {
         fn clears_session_and_query_state() {
             let mut session = BrowseSession::default();
             session.mark_connected(make_metadata("db"));
-            session.set_dsn_for_test("postgres://host/db");
-            session.set_active_connection_id_for_test(Some(ConnectionId::new()));
-            session.set_active_connection_name_for_test(Some("mydb".to_string()));
-            session.set_active_database_type_for_test(Some(DatabaseType::PostgreSQL));
+            session.set_active_connection(
+                &ConnectionId::new(),
+                "mydb",
+                DatabaseType::PostgreSQL,
+                "postgres://host/db",
+            );
             session.enable_read_only();
             let _ = session.begin_reload();
             let mut query = QueryExecution::default();
             query.set_current_result(make_query_result());
-            query.pagination.set_page_for_test(3);
             query
                 .pagination
-                .set_total_rows_estimate_for_test(Some(1000));
-            query.pagination.mark_reached_end_for_test();
-            query.pagination.set_table_for_test("public", "users");
+                .set_page_result(3, query.pagination.reached_end());
+            query.pagination.set_total_rows_estimate(Some(1000));
+            query
+                .pagination
+                .set_page_result(query.pagination.current_page(), true);
+            query.pagination.reset_for_table("public", "users");
             query.enter_history(2);
 
             session.reset(&mut query);

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -146,7 +146,9 @@ impl BrowseSession {
         self.dsn = Some(dsn.to_string());
     }
 
-    pub fn set_active_connection_identity(
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_active_connection_identity_for_test(
         &mut self,
         id: &ConnectionId,
         name: &str,

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -334,10 +334,6 @@ impl BrowseSession {
         self.dsn.as_deref()
     }
 
-    pub fn dsn_owned(&self) -> Option<String> {
-        self.dsn.clone()
-    }
-
     pub fn dsn_matches(&self, expected: &str) -> bool {
         self.dsn() == Some(expected)
     }
@@ -402,6 +398,12 @@ impl BrowseSession {
     #[cfg(test)]
     pub(crate) fn set_selection_generation(&mut self, value: u64) {
         self.selection_generation = value;
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_dsn_for_test(&mut self, dsn: impl Into<String>) {
+        self.dsn = Some(dsn.into());
     }
 }
 
@@ -491,10 +493,9 @@ mod tests {
         fn resets_pagination() {
             let mut session = BrowseSession::default();
             let mut pagination = PaginationState::default();
-            pagination.set_page_result(5, pagination.reached_end());
-            pagination.set_total_rows_estimate(Some(10000));
-            pagination.set_page_result(pagination.current_page(), true);
             pagination.reset_for_table("old", "old");
+            pagination.set_total_rows_estimate(Some(10000));
+            pagination.set_page_result(5, true);
 
             let _ = session.select_table("public", "users", &mut pagination);
 
@@ -586,7 +587,7 @@ mod tests {
         #[test]
         fn mark_connecting_sets_pair_without_changing_dsn() {
             let mut session = BrowseSession::default();
-            let _ = session.begin_connecting("postgres://localhost/test");
+            session.set_dsn_for_test("postgres://localhost/test");
 
             session.mark_connecting();
 
@@ -776,14 +777,9 @@ mod tests {
             let _ = session.begin_reload();
             let mut query = QueryExecution::default();
             query.set_current_result(make_query_result());
-            query
-                .pagination
-                .set_page_result(3, query.pagination.reached_end());
-            query.pagination.set_total_rows_estimate(Some(1000));
-            query
-                .pagination
-                .set_page_result(query.pagination.current_page(), true);
             query.pagination.reset_for_table("public", "users");
+            query.pagination.set_total_rows_estimate(Some(1000));
+            query.pagination.set_page_result(3, true);
             query.enter_history(2);
 
             session.reset(&mut query);

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -160,7 +160,9 @@ impl BrowseSession {
         self.active_db_capabilities = DbCapabilities::for_database_type(database_type);
     }
 
-    pub fn set_active_database_type(&mut self, database_type: DatabaseType) {
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn set_active_database_type_for_test(&mut self, database_type: DatabaseType) {
         self.active_database_type = Some(database_type);
         self.active_db_capabilities = DbCapabilities::for_database_type(database_type);
     }
@@ -338,6 +340,8 @@ impl BrowseSession {
         self.dsn.as_deref()
     }
 
+    // Async completion reducers use this guard with run ids to reject stale
+    // effects from a previous connection.
     pub fn dsn_matches(&self, expected: &str) -> bool {
         self.dsn() == Some(expected)
     }

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -18,12 +18,14 @@ use crate::model::shared::inspector_tab::InspectorTab;
 // - `selected_table_key`, `table_detail`, and `selection_generation` change
 //   together via `select_table` / `clear_table_selection`.
 // - `database_name` is derived from `metadata` (single source of truth).
+// - Cache restore for a connection exits transient reload/read-only state.
 //
 // # Transitional raw setters
 //
-// `set_metadata`, `set_table_detail_raw`, `set_connection_state`,
-// `set_metadata_state` are `pub(crate)` for reducers where the aggregate API
-// does not cover the exact semantics needed (e.g. ER refresh, reload).
+// `set_metadata` and `set_table_detail_raw` are `pub(crate)` for reducers
+// where the aggregate API does not cover the exact semantics needed.
+// `set_connection_state` and `set_metadata_state` are test-only lifecycle
+// fixtures.
 #[derive(Debug, Clone)]
 pub struct BrowseSession {
     // -- co-dependent: connection lifecycle --
@@ -130,7 +132,7 @@ impl BrowseSession {
         self.begin_metadata_run()
     }
 
-    pub fn set_active_connection(
+    pub fn set_active_connection_with_dsn(
         &mut self,
         id: &ConnectionId,
         name: &str,
@@ -277,7 +279,7 @@ impl BrowseSession {
         dsn: &str,
     ) {
         self.restore_from_cache(cache, query);
-        self.set_active_connection(id, name, database_type, dsn);
+        self.set_active_connection_with_dsn(id, name, database_type, dsn);
         self.disable_read_only();
     }
 
@@ -767,7 +769,7 @@ mod tests {
         fn clears_session_and_query_state() {
             let mut session = BrowseSession::default();
             session.mark_connected(make_metadata("db"));
-            session.set_active_connection(
+            session.set_active_connection_with_dsn(
                 &ConnectionId::new(),
                 "mydb",
                 DatabaseType::PostgreSQL,

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -115,6 +115,7 @@ impl ErPreparationState {
     pub fn on_table_cached(&mut self, qualified_name: &str) {
         self.fetching_tables.remove(qualified_name);
         self.pending_tables.remove(qualified_name);
+        self.failed_tables.remove(qualified_name);
     }
 
     pub fn on_table_failed(&mut self, qualified_name: &str, error: String) {
@@ -263,13 +264,6 @@ impl ErPreparationState {
         self.fetching_tables.remove(&table);
         self.failed_tables.remove(&table);
         self.pending_tables.insert(table)
-    }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn insert_fetching_table(&mut self, table: String) {
-        self.pending_tables.remove(&table);
-        self.fetching_tables.insert(table);
     }
 }
 

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -12,15 +12,15 @@ pub enum ErStatus {
 
 #[derive(Debug, Clone, Default)]
 pub struct ErPreparationState {
-    pub pending_tables: HashSet<String>,
-    pub fetching_tables: HashSet<String>,
-    pub failed_tables: HashMap<String, String>,
-    pub status: ErStatus,
-    pub total_tables: usize,
-    pub target_tables: Vec<String>,
-    pub seed_tables: Vec<String>,
-    pub fk_expanded: bool,
-    pub last_signatures: HashMap<String, String>,
+    pending_tables: HashSet<String>,
+    fetching_tables: HashSet<String>,
+    failed_tables: HashMap<String, String>,
+    status: ErStatus,
+    total_tables: usize,
+    target_tables: Vec<String>,
+    seed_tables: Vec<String>,
+    fk_expanded: bool,
+    last_signatures: HashMap<String, String>,
     run: AsyncRun,
 }
 
@@ -35,6 +35,10 @@ pub struct ErPreparationProgress {
 impl ErPreparationState {
     pub fn status(&self) -> ErStatus {
         self.status
+    }
+
+    pub fn is_waiting(&self) -> bool {
+        self.status == ErStatus::Waiting
     }
 
     pub fn progress(&self) -> ErPreparationProgress {
@@ -82,6 +86,10 @@ impl ErPreparationState {
 
     pub fn target_tables(&self) -> &[String] {
         &self.target_tables
+    }
+
+    pub fn target_tables_owned(&self) -> Vec<String> {
+        self.target_tables.clone()
     }
 
     pub fn seed_tables(&self) -> &[String] {
@@ -166,6 +174,10 @@ impl ErPreparationState {
         self.status = ErStatus::Idle;
     }
 
+    pub fn mark_waiting(&mut self) {
+        self.status = ErStatus::Waiting;
+    }
+
     pub fn begin_smart_refresh(&mut self) -> u64 {
         let run_id = self.run.begin();
         self.status = ErStatus::Waiting;
@@ -226,6 +238,10 @@ impl ErPreparationState {
         self.fk_expanded = true;
     }
 
+    pub fn mark_fk_unexpanded(&mut self) {
+        self.fk_expanded = false;
+    }
+
     pub fn apply_refresh_metadata(
         &mut self,
         signatures: HashMap<String, String>,
@@ -240,14 +256,22 @@ impl ErPreparationState {
         self.total_tables = total_tables;
     }
 
+    pub fn scoped_fallback_tables(&self, total_table_count: usize) -> Option<Vec<String>> {
+        if !self.target_tables.is_empty() && self.target_tables.len() < total_table_count {
+            Some(self.target_tables.clone())
+        } else {
+            None
+        }
+    }
+
     pub fn clear_table_tracking(&mut self) {
         self.pending_tables.clear();
         self.fetching_tables.clear();
         self.failed_tables.clear();
     }
 
-    pub fn insert_pending_table(&mut self, table: String) {
-        self.pending_tables.insert(table);
+    pub fn insert_pending_table(&mut self, table: String) -> bool {
+        self.pending_tables.insert(table)
     }
 
     pub fn remove_pending_table(&mut self, table: &str) {

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -257,6 +257,8 @@ impl ErPreparationState {
         self.failed_tables.clear();
     }
 
+    // Re-queueing a table starts a fresh attempt and clears any prior failure
+    // record for that table.
     pub fn queue_pending_table(&mut self, table: String) -> bool {
         self.fetching_tables.remove(&table);
         self.failed_tables.remove(&table);
@@ -267,7 +269,6 @@ impl ErPreparationState {
     #[doc(hidden)]
     pub fn insert_fetching_table(&mut self, table: String) {
         self.pending_tables.remove(&table);
-        self.failed_tables.remove(&table);
         self.fetching_tables.insert(table);
     }
 }

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -88,10 +88,6 @@ impl ErPreparationState {
         &self.target_tables
     }
 
-    pub fn target_tables_owned(&self) -> Vec<String> {
-        self.target_tables.clone()
-    }
-
     pub fn seed_tables(&self) -> &[String] {
         &self.seed_tables
     }

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -174,12 +174,6 @@ impl ErPreparationState {
         self.status = ErStatus::Waiting;
     }
 
-    pub fn begin_smart_refresh(&mut self) -> u64 {
-        let run_id = self.run.begin();
-        self.status = ErStatus::Waiting;
-        run_id
-    }
-
     pub fn is_current_run(&self, run_id: u64) -> bool {
         self.run.is_current(run_id)
     }
@@ -190,10 +184,6 @@ impl ErPreparationState {
 
     pub fn can_generate_from_cache(&self) -> bool {
         matches!(self.status, ErStatus::Idle | ErStatus::Waiting)
-    }
-
-    pub fn begin_rendering(&mut self) {
-        self.status = ErStatus::Rendering;
     }
 
     pub fn reset(&mut self) {
@@ -213,6 +203,7 @@ impl ErPreparationState {
         self.status = ErStatus::Rendering;
     }
 
+    #[must_use]
     pub fn start_waiting_run(&mut self) -> u64 {
         let run_id = self.run.begin();
         self.status = ErStatus::Waiting;
@@ -260,21 +251,23 @@ impl ErPreparationState {
         }
     }
 
-    pub fn clear_table_tracking(&mut self) {
+    fn clear_table_tracking(&mut self) {
         self.pending_tables.clear();
         self.fetching_tables.clear();
         self.failed_tables.clear();
     }
 
-    pub fn insert_pending_table(&mut self, table: String) -> bool {
+    pub fn queue_pending_table(&mut self, table: String) -> bool {
+        self.fetching_tables.remove(&table);
+        self.failed_tables.remove(&table);
         self.pending_tables.insert(table)
     }
 
-    pub fn remove_pending_table(&mut self, table: &str) {
-        self.pending_tables.remove(table);
-    }
-
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn insert_fetching_table(&mut self, table: String) {
+        self.pending_tables.remove(&table);
+        self.failed_tables.remove(&table);
         self.fetching_tables.insert(table);
     }
 }
@@ -285,7 +278,7 @@ mod tests {
 
     fn set_active_run_id(state: &mut ErPreparationState, run_id: u64) {
         for _ in 0..run_id {
-            state.begin_smart_refresh();
+            let _ = state.start_waiting_run();
         }
         state.mark_idle();
     }

--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -25,7 +25,7 @@ pub(super) fn reduce_er_neighbors(state: &mut AppState, action: &Action) -> Disp
             for qualified_name in tables {
                 let is_new_pending = state
                     .er_preparation
-                    .insert_pending_table(qualified_name.clone());
+                    .queue_pending_table(qualified_name.clone());
                 let already_fetching = state.sql_modal.prefetching_tables.contains(qualified_name);
                 let already_queued = state.sql_modal.prefetch_queue.contains(qualified_name);
 

--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -8,14 +8,14 @@ use super::check_er_completion;
 pub(super) fn reduce_er_neighbors(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::ExpandPrefetchWithFkNeighbors => {
-            let seed_tables = state.er_preparation.seed_tables.clone();
+            let seed_tables = state.er_preparation.seed_tables().to_vec();
             DispatchResult::handled_with(vec![Effect::ExtractFkNeighbors { seed_tables }])
         }
         Action::FkNeighborsDiscovered { tables } => {
             let Some(run_id) = state.sql_modal.active_prefetch_run_id() else {
                 return DispatchResult::handled();
             };
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.mark_fk_expanded();
 
             if tables.is_empty() {
                 // No new neighbors — proceed to generate with what we have
@@ -25,8 +25,7 @@ pub(super) fn reduce_er_neighbors(state: &mut AppState, action: &Action) -> Disp
             for qualified_name in tables {
                 let is_new_pending = state
                     .er_preparation
-                    .pending_tables
-                    .insert(qualified_name.clone());
+                    .insert_pending_table(qualified_name.clone());
                 let already_fetching = state.sql_modal.prefetching_tables.contains(qualified_name);
                 let already_queued = state.sql_modal.prefetch_queue.contains(qualified_name);
 

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -120,7 +120,7 @@ pub(super) fn reduce_loading(
             DispatchResult::handled()
         }
         Action::LoadMetadata => {
-            if let Some(dsn) = state.session.dsn_owned() {
+            if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.session.begin_metadata_refresh();
                 DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
             } else {
@@ -128,7 +128,7 @@ pub(super) fn reduce_loading(
             }
         }
         Action::ReloadMetadata => {
-            if let Some(dsn) = state.session.dsn_owned() {
+            if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.session.begin_reload();
                 state.sql_modal.reset_prefetch();
                 state.er_preparation.reset();

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -21,9 +21,7 @@ pub(super) fn reduce_loading(
             run_id,
             metadata,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.session.is_current_metadata_run(*run_id)
-            {
+            if !state.session.dsn_matches(dsn) || !state.session.is_current_metadata_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -32,41 +30,41 @@ pub(super) fn reduce_loading(
 
             let mut effects = vec![];
 
-            if state.query.pagination.table.is_empty() {
+            if state.query.pagination.table().is_empty() {
                 state
                     .ui
                     .set_explorer_selection(if has_tables { Some(0) } else { None });
             } else {
-                let prev_schema = &state.query.pagination.schema;
-                let prev_table = &state.query.pagination.table;
+                let prev_schema = state.query.pagination.schema();
+                let prev_table = state.query.pagination.table();
                 let found_index = metadata
                     .table_summaries
                     .iter()
-                    .position(|t| &t.schema == prev_schema && &t.name == prev_table);
+                    .position(|t| t.schema == prev_schema && t.name == prev_table);
                 if let Some(idx) = found_index {
                     state.ui.set_explorer_selection(Some(idx));
                     // Refresh preview and detail: DDL or reload may have changed
                     // data/schema even though the table still exists.
                     let dsn = dsn.clone();
-                    let page = state.query.pagination.current_page;
+                    let page = state.query.pagination.current_page();
                     let generation = state.session.selection_generation();
                     let query_run_id = state.query.begin_running(now);
                     let detail_run_id = state.session.begin_table_detail_run();
                     effects.push(Effect::ExecutePreview {
                         dsn: dsn.clone(),
-                        schema: state.query.pagination.schema.clone(),
-                        table: state.query.pagination.table.clone(),
+                        schema: state.query.pagination.schema().to_string(),
+                        table: state.query.pagination.table().to_string(),
                         generation,
                         run_id: query_run_id,
                         limit: PREVIEW_PAGE_SIZE,
                         offset: page * PREVIEW_PAGE_SIZE,
                         target_page: page,
-                        read_only: state.session.read_only,
+                        read_only: state.session.is_read_only(),
                     });
                     effects.push(Effect::FetchTableDetail {
                         dsn,
-                        schema: state.query.pagination.schema.clone(),
-                        table: state.query.pagination.table.clone(),
+                        schema: state.query.pagination.schema().to_string(),
+                        table: state.query.pagination.table().to_string(),
                         generation,
                         run_id: detail_run_id,
                     });
@@ -85,7 +83,7 @@ pub(super) fn reduce_loading(
 
             state.connection_error.clear();
 
-            if state.session.is_reloading {
+            if state.session.is_reloading() {
                 state.messages.set_success_at("Reloaded!".to_string(), now);
                 state.session.finish_reload();
             }
@@ -105,9 +103,7 @@ pub(super) fn reduce_loading(
             DispatchResult::handled_with(effects)
         }
         Action::MetadataFailed { dsn, run_id, error } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.session.is_current_metadata_run(*run_id)
-            {
+            if !state.session.dsn_matches(dsn) || !state.session.is_current_metadata_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -118,13 +114,13 @@ pub(super) fn reduce_loading(
             if !was_connected {
                 state.modal.replace_mode(InputMode::ConnectionError);
             }
-            if state.er_preparation.status == ErStatus::Waiting {
+            if state.er_preparation.status() == ErStatus::Waiting {
                 state.er_preparation.mark_idle();
             }
             DispatchResult::handled()
         }
         Action::LoadMetadata => {
-            if let Some(dsn) = state.session.dsn.clone() {
+            if let Some(dsn) = state.session.dsn_owned() {
                 let run_id = state.session.begin_metadata_refresh();
                 DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
             } else {
@@ -132,7 +128,7 @@ pub(super) fn reduce_loading(
             }
         }
         Action::ReloadMetadata => {
-            if let Some(dsn) = state.session.dsn.clone() {
+            if let Some(dsn) = state.session.dsn_owned() {
                 let run_id = state.session.begin_reload();
                 state.sql_modal.reset_prefetch();
                 state.er_preparation.reset();

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -12,28 +12,23 @@ use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
-    if state.er_preparation.status != ErStatus::Waiting || !state.er_preparation.is_complete() {
+    if state.er_preparation.status() != ErStatus::Waiting || !state.er_preparation.is_complete() {
         return vec![];
     }
 
-    if !state.er_preparation.fk_expanded {
+    if !state.er_preparation.fk_expanded() {
         return vec![Effect::DispatchActions(vec![
             Action::ExpandPrefetchWithFkNeighbors,
         ])];
     }
 
     if !state.er_preparation.has_failures() {
-        state.er_preparation.status = ErStatus::Idle;
+        state.er_preparation.mark_idle();
         return vec![Effect::DispatchActions(vec![Action::ErGenerateFromCache])];
     }
 
-    state.er_preparation.status = ErStatus::Idle;
-    let failed_data: Vec<(String, String)> = state
-        .er_preparation
-        .failed_tables
-        .iter()
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
+    state.er_preparation.mark_idle();
+    let failed_data: Vec<(String, String)> = state.er_preparation.failed_table_errors();
     state.set_error(format!(
         "ER failed: {} table(s) failed. 'e' to retry.",
         failed_data.len()
@@ -62,7 +57,7 @@ mod tests {
 
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
-        state.session.dsn = Some(dsn.to_string());
+        let _ = state.session.begin_connecting(dsn);
         state
     }
 
@@ -245,10 +240,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             let run_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
-            state
-                .er_preparation
-                .pending_tables
-                .insert(qualified.clone());
+            state.er_preparation.insert_pending_table(qualified.clone());
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -264,8 +256,8 @@ mod tests {
             assert!(effects.is_empty());
             assert_eq!(state.sql_modal.prefetch_queue.front(), Some(&qualified));
             assert!(!state.sql_modal.prefetching_tables.contains(&qualified));
-            assert!(!state.er_preparation.fetching_tables.contains(&qualified));
-            assert!(state.er_preparation.pending_tables.contains(&qualified));
+            assert!(!state.er_preparation.fetching_tables().contains(&qualified));
+            assert!(state.er_preparation.pending_tables().contains(&qualified));
         }
 
         #[test]
@@ -273,10 +265,7 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
-            state
-                .er_preparation
-                .pending_tables
-                .insert(qualified.clone());
+            state.er_preparation.insert_pending_table(qualified.clone());
             state.sql_modal.failed_prefetch_tables.insert(
                 qualified.clone(),
                 FailedPrefetchEntry {
@@ -297,22 +286,24 @@ mod tests {
             );
 
             assert!(!state.sql_modal.prefetch_queue.contains(&qualified));
-            assert!(state.er_preparation.failed_tables.contains_key(&qualified));
-            assert!(!state.er_preparation.pending_tables.contains(&qualified));
+            assert!(
+                state
+                    .er_preparation
+                    .failed_tables()
+                    .contains_key(&qualified)
+            );
+            assert!(!state.er_preparation.pending_tables().contains(&qualified));
         }
 
         #[test]
         fn retry_limit_exceeded_as_last_table_triggers_er_completion() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
             // Only table remaining; retry limit exceeded
-            state
-                .er_preparation
-                .pending_tables
-                .insert(qualified.clone());
+            state.er_preparation.insert_pending_table(qualified.clone());
             state.sql_modal.failed_prefetch_tables.insert(
                 qualified,
                 FailedPrefetchEntry {
@@ -333,7 +324,7 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(
                 effects
                     .iter()
@@ -345,16 +336,13 @@ mod tests {
         fn retry_limit_exceeded_with_queue_remaining_redrives_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_fk_expanded();
             let failed = "public.users".to_string();
             let remaining = "public.posts".to_string();
             // users exhausted retries; posts still awaiting in queue
-            state.er_preparation.pending_tables.insert(failed.clone());
-            state
-                .er_preparation
-                .pending_tables
-                .insert(remaining.clone());
+            state.er_preparation.insert_pending_table(failed.clone());
+            state.er_preparation.insert_pending_table(remaining.clone());
             state.sql_modal.prefetch_queue.push_back(remaining);
             state.sql_modal.failed_prefetch_tables.insert(
                 failed,
@@ -381,7 +369,7 @@ mod tests {
                     .iter()
                     .any(|e| matches!(e, Effect::ProcessPrefetchQueue { .. }))
             );
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
         }
 
         #[test]
@@ -422,7 +410,6 @@ mod tests {
 
     mod table_detail_cache_failed {
         use super::*;
-        use crate::model::er_state::ErStatus;
         use crate::ports::outbound::DbOperationError;
 
         #[test]
@@ -501,8 +488,7 @@ mod tests {
             state.sql_modal.prefetching_tables.insert(qualified.clone());
             state
                 .er_preparation
-                .fetching_tables
-                .insert(qualified.clone());
+                .insert_fetching_table(qualified.clone());
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -518,9 +504,14 @@ mod tests {
             .unwrap();
 
             assert_eq!(state.sql_modal.prefetch_queue.back(), Some(&qualified));
-            assert!(state.er_preparation.pending_tables.contains(&qualified));
-            assert!(!state.er_preparation.fetching_tables.contains(&qualified));
-            assert!(!state.er_preparation.failed_tables.contains_key(&qualified));
+            assert!(state.er_preparation.pending_tables().contains(&qualified));
+            assert!(!state.er_preparation.fetching_tables().contains(&qualified));
+            assert!(
+                !state
+                    .er_preparation
+                    .failed_tables()
+                    .contains_key(&qualified)
+            );
             assert!(
                 effects
                     .iter()
@@ -541,7 +532,7 @@ mod tests {
             let queued = "public.posts".to_string();
             state.sql_modal.prefetching_tables.insert(failed.clone());
             state.sql_modal.prefetch_queue.push_back(queued);
-            state.er_preparation.fetching_tables.insert(failed);
+            state.er_preparation.insert_fetching_table(failed);
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -572,14 +563,13 @@ mod tests {
         fn transient_failure_then_success_clears_er_failure_state() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
             state.sql_modal.prefetching_tables.insert(qualified.clone());
             state
                 .er_preparation
-                .fetching_tables
-                .insert(qualified.clone());
+                .insert_fetching_table(qualified.clone());
 
             dispatch_metadata(
                 &mut state,
@@ -593,11 +583,10 @@ mod tests {
                 Instant::now(),
             );
             state.sql_modal.prefetch_queue.clear();
-            state.er_preparation.pending_tables.remove(&qualified);
+            state.er_preparation.remove_pending_table(&qualified);
             state
                 .er_preparation
-                .fetching_tables
-                .insert(qualified.clone());
+                .insert_fetching_table(qualified.clone());
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -612,7 +601,7 @@ mod tests {
             )
             .unwrap();
 
-            assert!(state.er_preparation.failed_tables.is_empty());
+            assert!(state.er_preparation.failed_tables().is_empty());
             assert!(
                 effects
                     .iter()
@@ -680,7 +669,7 @@ mod tests {
             let action = metadata_loaded_action(&mut state, metadata);
             dispatch_metadata(&mut state, &action, Instant::now());
 
-            assert!(state.query.pagination.table.is_empty());
+            assert!(state.query.pagination.table().is_empty());
             assert!(state.query.current_result().is_none());
             assert!(state.session.table_detail().is_none());
             assert!(state.session.selected_table_key().is_none());
@@ -690,15 +679,14 @@ mod tests {
         #[test]
         fn table_still_exists_preserves_pagination_and_emits_refresh_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.reset_for_table("public", "users");
 
             // "orders" comes before "users" alphabetically, so "users" → index 1
             let metadata = make_metadata(vec![("public", "orders"), ("public", "users")]);
             let action = metadata_loaded_action(&mut state, metadata);
             let effects = dispatch_metadata(&mut state, &action, Instant::now()).unwrap();
 
-            assert_eq!(state.query.pagination.table, "users");
+            assert_eq!(state.query.pagination.table(), "users");
             assert_eq!(state.ui.explorer_selected, 1);
             assert!(
                 effects
@@ -803,7 +791,7 @@ mod tests {
 
             dispatch_metadata(&mut state, &Action::StartPrefetchAll, Instant::now());
 
-            assert!(state.er_preparation.fk_expanded);
+            assert!(state.er_preparation.fk_expanded());
         }
     }
 
@@ -816,8 +804,7 @@ mod tests {
             let _ = state.sql_modal.begin_prefetch();
             state
                 .er_preparation
-                .pending_tables
-                .insert("public.users".to_string());
+                .insert_pending_table("public.users".to_string());
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -829,7 +816,12 @@ mod tests {
             .unwrap();
 
             // In-progress prefetch must not be silently reset
-            assert!(state.er_preparation.pending_tables.contains("public.users"));
+            assert!(
+                state
+                    .er_preparation
+                    .pending_tables()
+                    .contains("public.users")
+            );
             assert!(effects.is_empty());
         }
 
@@ -848,15 +840,20 @@ mod tests {
             .unwrap();
 
             assert_eq!(state.sql_modal.prefetch_queue.len(), 2);
-            assert!(state.er_preparation.pending_tables.contains("public.users"));
             assert!(
                 state
                     .er_preparation
-                    .pending_tables
+                    .pending_tables()
+                    .contains("public.users")
+            );
+            assert!(
+                state
+                    .er_preparation
+                    .pending_tables()
                     .contains("public.orders")
             );
-            assert!(!state.er_preparation.fk_expanded);
-            assert_eq!(state.er_preparation.seed_tables, tables);
+            assert!(!state.er_preparation.fk_expanded());
+            assert_eq!(state.er_preparation.seed_tables(), tables);
             assert!(
                 effects
                     .iter()
@@ -867,13 +864,12 @@ mod tests {
 
     mod completion_check {
         use super::*;
-        use crate::model::er_state::ErStatus;
 
         #[test]
         fn complete_not_fk_expanded_dispatches_expand() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.fk_expanded = false;
+            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_fk_unexpanded();
             // pending and fetching are empty → is_complete() = true
 
             let effects = check_er_completion(&mut state);
@@ -888,8 +884,8 @@ mod tests {
         #[test]
         fn complete_fk_expanded_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_fk_expanded();
 
             let effects = check_er_completion(&mut state);
 
@@ -910,7 +906,7 @@ mod tests {
         fn empty_neighbors_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -919,7 +915,7 @@ mod tests {
             )
             .unwrap();
 
-            assert!(state.er_preparation.fk_expanded);
+            assert!(state.er_preparation.fk_expanded());
             assert!(effects.iter().any(|e| matches!(
                 e,
                 Effect::DispatchActions(actions)
@@ -931,7 +927,7 @@ mod tests {
         fn non_empty_neighbors_adds_to_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -942,9 +938,19 @@ mod tests {
             )
             .unwrap();
 
-            assert!(state.er_preparation.fk_expanded);
-            assert!(state.er_preparation.pending_tables.contains("public.posts"));
-            assert!(state.er_preparation.pending_tables.contains("public.tags"));
+            assert!(state.er_preparation.fk_expanded());
+            assert!(
+                state
+                    .er_preparation
+                    .pending_tables()
+                    .contains("public.posts")
+            );
+            assert!(
+                state
+                    .er_preparation
+                    .pending_tables()
+                    .contains("public.tags")
+            );
             assert_eq!(state.sql_modal.prefetch_queue.len(), 2);
             assert!(
                 effects
@@ -956,7 +962,7 @@ mod tests {
         #[test]
         fn stale_neighbors_without_active_run_do_not_mutate_state() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -967,8 +973,8 @@ mod tests {
             )
             .unwrap();
 
-            assert!(!state.er_preparation.fk_expanded);
-            assert!(state.er_preparation.pending_tables.is_empty());
+            assert!(!state.er_preparation.fk_expanded());
+            assert!(state.er_preparation.pending_tables().is_empty());
             assert!(state.sql_modal.prefetch_queue.is_empty());
             assert!(effects.is_empty());
         }
@@ -977,11 +983,10 @@ mod tests {
         fn duplicate_neighbors_are_not_requeued() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state
                 .er_preparation
-                .pending_tables
-                .insert("public.posts".to_string());
+                .insert_pending_table("public.posts".to_string());
             state
                 .sql_modal
                 .prefetch_queue
@@ -1032,10 +1037,10 @@ mod tests {
             // All Phase 2 tables fail → completion must still fire
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_fk_expanded();
             let neighbor = "public.posts".to_string();
-            state.er_preparation.pending_tables.insert(neighbor.clone());
+            state.er_preparation.insert_pending_table(neighbor.clone());
             state.sql_modal.failed_prefetch_tables.insert(
                 neighbor,
                 FailedPrefetchEntry {
@@ -1056,7 +1061,7 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(
                 effects
                     .iter()

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -486,9 +486,7 @@ mod tests {
             let run_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
             state.sql_modal.prefetching_tables.insert(qualified.clone());
-            state
-                .er_preparation
-                .insert_fetching_table(qualified.clone());
+            state.er_preparation.start_fetching(&qualified);
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -532,7 +530,7 @@ mod tests {
             let queued = "public.posts".to_string();
             state.sql_modal.prefetching_tables.insert(failed.clone());
             state.sql_modal.prefetch_queue.push_back(queued);
-            state.er_preparation.insert_fetching_table(failed);
+            state.er_preparation.start_fetching(&failed);
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -567,9 +565,7 @@ mod tests {
             state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
             state.sql_modal.prefetching_tables.insert(qualified.clone());
-            state
-                .er_preparation
-                .insert_fetching_table(qualified.clone());
+            state.er_preparation.start_fetching(&qualified);
 
             dispatch_metadata(
                 &mut state,
@@ -585,7 +581,9 @@ mod tests {
             state.sql_modal.prefetch_queue.clear();
             state
                 .er_preparation
-                .insert_fetching_table(qualified.clone());
+                .on_table_failed(&qualified, "timed out".to_string());
+            assert!(!state.er_preparation.failed_tables().is_empty());
+            state.er_preparation.start_fetching(&qualified);
 
             let effects = dispatch_metadata(
                 &mut state,

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -240,7 +240,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             let run_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
-            state.er_preparation.insert_pending_table(qualified.clone());
+            state.er_preparation.queue_pending_table(qualified.clone());
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -265,7 +265,7 @@ mod tests {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             let qualified = "public.users".to_string();
-            state.er_preparation.insert_pending_table(qualified.clone());
+            state.er_preparation.queue_pending_table(qualified.clone());
             state.sql_modal.failed_prefetch_tables.insert(
                 qualified.clone(),
                 FailedPrefetchEntry {
@@ -303,7 +303,7 @@ mod tests {
             state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
             // Only table remaining; retry limit exceeded
-            state.er_preparation.insert_pending_table(qualified.clone());
+            state.er_preparation.queue_pending_table(qualified.clone());
             state.sql_modal.failed_prefetch_tables.insert(
                 qualified,
                 FailedPrefetchEntry {
@@ -341,8 +341,8 @@ mod tests {
             let failed = "public.users".to_string();
             let remaining = "public.posts".to_string();
             // users exhausted retries; posts still awaiting in queue
-            state.er_preparation.insert_pending_table(failed.clone());
-            state.er_preparation.insert_pending_table(remaining.clone());
+            state.er_preparation.queue_pending_table(failed.clone());
+            state.er_preparation.queue_pending_table(remaining.clone());
             state.sql_modal.prefetch_queue.push_back(remaining);
             state.sql_modal.failed_prefetch_tables.insert(
                 failed,
@@ -583,7 +583,6 @@ mod tests {
                 Instant::now(),
             );
             state.sql_modal.prefetch_queue.clear();
-            state.er_preparation.remove_pending_table(&qualified);
             state
                 .er_preparation
                 .insert_fetching_table(qualified.clone());
@@ -804,7 +803,7 @@ mod tests {
             let _ = state.sql_modal.begin_prefetch();
             state
                 .er_preparation
-                .insert_pending_table("public.users".to_string());
+                .queue_pending_table("public.users".to_string());
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -986,7 +985,7 @@ mod tests {
             state.er_preparation.mark_waiting();
             state
                 .er_preparation
-                .insert_pending_table("public.posts".to_string());
+                .queue_pending_table("public.posts".to_string());
             state
                 .sql_modal
                 .prefetch_queue
@@ -1040,7 +1039,7 @@ mod tests {
             state.er_preparation.mark_waiting();
             state.er_preparation.mark_fk_expanded();
             let neighbor = "public.posts".to_string();
-            state.er_preparation.insert_pending_table(neighbor.clone());
+            state.er_preparation.queue_pending_table(neighbor.clone());
             state.sql_modal.failed_prefetch_tables.insert(
                 neighbor,
                 FailedPrefetchEntry {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -57,7 +57,7 @@ mod tests {
 
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
-        let _ = state.session.begin_connecting(dsn);
+        state.session.set_dsn_for_test(dsn);
         state
     }
 

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -2,7 +2,6 @@ use std::time::Instant;
 
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
-use crate::model::er_state::ErStatus;
 use crate::model::sql_editor::modal::FailedPrefetchEntry;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
@@ -116,13 +115,13 @@ pub(super) fn reduce_prefetch(
             if let Some(entry) = state.sql_modal.failed_prefetch_tables.get(&qualified_name) {
                 if entry.retry_count >= MAX_PREFETCH_RETRIES {
                     // Exceeded retry limit — give up, don't re-queue
-                    state.er_preparation.pending_tables.remove(&qualified_name);
+                    state.er_preparation.remove_pending_table(&qualified_name);
                     state
                         .er_preparation
                         .on_table_failed(&qualified_name, entry.error.clone());
                     let mut effects = check_er_completion(state);
                     // No fetch started → no completion event to re-drive the queue.
-                    if effects.is_empty() && state.er_preparation.status == ErStatus::Waiting {
+                    if effects.is_empty() && state.er_preparation.is_waiting() {
                         effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
                     }
                     return DispatchResult::handled_with(effects);
@@ -144,7 +143,7 @@ pub(super) fn reduce_prefetch(
                 }
             }
 
-            let Some(dsn) = &state.session.dsn else {
+            let Some(dsn) = state.session.dsn_owned() else {
                 state.sql_modal.prefetch_queue.push_front(qualified_name);
                 return DispatchResult::handled();
             };
@@ -156,7 +155,7 @@ pub(super) fn reduce_prefetch(
             state.er_preparation.start_fetching(&qualified_name);
 
             DispatchResult::handled_with(vec![Effect::PrefetchTableDetail {
-                dsn: dsn.clone(),
+                dsn,
                 run_id: *run_id,
                 schema: schema.clone(),
                 table: table.clone(),
@@ -170,8 +169,7 @@ pub(super) fn reduce_prefetch(
             table,
             detail,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.sql_modal.is_current_prefetch_run(*run_id)
+            if !state.session.dsn_matches(dsn) || !state.sql_modal.is_current_prefetch_run(*run_id)
             {
                 return DispatchResult::handled();
             }
@@ -204,8 +202,7 @@ pub(super) fn reduce_prefetch(
             table,
             error,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.sql_modal.is_current_prefetch_run(*run_id)
+            if !state.session.dsn_matches(dsn) || !state.sql_modal.is_current_prefetch_run(*run_id)
             {
                 return DispatchResult::handled();
             }
@@ -252,8 +249,7 @@ pub(super) fn reduce_prefetch(
             schema,
             table,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.sql_modal.is_current_prefetch_run(*run_id)
+            if !state.session.dsn_matches(dsn) || !state.sql_modal.is_current_prefetch_run(*run_id)
             {
                 return DispatchResult::handled();
             }

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -115,7 +115,6 @@ pub(super) fn reduce_prefetch(
             if let Some(entry) = state.sql_modal.failed_prefetch_tables.get(&qualified_name) {
                 if entry.retry_count >= MAX_PREFETCH_RETRIES {
                     // Exceeded retry limit — give up, don't re-queue
-                    state.er_preparation.remove_pending_table(&qualified_name);
                     state
                         .er_preparation
                         .on_table_failed(&qualified_name, entry.error.clone());

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -143,7 +143,7 @@ pub(super) fn reduce_prefetch(
                 }
             }
 
-            let Some(dsn) = state.session.dsn_owned() else {
+            let Some(dsn) = state.session.dsn().map(String::from) else {
                 state.sql_modal.prefetch_queue.push_front(qualified_name);
                 return DispatchResult::handled();
             };

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -44,7 +44,7 @@ pub(super) fn reduce_table_detail(state: &mut AppState, action: &Action) -> Disp
             table,
             generation,
         }) => {
-            if let Some(dsn) = state.session.dsn_owned() {
+            if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.session.begin_table_detail_run();
                 DispatchResult::handled_with(vec![Effect::FetchTableDetail {
                     dsn,

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -11,7 +11,7 @@ pub(super) fn reduce_table_detail(state: &mut AppState, action: &Action) -> Disp
             detail,
             generation,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
+            if !state.session.dsn_matches(dsn)
                 || !state.session.is_current_table_detail_run(*run_id)
             {
                 return DispatchResult::handled();
@@ -28,7 +28,7 @@ pub(super) fn reduce_table_detail(state: &mut AppState, action: &Action) -> Disp
             error,
             generation,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn)
+            if !state.session.dsn_matches(dsn)
                 || !state.session.is_current_table_detail_run(*run_id)
             {
                 return DispatchResult::handled();
@@ -44,7 +44,7 @@ pub(super) fn reduce_table_detail(state: &mut AppState, action: &Action) -> Disp
             table,
             generation,
         }) => {
-            if let Some(dsn) = state.session.dsn.clone() {
+            if let Some(dsn) = state.session.dsn_owned() {
                 let run_id = state.session.begin_table_detail_run();
                 DispatchResult::handled_with(vec![Effect::FetchTableDetail {
                     dsn,

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -329,7 +329,7 @@ mod tests {
                 create_test_profile_with_id("active", active_id.clone()),
                 create_test_profile_with_id("other", other_id),
             ]);
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &active_id,
                 "active",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -363,7 +363,7 @@ mod tests {
                 "active",
                 active_id.clone(),
             )]);
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &active_id,
                 "active",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -407,7 +407,7 @@ mod tests {
                 create_test_profile_with_id("active", active_id.clone()),
                 create_test_profile_with_id("other", other_id),
             ]);
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &active_id,
                 "active",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -439,7 +439,7 @@ mod tests {
                 "active",
                 active_id.clone(),
             )]);
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &active_id,
                 "active",
                 crate::domain::DatabaseType::PostgreSQL,

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -329,9 +329,12 @@ mod tests {
                 create_test_profile_with_id("active", active_id.clone()),
                 create_test_profile_with_id("other", other_id),
             ]);
-            state
-                .session
-                .set_active_connection_id_for_test(Some(active_id));
+            state.session.set_active_connection(
+                &active_id,
+                "active",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.ui.set_connection_list_selection(Some(1));
 
             let effects = dispatch_navigation(
@@ -360,9 +363,12 @@ mod tests {
                 "active",
                 active_id.clone(),
             )]);
-            state
-                .session
-                .set_active_connection_id_for_test(Some(active_id));
+            state.session.set_active_connection(
+                &active_id,
+                "active",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.ui.set_connection_list_selection(Some(0));
 
             let effects = dispatch_navigation(
@@ -401,9 +407,12 @@ mod tests {
                 create_test_profile_with_id("active", active_id.clone()),
                 create_test_profile_with_id("other", other_id),
             ]);
-            state
-                .session
-                .set_active_connection_id_for_test(Some(active_id));
+            state.session.set_active_connection(
+                &active_id,
+                "active",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.modal.set_mode(InputMode::ConnectionSelector);
             state.ui.set_connection_list_selection(Some(1));
 
@@ -430,9 +439,12 @@ mod tests {
                 "active",
                 active_id.clone(),
             )]);
-            state
-                .session
-                .set_active_connection_id_for_test(Some(active_id));
+            state.session.set_active_connection(
+                &active_id,
+                "active",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.modal.set_mode(InputMode::ConnectionSelector);
             state.ui.set_connection_list_selection(Some(0));
 

--- a/src/app/update/browse/navigation/focus.rs
+++ b/src/app/update/browse/navigation/focus.rs
@@ -86,7 +86,7 @@ mod tests {
         #[test]
         fn rw_to_ro_switches_immediately() {
             let mut state = AppState::new("test".to_string());
-            assert!(!state.session.read_only);
+            assert!(!state.session.is_read_only());
 
             dispatch_navigation(
                 &mut state,
@@ -95,14 +95,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(state.session.read_only);
+            assert!(state.session.is_read_only());
             assert_eq!(state.input_mode(), InputMode::Normal);
         }
 
         #[test]
         fn ro_to_rw_opens_confirm_dialog() {
             let mut state = AppState::new("test".to_string());
-            state.session.read_only = true;
+            state.session.enable_read_only();
 
             dispatch_navigation(
                 &mut state,
@@ -111,7 +111,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert!(state.session.read_only);
+            assert!(state.session.is_read_only());
             assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
             assert!(matches!(
                 state.confirm_dialog.intent(),

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -264,7 +264,7 @@ mod tests {
         }
 
         fn use_sqlite_tabs(state: &mut AppState) {
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &ConnectionId::new(),
                 "sqlite",
                 DatabaseType::SQLite,

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -23,7 +23,7 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -
     if !tag.needs_refresh() {
         return vec![];
     }
-    let Some(dsn) = state.session.dsn.clone() else {
+    let Some(dsn) = state.session.dsn_owned() else {
         return vec![];
     };
 
@@ -37,19 +37,19 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -
         effects.push(Effect::CacheInvalidate { dsn: dsn.clone() });
         effects.push(Effect::ClearCompletionEngineCache);
         effects.push(Effect::FetchMetadata { dsn, run_id });
-    } else if !state.query.pagination.table.is_empty() {
-        let page = state.query.pagination.current_page;
+    } else if !state.query.pagination.table().is_empty() {
+        let page = state.query.pagination.current_page();
         let run_id = state.query.begin_running(now);
         effects.push(Effect::ExecutePreview {
             dsn,
-            schema: state.query.pagination.schema.clone(),
-            table: state.query.pagination.table.clone(),
+            schema: state.query.pagination.schema().to_string(),
+            table: state.query.pagination.table().to_string(),
             generation: state.session.selection_generation(),
             run_id,
             limit: PREVIEW_PAGE_SIZE,
             offset: page * PREVIEW_PAGE_SIZE,
             target_page: page,
-            read_only: state.session.read_only,
+            read_only: state.session.is_read_only(),
         });
     }
 
@@ -70,14 +70,14 @@ pub fn reduce_execution(
             generation,
             target_page,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if !state.session.dsn_matches(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
             if *generation == 0 || *generation == state.session.selection_generation() {
                 state.query.mark_idle();
                 let preserved_result_col = state.result_interaction.selection().cell();
-                let preserved_horizontal_offset = state.result_interaction.horizontal_offset;
+                let preserved_horizontal_offset = state.result_interaction.horizontal_offset();
 
                 let is_adhoc_error = result.source == QuerySource::Adhoc && result.is_error();
                 if !is_adhoc_error {
@@ -107,10 +107,10 @@ pub fn reduce_execution(
                 }
 
                 if let Some(page) = target_page {
-                    state.query.pagination.current_page = *page;
-                    if result.rows.len() < PREVIEW_PAGE_SIZE {
-                        state.query.pagination.reached_end = true;
-                    }
+                    state
+                        .query
+                        .pagination
+                        .set_page_result(*page, result.rows.len() < PREVIEW_PAGE_SIZE);
                 }
 
                 if !result.is_error() || result.source != QuerySource::Adhoc {
@@ -130,13 +130,16 @@ pub fn reduce_execution(
                                 let col = preserved_result_col
                                     .unwrap_or(preserved_horizontal_offset)
                                     .min(max_col);
-                                state.result_interaction.horizontal_offset =
-                                    preserved_horizontal_offset.min(max_col).min(col);
+                                state.result_interaction.set_horizontal_offset(
+                                    preserved_horizontal_offset.min(max_col).min(col),
+                                );
                                 state.result_interaction.activate_cell(clamped, col);
 
                                 let visible = state.result_visible_rows();
                                 if visible > 0 && clamped >= visible {
-                                    state.result_interaction.scroll_offset = clamped - visible + 1;
+                                    state
+                                        .result_interaction
+                                        .set_scroll_offset(clamped - visible + 1);
                                 }
                             }
                         }
@@ -158,7 +161,7 @@ pub fn reduce_execution(
             generation,
             source,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if !state.session.dsn_matches(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -170,14 +173,7 @@ pub fn reduce_execution(
                         .query
                         .set_post_delete_selection(PostDeleteRowSelection::Keep);
                     state.query.clear_delete_refresh_target();
-                    let preview_query = if state.query.pagination.schema.is_empty() {
-                        state.query.pagination.table.clone()
-                    } else {
-                        format!(
-                            "{}.{}",
-                            state.query.pagination.schema, state.query.pagination.table
-                        )
-                    };
+                    let preview_query = state.query.pagination.preview_label();
                     state.query.set_current_result(Arc::new(QueryResult::error(
                         preview_query,
                         error.result_message(),
@@ -242,12 +238,8 @@ pub fn reduce_execution(
             table,
             generation,
         }) => {
-            if let Some(dsn) = &state.session.dsn {
+            if let Some(dsn) = state.session.dsn_owned() {
                 let run_id = state.query.begin_running(now);
-
-                state.query.pagination.reset();
-                state.query.pagination.schema.clone_from(schema);
-                state.query.pagination.table.clone_from(table);
 
                 let row_estimate = state
                     .session
@@ -262,10 +254,13 @@ pub fn reduce_execution(
                             }
                         })
                     });
-                state.query.pagination.total_rows_estimate = row_estimate;
+                state
+                    .query
+                    .pagination
+                    .reset_for_table_with_estimate(schema, table, row_estimate);
 
                 DispatchResult::handled_with(vec![Effect::ExecutePreview {
-                    dsn: dsn.clone(),
+                    dsn,
                     schema: schema.clone(),
                     table: table.clone(),
                     generation: *generation,
@@ -273,7 +268,7 @@ pub fn reduce_execution(
                     limit: PREVIEW_PAGE_SIZE,
                     offset: 0,
                     target_page: 0,
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             } else {
                 DispatchResult::handled()
@@ -281,13 +276,13 @@ pub fn reduce_execution(
         }
 
         Action::ExecuteAdhoc(query) => {
-            if let Some(dsn) = &state.session.dsn {
+            if let Some(dsn) = state.session.dsn_owned() {
                 let run_id = state.query.begin_running(now);
                 DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
-                    dsn: dsn.clone(),
+                    dsn,
                     run_id,
                     query: query.clone(),
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             } else {
                 DispatchResult::handled()
@@ -301,7 +296,6 @@ pub fn reduce_execution(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::browse::query_execution::PaginationState;
     use crate::ports::outbound::DbOperationError;
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
@@ -470,13 +464,12 @@ mod tests {
         #[test]
         fn resets_pagination() {
             let mut state = create_test_state();
-            state.query.pagination = PaginationState {
-                current_page: 5,
-                total_rows_estimate: Some(10000),
-                reached_end: true,
-                schema: "old_schema".to_string(),
-                table: "old_table".to_string(),
-            };
+            state.query.pagination.reset_for_table_with_estimate(
+                "old_schema",
+                "old_table",
+                Some(10000),
+            );
+            state.query.pagination.set_page_result(5, true);
             let now = Instant::now();
 
             dispatch_query(
@@ -490,10 +483,10 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.query.pagination.current_page, 0);
-            assert!(!state.query.pagination.reached_end);
-            assert_eq!(state.query.pagination.schema, "public");
-            assert_eq!(state.query.pagination.table, "users");
+            assert_eq!(state.query.pagination.current_page(), 0);
+            assert!(!state.query.pagination.reached_end());
+            assert_eq!(state.query.pagination.schema(), "public");
+            assert_eq!(state.query.pagination.table(), "users");
         }
     }
 
@@ -510,8 +503,8 @@ mod tests {
 
             dispatch_query(&mut state, &action, now, &AppServices::stub());
 
-            assert_eq!(state.query.pagination.current_page, 2);
-            assert!(state.query.pagination.reached_end);
+            assert_eq!(state.query.pagination.current_page(), 2);
+            assert!(state.query.pagination.reached_end());
         }
 
         #[test]
@@ -524,28 +517,31 @@ mod tests {
 
             dispatch_query(&mut state, &action, now, &AppServices::stub());
 
-            assert_eq!(state.query.pagination.current_page, 0);
-            assert!(!state.query.pagination.reached_end);
+            assert_eq!(state.query.pagination.current_page(), 0);
+            assert!(!state.query.pagination.reached_end());
         }
 
         #[test]
         fn adhoc_does_not_update_pagination() {
             let mut state = create_test_state();
-            state.query.pagination.current_page = 3;
+            state
+                .query
+                .pagination
+                .set_page_result(3, state.query.pagination.reached_end());
             let result = adhoc_result();
             let now = Instant::now();
             let action = query_completed_action(&mut state, result, 0, None);
 
             dispatch_query(&mut state, &action, now, &AppServices::stub());
 
-            assert_eq!(state.query.pagination.current_page, 3);
+            assert_eq!(state.query.pagination.current_page(), 3);
         }
 
         #[test]
         fn adhoc_success_writes_current_result_without_touching_history_index() {
             let mut state = create_test_state();
-            state.result_interaction.scroll_offset = 50;
-            state.result_interaction.horizontal_offset = 10;
+            state.result_interaction.set_scroll_offset(50);
+            state.result_interaction.set_horizontal_offset(10);
             state.result_interaction.activate_cell(5, 0);
             state.result_interaction.stage_row(0);
             state.result_interaction.stage_row(2);
@@ -561,8 +557,8 @@ mod tests {
                 state.query.current_result().unwrap().source,
                 QuerySource::Adhoc,
             );
-            assert_eq!(state.result_interaction.scroll_offset, 0);
-            assert_eq!(state.result_interaction.horizontal_offset, 0);
+            assert_eq!(state.result_interaction.scroll_offset(), 0);
+            assert_eq!(state.result_interaction.horizontal_offset(), 0);
             assert_eq!(state.result_interaction.selection().row(), None);
             assert!(state.result_interaction.staged_delete_rows().is_empty());
         }
@@ -571,8 +567,8 @@ mod tests {
         fn adhoc_error_preserves_current_result_and_view_state() {
             let mut state = create_test_state();
             state.query.set_current_result(preview_result(5));
-            state.result_interaction.scroll_offset = 20;
-            state.result_interaction.horizontal_offset = 5;
+            state.result_interaction.set_scroll_offset(20);
+            state.result_interaction.set_horizontal_offset(5);
             state.result_interaction.activate_cell(3, 0);
             let result = adhoc_error_result();
             let action = query_completed_action(&mut state, result, 0, None);
@@ -585,8 +581,8 @@ mod tests {
                 state.query.current_result().unwrap().source,
                 QuerySource::Preview,
             );
-            assert_eq!(state.result_interaction.scroll_offset, 20);
-            assert_eq!(state.result_interaction.horizontal_offset, 5);
+            assert_eq!(state.result_interaction.scroll_offset(), 20);
+            assert_eq!(state.result_interaction.horizontal_offset(), 5);
             assert_eq!(state.result_interaction.selection().row(), Some(3));
         }
 
@@ -632,7 +628,7 @@ mod tests {
             state
                 .query
                 .set_post_delete_selection(PostDeleteRowSelection::Select(1));
-            state.result_interaction.horizontal_offset = 1;
+            state.result_interaction.set_horizontal_offset(1);
             state.result_interaction.activate_cell(3, 2);
             state.query.set_current_result(Arc::clone(&result));
             let action = query_completed_action(&mut state, result, 0, Some(0));
@@ -641,7 +637,7 @@ mod tests {
 
             assert_eq!(state.result_interaction.selection().row(), Some(1));
             assert_eq!(state.result_interaction.selection().cell(), Some(2));
-            assert_eq!(state.result_interaction.horizontal_offset, 1);
+            assert_eq!(state.result_interaction.horizontal_offset(), 1);
         }
 
         #[test]
@@ -694,8 +690,8 @@ mod tests {
             let mut state = create_test_state();
             state.session.set_selection_generation(1);
             state.result_interaction.activate_cell(5, 2);
-            state.result_interaction.scroll_offset = 10;
-            state.result_interaction.horizontal_offset = 3;
+            state.result_interaction.set_scroll_offset(10);
+            state.result_interaction.set_horizontal_offset(3);
             let action = query_failed_action(
                 &mut state,
                 DbOperationError::QueryFailed("error".to_string()),
@@ -709,8 +705,8 @@ mod tests {
                 state.result_interaction.selection().mode(),
                 ResultNavMode::Scroll
             );
-            assert_eq!(state.result_interaction.scroll_offset, 0);
-            assert_eq!(state.result_interaction.horizontal_offset, 0);
+            assert_eq!(state.result_interaction.scroll_offset(), 0);
+            assert_eq!(state.result_interaction.horizontal_offset(), 0);
         }
 
         #[test]
@@ -1004,7 +1000,7 @@ mod tests {
             let meta_effects = dispatch_metadata(&mut state, &action, Instant::now()).unwrap();
 
             assert_eq!(state.ui.explorer_selected, 1);
-            assert_eq!(state.query.pagination.table, "users");
+            assert_eq!(state.query.pagination.table(), "users");
             assert!(
                 meta_effects
                     .iter()
@@ -1041,7 +1037,7 @@ mod tests {
             };
             dispatch_metadata(&mut state, &action, Instant::now());
 
-            assert!(state.query.pagination.table.is_empty());
+            assert!(state.query.pagination.table().is_empty());
             assert!(state.query.current_result().is_none());
             assert!(state.session.table_detail().is_none());
             assert_eq!(state.ui.explorer_selected, 0);

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -23,7 +23,7 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -
     if !tag.needs_refresh() {
         return vec![];
     }
-    let Some(dsn) = state.session.dsn_owned() else {
+    let Some(dsn) = state.session.dsn().map(String::from) else {
         return vec![];
     };
 
@@ -173,7 +173,7 @@ pub fn reduce_execution(
                         .query
                         .set_post_delete_selection(PostDeleteRowSelection::Keep);
                     state.query.clear_delete_refresh_target();
-                    let preview_query = state.query.pagination.preview_label();
+                    let preview_query = state.query.pagination.qualified_name();
                     state.query.set_current_result(Arc::new(QueryResult::error(
                         preview_query,
                         error.result_message(),
@@ -238,7 +238,7 @@ pub fn reduce_execution(
             table,
             generation,
         }) => {
-            if let Some(dsn) = state.session.dsn_owned() {
+            if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.query.begin_running(now);
 
                 let row_estimate = state
@@ -276,7 +276,7 @@ pub fn reduce_execution(
         }
 
         Action::ExecuteAdhoc(query) => {
-            if let Some(dsn) = state.session.dsn_owned() {
+            if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.query.begin_running(now);
                 DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
                     dsn,
@@ -524,10 +524,7 @@ mod tests {
         #[test]
         fn adhoc_does_not_update_pagination() {
             let mut state = create_test_state();
-            state
-                .query
-                .pagination
-                .set_page_result(3, state.query.pagination.reached_end());
+            state.query.pagination.set_current_page(3);
             let result = adhoc_result();
             let now = Instant::now();
             let action = query_completed_action(&mut state, result, 0, None);

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -33,7 +33,7 @@ pub(super) mod tests {
 
     pub fn create_test_state() -> AppState {
         let mut state = AppState::new("test_project".to_string());
-        let _ = state.session.begin_connecting("postgres://localhost/test");
+        state.session.set_dsn_for_test("postgres://localhost/test");
         state
     }
 

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -33,7 +33,7 @@ pub(super) mod tests {
 
     pub fn create_test_state() -> AppState {
         let mut state = AppState::new("test_project".to_string());
-        state.session.dsn = Some("postgres://localhost/test".to_string());
+        let _ = state.session.begin_connecting("postgres://localhost/test");
         state
     }
 
@@ -181,8 +181,7 @@ pub(super) mod tests {
 
     pub fn state_with_table(schema: &str, table: &str) -> AppState {
         let mut state = create_test_state();
-        state.query.pagination.schema = schema.to_string();
-        state.query.pagination.table = table.to_string();
+        state.query.pagination.reset_for_table(schema, table);
         state
     }
 }

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -24,15 +24,15 @@ pub fn reduce_pagination(
             let Some(result) = state.query.visible_result() else {
                 return DispatchResult::handled();
             };
-            let dsn = match &state.session.dsn {
-                Some(d) => d.clone(),
+            let dsn = match state.session.dsn_owned() {
+                Some(d) => d,
                 None => return DispatchResult::handled(),
             };
 
             let export_query = result.query.clone();
             let file_name = match result.source {
                 QuerySource::Preview => {
-                    let table = &state.query.pagination.table;
+                    let table = state.query.pagination.table();
                     table
                         .chars()
                         .map(|c| {
@@ -57,7 +57,7 @@ pub fn reduce_pagination(
                 count_query,
                 export_query,
                 file_name,
-                read_only: state.session.read_only,
+                read_only: state.session.is_read_only(),
             }])
         }
 
@@ -68,7 +68,7 @@ pub fn reduce_pagination(
             export_query,
             file_name,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if !state.session.dsn_matches(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -104,7 +104,7 @@ pub fn reduce_pagination(
                     query: export_query.clone(),
                     file_name: file_name.clone(),
                     row_count: *row_count,
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             }
         }
@@ -116,7 +116,7 @@ pub fn reduce_pagination(
             file_name,
             row_count,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if !state.session.dsn_matches(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -126,7 +126,7 @@ pub fn reduce_pagination(
                 query: export_query.clone(),
                 file_name: file_name.clone(),
                 row_count: *row_count,
-                read_only: state.session.read_only,
+                read_only: state.session.is_read_only(),
             }])
         }
 
@@ -136,7 +136,7 @@ pub fn reduce_pagination(
             path,
             row_count,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if !state.session.dsn_matches(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -153,7 +153,7 @@ pub fn reduce_pagination(
         }
 
         Action::CsvExportFailed { dsn, run_id, error } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if !state.session.dsn_matches(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -177,20 +177,20 @@ pub fn reduce_pagination(
             if !state.query.pagination.can_next() {
                 return DispatchResult::handled();
             }
-            if let Some(dsn) = state.session.dsn.clone() {
-                let next_page = state.query.pagination.current_page + 1;
+            if let Some(dsn) = state.session.dsn_owned() {
+                let next_page = state.query.pagination.next_page();
                 let run_id = state.query.begin_running(now);
                 state.result_interaction.reset_view();
                 DispatchResult::handled_with(vec![Effect::ExecutePreview {
                     dsn,
-                    schema: state.query.pagination.schema.clone(),
-                    table: state.query.pagination.table.clone(),
+                    schema: state.query.pagination.schema().to_string(),
+                    table: state.query.pagination.table().to_string(),
                     generation: state.session.selection_generation(),
                     run_id,
                     limit: PREVIEW_PAGE_SIZE,
                     offset: next_page * PREVIEW_PAGE_SIZE,
                     target_page: next_page,
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             } else {
                 DispatchResult::handled()
@@ -204,21 +204,21 @@ pub fn reduce_pagination(
             if !state.query.pagination.can_prev() {
                 return DispatchResult::handled();
             }
-            if let Some(dsn) = state.session.dsn.clone() {
-                let prev_page = state.query.pagination.current_page - 1;
+            if let Some(dsn) = state.session.dsn_owned() {
+                let prev_page = state.query.pagination.prev_page();
                 let run_id = state.query.begin_running(now);
                 state.result_interaction.reset_view();
-                state.query.pagination.reached_end = false;
+                state.query.pagination.allow_next_page_after_refresh();
                 DispatchResult::handled_with(vec![Effect::ExecutePreview {
                     dsn,
-                    schema: state.query.pagination.schema.clone(),
-                    table: state.query.pagination.table.clone(),
+                    schema: state.query.pagination.schema().to_string(),
+                    table: state.query.pagination.table().to_string(),
                     generation: state.session.selection_generation(),
                     run_id,
                     limit: PREVIEW_PAGE_SIZE,
                     offset: prev_page * PREVIEW_PAGE_SIZE,
                     target_page: prev_page,
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             } else {
                 DispatchResult::handled()
@@ -236,7 +236,6 @@ mod tests {
     use crate::ports::outbound::DbOperationError;
     use std::sync::Arc;
 
-    use crate::model::browse::query_execution::PaginationState;
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
 
@@ -305,13 +304,10 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination = PaginationState {
-                current_page: 0,
-                total_rows_estimate: Some(1500),
-                reached_end: false,
-                schema: "public".to_string(),
-                table: "users".to_string(),
-            };
+            state
+                .query
+                .pagination
+                .reset_for_table_with_estimate("public", "users", Some(1500));
             let now = Instant::now();
 
             let effects = dispatch_query(
@@ -340,7 +336,7 @@ mod tests {
         fn noop_when_reached_end() {
             let mut state = create_test_state();
             state.query.set_current_result(preview_result(100));
-            state.query.pagination.reached_end = true;
+            state.query.pagination.set_page_result(0, true);
             let now = Instant::now();
 
             let effects = dispatch_query(
@@ -397,7 +393,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result_with_two_columns(100));
-            state.query.pagination.reached_end = true;
+            state.query.pagination.set_page_result(0, true);
             state.result_interaction.activate_cell(2, 1);
             state.result_interaction.stage_row(2);
 
@@ -419,13 +415,10 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination = PaginationState {
-                current_page: 0,
-                total_rows_estimate: Some(1500),
-                reached_end: false,
-                schema: "public".to_string(),
-                table: "users".to_string(),
-            };
+            state
+                .query
+                .pagination
+                .reset_for_table_with_estimate("public", "users", Some(1500));
             state.result_interaction.activate_cell(3, 1);
             state.result_interaction.stage_row(3);
 
@@ -451,13 +444,11 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination = PaginationState {
-                current_page: 2,
-                total_rows_estimate: Some(1500),
-                reached_end: false,
-                schema: "public".to_string(),
-                table: "users".to_string(),
-            };
+            state
+                .query
+                .pagination
+                .reset_for_table_with_estimate("public", "users", Some(1500));
+            state.query.pagination.set_page_result(2, false);
             let now = Instant::now();
 
             let effects = dispatch_query(
@@ -488,7 +479,10 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state.query.pagination.current_page = 0;
+            state
+                .query
+                .pagination
+                .set_page_result(0, state.query.pagination.reached_end());
             let now = Instant::now();
 
             let effects = dispatch_query(
@@ -508,7 +502,10 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result_with_two_columns(PREVIEW_PAGE_SIZE));
-            state.query.pagination.current_page = 0;
+            state
+                .query
+                .pagination
+                .set_page_result(0, state.query.pagination.reached_end());
             state.result_interaction.activate_cell(1, 1);
             state.result_interaction.stage_row(1);
 
@@ -532,7 +529,7 @@ mod tests {
 
         fn export_test_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state
         }
 
@@ -540,9 +537,8 @@ mod tests {
         fn request_with_preview_result_emits_count_effect() {
             let mut state = export_test_state();
             state.query.set_current_result(preview_result(10));
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
-            state.query.pagination.total_rows_estimate = Some(100);
+            state.query.pagination.reset_for_table("public", "users");
+            state.query.pagination.set_total_rows_estimate(Some(100));
 
             let effects = dispatch_query(
                 &mut state,

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -24,7 +24,7 @@ pub fn reduce_pagination(
             let Some(result) = state.query.visible_result() else {
                 return DispatchResult::handled();
             };
-            let dsn = match state.session.dsn_owned() {
+            let dsn = match state.session.dsn().map(String::from) {
                 Some(d) => d,
                 None => return DispatchResult::handled(),
             };
@@ -177,7 +177,7 @@ pub fn reduce_pagination(
             if !state.query.pagination.can_next() {
                 return DispatchResult::handled();
             }
-            if let Some(dsn) = state.session.dsn_owned() {
+            if let Some(dsn) = state.session.dsn().map(String::from) {
                 let next_page = state.query.pagination.next_page();
                 let run_id = state.query.begin_running(now);
                 state.result_interaction.reset_view();
@@ -204,11 +204,11 @@ pub fn reduce_pagination(
             if !state.query.pagination.can_prev() {
                 return DispatchResult::handled();
             }
-            if let Some(dsn) = state.session.dsn_owned() {
+            if let Some(dsn) = state.session.dsn().map(String::from) {
                 let prev_page = state.query.pagination.prev_page();
                 let run_id = state.query.begin_running(now);
                 state.result_interaction.reset_view();
-                state.query.pagination.allow_next_page_after_refresh();
+                state.query.pagination.clear_reached_end();
                 DispatchResult::handled_with(vec![Effect::ExecutePreview {
                     dsn,
                     schema: state.query.pagination.schema().to_string(),
@@ -479,10 +479,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result(PREVIEW_PAGE_SIZE));
-            state
-                .query
-                .pagination
-                .set_page_result(0, state.query.pagination.reached_end());
+            state.query.pagination.set_current_page(0);
             let now = Instant::now();
 
             let effects = dispatch_query(
@@ -502,10 +499,7 @@ mod tests {
             state
                 .query
                 .set_current_result(preview_result_with_two_columns(PREVIEW_PAGE_SIZE));
-            state
-                .query
-                .pagination
-                .set_page_result(0, state.query.pagination.reached_end());
+            state.query.pagination.set_current_page(0);
             state.result_interaction.activate_cell(1, 1);
             state.result_interaction.stage_row(1);
 
@@ -529,7 +523,7 @@ mod tests {
 
         fn export_test_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
         }
 

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -57,8 +57,8 @@ fn build_update_preview(
 
     let pk_pairs = build_pk_pairs(&result.columns, row, pk_cols);
     let target = crate::policy::write::write_guardrails::TargetSummary {
-        schema: state.query.pagination.schema.clone(),
-        table: state.query.pagination.table.clone(),
+        schema: state.query.pagination.schema().to_string(),
+        table: state.query.pagination.table().to_string(),
         key_values: pk_pairs.clone().unwrap_or_default(),
     };
     let has_where = pk_pairs.as_ref().is_some_and(|pairs| !pairs.is_empty());
@@ -183,7 +183,7 @@ pub fn reduce_write(
         }
 
         Action::OpenWritePreviewConfirm(preview) => {
-            if state.session.read_only {
+            if state.session.is_read_only() {
                 state.messages.set_error_at(
                     "Read-only mode: write operations are disabled".to_string(),
                     now,
@@ -230,20 +230,20 @@ pub fn reduce_write(
         }
 
         Action::ExecuteWrite(query) => {
-            if state.session.read_only {
+            if state.session.is_read_only() {
                 state.messages.set_error_at(
                     "Read-only mode: write operations are disabled".to_string(),
                     now,
                 );
                 return DispatchResult::handled();
             }
-            if let Some(dsn) = &state.session.dsn {
+            if let Some(dsn) = state.session.dsn_owned() {
                 let run_id = state.query.begin_running(now);
                 DispatchResult::handled_with(vec![Effect::ExecuteWrite {
-                    dsn: dsn.clone(),
+                    dsn,
                     run_id,
                     query: query.clone(),
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }])
             } else {
                 state
@@ -258,7 +258,7 @@ pub fn reduce_write(
             run_id,
             affected_rows,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if !state.session.dsn_matches(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -285,19 +285,19 @@ pub fn reduce_write(
                     state.result_interaction.clear_cell_edit();
                     state.modal.set_mode(InputMode::Normal);
 
-                    if let Some(dsn) = &state.session.dsn {
-                        let page = state.query.pagination.current_page;
+                    if let Some(dsn) = state.session.dsn_owned() {
+                        let page = state.query.pagination.current_page();
                         let run_id = state.query.begin_running(now);
                         DispatchResult::handled_with(vec![Effect::ExecutePreview {
-                            dsn: dsn.clone(),
-                            schema: state.query.pagination.schema.clone(),
-                            table: state.query.pagination.table.clone(),
+                            dsn,
+                            schema: state.query.pagination.schema().to_string(),
+                            table: state.query.pagination.table().to_string(),
                             generation: state.session.selection_generation(),
                             run_id,
                             limit: PREVIEW_PAGE_SIZE,
                             offset: page * PREVIEW_PAGE_SIZE,
                             target_page: page,
-                            read_only: state.session.read_only,
+                            read_only: state.session.is_read_only(),
                         }])
                     } else {
                         DispatchResult::handled()
@@ -312,7 +312,7 @@ pub fn reduce_write(
                         .query
                         .take_delete_refresh_target()
                         .unwrap_or(DeleteRefreshTarget {
-                            target_page: state.query.pagination.current_page,
+                            target_page: state.query.pagination.current_page(),
                             target_row: None,
                             expected_delete_count: 1,
                         });
@@ -344,19 +344,19 @@ pub fn reduce_write(
                         PostDeleteRowSelection::Select,
                     ));
 
-                    if let Some(dsn) = &state.session.dsn {
+                    if let Some(dsn) = state.session.dsn_owned() {
                         let run_id = state.query.begin_running(now);
-                        state.query.pagination.reached_end = false;
+                        state.query.pagination.allow_next_page_after_refresh();
                         DispatchResult::handled_with(vec![Effect::ExecutePreview {
-                            dsn: dsn.clone(),
-                            schema: state.query.pagination.schema.clone(),
-                            table: state.query.pagination.table.clone(),
+                            dsn,
+                            schema: state.query.pagination.schema().to_string(),
+                            table: state.query.pagination.table().to_string(),
                             generation: state.session.selection_generation(),
                             run_id,
                             limit: PREVIEW_PAGE_SIZE,
                             offset: target_page * PREVIEW_PAGE_SIZE,
                             target_page,
-                            read_only: state.session.read_only,
+                            read_only: state.session.is_read_only(),
                         }])
                     } else {
                         DispatchResult::handled()
@@ -366,7 +366,7 @@ pub fn reduce_write(
         }
 
         Action::ExecuteWriteFailed { dsn, run_id, error } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if !state.session.dsn_matches(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -448,13 +448,12 @@ mod tests {
 
         fn editable_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state.query.set_current_result(editable_preview_result());
             state
                 .session
                 .set_table_detail_raw(Some(users_table_detail()));
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.reset_for_table("public", "users");
             state.modal.set_mode(InputMode::CellEdit);
             state
                 .result_interaction
@@ -566,14 +565,16 @@ mod tests {
         #[test]
         fn sqlite_active_database_type_uses_sqlite_update_preview() {
             let mut state = editable_state();
-            state.session.set_dsn_for_test("sqlite:///tmp/app.db");
-            state
-                .session
-                .set_active_database_type_for_test(Some(DatabaseType::SQLite));
+            state.session.set_active_connection(
+                &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
             let mut detail = users_table_detail();
             detail.schema = "main".to_string();
             state.session.set_table_detail_raw(Some(detail));
-            state.query.pagination.set_table_for_test("main", "users");
+            state.query.pagination.reset_for_table("main", "users");
 
             let effects = dispatch_query(
                 &mut state,
@@ -600,15 +601,14 @@ mod tests {
 
         fn editable_state_with_jsonb() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state
                 .query
                 .set_current_result(editable_preview_result_with_jsonb());
             state
                 .session
                 .set_table_detail_raw(Some(jsonb_table_detail()));
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.reset_for_table("public", "users");
             state.modal.set_mode(InputMode::CellEdit);
             // col 2 = metadata (jsonb)
             state
@@ -728,7 +728,10 @@ mod tests {
         #[test]
         fn execute_write_success_refreshes_preview_page() {
             let mut state = editable_state();
-            state.query.pagination.current_page = 2;
+            state
+                .query
+                .pagination
+                .set_page_result(2, state.query.pagination.reached_end());
             let action = write_succeeded_action(&mut state, 1);
 
             let effects =
@@ -870,8 +873,7 @@ mod tests {
         #[test]
         fn execute_write_success_for_delete_refreshes_target_page() {
             let mut state = create_test_state();
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.reset_for_table("public", "users");
             state.query.set_delete_refresh_target(1, Some(499), 1);
             state.result_interaction.set_write_preview(delete_preview());
             let action = write_succeeded_action(&mut state, 1);
@@ -905,8 +907,7 @@ mod tests {
         #[test]
         fn execute_write_non_one_rows_for_delete_sets_error() {
             let mut state = create_test_state();
-            state.query.pagination.schema = "public".to_string();
-            state.query.pagination.table = "users".to_string();
+            state.query.pagination.reset_for_table("public", "users");
             state.result_interaction.set_write_preview(delete_preview());
             let action = write_succeeded_action(&mut state, 0);
 

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -565,7 +565,7 @@ mod tests {
         #[test]
         fn sqlite_active_database_type_uses_sqlite_update_preview() {
             let mut state = editable_state();
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
                 "sqlite",
                 DatabaseType::SQLite,

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -237,7 +237,7 @@ pub fn reduce_write(
                 );
                 return DispatchResult::handled();
             }
-            if let Some(dsn) = state.session.dsn_owned() {
+            if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.query.begin_running(now);
                 DispatchResult::handled_with(vec![Effect::ExecuteWrite {
                     dsn,
@@ -285,7 +285,7 @@ pub fn reduce_write(
                     state.result_interaction.clear_cell_edit();
                     state.modal.set_mode(InputMode::Normal);
 
-                    if let Some(dsn) = state.session.dsn_owned() {
+                    if let Some(dsn) = state.session.dsn().map(String::from) {
                         let page = state.query.pagination.current_page();
                         let run_id = state.query.begin_running(now);
                         DispatchResult::handled_with(vec![Effect::ExecutePreview {
@@ -344,9 +344,9 @@ pub fn reduce_write(
                         PostDeleteRowSelection::Select,
                     ));
 
-                    if let Some(dsn) = state.session.dsn_owned() {
+                    if let Some(dsn) = state.session.dsn().map(String::from) {
                         let run_id = state.query.begin_running(now);
-                        state.query.pagination.allow_next_page_after_refresh();
+                        state.query.pagination.clear_reached_end();
                         DispatchResult::handled_with(vec![Effect::ExecutePreview {
                             dsn,
                             schema: state.query.pagination.schema().to_string(),
@@ -448,7 +448,7 @@ mod tests {
 
         fn editable_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.query.set_current_result(editable_preview_result());
             state
                 .session
@@ -601,7 +601,7 @@ mod tests {
 
         fn editable_state_with_jsonb() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
                 .query
                 .set_current_result(editable_preview_result_with_jsonb());
@@ -728,10 +728,7 @@ mod tests {
         #[test]
         fn execute_write_success_refreshes_preview_page() {
             let mut state = editable_state();
-            state
-                .query
-                .pagination
-                .set_page_result(2, state.query.pagination.reached_end());
+            state.query.pagination.set_current_page(2);
             let action = write_succeeded_action(&mut state, 1);
 
             let effects =

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -190,7 +190,7 @@ mod tests {
                 error: None,
                 command_tag: None,
             }));
-            state.query.pagination.set_table_for_test("public", "users");
+            state.query.pagination.reset_for_table("public", "users");
             state.result_interaction.activate_cell(0, 1);
             state
         }

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -30,8 +30,8 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
 
             let table_detail = match state.session.table_detail() {
                 Some(td)
-                    if td.schema == state.query.pagination.schema
-                        && td.name == state.query.pagination.table =>
+                    if td.schema == state.query.pagination.schema()
+                        && td.name == state.query.pagination.table() =>
                 {
                     td
                 }
@@ -98,7 +98,7 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
         }
 
         Action::JsonbEnterEdit => {
-            if state.session.read_only {
+            if state.session.is_read_only() {
                 state
                     .messages
                     .set_error_at("Read-only mode: editing is disabled".to_string(), now);
@@ -110,7 +110,7 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
         }
 
         Action::JsonbAppendInsert => {
-            if state.session.read_only {
+            if state.session.is_read_only() {
                 state
                     .messages
                     .set_error_at("Read-only mode: editing is disabled".to_string(), now);
@@ -454,8 +454,7 @@ mod tests {
             error: None,
             command_tag: None,
         }));
-        state.query.pagination.schema = "public".to_string();
-        state.query.pagination.table = "users".to_string();
+        state.query.pagination.reset_for_table("public", "users");
         state.session.set_table_detail_raw(Some(jsonb_table()));
         state.result_interaction.activate_cell(0, 1);
         state
@@ -752,7 +751,7 @@ mod tests {
         fn enter_edit_blocked_in_read_only_mode() {
             let mut state = state_with_jsonb_cell();
             open_detail(&mut state);
-            state.session.read_only = true;
+            state.session.enable_read_only();
 
             reduce_jsonb(&mut state, &Action::JsonbEnterEdit, Instant::now());
 
@@ -764,7 +763,7 @@ mod tests {
         fn append_insert_blocked_in_read_only_mode() {
             let mut state = state_with_jsonb_cell();
             open_detail(&mut state);
-            state.session.read_only = true;
+            state.session.enable_read_only();
             let cursor_before = state.jsonb_detail.editor().cursor();
 
             reduce_jsonb(&mut state, &Action::JsonbAppendInsert, Instant::now());

--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -25,10 +25,12 @@ fn ensure_row_visible(state: &mut AppState) {
         if visible == 0 {
             return;
         }
-        if row < state.result_interaction.scroll_offset {
-            state.result_interaction.scroll_offset = row;
-        } else if row >= state.result_interaction.scroll_offset + visible {
-            state.result_interaction.scroll_offset = row - visible + 1;
+        if row < state.result_interaction.scroll_offset() {
+            state.result_interaction.set_scroll_offset(row);
+        } else if row >= state.result_interaction.scroll_offset() + visible {
+            state
+                .result_interaction
+                .set_scroll_offset(row - visible + 1);
         }
     }
 }
@@ -48,8 +50,12 @@ fn page_scroll_delta(state: &AppState, amount: ScrollAmount) -> Option<usize> {
 
 fn scroll_result_by(state: &mut AppState, direction: ScrollDirection, delta: usize) {
     let max_scroll = result_max_scroll(state);
-    state.result_interaction.scroll_offset =
-        direction.clamp_vertical_offset(state.result_interaction.scroll_offset, max_scroll, delta);
+    let offset = direction.clamp_vertical_offset(
+        state.result_interaction.scroll_offset(),
+        max_scroll,
+        delta,
+    );
+    state.result_interaction.set_scroll_offset(offset);
 }
 
 fn move_result_row_and_scroll(state: &mut AppState, direction: ScrollDirection, delta: usize) {
@@ -80,8 +86,9 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             match new_row {
                 Some(r) => move_row_or_scroll(state, r, |_| {}),
                 None if state.result_interaction.selection().row().is_none() => {
-                    state.result_interaction.scroll_offset =
-                        state.result_interaction.scroll_offset.saturating_sub(1);
+                    state.result_interaction.set_scroll_offset(
+                        state.result_interaction.scroll_offset().saturating_sub(1),
+                    );
                 }
                 _ => {} // row == 0, no-op
             }
@@ -100,8 +107,9 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
                 .map_or(0, |r| (r + 1).min(max_row));
             move_row_or_scroll(state, new_row, |s| {
                 let max_scroll = result_max_scroll(s);
-                if s.result_interaction.scroll_offset < max_scroll {
-                    s.result_interaction.scroll_offset += 1;
+                let offset = s.result_interaction.scroll_offset();
+                if offset < max_scroll {
+                    s.result_interaction.set_scroll_offset(offset + 1);
                 }
             });
             DispatchResult::handled()
@@ -111,7 +119,7 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             direction: ScrollDirection::Up,
             amount: ScrollAmount::ToStart,
         } => {
-            move_row_or_scroll(state, 0, |s| s.result_interaction.scroll_offset = 0);
+            move_row_or_scroll(state, 0, |s| s.result_interaction.set_scroll_offset(0));
             DispatchResult::handled()
         }
         Action::Scroll {
@@ -122,7 +130,7 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             let max_row = result_row_count(state).saturating_sub(1);
             let max_scroll = result_max_scroll(state);
             move_row_or_scroll(state, max_row, |s| {
-                s.result_interaction.scroll_offset = max_scroll;
+                s.result_interaction.set_scroll_offset(max_scroll);
             });
             DispatchResult::handled()
         }
@@ -134,7 +142,7 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             if state.result_interaction.selection().row().is_some() {
                 let visible = state.result_visible_rows();
                 let total = result_row_count(state);
-                let offset = state.result_interaction.scroll_offset;
+                let offset = state.result_interaction.scroll_offset();
                 let displayed = visible.min(total.saturating_sub(offset));
                 let target_row = offset + displayed / 2;
                 state.result_interaction.move_row(target_row);
@@ -148,7 +156,7 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             amount: ScrollAmount::ViewportTop,
         } => {
             if state.result_interaction.selection().row().is_some() {
-                let target = state.result_interaction.scroll_offset;
+                let target = state.result_interaction.scroll_offset();
                 state.result_interaction.move_row(target);
                 ensure_row_visible(state);
             }
@@ -162,7 +170,7 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             if state.result_interaction.selection().row().is_some() {
                 let visible = state.result_visible_rows();
                 let total = result_row_count(state);
-                let offset = state.result_interaction.scroll_offset;
+                let offset = state.result_interaction.scroll_offset();
                 let displayed = visible.min(total.saturating_sub(offset));
                 let target = offset + displayed.saturating_sub(1);
                 state.result_interaction.move_row(target);
@@ -191,8 +199,9 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
                 let visible = state.result_visible_rows();
                 if visible > 0 {
                     let max_scroll = result_max_scroll(state);
-                    state.result_interaction.scroll_offset =
-                        row.saturating_sub(visible / 2).min(max_scroll);
+                    state
+                        .result_interaction
+                        .set_scroll_offset(row.saturating_sub(visible / 2).min(max_scroll));
                 }
             }
             DispatchResult::handled()
@@ -206,7 +215,9 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
                 let visible = state.result_visible_rows();
                 if visible > 0 {
                     let max_scroll = result_max_scroll(state);
-                    state.result_interaction.scroll_offset = row.min(max_scroll);
+                    state
+                        .result_interaction
+                        .set_scroll_offset(row.min(max_scroll));
                 }
             }
             DispatchResult::handled()
@@ -220,9 +231,10 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
                 let visible = state.result_visible_rows();
                 if visible > 0 {
                     let max_scroll = result_max_scroll(state);
-                    state.result_interaction.scroll_offset = row
-                        .saturating_sub(visible.saturating_sub(1))
-                        .min(max_scroll);
+                    state.result_interaction.set_scroll_offset(
+                        row.saturating_sub(visible.saturating_sub(1))
+                            .min(max_scroll),
+                    );
                 }
             }
             DispatchResult::handled()
@@ -232,8 +244,11 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             direction: ScrollDirection::Left,
             amount: ScrollAmount::Line,
         } => {
-            state.result_interaction.horizontal_offset =
-                calculate_prev_column_offset(state.result_interaction.horizontal_offset);
+            state
+                .result_interaction
+                .set_horizontal_offset(calculate_prev_column_offset(
+                    state.result_interaction.horizontal_offset(),
+                ));
             DispatchResult::handled()
         }
         Action::Scroll {
@@ -243,11 +258,13 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
         } => {
             let plan = &state.ui.result_viewport_plan;
             let all_widths_len = plan.max_offset + plan.column_count;
-            state.result_interaction.horizontal_offset = calculate_next_column_offset(
-                all_widths_len,
-                state.result_interaction.horizontal_offset,
-                plan.column_count,
-            );
+            state
+                .result_interaction
+                .set_horizontal_offset(calculate_next_column_offset(
+                    all_widths_len,
+                    state.result_interaction.horizontal_offset(),
+                    plan.column_count,
+                ));
             DispatchResult::handled()
         }
         _ => DispatchResult::pass(),
@@ -303,13 +320,13 @@ mod tests {
                 );
 
                 assert!(effects.is_handled());
-                assert_eq!(state.result_interaction.scroll_offset, 10);
+                assert_eq!(state.result_interaction.scroll_offset(), 10);
             }
 
             #[test]
             fn half_page_up_from_middle() {
                 let mut state = state_with_result_rows(100, 25);
-                state.result_interaction.scroll_offset = 50;
+                state.result_interaction.set_scroll_offset(50);
 
                 reduce_scroll(
                     &mut state,
@@ -320,14 +337,14 @@ mod tests {
                     },
                 );
 
-                assert_eq!(state.result_interaction.scroll_offset, 40);
+                assert_eq!(state.result_interaction.scroll_offset(), 40);
             }
 
             #[test]
             fn full_page_down_clamped_at_max() {
                 let mut state = state_with_result_rows(30, 25);
                 // visible = 20, max_scroll = 30-20 = 10
-                state.result_interaction.scroll_offset = 5;
+                state.result_interaction.set_scroll_offset(5);
 
                 reduce_scroll(
                     &mut state,
@@ -338,13 +355,13 @@ mod tests {
                     },
                 );
 
-                assert_eq!(state.result_interaction.scroll_offset, 10);
+                assert_eq!(state.result_interaction.scroll_offset(), 10);
             }
 
             #[test]
             fn full_page_up_clamped_at_zero() {
                 let mut state = state_with_result_rows(100, 25);
-                state.result_interaction.scroll_offset = 5;
+                state.result_interaction.set_scroll_offset(5);
 
                 reduce_scroll(
                     &mut state,
@@ -355,7 +372,7 @@ mod tests {
                     },
                 );
 
-                assert_eq!(state.result_interaction.scroll_offset, 0);
+                assert_eq!(state.result_interaction.scroll_offset(), 0);
             }
         }
 
@@ -393,7 +410,7 @@ mod tests {
                     },
                 );
 
-                assert_eq!(state.result_interaction.scroll_offset, 0);
+                assert_eq!(state.result_interaction.scroll_offset(), 0);
             }
         }
 
@@ -404,7 +421,7 @@ mod tests {
             fn half_page_down_moves_both_cursor_and_viewport() {
                 let mut state = state_with_result_rows(100, 25);
                 state.result_interaction.activate_cell(10, 0);
-                state.result_interaction.scroll_offset = 5;
+                state.result_interaction.set_scroll_offset(5);
 
                 reduce_scroll(
                     &mut state,
@@ -416,14 +433,14 @@ mod tests {
                 );
 
                 assert_eq!(state.result_interaction.selection().row(), Some(20));
-                assert_eq!(state.result_interaction.scroll_offset, 15);
+                assert_eq!(state.result_interaction.scroll_offset(), 15);
             }
 
             #[test]
             fn half_page_up_moves_both_cursor_and_viewport() {
                 let mut state = state_with_result_rows(100, 25);
                 state.result_interaction.activate_cell(30, 0);
-                state.result_interaction.scroll_offset = 25;
+                state.result_interaction.set_scroll_offset(25);
 
                 reduce_scroll(
                     &mut state,
@@ -435,14 +452,14 @@ mod tests {
                 );
 
                 assert_eq!(state.result_interaction.selection().row(), Some(20));
-                assert_eq!(state.result_interaction.scroll_offset, 15);
+                assert_eq!(state.result_interaction.scroll_offset(), 15);
             }
 
             #[test]
             fn half_page_down_preserves_relative_position() {
                 let mut state = state_with_result_rows(100, 25);
                 state.result_interaction.activate_cell(15, 3);
-                state.result_interaction.scroll_offset = 10;
+                state.result_interaction.set_scroll_offset(10);
 
                 reduce_scroll(
                     &mut state,
@@ -455,9 +472,9 @@ mod tests {
 
                 assert_eq!(state.result_interaction.selection().row(), Some(25));
                 assert_eq!(state.result_interaction.selection().cell(), Some(3));
-                assert_eq!(state.result_interaction.scroll_offset, 20);
+                assert_eq!(state.result_interaction.scroll_offset(), 20);
                 let relative = state.result_interaction.selection().row().unwrap()
-                    - state.result_interaction.scroll_offset;
+                    - state.result_interaction.scroll_offset();
                 assert_eq!(relative, 5);
             }
 
@@ -465,7 +482,7 @@ mod tests {
             fn half_page_down_preserves_column() {
                 let mut state = state_with_result_rows(100, 25);
                 state.result_interaction.activate_cell(10, 3);
-                state.result_interaction.scroll_offset = 5;
+                state.result_interaction.set_scroll_offset(5);
 
                 reduce_scroll(
                     &mut state,
@@ -478,14 +495,14 @@ mod tests {
 
                 assert_eq!(state.result_interaction.selection().row(), Some(20));
                 assert_eq!(state.result_interaction.selection().cell(), Some(3));
-                assert_eq!(state.result_interaction.scroll_offset, 15);
+                assert_eq!(state.result_interaction.scroll_offset(), 15);
             }
 
             #[test]
             fn full_page_down_moves_both() {
                 let mut state = state_with_result_rows(100, 25);
                 state.result_interaction.activate_cell(10, 0);
-                state.result_interaction.scroll_offset = 5;
+                state.result_interaction.set_scroll_offset(5);
 
                 reduce_scroll(
                     &mut state,
@@ -497,14 +514,14 @@ mod tests {
                 );
 
                 assert_eq!(state.result_interaction.selection().row(), Some(30));
-                assert_eq!(state.result_interaction.scroll_offset, 25);
+                assert_eq!(state.result_interaction.scroll_offset(), 25);
             }
 
             #[test]
             fn full_page_up_moves_both() {
                 let mut state = state_with_result_rows(100, 25);
                 state.result_interaction.activate_cell(40, 0);
-                state.result_interaction.scroll_offset = 30;
+                state.result_interaction.set_scroll_offset(30);
 
                 reduce_scroll(
                     &mut state,
@@ -516,7 +533,7 @@ mod tests {
                 );
 
                 assert_eq!(state.result_interaction.selection().row(), Some(20));
-                assert_eq!(state.result_interaction.scroll_offset, 10);
+                assert_eq!(state.result_interaction.scroll_offset(), 10);
             }
         }
 
@@ -535,14 +552,14 @@ mod tests {
                     },
                 );
 
-                assert_eq!(state.result_interaction.scroll_offset, 0);
+                assert_eq!(state.result_interaction.scroll_offset(), 0);
             }
 
             #[test]
             fn half_page_down_clamps_near_bottom() {
                 let mut state = state_with_result_rows(100, 25);
                 state.result_interaction.activate_cell(95, 0);
-                state.result_interaction.scroll_offset = 75;
+                state.result_interaction.set_scroll_offset(75);
 
                 reduce_scroll(
                     &mut state,
@@ -554,14 +571,14 @@ mod tests {
                 );
 
                 assert_eq!(state.result_interaction.selection().row(), Some(99));
-                assert_eq!(state.result_interaction.scroll_offset, 80);
+                assert_eq!(state.result_interaction.scroll_offset(), 80);
             }
 
             #[test]
             fn half_page_up_clamps_near_top() {
                 let mut state = state_with_result_rows(100, 25);
                 state.result_interaction.activate_cell(5, 0);
-                state.result_interaction.scroll_offset = 3;
+                state.result_interaction.set_scroll_offset(3);
 
                 reduce_scroll(
                     &mut state,
@@ -573,14 +590,14 @@ mod tests {
                 );
 
                 assert_eq!(state.result_interaction.selection().row(), Some(0));
-                assert_eq!(state.result_interaction.scroll_offset, 0);
+                assert_eq!(state.result_interaction.scroll_offset(), 0);
             }
 
             #[test]
             fn visible_zero_cell_active_is_noop() {
                 let mut state = state_with_result_rows(100, 0);
                 state.result_interaction.activate_cell(5, 1);
-                state.result_interaction.scroll_offset = 3;
+                state.result_interaction.set_scroll_offset(3);
 
                 reduce_scroll(
                     &mut state,
@@ -593,7 +610,7 @@ mod tests {
 
                 assert_eq!(state.result_interaction.selection().row(), Some(5));
                 assert_eq!(state.result_interaction.selection().cell(), Some(1));
-                assert_eq!(state.result_interaction.scroll_offset, 3);
+                assert_eq!(state.result_interaction.scroll_offset(), 3);
             }
 
             #[test]
@@ -611,14 +628,14 @@ mod tests {
                 );
 
                 assert_eq!(state.result_interaction.selection().row(), Some(9));
-                assert_eq!(state.result_interaction.scroll_offset, 0);
+                assert_eq!(state.result_interaction.scroll_offset(), 0);
             }
 
             #[test]
             fn full_page_down_clamps_near_bottom() {
                 let mut state = state_with_result_rows(100, 25);
                 state.result_interaction.activate_cell(90, 0);
-                state.result_interaction.scroll_offset = 75;
+                state.result_interaction.set_scroll_offset(75);
 
                 reduce_scroll(
                     &mut state,
@@ -630,14 +647,14 @@ mod tests {
                 );
 
                 assert_eq!(state.result_interaction.selection().row(), Some(99));
-                assert_eq!(state.result_interaction.scroll_offset, 80);
+                assert_eq!(state.result_interaction.scroll_offset(), 80);
             }
 
             #[test]
             fn full_page_up_clamps_near_top() {
                 let mut state = state_with_result_rows(100, 25);
                 state.result_interaction.activate_cell(10, 0);
-                state.result_interaction.scroll_offset = 5;
+                state.result_interaction.set_scroll_offset(5);
 
                 reduce_scroll(
                     &mut state,
@@ -649,14 +666,14 @@ mod tests {
                 );
 
                 assert_eq!(state.result_interaction.selection().row(), Some(0));
-                assert_eq!(state.result_interaction.scroll_offset, 0);
+                assert_eq!(state.result_interaction.scroll_offset(), 0);
             }
 
             #[test]
             fn visible_zero_cell_active_full_page_is_noop() {
                 let mut state = state_with_result_rows(100, 0);
                 state.result_interaction.activate_cell(5, 1);
-                state.result_interaction.scroll_offset = 3;
+                state.result_interaction.set_scroll_offset(3);
 
                 reduce_scroll(
                     &mut state,
@@ -669,7 +686,7 @@ mod tests {
 
                 assert_eq!(state.result_interaction.selection().row(), Some(5));
                 assert_eq!(state.result_interaction.selection().cell(), Some(1));
-                assert_eq!(state.result_interaction.scroll_offset, 3);
+                assert_eq!(state.result_interaction.scroll_offset(), 3);
             }
         }
     }
@@ -682,7 +699,7 @@ mod tests {
             let mut state = state_with_result_rows(100, 25);
             // visible = 20
             state.result_interaction.activate_cell(50, 0);
-            state.result_interaction.scroll_offset = 50;
+            state.result_interaction.set_scroll_offset(50);
             state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
 
             reduce_scroll(
@@ -694,7 +711,7 @@ mod tests {
             );
 
             // row=50, visible=20, offset=50-10=40, max=80 → 40
-            assert_eq!(state.result_interaction.scroll_offset, 40);
+            assert_eq!(state.result_interaction.scroll_offset(), 40);
             assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
         }
 
@@ -702,7 +719,7 @@ mod tests {
         fn scroll_cursor_top_puts_row_at_top() {
             let mut state = state_with_result_rows(100, 25);
             state.result_interaction.activate_cell(30, 0);
-            state.result_interaction.scroll_offset = 20;
+            state.result_interaction.set_scroll_offset(20);
             state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
 
             reduce_scroll(
@@ -713,7 +730,7 @@ mod tests {
                 },
             );
 
-            assert_eq!(state.result_interaction.scroll_offset, 30);
+            assert_eq!(state.result_interaction.scroll_offset(), 30);
             assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
         }
 
@@ -721,7 +738,7 @@ mod tests {
         fn scroll_cursor_bottom_puts_row_at_bottom() {
             let mut state = state_with_result_rows(100, 25);
             state.result_interaction.activate_cell(30, 0);
-            state.result_interaction.scroll_offset = 30;
+            state.result_interaction.set_scroll_offset(30);
             state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
 
             reduce_scroll(
@@ -733,14 +750,14 @@ mod tests {
             );
 
             // row=30, visible=20, offset=30-19=11, max=80 → 11
-            assert_eq!(state.result_interaction.scroll_offset, 11);
+            assert_eq!(state.result_interaction.scroll_offset(), 11);
             assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
         }
 
         #[test]
         fn scroll_cursor_center_is_noop_in_scroll_mode() {
             let mut state = state_with_result_rows(100, 25);
-            state.result_interaction.scroll_offset = 20;
+            state.result_interaction.set_scroll_offset(20);
             state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
 
             reduce_scroll(
@@ -752,7 +769,7 @@ mod tests {
             );
 
             // No row selected, offset unchanged
-            assert_eq!(state.result_interaction.scroll_offset, 20);
+            assert_eq!(state.result_interaction.scroll_offset(), 20);
             assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
         }
 
@@ -761,7 +778,7 @@ mod tests {
             let mut state = state_with_result_rows(100, 25);
             // visible=20, max_scroll=80
             state.result_interaction.activate_cell(95, 0);
-            state.result_interaction.scroll_offset = 80;
+            state.result_interaction.set_scroll_offset(80);
             state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
 
             reduce_scroll(
@@ -773,7 +790,7 @@ mod tests {
             );
 
             // row=95, clamped to max_scroll=80
-            assert_eq!(state.result_interaction.scroll_offset, 80);
+            assert_eq!(state.result_interaction.scroll_offset(), 80);
             assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
         }
     }
@@ -815,7 +832,7 @@ mod tests {
             state.query.enter_history(0);
 
             state.result_interaction.activate_cell(2, 0);
-            state.result_interaction.scroll_offset = 0;
+            state.result_interaction.set_scroll_offset(0);
 
             reduce_scroll(
                 &mut state,
@@ -829,7 +846,7 @@ mod tests {
             // Should clamp to history entry max_row=4, not live preview max_row=99
             assert_eq!(state.result_interaction.selection().row(), Some(4));
             // max_scroll = 5 - 20 = 0 (history has fewer rows than viewport)
-            assert_eq!(state.result_interaction.scroll_offset, 0);
+            assert_eq!(state.result_interaction.scroll_offset(), 0);
         }
 
         #[test]

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -107,11 +107,11 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             let _ = state.session.begin_connecting("postgres://localhost/test");
             state.session.set_selection_generation(7);
+            state.query.pagination.reset_for_table("public", "users");
             state
                 .query
                 .pagination
                 .set_page_result(current_page, state.query.pagination.reached_end());
-            state.query.pagination.reset_for_table("public", "users");
             state.query.set_current_result(Arc::new(QueryResult {
                 query: "SELECT * FROM public.users".to_string(),
                 columns: vec!["id".to_string(), "name".to_string()],

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -105,10 +105,13 @@ mod tests {
             current_page: usize,
         ) -> AppState {
             let mut state = AppState::new("test".to_string());
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state.session.set_selection_generation(7);
-            state.query.pagination.set_page_for_test(current_page);
-            state.query.pagination.set_table_for_test("public", "users");
+            state
+                .query
+                .pagination
+                .set_page_result(current_page, state.query.pagination.reached_end());
+            state.query.pagination.reset_for_table("public", "users");
             state.query.set_current_result(Arc::new(QueryResult {
                 query: "SELECT * FROM public.users".to_string(),
                 columns: vec!["id".to_string(), "name".to_string()],

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -31,11 +31,11 @@ pub fn reduce_yank(
                     .and_then(|row| row.get(col_idx))
                     .cloned();
                 if let Some(value) = content {
-                    state.result_interaction.yank_flash = Some(YankFlash {
+                    state.result_interaction.set_yank_flash(Some(YankFlash {
                         row: row_idx,
                         col: Some(col_idx),
                         until: now + Duration::from_millis(200),
-                    });
+                    }));
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: value,
                         on_success: Some(Box::new(Action::CellCopied)),
@@ -88,11 +88,11 @@ pub fn reduce_yank(
                             .join("\t")
                     });
                 if let Some(tsv) = content {
-                    state.result_interaction.yank_flash = Some(YankFlash {
+                    state.result_interaction.set_yank_flash(Some(YankFlash {
                         row: row_idx,
                         col: None,
                         until: now + Duration::from_millis(200),
-                    });
+                    }));
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: tsv,
                         on_success: Some(Box::new(Action::CellCopied)),

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -73,10 +73,10 @@ pub(super) fn reduce_connection_error(
             DispatchResult::handled()
         }
         Action::RetryServiceConnection => {
-            if let Some(dsn) = state.session.dsn.clone() {
+            if let Some(dsn) = state.session.dsn_owned() {
                 state.connection_error.clear();
                 let run_id = state.session.begin_connecting(&dsn);
-                state.session.read_only = false;
+                state.session.disable_read_only();
                 state.modal.set_mode(InputMode::Normal);
                 DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
             } else {
@@ -132,7 +132,7 @@ mod tests {
         #[test]
         fn blocked_for_service_connection() {
             let mut state = AppState::new("test".to_string());
-            state.session.dsn = Some("service=mydb".to_string());
+            let _ = state.session.begin_connecting("service=mydb");
             state.modal.set_mode(InputMode::ConnectionError);
 
             reduce_connection_error(&mut state, &Action::ReenterConnectionSetup, Instant::now());
@@ -143,7 +143,7 @@ mod tests {
         #[test]
         fn allowed_for_profile_connection() {
             let mut state = AppState::new("test".to_string());
-            state.session.dsn = Some("postgres://localhost/db".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/db");
             state.modal.set_mode(InputMode::ConnectionError);
 
             reduce_connection_error(&mut state, &Action::ReenterConnectionSetup, Instant::now());

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -73,7 +73,7 @@ pub(super) fn reduce_connection_error(
             DispatchResult::handled()
         }
         Action::RetryServiceConnection => {
-            if let Some(dsn) = state.session.dsn_owned() {
+            if let Some(dsn) = state.session.dsn().map(String::from) {
                 state.connection_error.clear();
                 let run_id = state.session.begin_connecting(&dsn);
                 state.session.disable_read_only();
@@ -132,7 +132,7 @@ mod tests {
         #[test]
         fn blocked_for_service_connection() {
             let mut state = AppState::new("test".to_string());
-            let _ = state.session.begin_connecting("service=mydb");
+            state.session.set_dsn_for_test("service=mydb");
             state.modal.set_mode(InputMode::ConnectionError);
 
             reduce_connection_error(&mut state, &Action::ReenterConnectionSetup, Instant::now());
@@ -143,7 +143,7 @@ mod tests {
         #[test]
         fn allowed_for_profile_connection() {
             let mut state = AppState::new("test".to_string());
-            let _ = state.session.begin_connecting("postgres://localhost/db");
+            state.session.set_dsn_for_test("postgres://localhost/db");
             state.modal.set_mode(InputMode::ConnectionError);
 
             reduce_connection_error(&mut state, &Action::ReenterConnectionSetup, Instant::now());

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -38,12 +38,12 @@ pub fn reduce_connection_lifecycle(
             {
                 if let Some(dsn) = state.session.dsn().map(str::to_string) {
                     let run_id = state.session.begin_connecting(&dsn);
-                    DispatchResult::Handled(vec![Effect::FetchMetadata { dsn, run_id }])
+                    DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
                 } else {
-                    DispatchResult::Handled(vec![])
+                    DispatchResult::handled()
                 }
             } else {
-                DispatchResult::Handled(vec![])
+                DispatchResult::handled()
             }
         }
 
@@ -60,12 +60,12 @@ pub fn reduce_connection_lifecycle(
 
             if let Some(cached) = state.connection_caches.get(id).cloned() {
                 restore_cache(state, &cached, id, name, *database_type, dsn);
-                DispatchResult::Handled(vec![Effect::ClearCompletionEngineCache])
+                DispatchResult::handled_with(vec![Effect::ClearCompletionEngineCache])
             } else {
                 // No cache: reset and fetch metadata
                 reset_for_new_connection(state, id, dsn, name, *database_type);
                 let run_id = state.session.begin_connecting(dsn);
-                DispatchResult::Handled(vec![
+                DispatchResult::handled_with(vec![
                     Effect::ClearCompletionEngineCache,
                     Effect::FetchMetadata {
                         dsn: dsn.clone(),

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -21,7 +21,7 @@ fn reset_for_new_connection(
     state.ui.set_explorer_selection(None);
     state
         .session
-        .set_active_connection(id, name, database_type, dsn);
+        .set_active_connection_with_dsn(id, name, database_type, dsn);
     state.session.disable_read_only();
 }
 
@@ -112,7 +112,7 @@ mod tests {
         let current_id = ConnectionId::new();
         let new_id = ConnectionId::new();
 
-        state.session.set_active_connection(
+        state.session.set_active_connection_with_dsn(
             &current_id,
             "current",
             DatabaseType::PostgreSQL,
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn sqlite_try_connect_fetches_metadata() {
         let mut state = AppState::new("test".to_string());
-        state.session.set_active_connection(
+        state.session.set_active_connection_with_dsn(
             &ConnectionId::from_string("sqlite-test"),
             "sqlite",
             DatabaseType::SQLite,

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -112,9 +112,12 @@ mod tests {
         let current_id = ConnectionId::new();
         let new_id = ConnectionId::new();
 
-        state
-            .session
-            .set_active_connection_id_for_test(Some(current_id.clone()));
+        state.session.set_active_connection(
+            &current_id,
+            "current",
+            DatabaseType::PostgreSQL,
+            "postgres://localhost/current",
+        );
         state.ui.set_explorer_selected_raw(5);
         state.ui.set_inspector_tab(InspectorTab::Indexes);
 
@@ -257,10 +260,12 @@ mod tests {
     #[test]
     fn sqlite_try_connect_fetches_metadata() {
         let mut state = AppState::new("test".to_string());
-        state.session.set_dsn_for_test("sqlite:///tmp/app.db");
-        state
-            .session
-            .set_active_database_type_for_test(Some(DatabaseType::SQLite));
+        state.session.set_active_connection(
+            &ConnectionId::from_string("sqlite-test"),
+            "sqlite",
+            DatabaseType::SQLite,
+            "sqlite:///tmp/app.db",
+        );
         state
             .session
             .set_connection_state(ConnectionState::NotConnected);

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -190,7 +190,7 @@ mod tests {
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
             state.ui.set_connection_list_selected_raw(0);
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &profile_id,
                 "Production",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -303,7 +303,7 @@ mod tests {
             let profile = create_profile("Production");
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &profile_id,
                 "Production",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -330,7 +330,7 @@ mod tests {
             let profile = create_profile("Production");
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &profile_id,
                 "Production",
                 crate::domain::DatabaseType::PostgreSQL,

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -342,10 +342,7 @@ mod tests {
 
             // Set state that was previously not reset by ConnectionDeleted
             state.query.enter_history(2);
-            state
-                .query
-                .pagination
-                .set_page_result(3, state.query.pagination.reached_end());
+            state.query.pagination.set_current_page(3);
             state.result_interaction.activate_cell(5, 0);
             state.result_interaction.set_scroll_offset(10);
             state.result_interaction.set_horizontal_offset(20);

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -190,9 +190,12 @@ mod tests {
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
             state.ui.set_connection_list_selected_raw(0);
-            state
-                .session
-                .set_active_connection_id_for_test(Some(profile_id));
+            state.session.set_active_connection(
+                &profile_id,
+                "Production",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/db",
+            );
 
             reduce_connection_selector(
                 &mut state,
@@ -300,10 +303,12 @@ mod tests {
             let profile = create_profile("Production");
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
-            state
-                .session
-                .set_active_connection_id_for_test(Some(profile_id.clone()));
-            state.session.set_dsn_for_test("postgres://localhost/db");
+            state.session.set_active_connection(
+                &profile_id,
+                "Production",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/db",
+            );
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -325,17 +330,22 @@ mod tests {
             let profile = create_profile("Production");
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
-            state
-                .session
-                .set_active_connection_id_for_test(Some(profile_id.clone()));
-            state.session.set_dsn_for_test("postgres://localhost/db");
+            state.session.set_active_connection(
+                &profile_id,
+                "Production",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/db",
+            );
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
 
             // Set state that was previously not reset by ConnectionDeleted
             state.query.enter_history(2);
-            state.query.pagination.set_page_for_test(3);
+            state
+                .query
+                .pagination
+                .set_page_result(3, state.query.pagination.reached_end());
             state.result_interaction.activate_cell(5, 0);
             state.result_interaction.set_scroll_offset(10);
             state.result_interaction.set_horizontal_offset(20);

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -572,7 +572,7 @@ mod tests {
         #[test]
         fn is_first_run_false_when_already_connected() {
             let mut state = AppState::new("test".to_string());
-            state.session.set_dsn_for_test("postgres://localhost/db");
+            let _ = state.session.begin_connecting("postgres://localhost/db");
 
             reduce(
                 &mut state,

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -572,7 +572,7 @@ mod tests {
         #[test]
         fn is_first_run_false_when_already_connected() {
             let mut state = AppState::new("test".to_string());
-            let _ = state.session.begin_connecting("postgres://localhost/db");
+            state.session.set_dsn_for_test("postgres://localhost/db");
 
             reduce(
                 &mut state,

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -197,7 +197,7 @@ pub fn reduce_connection_setup(
             state.modal.set_mode(InputMode::Normal);
             state
                 .session
-                .set_active_connection(id, name, *database_type, dsn);
+                .set_active_connection_with_dsn(id, name, *database_type, dsn);
             state.session.disable_read_only();
             let run_id = state.session.begin_connecting(dsn);
             DispatchResult::Handled(vec![Effect::FetchMetadata {

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -38,7 +38,7 @@ pub(super) fn reduce_diagram_lifecycle(
                 return DispatchResult::handled();
             }
 
-            let Some(dsn) = state.session.dsn.clone() else {
+            let Some(dsn) = state.session.dsn_owned() else {
                 state.set_error("No active connection".to_string());
                 return DispatchResult::handled();
             };
@@ -67,7 +67,7 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled_with(vec![Effect::GenerateErDiagramFromCache {
                 total_tables,
                 project_name: state.runtime.project_name.clone(),
-                target_tables: state.er_preparation.target_tables.clone(),
+                target_tables: state.er_preparation.target_tables_owned(),
             }])
         }
         _ => DispatchResult::pass(),

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -48,7 +48,7 @@ pub(super) fn reduce_diagram_lifecycle(
             }
 
             state.sql_modal.invalidate_prefetch();
-            let run_id = state.er_preparation.begin_smart_refresh();
+            let run_id = state.er_preparation.start_waiting_run();
             state.set_success("Checking for schema changes...".to_string());
 
             DispatchResult::handled_with(vec![Effect::SmartErRefresh { dsn, run_id }])
@@ -58,7 +58,7 @@ pub(super) fn reduce_diagram_lifecycle(
                 return DispatchResult::handled();
             }
 
-            state.er_preparation.begin_rendering();
+            state.er_preparation.mark_rendering();
             let total_tables = state
                 .session
                 .metadata()

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -38,7 +38,7 @@ pub(super) fn reduce_diagram_lifecycle(
                 return DispatchResult::handled();
             }
 
-            let Some(dsn) = state.session.dsn_owned() else {
+            let Some(dsn) = state.session.dsn().map(String::from) else {
                 state.set_error("No active connection".to_string());
                 return DispatchResult::handled();
             };
@@ -67,7 +67,7 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled_with(vec![Effect::GenerateErDiagramFromCache {
                 total_tables,
                 project_name: state.runtime.project_name.clone(),
-                target_tables: state.er_preparation.target_tables_owned(),
+                target_tables: state.er_preparation.target_tables().to_vec(),
             }])
         }
         _ => DispatchResult::pass(),

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -32,7 +32,7 @@ mod tests {
 
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
-        let _ = state.session.begin_connecting(dsn);
+        state.session.set_dsn_for_test(dsn);
         state
     }
 

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -38,7 +38,7 @@ mod tests {
 
     fn set_active_run_id(state: &mut AppState, run_id: u64) {
         for _ in 0..run_id {
-            state.er_preparation.begin_smart_refresh();
+            let _ = state.er_preparation.start_waiting_run();
         }
         state.er_preparation.mark_idle();
     }

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -16,6 +16,7 @@ pub fn dispatch_er(state: &mut AppState, action: &Action, now: Instant) -> Dispa
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::time::Instant;
 
     use super::*;
@@ -31,7 +32,7 @@ mod tests {
 
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
-        state.session.dsn = Some(dsn.to_string());
+        let _ = state.session.begin_connecting(dsn);
         state
     }
 
@@ -67,7 +68,7 @@ mod tests {
                 .into_effects()
                 .expect("reducer should handle action");
 
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
             assert_eq!(state.er_preparation.run_id(), 1);
             assert_eq!(effects.len(), 1);
             assert!(matches!(
@@ -104,7 +105,7 @@ mod tests {
                 .expect("reducer should handle action");
 
             assert!(!state.sql_modal.is_prefetch_started());
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
         }
@@ -125,7 +126,7 @@ mod tests {
         #[test]
         fn rendering_status_returns_empty_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Rendering;
+            state.er_preparation.mark_rendering();
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
                 .into_effects()
@@ -137,7 +138,7 @@ mod tests {
         #[test]
         fn waiting_status_returns_empty_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
                 .into_effects()
@@ -167,14 +168,16 @@ mod tests {
         #[test]
         fn idle_status_returns_generate_effect() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Idle;
+            state.er_preparation.mark_idle();
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
                 table_summaries: vec![],
                 fetched_at: Instant::now(),
             })));
-            state.er_preparation.target_tables = vec!["public.users".to_string()];
+            state
+                .er_preparation
+                .set_targets(vec!["public.users".to_string()]);
 
             let effects = reduce_er(&mut state, &Action::ErGenerateFromCache, Instant::now())
                 .into_effects()
@@ -186,13 +189,13 @@ mod tests {
                 Effect::GenerateErDiagramFromCache { target_tables, .. }
                     if target_tables == &vec!["public.users".to_string()]
             ));
-            assert_eq!(state.er_preparation.status, ErStatus::Rendering);
+            assert_eq!(state.er_preparation.status(), ErStatus::Rendering);
         }
 
         #[test]
         fn rendering_status_returns_empty_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.status = ErStatus::Rendering;
+            state.er_preparation.mark_rendering();
 
             let effects = reduce_er(&mut state, &Action::ErGenerateFromCache, Instant::now())
                 .into_effects()
@@ -224,7 +227,7 @@ mod tests {
         fn no_changes_dispatches_generate_from_cache() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -253,7 +256,7 @@ mod tests {
         fn stale_tables_trigger_evict_and_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -287,7 +290,7 @@ mod tests {
         fn added_tables_trigger_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -316,7 +319,7 @@ mod tests {
         fn removed_tables_trigger_evict() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -345,7 +348,7 @@ mod tests {
         fn missing_in_cache_triggers_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -374,7 +377,7 @@ mod tests {
         fn mismatched_run_id_returns_empty_for_completed() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 5);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
                 dsn: "postgres://localhost/test".to_string(),
@@ -398,7 +401,7 @@ mod tests {
         fn updates_metadata_and_signatures() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let new_sigs: HashMap<String, String> =
@@ -427,7 +430,7 @@ mod tests {
                     .len(),
                 5
             );
-            assert_eq!(state.er_preparation.last_signatures, new_sigs);
+            assert_eq!(state.er_preparation.last_signatures(), &new_sigs);
         }
     }
 
@@ -452,12 +455,12 @@ mod tests {
         fn falls_back_to_full_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state.session.set_metadata(Some(make_metadata(5)));
-            state
-                .er_preparation
-                .last_signatures
-                .insert("public.old".to_string(), "sig".to_string());
+            state.er_preparation.apply_refresh_metadata(
+                HashMap::from([("public.old".to_string(), "sig".to_string())]),
+                5,
+            );
 
             let effects = reduce_er(
                 &mut state,
@@ -471,7 +474,7 @@ mod tests {
             )
             .unwrap();
 
-            assert!(state.er_preparation.last_signatures.is_empty());
+            assert!(state.er_preparation.last_signatures().is_empty());
             assert!(state.messages.last_error.is_some());
             assert!(
                 state
@@ -496,9 +499,11 @@ mod tests {
         fn falls_back_to_scoped_prefetch_when_targets_set() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state.session.set_metadata(Some(make_metadata(10)));
-            state.er_preparation.target_tables = vec!["public.t0".to_string()];
+            state
+                .er_preparation
+                .set_targets(vec!["public.t0".to_string()]);
 
             let effects = reduce_er(
                 &mut state,
@@ -522,7 +527,7 @@ mod tests {
                 Effect::DispatchActions(actions)
                     if actions.iter().any(|a| matches!(a, Action::StartPrefetchScoped { .. }))
             )));
-            assert!(state.er_preparation.last_signatures.is_empty());
+            assert!(state.er_preparation.last_signatures().is_empty());
             assert!(
                 state
                     .messages
@@ -536,7 +541,7 @@ mod tests {
         fn mismatched_run_id_returns_empty_for_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 5);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state.session.set_metadata(Some(make_metadata(5)));
 
             let effects = reduce_er(
@@ -558,7 +563,7 @@ mod tests {
         fn mismatched_dsn_returns_empty_for_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state.session.set_metadata(Some(make_metadata(5)));
 
             let effects = reduce_er(
@@ -574,7 +579,7 @@ mod tests {
             .unwrap();
 
             assert!(effects.is_empty());
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
             assert_eq!(state.session.metadata().unwrap().table_summaries.len(), 5);
             assert!(state.messages.last_error.is_none());
         }
@@ -583,7 +588,7 @@ mod tests {
         fn no_metadata_sets_idle_and_error() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
 
             let effects = reduce_er(
                 &mut state,
@@ -597,7 +602,7 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(effects.is_empty());
             assert!(state.messages.last_error.is_some());
         }
@@ -606,7 +611,7 @@ mod tests {
         fn new_metadata_applied_before_fallback() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             state.session.set_metadata(Some(make_metadata(3)));
 
             let effects = reduce_er(

--- a/src/app/update/er/smart_refresh_completed.rs
+++ b/src/app/update/er/smart_refresh_completed.rs
@@ -22,18 +22,14 @@ pub(super) fn reduce_smart_refresh_completed(
             missing_in_cache,
             new_signatures,
         }) => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.er_preparation.is_current_run(*run_id)
-            {
+            if !state.session.dsn_matches(dsn) || !state.er_preparation.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
             state.session.set_metadata(Some(Arc::clone(new_metadata)));
             state
                 .er_preparation
-                .last_signatures
-                .clone_from(new_signatures);
-            state.er_preparation.total_tables = new_metadata.table_summaries.len();
+                .apply_refresh_metadata(new_signatures.clone(), new_metadata.table_summaries.len());
 
             let mut effects: Vec<Effect> = Vec::new();
 

--- a/src/app/update/er/smart_refresh_failed.rs
+++ b/src/app/update/er/smart_refresh_failed.rs
@@ -18,9 +18,7 @@ pub(super) fn reduce_smart_refresh_failed(
             error,
             new_metadata,
         }) => {
-            if state.session.dsn.as_ref() != Some(dsn)
-                || !state.er_preparation.is_current_run(*run_id)
-            {
+            if !state.session.dsn_matches(dsn) || !state.er_preparation.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
 
@@ -33,18 +31,17 @@ pub(super) fn reduce_smart_refresh_failed(
                 state.set_error("Metadata not loaded yet".to_string());
                 return DispatchResult::handled();
             };
-            let total_table_count = metadata.table_summaries.len();
-            let is_scoped = !state.er_preparation.target_tables.is_empty()
-                && state.er_preparation.target_tables.len() < total_table_count;
+            let scoped_tables = state
+                .er_preparation
+                .scoped_fallback_tables(metadata.table_summaries.len());
+            state
+                .er_preparation
+                .invalidate_refresh_signatures(metadata.table_summaries.len());
 
-            state.er_preparation.total_tables = total_table_count;
-            state.er_preparation.last_signatures.clear();
-
-            if is_scoped {
+            if let Some(scoped_tables) = scoped_tables {
                 state.set_error(format!(
                     "Smart refresh failed ({error}), falling back to scoped prefetch"
                 ));
-                let scoped_tables = state.er_preparation.target_tables.clone();
                 DispatchResult::handled_with(vec![
                     Effect::ClearCompletionEngineCache,
                     Effect::DispatchActions(vec![Action::StartPrefetchScoped {

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -30,10 +30,9 @@ pub(super) fn reduce_analyze(
             if content.is_empty() {
                 return DispatchResult::handled();
             }
-            let Some(dsn) = &state.session.dsn else {
+            let Some(dsn) = state.session.dsn_owned() else {
                 return DispatchResult::handled();
             };
-            let dsn = dsn.clone();
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {
                 return DispatchResult::handled();
             }
@@ -49,7 +48,7 @@ pub(super) fn reduce_analyze(
 
             let is_dml = !matches!(kind, StatementKind::Select | StatementKind::Transaction);
 
-            if state.session.read_only && is_dml {
+            if state.session.is_read_only() && is_dml {
                 show_explain_error_on_plan(
                     state,
                     "Read-only mode: EXPLAIN ANALYZE is blocked for DML statements.",
@@ -79,7 +78,7 @@ pub(super) fn reduce_analyze(
                         query: explain_query,
                         source_query: content,
                         is_analyze: true,
-                        read_only: state.session.read_only,
+                        read_only: state.session.is_read_only(),
                     }]);
                 }
             }
@@ -103,7 +102,7 @@ pub(super) fn reduce_analyze(
                 _ => None,
             };
             if let Some(query) = query
-                && let Some(dsn) = state.session.dsn.clone()
+                && let Some(dsn) = state.session.dsn_owned()
             {
                 let Some(explain_query) = services.sql_dialect.build_explain_analyze_sql(&query)
                 else {
@@ -117,7 +116,7 @@ pub(super) fn reduce_analyze(
                     query: explain_query,
                     source_query: query,
                     is_analyze: true,
-                    read_only: state.session.read_only,
+                    read_only: state.session.is_read_only(),
                 }]);
             }
             DispatchResult::handled()

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -30,7 +30,7 @@ pub(super) fn reduce_analyze(
             if content.is_empty() {
                 return DispatchResult::handled();
             }
-            let Some(dsn) = state.session.dsn_owned() else {
+            let Some(dsn) = state.session.dsn().map(String::from) else {
                 return DispatchResult::handled();
             };
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {
@@ -102,7 +102,7 @@ pub(super) fn reduce_analyze(
                 _ => None,
             };
             if let Some(query) = query
-                && let Some(dsn) = state.session.dsn_owned()
+                && let Some(dsn) = state.session.dsn().map(String::from)
             {
                 let Some(explain_query) = services.sql_dialect.build_explain_analyze_sql(&query)
                 else {

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -66,10 +66,12 @@ mod tests {
     }
 
     fn use_sqlite_connection(state: &mut AppState) {
-        state.session.set_dsn_for_test("sqlite:///tmp/app.db");
-        state
-            .session
-            .set_active_database_type_for_test(Some(DatabaseType::SQLite));
+        state.session.set_active_connection(
+            &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
+            "sqlite",
+            DatabaseType::SQLite,
+            "sqlite:///tmp/app.db",
+        );
     }
 
     mod explain_request {
@@ -79,7 +81,7 @@ mod tests {
         fn empty_query_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("  ".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
                 .into_effects()
@@ -104,7 +106,7 @@ mod tests {
         fn running_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
@@ -118,7 +120,7 @@ mod tests {
         fn unsupported_database_sets_error_without_effects() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             let effects = reduce_explain_with_services(
                 &mut state,
@@ -165,7 +167,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT 1; DELETE FROM users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
                 .into_effects()
@@ -183,7 +185,7 @@ mod tests {
         fn starts_query_timer() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainRequest, Instant::now());
 
@@ -195,7 +197,7 @@ mod tests {
         fn emits_execute_explain_effect() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
                 .into_effects()
@@ -222,7 +224,7 @@ mod tests {
         #[test]
         fn empty_query_is_noop() {
             let mut state = sql_modal_state();
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -239,7 +241,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT 1; DELETE FROM users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -259,7 +261,7 @@ mod tests {
         fn unsupported_database_sets_error_without_effects() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             let effects = reduce_explain_with_services(
                 &mut state,
@@ -281,7 +283,7 @@ mod tests {
         fn select_executes_immediately_without_confirm() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -306,7 +308,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("INSERT INTO users VALUES (1)".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -331,7 +333,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("UPDATE users SET name='x' WHERE id=1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -356,7 +358,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -376,7 +378,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id=1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -401,7 +403,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DROP TABLE users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -421,7 +423,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("TRUNCATE users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -445,8 +447,8 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id=1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
-            state.session.read_only = true;
+            let _ = state.session.begin_connecting("dsn://test");
+            state.session.enable_read_only();
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -470,8 +472,8 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT * FROM users".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
-            state.session.read_only = true;
+            let _ = state.session.begin_connecting("dsn://test");
+            state.session.enable_read_only();
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -496,8 +498,8 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("INSERT INTO users VALUES (1)".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
-            state.session.read_only = true;
+            let _ = state.session.begin_connecting("dsn://test");
+            state.session.enable_read_only();
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -519,7 +521,7 @@ mod tests {
         #[test]
         fn confirm_from_high_with_matching_table_emits_effect() {
             let mut state = sql_modal_state();
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
             let mut input = crate::model::shared::text_input::TextInputState::default();
             for c in "users".chars() {
                 input.insert_char(c);
@@ -544,7 +546,7 @@ mod tests {
         #[test]
         fn confirm_from_high_with_mismatch_is_noop() {
             let mut state = sql_modal_state();
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
             let mut input = crate::model::shared::text_input::TextInputState::default();
             input.insert_char('x');
             state
@@ -590,7 +592,7 @@ mod tests {
         #[test]
         fn sets_plan_and_switches_to_plan_tab() {
             let mut state = sql_modal_state();
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
@@ -616,7 +618,7 @@ mod tests {
         #[test]
         fn mismatched_dsn_does_not_replace_plan() {
             let mut state = sql_modal_state();
-            state.session.dsn = Some("dsn://current".to_string());
+            let _ = state.session.begin_connecting("dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
             state
@@ -652,7 +654,7 @@ mod tests {
         #[test]
         fn sets_error_and_switches_to_plan_tab() {
             let mut state = sql_modal_state();
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
@@ -678,7 +680,7 @@ mod tests {
         #[test]
         fn mismatched_dsn_does_not_replace_plan_with_error() {
             let mut state = sql_modal_state();
-            state.session.dsn = Some("dsn://current".to_string());
+            let _ = state.session.begin_connecting("dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
             state
@@ -708,7 +710,7 @@ mod tests {
         fn two_explains_auto_advance_returns_comparable_slots() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("dsn://test".to_string());
+            let _ = state.session.begin_connecting("dsn://test");
             let now = Instant::now();
 
             // Step 1: First EXPLAIN

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -66,7 +66,7 @@ mod tests {
     }
 
     fn use_sqlite_connection(state: &mut AppState) {
-        state.session.set_active_connection(
+        state.session.set_active_connection_with_dsn(
             &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
             "sqlite",
             DatabaseType::SQLite,

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -81,7 +81,7 @@ mod tests {
         fn empty_query_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("  ".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
                 .into_effects()
@@ -106,7 +106,7 @@ mod tests {
         fn running_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
@@ -120,7 +120,7 @@ mod tests {
         fn unsupported_database_sets_error_without_effects() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects = reduce_explain_with_services(
                 &mut state,
@@ -167,7 +167,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT 1; DELETE FROM users".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
                 .into_effects()
@@ -185,7 +185,7 @@ mod tests {
         fn starts_query_timer() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainRequest, Instant::now());
 
@@ -197,7 +197,7 @@ mod tests {
         fn emits_execute_explain_effect() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
                 .into_effects()
@@ -224,7 +224,7 @@ mod tests {
         #[test]
         fn empty_query_is_noop() {
             let mut state = sql_modal_state();
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -241,7 +241,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT 1; DELETE FROM users".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -261,7 +261,7 @@ mod tests {
         fn unsupported_database_sets_error_without_effects() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects = reduce_explain_with_services(
                 &mut state,
@@ -283,7 +283,7 @@ mod tests {
         fn select_executes_immediately_without_confirm() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -308,7 +308,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("INSERT INTO users VALUES (1)".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -333,7 +333,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("UPDATE users SET name='x' WHERE id=1".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -358,7 +358,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -378,7 +378,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id=1".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -403,7 +403,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DROP TABLE users".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -423,7 +423,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("TRUNCATE users".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -447,7 +447,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id=1".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
             state.session.enable_read_only();
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
@@ -472,7 +472,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT * FROM users".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
             state.session.enable_read_only();
 
             let effects =
@@ -498,7 +498,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("INSERT INTO users VALUES (1)".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
             state.session.enable_read_only();
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
@@ -521,7 +521,7 @@ mod tests {
         #[test]
         fn confirm_from_high_with_matching_table_emits_effect() {
             let mut state = sql_modal_state();
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
             let mut input = crate::model::shared::text_input::TextInputState::default();
             for c in "users".chars() {
                 input.insert_char(c);
@@ -546,7 +546,7 @@ mod tests {
         #[test]
         fn confirm_from_high_with_mismatch_is_noop() {
             let mut state = sql_modal_state();
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
             let mut input = crate::model::shared::text_input::TextInputState::default();
             input.insert_char('x');
             state
@@ -592,7 +592,7 @@ mod tests {
         #[test]
         fn sets_plan_and_switches_to_plan_tab() {
             let mut state = sql_modal_state();
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
@@ -618,7 +618,7 @@ mod tests {
         #[test]
         fn mismatched_dsn_does_not_replace_plan() {
             let mut state = sql_modal_state();
-            let _ = state.session.begin_connecting("dsn://current");
+            state.session.set_dsn_for_test("dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
             state
@@ -654,7 +654,7 @@ mod tests {
         #[test]
         fn sets_error_and_switches_to_plan_tab() {
             let mut state = sql_modal_state();
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
@@ -680,7 +680,7 @@ mod tests {
         #[test]
         fn mismatched_dsn_does_not_replace_plan_with_error() {
             let mut state = sql_modal_state();
-            let _ = state.session.begin_connecting("dsn://current");
+            state.session.set_dsn_for_test("dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
             state
@@ -710,7 +710,7 @@ mod tests {
         fn two_explains_auto_advance_returns_comparable_slots() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            let _ = state.session.begin_connecting("dsn://test");
+            state.session.set_dsn_for_test("dsn://test");
             let now = Instant::now();
 
             // Step 1: First EXPLAIN

--- a/src/app/update/explain/output.rs
+++ b/src/app/update/explain/output.rs
@@ -20,7 +20,7 @@ pub(super) fn reduce_output(
             is_analyze,
             execution_time_ms,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if !state.session.dsn_matches(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_success(
@@ -34,7 +34,7 @@ pub(super) fn reduce_output(
         }
 
         Action::ExplainFailed { dsn, run_id, error } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if !state.session.dsn_matches(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_error(state, error.user_message());

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -28,7 +28,7 @@ pub(super) fn reduce_request(
             if content.is_empty() {
                 return DispatchResult::handled();
             }
-            let Some(dsn) = state.session.dsn.clone() else {
+            let Some(dsn) = state.session.dsn_owned() else {
                 return DispatchResult::handled();
             };
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -28,7 +28,7 @@ pub(super) fn reduce_request(
             if content.is_empty() {
                 return DispatchResult::handled();
             }
-            let Some(dsn) = state.session.dsn_owned() else {
+            let Some(dsn) = state.session.dsn().map(String::from) else {
                 return DispatchResult::handled();
             };
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -532,7 +532,7 @@ mod tests {
                 DatabaseType::PostgreSQL => "postgres://localhost/test",
                 DatabaseType::SQLite => "sqlite:///tmp/app.db",
             };
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("test-connection"),
                 "test",
                 database_type,

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -528,13 +528,16 @@ mod tests {
 
         fn editable_state(database_type: DatabaseType) -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.set_dsn_for_test(match database_type {
+            let dsn = match database_type {
                 DatabaseType::PostgreSQL => "postgres://localhost/test",
                 DatabaseType::SQLite => "sqlite:///tmp/app.db",
-            });
-            state
-                .session
-                .set_active_database_type_for_test(Some(database_type));
+            };
+            state.session.set_active_connection(
+                &crate::domain::connection::ConnectionId::from_string("test-connection"),
+                "test",
+                database_type,
+                dsn,
+            );
             state.query.set_current_result(Arc::new(QueryResult {
                 query: "SELECT * FROM users".to_string(),
                 columns: vec!["id".to_string(), "name".to_string()],
@@ -576,7 +579,7 @@ mod tests {
                 row_count_estimate: None,
                 comment: None,
             }));
-            state.query.pagination.set_table_for_test("main", "users");
+            state.query.pagination.reset_for_table("main", "users");
             state.result_interaction.stage_row(0);
             state
         }

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -122,7 +122,7 @@ mod tests {
                 .sql_modal
                 .set_active_tab(crate::model::sql_editor::modal::SqlModalTab::Plan);
 
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
                 "sqlite",
                 crate::domain::DatabaseType::SQLite,

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -122,9 +122,12 @@ mod tests {
                 .sql_modal
                 .set_active_tab(crate::model::sql_editor::modal::SqlModalTab::Plan);
 
-            state
-                .session
-                .set_active_database_type_for_test(Some(crate::domain::DatabaseType::SQLite));
+            state.session.set_active_connection(
+                &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                crate::domain::DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
 
             let result = handle_key_event(combo(Key::Char('i')), &state);
 

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -47,7 +47,7 @@ pub(super) fn reduce_confirm_dialog(
                     sql,
                     blocked: false,
                 }) => {
-                    if let Some(dsn) = state.session.dsn_owned() {
+                    if let Some(dsn) = state.session.dsn().map(String::from) {
                         let run_id = state.query.begin_running(now);
                         DispatchResult::handled_with(vec![Effect::ExecuteWrite {
                             dsn,

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -47,13 +47,13 @@ pub(super) fn reduce_confirm_dialog(
                     sql,
                     blocked: false,
                 }) => {
-                    if let Some(dsn) = &state.session.dsn {
+                    if let Some(dsn) = state.session.dsn_owned() {
                         let run_id = state.query.begin_running(now);
                         DispatchResult::handled_with(vec![Effect::ExecuteWrite {
-                            dsn: dsn.clone(),
+                            dsn,
                             run_id,
                             query: sql,
-                            read_only: state.session.read_only,
+                            read_only: state.session.is_read_only(),
                         }])
                     } else {
                         state.result_interaction.clear_write_preview();
@@ -65,7 +65,7 @@ pub(super) fn reduce_confirm_dialog(
                     }
                 }
                 Some(ConfirmIntent::DisableReadOnly) => {
-                    state.session.read_only = false;
+                    state.session.disable_read_only();
                     DispatchResult::handled()
                 }
                 Some(ConfirmIntent::CsvExport {
@@ -75,7 +75,7 @@ pub(super) fn reduce_confirm_dialog(
                     file_name,
                     row_count,
                 }) => {
-                    if state.session.dsn.as_ref() == Some(&dsn)
+                    if state.session.dsn() == Some(dsn.as_str())
                         && state.query.is_current_run(run_id)
                     {
                         DispatchResult::handled_with(vec![Effect::ExportCsv {
@@ -84,7 +84,7 @@ pub(super) fn reduce_confirm_dialog(
                             query: export_query,
                             file_name,
                             row_count,
-                            read_only: state.session.read_only,
+                            read_only: state.session.is_read_only(),
                         }])
                     } else {
                         DispatchResult::handled()
@@ -100,7 +100,7 @@ pub(super) fn reduce_confirm_dialog(
 
             if matches!(intent, Some(ConfirmIntent::QuitNoConnection)) {
                 state.connection_setup.reset();
-                if !state.connections().is_empty() || state.session.dsn.is_some() {
+                if !state.connections().is_empty() || state.session.dsn().is_some() {
                     state.connection_setup.is_first_run = false;
                 }
                 state.modal.pop_mode_override(InputMode::ConnectionSetup);

--- a/src/app/update/modal/er_picker.rs
+++ b/src/app/update/modal/er_picker.rs
@@ -74,8 +74,9 @@ pub(super) fn reduce_er_picker(
                 state.set_error("No tables selected".to_string());
                 return DispatchResult::handled();
             }
-            state.er_preparation.target_tables =
-                state.ui.er_selected_tables.iter().cloned().collect();
+            state
+                .er_preparation
+                .set_targets(state.ui.er_selected_tables.iter().cloned().collect());
             state.modal.set_mode(InputMode::Normal);
             state.ui.er_picker.clear_filter();
             state.ui.er_selected_tables.clear();

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -827,7 +827,7 @@ mod tests {
 
         fn connected_state() -> AppState {
             let mut state = create_test_state();
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &ConnectionId::from_string("test-conn"),
                 "test",
                 crate::domain::DatabaseType::PostgreSQL,

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -402,7 +402,7 @@ mod tests {
             fn execute_write_sets_running_state_and_returns_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::CellEdit);
-                let _ = state.session.begin_connecting("postgres://localhost/test");
+                state.session.set_dsn_for_test("postgres://localhost/test");
                 state.confirm_dialog.open(
                     "",
                     "",
@@ -520,7 +520,7 @@ mod tests {
             fn csv_export_returns_export_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                let _ = state.session.begin_connecting("postgres://localhost/test");
+                state.session.set_dsn_for_test("postgres://localhost/test");
                 let _ = state.query.begin_running(Instant::now());
                 state.confirm_dialog.open(
                     "",
@@ -579,7 +579,7 @@ mod tests {
             fn csv_export_ignores_mismatched_run_id() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                let _ = state.session.begin_connecting("postgres://localhost/test");
+                state.session.set_dsn_for_test("postgres://localhost/test");
                 let _ = state.query.begin_running(Instant::now());
                 state.confirm_dialog.open(
                     "",

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -402,7 +402,7 @@ mod tests {
             fn execute_write_sets_running_state_and_returns_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::CellEdit);
-                state.session.dsn = Some("postgres://localhost/test".to_string());
+                let _ = state.session.begin_connecting("postgres://localhost/test");
                 state.confirm_dialog.open(
                     "",
                     "",
@@ -428,7 +428,7 @@ mod tests {
             fn execute_write_no_dsn_sets_error() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                state.session.dsn = None;
+                state.session.clear_connection();
                 state.confirm_dialog.open(
                     "",
                     "",
@@ -520,7 +520,7 @@ mod tests {
             fn csv_export_returns_export_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                state.session.dsn = Some("postgres://localhost/test".to_string());
+                let _ = state.session.begin_connecting("postgres://localhost/test");
                 let _ = state.query.begin_running(Instant::now());
                 state.confirm_dialog.open(
                     "",
@@ -549,7 +549,9 @@ mod tests {
             fn csv_export_ignores_mismatched_dsn() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                state.session.dsn = Some("postgres://localhost/current".to_string());
+                let _ = state
+                    .session
+                    .begin_connecting("postgres://localhost/current");
                 let _ = state.query.begin_running(Instant::now());
                 state.confirm_dialog.open(
                     "",
@@ -577,7 +579,7 @@ mod tests {
             fn csv_export_ignores_mismatched_run_id() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                state.session.dsn = Some("postgres://localhost/test".to_string());
+                let _ = state.session.begin_connecting("postgres://localhost/test");
                 let _ = state.query.begin_running(Instant::now());
                 state.confirm_dialog.open(
                     "",
@@ -604,7 +606,7 @@ mod tests {
             #[test]
             fn disable_read_only_confirm_sets_read_only_false() {
                 let mut state = create_test_state();
-                state.session.read_only = true;
+                state.session.enable_read_only();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
                 state
                     .confirm_dialog
@@ -617,7 +619,7 @@ mod tests {
                 )
                 .unwrap();
 
-                assert!(!state.session.read_only);
+                assert!(!state.session.is_read_only());
                 assert_eq!(state.input_mode(), InputMode::Normal);
                 assert!(effects.is_empty());
             }
@@ -825,7 +827,12 @@ mod tests {
 
         fn connected_state() -> AppState {
             let mut state = create_test_state();
-            state.session.active_connection_id = Some(ConnectionId::from_string("test-conn"));
+            state.session.set_active_connection(
+                &ConnectionId::from_string("test-conn"),
+                "test",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.runtime.project_name = "test-project".to_string();
             state
         }
@@ -841,7 +848,7 @@ mod tests {
             #[test]
             fn open_when_not_connected_is_noop() {
                 let mut state = create_test_state();
-                state.session.active_connection_id = None;
+                state.session.clear_connection();
 
                 let effects = super::dispatch_modal(
                     &mut state,

--- a/src/app/update/modal/query_history.rs
+++ b/src/app/update/modal/query_history.rs
@@ -16,7 +16,7 @@ pub(super) fn reduce_query_history_picker(
             if state.modal.active_mode() == InputMode::QueryHistoryPicker {
                 return DispatchResult::handled();
             }
-            if state.session.active_connection_id.is_none() {
+            if state.session.active_connection_id().is_none() {
                 return DispatchResult::handled();
             }
             if state.query.is_running() {
@@ -34,7 +34,7 @@ pub(super) fn reduce_query_history_picker(
             state.query_history_picker.reset();
             state.modal.push_mode(InputMode::QueryHistoryPicker);
 
-            let conn_id = state.session.active_connection_id.as_ref().unwrap();
+            let conn_id = state.session.active_connection_id().unwrap();
             DispatchResult::handled_with(vec![Effect::LoadQueryHistory {
                 project_name: state.runtime.project_name.clone(),
                 connection_id: conn_id.clone(),
@@ -49,7 +49,7 @@ pub(super) fn reduce_query_history_picker(
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
                 return DispatchResult::handled();
             }
-            if state.session.active_connection_id.as_ref() != Some(conn_id) {
+            if state.session.active_connection_id() != Some(conn_id) {
                 return DispatchResult::handled();
             }
             state.query_history_picker.replace_entries(entries);
@@ -59,7 +59,7 @@ pub(super) fn reduce_query_history_picker(
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
                 return DispatchResult::handled();
             }
-            if state.session.active_connection_id.as_ref() != Some(conn_id) {
+            if state.session.active_connection_id() != Some(conn_id) {
                 return DispatchResult::handled();
             }
             state.messages.set_error_at(e.to_string(), now);

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -155,7 +155,7 @@ fn select_table(state: &mut AppState, table: &TableSummary) -> Vec<Effect> {
     let table_name = table.name.clone();
 
     let mut effects = Vec::new();
-    if let Some(dsn) = state.session.dsn_owned() {
+    if let Some(dsn) = state.session.dsn().map(String::from) {
         let run_id = state.session.begin_table_detail_run();
         effects.push(Effect::FetchTableDetail {
             dsn,
@@ -904,7 +904,7 @@ mod tests {
         use crate::model::connection::error::ConnectionErrorInfo;
 
         fn metadata_loaded_action(state: &mut AppState, metadata: DatabaseMetadata) -> Action {
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
@@ -914,7 +914,7 @@ mod tests {
         }
 
         fn metadata_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
@@ -1231,7 +1231,7 @@ mod tests {
         #[test]
         fn load_metadata_with_dsn_returns_fetch_effect() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::LoadMetadata, now, &AppServices::stub());
@@ -1258,7 +1258,7 @@ mod tests {
         #[test]
         fn reload_metadata_returns_sequence_effect() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -1282,7 +1282,7 @@ mod tests {
         #[test]
         fn reload_metadata_sets_is_reloading_flag() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let now = Instant::now();
 
             reduce(
@@ -1337,7 +1337,7 @@ mod tests {
         #[test]
         fn execute_adhoc_with_dsn_returns_effect() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -1371,7 +1371,7 @@ mod tests {
         #[test]
         fn always_emits_smart_refresh_even_with_pending_tables() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1395,7 +1395,7 @@ mod tests {
         #[test]
         fn prefetch_started_true_emits_smart_refresh() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1415,7 +1415,7 @@ mod tests {
         #[test]
         fn no_prefetch_emits_smart_refresh() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1448,7 +1448,7 @@ mod tests {
             let mut state = create_test_state();
             state.er_preparation.mark_waiting();
             let now = Instant::now();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let action = Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
@@ -1485,7 +1485,7 @@ mod tests {
         #[test]
         fn emits_cache_effect() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
@@ -1517,7 +1517,7 @@ mod tests {
         #[test]
         fn with_queue_returns_process_effect() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
@@ -1819,7 +1819,7 @@ mod tests {
             };
 
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             let delete_sql = "DELETE FROM \"public\".\"users\"\nWHERE \"id\" = '2';".to_string();
@@ -1896,7 +1896,7 @@ mod tests {
             };
 
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             state.result_interaction.set_write_preview(WritePreview {
@@ -1957,7 +1957,7 @@ mod tests {
         #[test]
         fn try_connect_with_dsn_starts_connecting() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -1994,7 +1994,7 @@ mod tests {
         #[test]
         fn try_connect_when_already_connecting_is_noop() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
@@ -2010,7 +2010,7 @@ mod tests {
         #[test]
         fn try_connect_when_already_connected_is_noop() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -2026,7 +2026,7 @@ mod tests {
         #[test]
         fn try_connect_when_not_in_normal_mode_is_noop() {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -2045,7 +2045,7 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let metadata = DatabaseMetadata {
                 database_name: "test".to_string(),
@@ -2079,7 +2079,7 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let now = Instant::now();
 
@@ -2403,7 +2403,7 @@ mod tests {
         }
 
         fn metadata_loaded_action(state: &mut AppState) -> Action {
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
@@ -2528,7 +2528,7 @@ mod tests {
         #[test]
         fn target_tables_survive_er_open() {
             let mut state = state_with_metadata();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
             state
                 .er_preparation
@@ -2550,7 +2550,7 @@ mod tests {
             use crate::model::er_state::ErStatus;
 
             let mut state = state_with_metadata();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting();
             state.er_preparation.begin_full_prefetch(1);
@@ -2584,7 +2584,7 @@ mod tests {
             use crate::model::er_state::ErStatus;
 
             let mut state = state_with_metadata();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting();
             state.er_preparation.begin_full_prefetch(2);
@@ -2626,7 +2626,7 @@ mod tests {
 
         fn state_after_confirm_and_complete() -> (AppState, Instant) {
             let mut state = create_test_state();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             let now = Instant::now();
 
             // Load metadata with a table
@@ -2751,11 +2751,7 @@ mod tests {
         #[test]
         fn prev_page_after_confirm_flows_through_result_to_query() {
             let (mut state, now) = state_after_confirm_and_complete();
-            state
-                .query
-                .pagination
-                .set_page_result(1, state.query.pagination.reached_end());
-            state.query.pagination.allow_next_page_after_refresh();
+            state.query.pagination.set_page_result(1, true);
 
             let effects = reduce(
                 &mut state,
@@ -2843,7 +2839,7 @@ mod tests {
             let entry_index = palette_index_of(|a| matches!(a, Action::ReloadMetadata));
 
             let mut state = state_in_palette_mode();
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.ui.table_picker.set_selection(entry_index);
             let now = Instant::now();
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -155,7 +155,7 @@ fn select_table(state: &mut AppState, table: &TableSummary) -> Vec<Effect> {
     let table_name = table.name.clone();
 
     let mut effects = Vec::new();
-    if let Some(dsn) = state.session.dsn.clone() {
+    if let Some(dsn) = state.session.dsn_owned() {
         let run_id = state.session.begin_table_detail_run();
         effects.push(Effect::FetchTableDetail {
             dsn,
@@ -286,7 +286,7 @@ mod tests {
         #[test]
         fn result_scroll_up_decrements_offset() {
             let mut state = create_test_state();
-            state.result_interaction.scroll_offset = 5;
+            state.result_interaction.set_scroll_offset(5);
             let now = Instant::now();
 
             let effects = reduce(
@@ -300,14 +300,14 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.result_interaction.scroll_offset, 4);
+            assert_eq!(state.result_interaction.scroll_offset(), 4);
             assert!(effects.is_empty());
         }
 
         #[test]
         fn result_scroll_up_saturates_at_zero() {
             let mut state = create_test_state();
-            state.result_interaction.scroll_offset = 0;
+            state.result_interaction.set_scroll_offset(0);
             let now = Instant::now();
 
             let effects = reduce(
@@ -321,14 +321,14 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.result_interaction.scroll_offset, 0);
+            assert_eq!(state.result_interaction.scroll_offset(), 0);
             assert!(effects.is_empty());
         }
 
         #[test]
         fn result_scroll_top_resets_to_zero() {
             let mut state = create_test_state();
-            state.result_interaction.scroll_offset = 10;
+            state.result_interaction.set_scroll_offset(10);
             let now = Instant::now();
 
             let effects = reduce(
@@ -342,7 +342,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.result_interaction.scroll_offset, 0);
+            assert_eq!(state.result_interaction.scroll_offset(), 0);
             assert!(effects.is_empty());
         }
 
@@ -904,7 +904,7 @@ mod tests {
         use crate::model::connection::error::ConnectionErrorInfo;
 
         fn metadata_loaded_action(state: &mut AppState, metadata: DatabaseMetadata) -> Action {
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
@@ -914,7 +914,7 @@ mod tests {
         }
 
         fn metadata_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
@@ -1231,7 +1231,7 @@ mod tests {
         #[test]
         fn load_metadata_with_dsn_returns_fetch_effect() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::LoadMetadata, now, &AppServices::stub());
@@ -1247,7 +1247,7 @@ mod tests {
         #[test]
         fn load_metadata_without_dsn_returns_no_effects() {
             let mut state = create_test_state();
-            state.session.dsn = None;
+            state.session.clear_connection();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::LoadMetadata, now, &AppServices::stub());
@@ -1258,7 +1258,7 @@ mod tests {
         #[test]
         fn reload_metadata_returns_sequence_effect() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -1282,7 +1282,7 @@ mod tests {
         #[test]
         fn reload_metadata_sets_is_reloading_flag() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let now = Instant::now();
 
             reduce(
@@ -1292,13 +1292,18 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert!(state.session.is_reloading);
+            assert!(state.session.is_reloading());
         }
 
         #[test]
         fn reload_then_metadata_loaded_shows_reloaded_message() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            state.session.set_active_connection(
+                &crate::domain::connection::ConnectionId::from_string("test-connection"),
+                "test",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let now = Instant::now();
 
             // Trigger reload
@@ -1308,7 +1313,7 @@ mod tests {
                 now,
                 &AppServices::stub(),
             );
-            assert!(state.session.is_reloading);
+            assert!(state.session.is_reloading());
 
             // Metadata loaded
             let metadata = DatabaseMetadata {
@@ -1325,14 +1330,14 @@ mod tests {
             reduce(&mut state, action, now, &AppServices::stub());
 
             // Check reloading flag is cleared and message is shown
-            assert!(!state.session.is_reloading);
+            assert!(!state.session.is_reloading());
             assert_eq!(state.messages.last_success, Some("Reloaded!".to_string()));
         }
 
         #[test]
         fn execute_adhoc_with_dsn_returns_effect() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -1355,7 +1360,7 @@ mod tests {
         #[test]
         fn er_open_while_rendering_returns_no_effects() {
             let mut state = create_test_state();
-            state.er_preparation.status = ErStatus::Rendering;
+            state.er_preparation.mark_rendering();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
@@ -1366,7 +1371,7 @@ mod tests {
         #[test]
         fn always_emits_smart_refresh_even_with_pending_tables() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1376,13 +1381,12 @@ mod tests {
             let _ = state.sql_modal.begin_prefetch();
             state
                 .er_preparation
-                .pending_tables
-                .insert("public.users".to_string());
+                .insert_pending_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
 
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
             assert!(!state.sql_modal.is_prefetch_started());
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
@@ -1391,7 +1395,7 @@ mod tests {
         #[test]
         fn prefetch_started_true_emits_smart_refresh() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1411,7 +1415,7 @@ mod tests {
         #[test]
         fn no_prefetch_emits_smart_refresh() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1422,7 +1426,7 @@ mod tests {
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
 
-            assert_eq!(state.er_preparation.status, ErStatus::Waiting);
+            assert_eq!(state.er_preparation.status(), ErStatus::Waiting);
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
         }
@@ -1442,9 +1446,9 @@ mod tests {
         #[test]
         fn metadata_failed_resets_er_waiting_to_idle() {
             let mut state = create_test_state();
-            state.er_preparation.status = ErStatus::Waiting;
+            state.er_preparation.mark_waiting();
             let now = Instant::now();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let action = Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
@@ -1454,7 +1458,7 @@ mod tests {
 
             reduce(&mut state, action, now, &AppServices::stub());
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
         }
     }
 
@@ -1481,7 +1485,7 @@ mod tests {
         #[test]
         fn emits_cache_effect() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
@@ -1513,7 +1517,7 @@ mod tests {
         #[test]
         fn with_queue_returns_process_effect() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
@@ -1692,13 +1696,10 @@ mod tests {
             );
 
             assert!(!state.connection_setup.is_first_run);
+            assert_eq!(state.session.dsn(), Some("postgres://db.example.com/mydb"));
             assert_eq!(
-                state.session.dsn,
-                Some("postgres://db.example.com/mydb".to_string())
-            );
-            assert_eq!(
-                state.session.active_connection_name,
-                Some("Test Connection".to_string())
+                state.session.active_connection_name(),
+                Some("Test Connection")
             );
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert_eq!(effects.len(), 1);
@@ -1818,7 +1819,7 @@ mod tests {
             };
 
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             let delete_sql = "DELETE FROM \"public\".\"users\"\nWHERE \"id\" = '2';".to_string();
@@ -1895,7 +1896,7 @@ mod tests {
             };
 
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             state.result_interaction.set_write_preview(WritePreview {
@@ -1956,7 +1957,7 @@ mod tests {
         #[test]
         fn try_connect_with_dsn_starts_connecting() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -1977,7 +1978,7 @@ mod tests {
         #[test]
         fn try_connect_without_dsn_does_nothing() {
             let mut state = create_test_state();
-            state.session.dsn = None;
+            state.session.clear_connection();
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -1993,7 +1994,7 @@ mod tests {
         #[test]
         fn try_connect_when_already_connecting_is_noop() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
@@ -2009,7 +2010,7 @@ mod tests {
         #[test]
         fn try_connect_when_already_connected_is_noop() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -2025,7 +2026,7 @@ mod tests {
         #[test]
         fn try_connect_when_not_in_normal_mode_is_noop() {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -2044,7 +2045,7 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let metadata = DatabaseMetadata {
                 database_name: "test".to_string(),
@@ -2078,7 +2079,7 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let now = Instant::now();
 
@@ -2105,10 +2106,15 @@ mod tests {
             // When already connected, metadata failure should preserve connection state
             // (metadata-only failure, e.g., permission denied on schema)
             let mut state = create_test_state();
+            state.session.set_active_connection(
+                &crate::domain::connection::ConnectionId::from_string("test-connection"),
+                "test",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
-            state.session.dsn = Some("postgres://localhost/test".to_string());
             state.session.set_metadata_state(MetadataState::Loaded);
             let run_id = state.session.begin_metadata_refresh();
             let now = Instant::now();
@@ -2228,7 +2234,12 @@ mod tests {
             let conn_a = ConnectionId::new();
             let conn_b = ConnectionId::new();
 
-            state.session.active_connection_id = Some(conn_a.clone());
+            state.session.set_active_connection(
+                &conn_a,
+                "conn-a",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/a",
+            );
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -2247,7 +2258,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.session.active_connection_id, Some(conn_b));
+            assert_eq!(state.session.active_connection_id(), Some(&conn_b));
             assert!(state.session.connection_state().is_connecting());
             assert!(state.connection_caches.get(&conn_a).is_some());
             assert_eq!(
@@ -2269,7 +2280,12 @@ mod tests {
             let conn_a = ConnectionId::new();
             let conn_b = ConnectionId::new();
 
-            state.session.active_connection_id = Some(conn_a);
+            state.session.set_active_connection(
+                &conn_a,
+                "conn-a",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/a",
+            );
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -2301,7 +2317,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.session.active_connection_id, Some(conn_b));
+            assert_eq!(state.session.active_connection_id(), Some(&conn_b));
             assert!(state.session.connection_state().is_connected());
             assert_eq!(state.ui.explorer_selected, 10);
             assert_eq!(state.ui.inspector_tab, InspectorTab::Indexes);
@@ -2387,7 +2403,7 @@ mod tests {
         }
 
         fn metadata_loaded_action(state: &mut AppState) -> Action {
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
@@ -2482,7 +2498,7 @@ mod tests {
             );
 
             assert_eq!(
-                state.er_preparation.target_tables,
+                state.er_preparation.target_tables(),
                 vec!["public.users".to_string()]
             );
             assert_eq!(state.input_mode(), InputMode::Normal);
@@ -2512,9 +2528,11 @@ mod tests {
         #[test]
         fn target_tables_survive_er_open() {
             let mut state = state_with_metadata();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
-            state.er_preparation.target_tables = vec!["public.users".to_string()];
+            state
+                .er_preparation
+                .set_targets(vec!["public.users".to_string()]);
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
@@ -2522,7 +2540,7 @@ mod tests {
             assert_eq!(effects.len(), 1);
             assert!(matches!(&effects[0], Effect::SmartErRefresh { .. }));
             assert_eq!(
-                state.er_preparation.target_tables,
+                state.er_preparation.target_tables(),
                 vec!["public.users".to_string()]
             );
         }
@@ -2532,15 +2550,14 @@ mod tests {
             use crate::model::er_state::ErStatus;
 
             let mut state = state_with_metadata();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.total_tables = 1;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.mark_waiting();
+            state.er_preparation.begin_full_prefetch(1);
+            state.er_preparation.mark_fk_expanded();
             state
                 .er_preparation
-                .pending_tables
-                .insert("public.users".to_string());
+                .insert_pending_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(
@@ -2555,7 +2572,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(effects.iter().any(|e| {
                 matches!(e, Effect::DispatchActions(actions)
                     if actions.iter().any(|a| matches!(a, Action::ErGenerateFromCache)))
@@ -2567,19 +2584,17 @@ mod tests {
             use crate::model::er_state::ErStatus;
 
             let mut state = state_with_metadata();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.status = ErStatus::Waiting;
-            state.er_preparation.total_tables = 2;
-            state.er_preparation.fk_expanded = true;
+            state.er_preparation.mark_waiting();
+            state.er_preparation.begin_full_prefetch(2);
+            state.er_preparation.mark_fk_expanded();
             state
                 .er_preparation
-                .failed_tables
-                .insert("public.posts".to_string(), "timeout".to_string());
+                .on_table_failed("public.posts", "timeout".to_string());
             state
                 .er_preparation
-                .pending_tables
-                .insert("public.users".to_string());
+                .insert_pending_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(
@@ -2594,7 +2609,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.er_preparation.status, ErStatus::Idle);
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(!effects.iter().any(|e| {
                 matches!(e, Effect::DispatchActions(actions)
                     if actions.iter().any(|a| matches!(a, Action::ErOpenDiagram)))
@@ -2611,7 +2626,7 @@ mod tests {
 
         fn state_after_confirm_and_complete() -> (AppState, Instant) {
             let mut state = create_test_state();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             let now = Instant::now();
 
             // Load metadata with a table
@@ -2696,11 +2711,11 @@ mod tests {
         fn confirm_selection_initializes_pagination_via_dispatch() {
             let (state, _now) = state_after_confirm_and_complete();
 
-            assert_eq!(state.query.pagination.schema, "public");
-            assert_eq!(state.query.pagination.table, "users");
-            assert_eq!(state.query.pagination.total_rows_estimate, Some(1200));
-            assert_eq!(state.query.pagination.current_page, 0);
-            assert!(!state.query.pagination.reached_end);
+            assert_eq!(state.query.pagination.schema(), "public");
+            assert_eq!(state.query.pagination.table(), "users");
+            assert_eq!(state.query.pagination.total_rows_estimate(), Some(1200));
+            assert_eq!(state.query.pagination.current_page(), 0);
+            assert!(!state.query.pagination.reached_end());
         }
 
         #[test]
@@ -2736,8 +2751,11 @@ mod tests {
         #[test]
         fn prev_page_after_confirm_flows_through_result_to_query() {
             let (mut state, now) = state_after_confirm_and_complete();
-            state.query.pagination.current_page = 1;
-            state.query.pagination.reached_end = true;
+            state
+                .query
+                .pagination
+                .set_page_result(1, state.query.pagination.reached_end());
+            state.query.pagination.allow_next_page_after_refresh();
 
             let effects = reduce(
                 &mut state,
@@ -2763,7 +2781,7 @@ mod tests {
                 assert_eq!(schema, "public");
                 assert_eq!(table, "users");
             }
-            assert!(!state.query.pagination.reached_end);
+            assert!(!state.query.pagination.reached_end());
         }
     }
 
@@ -2825,7 +2843,7 @@ mod tests {
             let entry_index = palette_index_of(|a| matches!(a, Action::ReloadMetadata));
 
             let mut state = state_in_palette_mode();
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state.ui.table_picker.set_selection(entry_index);
             let now = Instant::now();
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1298,7 +1298,7 @@ mod tests {
         #[test]
         fn reload_then_metadata_loaded_shows_reloaded_message() {
             let mut state = create_test_state();
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("test-connection"),
                 "test",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -1381,7 +1381,7 @@ mod tests {
             let _ = state.sql_modal.begin_prefetch();
             state
                 .er_preparation
-                .insert_pending_table("public.users".to_string());
+                .queue_pending_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
@@ -2106,7 +2106,7 @@ mod tests {
             // When already connected, metadata failure should preserve connection state
             // (metadata-only failure, e.g., permission denied on schema)
             let mut state = create_test_state();
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("test-connection"),
                 "test",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -2234,7 +2234,7 @@ mod tests {
             let conn_a = ConnectionId::new();
             let conn_b = ConnectionId::new();
 
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &conn_a,
                 "conn-a",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -2280,7 +2280,7 @@ mod tests {
             let conn_a = ConnectionId::new();
             let conn_b = ConnectionId::new();
 
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &conn_a,
                 "conn-a",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -2557,7 +2557,7 @@ mod tests {
             state.er_preparation.mark_fk_expanded();
             state
                 .er_preparation
-                .insert_pending_table("public.users".to_string());
+                .queue_pending_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(
@@ -2594,7 +2594,7 @@ mod tests {
                 .on_table_failed("public.posts", "timeout".to_string());
             state
                 .er_preparation
-                .insert_pending_table("public.users".to_string());
+                .queue_pending_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(

--- a/src/app/update/sql_editor/helpers.rs
+++ b/src/app/update/sql_editor/helpers.rs
@@ -9,7 +9,7 @@ pub(super) fn start_adhoc_if_connected(
     query: String,
     now: Instant,
 ) -> DispatchResult {
-    let Some(dsn) = state.session.dsn_owned() else {
+    let Some(dsn) = state.session.dsn().map(String::from) else {
         state
             .sql_modal
             .finish_adhoc_error("No active connection".to_string());

--- a/src/app/update/sql_editor/helpers.rs
+++ b/src/app/update/sql_editor/helpers.rs
@@ -9,7 +9,7 @@ pub(super) fn start_adhoc_if_connected(
     query: String,
     now: Instant,
 ) -> DispatchResult {
-    let Some(dsn) = state.session.dsn.clone() else {
+    let Some(dsn) = state.session.dsn_owned() else {
         state
             .sql_modal
             .finish_adhoc_error("No active connection".to_string());
@@ -22,6 +22,6 @@ pub(super) fn start_adhoc_if_connected(
         dsn,
         run_id,
         query,
-        read_only: state.session.read_only,
+        read_only: state.session.is_read_only(),
     }])
 }

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -276,7 +276,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT * INTO backup FROM users".to_string());
-            state.session.dsn = Some("postgres://test".to_string());
+            let _ = state.session.begin_connecting("postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -290,7 +290,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("COPY users FROM '/tmp/data.csv'".to_string());
-            state.session.dsn = Some("postgres://test".to_string());
+            let _ = state.session.begin_connecting("postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -304,7 +304,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("UPDATE users SET x=1 WHERE id=1".to_string());
-            state.session.dsn = Some("postgres://test".to_string());
+            let _ = state.session.begin_connecting("postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -387,7 +387,7 @@ mod tests {
         #[test]
         fn high_risk_confirm_executes_on_match() {
             let mut state = confirming_high_state("DROP TABLE users", Some("users"));
-            state.session.dsn = Some("postgres://test".to_string());
+            let _ = state.session.begin_connecting("postgres://test");
             for c in "users".chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -604,7 +604,7 @@ mod tests {
             let full_name = "my_schema.very_long_table_name";
             let mut state =
                 confirming_high_state(&format!("DROP TABLE {full_name}"), Some(full_name));
-            state.session.dsn = Some("postgres://test".to_string());
+            let _ = state.session.begin_connecting("postgres://test");
             for c in full_name.chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -642,8 +642,8 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id = 1".to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
-            state.session.read_only = true;
+            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
                 .into_effects()
@@ -661,8 +661,8 @@ mod tests {
         fn read_only_reject_clears_prior_success() {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
-            state.session.dsn = Some("postgres://localhost/test".to_string());
-            state.session.read_only = true;
+            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.enable_read_only();
 
             // Simulate a prior adhoc success
             state.sql_modal.finish_adhoc_success(
@@ -693,8 +693,8 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
-            state.session.read_only = true;
+            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
                 .into_effects()
@@ -713,7 +713,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content(query.to_string());
-            state.session.dsn = Some("postgres://localhost/test".to_string());
+            let _ = state.session.begin_connecting("postgres://localhost/test");
             state
         }
 

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -276,7 +276,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT * INTO backup FROM users".to_string());
-            let _ = state.session.begin_connecting("postgres://test");
+            state.session.set_dsn_for_test("postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -290,7 +290,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("COPY users FROM '/tmp/data.csv'".to_string());
-            let _ = state.session.begin_connecting("postgres://test");
+            state.session.set_dsn_for_test("postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -304,7 +304,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("UPDATE users SET x=1 WHERE id=1".to_string());
-            let _ = state.session.begin_connecting("postgres://test");
+            state.session.set_dsn_for_test("postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -387,7 +387,7 @@ mod tests {
         #[test]
         fn high_risk_confirm_executes_on_match() {
             let mut state = confirming_high_state("DROP TABLE users", Some("users"));
-            let _ = state.session.begin_connecting("postgres://test");
+            state.session.set_dsn_for_test("postgres://test");
             for c in "users".chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -604,7 +604,7 @@ mod tests {
             let full_name = "my_schema.very_long_table_name";
             let mut state =
                 confirming_high_state(&format!("DROP TABLE {full_name}"), Some(full_name));
-            let _ = state.session.begin_connecting("postgres://test");
+            state.session.set_dsn_for_test("postgres://test");
             for c in full_name.chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -642,7 +642,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id = 1".to_string());
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
@@ -661,7 +661,7 @@ mod tests {
         fn read_only_reject_clears_prior_success() {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.enable_read_only();
 
             // Simulate a prior adhoc success
@@ -693,7 +693,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
@@ -713,7 +713,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content(query.to_string());
-            let _ = state.session.begin_connecting("postgres://localhost/test");
+            state.session.set_dsn_for_test("postgres://localhost/test");
             state
         }
 

--- a/src/app/update/sql_editor/submit.rs
+++ b/src/app/update/sql_editor/submit.rs
@@ -54,7 +54,7 @@ pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant)
                         let kind = statement_classifier::classify(s);
                         !matches!(kind, StatementKind::Select | StatementKind::Transaction)
                     });
-                    if state.session.read_only && has_write {
+                    if state.session.is_read_only() && has_write {
                         state.sql_modal.finish_adhoc_error(
                             "Read-only mode: write operations are disabled".to_string(),
                         );

--- a/src/tests/harness/mod.rs
+++ b/src/tests/harness/mod.rs
@@ -13,7 +13,7 @@ use sabiql_app::model::app_state::AppState;
 use sabiql_app::model::connection::setup::ConnectionField;
 use sabiql_app::model::shared::text_input::TextInputState;
 use sabiql_app::services::AppServices;
-use sabiql_domain::DatabaseType;
+use sabiql_domain::{ConnectionId, DatabaseType};
 use sabiql_ui::shell::layout::MainLayout;
 use sabiql_ui::theme::{ThemePalette, palette_for};
 
@@ -26,12 +26,11 @@ pub fn test_instant() -> Instant {
 
 pub fn create_test_state() -> AppState {
     let mut state = AppState::new("test_project".to_string());
-    state
-        .session
-        .set_active_connection_name_for_test(Some("localhost:5432/test".to_string()));
-    state
-        .session
-        .set_active_database_type_for_test(Some(DatabaseType::PostgreSQL));
+    state.session.set_active_connection_identity(
+        &ConnectionId::from_string("test-connection"),
+        "localhost:5432/test",
+        DatabaseType::PostgreSQL,
+    );
     state
 }
 

--- a/src/tests/harness/mod.rs
+++ b/src/tests/harness/mod.rs
@@ -26,7 +26,7 @@ pub fn test_instant() -> Instant {
 
 pub fn create_test_state() -> AppState {
     let mut state = AppState::new("test_project".to_string());
-    state.session.set_active_connection_identity(
+    state.session.set_active_connection_identity_for_test(
         &ConnectionId::from_string("test-connection"),
         "localhost:5432/test",
         DatabaseType::PostgreSQL,

--- a/src/tests/render_snapshots/connection_management.rs
+++ b/src/tests/render_snapshots/connection_management.rs
@@ -48,9 +48,11 @@ fn connection_selector_with_multiple_connections() {
 
     let (active_id, connections) = three_connections();
     state.set_connections(connections);
-    state
-        .session
-        .set_active_connection_id_for_test(Some(active_id));
+    state.session.set_active_connection_identity(
+        &active_id,
+        "localhost:5432/test",
+        sabiql_domain::DatabaseType::PostgreSQL,
+    );
     state.modal.set_mode(InputMode::ConnectionSelector);
     state.ui.set_connection_list_selection(Some(0));
 
@@ -84,9 +86,11 @@ fn connection_selector_with_service_entries() {
             },
         ],
     );
-    state
-        .session
-        .set_active_connection_id_for_test(Some(active_id));
+    state.session.set_active_connection_identity(
+        &active_id,
+        "localhost:5432/test",
+        sabiql_domain::DatabaseType::PostgreSQL,
+    );
     state.modal.set_mode(InputMode::ConnectionSelector);
     state.ui.set_connection_list_selection(Some(0));
 
@@ -146,11 +150,11 @@ fn connection_selector_with_active_service() {
         },
     ]);
     // Set active connection to the first service entry
-    state
-        .session
-        .set_active_connection_id_for_test(Some(ConnectionId::from_string(
-            "service:dev-local".to_string(),
-        )));
+    state.session.set_active_connection_identity(
+        &ConnectionId::from_string("service:dev-local".to_string()),
+        "localhost:5432/test",
+        sabiql_domain::DatabaseType::PostgreSQL,
+    );
     state.modal.set_mode(InputMode::ConnectionSelector);
     state.ui.set_connection_list_selection(Some(0));
 

--- a/src/tests/render_snapshots/connection_management.rs
+++ b/src/tests/render_snapshots/connection_management.rs
@@ -48,7 +48,7 @@ fn connection_selector_with_multiple_connections() {
 
     let (active_id, connections) = three_connections();
     state.set_connections(connections);
-    state.session.set_active_connection_identity(
+    state.session.set_active_connection_identity_for_test(
         &active_id,
         "localhost:5432/test",
         sabiql_domain::DatabaseType::PostgreSQL,
@@ -86,7 +86,7 @@ fn connection_selector_with_service_entries() {
             },
         ],
     );
-    state.session.set_active_connection_identity(
+    state.session.set_active_connection_identity_for_test(
         &active_id,
         "localhost:5432/test",
         sabiql_domain::DatabaseType::PostgreSQL,
@@ -150,7 +150,7 @@ fn connection_selector_with_active_service() {
         },
     ]);
     // Set active connection to the first service entry
-    state.session.set_active_connection_identity(
+    state.session.set_active_connection_identity_for_test(
         &ConnectionId::from_string("service:dev-local".to_string()),
         "localhost:5432/test",
         sabiql_domain::DatabaseType::PostgreSQL,

--- a/src/tests/render_snapshots/er_diagram.rs
+++ b/src/tests/render_snapshots/er_diagram.rs
@@ -6,11 +6,11 @@ fn er_waiting_progress() {
     let (mut state, _now) = explorer_selected_state();
     let mut terminal = create_test_terminal();
 
-    state.er_preparation.start_waiting_run();
+    let _ = state.er_preparation.start_waiting_run();
     state.er_preparation.begin_full_prefetch(3);
     state
         .er_preparation
-        .insert_pending_table("public.comments".to_string());
+        .queue_pending_table("public.comments".to_string());
     state
         .er_preparation
         .insert_fetching_table("public.posts".to_string());

--- a/src/tests/render_snapshots/er_diagram.rs
+++ b/src/tests/render_snapshots/er_diagram.rs
@@ -11,9 +11,7 @@ fn er_waiting_progress() {
     state
         .er_preparation
         .queue_pending_table("public.comments".to_string());
-    state
-        .er_preparation
-        .insert_fetching_table("public.posts".to_string());
+    state.er_preparation.start_fetching("public.posts");
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/initial_state.rs
+++ b/src/tests/render_snapshots/initial_state.rs
@@ -16,7 +16,7 @@ fn explorer_shows_not_connected_when_no_active_connection() {
     state.session.clear_connection();
     state
         .session
-        .set_active_database_type(sabiql_domain::DatabaseType::PostgreSQL);
+        .set_active_database_type_for_test(sabiql_domain::DatabaseType::PostgreSQL);
     let mut terminal = create_test_terminal();
 
     let output = render_to_string(&mut terminal, &mut state);

--- a/src/tests/render_snapshots/initial_state.rs
+++ b/src/tests/render_snapshots/initial_state.rs
@@ -13,7 +13,10 @@ fn initial_state_no_metadata() {
 #[test]
 fn explorer_shows_not_connected_when_no_active_connection() {
     let mut state = create_test_state();
-    state.session.set_active_connection_name_for_test(None);
+    state.session.clear_connection();
+    state
+        .session
+        .set_active_database_type(sabiql_domain::DatabaseType::PostgreSQL);
     let mut terminal = create_test_terminal();
 
     let output = render_to_string(&mut terminal, &mut state);

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -44,7 +44,7 @@ fn jsonb_detail_state() -> (AppState, std::time::Instant) {
         error: None,
         command_tag: None,
     }));
-    state.query.pagination.set_table_for_test("public", "users");
+    state.query.pagination.reset_for_table("public", "users");
     state.ui.set_focused_pane(FocusedPane::Result);
     state.result_interaction.activate_cell(0, 3);
     (state, now)

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -81,7 +81,7 @@ fn jsonb_detail_state() -> (AppState, Instant) {
         error: None,
         command_tag: None,
     }));
-    state.query.pagination.set_table_for_test("public", "users");
+    state.query.pagination.reset_for_table("public", "users");
     state.ui.set_focused_pane(FocusedPane::Result);
     state.result_interaction.activate_cell(0, 3);
     dispatch_result(

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -390,7 +390,7 @@ mod tests {
     ) {
         let mut state = inspector_state();
         if let Some(database_type) = database_type {
-            state.session.set_active_connection(
+            state.session.set_active_connection_with_dsn(
                 &ConnectionId::new(),
                 "database",
                 database_type,


### PR DESCRIPTION
## Problem
App aggregate fields could still be mutated directly from reducers and tests, which made lifecycle invariants easy to bypass and kept redundant test-only seams alive.

## Background
SAB-251 tightens the app-state boundary around browse session, pagination, result interaction, and ER preparation state. This follows the aggregate-first rules and keeps state transitions behind semantic APIs.

## Approach
Scope: app aggregate encapsulation for BrowseSession, PaginationState, ResultInteraction, and ErPreparationState, plus the call sites needed to preserve current behavior.

The change makes aggregate-owned fields private, routes reducers and fixtures through intent APIs, and removes redundant test-only helpers. A narrow DSN-only test helper remains because that fixture state is not a production lifecycle transition.

UiState encapsulation is intentionally out of this PR scope and should be handled as follow-up work.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Refactor**
  * 内部APIの可視性管理を改善し、状態管理をメソッド呼び出しに統一しました。これにより、コードの保守性と構造が向上しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/riii111/sabiql/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->