### PR TITLE
feat: execute sqlite queries through sqlite3 cli

### DIFF
--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -35,12 +35,6 @@ impl DbAdapterRegistry {
             "Unsupported database DSN scheme: {dsn}"
         )))
     }
-
-    fn sqlite_query_not_implemented() -> DbOperationError {
-        DbOperationError::UnsupportedOperation(
-            "SQLite query execution is not implemented yet".to_string(),
-        )
-    }
 }
 
 impl DsnBuilder for DbAdapterRegistry {
@@ -127,7 +121,11 @@ impl QueryExecutor for DbAdapterRegistry {
                     .execute_preview(dsn, schema, table, limit, offset, read_only)
                     .await
             }
-            DatabaseType::SQLite => Err(Self::sqlite_query_not_implemented()),
+            DatabaseType::SQLite => {
+                self.sqlite
+                    .execute_preview(dsn, schema, table, limit, offset, read_only)
+                    .await
+            }
         }
     }
 
@@ -139,7 +137,7 @@ impl QueryExecutor for DbAdapterRegistry {
     ) -> Result<QueryResult, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.execute_adhoc(dsn, query, read_only).await,
-            DatabaseType::SQLite => Err(Self::sqlite_query_not_implemented()),
+            DatabaseType::SQLite => self.sqlite.execute_adhoc(dsn, query, read_only).await,
         }
     }
 
@@ -151,7 +149,7 @@ impl QueryExecutor for DbAdapterRegistry {
     ) -> Result<WriteExecutionResult, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.execute_write(dsn, query, read_only).await,
-            DatabaseType::SQLite => Err(Self::sqlite_query_not_implemented()),
+            DatabaseType::SQLite => self.sqlite.execute_write(dsn, query, read_only).await,
         }
     }
 
@@ -163,7 +161,7 @@ impl QueryExecutor for DbAdapterRegistry {
     ) -> Result<usize, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => self.postgres.count_query_rows(dsn, query, read_only).await,
-            DatabaseType::SQLite => Err(Self::sqlite_query_not_implemented()),
+            DatabaseType::SQLite => self.sqlite.count_query_rows(dsn, query, read_only).await,
         }
     }
 
@@ -180,7 +178,7 @@ impl QueryExecutor for DbAdapterRegistry {
                     .export_to_csv(dsn, query, path, read_only)
                     .await
             }
-            DatabaseType::SQLite => Err(Self::sqlite_query_not_implemented()),
+            DatabaseType::SQLite => self.sqlite.export_to_csv(dsn, query, path, read_only).await,
         }
     }
 }
@@ -419,6 +417,20 @@ mod tests {
         assert_eq!(detail.schema, "main");
         assert_eq!(detail.name, "users");
         assert_eq!(detail.primary_key, Some(vec!["id".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn sqlite_query_execution_is_dispatched_to_sqlite_adapter() {
+        let (_dir, dsn) = make_sqlite_dsn("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+
+        let result = registry
+            .execute_adhoc(&dsn, "SELECT 1 AS value", true)
+            .await
+            .unwrap();
+
+        assert_eq!(result.columns, vec!["value"]);
+        assert_eq!(result.rows, vec![vec!["1".to_string()]]);
     }
 
     #[tokio::test]

--- a/src/infra/adapters/sqlite/cli.rs
+++ b/src/infra/adapters/sqlite/cli.rs
@@ -69,7 +69,7 @@ impl SqliteCli {
         if read_only {
             cmd.arg("-readonly");
         }
-        cmd.arg(path).arg(sql);
+        cmd.arg("--").arg(path).arg(sql);
 
         let mut child = cmd
             .stdout(Stdio::piped())
@@ -139,7 +139,7 @@ impl SqliteCli {
         for arg in args {
             cmd.arg(arg);
         }
-        cmd.arg(path).arg(sql);
+        cmd.arg("--").arg(path).arg(sql);
         Self::collect_output(&mut cmd, self.timeout_secs).await
     }
 

--- a/src/infra/adapters/sqlite/cli.rs
+++ b/src/infra/adapters/sqlite/cli.rs
@@ -2,7 +2,7 @@ use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
 
 use serde::de::DeserializeOwned;
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -29,7 +29,7 @@ impl SqliteCli {
         path: &str,
         sql: &str,
     ) -> Result<T, DbOperationError> {
-        let output = self.run(path, sql).await?;
+        let output = self.run(path, &["-readonly", "-json"], sql).await?;
         if !output.status.success() {
             return Err(DbOperationError::QueryFailed(output.stderr));
         }
@@ -40,9 +40,106 @@ impl SqliteCli {
         serde_json::from_str(stdout).map_err(DbOperationError::from)
     }
 
-    async fn run(&self, path: &str, sql: &str) -> Result<SqliteOutput, DbOperationError> {
+    pub(super) async fn execute_csv(
+        &self,
+        path: &str,
+        sql: &str,
+        read_only: bool,
+    ) -> Result<String, DbOperationError> {
+        let mut args = vec!["-batch", "-bail", "-csv", "-header"];
+        if read_only {
+            args.push("-readonly");
+        }
+        let output = self.run(path, &args, sql).await?;
+        if !output.status.success() {
+            return Err(DbOperationError::QueryFailed(output.stderr));
+        }
+        Ok(output.stdout)
+    }
+
+    pub(super) async fn export_csv(
+        &self,
+        path: &str,
+        sql: &str,
+        output_path: &std::path::Path,
+        read_only: bool,
+    ) -> Result<usize, DbOperationError> {
         let mut cmd = Command::new("sqlite3");
-        cmd.arg("-readonly").arg("-json").arg(path).arg(sql);
+        cmd.arg("-batch").arg("-bail").arg("-csv").arg("-header");
+        if read_only {
+            cmd.arg("-readonly");
+        }
+        cmd.arg(path).arg(sql);
+
+        let mut child = cmd
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|error| DbOperationError::CommandNotFound(error.to_string()))?;
+
+        let stdout = child.stdout.take();
+        let mut stderr_handle = child.stderr.take();
+
+        let file = tokio::fs::File::create(output_path)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        let mut writer = tokio::io::BufWriter::new(file);
+
+        let result = timeout(Duration::from_secs(self.timeout_secs * 10), async {
+            let mut newline_count = 0usize;
+            if let Some(mut stdout) = stdout {
+                let mut buf = [0u8; 8192];
+                loop {
+                    let n = stdout.read(&mut buf).await?;
+                    if n == 0 {
+                        break;
+                    }
+                    newline_count += buf[..n].iter().filter(|&&b| b == b'\n').count();
+                    writer.write_all(&buf[..n]).await?;
+                }
+                writer.flush().await?;
+            }
+
+            let stderr = {
+                let mut buf = Vec::new();
+                if let Some(ref mut stderr) = stderr_handle {
+                    stderr.read_to_end(&mut buf).await?;
+                }
+                String::from_utf8_lossy(&buf).into_owned()
+            };
+            let status = child.wait().await?;
+            Ok::<_, std::io::Error>((status, stderr, newline_count))
+        })
+        .await;
+
+        let (status, stderr, newline_count) = match result {
+            Ok(inner) => inner.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?,
+            Err(error) => {
+                let _ = tokio::fs::remove_file(output_path).await;
+                return Err(DbOperationError::Timeout(error.to_string()));
+            }
+        };
+
+        if !status.success() {
+            let _ = tokio::fs::remove_file(output_path).await;
+            return Err(DbOperationError::QueryFailed(stderr));
+        }
+
+        Ok(newline_count.saturating_sub(1))
+    }
+
+    async fn run(
+        &self,
+        path: &str,
+        args: &[&str],
+        sql: &str,
+    ) -> Result<SqliteOutput, DbOperationError> {
+        let mut cmd = Command::new("sqlite3");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        cmd.arg(path).arg(sql);
         Self::collect_output(&mut cmd, self.timeout_secs).await
     }
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -391,6 +391,8 @@ impl SqliteAdapter {
 
 fn append_changes_query(query: &str) -> String {
     let trimmed = query.trim_end();
+    // The standalone separator also terminates a trailing line comment before
+    // appending the changes() probe.
     format!("{trimmed}\n;\nSELECT changes() AS affected_rows;")
 }
 
@@ -407,9 +409,28 @@ fn csv_field_count(line: &str) -> usize {
     count
 }
 
-fn first_keyword(sql: &str) -> &str {
+fn is_ident_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+fn skip_quoted(bytes: &[u8], mut i: usize, quote: u8) -> usize {
+    i += 1;
+    while i < bytes.len() {
+        if bytes[i] == quote {
+            if i + 1 < bytes.len() && bytes[i + 1] == quote {
+                i += 2;
+            } else {
+                return i + 1;
+            }
+        } else {
+            i += 1;
+        }
+    }
+    i
+}
+
+fn next_keyword_from(sql: &str, mut i: usize) -> Option<(&str, usize)> {
     let bytes = sql.as_bytes();
-    let mut i = 0;
     while i < bytes.len() {
         match bytes[i] {
             b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
@@ -426,85 +447,40 @@ fn first_keyword(sql: &str) -> &str {
                     i += 2;
                 }
             }
+            b'\'' | b'"' => {
+                i = skip_quoted(bytes, i, bytes[i]);
+            }
             b if b.is_ascii_alphabetic() => {
                 let start = i;
-                while i < bytes.len() && bytes[i].is_ascii_alphanumeric() {
+                while i < bytes.len() && is_ident_char(bytes[i]) {
                     i += 1;
                 }
-                return &sql[start..i];
+                return Some((&sql[start..i], i));
             }
             _ => i += 1,
         }
     }
-    ""
+    None
+}
+
+fn first_keyword(sql: &str) -> &str {
+    next_keyword_from(sql, 0)
+        .map(|(keyword, _)| keyword)
+        .unwrap_or("")
 }
 
 fn second_keyword(sql: &str) -> Option<&str> {
-    let first = first_keyword(sql);
-    let start = sql.find(first)? + first.len();
-    Some(first_keyword(&sql[start..])).filter(|keyword| !keyword.is_empty())
+    let (_, end) = next_keyword_from(sql, 0)?;
+    next_keyword_from(sql, end).map(|(keyword, _)| keyword)
 }
 
 fn contains_keyword(sql: &str, expected: &str) -> bool {
-    let bytes = sql.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        match bytes[i] {
-            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
-                while i < bytes.len() && bytes[i] != b'\n' {
-                    i += 1;
-                }
-            }
-            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
-                i += 2;
-                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    i += 1;
-                }
-                if i + 1 < bytes.len() {
-                    i += 2;
-                }
-            }
-            b'\'' => {
-                i += 1;
-                while i < bytes.len() {
-                    if bytes[i] == b'\'' {
-                        if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
-                            i += 2;
-                        } else {
-                            i += 1;
-                            break;
-                        }
-                    } else {
-                        i += 1;
-                    }
-                }
-            }
-            b'"' => {
-                i += 1;
-                while i < bytes.len() {
-                    if bytes[i] == b'"' {
-                        if i + 1 < bytes.len() && bytes[i + 1] == b'"' {
-                            i += 2;
-                        } else {
-                            i += 1;
-                            break;
-                        }
-                    } else {
-                        i += 1;
-                    }
-                }
-            }
-            b if b.is_ascii_alphabetic() => {
-                let start = i;
-                while i < bytes.len() && bytes[i].is_ascii_alphanumeric() {
-                    i += 1;
-                }
-                if sql[start..i].eq_ignore_ascii_case(expected) {
-                    return true;
-                }
-            }
-            _ => i += 1,
+    let mut offset = 0;
+    while let Some((keyword, end)) = next_keyword_from(sql, offset) {
+        if keyword.eq_ignore_ascii_case(expected) {
+            return true;
         }
+        offset = end;
     }
     false
 }
@@ -619,8 +595,28 @@ fn first_csv_cell(stdout: &str) -> Result<String, DbOperationError> {
         .ok_or_else(|| DbOperationError::EmptyResponse(stdout.to_string()))
 }
 
+fn last_csv_cell(stdout: &str) -> Result<String, DbOperationError> {
+    let line = stdout
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .ok_or_else(|| DbOperationError::EmptyResponse(stdout.to_string()))?;
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .from_reader(line.as_bytes());
+    let mut records = reader.records();
+    let record = records
+        .next()
+        .transpose()?
+        .ok_or_else(|| DbOperationError::EmptyResponse(stdout.to_string()))?;
+    record
+        .get(0)
+        .map(ToString::to_string)
+        .ok_or_else(|| DbOperationError::EmptyResponse(stdout.to_string()))
+}
+
 fn parse_affected_rows(stdout: &str) -> Result<usize, DbOperationError> {
-    first_csv_cell(stdout)
+    last_csv_cell(stdout)
         .map_err(|error| match error {
             DbOperationError::EmptyResponse(_) => {
                 DbOperationError::CommandTagParseFailed(stdout.to_string())
@@ -632,9 +628,17 @@ fn parse_affected_rows(stdout: &str) -> Result<usize, DbOperationError> {
 }
 
 fn parse_count_result(stdout: &str) -> Result<usize, DbOperationError> {
-    first_csv_cell(stdout)?.parse::<usize>().map_err(|error| {
-        DbOperationError::QueryFailed(format!("Failed to parse COUNT result: {error}"))
-    })
+    first_csv_cell(stdout)
+        .map_err(|error| match error {
+            DbOperationError::EmptyResponse(_) => {
+                DbOperationError::QueryFailed("Failed to parse COUNT result".to_string())
+            }
+            other => other,
+        })?
+        .parse::<usize>()
+        .map_err(|error| {
+            DbOperationError::QueryFailed(format!("Failed to parse COUNT result: {error}"))
+        })
 }
 
 fn ddl_tag(query: &str) -> Option<CommandTag> {
@@ -927,6 +931,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn adhoc_dml_with_following_select_uses_trailing_changes_result() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            INSERT INTO users(id, name) VALUES (1, 'a');
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(
+                &dsn,
+                "UPDATE users SET name = 'x' WHERE id = 1; SELECT 42",
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.row_count, 1);
+        assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
+    }
+
+    #[tokio::test]
     async fn adhoc_dml_with_trailing_line_comment_returns_affected_rows() {
         let (_dir, dsn) = make_db(
             r#"
@@ -965,6 +992,66 @@ mod tests {
 
         assert_eq!(result.columns, vec!["id", "name"]);
         assert_eq!(result.rows, vec![vec!["1".to_string(), "a".to_string()]]);
+        assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+    }
+
+    #[tokio::test]
+    async fn adhoc_update_returning_preserves_returned_rows() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(
+                &dsn,
+                "UPDATE users SET name = 'x' RETURNING id, name",
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.rows.len(), 2);
+        assert_eq!(result.command_tag, Some(CommandTag::Update(2)));
+    }
+
+    #[tokio::test]
+    async fn adhoc_delete_returning_preserves_returned_rows() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(
+                &dsn,
+                "DELETE FROM users WHERE id = 1 RETURNING id, name",
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.rows, vec![vec!["1".to_string(), "a".to_string()]]);
+        assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
+    }
+
+    #[tokio::test]
+    async fn adhoc_dml_table_name_containing_returning_reports_affected_rows() {
+        let (_dir, dsn) = make_db("CREATE TABLE returning_log(id INTEGER PRIMARY KEY, name TEXT);");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(&dsn, "INSERT INTO returning_log(name) VALUES ('a')", false)
+            .await
+            .unwrap();
+
+        assert_eq!(result.row_count, 1);
         assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
     }
 
@@ -1234,18 +1321,25 @@ mod tests {
 
     #[tokio::test]
     async fn relative_path_starting_with_dash_is_opened_as_database_path() {
+        struct CleanupPath(String);
+        impl Drop for CleanupPath {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_file(&self.0);
+            }
+        }
+
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
         let path = format!("-sabiql-{unique}.db");
+        let _cleanup = CleanupPath(path.clone());
         let dsn = format!("sqlite://{path}");
         let adapter = SqliteAdapter::new();
 
         let result = adapter
             .execute_adhoc(&dsn, "SELECT 1 AS value", false)
             .await;
-        let _ = std::fs::remove_file(&path);
 
         let result = result.unwrap();
         assert_eq!(result.rows, vec![vec!["1".to_string()]]);

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -429,6 +429,18 @@ fn skip_quoted(bytes: &[u8], mut i: usize, quote: u8) -> usize {
     i
 }
 
+fn skip_bracket_quoted(bytes: &[u8], mut i: usize) -> usize {
+    i += 1;
+    while i < bytes.len() {
+        if bytes[i] == b']' {
+            return i + 1;
+        }
+        i += 1;
+    }
+    i
+}
+
+/// Returns the next SQL keyword and the byte offset immediately after it.
 fn next_keyword_from(sql: &str, mut i: usize) -> Option<(&str, usize)> {
     let bytes = sql.as_bytes();
     while i < bytes.len() {
@@ -447,8 +459,11 @@ fn next_keyword_from(sql: &str, mut i: usize) -> Option<(&str, usize)> {
                     i += 2;
                 }
             }
-            b'\'' | b'"' => {
+            b'\'' | b'"' | b'`' => {
                 i = skip_quoted(bytes, i, bytes[i]);
+            }
+            b'[' => {
+                i = skip_bracket_quoted(bytes, i);
             }
             b if b.is_ascii_alphabetic() => {
                 let start = i;
@@ -1048,6 +1063,36 @@ mod tests {
 
         let result = adapter
             .execute_adhoc(&dsn, "INSERT INTO returning_log(name) VALUES ('a')", false)
+            .await
+            .unwrap();
+
+        assert_eq!(result.row_count, 1);
+        assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+    }
+
+    #[tokio::test]
+    async fn adhoc_dml_backtick_quoted_identifier_containing_returning_reports_affected_rows() {
+        let (_dir, dsn) =
+            make_db("CREATE TABLE `my returning`(id INTEGER PRIMARY KEY, name TEXT);");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(&dsn, "INSERT INTO `my returning`(name) VALUES ('a')", false)
+            .await
+            .unwrap();
+
+        assert_eq!(result.row_count, 1);
+        assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+    }
+
+    #[tokio::test]
+    async fn adhoc_dml_bracket_quoted_identifier_containing_returning_reports_affected_rows() {
+        let (_dir, dsn) =
+            make_db("CREATE TABLE [my returning](id INTEGER PRIMARY KEY, name TEXT);");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(&dsn, "INSERT INTO [my returning](name) VALUES ('a')", false)
             .await
             .unwrap();
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -391,11 +391,7 @@ impl SqliteAdapter {
 
 fn append_changes_query(query: &str) -> String {
     let trimmed = query.trim_end();
-    if trimmed.ends_with(';') {
-        format!("{trimmed}\nSELECT changes() AS affected_rows;")
-    } else {
-        format!("{trimmed};\nSELECT changes() AS affected_rows;")
-    }
+    format!("{trimmed}\n;\nSELECT changes() AS affected_rows;")
 }
 
 fn csv_field_count(line: &str) -> usize {
@@ -447,6 +443,70 @@ fn second_keyword(sql: &str) -> Option<&str> {
     let first = first_keyword(sql);
     let start = sql.find(first)? + first.len();
     Some(first_keyword(&sql[start..])).filter(|keyword| !keyword.is_empty())
+}
+
+fn contains_keyword(sql: &str, expected: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                if i + 1 < bytes.len() {
+                    i += 2;
+                }
+            }
+            b'\'' => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\'' {
+                        if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                            i += 2;
+                        } else {
+                            i += 1;
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            b'"' => {
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'"' {
+                        if i + 1 < bytes.len() && bytes[i + 1] == b'"' {
+                            i += 2;
+                        } else {
+                            i += 1;
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            b if b.is_ascii_alphabetic() => {
+                let start = i;
+                while i < bytes.len() && bytes[i].is_ascii_alphanumeric() {
+                    i += 1;
+                }
+                if sql[start..i].eq_ignore_ascii_case(expected) {
+                    return true;
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    false
 }
 
 fn count_select_statements(sql: &str) -> usize {
@@ -544,15 +604,37 @@ fn csv_to_query_result(
     ))
 }
 
+fn first_csv_cell(stdout: &str) -> Result<String, DbOperationError> {
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .from_reader(stdout.trim().as_bytes());
+    let mut records = reader.records();
+    let record = records
+        .next()
+        .transpose()?
+        .ok_or_else(|| DbOperationError::EmptyResponse(stdout.to_string()))?;
+    record
+        .get(0)
+        .map(ToString::to_string)
+        .ok_or_else(|| DbOperationError::EmptyResponse(stdout.to_string()))
+}
+
 fn parse_affected_rows(stdout: &str) -> Result<usize, DbOperationError> {
-    let result = csv_to_query_result(stdout, stdout, QuerySource::Adhoc, 0)?;
-    result
-        .rows
-        .first()
-        .and_then(|row| row.first())
-        .ok_or_else(|| DbOperationError::CommandTagParseFailed(stdout.to_string()))?
+    first_csv_cell(stdout)
+        .map_err(|error| match error {
+            DbOperationError::EmptyResponse(_) => {
+                DbOperationError::CommandTagParseFailed(stdout.to_string())
+            }
+            other => other,
+        })?
         .parse::<usize>()
         .map_err(|error| DbOperationError::CommandTagParseFailed(error.to_string()))
+}
+
+fn parse_count_result(stdout: &str) -> Result<usize, DbOperationError> {
+    first_csv_cell(stdout)?.parse::<usize>().map_err(|error| {
+        DbOperationError::QueryFailed(format!("Failed to parse COUNT result: {error}"))
+    })
 }
 
 fn ddl_tag(query: &str) -> Option<CommandTag> {
@@ -607,11 +689,7 @@ impl MetadataProvider for SqliteAdapter {
         schema: &str,
         table: &str,
     ) -> Result<Table, DbOperationError> {
-        if schema != MAIN_SCHEMA {
-            return Err(DbOperationError::ObjectMissing(format!(
-                "SQLite schema not found: {schema}"
-            )));
-        }
+        Self::validate_main_schema(schema)?;
         self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, true)
             .await
     }
@@ -622,11 +700,7 @@ impl MetadataProvider for SqliteAdapter {
         schema: &str,
         table: &str,
     ) -> Result<Table, DbOperationError> {
-        if schema != MAIN_SCHEMA {
-            return Err(DbOperationError::ObjectMissing(format!(
-                "SQLite schema not found: {schema}"
-            )));
-        }
+        Self::validate_main_schema(schema)?;
         self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, false)
             .await
     }
@@ -676,6 +750,22 @@ impl QueryExecutor for SqliteAdapter {
             || keyword.eq_ignore_ascii_case("UPDATE")
             || keyword.eq_ignore_ascii_case("DELETE")
         {
+            if contains_keyword(query, "RETURNING") {
+                let mut result = self
+                    .execute_csv_query(path, query, QuerySource::Adhoc, read_only)
+                    .await?;
+                let affected_rows = result.row_count as u64;
+                let tag = if keyword.eq_ignore_ascii_case("INSERT") {
+                    CommandTag::Insert(affected_rows)
+                } else if keyword.eq_ignore_ascii_case("UPDATE") {
+                    CommandTag::Update(affected_rows)
+                } else {
+                    CommandTag::Delete(affected_rows)
+                };
+                result = result.with_command_tag(tag);
+                return Ok(result);
+            }
+
             let (affected_rows, elapsed) =
                 self.execute_changes_query(path, query, read_only).await?;
             let tag = if keyword.eq_ignore_ascii_case("INSERT") {
@@ -729,25 +819,11 @@ impl QueryExecutor for SqliteAdapter {
         query: &str,
         read_only: bool,
     ) -> Result<usize, DbOperationError> {
-        let result = self
-            .execute_csv_query(
-                Self::path_from_dsn(dsn)?,
-                query,
-                QuerySource::Adhoc,
-                read_only,
-            )
+        let stdout = self
+            .cli
+            .execute_csv(Self::path_from_dsn(dsn)?, query, read_only)
             .await?;
-        result
-            .rows
-            .first()
-            .and_then(|row| row.first())
-            .ok_or_else(|| {
-                DbOperationError::QueryFailed("Failed to parse COUNT result".to_string())
-            })?
-            .parse::<usize>()
-            .map_err(|error| {
-                DbOperationError::QueryFailed(format!("Failed to parse COUNT result: {error}"))
-            })
+        parse_count_result(&stdout)
     }
 
     async fn export_to_csv(
@@ -848,6 +924,48 @@ mod tests {
 
         assert_eq!(result.row_count, 1);
         assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
+    }
+
+    #[tokio::test]
+    async fn adhoc_dml_with_trailing_line_comment_returns_affected_rows() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            INSERT INTO users(id, name) VALUES (1, 'a');
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(
+                &dsn,
+                "DELETE FROM users WHERE id = 1 -- cleanup selected row",
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.row_count, 1);
+        assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
+    }
+
+    #[tokio::test]
+    async fn adhoc_dml_returning_preserves_returned_rows() {
+        let (_dir, dsn) = make_db("CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(
+                &dsn,
+                "INSERT INTO users(name) VALUES ('a') RETURNING id, name",
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.columns, vec!["id", "name"]);
+        assert_eq!(result.rows, vec![vec!["1".to_string(), "a".to_string()]]);
+        assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
     }
 
     #[tokio::test]
@@ -1112,6 +1230,25 @@ mod tests {
             empty_result,
             Err(DbOperationError::ConnectionFailed(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn relative_path_starting_with_dash_is_opened_as_database_path() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = format!("-sabiql-{unique}.db");
+        let dsn = format!("sqlite://{path}");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(&dsn, "SELECT 1 AS value", false)
+            .await;
+        let _ = std::fs::remove_file(&path);
+
+        let result = result.unwrap();
+        assert_eq!(result.rows, vec![vec!["1".to_string()]]);
     }
 
     #[tokio::test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use serde::Deserialize;
 
-use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
+use crate::app::ports::outbound::{DbOperationError, MetadataProvider, QueryExecutor};
 use crate::domain::{
-    Column, ColumnAttributes, DatabaseMetadata, FkAction, ForeignKey, Index, IndexAttributes,
-    IndexType, Schema, Table, TableSignature, TableSummary,
+    Column, ColumnAttributes, CommandTag, DatabaseMetadata, FkAction, ForeignKey, Index,
+    IndexAttributes, IndexType, QueryResult, QuerySource, Schema, Table, TableSignature,
+    TableSummary, WriteExecutionResult,
 };
 
 mod cli;
@@ -135,6 +137,50 @@ impl SqliteAdapter {
     ) -> Result<Vec<String>, DbOperationError> {
         let columns = self.columns(path, table).await?;
         Ok(Self::extract_primary_key(&columns))
+    }
+
+    fn validate_main_schema(schema: &str) -> Result<(), DbOperationError> {
+        if schema == MAIN_SCHEMA {
+            Ok(())
+        } else {
+            Err(DbOperationError::ObjectMissing(format!(
+                "SQLite schema not found: {schema}"
+            )))
+        }
+    }
+
+    async fn preview_order_columns(&self, path: &str, table: &str) -> Vec<String> {
+        self.primary_key_columns(path, table)
+            .await
+            .unwrap_or_default()
+    }
+
+    async fn execute_csv_query(
+        &self,
+        path: &str,
+        query: &str,
+        source: QuerySource,
+        read_only: bool,
+    ) -> Result<QueryResult, DbOperationError> {
+        let start = Instant::now();
+        let stdout = self.cli.execute_csv(path, query, read_only).await?;
+        let elapsed = start.elapsed().as_millis() as u64;
+        csv_to_query_result(query, &stdout, source, elapsed)
+    }
+
+    async fn execute_changes_query(
+        &self,
+        path: &str,
+        query: &str,
+        read_only: bool,
+    ) -> Result<(usize, u64), DbOperationError> {
+        let start = Instant::now();
+        let stdout = self
+            .cli
+            .execute_csv(path, &append_changes_query(query), read_only)
+            .await?;
+        let elapsed = start.elapsed().as_millis() as u64;
+        Ok((parse_affected_rows(&stdout)?, elapsed))
     }
 
     async fn indexes(&self, path: &str, table: &str) -> Result<Vec<Index>, DbOperationError> {
@@ -343,6 +389,188 @@ impl SqliteAdapter {
     }
 }
 
+fn append_changes_query(query: &str) -> String {
+    let trimmed = query.trim_end();
+    if trimmed.ends_with(';') {
+        format!("{trimmed}\nSELECT changes() AS affected_rows;")
+    } else {
+        format!("{trimmed};\nSELECT changes() AS affected_rows;")
+    }
+}
+
+fn csv_field_count(line: &str) -> usize {
+    let mut count = 1;
+    let mut in_quotes = false;
+    for ch in line.chars() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => count += 1,
+            _ => {}
+        }
+    }
+    count
+}
+
+fn first_keyword(sql: &str) -> &str {
+    let bytes = sql.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                if i + 1 < bytes.len() {
+                    i += 2;
+                }
+            }
+            b if b.is_ascii_alphabetic() => {
+                let start = i;
+                while i < bytes.len() && bytes[i].is_ascii_alphanumeric() {
+                    i += 1;
+                }
+                return &sql[start..i];
+            }
+            _ => i += 1,
+        }
+    }
+    ""
+}
+
+fn second_keyword(sql: &str) -> Option<&str> {
+    let first = first_keyword(sql);
+    let start = sql.find(first)? + first.len();
+    Some(first_keyword(&sql[start..])).filter(|keyword| !keyword.is_empty())
+}
+
+fn count_select_statements(sql: &str) -> usize {
+    sql.split(';')
+        .filter(|stmt| {
+            let keyword = first_keyword(stmt);
+            keyword.eq_ignore_ascii_case("SELECT") || keyword.eq_ignore_ascii_case("WITH")
+        })
+        .count()
+}
+
+fn extract_last_csv_block<'a>(stdout: &'a str, sql: &str) -> &'a str {
+    let lines: Vec<&str> = stdout.lines().collect();
+    if lines.len() <= 2 {
+        return stdout;
+    }
+
+    let expected_sets = count_select_statements(sql);
+    let first_header = lines[0];
+    let mut current_fc = csv_field_count(first_header);
+    let mut known_headers: Vec<&str> = vec![first_header];
+    let mut last_header_idx = 0;
+    let mut data_rows_since_header = 0usize;
+
+    for (i, &line) in lines.iter().enumerate().skip(1) {
+        let fc = csv_field_count(line);
+        if fc != current_fc {
+            last_header_idx = i;
+            current_fc = fc;
+            data_rows_since_header = 0;
+            if !known_headers.contains(&line) {
+                known_headers.push(line);
+            }
+        } else if known_headers.contains(&line) {
+            last_header_idx = i;
+            data_rows_since_header = 0;
+        } else if expected_sets > 1
+            && data_rows_since_header >= 1
+            && known_headers.len() < expected_sets
+        {
+            last_header_idx = i;
+            known_headers.push(line);
+            data_rows_since_header = 0;
+        } else {
+            data_rows_since_header += 1;
+        }
+    }
+
+    if last_header_idx == 0 {
+        return stdout;
+    }
+
+    let byte_offset: usize = stdout
+        .lines()
+        .take(last_header_idx)
+        .map(|line| line.len() + 1)
+        .sum();
+
+    &stdout[byte_offset..]
+}
+
+fn csv_to_query_result(
+    query: &str,
+    stdout: &str,
+    source: QuerySource,
+    execution_time_ms: u64,
+) -> Result<QueryResult, DbOperationError> {
+    let stdout = stdout.trim();
+    if stdout.is_empty() {
+        return Ok(QueryResult::success(
+            query.to_string(),
+            Vec::new(),
+            Vec::new(),
+            execution_time_ms,
+            source,
+        ));
+    }
+
+    let csv_block = extract_last_csv_block(stdout, query);
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .from_reader(csv_block.as_bytes());
+    let columns = reader.headers()?.iter().map(ToString::to_string).collect();
+    let mut rows = Vec::new();
+    for result in reader.records() {
+        rows.push(result?.iter().map(ToString::to_string).collect());
+    }
+
+    Ok(QueryResult::success(
+        query.to_string(),
+        columns,
+        rows,
+        execution_time_ms,
+        source,
+    ))
+}
+
+fn parse_affected_rows(stdout: &str) -> Result<usize, DbOperationError> {
+    let result = csv_to_query_result(stdout, stdout, QuerySource::Adhoc, 0)?;
+    result
+        .rows
+        .first()
+        .and_then(|row| row.first())
+        .ok_or_else(|| DbOperationError::CommandTagParseFailed(stdout.to_string()))?
+        .parse::<usize>()
+        .map_err(|error| DbOperationError::CommandTagParseFailed(error.to_string()))
+}
+
+fn ddl_tag(query: &str) -> Option<CommandTag> {
+    let object = second_keyword(query)
+        .unwrap_or("OBJECT")
+        .to_ascii_uppercase();
+    let keyword = first_keyword(query);
+    if keyword.eq_ignore_ascii_case("CREATE") {
+        Some(CommandTag::Create(object))
+    } else if keyword.eq_ignore_ascii_case("DROP") {
+        Some(CommandTag::Drop(object))
+    } else if keyword.eq_ignore_ascii_case("ALTER") {
+        Some(CommandTag::Alter(object))
+    } else {
+        None
+    }
+}
+
 fn parse_fk_action(action: &str) -> Result<FkAction, DbOperationError> {
     action
         .parse::<FkAction>()
@@ -417,11 +645,130 @@ impl MetadataProvider for SqliteAdapter {
     }
 }
 
+#[async_trait]
+impl QueryExecutor for SqliteAdapter {
+    async fn execute_preview(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+        limit: usize,
+        offset: usize,
+        read_only: bool,
+    ) -> Result<QueryResult, DbOperationError> {
+        Self::validate_main_schema(schema)?;
+        let path = Self::path_from_dsn(dsn)?;
+        let order_columns = self.preview_order_columns(path, table).await;
+        let query = sql::build_preview_query(table, &order_columns, limit, offset);
+        self.execute_csv_query(path, &query, QuerySource::Preview, read_only)
+            .await
+    }
+
+    async fn execute_adhoc(
+        &self,
+        dsn: &str,
+        query: &str,
+        read_only: bool,
+    ) -> Result<QueryResult, DbOperationError> {
+        let path = Self::path_from_dsn(dsn)?;
+        let keyword = first_keyword(query);
+        if keyword.eq_ignore_ascii_case("INSERT")
+            || keyword.eq_ignore_ascii_case("UPDATE")
+            || keyword.eq_ignore_ascii_case("DELETE")
+        {
+            let (affected_rows, elapsed) =
+                self.execute_changes_query(path, query, read_only).await?;
+            let tag = if keyword.eq_ignore_ascii_case("INSERT") {
+                CommandTag::Insert(affected_rows as u64)
+            } else if keyword.eq_ignore_ascii_case("UPDATE") {
+                CommandTag::Update(affected_rows as u64)
+            } else {
+                CommandTag::Delete(affected_rows as u64)
+            };
+            let mut result = QueryResult::success(
+                query.to_string(),
+                Vec::new(),
+                Vec::new(),
+                elapsed,
+                QuerySource::Adhoc,
+            );
+            result.row_count = affected_rows;
+            return Ok(result.with_command_tag(tag));
+        }
+
+        let mut result = self
+            .execute_csv_query(path, query, QuerySource::Adhoc, read_only)
+            .await?;
+        if let Some(tag) = ddl_tag(query) {
+            result = result.with_command_tag(tag);
+        } else if keyword.eq_ignore_ascii_case("SELECT") || keyword.eq_ignore_ascii_case("WITH") {
+            let row_count = result.row_count;
+            result = result.with_command_tag(CommandTag::Select(row_count as u64));
+        }
+        Ok(result)
+    }
+
+    async fn execute_write(
+        &self,
+        dsn: &str,
+        query: &str,
+        read_only: bool,
+    ) -> Result<WriteExecutionResult, DbOperationError> {
+        let (affected_rows, execution_time_ms) = self
+            .execute_changes_query(Self::path_from_dsn(dsn)?, query, read_only)
+            .await?;
+        Ok(WriteExecutionResult {
+            affected_rows,
+            execution_time_ms,
+        })
+    }
+
+    async fn count_query_rows(
+        &self,
+        dsn: &str,
+        query: &str,
+        read_only: bool,
+    ) -> Result<usize, DbOperationError> {
+        let result = self
+            .execute_csv_query(
+                Self::path_from_dsn(dsn)?,
+                query,
+                QuerySource::Adhoc,
+                read_only,
+            )
+            .await?;
+        result
+            .rows
+            .first()
+            .and_then(|row| row.first())
+            .ok_or_else(|| {
+                DbOperationError::QueryFailed("Failed to parse COUNT result".to_string())
+            })?
+            .parse::<usize>()
+            .map_err(|error| {
+                DbOperationError::QueryFailed(format!("Failed to parse COUNT result: {error}"))
+            })
+    }
+
+    async fn export_to_csv(
+        &self,
+        dsn: &str,
+        query: &str,
+        path: &std::path::Path,
+        read_only: bool,
+    ) -> Result<usize, DbOperationError> {
+        self.cli
+            .export_csv(Self::path_from_dsn(dsn)?, query, path, read_only)
+            .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::process::Command;
 
-    use crate::app::ports::outbound::MetadataProvider;
+    use crate::app::ports::outbound::{MetadataProvider, QueryExecutor};
+    use crate::domain::{CommandTag, QuerySource};
 
     use super::*;
 
@@ -435,6 +782,157 @@ mod tests {
             .unwrap();
         assert!(status.success());
         (dir, format!("sqlite://{}", path.display()))
+    }
+
+    #[tokio::test]
+    async fn preview_returns_columns_rows_and_respects_pagination() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            INSERT INTO users(id, name) VALUES (2, 'b'), (1, 'a'), (3, 'c');
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_preview(&dsn, "main", "users", 1, 1, true)
+            .await
+            .unwrap();
+
+        assert_eq!(result.source, QuerySource::Preview);
+        assert_eq!(result.columns, vec!["id", "name"]);
+        assert_eq!(result.rows, vec![vec!["2".to_string(), "b".to_string()]]);
+    }
+
+    #[tokio::test]
+    async fn preview_rejects_non_main_schema() {
+        let (_dir, dsn) = make_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_preview(&dsn, "other", "users", 10, 0, true)
+            .await;
+
+        assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+    }
+
+    #[tokio::test]
+    async fn adhoc_select_returns_query_result() {
+        let (_dir, dsn) = make_db("CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(&dsn, "SELECT 1 AS value", true)
+            .await
+            .unwrap();
+
+        assert_eq!(result.columns, vec!["value"]);
+        assert_eq!(result.rows, vec![vec!["1".to_string()]]);
+        assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
+    }
+
+    #[tokio::test]
+    async fn adhoc_dml_returns_affected_rows_command_tag() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(&dsn, "UPDATE users SET name = 'x' WHERE id = 1", false)
+            .await
+            .unwrap();
+
+        assert_eq!(result.row_count, 1);
+        assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
+    }
+
+    #[tokio::test]
+    async fn adhoc_ddl_returns_schema_refresh_command_tag() {
+        let (_dir, dsn) = make_db("");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(&dsn, "CREATE TABLE users(id INTEGER PRIMARY KEY)", false)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.command_tag,
+            Some(CommandTag::Create("TABLE".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn write_execution_returns_affected_rows() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_write(&dsn, "DELETE FROM users WHERE id IN (1, 2)", false)
+            .await
+            .unwrap();
+
+        assert_eq!(result.affected_rows, 2);
+    }
+
+    #[tokio::test]
+    async fn count_query_rows_parses_count_result() {
+        let (_dir, dsn) = make_db(
+            r#"
+            CREATE TABLE users(id INTEGER PRIMARY KEY);
+            INSERT INTO users(id) VALUES (1), (2), (3);
+            "#,
+        );
+        let adapter = SqliteAdapter::new();
+
+        let count = adapter
+            .count_query_rows(&dsn, "SELECT COUNT(*) FROM users", true)
+            .await
+            .unwrap();
+
+        assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn export_to_csv_writes_rows_and_returns_row_count() {
+        let (dir, dsn) = make_db(
+            r#"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
+            "#,
+        );
+        let path = dir.path().join("users.csv");
+        let adapter = SqliteAdapter::new();
+
+        let row_count = adapter
+            .export_to_csv(&dsn, "SELECT id, name FROM users ORDER BY id", &path, true)
+            .await
+            .unwrap();
+        let csv = std::fs::read_to_string(path).unwrap();
+
+        assert_eq!(row_count, 2);
+        assert_eq!(csv, "id,name\n1,a\n2,b\n");
+    }
+
+    #[tokio::test]
+    async fn read_only_write_fails() {
+        let (_dir, dsn) = make_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_write(&dsn, "INSERT INTO users(id) VALUES (1)", true)
+            .await;
+
+        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
     }
 
     #[tokio::test]

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -35,6 +35,32 @@ pub(super) fn row_count_query(table: &str) -> String {
     format!("SELECT COUNT(*) AS count FROM {}", quote_ident(table))
 }
 
+pub(super) fn build_preview_query(
+    table: &str,
+    order_columns: &[String],
+    limit: usize,
+    offset: usize,
+) -> String {
+    let order_clause = if order_columns.is_empty() {
+        String::new()
+    } else {
+        let cols = order_columns
+            .iter()
+            .map(|col| quote_ident(col))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(" ORDER BY {cols}")
+    };
+
+    format!(
+        "SELECT * FROM {}{} LIMIT {} OFFSET {}",
+        quote_ident(table),
+        order_clause,
+        limit,
+        offset
+    )
+}
+
 pub(super) fn table_xinfo_query(table: &str) -> String {
     format!("PRAGMA table_xinfo({})", quote_ident(table))
 }
@@ -238,6 +264,14 @@ mod tests {
         assert_eq!(
             row_count_query(r#"my"table"#),
             r#"SELECT COUNT(*) AS count FROM "my""table""#
+        );
+    }
+
+    #[test]
+    fn build_preview_query_orders_by_primary_key_columns_when_available() {
+        assert_eq!(
+            build_preview_query("users", &["id".to_string()], 10, 20),
+            r#"SELECT * FROM "users" ORDER BY "id" LIMIT 10 OFFSET 20"#
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,7 @@ async fn main() -> Result<()> {
     let services = AppServices {
         ddl_generator: Arc::clone(&adapter_registry) as _,
         sql_dialect: Arc::clone(&adapter_registry) as _,
-        db_capabilities: DbCapabilities::postgres_like(),
+        db_capabilities: DbCapabilities::disconnected(),
     };
 
     let mut state = AppState::new(project_name);


### PR DESCRIPTION
## Scope

- SAB-234: SQLite query execution through the sqlite3 CLI subprocess
- Includes disconnected capability fallback cleanup needed for non-PostgreSQL defaults
- Defers multi-statement / transaction command-tag parity to SAB-252

## Summary

- Routes SQLite query execution through the existing QueryExecutor port instead of returning unsupported operation
- Adds SQLite preview, adhoc query, write, count, and CSV export behavior while keeping the driver-less adapter model
- Uses minimal command-tag behavior for normal single-statement SQLite UX

## Verification
test code