### PR TITLE
refactor: encapsulate ui state fields

### DIFF
--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -18,8 +18,8 @@ const SECTION_HEADER_LINE_COUNT: usize = 1;
 
 impl HelpDocument {
     pub fn from_state(state: &AppState) -> Self {
-        let filter = state.ui.help.filter();
-        Self::new_with_cursor(state.ui.help.origin(), filter.content(), filter.cursor())
+        let filter = state.ui.help().filter();
+        Self::new_with_cursor(state.ui.help().origin(), filter.content(), filter.cursor())
     }
 
     pub fn new(origin: HelpOrigin, filter: &str) -> Self {

--- a/src/app/model/shared/help.rs
+++ b/src/app/model/shared/help.rs
@@ -117,7 +117,7 @@ impl HelpOrigin {
     pub fn from_state(state: &AppState) -> Self {
         match state.input_mode() {
             InputMode::Normal => Self::Normal {
-                focused_pane: state.ui.focused_pane,
+                focused_pane: state.ui.focused_pane(),
                 result_active: state.result_interaction.selection().cell().is_some(),
                 history_mode: state.query.is_history_mode(),
             },
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     fn normal_origin_captures_focused_pane() {
         let mut state = AppState::new("test".to_string());
-        state.ui.focused_pane = FocusedPane::Inspector;
+        state.ui.set_focused_pane(FocusedPane::Inspector);
 
         let origin = HelpOrigin::from_state(&state);
 

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -162,45 +162,45 @@ impl ResultSelection {
 
 #[derive(Debug, Clone, Default)]
 pub struct UiState {
-    pub(crate) theme_id: ThemeId,
-    pub(crate) focused_pane: FocusedPane,
-    pub(crate) focus_mode: FocusMode,
-    pub(crate) explorer_selected: usize,
-    pub(crate) explorer_scroll_offset: usize,
-    pub(crate) explorer_horizontal_offset: usize,
+    theme_id: ThemeId,
+    focused_pane: FocusedPane,
+    focus_mode: FocusMode,
+    explorer_selected: usize,
+    explorer_scroll_offset: usize,
+    explorer_horizontal_offset: usize,
     // Default::default() leaves this at 0 until the first render updates it, so
     // scroll_max_offset may temporarily return the full content width.
-    pub(crate) explorer_content_width: usize,
+    explorer_content_width: usize,
 
-    pub(crate) connection_list_selected: usize,
-    pub(crate) connection_list_scroll_offset: usize,
-    pub(crate) connection_list_pane_height: u16,
+    connection_list_selected: usize,
+    connection_list_scroll_offset: usize,
+    connection_list_pane_height: u16,
 
-    pub(crate) table_picker: PickerState,
+    table_picker: PickerState,
 
-    pub(crate) er_picker: PickerState,
-    pub(crate) er_selected_tables: BTreeSet<String>,
-    pub(crate) pending_er_picker: bool,
+    er_picker: PickerState,
+    er_selected_tables: BTreeSet<String>,
+    pending_er_picker: bool,
 
-    pub(crate) inspector_tab: InspectorTab,
-    pub(crate) inspector_scroll_offset: usize,
-    pub(crate) inspector_horizontal_offset: usize,
-    pub(crate) inspector_viewport_plan: ViewportPlan,
-    pub(crate) inspector_pane_height: u16,
+    inspector_tab: InspectorTab,
+    inspector_scroll_offset: usize,
+    inspector_horizontal_offset: usize,
+    inspector_viewport_plan: ViewportPlan,
+    inspector_pane_height: u16,
 
-    pub(crate) explorer_pane_height: u16,
+    explorer_pane_height: u16,
 
-    pub(crate) result_viewport_plan: ViewportPlan,
-    pub(crate) result_widths_cache: ColumnWidthsCache,
-    pub(crate) result_pane_height: u16,
-    pub(crate) jsonb_detail_editor_visible_rows: usize,
+    result_viewport_plan: ViewportPlan,
+    result_widths_cache: ColumnWidthsCache,
+    result_pane_height: u16,
+    jsonb_detail_editor_visible_rows: usize,
 
     pub help: HelpState,
 
     pub terminal_width: u16,
     pub terminal_height: u16,
 
-    pub(crate) key_sequence: KeySequenceState,
+    key_sequence: KeySequenceState,
 }
 
 impl UiState {

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -249,8 +249,8 @@ impl UiState {
         self.explorer_scroll_offset = offset;
     }
 
-    // Sets selection index without adjusting scroll offset.
-    // Used when the caller manages scroll state independently (page scroll, cache restore).
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn set_explorer_selected_raw(&mut self, selected: usize) {
         self.explorer_selected = selected;
     }
@@ -269,7 +269,13 @@ impl UiState {
         self.explorer_scroll_offset = (self.explorer_scroll_offset + delta).min(max_offset);
     }
 
-    pub fn scroll_explorer_page_up(&mut self, delta: usize) {
+    pub fn scroll_explorer_page_up(&mut self, item_count: usize, delta: usize) {
+        if item_count == 0 {
+            return;
+        }
+        if self.explorer_visible_items() == 0 {
+            return;
+        }
         self.explorer_selected = self.explorer_selected.saturating_sub(delta);
         self.explorer_scroll_offset = self.explorer_scroll_offset.saturating_sub(delta);
     }
@@ -302,7 +308,8 @@ impl UiState {
         self.connection_list_pane_height = height;
     }
 
-    // Test/setup helper for selection-only states where scroll is controlled separately.
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
     pub fn set_connection_list_selected_raw(&mut self, selected: usize) {
         self.connection_list_selected = selected;
     }

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -195,10 +195,10 @@ pub struct UiState {
     result_pane_height: u16,
     jsonb_detail_editor_visible_rows: usize,
 
-    pub help: HelpState,
+    help: HelpState,
 
-    pub terminal_width: u16,
-    pub terminal_height: u16,
+    terminal_width: u16,
+    terminal_height: u16,
 
     key_sequence: KeySequenceState,
 }
@@ -253,6 +253,25 @@ impl UiState {
     // Used when the caller manages scroll state independently (page scroll, cache restore).
     pub fn set_explorer_selected_raw(&mut self, selected: usize) {
         self.explorer_selected = selected;
+    }
+
+    pub fn scroll_explorer_page_down(&mut self, item_count: usize, delta: usize) {
+        if item_count == 0 {
+            return;
+        }
+        let visible = self.explorer_visible_items();
+        if visible == 0 {
+            return;
+        }
+        let max_idx = item_count.saturating_sub(1);
+        let max_offset = item_count.saturating_sub(visible);
+        self.explorer_selected = (self.explorer_selected + delta).min(max_idx);
+        self.explorer_scroll_offset = (self.explorer_scroll_offset + delta).min(max_offset);
+    }
+
+    pub fn scroll_explorer_page_up(&mut self, delta: usize) {
+        self.explorer_selected = self.explorer_selected.saturating_sub(delta);
+        self.explorer_scroll_offset = self.explorer_scroll_offset.saturating_sub(delta);
     }
 
     pub fn set_explorer_horizontal_offset(&mut self, offset: usize) {
@@ -414,6 +433,14 @@ impl UiState {
         self.jsonb_detail_editor_visible_rows = rows;
     }
 
+    pub fn help(&self) -> &HelpState {
+        &self.help
+    }
+
+    pub fn help_mut(&mut self) -> &mut HelpState {
+        &mut self.help
+    }
+
     pub fn help_scroll_offset(&self) -> usize {
         self.help.scroll_offset()
     }
@@ -426,7 +453,20 @@ impl UiState {
         self.terminal_height
     }
 
+    pub fn terminal_width(&self) -> u16 {
+        self.terminal_width
+    }
+
     pub fn set_terminal_height(&mut self, height: u16) {
+        self.terminal_height = height;
+    }
+
+    pub fn set_terminal_width(&mut self, width: u16) {
+        self.terminal_width = width;
+    }
+
+    pub fn set_terminal_size(&mut self, width: u16, height: u16) {
+        self.terminal_width = width;
         self.terminal_height = height;
     }
 

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -216,10 +216,10 @@ impl SqlModalContext {
         table: String,
         entry: FailedPrefetchEntry,
     ) -> bool {
-        let had_pending_before_requeue = self.has_pending_prefetch();
+        let had_other_pending_before_requeue = self.has_pending_prefetch();
         self.record_prefetch_failure(table.clone(), entry);
         self.enqueue_prefetch(table);
-        had_pending_before_requeue
+        had_other_pending_before_requeue
     }
 
     pub fn active_prefetch_run_id(&self) -> Option<u64> {
@@ -573,13 +573,24 @@ mod tests {
         }
 
         #[test]
+        fn prioritize_prefetch_pushes_to_front_of_pending_queue() {
+            let mut ctx = SqlModalContext::default();
+
+            ctx.enqueue_prefetch("public.orders".to_string());
+            ctx.prioritize_prefetch("public.users".to_string());
+
+            let queued: Vec<&str> = ctx.prefetch_queue().iter().map(String::as_str).collect();
+            assert_eq!(queued, vec!["public.users", "public.orders"]);
+        }
+
+        #[test]
         fn failure_requeue_appends_after_existing_pending_tables() {
             let mut ctx = SqlModalContext::default();
             let failed_at = Instant::now();
 
             ctx.mark_prefetching("public.users".to_string());
             ctx.enqueue_prefetch("public.orders".to_string());
-            ctx.record_prefetch_failure_and_requeue(
+            let had_other_pending_before_requeue = ctx.record_prefetch_failure_and_requeue(
                 "public.users".to_string(),
                 FailedPrefetchEntry {
                     failed_at,
@@ -588,8 +599,35 @@ mod tests {
                 },
             );
 
+            assert!(had_other_pending_before_requeue);
             let queued: Vec<&str> = ctx.prefetch_queue().iter().map(String::as_str).collect();
             assert_eq!(queued, vec!["public.orders", "public.users"]);
+            assert!(!ctx.is_prefetching("public.users"));
+            assert_eq!(
+                ctx.failed_prefetch_entry("public.users")
+                    .map(|entry| (entry.failed_at, entry.retry_count)),
+                Some((failed_at, 1))
+            );
+        }
+
+        #[test]
+        fn failure_requeue_returns_false_for_self_retry_only() {
+            let mut ctx = SqlModalContext::default();
+            let failed_at = Instant::now();
+
+            ctx.mark_prefetching("public.users".to_string());
+            let had_other_pending_before_requeue = ctx.record_prefetch_failure_and_requeue(
+                "public.users".to_string(),
+                FailedPrefetchEntry {
+                    failed_at,
+                    error: "timeout".to_string(),
+                    retry_count: 1,
+                },
+            );
+
+            assert!(!had_other_pending_before_requeue);
+            let queued: Vec<&str> = ctx.prefetch_queue().iter().map(String::as_str).collect();
+            assert_eq!(queued, vec!["public.users"]);
             assert!(!ctx.is_prefetching("public.users"));
             assert_eq!(
                 ctx.failed_prefetch_entry("public.users")

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -172,17 +172,22 @@ impl SqlModalContext {
     }
 
     pub fn enqueue_prefetch(&mut self, table: String) {
-        if self.prefetching_tables.contains(&table) || self.prefetch_queue.contains(&table) {
+        if self.has_prefetch_entry(&table) {
             return;
         }
         self.prefetch_queue.push_back(table);
     }
 
-    pub fn requeue_prefetch_for_missing_dsn(&mut self, table: String) {
-        if self.prefetching_tables.contains(&table) || self.prefetch_queue.contains(&table) {
+    pub fn prioritize_prefetch(&mut self, table: String) {
+        if self.has_prefetch_entry(&table) {
             return;
         }
         self.prefetch_queue.push_front(table);
+    }
+
+    fn has_prefetch_entry(&self, table: &str) -> bool {
+        self.prefetching_tables.contains(table)
+            || self.prefetch_queue.iter().any(|queued| queued == table)
     }
 
     pub fn dequeue_prefetch(&mut self) -> Option<String> {
@@ -210,9 +215,11 @@ impl SqlModalContext {
         &mut self,
         table: String,
         entry: FailedPrefetchEntry,
-    ) {
+    ) -> bool {
+        let had_pending_before_requeue = self.has_pending_prefetch();
         self.record_prefetch_failure(table.clone(), entry);
         self.enqueue_prefetch(table);
+        had_pending_before_requeue
     }
 
     pub fn active_prefetch_run_id(&self) -> Option<u64> {
@@ -541,17 +548,28 @@ mod tests {
         }
 
         #[test]
-        fn requeue_for_missing_dsn_skips_already_queued_table() {
+        fn prioritize_prefetch_skips_already_queued_table() {
             let mut ctx = SqlModalContext::default();
 
             ctx.enqueue_prefetch("public.users".to_string());
-            ctx.requeue_prefetch_for_missing_dsn("public.users".to_string());
+            ctx.prioritize_prefetch("public.users".to_string());
 
             assert_eq!(ctx.prefetch_queue().len(), 1);
             assert_eq!(
                 ctx.prefetch_queue().front().map(String::as_str),
                 Some("public.users")
             );
+        }
+
+        #[test]
+        fn prioritize_prefetch_skips_in_flight_table() {
+            let mut ctx = SqlModalContext::default();
+
+            ctx.mark_prefetching("public.users".to_string());
+            ctx.prioritize_prefetch("public.users".to_string());
+
+            assert!(ctx.prefetch_queue().is_empty());
+            assert!(ctx.is_prefetching("public.users"));
         }
 
         #[test]

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -658,7 +658,7 @@ mod tests {
             assert!(state.query.current_result().is_none());
             assert!(state.session.table_detail().is_none());
             assert!(state.session.selected_table_key().is_none());
-            assert_eq!(state.ui.explorer_selected, 0);
+            assert_eq!(state.ui.explorer_selected(), 0);
         }
 
         #[test]
@@ -672,7 +672,7 @@ mod tests {
             let effects = dispatch_metadata(&mut state, &action, Instant::now()).unwrap();
 
             assert_eq!(state.query.pagination.table(), "users");
-            assert_eq!(state.ui.explorer_selected, 1);
+            assert_eq!(state.ui.explorer_selected(), 1);
             assert!(
                 effects
                     .iter()
@@ -693,7 +693,7 @@ mod tests {
             let action = metadata_loaded_action(&mut state, metadata);
             dispatch_metadata(&mut state, &action, Instant::now());
 
-            assert_eq!(state.ui.explorer_selected, 0);
+            assert_eq!(state.ui.explorer_selected(), 0);
         }
 
         #[test]

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -140,9 +140,7 @@ pub(super) fn reduce_prefetch(
             }
 
             let Some(dsn) = state.session.dsn().map(String::from) else {
-                state
-                    .sql_modal
-                    .requeue_prefetch_for_missing_dsn(qualified_name);
+                state.sql_modal.prioritize_prefetch(qualified_name);
                 return DispatchResult::handled();
             };
 
@@ -203,18 +201,15 @@ pub(super) fn reduce_prefetch(
                 .sql_modal
                 .failed_prefetch_entry(&qualified_name)
                 .map_or(0, |e| e.retry_count);
-            // Snapshot before record_prefetch_failure_and_requeue so this self retry is not
-            // counted by has_pending_prefetch; immediate processing is only for peers, while
-            // this entry resumes through DelayedProcessPrefetchQueue with backoff_secs_for.
-            let had_other_pending_before_requeue = state.sql_modal.has_pending_prefetch();
-            state.sql_modal.record_prefetch_failure_and_requeue(
-                qualified_name.clone(),
-                FailedPrefetchEntry {
-                    failed_at: now,
-                    error: error.user_message(),
-                    retry_count: prev_count + 1,
-                },
-            );
+            let had_other_pending_before_requeue =
+                state.sql_modal.record_prefetch_failure_and_requeue(
+                    qualified_name.clone(),
+                    FailedPrefetchEntry {
+                        failed_at: now,
+                        error: error.user_message(),
+                        retry_count: prev_count + 1,
+                    },
+                );
             state.er_preparation.requeue_for_retry(&qualified_name);
 
             let mut effects = Vec::new();

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -18,7 +18,7 @@ pub(super) fn reduce_table_detail(state: &mut AppState, action: &Action) -> Disp
             }
 
             if state.session.set_table_detail(*detail.clone(), *generation) {
-                state.ui.inspector_scroll_offset = 0;
+                state.ui.set_inspector_scroll_offset(0);
             }
             DispatchResult::handled()
         }

--- a/src/app/update/browse/navigation/explorer.rs
+++ b/src/app/update/browse/navigation/explorer.rs
@@ -135,13 +135,7 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
 
         Action::Select(motion @ (SelectMotion::HalfPageDown | SelectMotion::FullPageDown)) => {
             let len = explorer_item_count(state);
-            if len == 0 {
-                return DispatchResult::handled();
-            }
             let visible = state.ui.explorer_visible_items();
-            if visible == 0 {
-                return DispatchResult::handled();
-            }
             let delta = match motion {
                 SelectMotion::HalfPageDown => (visible / 2).max(1),
                 _ => visible.max(1),
@@ -151,18 +145,12 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
         }
         Action::Select(motion @ (SelectMotion::HalfPageUp | SelectMotion::FullPageUp)) => {
             let len = explorer_item_count(state);
-            if len == 0 {
-                return DispatchResult::handled();
-            }
             let visible = state.ui.explorer_visible_items();
-            if visible == 0 {
-                return DispatchResult::handled();
-            }
             let delta = match motion {
                 SelectMotion::HalfPageUp => (visible / 2).max(1),
                 _ => visible.max(1),
             };
-            state.ui.scroll_explorer_page_up(delta);
+            state.ui.scroll_explorer_page_up(len, delta);
             DispatchResult::handled()
         }
 

--- a/src/app/update/browse/navigation/explorer.rs
+++ b/src/app/update/browse/navigation/explorer.rs
@@ -146,14 +146,7 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
                 SelectMotion::HalfPageDown => (visible / 2).max(1),
                 _ => visible.max(1),
             };
-            let max_idx = len.saturating_sub(1);
-            let max_offset = len.saturating_sub(visible);
-            state
-                .ui
-                .set_explorer_selected_raw((state.ui.explorer_selected() + delta).min(max_idx));
-            state.ui.set_explorer_scroll_offset(
-                (state.ui.explorer_scroll_offset() + delta).min(max_offset),
-            );
+            state.ui.scroll_explorer_page_down(len, delta);
             DispatchResult::handled()
         }
         Action::Select(motion @ (SelectMotion::HalfPageUp | SelectMotion::FullPageUp)) => {
@@ -169,12 +162,7 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
                 SelectMotion::HalfPageUp => (visible / 2).max(1),
                 _ => visible.max(1),
             };
-            state
-                .ui
-                .set_explorer_selected_raw(state.ui.explorer_selected().saturating_sub(delta));
-            state.ui.set_explorer_scroll_offset(
-                state.ui.explorer_scroll_offset().saturating_sub(delta),
-            );
+            state.ui.scroll_explorer_page_up(delta);
             DispatchResult::handled()
         }
 

--- a/src/app/update/browse/navigation/explorer.rs
+++ b/src/app/update/browse/navigation/explorer.rs
@@ -13,31 +13,31 @@ use super::explorer_item_count;
 pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::Select(SelectMotion::Next) => {
-            if state.ui.focused_pane == FocusedPane::Explorer {
+            if state.ui.focused_pane() == FocusedPane::Explorer {
                 let len = state.tables().len();
-                if len > 0 && state.ui.explorer_selected < len - 1 {
+                if len > 0 && state.ui.explorer_selected() < len - 1 {
                     state
                         .ui
-                        .set_explorer_selection(Some(state.ui.explorer_selected + 1));
+                        .set_explorer_selection(Some(state.ui.explorer_selected() + 1));
                 }
             }
             DispatchResult::handled()
         }
         Action::Select(SelectMotion::Previous) => {
-            if state.ui.focused_pane == FocusedPane::Explorer && !state.tables().is_empty() {
-                let new_idx = state.ui.explorer_selected.saturating_sub(1);
+            if state.ui.focused_pane() == FocusedPane::Explorer && !state.tables().is_empty() {
+                let new_idx = state.ui.explorer_selected().saturating_sub(1);
                 state.ui.set_explorer_selection(Some(new_idx));
             }
             DispatchResult::handled()
         }
         Action::Select(SelectMotion::First) => {
-            if state.ui.focused_pane == FocusedPane::Explorer && !state.tables().is_empty() {
+            if state.ui.focused_pane() == FocusedPane::Explorer && !state.tables().is_empty() {
                 state.ui.set_explorer_selection(Some(0));
             }
             DispatchResult::handled()
         }
         Action::Select(SelectMotion::Last) => {
-            if state.ui.focused_pane == FocusedPane::Explorer {
+            if state.ui.focused_pane() == FocusedPane::Explorer {
                 let len = state.tables().len();
                 if len > 0 {
                     state.ui.set_explorer_selection(Some(len - 1));
@@ -46,36 +46,36 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
             DispatchResult::handled()
         }
         Action::Select(SelectMotion::ViewportMiddle) => {
-            if state.ui.focused_pane == FocusedPane::Explorer {
+            if state.ui.focused_pane() == FocusedPane::Explorer {
                 let len = explorer_item_count(state);
                 let visible = state.ui.explorer_visible_items();
                 if len > 0 && visible > 0 {
                     let displayed =
-                        visible.min(len.saturating_sub(state.ui.explorer_scroll_offset));
-                    let target = state.ui.explorer_scroll_offset + displayed / 2;
+                        visible.min(len.saturating_sub(state.ui.explorer_scroll_offset()));
+                    let target = state.ui.explorer_scroll_offset() + displayed / 2;
                     state.ui.set_explorer_selection(Some(target));
                 }
             }
             DispatchResult::handled()
         }
         Action::Select(SelectMotion::ViewportTop) => {
-            if state.ui.focused_pane == FocusedPane::Explorer {
+            if state.ui.focused_pane() == FocusedPane::Explorer {
                 let len = explorer_item_count(state);
                 if len > 0 {
-                    let target = state.ui.explorer_scroll_offset.min(len.saturating_sub(1));
+                    let target = state.ui.explorer_scroll_offset().min(len.saturating_sub(1));
                     state.ui.set_explorer_selection(Some(target));
                 }
             }
             DispatchResult::handled()
         }
         Action::Select(SelectMotion::ViewportBottom) => {
-            if state.ui.focused_pane == FocusedPane::Explorer {
+            if state.ui.focused_pane() == FocusedPane::Explorer {
                 let len = explorer_item_count(state);
                 let visible = state.ui.explorer_visible_items();
                 if len > 0 && visible > 0 {
                     let displayed =
-                        visible.min(len.saturating_sub(state.ui.explorer_scroll_offset));
-                    let target = state.ui.explorer_scroll_offset + displayed.saturating_sub(1);
+                        visible.min(len.saturating_sub(state.ui.explorer_scroll_offset()));
+                    let target = state.ui.explorer_scroll_offset() + displayed.saturating_sub(1);
                     state.ui.set_explorer_selection(Some(target));
                 }
             }
@@ -86,14 +86,15 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
             target: ScrollToCursorTarget::Explorer,
             position: CursorPosition::Center,
         } => {
-            state.ui.key_sequence = KeySequenceState::Idle;
+            state.ui.set_key_sequence(KeySequenceState::Idle);
             let len = explorer_item_count(state);
             let visible = state.ui.explorer_visible_items();
             if len > 0 && visible > 0 {
-                let selected = state.ui.explorer_selected;
+                let selected = state.ui.explorer_selected();
                 let max_offset = len.saturating_sub(visible);
-                state.ui.explorer_scroll_offset =
-                    selected.saturating_sub(visible / 2).min(max_offset);
+                state.ui.set_explorer_scroll_offset(
+                    selected.saturating_sub(visible / 2).min(max_offset),
+                );
             }
             DispatchResult::handled()
         }
@@ -101,13 +102,15 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
             target: ScrollToCursorTarget::Explorer,
             position: CursorPosition::Top,
         } => {
-            state.ui.key_sequence = KeySequenceState::Idle;
+            state.ui.set_key_sequence(KeySequenceState::Idle);
             let len = explorer_item_count(state);
             let visible = state.ui.explorer_visible_items();
             if len > 0 && visible > 0 {
-                let selected = state.ui.explorer_selected;
+                let selected = state.ui.explorer_selected();
                 let max_offset = len.saturating_sub(visible);
-                state.ui.explorer_scroll_offset = selected.min(max_offset);
+                state
+                    .ui
+                    .set_explorer_scroll_offset(selected.min(max_offset));
             }
             DispatchResult::handled()
         }
@@ -115,15 +118,17 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
             target: ScrollToCursorTarget::Explorer,
             position: CursorPosition::Bottom,
         } => {
-            state.ui.key_sequence = KeySequenceState::Idle;
+            state.ui.set_key_sequence(KeySequenceState::Idle);
             let len = explorer_item_count(state);
             let visible = state.ui.explorer_visible_items();
             if len > 0 && visible > 0 {
-                let selected = state.ui.explorer_selected;
+                let selected = state.ui.explorer_selected();
                 let max_offset = len.saturating_sub(visible);
-                state.ui.explorer_scroll_offset = selected
-                    .saturating_sub(visible.saturating_sub(1))
-                    .min(max_offset);
+                state.ui.set_explorer_scroll_offset(
+                    selected
+                        .saturating_sub(visible.saturating_sub(1))
+                        .min(max_offset),
+                );
             }
             DispatchResult::handled()
         }
@@ -143,9 +148,12 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
             };
             let max_idx = len.saturating_sub(1);
             let max_offset = len.saturating_sub(visible);
-            state.ui.explorer_selected = (state.ui.explorer_selected + delta).min(max_idx);
-            state.ui.explorer_scroll_offset =
-                (state.ui.explorer_scroll_offset + delta).min(max_offset);
+            state
+                .ui
+                .set_explorer_selected_raw((state.ui.explorer_selected() + delta).min(max_idx));
+            state.ui.set_explorer_scroll_offset(
+                (state.ui.explorer_scroll_offset() + delta).min(max_offset),
+            );
             DispatchResult::handled()
         }
         Action::Select(motion @ (SelectMotion::HalfPageUp | SelectMotion::FullPageUp)) => {
@@ -161,8 +169,12 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
                 SelectMotion::HalfPageUp => (visible / 2).max(1),
                 _ => visible.max(1),
             };
-            state.ui.explorer_selected = state.ui.explorer_selected.saturating_sub(delta);
-            state.ui.explorer_scroll_offset = state.ui.explorer_scroll_offset.saturating_sub(delta);
+            state
+                .ui
+                .set_explorer_selected_raw(state.ui.explorer_selected().saturating_sub(delta));
+            state.ui.set_explorer_scroll_offset(
+                state.ui.explorer_scroll_offset().saturating_sub(delta),
+            );
             DispatchResult::handled()
         }
 
@@ -171,8 +183,9 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
             direction: ScrollDirection::Left,
             amount: ScrollAmount::Line,
         } => {
-            state.ui.explorer_horizontal_offset =
-                state.ui.explorer_horizontal_offset.saturating_sub(1);
+            state.ui.set_explorer_horizontal_offset(
+                state.ui.explorer_horizontal_offset().saturating_sub(1),
+            );
             DispatchResult::handled()
         }
         Action::Scroll {
@@ -186,9 +199,11 @@ pub fn reduce_explorer(state: &mut AppState, action: &Action) -> DispatchResult 
                 .map(|t| text_display_width(&t.qualified_name()))
                 .max()
                 .unwrap_or(0);
-            let max_offset = scroll_max_offset(max_name_width, state.ui.explorer_content_width);
-            if state.ui.explorer_horizontal_offset < max_offset {
-                state.ui.explorer_horizontal_offset += 1;
+            let max_offset = scroll_max_offset(max_name_width, state.ui.explorer_content_width());
+            if state.ui.explorer_horizontal_offset() < max_offset {
+                state
+                    .ui
+                    .set_explorer_horizontal_offset(state.ui.explorer_horizontal_offset() + 1);
             }
             DispatchResult::handled()
         }
@@ -210,8 +225,8 @@ mod tests {
 
     fn state_with_tables(count: usize, pane_height: u16) -> AppState {
         let mut state = AppState::new("test".to_string());
-        state.ui.explorer_pane_height = pane_height;
-        state.ui.focused_pane = FocusedPane::Explorer;
+        state.ui.set_explorer_pane_height(pane_height);
+        state.ui.set_focused_pane(FocusedPane::Explorer);
         let tables: Vec<TableSummary> = (0..count)
             .map(|i| TableSummary::new("public".to_string(), format!("table_{i}"), Some(0), false))
             .collect();
@@ -227,8 +242,8 @@ mod tests {
 
     fn state_with_named_tables(names: &[&str], content_width: usize) -> AppState {
         let mut state = AppState::new("test".to_string());
-        state.ui.focused_pane = FocusedPane::Explorer;
-        state.ui.explorer_content_width = content_width;
+        state.ui.set_focused_pane(FocusedPane::Explorer);
+        state.ui.set_explorer_content_width(content_width);
         let tables: Vec<TableSummary> = names
             .iter()
             .map(|name| {
@@ -257,7 +272,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 10);
+            assert_eq!(state.ui.explorer_selected(), 10);
         }
 
         #[test]
@@ -272,7 +287,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 49);
+            assert_eq!(state.ui.explorer_selected(), 49);
         }
 
         #[test]
@@ -287,7 +302,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 0);
+            assert_eq!(state.ui.explorer_selected(), 0);
         }
 
         #[test]
@@ -300,13 +315,13 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 20);
+            assert_eq!(state.ui.explorer_selected(), 20);
         }
 
         #[test]
         fn empty_list_does_nothing() {
             let mut state = AppState::new("test".to_string());
-            state.ui.explorer_pane_height = 23;
+            state.ui.set_explorer_pane_height(23);
 
             let effects = dispatch_navigation(
                 &mut state,
@@ -316,7 +331,7 @@ mod tests {
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.explorer_selected, 0);
+            assert_eq!(state.ui.explorer_selected(), 0);
         }
 
         #[test]
@@ -329,15 +344,15 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 0);
-            assert_eq!(state.ui.explorer_scroll_offset, 0);
+            assert_eq!(state.ui.explorer_selected(), 0);
+            assert_eq!(state.ui.explorer_scroll_offset(), 0);
         }
 
         #[test]
         fn half_page_down_moves_both_selection_and_scroll() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_selected = 15;
-            state.ui.explorer_scroll_offset = 10;
+            state.ui.set_explorer_selected_raw(15);
+            state.ui.set_explorer_scroll_offset(10);
 
             dispatch_navigation(
                 &mut state,
@@ -346,15 +361,15 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 25);
-            assert_eq!(state.ui.explorer_scroll_offset, 20);
+            assert_eq!(state.ui.explorer_selected(), 25);
+            assert_eq!(state.ui.explorer_scroll_offset(), 20);
         }
 
         #[test]
         fn half_page_up_moves_both_selection_and_scroll() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_selected = 25;
-            state.ui.explorer_scroll_offset = 20;
+            state.ui.set_explorer_selected_raw(25);
+            state.ui.set_explorer_scroll_offset(20);
 
             dispatch_navigation(
                 &mut state,
@@ -363,15 +378,15 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 15);
-            assert_eq!(state.ui.explorer_scroll_offset, 10);
+            assert_eq!(state.ui.explorer_selected(), 15);
+            assert_eq!(state.ui.explorer_scroll_offset(), 10);
         }
 
         #[test]
         fn half_page_down_preserves_relative_position() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_selected = 15;
-            state.ui.explorer_scroll_offset = 10;
+            state.ui.set_explorer_selected_raw(15);
+            state.ui.set_explorer_scroll_offset(10);
 
             dispatch_navigation(
                 &mut state,
@@ -380,14 +395,14 @@ mod tests {
                 Instant::now(),
             );
 
-            let relative = state.ui.explorer_selected - state.ui.explorer_scroll_offset;
+            let relative = state.ui.explorer_selected() - state.ui.explorer_scroll_offset();
             assert_eq!(relative, 5);
         }
 
         #[test]
         fn data_fewer_than_viewport_scroll_stays_zero() {
             let mut state = state_with_tables(10, 23);
-            state.ui.explorer_selected = 3;
+            state.ui.set_explorer_selected_raw(3);
 
             dispatch_navigation(
                 &mut state,
@@ -396,15 +411,15 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 9);
-            assert_eq!(state.ui.explorer_scroll_offset, 0);
+            assert_eq!(state.ui.explorer_selected(), 9);
+            assert_eq!(state.ui.explorer_scroll_offset(), 0);
         }
 
         #[test]
         fn full_page_down_moves_both_selection_and_scroll() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_selected = 10;
-            state.ui.explorer_scroll_offset = 5;
+            state.ui.set_explorer_selected_raw(10);
+            state.ui.set_explorer_scroll_offset(5);
 
             dispatch_navigation(
                 &mut state,
@@ -413,15 +428,15 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 30);
-            assert_eq!(state.ui.explorer_scroll_offset, 25);
+            assert_eq!(state.ui.explorer_selected(), 30);
+            assert_eq!(state.ui.explorer_scroll_offset(), 25);
         }
 
         #[test]
         fn full_page_up_moves_both_selection_and_scroll() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_selected = 30;
-            state.ui.explorer_scroll_offset = 25;
+            state.ui.set_explorer_selected_raw(30);
+            state.ui.set_explorer_scroll_offset(25);
 
             dispatch_navigation(
                 &mut state,
@@ -430,15 +445,15 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 10);
-            assert_eq!(state.ui.explorer_scroll_offset, 5);
+            assert_eq!(state.ui.explorer_selected(), 10);
+            assert_eq!(state.ui.explorer_scroll_offset(), 5);
         }
 
         #[test]
         fn full_page_down_clamps_near_bottom() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_selected = 40;
-            state.ui.explorer_scroll_offset = 25;
+            state.ui.set_explorer_selected_raw(40);
+            state.ui.set_explorer_scroll_offset(25);
 
             dispatch_navigation(
                 &mut state,
@@ -447,15 +462,15 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 49);
-            assert_eq!(state.ui.explorer_scroll_offset, 30);
+            assert_eq!(state.ui.explorer_selected(), 49);
+            assert_eq!(state.ui.explorer_scroll_offset(), 30);
         }
 
         #[test]
         fn full_page_up_clamps_near_top() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_selected = 10;
-            state.ui.explorer_scroll_offset = 5;
+            state.ui.set_explorer_selected_raw(10);
+            state.ui.set_explorer_scroll_offset(5);
 
             dispatch_navigation(
                 &mut state,
@@ -464,8 +479,8 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 0);
-            assert_eq!(state.ui.explorer_scroll_offset, 0);
+            assert_eq!(state.ui.explorer_selected(), 0);
+            assert_eq!(state.ui.explorer_scroll_offset(), 0);
         }
     }
 
@@ -482,15 +497,15 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 10);
-            assert_eq!(state.ui.explorer_scroll_offset, 0);
+            assert_eq!(state.ui.explorer_selected(), 10);
+            assert_eq!(state.ui.explorer_scroll_offset(), 0);
         }
 
         #[test]
         fn select_middle_respects_scroll_offset() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_scroll_offset = 15;
-            state.ui.explorer_selected = 15;
+            state.ui.set_explorer_scroll_offset(15);
+            state.ui.set_explorer_selected_raw(15);
             dispatch_navigation(
                 &mut state,
                 &Action::Select(SelectMotion::ViewportMiddle),
@@ -498,15 +513,15 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 25);
-            assert_eq!(state.ui.explorer_scroll_offset, 15);
+            assert_eq!(state.ui.explorer_selected(), 25);
+            assert_eq!(state.ui.explorer_scroll_offset(), 15);
         }
 
         #[test]
         fn select_viewport_top_moves_to_first_visible_item() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_scroll_offset = 10;
-            state.ui.explorer_selected = 20;
+            state.ui.set_explorer_scroll_offset(10);
+            state.ui.set_explorer_selected_raw(20);
 
             dispatch_navigation(
                 &mut state,
@@ -515,14 +530,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 10);
+            assert_eq!(state.ui.explorer_selected(), 10);
         }
 
         #[test]
         fn select_viewport_bottom_moves_to_last_visible_item() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_scroll_offset = 10;
-            state.ui.explorer_selected = 15;
+            state.ui.set_explorer_scroll_offset(10);
+            state.ui.set_explorer_selected_raw(15);
 
             dispatch_navigation(
                 &mut state,
@@ -531,7 +546,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 29);
+            assert_eq!(state.ui.explorer_selected(), 29);
         }
 
         #[test]
@@ -544,14 +559,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 9);
+            assert_eq!(state.ui.explorer_selected(), 9);
         }
 
         #[test]
         fn select_viewport_middle_uses_displayed_count_near_end() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_scroll_offset = 40;
-            state.ui.explorer_selected = 40;
+            state.ui.set_explorer_scroll_offset(40);
+            state.ui.set_explorer_selected_raw(40);
 
             dispatch_navigation(
                 &mut state,
@@ -560,14 +575,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 45);
+            assert_eq!(state.ui.explorer_selected(), 45);
         }
 
         #[test]
         fn select_viewport_bottom_uses_displayed_count_near_end() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_scroll_offset = 40;
-            state.ui.explorer_selected = 40;
+            state.ui.set_explorer_scroll_offset(40);
+            state.ui.set_explorer_selected_raw(40);
 
             dispatch_navigation(
                 &mut state,
@@ -576,7 +591,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_selected, 49);
+            assert_eq!(state.ui.explorer_selected(), 49);
         }
     }
 
@@ -586,9 +601,11 @@ mod tests {
         #[test]
         fn scroll_cursor_center_centers_viewport_on_selected() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_selected = 30;
-            state.ui.explorer_scroll_offset = 30;
-            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
+            state.ui.set_explorer_selected_raw(30);
+            state.ui.set_explorer_scroll_offset(30);
+            state
+                .ui
+                .set_key_sequence(KeySequenceState::WaitingSecondKey(Prefix::Z));
 
             dispatch_navigation(
                 &mut state,
@@ -600,16 +617,18 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_scroll_offset, 20);
-            assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
+            assert_eq!(state.ui.explorer_scroll_offset(), 20);
+            assert_eq!(state.ui.key_sequence(), KeySequenceState::Idle);
         }
 
         #[test]
         fn scroll_cursor_top_puts_selected_at_top() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_selected = 15;
-            state.ui.explorer_scroll_offset = 0;
-            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
+            state.ui.set_explorer_selected_raw(15);
+            state.ui.set_explorer_scroll_offset(0);
+            state
+                .ui
+                .set_key_sequence(KeySequenceState::WaitingSecondKey(Prefix::Z));
 
             dispatch_navigation(
                 &mut state,
@@ -621,16 +640,18 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_scroll_offset, 15);
-            assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
+            assert_eq!(state.ui.explorer_scroll_offset(), 15);
+            assert_eq!(state.ui.key_sequence(), KeySequenceState::Idle);
         }
 
         #[test]
         fn scroll_cursor_bottom_puts_selected_at_bottom() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_selected = 25;
-            state.ui.explorer_scroll_offset = 25;
-            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
+            state.ui.set_explorer_selected_raw(25);
+            state.ui.set_explorer_scroll_offset(25);
+            state
+                .ui
+                .set_key_sequence(KeySequenceState::WaitingSecondKey(Prefix::Z));
 
             dispatch_navigation(
                 &mut state,
@@ -642,16 +663,18 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_scroll_offset, 6);
-            assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
+            assert_eq!(state.ui.explorer_scroll_offset(), 6);
+            assert_eq!(state.ui.key_sequence(), KeySequenceState::Idle);
         }
 
         #[test]
         fn scroll_cursor_top_clamps_to_max_offset() {
             let mut state = state_with_tables(50, 23);
-            state.ui.explorer_selected = 45;
-            state.ui.explorer_scroll_offset = 30;
-            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
+            state.ui.set_explorer_selected_raw(45);
+            state.ui.set_explorer_scroll_offset(30);
+            state
+                .ui
+                .set_key_sequence(KeySequenceState::WaitingSecondKey(Prefix::Z));
 
             dispatch_navigation(
                 &mut state,
@@ -663,8 +686,8 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.explorer_scroll_offset, 30);
-            assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
+            assert_eq!(state.ui.explorer_scroll_offset(), 30);
+            assert_eq!(state.ui.key_sequence(), KeySequenceState::Idle);
         }
     }
 
@@ -696,15 +719,16 @@ mod tests {
                 );
             }
 
-            assert_eq!(state.ui.explorer_horizontal_offset, expected);
+            assert_eq!(state.ui.explorer_horizontal_offset(), expected);
         }
 
         #[test]
         fn right_presses_past_end_do_not_increase_offset() {
             let mut state = state_with_named_tables(&["abcdefghij"], 4);
-            state.ui.explorer_horizontal_offset =
+            state.ui.set_explorer_horizontal_offset(
                 text_display_width(&state.tables()[0].qualified_name())
-                    .saturating_sub(state.ui.explorer_content_width);
+                    .saturating_sub(state.ui.explorer_content_width()),
+            );
 
             for _ in 0..3 {
                 dispatch_navigation(
@@ -720,18 +744,19 @@ mod tests {
             }
 
             assert_eq!(
-                state.ui.explorer_horizontal_offset,
+                state.ui.explorer_horizontal_offset(),
                 text_display_width(&state.tables()[0].qualified_name())
-                    .saturating_sub(state.ui.explorer_content_width)
+                    .saturating_sub(state.ui.explorer_content_width())
             );
         }
 
         #[test]
         fn left_press_after_end_recovers_one_column() {
             let mut state = state_with_named_tables(&["abcdefghij"], 4);
-            state.ui.explorer_horizontal_offset =
+            state.ui.set_explorer_horizontal_offset(
                 text_display_width(&state.tables()[0].qualified_name())
-                    .saturating_sub(state.ui.explorer_content_width);
+                    .saturating_sub(state.ui.explorer_content_width()),
+            );
 
             dispatch_navigation(
                 &mut state,
@@ -745,9 +770,9 @@ mod tests {
             );
 
             assert_eq!(
-                state.ui.explorer_horizontal_offset,
+                state.ui.explorer_horizontal_offset(),
                 text_display_width(&state.tables()[0].qualified_name())
-                    .saturating_sub(state.ui.explorer_content_width)
+                    .saturating_sub(state.ui.explorer_content_width())
                     .saturating_sub(1)
             );
         }

--- a/src/app/update/browse/navigation/focus.rs
+++ b/src/app/update/browse/navigation/focus.rs
@@ -133,7 +133,7 @@ mod tests {
         #[test]
         fn next_tab_wraps_between_supported_tabs() {
             let mut state = AppState::new("test".to_string());
-            state.ui.inspector_tab = InspectorTab::Info;
+            state.ui.set_inspector_tab(InspectorTab::Info);
 
             dispatch_navigation(
                 &mut state,
@@ -142,13 +142,13 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.inspector_tab, InspectorTab::Columns);
+            assert_eq!(state.ui.inspector_tab(), InspectorTab::Columns);
         }
 
         #[test]
         fn prev_tab_wraps_between_supported_tabs() {
             let mut state = AppState::new("test".to_string());
-            state.ui.inspector_tab = InspectorTab::Info;
+            state.ui.set_inspector_tab(InspectorTab::Info);
 
             dispatch_navigation(
                 &mut state,
@@ -157,7 +157,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.inspector_tab, InspectorTab::Columns);
+            assert_eq!(state.ui.inspector_tab(), InspectorTab::Columns);
         }
     }
 }

--- a/src/app/update/browse/navigation/input.rs
+++ b/src/app/update/browse/navigation/input.rs
@@ -8,11 +8,11 @@ pub fn reduce_input(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::Paste(text) => match state.modal.active_mode() {
             InputMode::TablePicker => {
-                state.ui.table_picker.insert_filter_str(text);
+                state.ui.table_picker_mut().insert_filter_str(text);
                 DispatchResult::handled()
             }
             InputMode::ErTablePicker => {
-                state.ui.er_picker.insert_filter_str(text);
+                state.ui.er_picker_mut().insert_filter_str(text);
                 DispatchResult::handled()
             }
             InputMode::CommandLine => {
@@ -42,20 +42,20 @@ pub fn reduce_input(state: &mut AppState, action: &Action) -> DispatchResult {
             target: InputTarget::Filter,
             ch: c,
         } => {
-            state.ui.table_picker.insert_filter_char(*c);
+            state.ui.table_picker_mut().insert_filter_char(*c);
             DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::Filter,
         } => {
-            state.ui.table_picker.backspace_filter();
+            state.ui.table_picker_mut().backspace_filter();
             DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: InputTarget::Filter,
             direction: movement,
         } => {
-            state.ui.table_picker.move_filter_cursor(*movement);
+            state.ui.table_picker_mut().move_filter_cursor(*movement);
             DispatchResult::handled()
         }
 
@@ -106,11 +106,9 @@ pub fn reduce_input(state: &mut AppState, action: &Action) -> DispatchResult {
             motion: ListMotion::Next,
         } => {
             let max = state.filtered_tables().len().saturating_sub(1);
-            if state.ui.table_picker.selected() < max {
-                state
-                    .ui
-                    .table_picker
-                    .set_selection(state.ui.table_picker.selected() + 1);
+            let selected = state.ui.table_picker().selected();
+            if selected < max {
+                state.ui.table_picker_mut().set_selection(selected + 1);
             }
             DispatchResult::handled()
         }
@@ -118,10 +116,11 @@ pub fn reduce_input(state: &mut AppState, action: &Action) -> DispatchResult {
             target: ListTarget::TablePicker | ListTarget::CommandPalette,
             motion: ListMotion::Previous,
         } => {
+            let selected = state.ui.table_picker().selected();
             state
                 .ui
-                .table_picker
-                .set_selection(state.ui.table_picker.selected().saturating_sub(1));
+                .table_picker_mut()
+                .set_selection(selected.saturating_sub(1));
             DispatchResult::handled()
         }
         Action::ListSelect {
@@ -129,11 +128,9 @@ pub fn reduce_input(state: &mut AppState, action: &Action) -> DispatchResult {
             motion: ListMotion::Next,
         } => {
             let max = state.er_filtered_tables().len().saturating_sub(1);
-            if state.ui.er_picker.selected() < max {
-                state
-                    .ui
-                    .er_picker
-                    .set_selection(state.ui.er_picker.selected() + 1);
+            let selected = state.ui.er_picker().selected();
+            if selected < max {
+                state.ui.er_picker_mut().set_selection(selected + 1);
             }
             DispatchResult::handled()
         }
@@ -141,10 +138,11 @@ pub fn reduce_input(state: &mut AppState, action: &Action) -> DispatchResult {
             target: ListTarget::ErTablePicker,
             motion: ListMotion::Previous,
         } => {
+            let selected = state.ui.er_picker().selected();
             state
                 .ui
-                .er_picker
-                .set_selection(state.ui.er_picker.selected().saturating_sub(1));
+                .er_picker_mut()
+                .set_selection(selected.saturating_sub(1));
             DispatchResult::handled()
         }
         Action::ListSelect {
@@ -152,11 +150,9 @@ pub fn reduce_input(state: &mut AppState, action: &Action) -> DispatchResult {
             motion: ListMotion::Next,
         } => {
             let max = palette_command_count().saturating_sub(1);
-            if state.ui.table_picker.selected() < max {
-                state
-                    .ui
-                    .table_picker
-                    .set_selection(state.ui.table_picker.selected() + 1);
+            let selected = state.ui.table_picker().selected();
+            if selected < max {
+                state.ui.table_picker_mut().set_selection(selected + 1);
             }
             DispatchResult::handled()
         }
@@ -188,7 +184,7 @@ mod tests {
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.table_picker.filter_input().content(), "hello");
+            assert_eq!(state.ui.table_picker().filter_input().content(), "hello");
         }
 
         #[test]
@@ -203,14 +199,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.table_picker.filter_input().content(), "hello");
+            assert_eq!(state.ui.table_picker().filter_input().content(), "hello");
         }
 
         #[test]
         fn table_picker_resets_selection() {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::TablePicker);
-            state.ui.table_picker.set_selection(5);
+            state.ui.table_picker_mut().set_selection(5);
 
             dispatch_navigation(
                 &mut state,
@@ -219,7 +215,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.table_picker.selected(), 0);
+            assert_eq!(state.ui.table_picker().selected(), 0);
         }
 
         #[test]
@@ -280,8 +276,11 @@ mod tests {
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.er_picker.filter_input().content(), "public.users");
-            assert_eq!(state.ui.er_picker.selected(), 0);
+            assert_eq!(
+                state.ui.er_picker().filter_input().content(),
+                "public.users"
+            );
+            assert_eq!(state.ui.er_picker().selected(), 0);
         }
 
         #[test]
@@ -296,7 +295,10 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.er_picker.filter_input().content(), "public.users");
+            assert_eq!(
+                state.ui.er_picker().filter_input().content(),
+                "public.users"
+            );
         }
 
         #[test]
@@ -414,14 +416,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.table_picker.selected(), 1);
+            assert_eq!(state.ui.table_picker().selected(), 1);
         }
 
         #[test]
         fn table_picker_next_stops_at_last() {
             let mut state = state_with_tables(3);
             state.modal.set_mode(InputMode::TablePicker);
-            state.ui.table_picker.set_selection(2);
+            state.ui.table_picker_mut().set_selection(2);
 
             dispatch_navigation(
                 &mut state,
@@ -433,14 +435,14 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.table_picker.selected(), 2);
+            assert_eq!(state.ui.table_picker().selected(), 2);
         }
 
         #[test]
         fn table_picker_previous_decrements() {
             let mut state = state_with_tables(5);
             state.modal.set_mode(InputMode::TablePicker);
-            state.ui.table_picker.set_selection(3);
+            state.ui.table_picker_mut().set_selection(3);
 
             dispatch_navigation(
                 &mut state,
@@ -452,7 +454,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.table_picker.selected(), 2);
+            assert_eq!(state.ui.table_picker().selected(), 2);
         }
 
         #[test]
@@ -470,7 +472,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.table_picker.selected(), 0);
+            assert_eq!(state.ui.table_picker().selected(), 0);
         }
 
         #[test]
@@ -488,7 +490,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.er_picker.selected(), 1);
+            assert_eq!(state.ui.er_picker().selected(), 1);
         }
 
         #[test]
@@ -506,7 +508,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.er_picker.selected(), 0);
+            assert_eq!(state.ui.er_picker().selected(), 0);
         }
 
         #[test]
@@ -524,7 +526,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.table_picker.selected(), 1);
+            assert_eq!(state.ui.table_picker().selected(), 1);
         }
 
         #[test]
@@ -542,7 +544,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.table_picker.selected(), 0);
+            assert_eq!(state.ui.table_picker().selected(), 0);
         }
     }
 }

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -13,7 +13,7 @@ fn inspector_page_scroll_delta(
     amount: ScrollAmount,
 ) -> Option<usize> {
     let visible = match active_capabilities(state, services)
-        .normalize_inspector_tab(state.ui.inspector_tab)
+        .normalize_inspector_tab(state.ui.inspector_tab())
     {
         InspectorTab::Ddl => state.inspector_ddl_visible_rows(),
         _ => state.inspector_visible_rows(),
@@ -34,8 +34,13 @@ pub fn reduce_inspector(
             amount: ScrollAmount::Line,
         } => {
             let max = inspector_max_scroll(state, services);
-            state.ui.inspector_scroll_offset =
-                direction.clamp_vertical_offset(state.ui.inspector_scroll_offset, max, 1);
+            state
+                .ui
+                .set_inspector_scroll_offset(direction.clamp_vertical_offset(
+                    state.ui.inspector_scroll_offset(),
+                    max,
+                    1,
+                ));
             DispatchResult::handled()
         }
         Action::Scroll {
@@ -43,7 +48,7 @@ pub fn reduce_inspector(
             direction: ScrollDirection::Up,
             amount: ScrollAmount::ToStart,
         } => {
-            state.ui.inspector_scroll_offset = 0;
+            state.ui.set_inspector_scroll_offset(0);
             DispatchResult::handled()
         }
         Action::Scroll {
@@ -51,7 +56,9 @@ pub fn reduce_inspector(
             direction: ScrollDirection::Down,
             amount: ScrollAmount::ToEnd,
         } => {
-            state.ui.inspector_scroll_offset = inspector_max_scroll(state, services);
+            state
+                .ui
+                .set_inspector_scroll_offset(inspector_max_scroll(state, services));
             DispatchResult::handled()
         }
         Action::Scroll {
@@ -61,8 +68,13 @@ pub fn reduce_inspector(
         } => {
             if let Some(delta) = inspector_page_scroll_delta(state, services, *amount) {
                 let max = inspector_max_scroll(state, services);
-                state.ui.inspector_scroll_offset =
-                    direction.clamp_vertical_offset(state.ui.inspector_scroll_offset, max, delta);
+                state
+                    .ui
+                    .set_inspector_scroll_offset(direction.clamp_vertical_offset(
+                        state.ui.inspector_scroll_offset(),
+                        max,
+                        delta,
+                    ));
             }
             DispatchResult::handled()
         }
@@ -71,8 +83,11 @@ pub fn reduce_inspector(
             direction: ScrollDirection::Left,
             amount: ScrollAmount::Line,
         } => {
-            state.ui.inspector_horizontal_offset =
-                calculate_prev_column_offset(state.ui.inspector_horizontal_offset);
+            state
+                .ui
+                .set_inspector_horizontal_offset(calculate_prev_column_offset(
+                    state.ui.inspector_horizontal_offset(),
+                ));
             DispatchResult::handled()
         }
         Action::Scroll {
@@ -80,13 +95,15 @@ pub fn reduce_inspector(
             direction: ScrollDirection::Right,
             amount: ScrollAmount::Line,
         } => {
-            let plan = &state.ui.inspector_viewport_plan;
+            let plan = &state.ui.inspector_viewport_plan();
             let all_widths_len = plan.max_offset + plan.column_count;
-            state.ui.inspector_horizontal_offset = calculate_next_column_offset(
-                all_widths_len,
-                state.ui.inspector_horizontal_offset,
-                plan.column_count,
-            );
+            state
+                .ui
+                .set_inspector_horizontal_offset(calculate_next_column_offset(
+                    all_widths_len,
+                    state.ui.inspector_horizontal_offset(),
+                    plan.column_count,
+                ));
             DispatchResult::handled()
         }
 
@@ -107,8 +124,8 @@ mod tests {
 
         fn state_with_table_detail(columns: usize) -> AppState {
             let mut state = AppState::new("test".to_string());
-            state.ui.inspector_pane_height = 10;
-            state.ui.inspector_tab = InspectorTab::Columns;
+            state.ui.set_inspector_pane_height(10);
+            state.ui.set_inspector_tab(InspectorTab::Columns);
             let cols: Vec<Column> = (0..columns)
                 .map(|i| Column {
                     name: format!("col_{i}"),
@@ -138,7 +155,7 @@ mod tests {
         #[test]
         fn inspector_scroll_top_resets_to_zero() {
             let mut state = state_with_table_detail(20);
-            state.ui.inspector_scroll_offset = 10;
+            state.ui.set_inspector_scroll_offset(10);
 
             let effects = dispatch_navigation(
                 &mut state,
@@ -152,13 +169,13 @@ mod tests {
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.inspector_scroll_offset, 0);
+            assert_eq!(state.ui.inspector_scroll_offset(), 0);
         }
 
         #[test]
         fn inspector_scroll_bottom_goes_to_max() {
             let mut state = state_with_table_detail(20);
-            state.ui.inspector_scroll_offset = 0;
+            state.ui.set_inspector_scroll_offset(0);
             let visible = state.inspector_visible_rows();
             let expected_max = 20_usize.saturating_sub(visible);
 
@@ -174,13 +191,13 @@ mod tests {
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.inspector_scroll_offset, expected_max);
+            assert_eq!(state.ui.inspector_scroll_offset(), expected_max);
         }
 
         #[test]
         fn inspector_scroll_bottom_no_detail_stays_zero() {
             let mut state = AppState::new("test".to_string());
-            state.ui.inspector_pane_height = 10;
+            state.ui.set_inspector_pane_height(10);
 
             let effects = dispatch_navigation(
                 &mut state,
@@ -194,13 +211,13 @@ mod tests {
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.inspector_scroll_offset, 0);
+            assert_eq!(state.ui.inspector_scroll_offset(), 0);
         }
 
         #[test]
         fn inspector_half_page_scroll_advances_by_half_visible_rows() {
             let mut state = state_with_table_detail(20);
-            state.ui.inspector_scroll_offset = 1;
+            state.ui.set_inspector_scroll_offset(1);
 
             let effects = dispatch_navigation(
                 &mut state,
@@ -214,13 +231,13 @@ mod tests {
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.inspector_scroll_offset, 3);
+            assert_eq!(state.ui.inspector_scroll_offset(), 3);
         }
 
         #[test]
         fn inspector_full_page_scroll_clamps_to_max() {
             let mut state = state_with_table_detail(20);
-            state.ui.inspector_scroll_offset = 12;
+            state.ui.set_inspector_scroll_offset(12);
 
             let effects = dispatch_navigation(
                 &mut state,
@@ -234,7 +251,7 @@ mod tests {
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.inspector_scroll_offset, 15);
+            assert_eq!(state.ui.inspector_scroll_offset(), 15);
         }
 
         #[test]
@@ -253,7 +270,7 @@ mod tests {
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.inspector_scroll_offset, 0);
+            assert_eq!(state.ui.inspector_scroll_offset(), 0);
         }
 
         fn services_without_ddl() -> AppServices {
@@ -322,9 +339,9 @@ mod tests {
         fn inspector_half_page_scroll_normalizes_unsupported_ddl_tab() {
             let mut state = state_with_table_detail(20);
             let services = services_without_ddl();
-            state.ui.inspector_pane_height = 7;
-            state.ui.inspector_tab = InspectorTab::Ddl;
-            state.ui.inspector_scroll_offset = 1;
+            state.ui.set_inspector_pane_height(7);
+            state.ui.set_inspector_tab(InspectorTab::Ddl);
+            state.ui.set_inspector_scroll_offset(1);
             let expected_delta = ScrollAmount::HalfPage
                 .page_delta(state.inspector_visible_rows())
                 .unwrap();
@@ -341,16 +358,16 @@ mod tests {
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.inspector_scroll_offset, 1 + expected_delta);
+            assert_eq!(state.ui.inspector_scroll_offset(), 1 + expected_delta);
         }
 
         #[test]
         fn inspector_full_page_scroll_normalizes_unsupported_ddl_tab() {
             let mut state = state_with_table_detail(20);
             let services = services_without_ddl();
-            state.ui.inspector_pane_height = 7;
-            state.ui.inspector_tab = InspectorTab::Ddl;
-            state.ui.inspector_scroll_offset = 1;
+            state.ui.set_inspector_pane_height(7);
+            state.ui.set_inspector_tab(InspectorTab::Ddl);
+            state.ui.set_inspector_scroll_offset(1);
 
             let effects = dispatch_navigation(
                 &mut state,
@@ -364,7 +381,7 @@ mod tests {
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.inspector_scroll_offset, 3);
+            assert_eq!(state.ui.inspector_scroll_offset(), 3);
         }
     }
 }

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -95,7 +95,7 @@ pub fn reduce_inspector(
             direction: ScrollDirection::Right,
             amount: ScrollAmount::Line,
         } => {
-            let plan = &state.ui.inspector_viewport_plan();
+            let plan = state.ui.inspector_viewport_plan();
             let all_widths_len = plan.max_offset + plan.column_count;
             state
                 .ui

--- a/src/app/update/browse/navigation/mod.rs
+++ b/src/app/update/browse/navigation/mod.rs
@@ -23,7 +23,7 @@ fn active_capabilities<'a>(state: &'a AppState, services: &'a AppServices) -> &'
 
 fn inspector_total_items(state: &AppState, services: &AppServices) -> usize {
     let active_tab =
-        active_capabilities(state, services).normalize_inspector_tab(state.ui.inspector_tab);
+        active_capabilities(state, services).normalize_inspector_tab(state.ui.inspector_tab());
     state
         .session
         .table_detail()
@@ -54,7 +54,7 @@ fn inspector_total_items(state: &AppState, services: &AppServices) -> usize {
 
 pub(super) fn inspector_max_scroll(state: &AppState, services: &AppServices) -> usize {
     let visible = match active_capabilities(state, services)
-        .normalize_inspector_tab(state.ui.inspector_tab)
+        .normalize_inspector_tab(state.ui.inspector_tab())
     {
         InspectorTab::Ddl => state.inspector_ddl_visible_rows(),
         _ => state.inspector_visible_rows(),

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -993,7 +993,7 @@ mod tests {
             };
             let meta_effects = dispatch_metadata(&mut state, &action, Instant::now()).unwrap();
 
-            assert_eq!(state.ui.explorer_selected, 1);
+            assert_eq!(state.ui.explorer_selected(), 1);
             assert_eq!(state.query.pagination.table(), "users");
             assert!(
                 meta_effects
@@ -1034,7 +1034,7 @@ mod tests {
             assert!(state.query.pagination.table().is_empty());
             assert!(state.query.current_result().is_none());
             assert!(state.session.table_detail().is_none());
-            assert_eq!(state.ui.explorer_selected, 0);
+            assert_eq!(state.ui.explorer_selected(), 0);
         }
 
         #[test]

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -201,7 +201,7 @@ pub fn reduce_execution(
                     vec![]
                 }
                 Action::ToggleModal(ModalKind::Help) => {
-                    state.ui.help.open(HelpOrigin::CommandLine);
+                    state.ui.help_mut().open(HelpOrigin::CommandLine);
                     state.modal.push_mode(InputMode::Help);
                     vec![]
                 }

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -183,7 +183,7 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 _ => state.jsonb_detail.editor_mut().move_cursor(*direction),
             }
             update_editor_scroll(state);
-            state.ui.key_sequence = KeySequenceState::Idle;
+            state.ui.set_key_sequence(KeySequenceState::Idle);
             DispatchResult::handled()
         }
 
@@ -670,7 +670,7 @@ mod tests {
         #[test]
         fn movement_updates_scroll_with_current_editor_viewport_height() {
             let mut state = state_with_jsonb_value(r#"{"items":["admin","writer","reader"]}"#);
-            state.ui.jsonb_detail_editor_visible_rows = 2;
+            state.ui.set_jsonb_detail_editor_visible_rows(2);
             open_detail(&mut state);
 
             reduce_jsonb(
@@ -703,7 +703,7 @@ mod tests {
         ) {
             let mut state =
                 state_with_jsonb_value("{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3,\n  \"d\": 4\n}");
-            state.ui.jsonb_detail_editor_visible_rows = 3;
+            state.ui.set_jsonb_detail_editor_visible_rows(3);
             open_detail(&mut state);
             state.modal.replace_mode(InputMode::JsonbEdit);
             state.jsonb_detail.set_mode(JsonbDetailMode::Editing);
@@ -733,7 +733,9 @@ mod tests {
             open_detail(&mut state);
             state.modal.replace_mode(InputMode::JsonbEdit);
             state.jsonb_detail.set_mode(JsonbDetailMode::Editing);
-            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::G);
+            state
+                .ui
+                .set_key_sequence(KeySequenceState::WaitingSecondKey(Prefix::G));
 
             reduce_jsonb(
                 &mut state,
@@ -744,7 +746,7 @@ mod tests {
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.key_sequence.pending_prefix(), None);
+            assert_eq!(state.ui.key_sequence().pending_prefix(), None);
         }
 
         #[test]

--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -256,7 +256,7 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             direction: ScrollDirection::Right,
             amount: ScrollAmount::Line,
         } => {
-            let plan = &state.ui.result_viewport_plan();
+            let plan = state.ui.result_viewport_plan();
             let all_widths_len = plan.max_offset + plan.column_count;
             state
                 .result_interaction

--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -194,7 +194,7 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             target: ScrollToCursorTarget::Result,
             position: CursorPosition::Center,
         } => {
-            state.ui.key_sequence = KeySequenceState::Idle;
+            state.ui.set_key_sequence(KeySequenceState::Idle);
             if let Some(row) = state.result_interaction.selection().row() {
                 let visible = state.result_visible_rows();
                 if visible > 0 {
@@ -210,7 +210,7 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             target: ScrollToCursorTarget::Result,
             position: CursorPosition::Top,
         } => {
-            state.ui.key_sequence = KeySequenceState::Idle;
+            state.ui.set_key_sequence(KeySequenceState::Idle);
             if let Some(row) = state.result_interaction.selection().row() {
                 let visible = state.result_visible_rows();
                 if visible > 0 {
@@ -226,7 +226,7 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             target: ScrollToCursorTarget::Result,
             position: CursorPosition::Bottom,
         } => {
-            state.ui.key_sequence = KeySequenceState::Idle;
+            state.ui.set_key_sequence(KeySequenceState::Idle);
             if let Some(row) = state.result_interaction.selection().row() {
                 let visible = state.result_visible_rows();
                 if visible > 0 {
@@ -256,7 +256,7 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             direction: ScrollDirection::Right,
             amount: ScrollAmount::Line,
         } => {
-            let plan = &state.ui.result_viewport_plan;
+            let plan = &state.ui.result_viewport_plan();
             let all_widths_len = plan.max_offset + plan.column_count;
             state
                 .result_interaction
@@ -281,7 +281,7 @@ mod tests {
 
     fn state_with_result_rows(rows: usize, pane_height: u16) -> AppState {
         let mut state = AppState::new("test".to_string());
-        state.ui.result_pane_height = pane_height;
+        state.ui.set_result_pane_height(pane_height);
         let result_rows: Vec<Vec<String>> = (0..rows).map(|i| vec![format!("{}", i)]).collect();
         let row_count = result_rows.len();
         state
@@ -700,7 +700,9 @@ mod tests {
             // visible = 20
             state.result_interaction.activate_cell(50, 0);
             state.result_interaction.set_scroll_offset(50);
-            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
+            state
+                .ui
+                .set_key_sequence(KeySequenceState::WaitingSecondKey(Prefix::Z));
 
             reduce_scroll(
                 &mut state,
@@ -712,7 +714,7 @@ mod tests {
 
             // row=50, visible=20, offset=50-10=40, max=80 → 40
             assert_eq!(state.result_interaction.scroll_offset(), 40);
-            assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
+            assert_eq!(state.ui.key_sequence(), KeySequenceState::Idle);
         }
 
         #[test]
@@ -720,7 +722,9 @@ mod tests {
             let mut state = state_with_result_rows(100, 25);
             state.result_interaction.activate_cell(30, 0);
             state.result_interaction.set_scroll_offset(20);
-            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
+            state
+                .ui
+                .set_key_sequence(KeySequenceState::WaitingSecondKey(Prefix::Z));
 
             reduce_scroll(
                 &mut state,
@@ -731,7 +735,7 @@ mod tests {
             );
 
             assert_eq!(state.result_interaction.scroll_offset(), 30);
-            assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
+            assert_eq!(state.ui.key_sequence(), KeySequenceState::Idle);
         }
 
         #[test]
@@ -739,7 +743,9 @@ mod tests {
             let mut state = state_with_result_rows(100, 25);
             state.result_interaction.activate_cell(30, 0);
             state.result_interaction.set_scroll_offset(30);
-            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
+            state
+                .ui
+                .set_key_sequence(KeySequenceState::WaitingSecondKey(Prefix::Z));
 
             reduce_scroll(
                 &mut state,
@@ -751,14 +757,16 @@ mod tests {
 
             // row=30, visible=20, offset=30-19=11, max=80 → 11
             assert_eq!(state.result_interaction.scroll_offset(), 11);
-            assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
+            assert_eq!(state.ui.key_sequence(), KeySequenceState::Idle);
         }
 
         #[test]
         fn scroll_cursor_center_is_noop_in_scroll_mode() {
             let mut state = state_with_result_rows(100, 25);
             state.result_interaction.set_scroll_offset(20);
-            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
+            state
+                .ui
+                .set_key_sequence(KeySequenceState::WaitingSecondKey(Prefix::Z));
 
             reduce_scroll(
                 &mut state,
@@ -770,7 +778,7 @@ mod tests {
 
             // No row selected, offset unchanged
             assert_eq!(state.result_interaction.scroll_offset(), 20);
-            assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
+            assert_eq!(state.ui.key_sequence(), KeySequenceState::Idle);
         }
 
         #[test]
@@ -779,7 +787,9 @@ mod tests {
             // visible=20, max_scroll=80
             state.result_interaction.activate_cell(95, 0);
             state.result_interaction.set_scroll_offset(80);
-            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(Prefix::Z);
+            state
+                .ui
+                .set_key_sequence(KeySequenceState::WaitingSecondKey(Prefix::Z));
 
             reduce_scroll(
                 &mut state,
@@ -791,7 +801,7 @@ mod tests {
 
             // row=95, clamped to max_scroll=80
             assert_eq!(state.result_interaction.scroll_offset(), 80);
-            assert_eq!(state.ui.key_sequence, KeySequenceState::Idle);
+            assert_eq!(state.ui.key_sequence(), KeySequenceState::Idle);
         }
     }
 
@@ -820,7 +830,7 @@ mod tests {
         #[test]
         fn page_scroll_uses_history_entry_row_count_not_live_preview() {
             let mut state = AppState::new("test".to_string());
-            state.ui.result_pane_height = 25; // visible = 20, half = 10
+            state.ui.set_result_pane_height(25); // visible = 20, half = 10
             // live preview: 100 rows
             state
                 .query

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -56,7 +56,7 @@ pub fn reduce_yank(
             DispatchResult::handled()
         }
         Action::DdlYank => {
-            if state.ui.inspector_tab == InspectorTab::Ddl
+            if state.ui.inspector_tab() == InspectorTab::Ddl
                 && let Some(table) = state.session.table_detail().as_ref()
             {
                 let ddl = services
@@ -449,7 +449,7 @@ mod tests {
 
         fn state_with_ddl_tab() -> AppState {
             let mut state = AppState::new("test".to_string());
-            state.ui.inspector_tab = InspectorTab::Ddl;
+            state.ui.set_inspector_tab(InspectorTab::Ddl);
             state.session.set_table_detail_raw(Some(Table {
                 schema: "public".to_string(),
                 name: "users".to_string(),
@@ -504,7 +504,7 @@ mod tests {
         #[test]
         fn without_table_detail_returns_empty() {
             let mut state = AppState::new("test".to_string());
-            state.ui.inspector_tab = InspectorTab::Ddl;
+            state.ui.set_inspector_tab(InspectorTab::Ddl);
 
             let effects = reduce_yank(
                 &mut state,
@@ -520,7 +520,7 @@ mod tests {
         #[test]
         fn on_non_ddl_tab_returns_empty() {
             let mut state = state_with_ddl_tab();
-            state.ui.inspector_tab = InspectorTab::Info;
+            state.ui.set_inspector_tab(InspectorTab::Info);
 
             let effects = reduce_yank(
                 &mut state,

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -27,7 +27,6 @@ pub(super) fn restore_cache(
         database_type,
         dsn,
     );
-    state.ui.set_explorer_selected_raw(cache.explorer_selected);
     state.ui.set_inspector_tab(
         state
             .session

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -783,7 +783,7 @@ mod tests {
         #[test]
         fn plan_scroll_down_increments() {
             let mut state = sql_modal_state();
-            state.ui.terminal_height = 24;
+            state.ui.set_terminal_height(24);
             let long_plan = (0..20)
                 .map(|i| format!("line{i}"))
                 .collect::<Vec<_>>()
@@ -806,14 +806,14 @@ mod tests {
         #[test]
         fn plan_scroll_down_clamps_at_max() {
             let mut state = sql_modal_state();
-            state.ui.terminal_height = 24;
+            state.ui.set_terminal_height(24);
             let long_plan = (0..20)
                 .map(|i| format!("line{i}"))
                 .collect::<Vec<_>>()
                 .join("\n");
             state.explain.set_plan(long_plan, false, 0, "Q1");
             let modal_inner = crate::model::explain_context::ExplainContext::modal_inner_height(
-                state.ui.terminal_height,
+                state.ui.terminal_height(),
             );
             let max = state.explain.line_count().saturating_sub(modal_inner);
             state.explain.scroll_offset = max;
@@ -875,7 +875,7 @@ mod tests {
         #[test]
         fn compare_scroll_down_stops_at_max() {
             let mut state = sql_modal_state();
-            state.ui.terminal_height = 24;
+            state.ui.set_terminal_height(24);
             let long_plan = (0..20)
                 .map(|i| format!("  ->  Node{i}  (cost=0.00..{i}.00 rows=1 width=32)"))
                 .collect::<Vec<_>>()
@@ -883,7 +883,7 @@ mod tests {
             state.explain.set_plan(long_plan.clone(), false, 0, "Q1");
             state.explain.set_plan(long_plan, false, 0, "Q2");
 
-            let max = state.explain.compare_max_scroll(state.ui.terminal_height);
+            let max = state.explain.compare_max_scroll(state.ui.terminal_height());
 
             // Scroll to max
             for _ in 0..max + 5 {
@@ -916,7 +916,7 @@ mod tests {
         #[test]
         fn right_only_plan_scroll_down_increments() {
             let mut state = sql_modal_state();
-            state.ui.terminal_height = 24;
+            state.ui.set_terminal_height(24);
             let long_plan = (0..20)
                 .map(|i| format!("  ->  Node{i}  (cost=0.00..{i}.00 rows=1 width=32)"))
                 .collect::<Vec<_>>()

--- a/src/app/update/explain/scroll.rs
+++ b/src/app/update/explain/scroll.rs
@@ -26,19 +26,21 @@ pub(super) fn reduce_scroll(
                     const CONFIRM_HEADER_LINES: usize = 8;
                     let content_lines =
                         CONFIRM_HEADER_LINES + state.sql_modal.editor.content().lines().count();
-                    let modal_inner = ExplainContext::modal_inner_height(state.ui.terminal_height);
+                    let modal_inner =
+                        ExplainContext::modal_inner_height(state.ui.terminal_height());
                     (
                         &mut state.explain.confirm_scroll_offset,
                         content_lines.saturating_sub(modal_inner),
                     )
                 }
                 ScrollTarget::ExplainPlan => {
-                    let modal_inner = ExplainContext::modal_inner_height(state.ui.terminal_height);
+                    let modal_inner =
+                        ExplainContext::modal_inner_height(state.ui.terminal_height());
                     let max = state.explain.line_count().saturating_sub(modal_inner);
                     (&mut state.explain.scroll_offset, max)
                 }
                 ScrollTarget::ExplainCompare => {
-                    let max = state.explain.compare_max_scroll(state.ui.terminal_height);
+                    let max = state.explain.compare_max_scroll(state.ui.terminal_height());
                     (&mut state.explain.compare_scroll_offset, max)
                 }
                 _ => unreachable!(),

--- a/src/app/update/modal/base.rs
+++ b/src/app/update/modal/base.rs
@@ -14,7 +14,7 @@ pub(super) fn reduce_base_lifecycle(
     match action {
         Action::OpenModal(ModalKind::TablePicker) => {
             state.modal.set_mode(InputMode::TablePicker);
-            state.ui.table_picker.clear_filter_and_reset();
+            state.ui.table_picker_mut().clear_filter_and_reset();
             DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::TablePicker)
@@ -32,7 +32,7 @@ pub(super) fn reduce_base_lifecycle(
         Action::OpenModal(ModalKind::CommandPalette) => {
             state.modal.set_mode(InputMode::CommandPalette);
             // Command palette currently reuses the generic picker selection state.
-            state.ui.table_picker.reset();
+            state.ui.table_picker_mut().reset();
             DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::SqlModal) => {

--- a/src/app/update/modal/er_picker.rs
+++ b/src/app/update/modal/er_picker.rs
@@ -20,12 +20,12 @@ pub(super) fn reduce_er_picker(
             }
             state.ui.reset_er_picker_request();
             state.modal.set_mode(InputMode::ErTablePicker);
-            state.ui.er_picker.clear_filter_and_reset();
+            state.ui.er_picker_mut().clear_filter_and_reset();
             DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::ErTablePicker) => {
             state.modal.set_mode(InputMode::Normal);
-            state.ui.er_picker.clear_filter();
+            state.ui.er_picker_mut().clear_filter();
             state.ui.reset_er_picker_request();
             DispatchResult::handled()
         }
@@ -33,53 +33,51 @@ pub(super) fn reduce_er_picker(
             target: InputTarget::ErFilter,
             ch: c,
         } => {
-            state.ui.er_picker.insert_filter_char(*c);
+            state.ui.er_picker_mut().insert_filter_char(*c);
             DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::ErFilter,
         } => {
-            state.ui.er_picker.backspace_filter();
+            state.ui.er_picker_mut().backspace_filter();
             DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: InputTarget::ErFilter,
             direction: movement,
         } => {
-            state.ui.er_picker.move_filter_cursor(*movement);
+            state.ui.er_picker_mut().move_filter_cursor(*movement);
             DispatchResult::handled()
         }
         Action::ErToggleSelection => {
             let filtered = state.er_filtered_tables();
-            if let Some(table) = filtered.get(state.ui.er_picker.selected()) {
+            if let Some(table) = filtered.get(state.ui.er_picker().selected()) {
                 let name = table.qualified_name();
-                if !state.ui.er_selected_tables.remove(&name) {
-                    state.ui.er_selected_tables.insert(name);
-                }
+                state.ui.toggle_er_selected_table(name);
             }
             DispatchResult::handled()
         }
         Action::ErSelectAll => {
             let all_tables: Vec<String> =
                 state.tables().iter().map(|t| t.qualified_name()).collect();
-            if state.ui.er_selected_tables.len() == all_tables.len() {
-                state.ui.er_selected_tables.clear();
+            if state.ui.er_selected_tables().len() == all_tables.len() {
+                state.ui.clear_er_selected_tables();
             } else {
-                state.ui.er_selected_tables = all_tables.into_iter().collect();
+                state.ui.replace_er_selected_tables(all_tables);
             }
             DispatchResult::handled()
         }
         Action::ErConfirmSelection => {
-            if state.ui.er_selected_tables.is_empty() {
+            if state.ui.er_selected_tables().is_empty() {
                 state.set_error("No tables selected".to_string());
                 return DispatchResult::handled();
             }
             state
                 .er_preparation
-                .set_targets(state.ui.er_selected_tables.iter().cloned().collect());
+                .set_targets(state.ui.er_selected_tables().iter().cloned().collect());
             state.modal.set_mode(InputMode::Normal);
-            state.ui.er_picker.clear_filter();
-            state.ui.er_selected_tables.clear();
+            state.ui.er_picker_mut().clear_filter();
+            state.ui.clear_er_selected_tables();
             DispatchResult::handled_with(vec![Effect::DispatchActions(vec![Action::ErOpenDiagram])])
         }
         _ => DispatchResult::pass(),

--- a/src/app/update/modal/help.rs
+++ b/src/app/update/modal/help.rs
@@ -17,27 +17,24 @@ fn scroll_help_by(
     content_width: usize,
 ) {
     let max_scroll = state.ui.help_max_scroll(line_count, content_width);
-    let offset = direction.clamp_vertical_offset(state.ui.help.scroll_offset(), max_scroll, delta);
-    state.ui.help.set_scroll_offset(offset);
+    let offset =
+        direction.clamp_vertical_offset(state.ui.help().scroll_offset(), max_scroll, delta);
+    state.ui.help_mut().set_scroll_offset(offset);
 }
 
 fn scroll_help_horizontally(state: &mut AppState, direction: ScrollDirection) {
     match direction {
         ScrollDirection::Left => {
-            state
-                .ui
-                .help
-                .set_horizontal_offset(state.ui.help.horizontal_offset().saturating_sub(1));
+            let offset = state.ui.help().horizontal_offset().saturating_sub(1);
+            state.ui.help_mut().set_horizontal_offset(offset);
         }
         ScrollDirection::Right => {
             let document = HelpDocument::from_state(state);
             let max_scroll = state
                 .ui
                 .help_max_horizontal_scroll(document.line_count(), document.content_width());
-            state
-                .ui
-                .help
-                .set_horizontal_offset((state.ui.help.horizontal_offset() + 1).min(max_scroll));
+            let offset = (state.ui.help().horizontal_offset() + 1).min(max_scroll);
+            state.ui.help_mut().set_horizontal_offset(offset);
         }
         ScrollDirection::Up | ScrollDirection::Down => {}
     }
@@ -45,7 +42,7 @@ fn scroll_help_horizontally(state: &mut AppState, direction: ScrollDirection) {
 
 fn close_help(state: &mut AppState) {
     state.modal.pop_mode();
-    state.ui.help.close();
+    state.ui.help_mut().close();
 }
 
 pub(super) fn reduce_help(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
@@ -55,7 +52,7 @@ pub(super) fn reduce_help(state: &mut AppState, action: &Action, _now: Instant) 
                 close_help(state);
             } else {
                 let origin = HelpOrigin::from_state(state);
-                state.ui.help.open(origin);
+                state.ui.help_mut().open(origin);
                 state.modal.push_mode(InputMode::Help);
             }
             DispatchResult::handled()
@@ -68,13 +65,13 @@ pub(super) fn reduce_help(state: &mut AppState, action: &Action, _now: Instant) 
             target: InputTarget::HelpFilter,
             ch,
         } => {
-            state.ui.help.insert_filter_char(*ch);
+            state.ui.help_mut().insert_filter_char(*ch);
             DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::HelpFilter,
         } => {
-            state.ui.help.backspace_filter();
+            state.ui.help_mut().backspace_filter();
             DispatchResult::handled()
         }
         Action::Scroll {
@@ -100,9 +97,9 @@ pub(super) fn reduce_help(state: &mut AppState, action: &Action, _now: Instant) 
                 }
                 ScrollAmount::ToStart => {
                     if matches!(direction, ScrollDirection::Left | ScrollDirection::Right) {
-                        state.ui.help.set_horizontal_offset(0);
+                        state.ui.help_mut().set_horizontal_offset(0);
                     } else {
-                        state.ui.help.set_scroll_offset(0);
+                        state.ui.help_mut().set_scroll_offset(0);
                     }
                 }
                 ScrollAmount::ToEnd => {
@@ -112,12 +109,12 @@ pub(super) fn reduce_help(state: &mut AppState, action: &Action, _now: Instant) 
                             document.line_count(),
                             document.content_width(),
                         );
-                        state.ui.help.set_horizontal_offset(max_scroll);
+                        state.ui.help_mut().set_horizontal_offset(max_scroll);
                     } else {
                         let max_scroll = state
                             .ui
                             .help_max_scroll(document.line_count(), document.content_width());
-                        state.ui.help.set_scroll_offset(max_scroll);
+                        state.ui.help_mut().set_scroll_offset(max_scroll);
                     }
                 }
                 ScrollAmount::HalfPage | ScrollAmount::FullPage => {

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -83,7 +83,7 @@ mod tests {
         fn escape_returns_to_help_origin_with_filter() {
             let mut state = create_test_state();
             open_help(&mut state);
-            state.ui.help.insert_filter_char('c');
+            state.ui.help_mut().insert_filter_char('c');
 
             let effects = super::dispatch_modal(
                 &mut state,
@@ -93,7 +93,7 @@ mod tests {
             .unwrap();
 
             assert_eq!(state.input_mode(), InputMode::CommandPalette);
-            assert!(state.ui.help.filter().content().is_empty());
+            assert!(state.ui.help().filter().content().is_empty());
             assert!(effects.is_empty());
         }
 
@@ -136,7 +136,7 @@ mod tests {
             )
             .unwrap();
 
-            assert!(state.ui.help.filter().content().is_empty());
+            assert!(state.ui.help().filter().content().is_empty());
             assert!(input_effects.is_empty());
             assert!(backspace_effects.is_empty());
         }

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -78,8 +78,8 @@ fn reduce_inner(
             vec![]
         }
         Action::Resize(w, h) => {
-            state.ui.terminal_width = w;
-            state.ui.terminal_height = h;
+            state.ui.set_terminal_width(w);
+            state.ui.set_terminal_height(h);
             let document = HelpDocument::from_state(state);
             state
                 .ui
@@ -221,10 +221,10 @@ mod tests {
         #[test]
         fn resize_updates_terminal_size_and_clamps_help_offsets() {
             let mut state = create_test_state();
-            state.ui.terminal_width = 20;
-            state.ui.terminal_height = 10;
-            state.ui.help.set_scroll_offset(usize::MAX);
-            state.ui.help.set_horizontal_offset(usize::MAX);
+            state.ui.set_terminal_width(20);
+            state.ui.set_terminal_height(10);
+            state.ui.help_mut().set_scroll_offset(usize::MAX);
+            state.ui.help_mut().set_horizontal_offset(usize::MAX);
             let now = Instant::now();
 
             let effects = reduce(
@@ -234,17 +234,17 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.ui.terminal_width, 100);
-            assert_eq!(state.ui.terminal_height, 50);
+            assert_eq!(state.ui.terminal_width(), 100);
+            assert_eq!(state.ui.terminal_height(), 50);
             let document = HelpDocument::from_state(&state);
             assert_eq!(
-                state.ui.help.scroll_offset(),
+                state.ui.help().scroll_offset(),
                 state
                     .ui
                     .help_max_scroll(document.line_count(), document.content_width())
             );
             assert_eq!(
-                state.ui.help.horizontal_offset(),
+                state.ui.help().horizontal_offset(),
                 state
                     .ui
                     .help_max_horizontal_scroll(document.line_count(), document.content_width())
@@ -431,7 +431,7 @@ mod tests {
         #[test]
         fn help_scroll_top_resets_offset_to_zero() {
             let mut state = create_test_state();
-            state.ui.help.set_scroll_offset(8);
+            state.ui.help_mut().set_scroll_offset(8);
             let now = Instant::now();
 
             let effects = reduce(
@@ -445,7 +445,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.ui.help.scroll_offset(), 0);
+            assert_eq!(state.ui.help().scroll_offset(), 0);
             assert!(effects.is_empty());
         }
 
@@ -465,15 +465,15 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.ui.help.scroll_offset(), help_max_scroll(&state));
+            assert_eq!(state.ui.help().scroll_offset(), help_max_scroll(&state));
             assert!(effects.is_empty());
         }
 
         #[test]
         fn help_half_page_scroll_uses_half_of_visible_rows() {
             let mut state = create_test_state();
-            state.ui.terminal_height = 24;
-            state.ui.help.set_scroll_offset(1);
+            state.ui.set_terminal_height(24);
+            state.ui.help_mut().set_scroll_offset(1);
             let now = Instant::now();
 
             let effects = reduce(
@@ -487,15 +487,15 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.ui.help.scroll_offset(), 9);
+            assert_eq!(state.ui.help().scroll_offset(), 9);
             assert!(effects.is_empty());
         }
 
         #[test]
         fn help_full_page_scroll_uses_visible_rows() {
             let mut state = create_test_state();
-            state.ui.terminal_height = 24;
-            state.ui.help.set_scroll_offset(2);
+            state.ui.set_terminal_height(24);
+            state.ui.help_mut().set_scroll_offset(2);
             let now = Instant::now();
 
             let effects = reduce(
@@ -509,14 +509,15 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.ui.help.scroll_offset(), 18);
+            assert_eq!(state.ui.help().scroll_offset(), 18);
             assert!(effects.is_empty());
         }
 
         #[test]
         fn help_page_scroll_saturates_at_bounds() {
             let mut state = create_test_state();
-            state.ui.help.set_scroll_offset(help_max_scroll(&state));
+            let max_scroll = help_max_scroll(&state);
+            state.ui.help_mut().set_scroll_offset(max_scroll);
             let now = Instant::now();
 
             reduce(
@@ -530,7 +531,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.ui.help.scroll_offset(), help_max_scroll(&state));
+            assert_eq!(state.ui.help().scroll_offset(), help_max_scroll(&state));
 
             reduce(
                 &mut state,
@@ -554,17 +555,15 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.ui.help.scroll_offset(), 0);
+            assert_eq!(state.ui.help().scroll_offset(), 0);
         }
 
         #[test]
         fn help_horizontal_scroll_saturates_at_bounds() {
             let mut state = create_test_state();
-            state.ui.terminal_width = 40;
-            state
-                .ui
-                .help
-                .set_horizontal_offset(help_max_horizontal_scroll(&state));
+            state.ui.set_terminal_width(40);
+            let max_scroll = help_max_horizontal_scroll(&state);
+            state.ui.help_mut().set_horizontal_offset(max_scroll);
             let now = Instant::now();
 
             reduce(
@@ -579,7 +578,7 @@ mod tests {
             );
 
             assert_eq!(
-                state.ui.help.horizontal_offset(),
+                state.ui.help().horizontal_offset(),
                 help_max_horizontal_scroll(&state)
             );
 
@@ -595,7 +594,7 @@ mod tests {
             );
 
             assert_eq!(
-                state.ui.help.horizontal_offset(),
+                state.ui.help().horizontal_offset(),
                 help_max_horizontal_scroll(&state).saturating_sub(1)
             );
         }
@@ -604,8 +603,8 @@ mod tests {
         fn help_close_resets_vertical_and_horizontal_offsets() {
             let mut state = create_test_state();
             state.modal.set_mode(InputMode::Help);
-            state.ui.help.set_scroll_offset(3);
-            state.ui.help.set_horizontal_offset(4);
+            state.ui.help_mut().set_scroll_offset(3);
+            state.ui.help_mut().set_horizontal_offset(4);
             let now = Instant::now();
 
             reduce(
@@ -615,8 +614,8 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.ui.help.scroll_offset(), 0);
-            assert_eq!(state.ui.help.horizontal_offset(), 0);
+            assert_eq!(state.ui.help().scroll_offset(), 0);
+            assert_eq!(state.ui.help().horizontal_offset(), 0);
         }
     }
 
@@ -689,7 +688,7 @@ mod tests {
         fn close_help_resets_scroll_offset() {
             let mut state = create_test_state();
             state.modal.set_mode(InputMode::Help);
-            state.ui.help.set_scroll_offset(12);
+            state.ui.help_mut().set_scroll_offset(12);
             let now = Instant::now();
 
             let effects = reduce(
@@ -700,7 +699,7 @@ mod tests {
             );
 
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert_eq!(state.ui.help.scroll_offset(), 0);
+            assert_eq!(state.ui.help().scroll_offset(), 0);
             assert!(effects.is_empty());
         }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -64,11 +64,13 @@ fn reduce_inner(
 
     match action {
         Action::BeginKeySequence(prefix) => {
-            state.ui.key_sequence = KeySequenceState::WaitingSecondKey(prefix);
+            state
+                .ui
+                .set_key_sequence(KeySequenceState::WaitingSecondKey(prefix));
             vec![]
         }
         Action::CancelKeySequence => {
-            state.ui.key_sequence = KeySequenceState::Idle;
+            state.ui.set_key_sequence(KeySequenceState::Idle);
             vec![]
         }
         Action::Quit => {
@@ -92,7 +94,7 @@ fn reduce_inner(
             if state.modal.active_mode() == InputMode::TablePicker {
                 let table = state
                     .filtered_tables()
-                    .get(state.ui.table_picker.selected())
+                    .get(state.ui.table_picker().selected())
                     .copied()
                     .cloned();
                 if let Some(table) = table {
@@ -104,12 +106,12 @@ fn reduce_inner(
                     state.modal.replace_mode(InputMode::ConnectionError);
                     return vec![];
                 }
-                if state.ui.focused_pane != FocusedPane::Explorer {
+                if state.ui.focused_pane() != FocusedPane::Explorer {
                     return vec![];
                 }
                 let table = state
                     .tables()
-                    .get(state.ui.explorer_selected)
+                    .get(state.ui.explorer_selected())
                     .copied()
                     .cloned();
                 if let Some(table) = table {
@@ -118,7 +120,7 @@ fn reduce_inner(
             } else if state.modal.active_mode() == InputMode::CommandPalette {
                 use crate::update::input::palette::palette_action_for_index;
 
-                let cmd_action = palette_action_for_index(state.ui.table_picker.selected());
+                let cmd_action = palette_action_for_index(state.ui.table_picker().selected());
                 state.modal.set_mode(InputMode::Normal);
                 return reduce(state, cmd_action, now, services);
             }
@@ -268,13 +270,13 @@ mod tests {
         #[case(Action::Select(SelectMotion::Previous))]
         fn selection_on_empty_tables_keeps_none(#[case] action: Action) {
             let mut state = create_test_state();
-            state.ui.focused_pane = FocusedPane::Explorer;
-            state.ui.explorer_selected = 0;
+            state.ui.set_focused_pane(FocusedPane::Explorer);
+            state.ui.set_explorer_selected_raw(0);
             let now = Instant::now();
 
             reduce(&mut state, action, now, &AppServices::stub());
 
-            assert_eq!(state.ui.explorer_selected, 0);
+            assert_eq!(state.ui.explorer_selected(), 0);
         }
     }
 
@@ -624,7 +626,7 @@ mod tests {
         #[test]
         fn open_table_picker_sets_mode_and_clears_filter() {
             let mut state = create_test_state();
-            state.ui.table_picker.insert_filter_str("test");
+            state.ui.table_picker_mut().insert_filter_str("test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -635,8 +637,8 @@ mod tests {
             );
 
             assert_eq!(state.input_mode(), InputMode::TablePicker);
-            assert!(state.ui.table_picker.filter_input().content().is_empty());
-            assert_eq!(state.ui.table_picker.selected(), 0);
+            assert!(state.ui.table_picker().filter_input().content().is_empty());
+            assert_eq!(state.ui.table_picker().selected(), 0);
             assert!(effects.is_empty());
         }
 
@@ -926,7 +928,7 @@ mod tests {
         #[test]
         fn metadata_loaded_with_empty_tables_selects_none() {
             let mut state = create_test_state();
-            state.ui.explorer_selected = 5;
+            state.ui.set_explorer_selected_raw(5);
             let metadata = DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -939,13 +941,13 @@ mod tests {
             reduce(&mut state, action, now, &AppServices::stub());
 
             assert!(state.session.metadata().is_some());
-            assert_eq!(state.ui.explorer_selected, 0);
+            assert_eq!(state.ui.explorer_selected(), 0);
         }
 
         #[test]
         fn metadata_loaded_with_tables_selects_first() {
             let mut state = create_test_state();
-            state.ui.explorer_selected = 3;
+            state.ui.set_explorer_selected_raw(3);
             let metadata = DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -963,7 +965,7 @@ mod tests {
             reduce(&mut state, action, now, &AppServices::stub());
 
             assert!(state.session.metadata().is_some());
-            assert_eq!(state.ui.explorer_selected, 0);
+            assert_eq!(state.ui.explorer_selected(), 0);
         }
 
         #[test]
@@ -992,7 +994,7 @@ mod tests {
             state
                 .connection_error
                 .set_error(ConnectionErrorInfo::new("error"));
-            state.ui.focused_pane = FocusedPane::Result; // Any pane works
+            state.ui.set_focused_pane(FocusedPane::Result); // Any pane works
             let now = Instant::now();
 
             reduce(
@@ -1068,7 +1070,7 @@ mod tests {
             state
                 .session
                 .set_metadata_state(MetadataState::Error("error".to_string()));
-            state.ui.focused_pane = FocusedPane::Explorer;
+            state.ui.set_focused_pane(FocusedPane::Explorer);
             let now = Instant::now();
 
             // Close modal
@@ -1189,7 +1191,7 @@ mod tests {
                 .session
                 .set_table_detail_raw(Some(stale_table_detail()));
             state.modal.set_mode(InputMode::Normal);
-            state.ui.focused_pane = FocusedPane::Explorer;
+            state.ui.set_focused_pane(FocusedPane::Explorer);
             state.ui.set_explorer_selection(Some(0));
 
             reduce(
@@ -1211,7 +1213,7 @@ mod tests {
                 .session
                 .set_table_detail_raw(Some(stale_table_detail()));
             state.modal.set_mode(InputMode::TablePicker);
-            state.ui.table_picker.set_selection(0);
+            state.ui.table_picker_mut().set_selection(0);
 
             reduce(
                 &mut state,
@@ -2239,7 +2241,7 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
-            state.ui.explorer_selected = 5;
+            state.ui.set_explorer_selected_raw(5);
             let now = Instant::now();
 
             let effects = reduce(
@@ -2285,7 +2287,7 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
-            state.ui.explorer_selected = 3;
+            state.ui.set_explorer_selected_raw(3);
 
             let cached = crate::model::connection::cache::ConnectionCache {
                 explorer_selected: 10,
@@ -2315,8 +2317,8 @@ mod tests {
 
             assert_eq!(state.session.active_connection_id(), Some(&conn_b));
             assert!(state.session.connection_state().is_connected());
-            assert_eq!(state.ui.explorer_selected, 10);
-            assert_eq!(state.ui.inspector_tab, InspectorTab::Indexes);
+            assert_eq!(state.ui.explorer_selected(), 10);
+            assert_eq!(state.ui.inspector_tab(), InspectorTab::Indexes);
             assert_eq!(
                 state.session.metadata().as_ref().unwrap().database_name,
                 "cached_db"
@@ -2346,11 +2348,10 @@ mod tests {
         #[test]
         fn open_clears_selections_and_filter() {
             let mut state = state_with_metadata();
-            state.ui.er_picker.insert_filter_str("old");
+            state.ui.er_picker_mut().insert_filter_str("old");
             state
                 .ui
-                .er_selected_tables
-                .insert("public.users".to_string());
+                .toggle_er_selected_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(
@@ -2361,8 +2362,8 @@ mod tests {
             );
 
             assert_eq!(state.input_mode(), InputMode::ErTablePicker);
-            assert!(state.ui.er_picker.filter_input().content().is_empty());
-            assert!(state.ui.er_selected_tables.is_empty());
+            assert!(state.ui.er_picker().filter_input().content().is_empty());
+            assert!(state.ui.er_selected_tables().is_empty());
             assert!(effects.is_empty());
         }
 
@@ -2378,7 +2379,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert!(state.ui.pending_er_picker);
+            assert!(state.ui.pending_er_picker());
             assert!(state.messages.last_success.is_some());
             assert_ne!(state.input_mode(), InputMode::ErTablePicker);
             assert!(effects.is_empty());
@@ -2418,21 +2419,21 @@ mod tests {
         #[test]
         fn metadata_loaded_with_pending_dispatches_open() {
             let mut state = create_test_state();
-            state.ui.pending_er_picker = true;
+            state.ui.set_pending_er_picker(true);
             state.modal.set_mode(InputMode::Normal);
             let now = Instant::now();
             let action = metadata_loaded_action(&mut state);
 
             let effects = reduce(&mut state, action, now, &AppServices::stub());
 
-            assert!(!state.ui.pending_er_picker);
+            assert!(!state.ui.pending_er_picker());
             assert!(has_open_er_dispatch(&effects));
         }
 
         #[test]
         fn metadata_loaded_without_pending_does_not_dispatch_open() {
             let mut state = create_test_state();
-            state.ui.pending_er_picker = false;
+            state.ui.set_pending_er_picker(false);
             let now = Instant::now();
             let action = metadata_loaded_action(&mut state);
 
@@ -2444,14 +2445,14 @@ mod tests {
         #[test]
         fn metadata_loaded_with_pending_but_non_normal_mode_discards() {
             let mut state = create_test_state();
-            state.ui.pending_er_picker = true;
+            state.ui.set_pending_er_picker(true);
             state.modal.set_mode(InputMode::SqlModal);
             let now = Instant::now();
             let action = metadata_loaded_action(&mut state);
 
             let effects = reduce(&mut state, action, now, &AppServices::stub());
 
-            assert!(!state.ui.pending_er_picker);
+            assert!(!state.ui.pending_er_picker());
             assert!(!has_open_er_dispatch(&effects));
         }
 
@@ -2460,7 +2461,7 @@ mod tests {
             let mut state = state_with_metadata();
             state.modal.set_mode(InputMode::ErTablePicker);
 
-            state.ui.er_picker.insert_filter_str("test");
+            state.ui.er_picker_mut().insert_filter_str("test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -2471,7 +2472,7 @@ mod tests {
             );
 
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert!(state.ui.er_picker.filter_input().content().is_empty());
+            assert!(state.ui.er_picker().filter_input().content().is_empty());
             assert!(effects.is_empty());
         }
 
@@ -2482,8 +2483,7 @@ mod tests {
 
             state
                 .ui
-                .er_selected_tables
-                .insert("public.users".to_string());
+                .toggle_er_selected_table("public.users".to_string());
             let now = Instant::now();
 
             let effects = reduce(
@@ -2651,8 +2651,8 @@ mod tests {
 
             // ConfirmSelection from Normal mode (explorer focused)
             state.modal.set_mode(InputMode::Normal);
-            state.ui.focused_pane = FocusedPane::Explorer;
-            state.ui.explorer_selected = 0;
+            state.ui.set_focused_pane(FocusedPane::Explorer);
+            state.ui.set_explorer_selected_raw(0);
             let effects = reduce(
                 &mut state,
                 Action::ConfirmSelection,
@@ -2817,7 +2817,7 @@ mod tests {
             let entry_index = palette_index_of(|a| same_palette_action(a, &target_action));
 
             let mut state = state_in_palette_mode();
-            state.ui.table_picker.set_selection(entry_index);
+            state.ui.table_picker_mut().set_selection(entry_index);
             let now = Instant::now();
 
             reduce(
@@ -2836,7 +2836,7 @@ mod tests {
 
             let mut state = state_in_palette_mode();
             state.session.set_dsn_for_test("postgres://localhost/test");
-            state.ui.table_picker.set_selection(entry_index);
+            state.ui.table_picker_mut().set_selection(entry_index);
             let now = Instant::now();
 
             let effects = reduce(
@@ -2858,7 +2858,7 @@ mod tests {
                 palette_index_of(|a| matches!(a, Action::OpenModal(ModalKind::ConnectionSelector)));
 
             let mut state = state_in_palette_mode();
-            state.ui.table_picker.set_selection(entry_index);
+            state.ui.table_picker_mut().set_selection(entry_index);
             let now = Instant::now();
 
             reduce(
@@ -2898,7 +2898,7 @@ mod tests {
         #[test]
         fn y_then_d_cancels_yank_starts_delete() {
             let mut state = create_test_state();
-            state.ui.focused_pane = FocusedPane::Result;
+            state.ui.set_focused_pane(FocusedPane::Result);
             state.result_interaction.activate_cell(0, 0);
             let now = Instant::now();
 
@@ -2924,7 +2924,7 @@ mod tests {
         #[test]
         fn d_then_y_cancels_delete_starts_yank() {
             let mut state = create_test_state();
-            state.ui.focused_pane = FocusedPane::Result;
+            state.ui.set_focused_pane(FocusedPane::Result);
             state.result_interaction.activate_cell(0, 0);
             let now = Instant::now();
 

--- a/src/app/update/sql_editor/completion.rs
+++ b/src/app/update/sql_editor/completion.rs
@@ -29,7 +29,7 @@ pub(super) fn reduce_completion(
         Action::CompletionAccept => {
             state
                 .sql_modal
-                .accept_selected_completion(sql_modal_visible_rows(state.ui.terminal_height));
+                .accept_selected_completion(sql_modal_visible_rows(state.ui.terminal_height()));
             DispatchResult::handled()
         }
 

--- a/src/app/update/sql_editor/editing.rs
+++ b/src/app/update/sql_editor/editing.rs
@@ -118,13 +118,13 @@ pub(super) fn reduce_editing(
                 .sql_modal
                 .editor
                 .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
-            state.ui.key_sequence = KeySequenceState::Idle;
+            state.ui.set_key_sequence(KeySequenceState::Idle);
             DispatchResult::handled()
         }
         Action::SqlModalClear => {
             state.sql_modal.editor.clear();
             state.sql_modal.reset_completion();
-            state.ui.key_sequence = KeySequenceState::Idle;
+            state.ui.set_key_sequence(KeySequenceState::Idle);
             DispatchResult::handled()
         }
         _ => DispatchResult::pass(),

--- a/src/app/update/sql_editor/editing.rs
+++ b/src/app/update/sql_editor/editing.rs
@@ -23,7 +23,7 @@ pub(super) fn reduce_editing(
             state
                 .sql_modal
                 .editor
-                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
+                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height()));
             state
                 .sql_modal
                 .schedule_completion_after_dismiss(now + Duration::from_millis(100));
@@ -41,7 +41,7 @@ pub(super) fn reduce_editing(
             state
                 .sql_modal
                 .editor
-                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
+                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height()));
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
@@ -55,7 +55,7 @@ pub(super) fn reduce_editing(
             state
                 .sql_modal
                 .editor
-                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
+                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height()));
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
@@ -69,7 +69,7 @@ pub(super) fn reduce_editing(
             state
                 .sql_modal
                 .editor
-                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
+                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height()));
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
@@ -81,7 +81,7 @@ pub(super) fn reduce_editing(
             state
                 .sql_modal
                 .editor
-                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
+                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height()));
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
@@ -93,7 +93,7 @@ pub(super) fn reduce_editing(
             state
                 .sql_modal
                 .editor
-                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
+                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height()));
             state
                 .sql_modal
                 .schedule_completion(now + Duration::from_millis(100));
@@ -109,7 +109,7 @@ pub(super) fn reduce_editing(
                 | CursorMove::ViewportBottom => {
                     state.sql_modal.editor.move_cursor_to_viewport_position(
                         *movement,
-                        sql_modal_visible_rows(state.ui.terminal_height),
+                        sql_modal_visible_rows(state.ui.terminal_height()),
                     );
                 }
                 _ => state.sql_modal.editor.move_cursor(*movement),
@@ -117,7 +117,7 @@ pub(super) fn reduce_editing(
             state
                 .sql_modal
                 .editor
-                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
+                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height()));
             state.ui.set_key_sequence(KeySequenceState::Idle);
             DispatchResult::handled()
         }

--- a/src/app/update/sql_editor/high_risk.rs
+++ b/src/app/update/sql_editor/high_risk.rs
@@ -34,7 +34,7 @@ pub(super) fn reduce_high_risk_confirmation(
                 SqlModalStatus::ConfirmingHigh { .. }
             ) {
                 state.sql_modal.cancel_confirmation();
-                state.ui.key_sequence = KeySequenceState::Idle;
+                state.ui.set_key_sequence(KeySequenceState::Idle);
                 DispatchResult::handled()
             } else {
                 DispatchResult::pass()

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -181,7 +181,7 @@ mod tests {
         #[test]
         fn moves_down_without_scrolling_while_cursor_stays_inside_visible_rows() {
             let mut state = sql_modal_state();
-            state.ui.terminal_height = 20;
+            state.ui.set_terminal_height(20);
             state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
             state
                 .sql_modal
@@ -206,7 +206,7 @@ mod tests {
         #[test]
         fn scrolls_once_cursor_moves_past_visible_rows() {
             let mut state = sql_modal_state();
-            state.ui.terminal_height = 20;
+            state.ui.set_terminal_height(20);
             state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
             state
                 .sql_modal

--- a/src/app/update/sql_editor/mode.rs
+++ b/src/app/update/sql_editor/mode.rs
@@ -28,7 +28,7 @@ pub(super) fn reduce_mode(state: &mut AppState, action: &Action, _now: Instant) 
             state
                 .sql_modal
                 .editor
-                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height));
+                .update_scroll(sql_modal_visible_rows(state.ui.terminal_height()));
             state.sql_modal.enter_editing();
             DispatchResult::handled()
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,8 +170,8 @@ async fn main() -> Result<()> {
     tui.enter()?;
 
     let initial_size = tui.terminal().size()?;
-    state.ui.terminal_width = initial_size.width;
-    state.ui.terminal_height = initial_size.height;
+    state.ui.set_terminal_width(initial_size.width);
+    state.ui.set_terminal_height(initial_size.height);
 
     if state.session.dsn().is_some() && state.input_mode() == InputMode::Normal {
         process_action(

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -383,9 +383,10 @@ fn help_overlay_filtered_current_result() {
 
     state.ui.set_focused_pane(FocusedPane::Result);
     state.result_interaction.activate_cell(0, 0);
-    state.ui.help.open(HelpOrigin::from_state(&state));
+    let origin = HelpOrigin::from_state(&state);
+    state.ui.help_mut().open(origin);
     for ch in "copy".chars() {
-        state.ui.help.insert_filter_char(ch);
+        state.ui.help_mut().insert_filter_char(ch);
     }
     state.modal.set_mode(InputMode::Help);
 
@@ -400,7 +401,7 @@ fn help_overlay_long_key_rows() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::Help);
-    state.ui.help.set_scroll_offset(58);
+    state.ui.help_mut().set_scroll_offset(58);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -413,10 +414,10 @@ fn help_overlay_narrow_horizontal_scroll() {
     let mut terminal = create_test_terminal_sized(50, 24);
 
     state.modal.set_mode(InputMode::Help);
-    state.ui.terminal_width = 50;
-    state.ui.terminal_height = 24;
-    state.ui.help.set_scroll_offset(58);
-    state.ui.help.set_horizontal_offset(18);
+    state.ui.set_terminal_width(50);
+    state.ui.set_terminal_height(24);
+    state.ui.help_mut().set_scroll_offset(58);
+    state.ui.help_mut().set_horizontal_offset(18);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -429,8 +430,8 @@ fn help_overlay_omits_scrollbars_when_content_fits() {
     let mut terminal = create_test_terminal_sized(180, 300);
 
     state.modal.set_mode(InputMode::Help);
-    state.ui.terminal_width = 180;
-    state.ui.terminal_height = 300;
+    state.ui.set_terminal_width(180);
+    state.ui.set_terminal_height(300);
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -332,7 +332,7 @@ fn help_overlay_uses_section_header_and_scrollbar_colors() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::Help);
-    state.ui.help.set_scroll_offset(14);
+    state.ui.help_mut().set_scroll_offset(14);
 
     let buffer = render_and_get_buffer_at(&mut terminal, &mut state, now);
 
@@ -368,7 +368,7 @@ fn test_contrast_theme_applies_help_overlay_navigation_colors() {
     let mut terminal = create_test_terminal();
 
     state.modal.set_mode(InputMode::Help);
-    state.ui.help.set_scroll_offset(14);
+    state.ui.help_mut().set_scroll_offset(14);
 
     let buffer =
         render_and_get_buffer_at_with_theme(&mut terminal, &mut state, now, &TEST_CONTRAST_THEME);

--- a/src/ui/features/overlays/help.rs
+++ b/src/ui/features/overlays/help.rs
@@ -53,11 +53,14 @@ impl HelpOverlay {
         );
         let content_area = Self::content_area(inner, viewport);
         let viewport_height = content_area.height as usize;
-        let scroll_offset =
-            clamp_scroll_offset(state.ui.help.scroll_offset(), viewport_height, total_lines);
+        let scroll_offset = clamp_scroll_offset(
+            state.ui.help().scroll_offset(),
+            viewport_height,
+            total_lines,
+        );
         let viewport_width = content_area.width as usize;
         let horizontal_offset = clamp_scroll_offset(
-            state.ui.help.horizontal_offset(),
+            state.ui.help().horizontal_offset(),
             viewport_width,
             content_width,
         );


### PR DESCRIPTION
## Problem
`UiState` still allowed app-crate callers to bypass its accessors, so aggregate ownership was not enforced.

Scope: complete `UiState` encapsulation for app-owned mutable fields while leaving terminal dimensions out of scope.

## Background
This follows the aggregate-first cleanup after the app state encapsulation work in the base branch.

## Approach
Route UI state reads and transitions through the existing intent APIs, then make aggregate-owned fields private so future direct mutation fails at compile time.

## Screenshots
N/A
