### PR TITLE
chore: unify inspector and SQL modal active capability source

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -230,9 +230,7 @@ mod tests {
     use std::time::Instant;
 
     use super::*;
-    use crate::domain::DatabaseMetadata;
-    use crate::domain::QuerySource;
-    use crate::domain::Table;
+    use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, QuerySource, Table};
     use crate::model::er_state::ErStatus;
     use crate::model::shared::focused_pane::FocusedPane;
     use crate::update::action::Action;
@@ -240,6 +238,15 @@ mod tests {
     use rstest::rstest;
     fn make_state() -> AppState {
         AppState::new("test".to_string())
+    }
+
+    fn use_postgres_connection(state: &mut AppState, dsn: &str) {
+        state.session.set_active_connection_with_dsn(
+            &ConnectionId::new(),
+            "postgres",
+            DatabaseType::PostgreSQL,
+            dsn,
+        );
     }
 
     fn make_query_result(source: QuerySource) -> Arc<crate::domain::QueryResult> {
@@ -538,12 +545,7 @@ mod tests {
 
         fn prepare_state_for_reload() -> AppState {
             let mut state = make_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
             state.sql_modal.enqueue_prefetch("public.users".to_string());
             state
@@ -694,12 +696,7 @@ mod tests {
                     .session
                     .select_table("public", "users", &mut state.query.pagination);
                 let generation = state.session.selection_generation();
-                state.session.set_active_connection_with_dsn(
-                    &crate::domain::ConnectionId::new(),
-                    "postgres",
-                    crate::domain::DatabaseType::PostgreSQL,
-                    "dsn://test",
-                );
+                use_postgres_connection(&mut state, "dsn://test");
                 let run_id = state.session.begin_table_detail_run();
                 state.ui.set_inspector_scroll_offset(42);
 

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -538,7 +538,12 @@ mod tests {
 
         fn prepare_state_for_reload() -> AppState {
             let mut state = make_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let _ = state.sql_modal.begin_prefetch();
             state.sql_modal.enqueue_prefetch("public.users".to_string());
             state
@@ -689,7 +694,12 @@ mod tests {
                     .session
                     .select_table("public", "users", &mut state.query.pagination);
                 let generation = state.session.selection_generation();
-                state.session.set_dsn_for_test("dsn://test");
+                state.session.set_active_connection_with_dsn(
+                    &crate::domain::ConnectionId::new(),
+                    "postgres",
+                    crate::domain::DatabaseType::PostgreSQL,
+                    "dsn://test",
+                );
                 let run_id = state.session.begin_table_detail_run();
                 state.ui.set_inspector_scroll_offset(42);
 

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -407,12 +407,6 @@ impl BrowseSession {
     pub(crate) fn set_selection_generation(&mut self, value: u64) {
         self.selection_generation = value;
     }
-
-    #[cfg(any(test, feature = "test-support"))]
-    #[doc(hidden)]
-    pub fn set_dsn_for_test(&mut self, dsn: impl Into<String>) {
-        self.dsn = Some(dsn.into());
-    }
 }
 
 #[cfg(test)]
@@ -595,7 +589,12 @@ mod tests {
         #[test]
         fn mark_connecting_sets_pair_without_changing_dsn() {
             let mut session = BrowseSession::default();
-            session.set_dsn_for_test("postgres://localhost/test");
+            session.set_active_connection_with_dsn(
+                &ConnectionId::new(),
+                "postgres",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
 
             session.mark_connecting();
 

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -4,12 +4,9 @@ use std::sync::Arc;
 use crate::domain::DatabaseType;
 
 use super::ports::outbound::{DdlGenerator, SqlDialect};
-use crate::model::shared::db_capabilities::DbCapabilities;
-
 pub struct AppServices {
     pub ddl_generator: Arc<dyn DdlGenerator>,
     pub sql_dialect: Arc<dyn SqlDialect>,
-    pub db_capabilities: DbCapabilities,
 }
 
 impl AppServices {
@@ -100,7 +97,6 @@ impl AppServices {
         Self {
             ddl_generator: Arc::new(StubDdlGenerator),
             sql_dialect: Arc::new(StubSqlDialect),
-            db_capabilities: DbCapabilities::postgres_like(),
         }
     }
 }

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -57,7 +57,12 @@ mod tests {
 
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
-        state.session.set_dsn_for_test(dsn);
+        state.session.set_active_connection_with_dsn(
+            &crate::domain::ConnectionId::new(),
+            "postgres",
+            crate::domain::DatabaseType::PostgreSQL,
+            dsn,
+        );
         state
     }
 

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -49,6 +49,7 @@ pub fn dispatch_metadata(state: &mut AppState, action: &Action, now: Instant) ->
 mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::app_state::AppState;
     use crate::model::sql_editor::modal::FailedPrefetchEntry;
     use crate::update::action::Action;
@@ -58,9 +59,9 @@ mod tests {
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
         state.session.set_active_connection_with_dsn(
-            &crate::domain::ConnectionId::new(),
+            &ConnectionId::new(),
             "postgres",
-            crate::domain::DatabaseType::PostgreSQL,
+            DatabaseType::PostgreSQL,
             dsn,
         );
         state

--- a/src/app/update/browse/navigation/focus.rs
+++ b/src/app/update/browse/navigation/focus.rs
@@ -1,19 +1,11 @@
-use std::time::Instant;
-
 use crate::model::app_state::AppState;
 use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
-use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-pub fn reduce_focus(
-    state: &mut AppState,
-    action: &Action,
-    _services: &AppServices,
-    _now: Instant,
-) -> DispatchResult {
+pub fn reduce_focus(state: &mut AppState, action: &Action) -> DispatchResult {
     match action {
         Action::SetFocusedPane(pane) => {
             if *pane != FocusedPane::Result {
@@ -76,6 +68,7 @@ mod tests {
     use crate::model::shared::inspector_tab::InspectorTab;
     use crate::services::AppServices;
     use crate::update::browse::navigation::dispatch_navigation;
+    use std::time::Instant;
 
     mod toggle_read_only {
         use super::*;

--- a/src/app/update/browse/navigation/focus.rs
+++ b/src/app/update/browse/navigation/focus.rs
@@ -2,25 +2,16 @@ use std::time::Instant;
 
 use crate::model::app_state::AppState;
 use crate::model::shared::confirm_dialog::ConfirmIntent;
-use crate::model::shared::db_capabilities::DbCapabilities;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-fn active_capabilities<'a>(state: &'a AppState, services: &'a AppServices) -> &'a DbCapabilities {
-    if state.session.active_database_type().is_some() {
-        state.session.active_db_capabilities()
-    } else {
-        &services.db_capabilities
-    }
-}
-
 pub fn reduce_focus(
     state: &mut AppState,
     action: &Action,
-    services: &AppServices,
+    _services: &AppServices,
     _now: Instant,
 ) -> DispatchResult {
     match action {
@@ -57,13 +48,19 @@ pub fn reduce_focus(
         }
         Action::InspectorNextTab => {
             state.ui.set_inspector_tab(
-                active_capabilities(state, services).next_inspector_tab(state.ui.inspector_tab()),
+                state
+                    .session
+                    .active_db_capabilities()
+                    .next_inspector_tab(state.ui.inspector_tab()),
             );
             DispatchResult::handled()
         }
         Action::InspectorPrevTab => {
             state.ui.set_inspector_tab(
-                active_capabilities(state, services).prev_inspector_tab(state.ui.inspector_tab()),
+                state
+                    .session
+                    .active_db_capabilities()
+                    .prev_inspector_tab(state.ui.inspector_tab()),
             );
             DispatchResult::handled()
         }
@@ -75,7 +72,7 @@ pub fn reduce_focus(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::shared::db_capabilities::{DbCapabilities, InspectorInfoField};
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::shared::inspector_tab::InspectorTab;
     use crate::services::AppServices;
     use crate::update::browse::navigation::dispatch_navigation;
@@ -123,25 +120,25 @@ mod tests {
     mod inspector_tabs {
         use super::*;
 
-        fn services_with_two_tabs() -> AppServices {
-            let mut services = AppServices::stub();
-            services.db_capabilities = DbCapabilities::new(
-                true,
-                vec![InspectorTab::Info, InspectorTab::Columns],
-                vec![InspectorInfoField::Owner],
+        fn use_sqlite_connection(state: &mut AppState) {
+            state.session.set_active_connection_with_dsn(
+                &ConnectionId::new(),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite://test.db",
             );
-            services
         }
 
         #[test]
-        fn next_tab_wraps_between_supported_tabs() {
+        fn next_tab_uses_session_capabilities() {
             let mut state = AppState::new("test".to_string());
+            use_sqlite_connection(&mut state);
             state.ui.set_inspector_tab(InspectorTab::Info);
 
             dispatch_navigation(
                 &mut state,
                 &Action::InspectorNextTab,
-                &services_with_two_tabs(),
+                &AppServices::stub(),
                 Instant::now(),
             );
 
@@ -149,18 +146,19 @@ mod tests {
         }
 
         #[test]
-        fn prev_tab_wraps_between_supported_tabs() {
+        fn prev_tab_uses_session_capabilities() {
             let mut state = AppState::new("test".to_string());
+            use_sqlite_connection(&mut state);
             state.ui.set_inspector_tab(InspectorTab::Info);
 
             dispatch_navigation(
                 &mut state,
                 &Action::InspectorPrevTab,
-                &services_with_two_tabs(),
+                &AppServices::stub(),
                 Instant::now(),
             );
 
-            assert_eq!(state.ui.inspector_tab(), InspectorTab::Columns);
+            assert_eq!(state.ui.inspector_tab(), InspectorTab::Ddl);
         }
     }
 }

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -385,8 +385,10 @@ mod tests {
             assert_eq!(state.ui.inspector_scroll_offset(), 0);
         }
 
-        #[test]
-        fn inspector_half_page_scroll_normalizes_unsupported_ddl_tab() {
+        #[rstest::rstest]
+        #[case(ScrollAmount::HalfPage)]
+        #[case(ScrollAmount::FullPage)]
+        fn page_scroll_normalizes_unsupported_ddl_tab(#[case] amount: ScrollAmount) {
             let mut state = state_with_table_detail(20);
             state.session.clear_connection();
             state.ui.set_inspector_pane_height(7);
@@ -398,30 +400,7 @@ mod tests {
                 &Action::Scroll {
                     target: ScrollTarget::Inspector,
                     direction: ScrollDirection::Down,
-                    amount: ScrollAmount::HalfPage,
-                },
-                &AppServices::stub(),
-                Instant::now(),
-            );
-
-            assert!(effects.is_handled());
-            assert_eq!(state.ui.inspector_scroll_offset(), 0);
-        }
-
-        #[test]
-        fn inspector_full_page_scroll_normalizes_unsupported_ddl_tab() {
-            let mut state = state_with_table_detail(20);
-            state.session.clear_connection();
-            state.ui.set_inspector_pane_height(7);
-            state.ui.set_inspector_tab(InspectorTab::Ddl);
-            state.ui.set_inspector_scroll_offset(1);
-
-            let effects = dispatch_navigation(
-                &mut state,
-                &Action::Scroll {
-                    target: ScrollTarget::Inspector,
-                    direction: ScrollDirection::Down,
-                    amount: ScrollAmount::FullPage,
+                    amount,
                 },
                 &AppServices::stub(),
                 Instant::now(),

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -5,14 +5,12 @@ use crate::services::AppServices;
 use crate::update::action::{Action, ScrollAmount, ScrollDirection, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
 
-use super::{active_capabilities, inspector_max_scroll};
+use super::inspector_max_scroll;
 
-fn inspector_page_scroll_delta(
-    state: &AppState,
-    services: &AppServices,
-    amount: ScrollAmount,
-) -> Option<usize> {
-    let visible = match active_capabilities(state, services)
+fn inspector_page_scroll_delta(state: &AppState, amount: ScrollAmount) -> Option<usize> {
+    let visible = match state
+        .session
+        .active_db_capabilities()
         .normalize_inspector_tab(state.ui.inspector_tab())
     {
         InspectorTab::Ddl => state.inspector_ddl_visible_rows(),
@@ -66,7 +64,7 @@ pub fn reduce_inspector(
             direction,
             amount: amount @ (ScrollAmount::HalfPage | ScrollAmount::FullPage),
         } => {
-            if let Some(delta) = inspector_page_scroll_delta(state, services, *amount) {
+            if let Some(delta) = inspector_page_scroll_delta(state, *amount) {
                 let max = inspector_max_scroll(state, services);
                 state
                     .ui
@@ -115,7 +113,7 @@ pub fn reduce_inspector(
 mod tests {
     use super::*;
     use crate::domain::{Column, ColumnAttributes, ConnectionId, DatabaseType, Table};
-    use crate::model::shared::db_capabilities::{DbCapabilities, InspectorInfoField};
+    use crate::model::shared::db_capabilities::DbCapabilities;
     use crate::update::browse::navigation::dispatch_navigation;
     use std::time::Instant;
 
@@ -126,6 +124,12 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.ui.set_inspector_pane_height(10);
             state.ui.set_inspector_tab(InspectorTab::Columns);
+            state.session.set_active_connection_with_dsn(
+                &ConnectionId::new(),
+                "postgres",
+                DatabaseType::PostgreSQL,
+                "postgres://test",
+            );
             let cols: Vec<Column> = (0..columns)
                 .map(|i| Column {
                     name: format!("col_{i}"),
@@ -273,22 +277,6 @@ mod tests {
             assert_eq!(state.ui.inspector_scroll_offset(), 0);
         }
 
-        fn services_without_ddl() -> AppServices {
-            let mut services = AppServices::stub();
-            services.db_capabilities = DbCapabilities::new(
-                true,
-                vec![InspectorTab::Info, InspectorTab::Columns],
-                vec![
-                    InspectorInfoField::Owner,
-                    InspectorInfoField::Comment,
-                    InspectorInfoField::RowCount,
-                    InspectorInfoField::Schema,
-                    InspectorInfoField::TableName,
-                ],
-            );
-            services
-        }
-
         fn use_sqlite_tabs(state: &mut AppState) {
             state.session.set_active_connection_with_dsn(
                 &ConnectionId::new(),
@@ -400,13 +388,10 @@ mod tests {
         #[test]
         fn inspector_half_page_scroll_normalizes_unsupported_ddl_tab() {
             let mut state = state_with_table_detail(20);
-            let services = services_without_ddl();
+            state.session.clear_connection();
             state.ui.set_inspector_pane_height(7);
             state.ui.set_inspector_tab(InspectorTab::Ddl);
             state.ui.set_inspector_scroll_offset(1);
-            let expected_delta = ScrollAmount::HalfPage
-                .page_delta(state.inspector_visible_rows())
-                .unwrap();
 
             let effects = dispatch_navigation(
                 &mut state,
@@ -415,18 +400,18 @@ mod tests {
                     direction: ScrollDirection::Down,
                     amount: ScrollAmount::HalfPage,
                 },
-                &services,
+                &AppServices::stub(),
                 Instant::now(),
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.inspector_scroll_offset(), 1 + expected_delta);
+            assert_eq!(state.ui.inspector_scroll_offset(), 0);
         }
 
         #[test]
         fn inspector_full_page_scroll_normalizes_unsupported_ddl_tab() {
             let mut state = state_with_table_detail(20);
-            let services = services_without_ddl();
+            state.session.clear_connection();
             state.ui.set_inspector_pane_height(7);
             state.ui.set_inspector_tab(InspectorTab::Ddl);
             state.ui.set_inspector_scroll_offset(1);
@@ -438,12 +423,12 @@ mod tests {
                     direction: ScrollDirection::Down,
                     amount: ScrollAmount::FullPage,
                 },
-                &services,
+                &AppServices::stub(),
                 Instant::now(),
             );
 
             assert!(effects.is_handled());
-            assert_eq!(state.ui.inspector_scroll_offset(), 3);
+            assert_eq!(state.ui.inspector_scroll_offset(), 0);
         }
     }
 }

--- a/src/app/update/browse/navigation/mod.rs
+++ b/src/app/update/browse/navigation/mod.rs
@@ -7,28 +7,19 @@ mod inspector;
 use std::time::Instant;
 
 use crate::model::app_state::AppState;
-use crate::model::shared::db_capabilities::DbCapabilities;
 use crate::model::shared::inspector_tab::InspectorTab;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-fn active_capabilities<'a>(state: &'a AppState, services: &'a AppServices) -> &'a DbCapabilities {
-    if state.session.active_database_type().is_some() {
-        state.session.active_db_capabilities()
-    } else {
-        &services.db_capabilities
-    }
-}
-
 fn inspector_total_items(state: &AppState, services: &AppServices) -> usize {
-    let active_tab =
-        active_capabilities(state, services).normalize_inspector_tab(state.ui.inspector_tab());
+    let capabilities = state.session.active_db_capabilities();
+    let active_tab = capabilities.normalize_inspector_tab(state.ui.inspector_tab());
     state
         .session
         .table_detail()
         .map_or(0, |t| match active_tab {
-            InspectorTab::Info => active_capabilities(state, services).inspector_info_line_count(),
+            InspectorTab::Info => capabilities.inspector_info_line_count(),
             InspectorTab::Columns => t.columns.len(),
             InspectorTab::Indexes => t.indexes.len(),
             InspectorTab::ForeignKeys => t.foreign_keys.len(),
@@ -53,7 +44,9 @@ fn inspector_total_items(state: &AppState, services: &AppServices) -> usize {
 }
 
 pub(super) fn inspector_max_scroll(state: &AppState, services: &AppServices) -> usize {
-    let visible = match active_capabilities(state, services)
+    let visible = match state
+        .session
+        .active_db_capabilities()
         .normalize_inspector_tab(state.ui.inspector_tab())
     {
         InspectorTab::Ddl => state.inspector_ddl_visible_rows(),

--- a/src/app/update/browse/navigation/mod.rs
+++ b/src/app/update/browse/navigation/mod.rs
@@ -65,7 +65,7 @@ pub fn dispatch_navigation(
     services: &AppServices,
     now: Instant,
 ) -> DispatchResult {
-    focus::reduce_focus(state, action, services, now)
+    focus::reduce_focus(state, action)
         .or_else(|| input::reduce_input(state, action))
         .or_else(|| explorer::reduce_explorer(state, action))
         .or_else(|| inspector::reduce_inspector(state, action, services))

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -33,7 +33,12 @@ pub(super) mod tests {
 
     pub fn create_test_state() -> AppState {
         let mut state = AppState::new("test_project".to_string());
-        state.session.set_dsn_for_test("postgres://localhost/test");
+        state.session.set_active_connection_with_dsn(
+            &crate::domain::ConnectionId::new(),
+            "postgres",
+            crate::domain::DatabaseType::PostgreSQL,
+            "postgres://localhost/test",
+        );
         state
     }
 

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -26,20 +26,24 @@ pub(super) mod tests {
     use std::time::Instant;
 
     use crate::domain::{
-        Column, ColumnAttributes, CommandTag, Index, IndexAttributes, IndexType, QueryResult,
-        QuerySource, Table, Trigger, TriggerEvent, TriggerTiming,
+        Column, ColumnAttributes, CommandTag, ConnectionId, DatabaseType, Index, IndexAttributes,
+        IndexType, QueryResult, QuerySource, Table, Trigger, TriggerEvent, TriggerTiming,
     };
     use crate::model::app_state::AppState;
 
     pub fn create_test_state() -> AppState {
         let mut state = AppState::new("test_project".to_string());
-        state.session.set_active_connection_with_dsn(
-            &crate::domain::ConnectionId::new(),
-            "postgres",
-            crate::domain::DatabaseType::PostgreSQL,
-            "postgres://localhost/test",
-        );
+        use_postgres_connection(&mut state, "postgres://localhost/test");
         state
+    }
+
+    pub fn use_postgres_connection(state: &mut AppState, dsn: &str) {
+        state.session.set_active_connection_with_dsn(
+            &ConnectionId::new(),
+            "postgres",
+            DatabaseType::PostgreSQL,
+            dsn,
+        );
     }
 
     pub fn preview_result(row_count: usize) -> Arc<QueryResult> {

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -234,6 +234,7 @@ mod tests {
     use super::*;
     use crate::domain::{QueryResult, QuerySource};
     use crate::ports::outbound::DbOperationError;
+    use crate::update::browse::query::tests::use_postgres_connection;
     use std::sync::Arc;
 
     use crate::update::browse::query::dispatch_query;
@@ -523,12 +524,7 @@ mod tests {
 
         fn export_test_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state
         }
 

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -523,7 +523,12 @@ mod tests {
 
         fn export_test_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state
         }
 

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -403,6 +403,7 @@ mod tests {
     };
     use crate::ports::outbound::DbOperationError;
     use crate::update::browse::query::dispatch_query;
+    use crate::update::browse::query::tests::use_postgres_connection;
     use crate::update::browse::query::tests::*;
 
     fn begin_query_run(state: &mut AppState) -> u64 {
@@ -448,12 +449,7 @@ mod tests {
 
         fn editable_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state.query.set_current_result(editable_preview_result());
             state
                 .session
@@ -606,12 +602,7 @@ mod tests {
 
         fn editable_state_with_jsonb() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .query
                 .set_current_result(editable_preview_result_with_jsonb());

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -448,7 +448,12 @@ mod tests {
 
         fn editable_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.query.set_current_result(editable_preview_result());
             state
                 .session
@@ -601,7 +606,12 @@ mod tests {
 
         fn editable_state_with_jsonb() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state
                 .query
                 .set_current_result(editable_preview_result_with_jsonb());

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -132,7 +132,12 @@ mod tests {
         #[test]
         fn blocked_for_service_connection() {
             let mut state = AppState::new("test".to_string());
-            state.session.set_dsn_for_test("service=mydb");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "service",
+                crate::domain::DatabaseType::PostgreSQL,
+                "service=mydb",
+            );
             state.modal.set_mode(InputMode::ConnectionError);
 
             reduce_connection_error(&mut state, &Action::ReenterConnectionSetup, Instant::now());
@@ -143,7 +148,12 @@ mod tests {
         #[test]
         fn allowed_for_profile_connection() {
             let mut state = AppState::new("test".to_string());
-            state.session.set_dsn_for_test("postgres://localhost/db");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/db",
+            );
             state.modal.set_mode(InputMode::ConnectionError);
 
             reduce_connection_error(&mut state, &Action::ReenterConnectionSetup, Instant::now());

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -91,6 +91,16 @@ pub(super) fn reduce_connection_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::{ConnectionId, DatabaseType};
+
+    fn use_postgres_connection(state: &mut AppState, dsn: &str) {
+        state.session.set_active_connection_with_dsn(
+            &ConnectionId::new(),
+            "postgres",
+            DatabaseType::PostgreSQL,
+            dsn,
+        );
+    }
 
     mod scroll_down {
         use super::*;
@@ -133,9 +143,9 @@ mod tests {
         fn blocked_for_service_connection() {
             let mut state = AppState::new("test".to_string());
             state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
+                &ConnectionId::new(),
                 "service",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "service=mydb",
             );
             state.modal.set_mode(InputMode::ConnectionError);
@@ -148,12 +158,7 @@ mod tests {
         #[test]
         fn allowed_for_profile_connection() {
             let mut state = AppState::new("test".to_string());
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/db",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/db");
             state.modal.set_mode(InputMode::ConnectionError);
 
             reduce_connection_error(&mut state, &Action::ReenterConnectionSetup, Instant::now());

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -572,7 +572,12 @@ mod tests {
         #[test]
         fn is_first_run_false_when_already_connected() {
             let mut state = AppState::new("test".to_string());
-            state.session.set_dsn_for_test("postgres://localhost/db");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/db",
+            );
 
             reduce(
                 &mut state,

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -221,6 +221,7 @@ pub fn reduce_connection_setup(
 mod tests {
     use super::*;
     use crate::domain::connection::{ConnectionProfile, SslMode};
+    use crate::domain::{ConnectionId, DatabaseType};
 
     fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
         reduce_connection_setup(state, action, now).into_effects()
@@ -237,6 +238,15 @@ mod tests {
             SslMode::default(),
         )
         .unwrap()
+    }
+
+    fn use_postgres_connection(state: &mut AppState, dsn: &str) {
+        state.session.set_active_connection_with_dsn(
+            &ConnectionId::new(),
+            "postgres",
+            DatabaseType::PostgreSQL,
+            dsn,
+        );
     }
 
     mod paste {
@@ -410,7 +420,6 @@ mod tests {
 
     mod connection_save {
         use super::*;
-        use crate::domain::DatabaseType;
         use crate::domain::MetadataState;
         use crate::model::connection::state::ConnectionState;
         use crate::update::action::ConnectionTarget;
@@ -499,7 +508,7 @@ mod tests {
             state.session.enable_read_only();
 
             let action = Action::ConnectionSaveCompleted(ConnectionTarget {
-                id: crate::domain::ConnectionId::new(),
+                id: ConnectionId::new(),
                 dsn: "postgres://localhost/new_db".to_string(),
                 name: "new_db".to_string(),
                 database_type: DatabaseType::PostgreSQL,
@@ -514,7 +523,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
 
             let action = Action::ConnectionSaveCompleted(ConnectionTarget {
-                id: crate::domain::ConnectionId::new(),
+                id: ConnectionId::new(),
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 name: "app.db".to_string(),
                 database_type: DatabaseType::SQLite,
@@ -572,12 +581,7 @@ mod tests {
         #[test]
         fn is_first_run_false_when_already_connected() {
             let mut state = AppState::new("test".to_string());
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/db",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/db");
 
             reduce(
                 &mut state,

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -32,7 +32,12 @@ mod tests {
 
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
-        state.session.set_dsn_for_test(dsn);
+        state.session.set_active_connection_with_dsn(
+            &crate::domain::ConnectionId::new(),
+            "postgres",
+            crate::domain::DatabaseType::PostgreSQL,
+            dsn,
+        );
         state
     }
 

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -21,6 +21,7 @@ mod tests {
 
     use super::*;
     use crate::cmd::effect::Effect;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::app_state::AppState;
     use crate::model::er_state::ErStatus;
     use crate::update::action::{SmartErRefreshError, SmartErRefreshResult};
@@ -33,9 +34,9 @@ mod tests {
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
         state.session.set_active_connection_with_dsn(
-            &crate::domain::ConnectionId::new(),
+            &ConnectionId::new(),
             "postgres",
-            crate::domain::DatabaseType::PostgreSQL,
+            DatabaseType::PostgreSQL,
             dsn,
         );
         state

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -23,7 +23,7 @@ pub(super) fn reduce_analyze(
 ) -> DispatchResult {
     match action {
         Action::ExplainAnalyzeRequest => {
-            if reject_unsupported_explain(state, services) {
+            if reject_unsupported_explain(state) {
                 return DispatchResult::handled();
             }
             let content = state.sql_modal.editor.content().trim().to_string();
@@ -68,7 +68,7 @@ pub(super) fn reduce_analyze(
                     let Some(explain_query) =
                         services.sql_dialect.build_explain_analyze_sql(&content)
                     else {
-                        mark_explain_unavailable(state, services);
+                        mark_explain_unavailable(state);
                         return DispatchResult::handled();
                     };
                     let run_id = begin_explain_running(state, now);
@@ -87,7 +87,7 @@ pub(super) fn reduce_analyze(
         }
 
         Action::ExplainAnalyzeConfirm => {
-            if reject_unsupported_explain(state, services) {
+            if reject_unsupported_explain(state) {
                 return DispatchResult::handled();
             }
             let query = match state.sql_modal.status() {
@@ -106,7 +106,7 @@ pub(super) fn reduce_analyze(
             {
                 let Some(explain_query) = services.sql_dialect.build_explain_analyze_sql(&query)
                 else {
-                    mark_explain_unavailable(state, services);
+                    mark_explain_unavailable(state);
                     return DispatchResult::handled();
                 };
                 let run_id = begin_explain_running(state, now);

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -4,29 +4,20 @@ use crate::model::app_state::AppState;
 use crate::model::shared::db_capabilities::DbCapabilities;
 use crate::model::sql_editor::modal::SqlModalTab;
 use crate::policy::write::sql_risk::split_statements;
-use crate::services::AppServices;
 
-pub(super) fn active_capabilities<'a>(
-    state: &'a AppState,
-    services: &'a AppServices,
-) -> &'a DbCapabilities {
-    if state.session.active_database_type().is_some() {
-        state.session.active_db_capabilities()
-    } else {
-        &services.db_capabilities
-    }
+pub(super) fn active_capabilities(state: &AppState) -> &DbCapabilities {
+    state.session.active_db_capabilities()
 }
 
 pub(super) fn is_multi_statement(content: &str) -> bool {
     split_statements(content).len() > 1
 }
 
-pub(super) fn mark_explain_unavailable(state: &mut AppState, services: &AppServices) {
+pub(super) fn mark_explain_unavailable(state: &mut AppState) {
     state
         .explain
         .set_error("EXPLAIN is unavailable for this database".to_string());
-    let tab =
-        active_capabilities(state, services).normalize_sql_modal_tab(state.sql_modal.active_tab());
+    let tab = active_capabilities(state).normalize_sql_modal_tab(state.sql_modal.active_tab());
     state.sql_modal.set_active_tab(tab);
 }
 
@@ -64,11 +55,11 @@ pub(super) fn finish_explain_error(state: &mut AppState, error: impl Into<String
     state.query.mark_idle();
 }
 
-pub(super) fn reject_unsupported_explain(state: &mut AppState, services: &AppServices) -> bool {
-    if active_capabilities(state, services).supports_explain() {
+pub(super) fn reject_unsupported_explain(state: &mut AppState) -> bool {
+    if active_capabilities(state).supports_explain() {
         return false;
     }
 
-    mark_explain_unavailable(state, services);
+    mark_explain_unavailable(state);
     true
 }

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -1,13 +1,8 @@
 use std::time::Instant;
 
 use crate::model::app_state::AppState;
-use crate::model::shared::db_capabilities::DbCapabilities;
 use crate::model::sql_editor::modal::SqlModalTab;
 use crate::policy::write::sql_risk::split_statements;
-
-pub(super) fn active_capabilities(state: &AppState) -> &DbCapabilities {
-    state.session.active_db_capabilities()
-}
 
 pub(super) fn is_multi_statement(content: &str) -> bool {
     split_statements(content).len() > 1
@@ -17,7 +12,10 @@ pub(super) fn mark_explain_unavailable(state: &mut AppState) {
     state
         .explain
         .set_error("EXPLAIN is unavailable for this database".to_string());
-    let tab = active_capabilities(state).normalize_sql_modal_tab(state.sql_modal.active_tab());
+    let tab = state
+        .session
+        .active_db_capabilities()
+        .normalize_sql_modal_tab(state.sql_modal.active_tab());
     state.sql_modal.set_active_tab(tab);
 }
 
@@ -56,7 +54,7 @@ pub(super) fn finish_explain_error(state: &mut AppState, error: impl Into<String
 }
 
 pub(super) fn reject_unsupported_explain(state: &mut AppState) -> bool {
-    if active_capabilities(state).supports_explain() {
+    if state.session.active_db_capabilities().supports_explain() {
         return false;
     }
 

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -22,7 +22,7 @@ pub fn dispatch_explain(
         .or_else(|| analyze::reduce_analyze(state, action, now, services))
         .or_else(|| output::reduce_output(state, action, now))
         .or_else(|| scroll::reduce_scroll(state, action, now))
-        .or_else(|| tabs::reduce_tabs(state, action, now, services))
+        .or_else(|| tabs::reduce_tabs(state, action, now))
 }
 
 #[cfg(test)]
@@ -44,11 +44,8 @@ fn reduce_explain(state: &mut AppState, action: &Action, now: Instant) -> Dispat
 mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
-    use crate::domain::DatabaseType;
-    use crate::model::shared::db_capabilities::DbCapabilities;
-    use crate::model::shared::db_capabilities::InspectorInfoField;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::shared::input_mode::InputMode;
-    use crate::model::shared::inspector_tab::InspectorTab;
     use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
     use crate::services::AppServices;
     use crate::update::action::{ScrollAmount, ScrollDirection, ScrollTarget};
@@ -60,19 +57,22 @@ mod tests {
         state
     }
 
-    fn services_without_explain() -> AppServices {
-        let mut services = AppServices::stub();
-        services.db_capabilities = DbCapabilities::new(
-            false,
-            vec![InspectorTab::Info],
-            vec![InspectorInfoField::Schema, InspectorInfoField::TableName],
+    fn use_postgres_connection(state: &mut AppState) {
+        use_postgres_connection_with_dsn(state, "dsn://test");
+    }
+
+    fn use_postgres_connection_with_dsn(state: &mut AppState, dsn: &str) {
+        state.session.set_active_connection_with_dsn(
+            &ConnectionId::from_string("postgres-test"),
+            "postgres",
+            DatabaseType::PostgreSQL,
+            dsn,
         );
-        services
     }
 
     fn use_sqlite_connection(state: &mut AppState) {
         state.session.set_active_connection_with_dsn(
-            &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
+            &ConnectionId::from_string("sqlite-test"),
             "sqlite",
             DatabaseType::SQLite,
             "sqlite:///tmp/app.db",
@@ -86,7 +86,7 @@ mod tests {
         fn empty_query_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("  ".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
                 .into_effects()
@@ -111,7 +111,7 @@ mod tests {
         fn running_is_noop() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
@@ -122,16 +122,15 @@ mod tests {
         }
 
         #[test]
-        fn unsupported_database_sets_error_without_effects() {
+        fn disconnected_session_sets_error_without_effects() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.set_dsn_for_test("dsn://test");
 
             let effects = reduce_explain_with_services(
                 &mut state,
                 &Action::ExplainRequest,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             )
             .unwrap();
 
@@ -172,7 +171,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT 1; DELETE FROM users".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
                 .into_effects()
@@ -190,7 +189,7 @@ mod tests {
         fn starts_query_timer() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             reduce_explain(&mut state, &Action::ExplainRequest, Instant::now());
 
@@ -202,7 +201,7 @@ mod tests {
         fn emits_execute_explain_effect() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             let effects = reduce_explain(&mut state, &Action::ExplainRequest, Instant::now())
                 .into_effects()
@@ -229,7 +228,7 @@ mod tests {
         #[test]
         fn empty_query_is_noop() {
             let mut state = sql_modal_state();
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -246,7 +245,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT 1; DELETE FROM users".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -263,16 +262,15 @@ mod tests {
         }
 
         #[test]
-        fn unsupported_database_sets_error_without_effects() {
+        fn disconnected_session_sets_error_without_effects() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.set_dsn_for_test("dsn://test");
 
             let effects = reduce_explain_with_services(
                 &mut state,
                 &Action::ExplainAnalyzeRequest,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             )
             .unwrap();
 
@@ -288,7 +286,7 @@ mod tests {
         fn select_executes_immediately_without_confirm() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -313,7 +311,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("INSERT INTO users VALUES (1)".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -338,7 +336,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("UPDATE users SET name='x' WHERE id=1".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -363,7 +361,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -383,7 +381,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id=1".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             let effects =
                 reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now())
@@ -408,7 +406,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DROP TABLE users".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -428,7 +426,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("TRUNCATE users".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
 
@@ -452,7 +450,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id=1".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
             state.session.enable_read_only();
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
@@ -477,7 +475,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT * FROM users".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
             state.session.enable_read_only();
 
             let effects =
@@ -503,7 +501,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("INSERT INTO users VALUES (1)".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
             state.session.enable_read_only();
 
             reduce_explain(&mut state, &Action::ExplainAnalyzeRequest, Instant::now());
@@ -526,7 +524,7 @@ mod tests {
         #[test]
         fn confirm_from_high_with_matching_table_emits_effect() {
             let mut state = sql_modal_state();
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
             let mut input = crate::model::shared::text_input::TextInputState::default();
             for c in "users".chars() {
                 input.insert_char(c);
@@ -551,7 +549,7 @@ mod tests {
         #[test]
         fn confirm_from_high_with_mismatch_is_noop() {
             let mut state = sql_modal_state();
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
             let mut input = crate::model::shared::text_input::TextInputState::default();
             input.insert_char('x');
             state
@@ -597,7 +595,7 @@ mod tests {
         #[test]
         fn sets_plan_and_switches_to_plan_tab() {
             let mut state = sql_modal_state();
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
@@ -623,7 +621,7 @@ mod tests {
         #[test]
         fn mismatched_dsn_does_not_replace_plan() {
             let mut state = sql_modal_state();
-            state.session.set_dsn_for_test("dsn://current");
+            use_postgres_connection_with_dsn(&mut state, "dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
             state
@@ -659,7 +657,7 @@ mod tests {
         #[test]
         fn sets_error_and_switches_to_plan_tab() {
             let mut state = sql_modal_state();
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
 
@@ -685,7 +683,7 @@ mod tests {
         #[test]
         fn mismatched_dsn_does_not_replace_plan_with_error() {
             let mut state = sql_modal_state();
-            state.session.set_dsn_for_test("dsn://current");
+            use_postgres_connection_with_dsn(&mut state, "dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
             state
@@ -715,7 +713,7 @@ mod tests {
         fn two_explains_auto_advance_returns_comparable_slots() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.set_dsn_for_test("dsn://test");
+            use_postgres_connection(&mut state);
             let now = Instant::now();
 
             // Step 1: First EXPLAIN
@@ -965,6 +963,7 @@ mod tests {
         #[test]
         fn next_tab_switches_sql_to_plan() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
             reduce_explain(&mut state, &Action::SqlModalNextTab, Instant::now());
@@ -975,6 +974,7 @@ mod tests {
         #[test]
         fn next_tab_switches_plan_to_compare() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
 
             reduce_explain(&mut state, &Action::SqlModalNextTab, Instant::now());
@@ -985,6 +985,7 @@ mod tests {
         #[test]
         fn next_tab_switches_compare_to_sql() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
             reduce_explain(&mut state, &Action::SqlModalNextTab, Instant::now());
@@ -1001,7 +1002,7 @@ mod tests {
                 &mut state,
                 &Action::SqlModalNextTab,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             );
 
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
@@ -1032,7 +1033,7 @@ mod tests {
                 &mut state,
                 &Action::SqlModalNextTab,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             );
 
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
@@ -1041,6 +1042,7 @@ mod tests {
         #[test]
         fn prev_tab_switches_sql_to_compare() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
             reduce_explain(&mut state, &Action::SqlModalPrevTab, Instant::now());
@@ -1051,6 +1053,7 @@ mod tests {
         #[test]
         fn prev_tab_switches_compare_to_plan() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
             reduce_explain(&mut state, &Action::SqlModalPrevTab, Instant::now());
@@ -1061,6 +1064,7 @@ mod tests {
         #[test]
         fn prev_tab_switches_plan_to_sql() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
 
             reduce_explain(&mut state, &Action::SqlModalPrevTab, Instant::now());
@@ -1077,7 +1081,7 @@ mod tests {
                 &mut state,
                 &Action::SqlModalPrevTab,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             );
 
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
@@ -1108,7 +1112,7 @@ mod tests {
                 &mut state,
                 &Action::SqlModalPrevTab,
                 Instant::now(),
-                &services_without_explain(),
+                &AppServices::stub(),
             );
 
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -26,16 +26,6 @@ pub fn dispatch_explain(
 }
 
 #[cfg(test)]
-fn reduce_explain_with_services(
-    state: &mut AppState,
-    action: &Action,
-    now: Instant,
-    services: &AppServices,
-) -> DispatchResult {
-    dispatch_explain(state, action, now, services)
-}
-
-#[cfg(test)]
 fn reduce_explain(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     dispatch_explain(state, action, now, &crate::services::AppServices::stub())
 }
@@ -126,7 +116,7 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
 
-            let effects = reduce_explain_with_services(
+            let effects = dispatch_explain(
                 &mut state,
                 &Action::ExplainRequest,
                 Instant::now(),
@@ -148,7 +138,7 @@ mod tests {
             state.sql_modal.editor.set_content("SELECT 1".to_string());
             use_sqlite_connection(&mut state);
 
-            let effects = reduce_explain_with_services(
+            let effects = dispatch_explain(
                 &mut state,
                 &Action::ExplainRequest,
                 Instant::now(),
@@ -266,7 +256,7 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
 
-            let effects = reduce_explain_with_services(
+            let effects = dispatch_explain(
                 &mut state,
                 &Action::ExplainAnalyzeRequest,
                 Instant::now(),
@@ -998,7 +988,7 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
-            reduce_explain_with_services(
+            dispatch_explain(
                 &mut state,
                 &Action::SqlModalNextTab,
                 Instant::now(),
@@ -1014,7 +1004,7 @@ mod tests {
             use_sqlite_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
-            reduce_explain_with_services(
+            dispatch_explain(
                 &mut state,
                 &Action::SqlModalNextTab,
                 Instant::now(),
@@ -1029,7 +1019,7 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
 
-            reduce_explain_with_services(
+            dispatch_explain(
                 &mut state,
                 &Action::SqlModalNextTab,
                 Instant::now(),
@@ -1077,7 +1067,7 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
-            reduce_explain_with_services(
+            dispatch_explain(
                 &mut state,
                 &Action::SqlModalPrevTab,
                 Instant::now(),
@@ -1093,7 +1083,7 @@ mod tests {
             use_sqlite_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
 
-            reduce_explain_with_services(
+            dispatch_explain(
                 &mut state,
                 &Action::SqlModalPrevTab,
                 Instant::now(),
@@ -1108,7 +1098,7 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
-            reduce_explain_with_services(
+            dispatch_explain(
                 &mut state,
                 &Action::SqlModalPrevTab,
                 Instant::now(),

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -21,7 +21,7 @@ pub(super) fn reduce_request(
 ) -> DispatchResult {
     match action {
         Action::ExplainRequest => {
-            if reject_unsupported_explain(state, services) {
+            if reject_unsupported_explain(state) {
                 return DispatchResult::handled();
             }
             let content = state.sql_modal.editor.content().trim().to_string();
@@ -40,7 +40,7 @@ pub(super) fn reduce_request(
             }
 
             let Some(query) = services.sql_dialect.build_explain_sql(&content) else {
-                mark_explain_unavailable(state, services);
+                mark_explain_unavailable(state);
                 return DispatchResult::handled();
             };
             let run_id = begin_explain_running(state, now);

--- a/src/app/update/explain/tabs.rs
+++ b/src/app/update/explain/tabs.rs
@@ -1,18 +1,12 @@
 use std::time::Instant;
 
 use crate::model::app_state::AppState;
-use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::active_capabilities;
 
-pub(super) fn reduce_tabs(
-    state: &mut AppState,
-    action: &Action,
-    _now: Instant,
-    services: &AppServices,
-) -> DispatchResult {
+pub(super) fn reduce_tabs(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
     match action {
         Action::CompareEditQuery => {
             if let Some(ref right) = state.explain.right {
@@ -23,15 +17,13 @@ pub(super) fn reduce_tabs(
         }
 
         Action::SqlModalNextTab => {
-            let tab = active_capabilities(state, services)
-                .next_sql_modal_tab(state.sql_modal.active_tab());
+            let tab = active_capabilities(state).next_sql_modal_tab(state.sql_modal.active_tab());
             state.sql_modal.set_active_tab(tab);
             DispatchResult::handled()
         }
 
         Action::SqlModalPrevTab => {
-            let tab = active_capabilities(state, services)
-                .prev_sql_modal_tab(state.sql_modal.active_tab());
+            let tab = active_capabilities(state).prev_sql_modal_tab(state.sql_modal.active_tab());
             state.sql_modal.set_active_tab(tab);
             DispatchResult::handled()
         }

--- a/src/app/update/explain/tabs.rs
+++ b/src/app/update/explain/tabs.rs
@@ -4,8 +4,6 @@ use crate::model::app_state::AppState;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-use super::helpers::active_capabilities;
-
 pub(super) fn reduce_tabs(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
     match action {
         Action::CompareEditQuery => {
@@ -17,13 +15,19 @@ pub(super) fn reduce_tabs(state: &mut AppState, action: &Action, _now: Instant) 
         }
 
         Action::SqlModalNextTab => {
-            let tab = active_capabilities(state).next_sql_modal_tab(state.sql_modal.active_tab());
+            let tab = state
+                .session
+                .active_db_capabilities()
+                .next_sql_modal_tab(state.sql_modal.active_tab());
             state.sql_modal.set_active_tab(tab);
             DispatchResult::handled()
         }
 
         Action::SqlModalPrevTab => {
-            let tab = active_capabilities(state).prev_sql_modal_tab(state.sql_modal.active_tab());
+            let tab = state
+                .session
+                .active_db_capabilities()
+                .prev_sql_modal_tab(state.sql_modal.active_tab());
             state.sql_modal.set_active_tab(tab);
             DispatchResult::handled()
         }

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -402,7 +402,12 @@ mod tests {
             fn execute_write_sets_running_state_and_returns_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::CellEdit);
-                state.session.set_dsn_for_test("postgres://localhost/test");
+                state.session.set_active_connection_with_dsn(
+                    &crate::domain::ConnectionId::new(),
+                    "postgres",
+                    crate::domain::DatabaseType::PostgreSQL,
+                    "postgres://localhost/test",
+                );
                 state.confirm_dialog.open(
                     "",
                     "",
@@ -520,7 +525,12 @@ mod tests {
             fn csv_export_returns_export_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                state.session.set_dsn_for_test("postgres://localhost/test");
+                state.session.set_active_connection_with_dsn(
+                    &crate::domain::ConnectionId::new(),
+                    "postgres",
+                    crate::domain::DatabaseType::PostgreSQL,
+                    "postgres://localhost/test",
+                );
                 let _ = state.query.begin_running(Instant::now());
                 state.confirm_dialog.open(
                     "",
@@ -579,7 +589,12 @@ mod tests {
             fn csv_export_ignores_mismatched_run_id() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                state.session.set_dsn_for_test("postgres://localhost/test");
+                state.session.set_active_connection_with_dsn(
+                    &crate::domain::ConnectionId::new(),
+                    "postgres",
+                    crate::domain::DatabaseType::PostgreSQL,
+                    "postgres://localhost/test",
+                );
                 let _ = state.query.begin_running(Instant::now());
                 state.confirm_dialog.open(
                     "",

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -26,6 +26,7 @@ mod tests {
 
     use super::*;
     use crate::cmd::effect::Effect;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::shared::confirm_dialog::ConfirmIntent;
     use crate::model::shared::input_mode::InputMode;
     use crate::ports::outbound::AppSettings;
@@ -37,6 +38,15 @@ mod tests {
 
     fn create_test_state() -> AppState {
         AppState::new("test".to_string())
+    }
+
+    fn use_postgres_connection(state: &mut AppState, dsn: &str) {
+        state.session.set_active_connection_with_dsn(
+            &ConnectionId::new(),
+            "postgres",
+            DatabaseType::PostgreSQL,
+            dsn,
+        );
     }
 
     mod base {
@@ -381,7 +391,7 @@ mod tests {
             fn delete_connection_returns_delete_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::ConnectionSelector);
-                let id = crate::domain::ConnectionId::new();
+                let id = ConnectionId::new();
                 state
                     .confirm_dialog
                     .open("", "", ConfirmIntent::DeleteConnection(id));
@@ -402,12 +412,7 @@ mod tests {
             fn execute_write_sets_running_state_and_returns_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::CellEdit);
-                state.session.set_active_connection_with_dsn(
-                    &crate::domain::ConnectionId::new(),
-                    "postgres",
-                    crate::domain::DatabaseType::PostgreSQL,
-                    "postgres://localhost/test",
-                );
+                use_postgres_connection(&mut state, "postgres://localhost/test");
                 state.confirm_dialog.open(
                     "",
                     "",
@@ -525,12 +530,7 @@ mod tests {
             fn csv_export_returns_export_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                state.session.set_active_connection_with_dsn(
-                    &crate::domain::ConnectionId::new(),
-                    "postgres",
-                    crate::domain::DatabaseType::PostgreSQL,
-                    "postgres://localhost/test",
-                );
+                use_postgres_connection(&mut state, "postgres://localhost/test");
                 let _ = state.query.begin_running(Instant::now());
                 state.confirm_dialog.open(
                     "",
@@ -589,12 +589,7 @@ mod tests {
             fn csv_export_ignores_mismatched_run_id() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                state.session.set_active_connection_with_dsn(
-                    &crate::domain::ConnectionId::new(),
-                    "postgres",
-                    crate::domain::DatabaseType::PostgreSQL,
-                    "postgres://localhost/test",
-                );
+                use_postgres_connection(&mut state, "postgres://localhost/test");
                 let _ = state.query.begin_running(Instant::now());
                 state.confirm_dialog.open(
                     "",
@@ -825,7 +820,6 @@ mod tests {
 
     mod query_history_picker {
         use super::*;
-        use crate::domain::ConnectionId;
         use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
         use crate::model::shared::text_input::TextInputLike;
         use crate::ports::outbound::query_history::QueryHistoryError;
@@ -845,7 +839,7 @@ mod tests {
             state.session.set_active_connection_with_dsn(
                 &ConnectionId::from_string("test-conn"),
                 "test",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
             );
             state.runtime.project_name = "test-project".to_string();
@@ -1011,7 +1005,7 @@ mod tests {
                 super::dispatch_modal(
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
-                        crate::domain::ConnectionId::from_string("test-conn"),
+                        ConnectionId::from_string("test-conn"),
                         QueryHistoryError::Io(Arc::new(std::io::Error::other("disk error"))),
                     ),
                     now,
@@ -1033,7 +1027,7 @@ mod tests {
                 super::dispatch_modal(
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
-                        crate::domain::ConnectionId::from_string("test-conn"),
+                        ConnectionId::from_string("test-conn"),
                         QueryHistoryError::Io(Arc::new(std::io::Error::other("stale error"))),
                     ),
                     now,

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -52,7 +52,7 @@ fn reduce_inner(
         // reset view state here and return Pass, relying on dispatch_query for the page change.
         .or_else(|| dispatch_result(state, &action, services, now))
         .or_else(|| dispatch_navigation(state, &action, services, now))
-        .or_else(|| dispatch_sql_modal(state, &action, now, services))
+        .or_else(|| dispatch_sql_modal(state, &action, now))
         .or_else(|| dispatch_explain(state, &action, now, services))
         .or_else(|| dispatch_metadata(state, &action, now))
         .or_else(|| dispatch_er(state, &action, now))

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -182,6 +182,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::ports::outbound::DbOperationError;
     use crate::ports::outbound::connection_store::ConnectionStoreError;
     use crate::update::action::ModalKind;
@@ -190,6 +191,15 @@ mod tests {
 
     fn create_test_state() -> AppState {
         AppState::new("test_project".to_string())
+    }
+
+    fn use_postgres_connection(state: &mut AppState, dsn: &str) {
+        state.session.set_active_connection_with_dsn(
+            &ConnectionId::new(),
+            "postgres",
+            DatabaseType::PostgreSQL,
+            dsn,
+        );
     }
 
     mod pure_actions {
@@ -905,12 +915,7 @@ mod tests {
         use crate::model::connection::error::ConnectionErrorInfo;
 
         fn metadata_loaded_action(state: &mut AppState, metadata: DatabaseMetadata) -> Action {
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
@@ -920,12 +925,7 @@ mod tests {
         }
 
         fn metadata_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
@@ -1242,12 +1242,7 @@ mod tests {
         #[test]
         fn load_metadata_with_dsn_returns_fetch_effect() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::LoadMetadata, now, &AppServices::stub());
@@ -1274,12 +1269,7 @@ mod tests {
         #[test]
         fn reload_metadata_returns_sequence_effect() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -1303,12 +1293,7 @@ mod tests {
         #[test]
         fn reload_metadata_sets_is_reloading_flag() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             reduce(
@@ -1327,7 +1312,7 @@ mod tests {
             state.session.set_active_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("test-connection"),
                 "test",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
             );
             let now = Instant::now();
@@ -1363,12 +1348,7 @@ mod tests {
         #[test]
         fn execute_adhoc_with_dsn_returns_effect() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -1402,12 +1382,7 @@ mod tests {
         #[test]
         fn always_emits_smart_refresh_even_with_pending_tables() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1431,12 +1406,7 @@ mod tests {
         #[test]
         fn prefetch_started_true_emits_smart_refresh() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1456,12 +1426,7 @@ mod tests {
         #[test]
         fn no_prefetch_emits_smart_refresh() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1494,12 +1459,7 @@ mod tests {
             let mut state = create_test_state();
             state.er_preparation.mark_waiting();
             let now = Instant::now();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let action = Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
@@ -1536,12 +1496,7 @@ mod tests {
         #[test]
         fn emits_cache_effect() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state.sql_modal.mark_prefetching("public.users".to_string());
             let now = Instant::now();
@@ -1570,12 +1525,7 @@ mod tests {
         #[test]
         fn with_queue_returns_process_effect() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
@@ -1722,7 +1672,6 @@ mod tests {
 
     mod connection_setup_transitions {
         use super::*;
-        use crate::domain::ConnectionId;
 
         #[test]
         fn save_completed_sets_dsn_and_returns_fetch_effect() {
@@ -1746,7 +1695,7 @@ mod tests {
                     id: ConnectionId::new(),
                     dsn: "postgres://db.example.com/mydb".to_string(),
                     name: "Test Connection".to_string(),
-                    database_type: crate::domain::DatabaseType::PostgreSQL,
+                    database_type: DatabaseType::PostgreSQL,
                 }),
                 now,
                 &AppServices::stub(),
@@ -1876,12 +1825,7 @@ mod tests {
             };
 
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             let delete_sql = "DELETE FROM \"public\".\"users\"\nWHERE \"id\" = '2';".to_string();
@@ -1958,12 +1902,7 @@ mod tests {
             };
 
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             state.result_interaction.set_write_preview(WritePreview {
@@ -2024,12 +1963,7 @@ mod tests {
         #[test]
         fn try_connect_with_dsn_starts_connecting() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -2066,12 +2000,7 @@ mod tests {
         #[test]
         fn try_connect_when_already_connecting_is_noop() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
@@ -2087,12 +2016,7 @@ mod tests {
         #[test]
         fn try_connect_when_already_connected_is_noop() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -2108,12 +2032,7 @@ mod tests {
         #[test]
         fn try_connect_when_not_in_normal_mode_is_noop() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -2132,12 +2051,7 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let metadata = DatabaseMetadata {
                 database_name: "test".to_string(),
@@ -2171,12 +2085,7 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let now = Instant::now();
 
@@ -2206,7 +2115,7 @@ mod tests {
             state.session.set_active_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("test-connection"),
                 "test",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
             );
             state
@@ -2310,7 +2219,7 @@ mod tests {
                     id: ConnectionId::new(),
                     dsn: "postgres://localhost/test".to_string(),
                     name: "Test".to_string(),
-                    database_type: crate::domain::DatabaseType::PostgreSQL,
+                    database_type: DatabaseType::PostgreSQL,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2334,7 +2243,7 @@ mod tests {
             state.session.set_active_connection_with_dsn(
                 &conn_a,
                 "conn-a",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/a",
             );
             state
@@ -2349,7 +2258,7 @@ mod tests {
                     id: conn_b.clone(),
                     dsn: "postgres://localhost/other".to_string(),
                     name: "Other".to_string(),
-                    database_type: crate::domain::DatabaseType::PostgreSQL,
+                    database_type: DatabaseType::PostgreSQL,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2380,7 +2289,7 @@ mod tests {
             state.session.set_active_connection_with_dsn(
                 &conn_a,
                 "conn-a",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/a",
             );
             state
@@ -2408,7 +2317,7 @@ mod tests {
                     id: conn_b.clone(),
                     dsn: "postgres://localhost/cached".to_string(),
                     name: "Cached".to_string(),
-                    database_type: crate::domain::DatabaseType::PostgreSQL,
+                    database_type: DatabaseType::PostgreSQL,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2499,12 +2408,7 @@ mod tests {
         }
 
         fn metadata_loaded_action(state: &mut AppState) -> Action {
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
@@ -2628,12 +2532,7 @@ mod tests {
         #[test]
         fn target_tables_survive_er_open() {
             let mut state = state_with_metadata();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
             state
                 .er_preparation
@@ -2655,12 +2554,7 @@ mod tests {
             use crate::model::er_state::ErStatus;
 
             let mut state = state_with_metadata();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting();
             state.er_preparation.begin_full_prefetch(1);
@@ -2694,12 +2588,7 @@ mod tests {
             use crate::model::er_state::ErStatus;
 
             let mut state = state_with_metadata();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting();
             state.er_preparation.begin_full_prefetch(2);
@@ -2741,12 +2630,7 @@ mod tests {
 
         fn state_after_confirm_and_complete() -> (AppState, Instant) {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             // Load metadata with a table
@@ -2959,12 +2843,7 @@ mod tests {
             let entry_index = palette_index_of(|a| matches!(a, Action::ReloadMetadata));
 
             let mut state = state_in_palette_mode();
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state.ui.table_picker_mut().set_selection(entry_index);
             let now = Instant::now();
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -905,7 +905,12 @@ mod tests {
         use crate::model::connection::error::ConnectionErrorInfo;
 
         fn metadata_loaded_action(state: &mut AppState, metadata: DatabaseMetadata) -> Action {
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
@@ -915,7 +920,12 @@ mod tests {
         }
 
         fn metadata_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
@@ -1232,7 +1242,12 @@ mod tests {
         #[test]
         fn load_metadata_with_dsn_returns_fetch_effect() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::LoadMetadata, now, &AppServices::stub());
@@ -1259,7 +1274,12 @@ mod tests {
         #[test]
         fn reload_metadata_returns_sequence_effect() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let now = Instant::now();
 
             let effects = reduce(
@@ -1283,7 +1303,12 @@ mod tests {
         #[test]
         fn reload_metadata_sets_is_reloading_flag() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let now = Instant::now();
 
             reduce(
@@ -1338,7 +1363,12 @@ mod tests {
         #[test]
         fn execute_adhoc_with_dsn_returns_effect() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let now = Instant::now();
 
             let effects = reduce(
@@ -1372,7 +1402,12 @@ mod tests {
         #[test]
         fn always_emits_smart_refresh_even_with_pending_tables() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1396,7 +1431,12 @@ mod tests {
         #[test]
         fn prefetch_started_true_emits_smart_refresh() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1416,7 +1456,12 @@ mod tests {
         #[test]
         fn no_prefetch_emits_smart_refresh() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -1449,7 +1494,12 @@ mod tests {
             let mut state = create_test_state();
             state.er_preparation.mark_waiting();
             let now = Instant::now();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let run_id = state.session.begin_metadata_refresh();
             let action = Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
@@ -1486,7 +1536,12 @@ mod tests {
         #[test]
         fn emits_cache_effect() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let run_id = state.sql_modal.begin_prefetch();
             state.sql_modal.mark_prefetching("public.users".to_string());
             let now = Instant::now();
@@ -1515,7 +1570,12 @@ mod tests {
         #[test]
         fn with_queue_returns_process_effect() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let run_id = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
@@ -1816,7 +1876,12 @@ mod tests {
             };
 
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             let delete_sql = "DELETE FROM \"public\".\"users\"\nWHERE \"id\" = '2';".to_string();
@@ -1893,7 +1958,12 @@ mod tests {
             };
 
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             state.result_interaction.set_write_preview(WritePreview {
@@ -1954,7 +2024,12 @@ mod tests {
         #[test]
         fn try_connect_with_dsn_starts_connecting() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -1991,7 +2066,12 @@ mod tests {
         #[test]
         fn try_connect_when_already_connecting_is_noop() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
@@ -2007,7 +2087,12 @@ mod tests {
         #[test]
         fn try_connect_when_already_connected_is_noop() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -2023,7 +2108,12 @@ mod tests {
         #[test]
         fn try_connect_when_not_in_normal_mode_is_noop() {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -2042,7 +2132,12 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let run_id = state.session.begin_metadata_refresh();
             let metadata = DatabaseMetadata {
                 database_name: "test".to_string(),
@@ -2076,7 +2171,12 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let run_id = state.session.begin_metadata_refresh();
             let now = Instant::now();
 
@@ -2399,7 +2499,12 @@ mod tests {
         }
 
         fn metadata_loaded_action(state: &mut AppState) -> Action {
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
@@ -2523,7 +2628,12 @@ mod tests {
         #[test]
         fn target_tables_survive_er_open() {
             let mut state = state_with_metadata();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let _ = state.sql_modal.begin_prefetch();
             state
                 .er_preparation
@@ -2545,7 +2655,12 @@ mod tests {
             use crate::model::er_state::ErStatus;
 
             let mut state = state_with_metadata();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting();
             state.er_preparation.begin_full_prefetch(1);
@@ -2579,7 +2694,12 @@ mod tests {
             use crate::model::er_state::ErStatus;
 
             let mut state = state_with_metadata();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting();
             state.er_preparation.begin_full_prefetch(2);
@@ -2621,7 +2741,12 @@ mod tests {
 
         fn state_after_confirm_and_complete() -> (AppState, Instant) {
             let mut state = create_test_state();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let now = Instant::now();
 
             // Load metadata with a table
@@ -2834,7 +2959,12 @@ mod tests {
             let entry_index = palette_index_of(|a| matches!(a, Action::ReloadMetadata));
 
             let mut state = state_in_palette_mode();
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.ui.table_picker_mut().set_selection(entry_index);
             let now = Instant::now();
 

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -9,28 +9,23 @@ mod yank;
 use std::time::Instant;
 
 use crate::model::app_state::AppState;
-use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-pub fn dispatch_sql_modal(
-    state: &mut AppState,
-    action: &Action,
-    now: Instant,
-    services: &AppServices,
-) -> DispatchResult {
+pub fn dispatch_sql_modal(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     completion::reduce_completion(state, action, now)
         .or_else(|| editing::reduce_editing(state, action, now))
         .or_else(|| mode::reduce_mode(state, action, now))
         .or_else(|| submit::reduce_submit(state, action, now))
         .or_else(|| high_risk::reduce_high_risk_confirmation(state, action, now))
-        .or_else(|| yank::reduce_yank(state, action, now, services))
+        .or_else(|| yank::reduce_yank(state, action, now))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::shared::flash_timer::FlashId;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::text_input::{TextInputLike, TextInputState};
@@ -40,13 +35,22 @@ mod tests {
     use std::time::Instant;
 
     fn reduce_sql_modal(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
-        super::dispatch_sql_modal(state, action, now, &crate::services::AppServices::stub())
+        super::dispatch_sql_modal(state, action, now)
     }
 
     fn sql_modal_state() -> AppState {
         let mut state = AppState::new("test".to_string());
         state.modal.set_mode(InputMode::SqlModal);
         state
+    }
+
+    fn use_postgres_connection(state: &mut AppState) {
+        state.session.set_active_connection_with_dsn(
+            &ConnectionId::from_string("postgres-test"),
+            "postgres",
+            DatabaseType::PostgreSQL,
+            "postgres://test",
+        );
     }
 
     mod paste {
@@ -974,6 +978,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_copies_plan_text() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = Some("Seq Scan on users".to_string());
 
@@ -990,6 +995,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_no_plan_is_noop() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = None;
 
@@ -1003,6 +1009,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_error_state_is_noop() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = None;
             state.explain.error = Some("syntax error".to_string());
@@ -1017,6 +1024,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_both_slots() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 420, SlotSource::AutoPrevious));
             state.explain.right = Some(make_slot("Index Scan", true, 50, SlotSource::AutoLatest));
@@ -1042,6 +1050,7 @@ mod tests {
         #[test]
         fn both_auto_slots_yank_returns_distinguishable_headers() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 300, SlotSource::AutoPrevious));
             state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
@@ -1062,6 +1071,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_right_only_is_noop() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = None;
             state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
@@ -1076,6 +1086,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_left_only_is_noop() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 200, SlotSource::AutoPrevious));
             state.explain.right = None;
@@ -1090,6 +1101,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_empty_is_noop() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = None;
             state.explain.right = None;
@@ -1104,6 +1116,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_includes_verdict_with_reasons() {
             let mut state = sql_modal_state();
+            use_postgres_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             // Use parseable EXPLAIN output so compare_plans produces a real verdict
             state.explain.left = Some(CompareSlot {

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -280,7 +280,12 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT * INTO backup FROM users".to_string());
-            state.session.set_dsn_for_test("postgres://test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://test",
+            );
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -294,7 +299,12 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("COPY users FROM '/tmp/data.csv'".to_string());
-            state.session.set_dsn_for_test("postgres://test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://test",
+            );
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -308,7 +318,12 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("UPDATE users SET x=1 WHERE id=1".to_string());
-            state.session.set_dsn_for_test("postgres://test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://test",
+            );
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -391,7 +406,12 @@ mod tests {
         #[test]
         fn high_risk_confirm_executes_on_match() {
             let mut state = confirming_high_state("DROP TABLE users", Some("users"));
-            state.session.set_dsn_for_test("postgres://test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://test",
+            );
             for c in "users".chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -608,7 +628,12 @@ mod tests {
             let full_name = "my_schema.very_long_table_name";
             let mut state =
                 confirming_high_state(&format!("DROP TABLE {full_name}"), Some(full_name));
-            state.session.set_dsn_for_test("postgres://test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://test",
+            );
             for c in full_name.chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -646,7 +671,12 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id = 1".to_string());
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
@@ -665,7 +695,12 @@ mod tests {
         fn read_only_reject_clears_prior_success() {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.session.enable_read_only();
 
             // Simulate a prior adhoc success
@@ -697,7 +732,12 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
@@ -717,7 +757,12 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content(query.to_string());
-            state.session.set_dsn_for_test("postgres://localhost/test");
+            state.session.set_active_connection_with_dsn(
+                &crate::domain::ConnectionId::new(),
+                "postgres",
+                crate::domain::DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             state
         }
 

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -44,12 +44,12 @@ mod tests {
         state
     }
 
-    fn use_postgres_connection(state: &mut AppState) {
+    fn use_postgres_connection(state: &mut AppState, dsn: &str) {
         state.session.set_active_connection_with_dsn(
             &ConnectionId::from_string("postgres-test"),
             "postgres",
             DatabaseType::PostgreSQL,
-            "postgres://test",
+            dsn,
         );
     }
 
@@ -280,12 +280,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT * INTO backup FROM users".to_string());
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://test",
-            );
+            use_postgres_connection(&mut state, "postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -299,12 +294,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("COPY users FROM '/tmp/data.csv'".to_string());
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://test",
-            );
+            use_postgres_connection(&mut state, "postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -318,12 +308,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("UPDATE users SET x=1 WHERE id=1".to_string());
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://test",
-            );
+            use_postgres_connection(&mut state, "postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -406,12 +391,7 @@ mod tests {
         #[test]
         fn high_risk_confirm_executes_on_match() {
             let mut state = confirming_high_state("DROP TABLE users", Some("users"));
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://test",
-            );
+            use_postgres_connection(&mut state, "postgres://test");
             for c in "users".chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -628,12 +608,7 @@ mod tests {
             let full_name = "my_schema.very_long_table_name";
             let mut state =
                 confirming_high_state(&format!("DROP TABLE {full_name}"), Some(full_name));
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://test",
-            );
+            use_postgres_connection(&mut state, "postgres://test");
             for c in full_name.chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -671,12 +646,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id = 1".to_string());
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
@@ -695,12 +665,7 @@ mod tests {
         fn read_only_reject_clears_prior_success() {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.enable_read_only();
 
             // Simulate a prior adhoc success
@@ -732,12 +697,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
@@ -757,12 +717,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content(query.to_string());
-            state.session.set_active_connection_with_dsn(
-                &crate::domain::ConnectionId::new(),
-                "postgres",
-                crate::domain::DatabaseType::PostgreSQL,
-                "postgres://localhost/test",
-            );
+            use_postgres_connection(&mut state, "postgres://localhost/test");
             state
         }
 
@@ -1023,7 +978,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_copies_plan_text() {
             let mut state = sql_modal_state();
-            use_postgres_connection(&mut state);
+            use_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = Some("Seq Scan on users".to_string());
 
@@ -1040,7 +995,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_no_plan_is_noop() {
             let mut state = sql_modal_state();
-            use_postgres_connection(&mut state);
+            use_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = None;
 
@@ -1054,7 +1009,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_error_state_is_noop() {
             let mut state = sql_modal_state();
-            use_postgres_connection(&mut state);
+            use_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = None;
             state.explain.error = Some("syntax error".to_string());
@@ -1069,7 +1024,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_both_slots() {
             let mut state = sql_modal_state();
-            use_postgres_connection(&mut state);
+            use_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 420, SlotSource::AutoPrevious));
             state.explain.right = Some(make_slot("Index Scan", true, 50, SlotSource::AutoLatest));
@@ -1095,7 +1050,7 @@ mod tests {
         #[test]
         fn both_auto_slots_yank_returns_distinguishable_headers() {
             let mut state = sql_modal_state();
-            use_postgres_connection(&mut state);
+            use_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 300, SlotSource::AutoPrevious));
             state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
@@ -1116,7 +1071,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_right_only_is_noop() {
             let mut state = sql_modal_state();
-            use_postgres_connection(&mut state);
+            use_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = None;
             state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
@@ -1131,7 +1086,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_left_only_is_noop() {
             let mut state = sql_modal_state();
-            use_postgres_connection(&mut state);
+            use_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 200, SlotSource::AutoPrevious));
             state.explain.right = None;
@@ -1146,7 +1101,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_empty_is_noop() {
             let mut state = sql_modal_state();
-            use_postgres_connection(&mut state);
+            use_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = None;
             state.explain.right = None;
@@ -1161,7 +1116,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_includes_verdict_with_reasons() {
             let mut state = sql_modal_state();
-            use_postgres_connection(&mut state);
+            use_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             // Use parseable EXPLAIN output so compare_plans produces a real verdict
             state.explain.left = Some(CompareSlot {

--- a/src/app/update/sql_editor/yank.rs
+++ b/src/app/update/sql_editor/yank.rs
@@ -4,32 +4,19 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::domain::explain_plan::{ComparisonVerdict, compare_plans};
 use crate::model::app_state::AppState;
-use crate::model::shared::db_capabilities::DbCapabilities;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalTab;
 use crate::ports::outbound::ClipboardError;
-use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-fn active_capabilities<'a>(state: &'a AppState, services: &'a AppServices) -> &'a DbCapabilities {
-    if state.session.active_database_type().is_some() {
-        state.session.active_db_capabilities()
-    } else {
-        &services.db_capabilities
-    }
-}
-
-pub(super) fn reduce_yank(
-    state: &mut AppState,
-    action: &Action,
-    now: Instant,
-    services: &AppServices,
-) -> DispatchResult {
+pub(super) fn reduce_yank(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::SqlModalYank => {
-            let active_tab = active_capabilities(state, services)
+            let active_tab = state
+                .session
+                .active_db_capabilities()
                 .normalize_sql_modal_tab(state.sql_modal.active_tab());
             let content = match active_tab {
                 SqlModalTab::Plan => state.explain.plan_text.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ use sabiql_app::cmd::effect::Effect;
 use sabiql_app::cmd::render_schedule::next_animation_deadline;
 use sabiql_app::cmd::runner::EffectRunner;
 use sabiql_app::model::app_state::AppState;
-use sabiql_app::model::shared::db_capabilities::DbCapabilities;
 use sabiql_app::model::shared::input_mode::InputMode;
 use sabiql_app::ports::outbound::{
     ConnectionStore, ConnectionStoreError, PgServiceEntryReader, ServiceFileError, SettingsStore,
@@ -120,7 +119,6 @@ async fn main() -> Result<()> {
     let services = AppServices {
         ddl_generator: Arc::clone(&adapter_registry) as _,
         sql_dialect: Arc::clone(&adapter_registry) as _,
-        db_capabilities: DbCapabilities::disconnected(),
     };
 
     let mut state = AppState::new(project_name);


### PR DESCRIPTION
## Problem
Inspector navigation and SQL modal reducers could resolve active DB capabilities through a different source than the renderers.

## Background
SQLite support made capability semantics user-visible across Inspector tabs and SQL modal explain tabs. Keeping a service fallback in reducers meant disconnected and test-injected states could drift from the session state rendered by the UI.

## Approach
Scope: active capability reads for Inspector navigation, SQL modal behavior, and the reducer tests that exercise those paths.

Use the browse session as the single active capability source and remove capability injection from app services. Tests now model PostgreSQL, SQLite, and disconnected states through session lifecycle setup so reducer and renderer behavior share the same semantics.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * アプリケーション内部の設計を改善し、データベース機能の依存関係を最適化しました。
  * セッション管理の初期化処理を強化し、接続コンテキストをより明確に追跡できるようにしました。
  * サービス層の依存関係を削減し、システムの保守性を向上させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/riii111/sabiql/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->