### PR TITLE
Void installation guide fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cargo install sabiql
 paru -S sabiql  # or yay -S sabiql
 
 # Void Linux (Unofficial Repo)
-echo repository=https://raw.githubusercontent.com/Event-Horizon-VL/blackhole-vl/repository-x86_64 | sudo tee /etc/xbps.d/20-repository-extra.conf
+echo "repository=https://mirror.black-hole.dev/$(xbps-uhelper arch)/" | sudo tee /etc/xbps.d/20-repository-extra.conf
 sudo xbps-install -S sabiql
 
 # FreeBSD (ports)


### PR DESCRIPTION
<!-- Write all PR content in English. -->

## Problem
URL in the installation guide for Void Linux no longer works

## Background
The repository has been moved to a new mirror.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * Void Linux の「Unofficial Repo」インストール手順を更新し、追記するリポジトリURLをシステムアーキテクチャに応じて自動解決する方式に改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->