### PR TITLE
Fix Android target build compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,19 +70,6 @@ jobs:
       - run: cargo build --workspace --release
       - run: cargo build --workspace --release --no-default-features
 
-  android-check:
-    name: Android Target Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
-        with:
-          targets: aarch64-linux-android
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: aarch64-linux-android
-      - run: cargo check --workspace --target aarch64-linux-android
-
   audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,19 @@ jobs:
       - run: cargo build --workspace --release
       - run: cargo build --workspace --release --no-default-features
 
+  android-check:
+    name: Android Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          targets: aarch64-linux-android
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: aarch64-linux-android
+      - run: cargo check --workspace --target aarch64-linux-android
+
   audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - run: cargo build --workspace --release --no-default-features
 
   android-check:
-    name: Android Check
+    name: Android Target Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,7 +2546,6 @@ dependencies = [
 name = "sabiql-app"
 version = "1.12.2"
 dependencies = [
- "arboard",
  "async-trait",
  "color-eyre",
  "crossterm",

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Open Settings with `Ctrl+K` to switch themes and configure the ER diagram browse
 
 ### Android / Termux
 
-Termux is build-only support, not full Android support. `cargo install sabiql` should compile on Android, but clipboard yank is unavailable because the desktop clipboard backend is not supported there. `psql` is still required.
+Android/Termux support is build-only, not full platform support. `cargo install sabiql` should compile on Android, but clipboard yank is unavailable because the desktop clipboard backend is not supported there. `psql` is still required.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Open Settings with `Ctrl+K` to switch themes and configure the ER diagram browse
 - `psql` CLI (PostgreSQL client)
 - Graphviz (optional, for ER diagrams): `brew install graphviz`
 
+### Android / Termux
+
+Termux builds are limited support. `cargo install sabiql` should compile on Android, but clipboard yank is unavailable because the desktop clipboard backend is not supported there. `psql` is still required.
+
 ## Development
 
 With Nix:

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Open Settings with `Ctrl+K` to switch themes and configure the ER diagram browse
 
 ### Android / Termux
 
-Termux builds are limited support. `cargo install sabiql` should compile on Android, but clipboard yank is unavailable because the desktop clipboard backend is not supported there. `psql` is still required.
+Termux is build-only support, not full Android support. `cargo install sabiql` should compile on Android, but clipboard yank is unavailable because the desktop clipboard backend is not supported there. `psql` is still required.
 
 ## Development
 

--- a/src/app/Cargo.toml
+++ b/src/app/Cargo.toml
@@ -13,7 +13,6 @@ path = "lib.rs"
 test-support = []
 
 [dependencies]
-arboard.workspace = true
 async-trait.workspace = true
 color-eyre.workspace = true
 crossterm.workspace = true

--- a/src/app/ports/outbound/clipboard.rs
+++ b/src/app/ports/outbound/clipboard.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ClipboardError {
     #[error("{0}")]
-    Backend(#[source] Arc<arboard::Error>),
+    Backend(#[source] Arc<dyn std::error::Error + Send + Sync>),
     #[error("{0}")]
     Unavailable(String),
 }
 
-impl From<arboard::Error> for ClipboardError {
-    fn from(e: arboard::Error) -> Self {
-        Self::Backend(Arc::new(e))
+impl ClipboardError {
+    pub fn backend(error: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self::Backend(Arc::new(error))
     }
 }
 

--- a/src/app/ports/outbound/graphviz.rs
+++ b/src/app/ports/outbound/graphviz.rs
@@ -16,6 +16,8 @@ pub enum GraphvizError {
 pub enum ViewerError {
     #[error("Failed to open viewer: {0}")]
     LaunchFailed(#[from] std::io::Error),
+    #[error("{operation} is unsupported on this platform")]
+    UnsupportedPlatform { operation: String },
     #[error("{browser} is not available on this platform")]
     UnsupportedBrowser { browser: String },
     #[error("Browser command not found for {browser}. Tried: {candidates}")]
@@ -79,6 +81,20 @@ mod tests {
 
             assert!(message.contains("Safari"));
             assert!(message.contains("not available"));
+        }
+
+        #[test]
+        fn unsupported_platform_names_operation() {
+            let error = ViewerError::UnsupportedPlatform {
+                operation: "Opening ER diagrams".to_string(),
+            };
+
+            let message = format!("{error}");
+
+            assert_eq!(
+                message,
+                "Opening ER diagrams is unsupported on this platform"
+            );
         }
 
         #[test]

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -1,8 +1,7 @@
 //! Port traits and their error types.
 //!
-//! Error variants carry source types (`std::io::Error`, `arboard::Error`, etc.)
-//! via `#[source]` to preserve `Error::source()` chains. Method signatures stay
-//! free of adapter-specific types; only error sources are exposed.
+//! Error variants may preserve `Error::source()` chains, but method signatures
+//! stay free of adapter-specific types.
 
 pub mod clipboard;
 pub mod config_writer;

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -530,6 +530,7 @@ pub enum Action {
     ResultDiscardCellEdit,
     SubmitCellEditWrite,
     OpenWritePreviewConfirm(Box<WritePreview>),
+    CellCopied,
     CopyFailed(ClipboardError),
     OpenFolderFailed(FolderOpenError),
     ToggleFocus,

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -530,7 +530,6 @@ pub enum Action {
     ResultDiscardCellEdit,
     SubmitCellEditWrite,
     OpenWritePreviewConfirm(Box<WritePreview>),
-    CellCopied,
     CopyFailed(ClipboardError),
     OpenFolderFailed(FolderOpenError),
     ToggleFocus,

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -509,9 +509,17 @@ pub enum Action {
     ResultCellLeft,
     ResultCellRight,
     ResultCellYank,
+    ResultCellYankSuccess {
+        row: usize,
+        col: usize,
+    },
     ResultRowYankOperatorPending,
     ResultRowYank,
+    ResultRowYankSuccess {
+        row: usize,
+    },
     DdlYank,
+    DdlYankSuccess,
     ResultDeleteOperatorPending,
     StageRowForDelete,
     UnstageLastStagedRow,
@@ -522,7 +530,6 @@ pub enum Action {
     ResultDiscardCellEdit,
     SubmitCellEditWrite,
     OpenWritePreviewConfirm(Box<WritePreview>),
-    CellCopied,
     CopyFailed(ClipboardError),
     OpenFolderFailed(FolderOpenError),
     ToggleFocus,
@@ -573,6 +580,7 @@ pub enum Action {
 
     // JSONB detail
     JsonbYankAll,
+    JsonbYankSuccess,
     JsonbEnterEdit,
     JsonbAppendInsert,
     JsonbExitEdit,

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -87,14 +87,18 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
 
         Action::JsonbYankAll => {
             let json = state.jsonb_detail.current_json_for_yank();
-            state.flash_timers.set(FlashId::JsonbDetail, now);
             DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                 content: json,
-                on_success: Some(Box::new(Action::CellCopied)),
+                on_success: Some(Box::new(Action::JsonbYankSuccess)),
                 on_failure: Some(Box::new(Action::CopyFailed(ClipboardError::Unavailable(
                     "Clipboard unavailable".into(),
                 )))),
             }])
+        }
+
+        Action::JsonbYankSuccess => {
+            state.flash_timers.set(FlashId::JsonbDetail, now);
+            DispatchResult::handled()
         }
 
         Action::JsonbEnterEdit => {
@@ -863,6 +867,16 @@ mod tests {
             assert!(
                 matches!(&effects[0], Effect::CopyToClipboard { content, .. } if content.contains("theme"))
             );
+        }
+
+        #[test]
+        fn success_sets_flash() {
+            let mut state = state_with_jsonb_cell();
+            let now = Instant::now();
+
+            reduce_jsonb(&mut state, &Action::JsonbYankSuccess, now);
+
+            assert!(state.flash_timers.is_active(FlashId::JsonbDetail, now));
         }
     }
 

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -860,13 +860,26 @@ mod tests {
                 Instant::now(),
             );
 
-            let effects = reduce_jsonb(&mut state, &Action::JsonbYankAll, Instant::now());
+            let now = Instant::now();
+            let effects = reduce_jsonb(&mut state, &Action::JsonbYankAll, now);
 
             let effects = effects.into_effects().expect("should return effects");
             assert_eq!(effects.len(), 1);
-            assert!(
-                matches!(&effects[0], Effect::CopyToClipboard { content, .. } if content.contains("theme"))
-            );
+            match &effects[0] {
+                Effect::CopyToClipboard {
+                    content,
+                    on_success,
+                    ..
+                } => {
+                    assert!(content.contains("theme"));
+                    assert!(matches!(
+                        on_success.as_deref(),
+                        Some(Action::JsonbYankSuccess)
+                    ));
+                }
+                other => panic!("expected CopyToClipboard, got {other:?}"),
+            }
+            assert!(!state.flash_timers.is_active(FlashId::JsonbDetail, now));
         }
 
         #[test]

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -118,7 +118,6 @@ pub fn reduce_yank(
             state.flash_timers.set(FlashId::Ddl, now);
             DispatchResult::handled()
         }
-        Action::CellCopied => DispatchResult::handled(),
         Action::CopyFailed(e) => {
             state.messages.set_error_at(e.to_string(), now);
             DispatchResult::handled()

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -215,8 +215,16 @@ mod tests {
 
             assert_eq!(effects.len(), 1);
             match &effects[0] {
-                Effect::CopyToClipboard { content, .. } => {
+                Effect::CopyToClipboard {
+                    content,
+                    on_success,
+                    ..
+                } => {
                     assert_eq!(content, "r1c2");
+                    assert!(matches!(
+                        on_success.as_deref(),
+                        Some(Action::ResultCellYankSuccess { row: 1, col: 2 })
+                    ));
                 }
                 other => panic!("expected CopyToClipboard, got {other:?}"),
             }
@@ -341,8 +349,16 @@ mod tests {
 
             assert_eq!(effects.len(), 1);
             match &effects[0] {
-                Effect::CopyToClipboard { content, .. } => {
+                Effect::CopyToClipboard {
+                    content,
+                    on_success,
+                    ..
+                } => {
                     assert_eq!(content, "v0\tv1\tv2");
+                    assert!(matches!(
+                        on_success.as_deref(),
+                        Some(Action::ResultRowYankSuccess { row: 0 })
+                    ));
                 }
                 other => panic!("expected CopyToClipboard, got {other:?}"),
             }
@@ -527,9 +543,20 @@ mod tests {
 
             let effects = effects.into_effects().expect("should return Some");
             assert_eq!(effects.len(), 1);
-            assert!(
-                matches!(&effects[0], Effect::CopyToClipboard { content, .. } if content.contains("CREATE TABLE"))
-            );
+            match &effects[0] {
+                Effect::CopyToClipboard {
+                    content,
+                    on_success,
+                    ..
+                } => {
+                    assert!(content.contains("CREATE TABLE"));
+                    assert!(matches!(
+                        on_success.as_deref(),
+                        Some(Action::DdlYankSuccess)
+                    ));
+                }
+                other => panic!("expected CopyToClipboard, got {other:?}"),
+            }
         }
 
         #[test]

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -31,14 +31,12 @@ pub fn reduce_yank(
                     .and_then(|row| row.get(col_idx))
                     .cloned();
                 if let Some(value) = content {
-                    state.result_interaction.yank_flash = Some(YankFlash {
-                        row: row_idx,
-                        col: Some(col_idx),
-                        until: now + Duration::from_millis(200),
-                    });
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: value,
-                        on_success: Some(Box::new(Action::CellCopied)),
+                        on_success: Some(Box::new(Action::ResultCellYankSuccess {
+                            row: row_idx,
+                            col: col_idx,
+                        })),
                         on_failure: Some(Box::new(clipboard_unavailable())),
                     }])
                 } else {
@@ -60,10 +58,9 @@ pub fn reduce_yank(
                 && let Some(table) = state.session.table_detail().as_ref()
             {
                 let ddl = services.ddl_generator.generate_ddl(table);
-                state.flash_timers.set(FlashId::Ddl, now);
                 return DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                     content: ddl,
-                    on_success: Some(Box::new(Action::CellCopied)),
+                    on_success: Some(Box::new(Action::DdlYankSuccess)),
                     on_failure: Some(Box::new(clipboard_unavailable())),
                 }]);
             }
@@ -86,14 +83,9 @@ pub fn reduce_yank(
                             .join("\t")
                     });
                 if let Some(tsv) = content {
-                    state.result_interaction.yank_flash = Some(YankFlash {
-                        row: row_idx,
-                        col: None,
-                        until: now + Duration::from_millis(200),
-                    });
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: tsv,
-                        on_success: Some(Box::new(Action::CellCopied)),
+                        on_success: Some(Box::new(Action::ResultRowYankSuccess { row: row_idx })),
                         on_failure: Some(Box::new(clipboard_unavailable())),
                     }])
                 } else {
@@ -106,7 +98,26 @@ pub fn reduce_yank(
                 DispatchResult::handled()
             }
         }
-        Action::CellCopied => DispatchResult::handled(),
+        Action::ResultCellYankSuccess { row, col } => {
+            state.result_interaction.yank_flash = Some(YankFlash {
+                row: *row,
+                col: Some(*col),
+                until: now + Duration::from_millis(200),
+            });
+            DispatchResult::handled()
+        }
+        Action::ResultRowYankSuccess { row } => {
+            state.result_interaction.yank_flash = Some(YankFlash {
+                row: *row,
+                col: None,
+                until: now + Duration::from_millis(200),
+            });
+            DispatchResult::handled()
+        }
+        Action::DdlYankSuccess => {
+            state.flash_timers.set(FlashId::Ddl, now);
+            DispatchResult::handled()
+        }
         Action::CopyFailed(e) => {
             state.messages.set_error_at(e.to_string(), now);
             DispatchResult::handled()
@@ -209,6 +220,24 @@ mod tests {
                 }
                 other => panic!("expected CopyToClipboard, got {other:?}"),
             }
+            assert!(state.result_interaction.yank_flash.is_none());
+        }
+
+        #[test]
+        fn success_sets_cell_flash() {
+            let mut state = state_with_grid(3, 3);
+            let now = Instant::now();
+
+            reduce_yank(
+                &mut state,
+                &Action::ResultCellYankSuccess { row: 1, col: 2 },
+                &AppServices::stub(),
+                now,
+            );
+
+            let flash = state.result_interaction.yank_flash.expect("flash set");
+            assert_eq!(flash.row, 1);
+            assert_eq!(flash.col, Some(2));
         }
 
         #[test]
@@ -317,6 +346,24 @@ mod tests {
                 }
                 other => panic!("expected CopyToClipboard, got {other:?}"),
             }
+            assert!(state.result_interaction.yank_flash.is_none());
+        }
+
+        #[test]
+        fn success_sets_row_flash() {
+            let mut state = state_with_row(vec!["v0", "v1"]);
+            let now = Instant::now();
+
+            reduce_yank(
+                &mut state,
+                &Action::ResultRowYankSuccess { row: 0 },
+                &AppServices::stub(),
+                now,
+            );
+
+            let flash = state.result_interaction.yank_flash.expect("flash set");
+            assert_eq!(flash.row, 0);
+            assert_eq!(flash.col, None);
         }
 
         #[test]
@@ -486,11 +533,11 @@ mod tests {
         }
 
         #[test]
-        fn sets_flash() {
+        fn success_sets_flash() {
             let mut state = state_with_ddl_tab();
             let now = Instant::now();
 
-            reduce_yank(&mut state, &Action::DdlYank, &fake_services(), now);
+            reduce_yank(&mut state, &Action::DdlYankSuccess, &fake_services(), now);
 
             assert!(state.flash_timers.is_active(FlashId::Ddl, now));
         }

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -118,6 +118,7 @@ pub fn reduce_yank(
             state.flash_timers.set(FlashId::Ddl, now);
             DispatchResult::handled()
         }
+        Action::CellCopied => DispatchResult::handled(),
         Action::CopyFailed(e) => {
             state.messages.set_error_at(e.to_string(), now);
             DispatchResult::handled()

--- a/src/infra/Cargo.toml
+++ b/src/infra/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 path = "lib.rs"
 
 [dependencies]
-arboard.workspace = true
 async-trait.workspace = true
 csv.workspace = true
 dirs.workspace = true
@@ -22,6 +21,9 @@ toml.workspace = true
 urlencoding.workspace = true
 sabiql-app.workspace = true
 sabiql-domain.workspace = true
+
+[target.'cfg(not(target_os = "android"))'.dependencies]
+arboard.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/src/infra/adapters/clipboard.rs
+++ b/src/infra/adapters/clipboard.rs
@@ -4,7 +4,18 @@ pub struct ArboardClipboard;
 
 impl ClipboardWriter for ArboardClipboard {
     fn copy_text(&self, content: &str) -> Result<(), ClipboardError> {
-        arboard::Clipboard::new().and_then(|mut cb| cb.set_text(content))?;
-        Ok(())
+        copy_text(content)
     }
+}
+
+#[cfg(not(target_os = "android"))]
+fn copy_text(content: &str) -> Result<(), ClipboardError> {
+    arboard::Clipboard::new()
+        .and_then(|mut cb| cb.set_text(content))
+        .map_err(ClipboardError::backend)
+}
+
+#[cfg(target_os = "android")]
+fn copy_text(_content: &str) -> Result<(), ClipboardError> {
+    Err(ClipboardError::Unavailable("Clipboard unavailable".into()))
 }

--- a/src/infra/adapters/folder_opener.rs
+++ b/src/infra/adapters/folder_opener.rs
@@ -6,21 +6,34 @@ pub struct NativeFolderOpener;
 
 impl FolderOpener for NativeFolderOpener {
     fn open(&self, path: &Path) -> Result<(), FolderOpenError> {
-        #[cfg(target_os = "macos")]
-        let result = std::process::Command::new("open").arg(path).spawn();
-        #[cfg(any(target_os = "freebsd", target_os = "linux"))]
-        let result = std::process::Command::new("xdg-open").arg(path).spawn();
-        #[cfg(target_os = "windows")]
-        let result = std::process::Command::new("explorer").arg(path).spawn();
-        #[cfg(not(any(
-            target_os = "freebsd",
-            target_os = "macos",
-            target_os = "linux",
-            target_os = "windows"
-        )))]
-        compile_error!("FolderOpener: unsupported target OS");
-
-        result?;
-        Ok(())
+        open_folder(path)
     }
+}
+
+#[cfg(target_os = "macos")]
+fn open_folder(path: &Path) -> Result<(), FolderOpenError> {
+    std::process::Command::new("open").arg(path).spawn()?;
+    Ok(())
+}
+
+#[cfg(any(target_os = "freebsd", target_os = "linux"))]
+fn open_folder(path: &Path) -> Result<(), FolderOpenError> {
+    std::process::Command::new("xdg-open").arg(path).spawn()?;
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn open_folder(path: &Path) -> Result<(), FolderOpenError> {
+    std::process::Command::new("explorer").arg(path).spawn()?;
+    Ok(())
+}
+
+#[cfg(not(any(
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "windows"
+)))]
+fn open_folder(_path: &Path) -> Result<(), FolderOpenError> {
+    Err(std::io::Error::other("Opening folders is unsupported on this platform").into())
 }

--- a/src/infra/export/dot.rs
+++ b/src/infra/export/dot.rs
@@ -41,23 +41,40 @@ impl ViewerLauncher for SystemViewerLauncher {
             return Ok(());
         }
 
-        #[cfg(target_os = "macos")]
-        {
-            open_with_default_browser(path)?;
-        }
-        #[cfg(any(target_os = "freebsd", target_os = "linux"))]
-        {
-            Command::new("xdg-open").arg(path).spawn()?;
-        }
-        #[cfg(target_os = "windows")]
-        {
-            Command::new("cmd")
-                .args(["/C", "start"])
-                .arg(path)
-                .spawn()?;
-        }
-        Ok(())
+        open_with_default_viewer(path)
     }
+}
+
+#[cfg(target_os = "macos")]
+fn open_with_default_viewer(path: &Path) -> Result<(), ViewerError> {
+    open_with_default_browser(path)
+}
+
+#[cfg(any(target_os = "freebsd", target_os = "linux"))]
+fn open_with_default_viewer(path: &Path) -> Result<(), ViewerError> {
+    Command::new("xdg-open").arg(path).spawn()?;
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn open_with_default_viewer(path: &Path) -> Result<(), ViewerError> {
+    Command::new("cmd")
+        .args(["/C", "start"])
+        .arg(path)
+        .spawn()?;
+    Ok(())
+}
+
+#[cfg(not(any(
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "windows"
+)))]
+fn open_with_default_viewer(_path: &Path) -> Result<(), ViewerError> {
+    Err(ViewerError::UnsupportedBrowser {
+        browser: "default browser".to_string(),
+    })
 }
 
 #[cfg(target_os = "macos")]
@@ -130,30 +147,40 @@ fn handler_bundle_id(handler: &serde_json::Value) -> Option<String> {
         .map(str::to_string)
 }
 
+#[cfg(target_os = "macos")]
 fn open_with_browser(path: &Path, browser: &str) -> Result<(), ViewerError> {
-    #[cfg(target_os = "macos")]
-    {
-        Command::new("open")
-            .arg("-a")
-            .arg(macos_browser_application_name(browser))
-            .arg(path)
-            .spawn()?;
-        Ok(())
-    }
+    Command::new("open")
+        .arg("-a")
+        .arg(macos_browser_application_name(browser))
+        .arg(path)
+        .spawn()?;
+    Ok(())
+}
 
-    #[cfg(any(target_os = "freebsd", target_os = "linux"))]
-    {
-        open_with_browser_candidates(path, browser, &browser_command_candidates(browser))
-    }
+#[cfg(any(target_os = "freebsd", target_os = "linux"))]
+fn open_with_browser(path: &Path, browser: &str) -> Result<(), ViewerError> {
+    open_with_browser_candidates(path, browser, &browser_command_candidates(browser))
+}
 
-    #[cfg(target_os = "windows")]
-    {
-        Command::new("cmd")
-            .args(["/C", "start", "", browser])
-            .arg(path)
-            .spawn()?;
-        Ok(())
-    }
+#[cfg(target_os = "windows")]
+fn open_with_browser(path: &Path, browser: &str) -> Result<(), ViewerError> {
+    Command::new("cmd")
+        .args(["/C", "start", "", browser])
+        .arg(path)
+        .spawn()?;
+    Ok(())
+}
+
+#[cfg(not(any(
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "windows"
+)))]
+fn open_with_browser(_path: &Path, browser: &str) -> Result<(), ViewerError> {
+    Err(ViewerError::UnsupportedBrowser {
+        browser: browser.to_string(),
+    })
 }
 
 #[cfg(any(target_os = "macos", test))]

--- a/src/infra/export/dot.rs
+++ b/src/infra/export/dot.rs
@@ -72,8 +72,8 @@ fn open_with_default_viewer(path: &Path) -> Result<(), ViewerError> {
     target_os = "windows"
 )))]
 fn open_with_default_viewer(_path: &Path) -> Result<(), ViewerError> {
-    Err(ViewerError::UnsupportedBrowser {
-        browser: "default browser".to_string(),
+    Err(ViewerError::UnsupportedPlatform {
+        operation: "Opening ER diagrams".to_string(),
     })
 }
 
@@ -178,8 +178,8 @@ fn open_with_browser(path: &Path, browser: &str) -> Result<(), ViewerError> {
     target_os = "windows"
 )))]
 fn open_with_browser(_path: &Path, browser: &str) -> Result<(), ViewerError> {
-    Err(ViewerError::UnsupportedBrowser {
-        browser: browser.to_string(),
+    Err(ViewerError::UnsupportedPlatform {
+        operation: format!("Opening ER diagrams with {browser}"),
     })
 }
 

--- a/src/infra/export/dot.rs
+++ b/src/infra/export/dot.rs
@@ -59,7 +59,7 @@ fn open_with_default_viewer(path: &Path) -> Result<(), ViewerError> {
 #[cfg(target_os = "windows")]
 fn open_with_default_viewer(path: &Path) -> Result<(), ViewerError> {
     Command::new("cmd")
-        .args(["/C", "start"])
+        .args(["/C", "start", ""])
         .arg(path)
         .spawn()?;
     Ok(())


### PR DESCRIPTION
issue #395 

## Problem
Android/Termux installs failed because the workspace pulled in desktop-only platform integrations during target compilation. Clipboard yank also showed success feedback before the copy operation actually succeeded.

## Background
SAB-263 tracks build-only Android/Termux support. Termux clipboard integration is intentionally out of scope for this change.

## Approach
Keep desktop-only integrations behind platform-specific adapters, return unsupported errors on Android, and add an Android target compile check to prevent regressions. Move yank feedback to copy-success actions so unavailable clipboard paths report failure without misleading success UI.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * README に Android/Termux のビルド対応についての説明を追加しました。

* **New Features**
  * Yank（コピー）成功時の視覚的フィードバック機能を改善しました。

* **Bug Fixes**
  * クリップボード機能のエラーハンドリングを汎用化し、信頼性を向上させました。
  * 非対応プラットフォームでのエラー表示を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->