### PR TITLE
Update ratatui scrollbar snapshot

### DIFF
--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
@@ -14,7 +14,7 @@ test_project | test_db | - | no dsn | localhost:54
 │       │                     Preview and││      │
 │       │                     Edit cell v││      │
 │       │                     Move cursor┃│      │
-│       │                     Jump to sta││──────┘
+│       │                     Jump to sta┃│──────┘
 │       │                     Open comman││──────┐
 │       │                     Exit to Cel││      │
 │       │                     Line start/││      │


### PR DESCRIPTION
## Problem
Ratatui 0.30.1 changed narrow scrollbar rendering and caused an existing snapshot test to fail on main.

## Background
The Dependabot PR CI detected the snapshot drift, but main did not have required status checks configured, so the dependency update could be merged before CI completion.

## Approach
Accept the Ratatui rendering drift as a snapshot-only change. Separately, main branch protection has been configured to require the CI checks before merge: Format, Lint, Test, Build, and Security Audit.

## Screenshots
N/A