### PR TITLE
chore: update Rust toolchain to 1.96

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,3 @@
-msrv = "1.94"
+msrv = "1.96"
 allow-dbg-in-tests = true
 too-many-arguments-threshold = 8

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1777000482,
-        "narHash": "sha256-CZ5FKUSA8FCJf0h9GWdPJXoVVDL9H5yC74GkVc5ubIM=",
+        "lastModified": 1780802404,
+        "narHash": "sha256-bGtIUeLb0yChX4h6hB40OOCwcYhcpQZHXSDvZGdWgeM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "403c09094a877e6c4816462d00b1a56ff8198e06",
+        "rev": "8e596a8430f2ce54d55c742198187d6945a5501e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,18 @@
       ];
 
       forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      rustVersion = "1.96.0";
+      mkRustToolchain =
+        pkgs:
+        pkgs.rust-bin.stable.${rustVersion}.default.override {
+          extensions = [
+            "clippy"
+            "rust-analyzer"
+            "rust-src"
+            "rustfmt"
+          ];
+        };
     in
     {
       packages = forAllSystems (
@@ -31,14 +43,7 @@
             overlays = [ rust-overlay.overlays.default ];
           };
 
-          rustToolchain = pkgs.rust-bin.stable."1.94.0".default.override {
-            extensions = [
-              "clippy"
-              "rust-analyzer"
-              "rust-src"
-              "rustfmt"
-            ];
-          };
+          rustToolchain = mkRustToolchain pkgs;
           rustPlatform = pkgs.makeRustPlatform {
             cargo = rustToolchain;
             rustc = rustToolchain;
@@ -86,14 +91,7 @@
             overlays = [ rust-overlay.overlays.default ];
           };
 
-          rustToolchain = pkgs.rust-bin.stable."1.94.0".default.override {
-            extensions = [
-              "clippy"
-              "rust-analyzer"
-              "rust-src"
-              "rustfmt"
-            ];
-          };
+          rustToolchain = mkRustToolchain pkgs;
         in
         {
           default = pkgs.mkShell {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -696,12 +696,9 @@ impl SqlLexer {
                     alias = Some(name.clone());
                     *i += 1;
                 }
-                TokenKind::Keyword(kw) => {
-                    // Don't treat SQL keywords as aliases
-                    if !Self::is_clause_keyword(kw) {
-                        alias = Some(kw.clone());
-                        *i += 1;
-                    }
+                TokenKind::Keyword(kw) if !Self::is_clause_keyword(kw) => {
+                    alias = Some(kw.clone());
+                    *i += 1;
                 }
                 _ => {}
             }

--- a/src/ui/primitives/atoms/scroll_indicator.rs
+++ b/src/ui/primitives/atoms/scroll_indicator.rs
@@ -36,11 +36,9 @@ pub fn render_horizontal_scroll_indicator(
     }
 
     let scrollable_range = params.total_items.saturating_sub(params.viewport_size);
-    let percentage = if scrollable_range > 0 {
-        (params.position * 100) / scrollable_range
-    } else {
-        0
-    };
+    let percentage = (params.position * 100)
+        .checked_div(scrollable_range)
+        .unwrap_or(0);
     let position_text = format!("col {:>3}%", percentage.min(100));
 
     // Layout: [col XXX%][space][scrollbar with < and >][1-cell gap for border]


### PR DESCRIPTION
## Problem
Local development was pinned to Rust 1.94.0 while CI and release workflows follow the current stable toolchain.

## Background
Rust 1.96.0 introduces new clippy diagnostics that make the existing code fail under the repository's `-D warnings` lint policy.

## Approach
Update the pinned Rust toolchain and Nix toolchain to 1.96.0, align clippy's MSRV setting, and apply the narrow clippy rewrites needed for the newer lint set.

## Screenshots
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Rust ツールチェーンと関連設定を 1.94 から 1.96 にアップグレードしました（ビルドと開発環境の基盤を更新）。

* **Refactor**
  * テーブル参照の別名判定ロジックをより読みやすく整理しました（動作は維持）。

* **Bug Fixes**
  * 水平スクロール指標の計算でゼロ除算や端数のエッジケースを回避し、表示が安定するよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->