### PR TITLE
Refactor native opener launch paths

### DIFF
--- a/src/infra/adapters/folder_opener.rs
+++ b/src/infra/adapters/folder_opener.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::process::Command;
 
 use crate::app::ports::outbound::folder_opener::{FolderOpenError, FolderOpener};
 
@@ -12,19 +13,27 @@ impl FolderOpener for NativeFolderOpener {
 
 #[cfg(target_os = "macos")]
 fn open_folder(path: &Path) -> Result<(), FolderOpenError> {
-    std::process::Command::new("open").arg(path).spawn()?;
-    Ok(())
+    spawn_folder_opener("open", &[], path)
 }
 
 #[cfg(any(target_os = "freebsd", target_os = "linux"))]
 fn open_folder(path: &Path) -> Result<(), FolderOpenError> {
-    std::process::Command::new("xdg-open").arg(path).spawn()?;
-    Ok(())
+    spawn_folder_opener("xdg-open", &[], path)
 }
 
 #[cfg(target_os = "windows")]
 fn open_folder(path: &Path) -> Result<(), FolderOpenError> {
-    std::process::Command::new("explorer").arg(path).spawn()?;
+    spawn_folder_opener("explorer", &[], path)
+}
+
+#[cfg(any(
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "windows"
+))]
+fn spawn_folder_opener(program: &str, args: &[&str], path: &Path) -> Result<(), FolderOpenError> {
+    Command::new(program).args(args).arg(path).spawn()?;
     Ok(())
 }
 

--- a/src/infra/export/dot.rs
+++ b/src/infra/export/dot.rs
@@ -578,6 +578,16 @@ mod tests {
         }
 
         #[test]
+        fn requested_browser_ignores_whitespace_only_values() {
+            assert_eq!(requested_browser(Some("   ")), None);
+        }
+
+        #[test]
+        fn requested_browser_trims_browser_name() {
+            assert_eq!(requested_browser(Some("  Firefox  ")), Some("Firefox"));
+        }
+
+        #[test]
         fn browser_command_candidates_include_common_presets() {
             assert_eq!(
                 browser_command_candidates("microsoft edge"),

--- a/src/infra/export/dot.rs
+++ b/src/infra/export/dot.rs
@@ -36,13 +36,15 @@ pub struct SystemViewerLauncher;
 
 impl ViewerLauncher for SystemViewerLauncher {
     fn open_file(&self, path: &Path, browser: Option<&str>) -> Result<(), ViewerError> {
-        if let Some(browser) = browser.map(str::trim).filter(|value| !value.is_empty()) {
-            open_with_browser(path, browser)?;
-            return Ok(());
+        match requested_browser(browser) {
+            Some(browser) => open_with_browser(path, browser),
+            None => open_with_default_viewer(path),
         }
-
-        open_with_default_viewer(path)
     }
+}
+
+fn requested_browser(browser: Option<&str>) -> Option<&str> {
+    browser.map(str::trim).filter(|value| !value.is_empty())
 }
 
 #[cfg(target_os = "macos")]
@@ -52,17 +54,12 @@ fn open_with_default_viewer(path: &Path) -> Result<(), ViewerError> {
 
 #[cfg(any(target_os = "freebsd", target_os = "linux"))]
 fn open_with_default_viewer(path: &Path) -> Result<(), ViewerError> {
-    Command::new("xdg-open").arg(path).spawn()?;
-    Ok(())
+    spawn_viewer("xdg-open", &[], path)
 }
 
 #[cfg(target_os = "windows")]
 fn open_with_default_viewer(path: &Path) -> Result<(), ViewerError> {
-    Command::new("cmd")
-        .args(["/C", "start", ""])
-        .arg(path)
-        .spawn()?;
-    Ok(())
+    spawn_viewer("cmd", &["/C", "start", ""], path)
 }
 
 #[cfg(not(any(
@@ -80,15 +77,9 @@ fn open_with_default_viewer(_path: &Path) -> Result<(), ViewerError> {
 #[cfg(target_os = "macos")]
 fn open_with_default_browser(path: &Path) -> Result<(), ViewerError> {
     if let Some(bundle_id) = default_web_browser_bundle_id() {
-        Command::new("open")
-            .arg("-b")
-            .arg(bundle_id)
-            .arg(path)
-            .spawn()?;
-    } else {
-        Command::new("open").arg(path).spawn()?;
+        return spawn_viewer("open", &["-b", &bundle_id], path);
     }
-    Ok(())
+    spawn_viewer("open", &[], path)
 }
 
 #[cfg(target_os = "macos")]
@@ -149,12 +140,11 @@ fn handler_bundle_id(handler: &serde_json::Value) -> Option<String> {
 
 #[cfg(target_os = "macos")]
 fn open_with_browser(path: &Path, browser: &str) -> Result<(), ViewerError> {
-    Command::new("open")
-        .arg("-a")
-        .arg(macos_browser_application_name(browser))
-        .arg(path)
-        .spawn()?;
-    Ok(())
+    spawn_viewer(
+        "open",
+        &["-a", macos_browser_application_name(browser)],
+        path,
+    )
 }
 
 #[cfg(any(target_os = "freebsd", target_os = "linux"))]
@@ -164,11 +154,7 @@ fn open_with_browser(path: &Path, browser: &str) -> Result<(), ViewerError> {
 
 #[cfg(target_os = "windows")]
 fn open_with_browser(path: &Path, browser: &str) -> Result<(), ViewerError> {
-    Command::new("cmd")
-        .args(["/C", "start", "", browser])
-        .arg(path)
-        .spawn()?;
-    Ok(())
+    spawn_viewer("cmd", &["/C", "start", "", browser], path)
 }
 
 #[cfg(not(any(
@@ -236,6 +222,11 @@ fn open_with_browser_candidates(
         browser: browser.to_string(),
         candidates: candidates.join(", "),
     })
+}
+
+fn spawn_viewer(program: &str, args: &[&str], path: &Path) -> Result<(), ViewerError> {
+    Command::new(program).args(args).arg(path).spawn()?;
+    Ok(())
 }
 
 pub struct DotExporter<G = SystemGraphvizRunner, V = SystemViewerLauncher> {


### PR DESCRIPTION
## Problem
Native opener code duplicated command spawning across platform-specific branches, which made small cross-platform changes harder to review.

## Background
This came from triaging rust-analyzer inactive-code hints around platform-specific opener paths.

## Approach
Keep behavior unchanged while moving repeated command spawning into shared helpers for ER diagram viewer and folder launch paths.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * フォルダを開く処理とER図/ファイル表示の起動処理を共通化し、プラットフォーム毎の呼び出しを統一しました。
  * macOS/Linux/Windows の既定／指定ビューア起動を共通化して起動フローを簡潔化しました。
* **Tests**
  * 指定ブラウザ引数のトリムと空文字除外を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->