### PR TITLE
fix: fill horizontal viewport slack in Result pane and Inspector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,12 @@ members = [
     "src/infra",
     "src/ui",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 version = "1.12.3"
 edition = "2024"
+rust-version = "1.96"
 license = "MIT"
 repository = "https://github.com/riii111/sabiql"
 
@@ -50,6 +51,7 @@ uuid = { version = "1", features = ["v4"] }
 name = "sabiql"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "A fast, driver-less TUI for browsing and editing PostgreSQL databases"
 license.workspace = true
 repository.workspace = true
@@ -84,11 +86,14 @@ insta.workspace = true
 mockall.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 
+[lints]
+workspace = true
+
 [profile.release]
 lto = true
 codegen-units = 1
 
-[lints.clippy]
+[workspace.lints.clippy]
 # Groups
 all = { level = "deny", priority = -1 }
 pedantic = { level = "warn", priority = -1 }

--- a/src/app/Cargo.toml
+++ b/src/app/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sabiql-app"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Application layer for sabiql"
 license.workspace = true
 repository.workspace = true
@@ -37,3 +38,6 @@ mockall.workspace = true
 rstest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -3,6 +3,10 @@ use unicode_width::UnicodeWidthStr;
 use crate::model::app_state::AppState;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::help::{HelpOrigin, JsonbHelpMode, SqlHelpMode};
+#[allow(
+    clippy::wildcard_imports,
+    reason = "help catalog enumerates nearly every keybindings table; explicit list is churn"
+)]
 use crate::update::input::keybindings::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/app/model/shared/settings.rs
+++ b/src/app/model/shared/settings.rs
@@ -84,7 +84,7 @@ impl ErBrowserChoice {
         match browser
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .map(|value| value.to_ascii_lowercase())
+            .map(str::to_ascii_lowercase)
             .as_deref()
         {
             None => Self::SystemDefault,

--- a/src/app/model/shared/theme_id.rs
+++ b/src/app/model/shared/theme_id.rs
@@ -30,6 +30,7 @@ impl ThemeId {
         }
     }
 
+    #[must_use]
     pub fn next(self) -> Self {
         let index = Self::ALL
             .iter()
@@ -38,6 +39,7 @@ impl ThemeId {
         Self::ALL[(index + 1).min(Self::ALL.len() - 1)]
     }
 
+    #[must_use]
     pub fn previous(self) -> Self {
         let index = Self::ALL
             .iter()

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -667,10 +667,7 @@ mod tests {
             assert_eq!(
                 max + viewport,
                 total_lines,
-                "max_scroll({}) + viewport({}) != total_lines({})",
-                max,
-                viewport,
-                total_lines
+                "max_scroll({max}) + viewport({viewport}) != total_lines({total_lines})"
             );
         }
 

--- a/src/app/model/shared/viewport.rs
+++ b/src/app/model/shared/viewport.rs
@@ -305,7 +305,7 @@ impl ViewportPlan {
     pub fn calculate(ideal_widths: &[u16], min_widths: &[u16], available_width: u16) -> Self {
         let column_count =
             calculate_viewport_column_count(ideal_widths, min_widths, available_width);
-        let max_offset = calculate_max_offset(ideal_widths.len(), column_count);
+        let max_offset = calculate_max_offset(ideal_widths, column_count, available_width);
         let min_widths_sum = min_widths.iter().sum();
         let ideal_widths_sum = ideal_widths.iter().sum();
         let ideal_widths_max = ideal_widths.iter().copied().max().unwrap_or(0);
@@ -338,8 +338,19 @@ impl ViewportPlan {
     }
 }
 
-pub fn calculate_max_offset(all_widths_len: usize, viewport_column_count: usize) -> usize {
-    all_widths_len.saturating_sub(viewport_column_count)
+// Scrolling stops at the first offset where every remaining column fits at its
+// ideal width — going further would only reveal blank space. When even the
+// suffix of guaranteed columns overflows (min-width fallback), keep the
+// count-based bound so the last column stays reachable.
+pub fn calculate_max_offset(
+    ideal_widths: &[u16],
+    viewport_column_count: usize,
+    available_width: u16,
+) -> usize {
+    let count_based = ideal_widths.len().saturating_sub(viewport_column_count);
+    (0..=count_based)
+        .find(|&offset| total_width_with_separators(&ideal_widths[offset..]) <= available_width)
+        .unwrap_or(count_based)
 }
 
 pub fn calculate_next_column_offset(current_offset: usize, max_offset: usize) -> usize {
@@ -439,7 +450,7 @@ mod tests {
             let available = 80;
 
             let count = calculate_viewport_column_count(&ideal, &min, available);
-            let max_offset = calculate_max_offset(5, count);
+            let max_offset = calculate_max_offset(&ideal, count, available);
 
             // 30+30+1sep = 61 <= 80 → 2 columns fit
             assert_eq!(count, 2);
@@ -524,7 +535,6 @@ mod tests {
                 min_widths_sum: 50,
                 ideal_widths_sum: 150,
                 ideal_widths_max: 30,
-                ..Default::default()
             }
         }
 
@@ -730,18 +740,36 @@ mod tests {
         use super::*;
 
         #[test]
-        fn basic() {
-            assert_eq!(calculate_max_offset(5, 3), 2);
+        fn ends_where_remaining_columns_fit() {
+            let ideal = vec![10, 10, 10, 10, 10];
+            // suffix from 2: 10+10+10 + 2 sep = 32 <= 32
+            assert_eq!(calculate_max_offset(&ideal, 2, 32), 2);
         }
 
         #[test]
-        fn all_fit() {
-            assert_eq!(calculate_max_offset(3, 3), 0);
+        fn zero_when_all_fit() {
+            let ideal = vec![10, 10, 10];
+            assert_eq!(calculate_max_offset(&ideal, 3, 100), 0);
         }
 
         #[test]
         fn more_viewport_than_columns() {
-            assert_eq!(calculate_max_offset(2, 5), 0);
+            let ideal = vec![10, 10];
+            assert_eq!(calculate_max_offset(&ideal, 5, 100), 0);
+        }
+
+        #[test]
+        fn stops_before_count_bound_when_tail_is_narrow() {
+            let ideal = vec![30, 30, 10, 10, 10];
+            // count 1 → count-based bound 4, but suffix from 2 (32) fits in 60
+            assert_eq!(calculate_max_offset(&ideal, 1, 60), 2);
+        }
+
+        #[test]
+        fn caps_at_count_bound_when_suffix_never_fits() {
+            // Last column alone exceeds the viewport (min-width fallback case)
+            let ideal = vec![10, 200];
+            assert_eq!(calculate_max_offset(&ideal, 1, 80), 1);
         }
     }
 
@@ -855,7 +883,7 @@ mod tests {
             let available = 50;
 
             let count = calculate_viewport_column_count(&ideal, &min, available);
-            let max_offset = calculate_max_offset(ideal.len(), count);
+            let max_offset = calculate_max_offset(&ideal, count, available);
 
             for offset in 0..=max_offset {
                 let cfg = config(&ideal, &min);

--- a/src/app/model/shared/viewport.rs
+++ b/src/app/model/shared/viewport.rs
@@ -204,7 +204,6 @@ fn select_fixed_columns(
 
     let mut widths: Vec<u16> = indices.iter().map(|&i| config.ideal_widths[i]).collect();
 
-    // Add bonus columns when scrolling is needed (max_offset > 0)
     if ctx.max_offset > 0 {
         while try_add_bonus_column(config, &mut indices, &mut widths, ctx.available_width) {}
         try_add_partial_column(config, &mut indices, &mut widths, ctx.available_width);
@@ -290,31 +289,17 @@ fn select_dynamic_columns(
     (indices, widths)
 }
 
-// Uses ideal_widths primarily so scrolling is enabled when content exceeds viewport,
-// even if headers (min_widths) would fit.
-pub fn calculate_viewport_column_count(
-    ideal_widths: &[u16],
-    min_widths: &[u16],
-    available_width: u16,
-) -> usize {
+// Uses ideal widths so scrolling is enabled when content exceeds the viewport.
+// A single column always counts as fitting (it renders truncated); squeezing
+// every column to its header width instead would disable scrolling entirely.
+pub fn calculate_viewport_column_count(ideal_widths: &[u16], available_width: u16) -> usize {
     if ideal_widths.is_empty() {
         return 0;
     }
 
-    for n in (1..=ideal_widths.len()).rev() {
+    for n in (2..=ideal_widths.len()).rev() {
         let all_windows_fit = (0..=ideal_widths.len() - n).all(|start| {
             let window = &ideal_widths[start..start + n];
-            total_width_with_separators(window) <= available_width
-        });
-        if all_windows_fit {
-            return n;
-        }
-    }
-
-    // When ideal widths are too wide, fall back to min_widths to show something
-    for n in (1..=min_widths.len()).rev() {
-        let all_windows_fit = (0..=min_widths.len() - n).all(|start| {
-            let window = &min_widths[start..start + n];
             total_width_with_separators(window) <= available_width
         });
         if all_windows_fit {
@@ -338,8 +323,7 @@ pub struct ViewportPlan {
 
 impl ViewportPlan {
     pub fn calculate(ideal_widths: &[u16], min_widths: &[u16], available_width: u16) -> Self {
-        let column_count =
-            calculate_viewport_column_count(ideal_widths, min_widths, available_width);
+        let column_count = calculate_viewport_column_count(ideal_widths, available_width);
         let max_offset = calculate_max_offset(ideal_widths, column_count, available_width);
         let min_widths_sum = min_widths.iter().sum();
         let ideal_widths_sum = ideal_widths.iter().sum();
@@ -374,9 +358,9 @@ impl ViewportPlan {
 }
 
 // Scrolling stops at the first offset where every remaining column fits at its
-// ideal width — going further would only reveal blank space. When even the
-// suffix of guaranteed columns overflows (min-width fallback), keep the
-// count-based bound so the last column stays reachable.
+// ideal width — going further would only reveal blank space. When no suffix
+// fits (an over-wide column near the end), keep the count-based bound so the
+// last column stays reachable.
 pub fn calculate_max_offset(
     ideal_widths: &[u16],
     viewport_column_count: usize,
@@ -470,21 +454,19 @@ mod tests {
         use super::*;
 
         #[test]
-        fn uses_ideal_widths_primarily() {
+        fn uses_ideal_widths() {
             let ideal = vec![15, 15, 15, 15];
-            let min = vec![10, 10, 10, 10];
             // 3 ideal cols + 2 sep = 47 <= 50
-            let count = calculate_viewport_column_count(&ideal, &min, 50);
+            let count = calculate_viewport_column_count(&ideal, 50);
             assert_eq!(count, 3);
         }
 
         #[test]
         fn scroll_enabled_when_ideal_exceeds_available() {
             let ideal = vec![30, 30, 30, 30, 30];
-            let min = vec![10, 10, 10, 10, 10];
             let available = 80;
 
-            let count = calculate_viewport_column_count(&ideal, &min, available);
+            let count = calculate_viewport_column_count(&ideal, available);
             let max_offset = calculate_max_offset(&ideal, count, available);
 
             // 30+30+1sep = 61 <= 80 → 2 columns fit
@@ -493,23 +475,25 @@ mod tests {
         }
 
         #[test]
-        fn falls_back_to_min_when_ideal_too_wide() {
+        fn over_wide_columns_keep_scrolling_enabled() {
             let ideal = vec![100, 100, 100];
-            let min = vec![10, 10, 10];
             let available = 50;
 
-            // Ideal: no fit, Min: 3 cols + 2 sep = 32 <= 50
-            let count = calculate_viewport_column_count(&ideal, &min, available);
-            assert_eq!(count, 3);
+            // Each column exceeds the viewport: show one at a time (truncated)
+            // instead of squeezing all to header width with no scrolling
+            let count = calculate_viewport_column_count(&ideal, available);
+            let max_offset = calculate_max_offset(&ideal, count, available);
+
+            assert_eq!(count, 1);
+            assert_eq!(max_offset, 2);
         }
 
         #[test]
         fn handles_varying_widths() {
             let ideal = vec![6, 6, 25, 6, 6];
-            let min = vec![6, 6, 25, 6, 6];
             let available = 40;
 
-            let count = calculate_viewport_column_count(&ideal, &min, available);
+            let count = calculate_viewport_column_count(&ideal, available);
 
             // Window [1,2,3] = 6 + 25 + 6 + 2 sep = 39 <= 40 OK
             assert_eq!(count, 3);
@@ -518,10 +502,9 @@ mod tests {
         #[test]
         fn reduces_count_when_long_column_in_middle() {
             let ideal = vec![10, 10, 50, 10, 10];
-            let min = vec![10, 10, 50, 10, 10];
             let available = 60;
 
-            let count = calculate_viewport_column_count(&ideal, &min, available);
+            let count = calculate_viewport_column_count(&ideal, available);
 
             // Window [1,2] = 10 + 50 + 1 sep = 61 > 60, so n=2 fails
             assert_eq!(count, 1);
@@ -530,14 +513,13 @@ mod tests {
         #[test]
         fn at_least_one_column() {
             let ideal = vec![100, 100];
-            let min = vec![100, 100];
-            let count = calculate_viewport_column_count(&ideal, &min, 50);
+            let count = calculate_viewport_column_count(&ideal, 50);
             assert_eq!(count, 1);
         }
 
         #[test]
         fn empty_input_returns_zero() {
-            let count = calculate_viewport_column_count(&[], &[], 100);
+            let count = calculate_viewport_column_count(&[], 100);
             assert_eq!(count, 0);
         }
     }
@@ -802,7 +784,7 @@ mod tests {
 
         #[test]
         fn caps_at_count_bound_when_suffix_never_fits() {
-            // Last column alone exceeds the viewport (min-width fallback case)
+            // Last column alone exceeds the viewport
             let ideal = vec![10, 200];
             assert_eq!(calculate_max_offset(&ideal, 1, 80), 1);
         }
@@ -928,7 +910,7 @@ mod tests {
             let min = vec![8, 8, 20, 8, 8];
             let available = 50;
 
-            let count = calculate_viewport_column_count(&ideal, &min, available);
+            let count = calculate_viewport_column_count(&ideal, available);
             let max_offset = calculate_max_offset(&ideal, count, available);
 
             for offset in 0..=max_offset {

--- a/src/app/model/shared/viewport.rs
+++ b/src/app/model/shared/viewport.rs
@@ -310,50 +310,43 @@ pub fn calculate_viewport_column_count(ideal_widths: &[u16], available_width: u1
     1
 }
 
+// Order-sensitive: max_offset depends on suffix widths, so reordered columns
+// must produce a different fingerprint even when len/sum/max are unchanged.
+pub fn widths_fingerprint(ideal_widths: &[u16], min_widths: &[u16]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    ideal_widths.hash(&mut hasher);
+    min_widths.hash(&mut hasher);
+    hasher.finish()
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ViewportPlan {
     pub column_count: usize,
     pub max_offset: usize,
     pub total_columns: usize,
     pub available_width: u16,
-    pub min_widths_sum: u16,
-    pub ideal_widths_sum: u16,
-    pub ideal_widths_max: u16,
+    pub widths_fingerprint: u64,
 }
 
 impl ViewportPlan {
     pub fn calculate(ideal_widths: &[u16], min_widths: &[u16], available_width: u16) -> Self {
         let column_count = calculate_viewport_column_count(ideal_widths, available_width);
         let max_offset = calculate_max_offset(ideal_widths, column_count, available_width);
-        let min_widths_sum = min_widths.iter().sum();
-        let ideal_widths_sum = ideal_widths.iter().sum();
-        let ideal_widths_max = ideal_widths.iter().copied().max().unwrap_or(0);
 
         Self {
             column_count,
             max_offset,
             total_columns: ideal_widths.len(),
             available_width,
-            min_widths_sum,
-            ideal_widths_sum,
-            ideal_widths_max,
+            widths_fingerprint: widths_fingerprint(ideal_widths, min_widths),
         }
     }
 
-    pub fn needs_recalculation(
-        &self,
-        new_widths_len: usize,
-        new_available_width: u16,
-        new_min_widths_sum: u16,
-        new_ideal_widths_sum: u16,
-        new_ideal_widths_max: u16,
-    ) -> bool {
+    pub fn needs_recalculation(&self, new_available_width: u16, new_fingerprint: u64) -> bool {
         self.column_count == 0
             || self.available_width != new_available_width
-            || self.total_columns != new_widths_len
-            || self.min_widths_sum != new_min_widths_sum
-            || self.ideal_widths_sum != new_ideal_widths_sum
-            || self.ideal_widths_max != new_ideal_widths_max
+            || self.widths_fingerprint != new_fingerprint
     }
 }
 
@@ -526,7 +519,6 @@ mod tests {
 
     mod viewport_plan {
         use super::*;
-        use rstest::rstest;
 
         #[test]
         fn calculate_returns_valid_plan() {
@@ -537,90 +529,58 @@ mod tests {
 
             assert_eq!(plan.column_count, 2);
             assert_eq!(plan.max_offset, 3);
+            assert_eq!(plan.total_columns, 5);
             assert_eq!(plan.available_width, 80);
-            assert_eq!(plan.min_widths_sum, 50);
-            assert_eq!(plan.ideal_widths_sum, 150);
-            assert_eq!(plan.ideal_widths_max, 30);
+            assert_eq!(plan.widths_fingerprint, widths_fingerprint(&ideal, &min));
         }
 
-        fn make_plan() -> ViewportPlan {
-            ViewportPlan {
-                column_count: 2,
-                max_offset: 3,
-                total_columns: 5,
-                available_width: 80,
-                min_widths_sum: 50,
-                ideal_widths_sum: 150,
-                ideal_widths_max: 30,
-            }
+        #[test]
+        fn same_widths_skip_recalculation() {
+            let ideal = vec![10, 20, 30, 40, 50];
+            let min = vec![5, 5, 5, 5, 5];
+            let plan = ViewportPlan::calculate(&ideal, &min, 80);
+
+            assert!(!plan.needs_recalculation(80, widths_fingerprint(&ideal, &min)));
         }
 
-        #[rstest]
-        #[case(5, 100, 50, 150, 30, true)] // width changes
-        #[case(5, 80, 50, 150, 30, false)] // no change
-        #[case(10, 80, 50, 150, 30, true)] // widths_len changes
-        #[case(5, 80, 60, 150, 30, true)] // min_widths_sum changes
-        #[case(5, 80, 50, 200, 30, true)] // ideal_widths_sum changes
-        #[case(5, 80, 50, 150, 50, true)] // ideal_widths_max changes
-        fn recalculates_when_inputs_change(
-            #[case] len: usize,
-            #[case] width: u16,
-            #[case] min_sum: u16,
-            #[case] ideal_sum: u16,
-            #[case] ideal_max: u16,
-            #[case] expected: bool,
-        ) {
-            let plan = make_plan();
+        #[test]
+        fn recalculates_when_available_width_changes() {
+            let ideal = vec![10, 20, 30];
+            let min = vec![5, 5, 5];
+            let plan = ViewportPlan::calculate(&ideal, &min, 80);
 
-            let result = plan.needs_recalculation(len, width, min_sum, ideal_sum, ideal_max);
+            assert!(plan.needs_recalculation(100, widths_fingerprint(&ideal, &min)));
+        }
 
-            assert_eq!(result, expected);
+        #[test]
+        fn recalculates_when_a_width_changes() {
+            let ideal = vec![10, 20, 30, 40, 50];
+            let min = vec![5, 5, 5, 5, 5];
+            let plan = ViewportPlan::calculate(&ideal, &min, 80);
+
+            let changed = vec![10, 20, 30, 40, 60];
+
+            assert!(plan.needs_recalculation(80, widths_fingerprint(&changed, &min)));
+        }
+
+        #[test]
+        fn reordered_widths_trigger_recalculation() {
+            // max_offset depends on suffix widths, so a stale plan would point
+            // at the wrong scroll range even though len/sum/max are unchanged
+            let ideal = vec![10, 20, 30, 40, 50];
+            let min = vec![5, 5, 5, 5, 5];
+            let plan = ViewportPlan::calculate(&ideal, &min, 80);
+
+            let reordered = vec![50, 40, 30, 20, 10];
+
+            assert!(plan.needs_recalculation(80, widths_fingerprint(&reordered, &min)));
         }
 
         #[test]
         fn default_plan_needs_recalculation() {
             let plan = ViewportPlan::default();
 
-            let result = plan.needs_recalculation(5, 80, 50, 150, 30);
-
-            assert!(result);
-        }
-
-        #[test]
-        fn different_max_triggers_recalculation() {
-            // Scenario: Data in a column changed width
-            // Original: [10, 20, 30, 40, 50] sum=150, max=50
-            // Changed:  [10, 20, 30, 40, 60] sum=160, max=60
-            let original_ideal = vec![10, 20, 30, 40, 50];
-            let original_min = vec![5, 5, 5, 5, 5];
-            let plan = ViewportPlan::calculate(&original_ideal, &original_min, 80);
-
-            let changed = [10, 20, 30, 40, 60];
-            let sum: u16 = changed.iter().sum();
-            let max: u16 = changed.iter().copied().max().unwrap();
-
-            let result = plan.needs_recalculation(5, 80, 25, sum, max);
-
-            assert!(result);
-        }
-
-        #[test]
-        fn same_sum_and_max_skips_recalculation() {
-            // Edge case: reordering doesn't change sum or max
-            // Original: [10, 20, 30, 40, 50] sum=150, max=50
-            // Changed:  [50, 40, 30, 20, 10] sum=150, max=50
-            let original_ideal = vec![10, 20, 30, 40, 50];
-            let original_min = vec![5, 5, 5, 5, 5];
-            let plan = ViewportPlan::calculate(&original_ideal, &original_min, 80);
-
-            let reordered = [50, 40, 30, 20, 10];
-            let sum: u16 = reordered.iter().sum();
-            let max: u16 = reordered.iter().copied().max().unwrap();
-
-            let result = plan.needs_recalculation(5, 80, 25, sum, max);
-
-            // Known limitation: reordering with same sum+max is not detected
-            assert!(!result);
+            assert!(plan.needs_recalculation(80, widths_fingerprint(&[10], &[4])));
         }
     }
 

--- a/src/app/model/shared/viewport.rs
+++ b/src/app/model/shared/viewport.rs
@@ -376,7 +376,7 @@ pub fn calculate_max_offset(
 }
 
 pub fn calculate_next_column_offset(current_offset: usize, max_offset: usize) -> usize {
-    (current_offset + 1).min(max_offset)
+    current_offset.saturating_add(1).min(max_offset)
 }
 
 pub fn calculate_prev_column_offset(current_offset: usize) -> usize {
@@ -771,6 +771,11 @@ mod tests {
         #[test]
         fn next_clamps_to_max() {
             assert_eq!(calculate_next_column_offset(2, 2), 2);
+        }
+
+        #[test]
+        fn next_saturates_at_usize_max() {
+            assert_eq!(calculate_next_column_offset(usize::MAX, 2), 2);
         }
 
         #[test]

--- a/src/app/model/shared/viewport.rs
+++ b/src/app/model/shared/viewport.rs
@@ -348,6 +348,16 @@ impl ViewportPlan {
             || self.available_width != new_available_width
             || self.widths_fingerprint != new_fingerprint
     }
+
+    pub fn has_horizontal_scroll(&self) -> bool {
+        self.max_offset > 0
+    }
+
+    // Sized from max_offset rather than the displayed column count so the
+    // indicator reaches 100% at the last scroll position
+    pub fn indicator_viewport_size(&self) -> usize {
+        self.total_columns.saturating_sub(self.max_offset)
+    }
 }
 
 // Scrolling stops at the first offset where every remaining column fits at its

--- a/src/app/model/shared/viewport.rs
+++ b/src/app/model/shared/viewport.rs
@@ -1230,15 +1230,15 @@ mod tests {
         }
 
         #[test]
-        fn no_bonus_at_last_column() {
+        fn no_append_past_last_column_when_not_at_right_edge() {
             let ideal = vec![10, 10, 10];
             let min = vec![4, 4, 4];
             let cfg = config(&ideal, &min);
 
-            // At offset 1 (not right edge), showing cols [1, 2], no col 3 exists
+            // Showing cols [1, 2]; nothing exists after col 2 to append
             let (indices, _) = select_viewport_columns(&cfg, &ctx(1, 50, Some(2), 2));
 
-            assert_eq!(indices.len(), 2, "No bonus when no more columns exist");
+            assert_eq!(indices.len(), 2);
         }
 
         #[test]

--- a/src/app/model/shared/viewport.rs
+++ b/src/app/model/shared/viewport.rs
@@ -1,13 +1,6 @@
 pub const MIN_COL_WIDTH: u16 = 4;
 pub const MAX_COL_WIDTH: u16 = 200;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum SlackPolicy {
-    #[default]
-    None,
-    RightmostLimited,
-}
-
 pub struct ColumnWidthConfig<'a> {
     pub ideal_widths: &'a [u16],
     pub min_widths: &'a [u16],
@@ -18,7 +11,6 @@ pub struct SelectionContext {
     pub available_width: u16,
     pub fixed_count: Option<usize>,
     pub max_offset: usize,
-    pub slack_policy: SlackPolicy,
 }
 
 fn total_width_with_separators(widths: &[u16]) -> u16 {
@@ -82,7 +74,6 @@ fn apply_slack_to_rightmost(widths: &mut [u16], available_width: u16) {
         return;
     }
 
-    // No upper limit: only called when max_offset == 0 (no scroll needed)
     let slack = available_width - current_total;
     if let Some(rightmost) = widths.last_mut() {
         *rightmost += slack;
@@ -119,6 +110,37 @@ fn try_add_bonus_column(
     false
 }
 
+// When the next column's ideal width doesn't fit, show it truncated as long as
+// its header (min width) still fits — leaving the space blank helps no one.
+fn try_add_partial_column(
+    config: &ColumnWidthConfig,
+    indices: &mut Vec<usize>,
+    widths: &mut Vec<u16>,
+    available_width: u16,
+) {
+    let Some(&rightmost_idx) = indices.last() else {
+        return;
+    };
+    let next_idx = rightmost_idx + 1;
+
+    if next_idx >= config.ideal_widths.len() {
+        return;
+    }
+
+    let current_total = total_width_with_separators(widths);
+    let remaining = available_width.saturating_sub(current_total + 1); // +1 for separator
+    let min_w = config
+        .min_widths
+        .get(next_idx)
+        .copied()
+        .unwrap_or(MIN_COL_WIDTH);
+
+    if remaining >= min_w {
+        indices.push(next_idx);
+        widths.push(remaining);
+    }
+}
+
 pub fn select_viewport_columns(
     config: &ColumnWidthConfig,
     ctx: &SelectionContext,
@@ -132,9 +154,7 @@ pub fn select_viewport_columns(
         None => select_dynamic_columns(config, ctx.horizontal_offset, ctx.available_width),
     };
 
-    if ctx.slack_policy == SlackPolicy::RightmostLimited {
-        apply_slack_to_rightmost(&mut widths, ctx.available_width);
-    }
+    apply_slack_to_rightmost(&mut widths, ctx.available_width);
 
     (indices, widths)
 }
@@ -153,9 +173,10 @@ fn select_fixed_columns(
 
     let mut widths: Vec<u16> = indices.iter().map(|&i| config.ideal_widths[i]).collect();
 
-    // Add bonus column when scrolling is needed (max_offset > 0)
+    // Add bonus columns when scrolling is needed (max_offset > 0)
     if ctx.max_offset > 0 {
-        try_add_bonus_column(config, &mut indices, &mut widths, ctx.available_width);
+        while try_add_bonus_column(config, &mut indices, &mut widths, ctx.available_width) {}
+        try_add_partial_column(config, &mut indices, &mut widths, ctx.available_width);
     }
 
     let total_needed = total_width_with_separators(&widths);
@@ -278,7 +299,6 @@ pub struct ViewportPlan {
     pub min_widths_sum: u16,
     pub ideal_widths_sum: u16,
     pub ideal_widths_max: u16,
-    pub slack_policy: SlackPolicy,
 }
 
 impl ViewportPlan {
@@ -289,11 +309,6 @@ impl ViewportPlan {
         let min_widths_sum = min_widths.iter().sum();
         let ideal_widths_sum = ideal_widths.iter().sum();
         let ideal_widths_max = ideal_widths.iter().copied().max().unwrap_or(0);
-        let slack_policy = if max_offset == 0 {
-            SlackPolicy::RightmostLimited
-        } else {
-            SlackPolicy::None
-        };
 
         Self {
             column_count,
@@ -303,7 +318,6 @@ impl ViewportPlan {
             min_widths_sum,
             ideal_widths_sum,
             ideal_widths_max,
-            slack_policy,
         }
     }
 
@@ -383,7 +397,6 @@ mod tests {
             available_width: width,
             fixed_count: fixed,
             max_offset: max,
-            slack_policy: SlackPolicy::None,
         }
     }
 
@@ -588,13 +601,14 @@ mod tests {
         use super::*;
 
         #[test]
-        fn basic_fit() {
+        fn basic_fit_absorbs_remainder_into_rightmost() {
             let ideal = vec![10, 10, 10, 10];
             let min = vec![4, 4, 4, 4];
             let cfg = config(&ideal, &min);
             let (indices, selected) = select_viewport_columns(&cfg, &ctx(0, 35, None, 0));
             assert_eq!(indices, vec![0, 1, 2]);
-            assert_eq!(selected, vec![10, 10, 10]);
+            // 10+10+10 + 2 sep = 32, remainder 3 absorbed by rightmost
+            assert_eq!(selected, vec![10, 10, 13]);
         }
 
         #[test]
@@ -636,10 +650,10 @@ mod tests {
             let min = vec![4, 4, 4, 4];
             let cfg = config(&ideal, &min);
             // max_offset=1, available=100, fixed=3
-            // 3 cols: 32, slack=68, bonus col needs 11 → bonus added
+            // 3 cols: 32, slack=68, bonus col needs 11 → bonus added, remainder absorbed
             let (indices, selected) = select_viewport_columns(&cfg, &ctx(0, 100, Some(3), 1));
             assert_eq!(indices, vec![0, 1, 2, 3]); // 3 fixed + 1 bonus
-            assert_eq!(selected, vec![10, 10, 10, 10]);
+            assert_eq!(selected, vec![10, 10, 10, 67]);
         }
 
         #[test]
@@ -648,10 +662,10 @@ mod tests {
             let min = vec![4, 4, 4, 4];
             let cfg = config(&ideal, &min);
             // max_offset=2, available=100, fixed=2
-            // 2 cols: 21, slack=79, bonus col needs 11 → bonus added
+            // 2 cols: 21, slack=79, bonus col needs 11 → bonus added, remainder absorbed
             let (indices, selected) = select_viewport_columns(&cfg, &ctx(1, 100, Some(2), 2));
             assert_eq!(indices, vec![1, 2, 3]); // 2 fixed + 1 bonus
-            assert_eq!(selected, vec![10, 10, 10]);
+            assert_eq!(selected, vec![10, 10, 78]);
         }
 
         #[test]
@@ -909,28 +923,13 @@ mod tests {
 
             assert_eq!(indices.len(), 1, "Should drop to 1 column");
             assert_eq!(indices[0], 2, "Should keep rightmost column");
-            assert_eq!(widths[0], 30, "Rightmost should have ideal width");
+            // 30 ideal + 5 absorbed slack
+            assert_eq!(widths[0], 35, "Rightmost should fill available width");
         }
     }
 
     mod slack_absorption {
         use super::*;
-
-        fn ctx_with_slack(
-            offset: usize,
-            width: u16,
-            fixed: Option<usize>,
-            max: usize,
-            policy: SlackPolicy,
-        ) -> SelectionContext {
-            SelectionContext {
-                horizontal_offset: offset,
-                available_width: width,
-                fixed_count: fixed,
-                max_offset: max,
-                slack_policy: policy,
-            }
-        }
 
         #[test]
         fn absorbs_slack_when_max_offset_zero() {
@@ -939,29 +938,12 @@ mod tests {
             let cfg = config(&ideal, &min);
 
             // 10+10+10 + 2sep = 32, available = 50, slack = 18
-            let (indices, widths) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(0, 50, Some(3), 0, SlackPolicy::RightmostLimited),
-            );
+            let (indices, widths) = select_viewport_columns(&cfg, &ctx(0, 50, Some(3), 0));
 
             assert_eq!(indices, vec![0, 1, 2]);
             assert_eq!(widths[0], 10);
             assert_eq!(widths[1], 10);
             assert_eq!(widths[2], 28); // 10 + 18 absorbed
-        }
-
-        #[test]
-        fn no_absorption_when_policy_none() {
-            let ideal = vec![10, 10, 10];
-            let min = vec![4, 4, 4];
-            let cfg = config(&ideal, &min);
-
-            let (_, widths) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(0, 50, Some(3), 0, SlackPolicy::None),
-            );
-
-            assert_eq!(widths, vec![10, 10, 10]);
         }
 
         #[test]
@@ -971,54 +953,40 @@ mod tests {
             let cfg = config(&ideal, &min);
 
             // 40+40 + 1sep = 81, available = 120, slack = 39
-            let (_, widths) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(0, 120, Some(2), 0, SlackPolicy::RightmostLimited),
-            );
+            let (_, widths) = select_viewport_columns(&cfg, &ctx(0, 120, Some(2), 0));
 
             assert_eq!(widths[0], 40);
             assert_eq!(widths[1], 79); // 40 + 39 (all slack absorbed)
         }
 
         #[test]
-        fn viewport_plan_sets_policy_based_on_max_offset() {
-            let ideal = vec![10, 10, 10];
-            let min = vec![4, 4, 4];
+        fn absorbs_residual_slack_when_scrolling() {
+            let ideal = vec![10, 10, 10, 20, 10];
+            let min = vec![4, 4, 4, 15, 4];
+            let cfg = config(&ideal, &min);
 
-            // All columns fit → max_offset = 0 → RightmostLimited
-            let plan = ViewportPlan::calculate(&ideal, &min, 100);
-            assert_eq!(plan.max_offset, 0);
-            assert_eq!(plan.slack_policy, SlackPolicy::RightmostLimited);
+            // 3 cols: 32; col 3 gets neither bonus (needs 21 > slack 8)
+            // nor partial (remaining 7 < min 15) → leftover goes to rightmost
+            let (indices, widths) = select_viewport_columns(&cfg, &ctx(0, 40, Some(3), 2));
 
-            // Need scroll → max_offset > 0 → None
-            let plan2 = ViewportPlan::calculate(&ideal, &min, 25);
-            assert!(plan2.max_offset > 0);
-            assert_eq!(plan2.slack_policy, SlackPolicy::None);
+            assert_eq!(indices, vec![0, 1, 2]);
+            assert_eq!(widths, vec![10, 10, 18]);
         }
 
         #[test]
-        fn one_scroll_still_changes_one_column_with_slack_none() {
+        fn one_scroll_still_changes_one_column_with_absorption() {
             let ideal = vec![15, 15, 15, 15, 15];
             let min = vec![8, 8, 8, 8, 8];
             let cfg = config(&ideal, &min);
             let max_offset = 2;
 
-            let (idx0, _) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(0, 60, Some(3), max_offset, SlackPolicy::None),
-            );
-            let (idx1, _) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(1, 60, Some(3), max_offset, SlackPolicy::None),
-            );
-            let (idx2, _) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(2, 60, Some(3), max_offset, SlackPolicy::None),
-            );
+            let (idx0, _) = select_viewport_columns(&cfg, &ctx(0, 60, Some(3), max_offset));
+            let (idx1, _) = select_viewport_columns(&cfg, &ctx(1, 60, Some(3), max_offset));
+            let (idx2, _) = select_viewport_columns(&cfg, &ctx(2, 60, Some(3), max_offset));
 
-            assert_eq!(idx0, vec![0, 1, 2]);
-            assert_eq!(idx1, vec![1, 2, 3]);
-            assert_eq!(idx2, vec![2, 3, 4]);
+            assert_eq!(idx0[0], 0);
+            assert_eq!(idx1[0], 1);
+            assert_eq!(idx2[0], 2);
         }
     }
 
@@ -1043,7 +1011,6 @@ mod tests {
                 available_width,
                 fixed_count: Some(plan.column_count),
                 max_offset: plan.max_offset,
-                slack_policy: plan.slack_policy,
             };
 
             select_viewport_columns(&cfg, &ctx)
@@ -1061,16 +1028,17 @@ mod tests {
             // At right edge (max offset)
             let (indices, widths) = run_full_pipeline(&ideal, &min, available, max_offset);
 
-            // Rightmost column should have its ideal width (40)
+            // Rightmost column should have at least its ideal width (40);
+            // residual slack may widen it further
             let last_idx = indices.len() - 1;
             assert_eq!(
                 indices[last_idx],
                 ideal.len() - 1,
                 "Should include the last column at right edge"
             );
-            assert_eq!(
-                widths[last_idx], ideal[indices[last_idx]],
-                "Rightmost column should have ideal width at right edge"
+            assert!(
+                widths[last_idx] >= ideal[indices[last_idx]],
+                "Rightmost column should not be truncated at right edge"
             );
         }
 
@@ -1129,7 +1097,6 @@ mod tests {
 
             let plan = ViewportPlan::calculate(&ideal, &min, available);
             assert_eq!(plan.max_offset, 0, "Should fit all columns");
-            assert_eq!(plan.slack_policy, SlackPolicy::RightmostLimited);
 
             let (_, widths) = run_full_pipeline(&ideal, &min, available, 0);
 
@@ -1156,8 +1123,8 @@ mod tests {
             for offset in 0..=plan.max_offset {
                 let (indices, widths) = run_full_pipeline(&ideal, &min, available, offset);
 
-                // Column count should be stable
-                assert_eq!(indices.len(), plan.column_count);
+                // At least the guaranteed count; bonus/partial columns may add more
+                assert!(indices.len() >= plan.column_count);
 
                 // Total width should not exceed available
                 let total: u16 =
@@ -1179,59 +1146,32 @@ mod tests {
     mod bonus_column {
         use super::*;
 
-        fn ctx_with_slack(
-            offset: usize,
-            width: u16,
-            fixed: Option<usize>,
-            max: usize,
-            policy: SlackPolicy,
-        ) -> SelectionContext {
-            SelectionContext {
-                horizontal_offset: offset,
-                available_width: width,
-                fixed_count: fixed,
-                max_offset: max,
-                slack_policy: policy,
-            }
-        }
-
         #[test]
-        fn adds_bonus_when_slack_sufficient() {
-            // 3 fixed columns + bonus potential
+        fn adds_bonus_columns_while_they_fit() {
             let ideal = vec![10, 10, 10, 10, 10];
             let min = vec![4, 4, 4, 4, 4];
             let cfg = config(&ideal, &min);
 
-            // Fixed count = 3, max_offset = 2
-            // 3 cols: 10+10+10 + 2 sep = 32
-            // Available: 50, slack: 18
-            // Next col needs: 10 + 1 sep = 11
-            // 18 >= 11, so bonus added
-            let (indices, _) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(0, 50, Some(3), 2, SlackPolicy::None),
-            );
+            // Fixed count = 2 (21), bonus cols 2,3,4 each need 11 → all added
+            let (indices, widths) = select_viewport_columns(&cfg, &ctx(0, 70, Some(2), 3));
 
-            assert_eq!(indices.len(), 4, "Should add 1 bonus column");
-            assert_eq!(indices, vec![0, 1, 2, 3]);
+            assert_eq!(indices, vec![0, 1, 2, 3, 4]);
+            let total = total_width_with_separators(&widths);
+            assert!(total <= 70);
         }
 
         #[test]
-        fn no_bonus_when_slack_insufficient() {
+        fn adds_partial_column_when_ideal_does_not_fit() {
             let ideal = vec![10, 10, 10, 20, 10];
             let min = vec![4, 4, 4, 4, 4];
             let cfg = config(&ideal, &min);
 
-            // 3 cols: 10+10+10 + 2 sep = 32
-            // Available: 40, slack: 8
-            // Next col needs: 20 + 1 sep = 21
-            // 8 < 21, no bonus
-            let (indices, _) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(0, 40, Some(3), 2, SlackPolicy::None),
-            );
+            // 3 cols: 32; col 3 needs 21 > slack 8 → no bonus,
+            // but remaining 7 >= min 4 → shown truncated
+            let (indices, widths) = select_viewport_columns(&cfg, &ctx(0, 40, Some(3), 2));
 
-            assert_eq!(indices.len(), 3, "Should not add bonus column");
+            assert_eq!(indices, vec![0, 1, 2, 3]);
+            assert_eq!(widths, vec![10, 10, 10, 7]);
         }
 
         #[test]
@@ -1241,10 +1181,7 @@ mod tests {
             let cfg = config(&ideal, &min);
 
             // At offset 1, showing cols [1, 2], no col 3 exists
-            let (indices, _) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(1, 50, Some(2), 1, SlackPolicy::None),
-            );
+            let (indices, _) = select_viewport_columns(&cfg, &ctx(1, 50, Some(2), 1));
 
             assert_eq!(indices.len(), 2, "No bonus when no more columns exist");
         }
@@ -1256,11 +1193,7 @@ mod tests {
             let min = vec![4, 4, 4, 4];
             let cfg = config(&ideal, &min);
 
-            // max_offset = 0 means all columns fit, bonus logic should not apply
-            let (indices, _) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(0, 100, Some(3), 0, SlackPolicy::RightmostLimited),
-            );
+            let (indices, _) = select_viewport_columns(&cfg, &ctx(0, 100, Some(3), 0));
 
             // Only 3 columns (fixed count), not 4
             assert_eq!(indices.len(), 3);
@@ -1274,14 +1207,8 @@ mod tests {
             // Fixed count = 3, max_offset = 3
             // With bonus, might show 4 columns
 
-            let (idx0, _) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(0, 70, Some(3), 3, SlackPolicy::None),
-            );
-            let (idx1, _) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(1, 70, Some(3), 3, SlackPolicy::None),
-            );
+            let (idx0, _) = select_viewport_columns(&cfg, &ctx(0, 70, Some(3), 3));
+            let (idx1, _) = select_viewport_columns(&cfg, &ctx(1, 70, Some(3), 3));
 
             // Scroll should still move by 1 (fixed count behavior)
             // idx0 starts at 0, idx1 starts at 1
@@ -1299,10 +1226,7 @@ mod tests {
             // Available: 80, slack: 18
             // Next col needs: 15 + 1 sep = 16
             // 18 >= 16, bonus added
-            let (indices, widths) = select_viewport_columns(
-                &cfg,
-                &ctx_with_slack(0, 80, Some(3), 1, SlackPolicy::None),
-            );
+            let (indices, widths) = select_viewport_columns(&cfg, &ctx(0, 80, Some(3), 1));
 
             assert_eq!(indices.len(), 4);
             let total = total_width_with_separators(&widths);

--- a/src/app/model/shared/viewport.rs
+++ b/src/app/model/shared/viewport.rs
@@ -141,6 +141,37 @@ fn try_add_partial_column(
     }
 }
 
+// At the right edge no next column exists, so leftover width goes to a
+// truncated peek of the previous column instead. By max_offset minimality the
+// previous column never fits fully here, so a single partial prepend suffices.
+fn try_prepend_partial_column(
+    config: &ColumnWidthConfig,
+    indices: &mut Vec<usize>,
+    widths: &mut Vec<u16>,
+    available_width: u16,
+) {
+    let Some(&leftmost_idx) = indices.first() else {
+        return;
+    };
+    if leftmost_idx == 0 {
+        return;
+    }
+    let prev_idx = leftmost_idx - 1;
+
+    let current_total = total_width_with_separators(widths);
+    let remaining = available_width.saturating_sub(current_total + 1); // +1 for separator
+    let min_w = config
+        .min_widths
+        .get(prev_idx)
+        .copied()
+        .unwrap_or(MIN_COL_WIDTH);
+
+    if remaining >= min_w {
+        indices.insert(0, prev_idx);
+        widths.insert(0, remaining.min(config.ideal_widths[prev_idx]));
+    }
+}
+
 pub fn select_viewport_columns(
     config: &ColumnWidthConfig,
     ctx: &SelectionContext,
@@ -209,6 +240,10 @@ fn select_fixed_columns(
                 shrink_columns(&mut widths, config.min_widths, &indices, new_excess, true);
             }
         }
+    }
+
+    if ctx.max_offset > 0 && ctx.horizontal_offset >= ctx.max_offset {
+        try_prepend_partial_column(config, &mut indices, &mut widths, ctx.available_width);
     }
 
     (indices, widths)
@@ -811,17 +846,28 @@ mod tests {
 
             let (idx0, _) = select_viewport_columns(&cfg, &ctx(0, 80, Some(3), max_offset));
             let (idx1, _) = select_viewport_columns(&cfg, &ctx(1, 80, Some(3), max_offset));
-            let (idx2, _) = select_viewport_columns(&cfg, &ctx(2, 80, Some(3), max_offset));
 
             // First column shifts by 1 each scroll
             assert_eq!(idx0[0], 0);
             assert_eq!(idx1[0], 1);
-            assert_eq!(idx2[0], 2);
 
             // At least fixed count columns are shown
             assert!(idx0.len() >= 3);
             assert!(idx1.len() >= 3);
-            assert!(idx2.len() >= 3);
+        }
+
+        #[test]
+        fn right_edge_keeps_anchor_at_full_width_behind_prepended_peek() {
+            let ideal = vec![15, 20, 30, 10, 25];
+            let min = vec![8, 8, 8, 8, 8];
+            let cfg = config(&ideal, &min);
+            let max_offset = 2;
+
+            let (indices, widths) = select_viewport_columns(&cfg, &ctx(2, 80, Some(3), max_offset));
+
+            // Truncated peek of col 1 fills the leftover; anchor col 2 keeps ideal width
+            assert_eq!(indices, vec![1, 2, 3, 4]);
+            assert_eq!(widths, vec![12, 30, 10, 25]);
         }
 
         #[test]
@@ -937,6 +983,37 @@ mod tests {
         }
 
         #[test]
+        fn fills_leftover_with_truncated_previous_column() {
+            let ideal = vec![20, 8, 8];
+            let min = vec![6, 6, 6];
+            let cfg = config(&ideal, &min);
+            let max_offset = 1;
+
+            // Suffix [1, 2] = 17 fits in 25; col 0 (ideal 20) can't fit fully,
+            // so the leftover 7 shows it truncated
+            let (indices, widths) =
+                select_viewport_columns(&cfg, &ctx(max_offset, 25, Some(1), max_offset));
+
+            assert_eq!(indices, vec![0, 1, 2]);
+            assert_eq!(widths, vec![7, 8, 8]);
+        }
+
+        #[test]
+        fn keeps_slack_in_rightmost_when_previous_header_does_not_fit() {
+            let ideal = vec![20, 8, 8];
+            let min = vec![15, 6, 6];
+            let cfg = config(&ideal, &min);
+            let max_offset = 1;
+
+            // Leftover 7 < col 0 min 15 → absorbed by rightmost instead
+            let (indices, widths) =
+                select_viewport_columns(&cfg, &ctx(max_offset, 25, Some(1), max_offset));
+
+            assert_eq!(indices, vec![1, 2]);
+            assert_eq!(widths, vec![8, 16]);
+        }
+
+        #[test]
         fn drops_leftmost_when_shrinking_not_enough() {
             let ideal = vec![30, 30, 30];
             let min = vec![20, 20, 20];
@@ -1010,11 +1087,9 @@ mod tests {
 
             let (idx0, _) = select_viewport_columns(&cfg, &ctx(0, 60, Some(3), max_offset));
             let (idx1, _) = select_viewport_columns(&cfg, &ctx(1, 60, Some(3), max_offset));
-            let (idx2, _) = select_viewport_columns(&cfg, &ctx(2, 60, Some(3), max_offset));
 
             assert_eq!(idx0[0], 0);
             assert_eq!(idx1[0], 1);
-            assert_eq!(idx2[0], 2);
         }
     }
 
@@ -1208,8 +1283,8 @@ mod tests {
             let min = vec![4, 4, 4];
             let cfg = config(&ideal, &min);
 
-            // At offset 1, showing cols [1, 2], no col 3 exists
-            let (indices, _) = select_viewport_columns(&cfg, &ctx(1, 50, Some(2), 1));
+            // At offset 1 (not right edge), showing cols [1, 2], no col 3 exists
+            let (indices, _) = select_viewport_columns(&cfg, &ctx(1, 50, Some(2), 2));
 
             assert_eq!(indices.len(), 2, "No bonus when no more columns exist");
         }

--- a/src/app/model/shared/viewport.rs
+++ b/src/app/model/shared/viewport.rs
@@ -273,6 +273,7 @@ pub fn calculate_viewport_column_count(
 pub struct ViewportPlan {
     pub column_count: usize,
     pub max_offset: usize,
+    pub total_columns: usize,
     pub available_width: u16,
     pub min_widths_sum: u16,
     pub ideal_widths_sum: u16,
@@ -297,6 +298,7 @@ impl ViewportPlan {
         Self {
             column_count,
             max_offset,
+            total_columns: ideal_widths.len(),
             available_width,
             min_widths_sum,
             ideal_widths_sum,
@@ -315,7 +317,7 @@ impl ViewportPlan {
     ) -> bool {
         self.column_count == 0
             || self.available_width != new_available_width
-            || self.max_offset + self.column_count != new_widths_len
+            || self.total_columns != new_widths_len
             || self.min_widths_sum != new_min_widths_sum
             || self.ideal_widths_sum != new_ideal_widths_sum
             || self.ideal_widths_max != new_ideal_widths_max
@@ -326,12 +328,7 @@ pub fn calculate_max_offset(all_widths_len: usize, viewport_column_count: usize)
     all_widths_len.saturating_sub(viewport_column_count)
 }
 
-pub fn calculate_next_column_offset(
-    all_widths_len: usize,
-    current_offset: usize,
-    viewport_column_count: usize,
-) -> usize {
-    let max_offset = calculate_max_offset(all_widths_len, viewport_column_count);
+pub fn calculate_next_column_offset(current_offset: usize, max_offset: usize) -> usize {
     (current_offset + 1).min(max_offset)
 }
 
@@ -509,6 +506,7 @@ mod tests {
             ViewportPlan {
                 column_count: 2,
                 max_offset: 3,
+                total_columns: 5,
                 available_width: 80,
                 min_widths_sum: 50,
                 ideal_widths_sum: 150,
@@ -738,12 +736,12 @@ mod tests {
 
         #[test]
         fn next_increments() {
-            assert_eq!(calculate_next_column_offset(5, 1, 3), 2);
+            assert_eq!(calculate_next_column_offset(1, 2), 2);
         }
 
         #[test]
         fn next_clamps_to_max() {
-            assert_eq!(calculate_next_column_offset(5, 2, 3), 2);
+            assert_eq!(calculate_next_column_offset(2, 2), 2);
         }
 
         #[test]

--- a/src/app/model/shared/viewport.rs
+++ b/src/app/model/shared/viewport.rs
@@ -215,7 +215,7 @@ fn select_fixed_columns(
         let excess = total_needed - ctx.available_width;
         let at_right_edge = ctx.horizontal_offset >= ctx.max_offset && ctx.max_offset > 0;
 
-        let remaining = shrink_columns(
+        let mut remaining = shrink_columns(
             &mut widths,
             config.min_widths,
             &indices,
@@ -223,20 +223,31 @@ fn select_fixed_columns(
             at_right_edge,
         );
 
-        if at_right_edge && remaining > 0 && indices.len() > 1 {
-            indices.remove(0);
-            widths.remove(0);
+        if at_right_edge {
+            while remaining > 0 && indices.len() > 1 {
+                indices.remove(0);
+                widths.remove(0);
 
-            if let Some(last_idx) = indices.last()
-                && let Some(last_w) = widths.last_mut()
-            {
-                *last_w = config.ideal_widths[*last_idx];
+                if let Some(last_idx) = indices.last()
+                    && let Some(last_w) = widths.last_mut()
+                {
+                    *last_w = config.ideal_widths[*last_idx];
+                }
+
+                let new_total = total_width_with_separators(&widths);
+                remaining = new_total.saturating_sub(ctx.available_width);
+                if remaining > 0 {
+                    remaining =
+                        shrink_columns(&mut widths, config.min_widths, &indices, remaining, true);
+                }
             }
 
-            let new_total = total_width_with_separators(&widths);
-            if new_total > ctx.available_width {
-                let new_excess = new_total - ctx.available_width;
-                shrink_columns(&mut widths, config.min_widths, &indices, new_excess, true);
+            // Pane narrower than the last header itself: clamp so the cell
+            // truncates with an ellipsis instead of overflowing the pane
+            if remaining > 0
+                && let Some(last_w) = widths.last_mut()
+            {
+                *last_w = ctx.available_width;
             }
         }
     }
@@ -968,6 +979,37 @@ mod tests {
 
             assert_eq!(indices, vec![1, 2]);
             assert_eq!(widths, vec![8, 16]);
+        }
+
+        #[test]
+        fn single_column_clamps_to_available_when_header_overflows() {
+            let ideal = vec![30, 30];
+            let min = vec![20, 20];
+            let cfg = config(&ideal, &min);
+            let max_offset = 1;
+
+            // Pane narrower than the column's header min width (20 > 15)
+            let (indices, widths) =
+                select_viewport_columns(&cfg, &ctx(max_offset, 15, Some(1), max_offset));
+
+            assert_eq!(indices, vec![1]);
+            assert_eq!(widths, vec![15]);
+        }
+
+        #[test]
+        fn drops_columns_until_remaining_fits_then_clamps() {
+            let ideal = vec![30, 30, 30];
+            let min = vec![20, 20, 20];
+            let cfg = config(&ideal, &min);
+            let max_offset = 1;
+
+            // [1, 2] exceeds 15 even at min widths; col 1 is dropped and the
+            // surviving col 2 still overflows → clamped to the pane
+            let (indices, widths) =
+                select_viewport_columns(&cfg, &ctx(max_offset, 15, Some(2), max_offset));
+
+            assert_eq!(indices, vec![2]);
+            assert_eq!(widths, vec![15]);
         }
 
         #[test]

--- a/src/app/policy/password_masking.rs
+++ b/src/app/policy/password_masking.rs
@@ -1,4 +1,4 @@
-pub(crate) fn mask_password(text: &str) -> String {
+pub fn mask_password(text: &str) -> String {
     let result = mask_url_passwords(text);
     let result = mask_kv_passwords(&result);
     mask_env_passwords(&result)
@@ -99,14 +99,14 @@ fn password_assignment_prefix_len(text: &str, pos: usize) -> Option<usize> {
 
     let bytes = text.as_bytes();
     let mut i = pos + key.len();
-    while bytes.get(i).is_some_and(|byte| byte.is_ascii_whitespace()) {
+    while bytes.get(i).is_some_and(u8::is_ascii_whitespace) {
         i += 1;
     }
     if bytes.get(i) != Some(&b'=') {
         return None;
     }
     i += 1;
-    while bytes.get(i).is_some_and(|byte| byte.is_ascii_whitespace()) {
+    while bytes.get(i).is_some_and(u8::is_ascii_whitespace) {
         i += 1;
     }
 

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -434,7 +434,7 @@ mod tests {
             state.sql_modal.failed_prefetch_tables.insert(
                 qualified.clone(),
                 FailedPrefetchEntry {
-                    failed_at: Instant::now().checked_sub(Duration::from_secs(60)).unwrap(),
+                    failed_at: Instant::now().checked_sub(Duration::from_mins(1)).unwrap(),
                     error: "old error".to_string(),
                     retry_count: 1,
                 },

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -31,7 +31,7 @@ pub(super) fn reduce_prefetch(
                 let qualified_names: Vec<String> = metadata
                     .table_summaries
                     .iter()
-                    .map(|table| table.qualified_name())
+                    .map(crate::domain::TableSummary::qualified_name)
                     .collect();
                 state
                     .er_preparation

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -81,12 +81,9 @@ pub fn reduce_inspector(
             direction: ScrollDirection::Right,
             amount: ScrollAmount::Line,
         } => {
-            let plan = &state.ui.inspector_viewport_plan;
-            let all_widths_len = plan.max_offset + plan.column_count;
             state.ui.inspector_horizontal_offset = calculate_next_column_offset(
-                all_widths_len,
                 state.ui.inspector_horizontal_offset,
-                plan.column_count,
+                state.ui.inspector_viewport_plan.max_offset,
             );
             DispatchResult::handled()
         }

--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -241,12 +241,9 @@ pub fn reduce_scroll(state: &mut AppState, action: &Action) -> DispatchResult {
             direction: ScrollDirection::Right,
             amount: ScrollAmount::Line,
         } => {
-            let plan = &state.ui.result_viewport_plan;
-            let all_widths_len = plan.max_offset + plan.column_count;
             state.result_interaction.horizontal_offset = calculate_next_column_offset(
-                all_widths_len,
                 state.result_interaction.horizontal_offset,
-                plan.column_count,
+                state.ui.result_viewport_plan.max_offset,
             );
             DispatchResult::handled()
         }

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -15,8 +15,11 @@ fn ensure_cell_visible(state: &mut AppState) {
         if col < h_offset {
             state.result_interaction.horizontal_offset = col;
         } else if col >= h_offset + plan.column_count {
-            state.result_interaction.horizontal_offset =
-                col.saturating_sub(plan.column_count.saturating_sub(1));
+            // At max_offset every remaining column is visible, so clamping
+            // never hides the active cell
+            state.result_interaction.horizontal_offset = col
+                .saturating_sub(plan.column_count.saturating_sub(1))
+                .min(plan.max_offset);
         }
     }
 }

--- a/src/app/update/dispatch_result.rs
+++ b/src/app/update/dispatch_result.rs
@@ -32,6 +32,7 @@ impl DispatchResult {
         }
     }
 
+    #[must_use]
     pub fn or_else<F>(self, f: F) -> Self
     where
         F: FnOnce() -> Self,

--- a/src/app/update/input/handlers/pickers.rs
+++ b/src/app/update/input/handlers/pickers.rs
@@ -140,7 +140,7 @@ mod tests {
 
             match expected {
                 Expected::Close => {
-                    assert!(matches!(result, Action::CloseModal(ModalKind::TablePicker)))
+                    assert!(matches!(result, Action::CloseModal(ModalKind::TablePicker)));
                 }
                 Expected::Confirm => assert!(matches!(result, Action::ConfirmSelection)),
                 Expected::SelectPrev => {

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -405,7 +405,7 @@ mod tests {
                 );
             }
             Expected::CloseModal(expected_kind) => {
-                assert!(matches!(result, Action::CloseModal(kind) if kind == expected_kind))
+                assert!(matches!(result, Action::CloseModal(kind) if kind == expected_kind));
             }
             Expected::SqlModalAppendInsert => {
                 assert!(matches!(result, Action::SqlModalAppendInsert));

--- a/src/app/update/modal/base.rs
+++ b/src/app/update/modal/base.rs
@@ -17,8 +17,7 @@ pub(super) fn reduce_base_lifecycle(
             state.ui.table_picker.clear_filter_and_reset();
             DispatchResult::handled()
         }
-        Action::CloseModal(ModalKind::TablePicker)
-        | Action::CloseModal(ModalKind::CommandPalette) => {
+        Action::CloseModal(ModalKind::TablePicker | ModalKind::CommandPalette) => {
             state.modal.set_mode(InputMode::Normal);
             DispatchResult::handled()
         }

--- a/src/domain/Cargo.toml
+++ b/src/domain/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sabiql-domain"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Domain layer for sabiql"
 license.workspace = true
 repository.workspace = true
@@ -17,3 +18,6 @@ uuid.workspace = true
 [dev-dependencies]
 rstest.workspace = true
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/src/infra/Cargo.toml
+++ b/src/infra/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sabiql-infra"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Infrastructure layer for sabiql"
 license.workspace = true
 repository.workspace = true
@@ -29,3 +30,6 @@ arboard.workspace = true
 rstest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/src/infra/adapters/app_config_file.rs
+++ b/src/infra/adapters/app_config_file.rs
@@ -3,16 +3,18 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard};
 
-pub(crate) const CONFIG_FILE_NAME: &str = "connections.toml";
+pub const CONFIG_FILE_NAME: &str = "connections.toml";
 
 static WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 static CONFIG_FILE_LOCK: Mutex<()> = Mutex::new(());
 
-pub(crate) fn lock() -> MutexGuard<'static, ()> {
-    CONFIG_FILE_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+pub fn lock() -> MutexGuard<'static, ()> {
+    CONFIG_FILE_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
-pub(crate) fn get_config_dir() -> Result<PathBuf, std::io::Error> {
+pub fn get_config_dir() -> Result<PathBuf, std::io::Error> {
     let config_base = dirs::config_dir().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -22,11 +24,11 @@ pub(crate) fn get_config_dir() -> Result<PathBuf, std::io::Error> {
     Ok(config_base.join("sabiql"))
 }
 
-pub(crate) fn config_file_path(config_dir: &Path) -> PathBuf {
+pub fn config_file_path(config_dir: &Path) -> PathBuf {
     config_dir.join(CONFIG_FILE_NAME)
 }
 
-pub(crate) fn write_config_file(config_dir: &Path, content: &str) -> Result<(), std::io::Error> {
+pub fn write_config_file(config_dir: &Path, content: &str) -> Result<(), std::io::Error> {
     if !config_dir.exists() {
         fs::create_dir_all(config_dir)?;
     }
@@ -57,7 +59,7 @@ pub(crate) fn write_config_file(config_dir: &Path, content: &str) -> Result<(), 
     Ok(())
 }
 
-pub(crate) fn render_config_file(content: &str) -> String {
+pub fn render_config_file(content: &str) -> String {
     format!(
         "# sabiql configuration\n# WARNING: Connection passwords are stored in plain text\n\n{content}"
     )

--- a/src/tests/render_snapshots/inspector.rs
+++ b/src/tests/render_snapshots/inspector.rs
@@ -23,6 +23,27 @@ fn inspector_columns_narrow_pane_keeps_horizontal_scroll() {
 }
 
 #[test]
+fn inspector_columns_narrow_pane_scrolled_fills_width() {
+    let (mut state, _now) = harness::explorer_selected_state();
+    let mut terminal = create_test_terminal_sized(110, 40);
+
+    let mut table = fixtures::sample_table_detail();
+    table.columns[0].comment = Some(
+        "Primary key, generated from the tenant sequence and never reused after deletion"
+            .to_string(),
+    );
+    let _ = state.session.set_table_detail(table, 0);
+    state.ui.inspector_tab = InspectorTab::Columns;
+    state.ui.focused_pane = FocusedPane::Inspector;
+    // Scrolled mid-way: the over-wide comment column fills the remaining width
+    state.ui.inspector_horizontal_offset = 2;
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn inspector_indexes_tab_with_data() {
     let (mut state, _now) = table_detail_loaded_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/inspector.rs
+++ b/src/tests/render_snapshots/inspector.rs
@@ -44,6 +44,28 @@ fn inspector_columns_narrow_pane_scrolled_fills_width() {
 }
 
 #[test]
+fn inspector_columns_narrow_pane_right_edge_truncates_cjk_comment() {
+    let (mut state, _now) = harness::explorer_selected_state();
+    let mut terminal = create_test_terminal_sized(110, 40);
+
+    // CJK renders two cells per char; the comment must end with an ellipsis
+    // instead of being clipped mid-text at the pane border
+    let mut table = fixtures::sample_table_detail();
+    table.columns[0].comment = Some(
+        "ステータス（PENDING:判断待ち、APPROVED:承認済み、REJECTED:却下済み、CANCELED:取消済み）"
+            .to_string(),
+    );
+    let _ = state.session.set_table_detail(table, 0);
+    state.ui.inspector_tab = InspectorTab::Columns;
+    state.ui.focused_pane = FocusedPane::Inspector;
+    state.ui.inspector_horizontal_offset = usize::MAX;
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn inspector_indexes_tab_with_data() {
     let (mut state, _now) = table_detail_loaded_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/inspector.rs
+++ b/src/tests/render_snapshots/inspector.rs
@@ -3,6 +3,26 @@ use harness::table_detail_loaded_state;
 use sabiql_app::model::shared::inspector_tab::InspectorTab;
 
 #[test]
+fn inspector_columns_narrow_pane_keeps_horizontal_scroll() {
+    let (mut state, _now) = harness::explorer_selected_state();
+    // Split-pane terminal: the comment column alone exceeds the pane width
+    let mut terminal = create_test_terminal_sized(110, 40);
+
+    let mut table = fixtures::sample_table_detail();
+    table.columns[0].comment = Some(
+        "Primary key, generated from the tenant sequence and never reused after deletion"
+            .to_string(),
+    );
+    let _ = state.session.set_table_detail(table, 0);
+    state.ui.inspector_tab = InspectorTab::Columns;
+    state.ui.focused_pane = FocusedPane::Inspector;
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn inspector_indexes_tab_with_data() {
     let (mut state, _now) = table_detail_loaded_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -52,6 +52,53 @@ fn jsonb_detail_state() -> (AppState, std::time::Instant) {
 }
 
 #[test]
+fn result_pane_scrolled_past_wide_column_fills_width() {
+    let (mut state, now) = table_detail_loaded_state();
+    let mut terminal = create_test_terminal();
+
+    // payload's ideal width nearly fills the pane; scrolled past it, the
+    // remaining narrow columns must fill the viewport instead of leaving
+    // most of the pane blank
+    state.query.set_current_result(Arc::new(QueryResult {
+        query: "SELECT * FROM events".to_string(),
+        columns: ["id", "payload", "status", "kind", "actor", "note"]
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
+        rows: vec![
+            vec![
+                "1".to_string(),
+                "x".repeat(100),
+                "active_pending_validation".to_string(),
+                "user_account_registration".to_string(),
+                "alice.anderson@example.com".to_string(),
+                "created via admin console".to_string(),
+            ],
+            vec![
+                "2".to_string(),
+                "y".repeat(100),
+                "suspended_awaiting_review".to_string(),
+                "service_account_creation".to_string(),
+                "bob.brown@example.com".to_string(),
+                "imported from legacy system".to_string(),
+            ],
+        ],
+        row_count: 2,
+        execution_time_ms: 3,
+        executed_at: now,
+        source: QuerySource::Preview,
+        error: None,
+        command_tag: None,
+    }));
+    state.ui.focused_pane = FocusedPane::Result;
+    state.result_interaction.horizontal_offset = 2;
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn result_pane_first_cell_active_mode() {
     let (mut state, now) = table_detail_loaded_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -145,6 +145,37 @@ fn result_pane_right_edge_peeks_truncated_previous_column() {
 }
 
 #[test]
+fn result_pane_narrow_pane_keeps_horizontal_scroll() {
+    let (mut state, now) = table_detail_loaded_state();
+    // Split-pane terminal: payload alone exceeds the pane width, which must
+    // not disable the scrollbar
+    let mut terminal = create_test_terminal_sized(110, 40);
+
+    state.query.set_current_result(Arc::new(QueryResult {
+        query: "SELECT * FROM events".to_string(),
+        columns: ["id", "payload", "status"]
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
+        rows: vec![
+            vec!["1".to_string(), "x".repeat(100), "active".to_string()],
+            vec!["2".to_string(), "y".repeat(100), "done".to_string()],
+        ],
+        row_count: 2,
+        execution_time_ms: 3,
+        executed_at: now,
+        source: QuerySource::Preview,
+        error: None,
+        command_tag: None,
+    }));
+    state.ui.focused_pane = FocusedPane::Result;
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn result_pane_first_cell_active_mode() {
     let (mut state, now) = table_detail_loaded_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -99,6 +99,52 @@ fn result_pane_scrolled_past_wide_column_fills_width() {
 }
 
 #[test]
+fn result_pane_right_edge_peeks_truncated_previous_column() {
+    let (mut state, now) = table_detail_loaded_state();
+    let mut terminal = create_test_terminal();
+
+    // At the right edge the trailing narrow columns leave leftover width;
+    // the hidden wide description column shows up truncated instead of blank
+    state.query.set_current_result(Arc::new(QueryResult {
+        query: "SELECT * FROM events".to_string(),
+        columns: ["id", "description", "status", "kind", "actor", "note"]
+            .iter()
+            .map(ToString::to_string)
+            .collect(),
+        rows: vec![
+            vec![
+                "1".to_string(),
+                "x".repeat(100),
+                "active".to_string(),
+                "create".to_string(),
+                "alice".to_string(),
+                "first".to_string(),
+            ],
+            vec![
+                "2".to_string(),
+                "y".repeat(100),
+                "suspended".to_string(),
+                "update".to_string(),
+                "bob".to_string(),
+                "second".to_string(),
+            ],
+        ],
+        row_count: 2,
+        execution_time_ms: 3,
+        executed_at: now,
+        source: QuerySource::Preview,
+        error: None,
+        command_tag: None,
+    }));
+    state.ui.focused_pane = FocusedPane::Result;
+    state.result_interaction.horizontal_offset = 2;
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn result_pane_first_cell_active_mode() {
     let (mut state, now) = table_detail_loaded_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_keeps_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_keeps_horizontal_scroll.snap
@@ -1,0 +1,43 @@
+---
+source: src/tests/render_snapshots/inspector.rs
+expression: output
+---
+test_project | test_db | - | no dsn | localhost:5432/test                                                     
+┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
+│> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
+│  public.posts            ││Name    Type           Null   PK   Default   Comment                            │
+│  public.comments         ││id      integer               ✓              Primary key, generated from th...  │
+│                          ││name    varchar(255)                                                            │
+│                          ││email   varchar(255)   ✓                                                        │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││ col   0% ◀︎═══════════════════════════════════════════════════════════════────▶︎ │
+│                          │└────────────────────────────────────────────────────────────────────────────────┘
+│                          │┌ [3] Result ────────────────────────────────────────────────────────────────────┐
+│                          ││(select a table to preview)                                                     │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+└──────────────────────────┘└────────────────────────────────────────────────────────────────────────────────┘
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Pale

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_right_edge_truncates_cjk_comment.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_right_edge_truncates_cjk_comment.snap
@@ -1,0 +1,43 @@
+---
+source: src/tests/render_snapshots/inspector.rs
+expression: output
+---
+test_project | test_db | - | no dsn | localhost:5432/test                                                     
+┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
+│> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
+│  public.posts            ││Comment                                                                         │
+│  public.comments         ││ス テ ー タ ス （ PENDING:判 断 待 ち 、 APPROVED:承 認 済 み 、 REJECTED:却 下 済 み 、 CANCELE...  │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││ col 100% ◀︎────═══════════════════════════════════════════════════════════════▶︎ │
+│                          │└────────────────────────────────────────────────────────────────────────────────┘
+│                          │┌ [3] Result ────────────────────────────────────────────────────────────────────┐
+│                          ││(select a table to preview)                                                     │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+└──────────────────────────┘└────────────────────────────────────────────────────────────────────────────────┘
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Pale

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_scrolled_fills_width.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_scrolled_fills_width.snap
@@ -1,0 +1,43 @@
+---
+source: src/tests/render_snapshots/inspector.rs
+expression: output
+---
+test_project | test_db | - | no dsn | localhost:5432/test                                                     
+┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
+│> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
+│  public.posts            ││Null   PK   Default   Comment                                                   │
+│  public.comments         ││       ✓              Primary key, generated from the tenant sequence and n...  │
+│                          ││                                                                                │
+│                          ││✓                                                                               │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││ col  40% ◀︎──═══════════════════════════════════════════════════════════════──▶︎ │
+│                          │└────────────────────────────────────────────────────────────────────────────────┘
+│                          │┌ [3] Result ────────────────────────────────────────────────────────────────────┐
+│                          ││(select a table to preview)                                                     │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+└──────────────────────────┘└────────────────────────────────────────────────────────────────────────────────┘
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Pale

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_narrow_pane_keeps_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_narrow_pane_keeps_horizontal_scroll.snap
@@ -1,0 +1,43 @@
+---
+source: src/tests/render_snapshots/result_pane.rs
+expression: output
+---
+test_project | test_db | - | no dsn | localhost:5432/test                                                     
+┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
+│> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
+│  public.posts            ││Owner:   postgres                                                               │
+│  public.comments         ││Comment: User accounts                                                          │
+│                          ││Rows:    ~100                                                                   │
+│                          ││Schema:  public                                                                 │
+│                          ││Table:   users                                                                  │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          │└────────────────────────────────────────────────────────────────────────────────┘
+│                          │┌ [3] Result (2 rows, 3ms) ──────────────────────────────────────────────────────┐
+│                          ││id   payload                                                                    │
+│                          ││1    xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx...│
+│                          ││2    yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy...│
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││                                                                                │
+│                          ││ col   0% ◀︎══════════════════════════════════════════════════════════════════─▶︎ │
+└──────────────────────────┘└────────────────────────────────────────────────────────────────────────────────┘
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_right_edge_peeks_truncated_previous_column.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_right_edge_peeks_truncated_previous_column.snap
@@ -1,0 +1,54 @@
+---
+source: src/tests/render_snapshots/result_pane.rs
+expression: output
+---
+test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
+│> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  public.posts                         ││Owner:   postgres                                                                                                         │
+│  public.comments                      ││Comment: User accounts                                                                                                    │
+│                                       ││Rows:    ~100                                                                                                             │
+│                                       ││Schema:  public                                                                                                           │
+│                                       ││Table:   users                                                                                                            │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       │└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+│                                       │┌ [3] Result (2 rows, 3ms) ────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                       ││description                                                                          status      kind     actor   note    │
+│                                       ││xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx... active      create   alice   first   │
+│                                       ││yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy... suspended   update   bob     second  │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││ col 100% ◀︎─════════════════════════════════════════════════════════════════════════════════════════════════════════════▶︎ │
+└───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_scrolled_past_wide_column_fills_width.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_scrolled_past_wide_column_fills_width.snap
@@ -1,0 +1,54 @@
+---
+source: src/tests/render_snapshots/result_pane.rs
+expression: output
+---
+test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
+│> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  public.posts                         ││Owner:   postgres                                                                                                         │
+│  public.comments                      ││Comment: User accounts                                                                                                    │
+│                                       ││Rows:    ~100                                                                                                             │
+│                                       ││Schema:  public                                                                                                           │
+│                                       ││Table:   users                                                                                                            │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       │└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+│                                       │┌ [3] Result (2 rows, 3ms) ────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                       ││status                      kind                        actor                        note                                 │
+│                                       ││active_pending_validation   user_account_registration   alice.anderson@example.com   created via admin console            │
+│                                       ││suspended_awaiting_review   service_account_creation    bob.brown@example.com        imported from legacy system          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││ col 100% ◀︎─════════════════════════════════════════════════════════════════════════════════════════════════════════════▶︎ │
+└───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  F1:Palette  ^K:Settings  q:Quit

--- a/src/ui/Cargo.toml
+++ b/src/ui/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sabiql-ui"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "UI layer for sabiql"
 license.workspace = true
 repository.workspace = true
@@ -27,3 +28,6 @@ sabiql-domain.workspace = true
 insta.workspace = true
 rstest.workspace = true
 sabiql-app = { workspace = true, features = ["test-support"] }
+
+[lints]
+workspace = true

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -384,7 +384,7 @@ impl Inspector {
             HorizontalScrollParams, VerticalScrollParams, render_horizontal_scroll_indicator,
             render_vertical_scroll_indicator_bar,
         };
-        let has_h_scroll = plan.max_offset > 0;
+        let has_h_scroll = plan.has_horizontal_scroll();
         render_vertical_scroll_indicator_bar(
             frame,
             area,
@@ -401,9 +401,7 @@ impl Inspector {
             area,
             HorizontalScrollParams {
                 position: clamped_offset,
-                // Derived from max_offset (not displayed count) so the
-                // indicator reaches 100% at the last scroll position
-                viewport_size: headers.len().saturating_sub(plan.max_offset),
+                viewport_size: plan.indicator_viewport_size(),
                 total_items: headers.len(),
             },
             theme,

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -392,7 +392,7 @@ impl Inspector {
             HorizontalScrollParams, VerticalScrollParams, render_horizontal_scroll_indicator,
             render_vertical_scroll_indicator_bar,
         };
-        let has_h_scroll = headers.len() > plan.column_count;
+        let has_h_scroll = plan.max_offset > 0;
         render_vertical_scroll_indicator_bar(
             frame,
             area,
@@ -409,7 +409,9 @@ impl Inspector {
             area,
             HorizontalScrollParams {
                 position: clamped_offset,
-                viewport_size: plan.column_count, // Use fixed count, not actual displayed (may include bonus)
+                // Derived from max_offset (not displayed count) so the
+                // indicator reaches 100% at the last scroll position
+                viewport_size: headers.len().saturating_sub(plan.max_offset),
                 total_items: headers.len(),
             },
             theme,

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -18,7 +18,9 @@ use crate::app::ports::outbound::DdlGenerator;
 use crate::app::services::AppServices;
 use crate::domain::Table;
 use crate::primitives::atoms::panel_block;
-use crate::primitives::utils::text_utils::{MIN_COL_WIDTH, PADDING, calculate_header_min_widths};
+use crate::primitives::utils::text_utils::{
+    MIN_COL_WIDTH, PADDING, calculate_header_min_widths, truncate_to_width,
+};
 use crate::theme::ThemePalette;
 
 pub struct Inspector;
@@ -290,7 +292,7 @@ impl Inspector {
         } else {
             &data_rows
         };
-        let (all_ideal_widths, _) = calculate_column_widths(&headers, sample);
+        let all_ideal_widths = calculate_column_widths(&headers, sample);
         let fingerprint = widths_fingerprint(&all_ideal_widths, &header_min_widths);
         let plan = if stored_plan.needs_recalculation(available_width, fingerprint) {
             ViewportPlan::calculate(&all_ideal_widths, &header_min_widths, available_width)
@@ -358,7 +360,7 @@ impl Inspector {
                 Row::new(viewport_indices.iter().zip(viewport_widths.iter()).map(
                     |(&col_idx, &col_width)| {
                         let text = row.get(col_idx).map_or("", String::as_str);
-                        let display = truncate_cell(text, col_width as usize);
+                        let display = truncate_to_width(text, col_width as usize);
 
                         // Special styling for PK and Comment columns
                         let cell_style = if col_idx == 3 && !text.is_empty() {
@@ -436,7 +438,7 @@ impl Inspector {
                 ]
             })
             .collect();
-        let (col_widths, _) = calculate_column_widths(&headers, &data_rows);
+        let col_widths = calculate_column_widths(&headers, &data_rows);
         let widths: Vec<Constraint> = col_widths.iter().map(|&w| Constraint::Length(w)).collect();
 
         use crate::primitives::molecules::{StripedTableConfig, render_striped_table};
@@ -489,7 +491,7 @@ impl Inspector {
                 ]
             })
             .collect();
-        let (col_widths, _) = calculate_column_widths(&headers, &data_rows);
+        let col_widths = calculate_column_widths(&headers, &data_rows);
         let widths: Vec<Constraint> = col_widths.iter().map(|&w| Constraint::Length(w)).collect();
 
         use crate::primitives::molecules::{StripedTableConfig, render_striped_table};
@@ -578,7 +580,7 @@ impl Inspector {
                         if let Some(qual) = &policy.qual {
                             lines.push(Line::from(format!(
                                 "    USING: {}",
-                                truncate_cell(qual, 50)
+                                truncate_to_width(qual, 50)
                             )));
                         }
                     }
@@ -715,35 +717,23 @@ impl Inspector {
     }
 }
 
-fn calculate_column_widths(headers: &[&str], rows: &[Vec<String>]) -> (Vec<u16>, u16) {
-    let mut true_total: u16 = 0;
-    let clamped: Vec<u16> = headers
+fn calculate_column_widths(headers: &[&str], rows: &[Vec<String>]) -> Vec<u16> {
+    use unicode_width::UnicodeWidthStr;
+
+    headers
         .iter()
         .enumerate()
         .map(|(col_idx, header)| {
-            let mut max_width = header.chars().count();
+            let mut max_width = UnicodeWidthStr::width(*header);
 
             for row in rows.iter().take(50) {
                 if let Some(cell) = row.get(col_idx) {
-                    max_width = max_width.max(cell.chars().count());
+                    max_width = max_width.max(UnicodeWidthStr::width(cell.as_str()));
                 }
             }
 
-            let true_width = max_width as u16 + PADDING;
-            true_total += true_width;
-            true_width.clamp(MIN_COL_WIDTH, MAX_COL_WIDTH)
+            let max_width = max_width.min(MAX_COL_WIDTH as usize) as u16;
+            (max_width + PADDING).clamp(MIN_COL_WIDTH, MAX_COL_WIDTH)
         })
-        .collect();
-
-    (clamped, true_total)
-}
-
-fn truncate_cell(s: &str, max_chars: usize) -> String {
-    let char_count = s.chars().count();
-    if char_count <= max_chars {
-        s.to_string()
-    } else {
-        let truncated: String = s.chars().take(max_chars.saturating_sub(3)).collect();
-        format!("{truncated}...")
-    }
+        .collect()
 }

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -317,7 +317,6 @@ impl Inspector {
             available_width,
             fixed_count: Some(plan.column_count),
             max_offset: plan.max_offset,
-            slack_policy: plan.slack_policy,
         };
         let (viewport_indices, viewport_widths) = select_viewport_columns(&config, &ctx);
 

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -12,6 +12,7 @@ use crate::app::model::shared::focused_pane::FocusedPane;
 use crate::app::model::shared::inspector_tab::InspectorTab;
 use crate::app::model::shared::viewport::{
     ColumnWidthConfig, MAX_COL_WIDTH, SelectionContext, ViewportPlan, select_viewport_columns,
+    widths_fingerprint,
 };
 use crate::app::ports::outbound::DdlGenerator;
 use crate::app::services::AppServices;
@@ -290,17 +291,8 @@ impl Inspector {
             &data_rows
         };
         let (all_ideal_widths, _) = calculate_column_widths(&headers, sample);
-        let current_min_widths_sum: u16 = header_min_widths.iter().sum();
-        let current_ideal_widths_sum: u16 = all_ideal_widths.iter().sum();
-        let current_ideal_widths_max: u16 = all_ideal_widths.iter().copied().max().unwrap_or(0);
-
-        let plan = if stored_plan.needs_recalculation(
-            all_ideal_widths.len(),
-            available_width,
-            current_min_widths_sum,
-            current_ideal_widths_sum,
-            current_ideal_widths_max,
-        ) {
+        let fingerprint = widths_fingerprint(&all_ideal_widths, &header_min_widths);
+        let plan = if stored_plan.needs_recalculation(available_width, fingerprint) {
             ViewportPlan::calculate(&all_ideal_widths, &header_min_widths, available_width)
         } else {
             stored_plan.clone()

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -361,7 +361,7 @@ impl ResultPane {
             HorizontalScrollParams, VerticalScrollParams, render_horizontal_scroll_indicator,
             render_vertical_scroll_indicator_bar,
         };
-        let has_h_scroll = plan.max_offset > 0;
+        let has_h_scroll = plan.has_horizontal_scroll();
         render_vertical_scroll_indicator_bar(
             frame,
             inner,
@@ -402,9 +402,7 @@ impl ResultPane {
             h_scroll_area,
             HorizontalScrollParams {
                 position: clamped_offset,
-                // Derived from max_offset (not displayed count) so the
-                // indicator reaches 100% at the last scroll position
-                viewport_size: total_cols.saturating_sub(plan.max_offset),
+                viewport_size: plan.indicator_viewport_size(),
                 total_items: total_cols,
             },
             theme,

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -14,7 +14,7 @@ use crate::app::model::shared::focused_pane::FocusedPane;
 use crate::app::model::shared::ui_state::{RESULT_INNER_OVERHEAD, ResultSelection, YankFlash};
 use crate::app::model::shared::viewport::{
     ColumnWidthConfig, ColumnWidthsCache, MAX_COL_WIDTH, SelectionContext, ViewportPlan,
-    select_viewport_columns,
+    select_viewport_columns, widths_fingerprint,
 };
 use crate::domain::{QueryResult, QuerySource};
 use crate::primitives::utils::text_utils::{MIN_COL_WIDTH, PADDING, calculate_header_min_widths};
@@ -196,17 +196,8 @@ impl ResultPane {
             (&fresh_ideal[..], &fresh_min[..])
         };
 
-        let current_min_widths_sum: u16 = min_widths.iter().sum();
-        let current_ideal_widths_sum: u16 = ideal_widths.iter().sum();
-        let current_ideal_widths_max: u16 = ideal_widths.iter().copied().max().unwrap_or(0);
-
-        let plan = if stored_plan.needs_recalculation(
-            ideal_widths.len(),
-            inner.width,
-            current_min_widths_sum,
-            current_ideal_widths_sum,
-            current_ideal_widths_max,
-        ) {
+        let fingerprint = widths_fingerprint(ideal_widths, min_widths);
+        let plan = if stored_plan.needs_recalculation(inner.width, fingerprint) {
             ViewportPlan::calculate(ideal_widths, min_widths, inner.width)
         } else {
             stored_plan.clone()

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -439,6 +439,8 @@ pub(crate) fn calculate_ideal_widths(headers: &[String], rows: &[Vec<String>]) -
         .collect()
 }
 
+// TODO: cursor windowing is char-based; editing a CJK cell can render wider
+// than the column until text_cursor_spans becomes display-width aware
 fn cell_edit_line_with_cursor(
     text: &str,
     cursor: usize,
@@ -656,19 +658,19 @@ mod tests {
     }
 
     #[test]
-    fn zero_max_chars_returns_ellipsis_only() {
+    fn zero_width_returns_empty() {
         let result = truncate_cell("hello", 0);
 
-        assert_eq!(result, "...");
+        assert_eq!(result, "");
     }
 
     #[rstest]
-    #[case(1, "...")]
-    #[case(2, "...")]
+    #[case(1, ".")]
+    #[case(2, "..")]
     #[case(3, "...")]
     #[case(4, "h...")]
     #[case(5, "he...")]
-    fn small_max_chars_handles_edge_cases(#[case] max: usize, #[case] expected: &str) {
+    fn small_widths_stay_within_contract(#[case] max: usize, #[case] expected: &str) {
         let result = truncate_cell("hello world", max);
 
         assert_eq!(result, expected);

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -370,7 +370,7 @@ impl ResultPane {
             HorizontalScrollParams, VerticalScrollParams, render_horizontal_scroll_indicator,
             render_vertical_scroll_indicator_bar,
         };
-        let has_h_scroll = total_cols > plan.column_count;
+        let has_h_scroll = plan.max_offset > 0;
         render_vertical_scroll_indicator_bar(
             frame,
             inner,
@@ -411,7 +411,9 @@ impl ResultPane {
             h_scroll_area,
             HorizontalScrollParams {
                 position: clamped_offset,
-                viewport_size: plan.column_count,
+                // Derived from max_offset (not displayed count) so the
+                // indicator reaches 100% at the last scroll position
+                viewport_size: total_cols.saturating_sub(plan.max_offset),
                 total_items: total_cols,
             },
             theme,

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -234,7 +234,6 @@ impl ResultPane {
             available_width: inner.width,
             fixed_count: Some(plan.column_count),
             max_offset: plan.max_offset,
-            slack_policy: plan.slack_policy,
         };
         let (viewport_indices, viewport_widths) = select_viewport_columns(&config, &ctx);
 

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -17,7 +17,9 @@ use crate::app::model::shared::viewport::{
     select_viewport_columns, widths_fingerprint,
 };
 use crate::domain::{QueryResult, QuerySource};
-use crate::primitives::utils::text_utils::{MIN_COL_WIDTH, PADDING, calculate_header_min_widths};
+use crate::primitives::utils::text_utils::{
+    MIN_COL_WIDTH, PADDING, calculate_header_min_widths, truncate_to_width,
+};
 use crate::theme::ThemePalette;
 
 pub struct ResultPane;
@@ -413,24 +415,26 @@ impl ResultPane {
 }
 
 pub(crate) fn calculate_ideal_widths(headers: &[String], rows: &[Vec<String>]) -> Vec<u16> {
+    use unicode_width::UnicodeWidthStr;
+
     const SAMPLE_ROWS: usize = 50;
 
     headers
         .iter()
         .enumerate()
         .map(|(col_idx, header)| {
-            let mut max_width = header.chars().count();
+            let mut max_width = UnicodeWidthStr::width(header.as_str());
 
             let sample_size = rows.len().min(SAMPLE_ROWS);
             for row in rows.iter().take(sample_size) {
                 if let Some(cell) = row.get(col_idx) {
                     let first_line = cell.lines().next().unwrap_or(cell);
-                    let cell_width = first_line.chars().count();
-                    max_width = max_width.max(cell_width);
+                    max_width = max_width.max(UnicodeWidthStr::width(first_line));
                 }
             }
 
-            (max_width as u16 + PADDING).clamp(MIN_COL_WIDTH, MAX_COL_WIDTH)
+            let max_width = max_width.min(MAX_COL_WIDTH as usize) as u16;
+            (max_width + PADDING).clamp(MIN_COL_WIDTH, MAX_COL_WIDTH)
         })
         .collect()
 }
@@ -464,19 +468,9 @@ fn cell_edit_line_with_cursor(
     ))
 }
 
-fn truncate_cell(s: &str, max_chars: usize) -> String {
+fn truncate_cell(s: &str, max_width: usize) -> String {
     let first_line = s.lines().next().unwrap_or(s);
-    let char_count = first_line.chars().count();
-
-    if char_count <= max_chars {
-        first_line.to_string()
-    } else {
-        let truncated: String = first_line
-            .chars()
-            .take(max_chars.saturating_sub(3))
-            .collect();
-        format!("{truncated}...")
-    }
+    truncate_to_width(first_line, max_width)
 }
 
 #[cfg(test)]
@@ -547,8 +541,8 @@ mod tests {
             let result = calculate_ideal_widths(&headers, &rows);
 
             assert_eq!(result.len(), 1);
-            // "日本語テスト" = 6 chars + 2 padding = 8
-            assert_eq!(result[0], 8);
+            // "日本語テスト" = 6 chars × 2 cells + 2 padding = 14
+            assert_eq!(result[0], 14);
         }
 
         #[test]
@@ -615,27 +609,29 @@ mod tests {
     }
 
     #[test]
-    fn multibyte_characters_count_correctly() {
+    fn multibyte_truncates_by_display_width() {
         let result = truncate_cell("こんにちは世界", 5);
 
-        assert_eq!(result, "こん...");
+        assert_eq!(result, "こ...");
     }
 
     #[rstest]
-    #[case("日本語テスト", 10, "日本語テスト")]
-    #[case("日本語テスト", 5, "日本...")]
-    #[case("日本語テスト", 4, "日...")]
-    #[case("日本語テスト", 3, "...")]
+    #[case("日本語テスト", 12, "日本語テスト")]
+    #[case("日本語テスト", 10, "日本語...")]
+    #[case("日本語テスト", 5, "日...")]
+    #[case("日本語テスト", 4, "...")]
     #[case("SELECT * FROM 日本語テーブル", 15, "SELECT * FRO...")]
     fn multibyte_truncation_is_safe(
         #[case] input: &str,
         #[case] max: usize,
         #[case] expected: &str,
     ) {
+        use unicode_width::UnicodeWidthStr;
+
         let result = truncate_cell(input, max);
 
         assert_eq!(result, expected);
-        assert!(result.chars().count() <= max);
+        assert!(UnicodeWidthStr::width(result.as_str()) <= max);
     }
 
     #[test]

--- a/src/ui/primitives/molecules/hint_bar.rs
+++ b/src/ui/primitives/molecules/hint_bar.rs
@@ -57,6 +57,7 @@ impl FooterHintBar {
         }
     }
 
+    #[must_use]
     pub fn without_item(mut self, key: &str) -> Self {
         self.items.retain(|item| item.key != key);
         self

--- a/src/ui/primitives/utils/text_utils.rs
+++ b/src/ui/primitives/utils/text_utils.rs
@@ -2,10 +2,36 @@ pub const MIN_COL_WIDTH: u16 = 4;
 pub const PADDING: u16 = 2;
 
 pub fn calculate_header_min_widths<S: AsRef<str>>(headers: &[S]) -> Vec<u16> {
+    use unicode_width::UnicodeWidthStr;
+
     headers
         .iter()
-        .map(|h| (h.as_ref().chars().count() as u16 + PADDING).max(MIN_COL_WIDTH))
+        .map(|h| (UnicodeWidthStr::width(h.as_ref()) as u16 + PADDING).max(MIN_COL_WIDTH))
         .collect()
+}
+
+// Counts display cells, not chars: CJK text renders two cells per char and
+// would otherwise overflow its column and get clipped without an ellipsis.
+pub fn truncate_to_width(s: &str, max_width: usize) -> String {
+    use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+    if UnicodeWidthStr::width(s) <= max_width {
+        return s.to_string();
+    }
+
+    let budget = max_width.saturating_sub(3); // "..." occupies 3 cells
+    let mut truncated = String::new();
+    let mut used = 0;
+    for ch in s.chars() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + w > budget {
+            break;
+        }
+        truncated.push(ch);
+        used += w;
+    }
+    truncated.push_str("...");
+    truncated
 }
 
 pub fn wrapped_line_count(text: &str, width: u16) -> u16 {
@@ -45,6 +71,40 @@ mod tests {
         let headers = ["a"];
         let widths = calculate_header_min_widths(&headers);
         assert_eq!(widths, vec![MIN_COL_WIDTH]);
+    }
+
+    #[test]
+    fn cjk_headers_measured_by_display_width() {
+        let headers = ["名前"];
+        let widths = calculate_header_min_widths(&headers);
+        // 2 chars × 2 cells + padding
+        assert_eq!(widths, vec![6]);
+    }
+
+    mod truncate_to_width_tests {
+        use super::super::truncate_to_width;
+        use rstest::rstest;
+        use unicode_width::UnicodeWidthStr;
+
+        #[rstest]
+        #[case("hello", 10, "hello")]
+        #[case("hello world", 8, "hello...")]
+        #[case("hello", 0, "...")]
+        #[case("こんにちは", 10, "こんにちは")]
+        #[case("こんにちは世界", 5, "こ...")]
+        #[case("日本語テスト", 10, "日本語...")]
+        fn truncates_by_display_cells(
+            #[case] input: &str,
+            #[case] max: usize,
+            #[case] expected: &str,
+        ) {
+            let result = truncate_to_width(input, max);
+
+            assert_eq!(result, expected);
+            if max >= 3 {
+                assert!(UnicodeWidthStr::width(result.as_str()) <= max);
+            }
+        }
     }
 
     mod wrapped_line_count_tests {

--- a/src/ui/primitives/utils/text_utils.rs
+++ b/src/ui/primitives/utils/text_utils.rs
@@ -19,7 +19,12 @@ pub fn truncate_to_width(s: &str, max_width: usize) -> String {
         return s.to_string();
     }
 
-    let budget = max_width.saturating_sub(3); // "..." occupies 3 cells
+    // The ellipsis itself must respect the width contract
+    if max_width < 3 {
+        return ".".repeat(max_width);
+    }
+
+    let budget = max_width - 3; // "..." occupies 3 cells
     let mut truncated = String::new();
     let mut used = 0;
     for ch in s.chars() {
@@ -89,7 +94,10 @@ mod tests {
         #[rstest]
         #[case("hello", 10, "hello")]
         #[case("hello world", 8, "hello...")]
-        #[case("hello", 0, "...")]
+        #[case("hello", 0, "")]
+        #[case("hello", 1, ".")]
+        #[case("hello", 2, "..")]
+        #[case("hello", 3, "...")]
         #[case("こんにちは", 10, "こんにちは")]
         #[case("こんにちは世界", 5, "こ...")]
         #[case("日本語テスト", 10, "日本語...")]
@@ -101,9 +109,7 @@ mod tests {
             let result = truncate_to_width(input, max);
 
             assert_eq!(result, expected);
-            if max >= 3 {
-                assert!(UnicodeWidthStr::width(result.as_str()) <= max);
-            }
+            assert!(UnicodeWidthStr::width(result.as_str()) <= max);
         }
     }
 

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -61,8 +61,7 @@ impl Footer {
         let now_ms = time_ms.unwrap_or_else(|| {
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_millis())
-                .unwrap_or(0)
+                .map_or(0, |d| d.as_millis())
         });
         let spinner = spinner_char(now_ms);
 


### PR DESCRIPTION
## Problem

Horizontal scrolling in the Result pane (and Inspector Columns tab) often left a large blank area on the right side of the viewport, especially when a wide column was present or in fullscreen focus mode. In narrow panes (split terminals), a single over-wide column silently disabled horizontal scrolling, and CJK text was clipped mid-text without an ellipsis — even in fullscreen — because widths were measured in chars instead of display cells.

## Background

The viewport shows a fixed column count derived from the worst-case window (the widest run of adjacent columns), so most scroll offsets have leftover width. The two existing mitigations rarely applied: only a single bonus column was added and only when its full ideal width fit, and slack absorption into the rightmost column ran only when no scrolling was needed at all. The scroll range also extended past the point where all remaining columns were already visible, so the right edge showed a near-empty viewport. When any single column's ideal width exceeded the pane, a min-width fallback squeezed every column to its header width and set the scroll range to zero. Width math used `chars().count()`, which undercounts CJK by half, so such columns were allocated half the cells they render.

## Approach

Keep the 1-scroll-=-1-column anchor semantics and greedily fill the rest of the viewport: append following columns while they fit, render the next column truncated when its header still fits, and absorb any residual slack into the rightmost visible column unconditionally (removing `SlackPolicy`). Cap `max_offset` at the first offset where every remaining column fits, so scrolling stops with the viewport full and the indicator reaches 100% there. At the right edge, where no next column exists, the leftover width shows a truncated peek of the previous (hidden) column instead of staying blank. An over-wide column now counts as a single-column viewport (rendered truncated) instead of triggering the min-width squeeze, keeping scrolling available in narrow panes. Column sizing and display-cell truncation moved to display-width (`unicode_width`) so CJK columns get correctly sized and truncate with an ellipsis; the cell-edit cursor path stays char-based and is out of scope here (TODO in code). Since `max_offset` now depends on column order, plan invalidation uses an order-sensitive widths fingerprint, and indicator metrics are derived on `ViewportPlan` to keep the semantics in one place.

## Screenshots

See render snapshots: `result_pane_scrolled_past_wide_column_fills_width`, `result_pane_right_edge_peeks_truncated_previous_column`, `result_pane_narrow_pane_keeps_horizontal_scroll`, `inspector_columns_narrow_pane_keeps_horizontal_scroll`, `inspector_columns_narrow_pane_scrolled_fills_width`, and `inspector_columns_narrow_pane_right_edge_truncates_cjk_comment`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * インスペクタと結果ペインの横スクロールとビューポート選択を再設計し、右端で列が部分表示／切り詰め表示される挙動をより一貫して反映します。
  * CJKを含むテキスト幅を表示幅（Unicode幅）で測定するように変え、列幅算出と表示品質を向上しました。
  * テキスト切り詰めと省略記号の動作を改善し、狭いペインでの表示が安定しました。

* **テスト**
  * 横スクロールや右端挙動、CJK表示に関するスナップショット／ユニットテストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->