### PR TITLE
ci: restore PostgreSQL integration test path and trim test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,21 @@ jobs:
         if: steps.test_all_features.outcome == 'failure' || steps.test_no_default_features.outcome == 'failure'
         run: exit 1
 
+  integration:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e # v2
+        with:
+          tool: nextest
+      - name: Start PostgreSQL
+        run: docker compose up -d --wait
+      - name: Run psql integration tests (Tier 2)
+        run: cargo nextest run -p sabiql --run-ignored ignored-only -E 'test(tests::adapter_postgres)' --show-progress=none
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: cargo nextest run --workspace --profile ci-all --all-features --show-progress=none --status-level=fail --final-status-level=fail
       - id: test_no_default_features
         continue-on-error: true
-        run: cargo nextest run --workspace --profile ci-no-default --no-default-features --show-progress=none --status-level=fail --final-status-level=fail
+        run: cargo nextest run -p sabiql --profile ci-no-default --no-default-features --show-progress=none --status-level=fail --final-status-level=fail
       - name: Summarize failed tests
         if: steps.test_all_features.outcome == 'failure' || steps.test_no_default_features.outcome == 'failure'
         run: |

--- a/scripts/ci_test_failure_summary.py
+++ b/scripts/ci_test_failure_summary.py
@@ -41,7 +41,7 @@ def rerun_command(profile: str, test_name: str) -> str:
         )
     if profile == "ci-no-default":
         return (
-            "cargo nextest run --workspace --profile ci-no-default --no-default-features"
+            "cargo nextest run -p sabiql --profile ci-no-default --no-default-features"
             f" -- {quoted_test_name} --exact"
         )
     return (

--- a/src/tests/adapter_postgres.rs
+++ b/src/tests/adapter_postgres.rs
@@ -1,17 +1,18 @@
 //! Integration tests for PostgresAdapter (Tier 2).
 //!
 //! All tests require a running PostgreSQL instance and are marked `#[ignore]`.
-//! Run with: `cargo test -- --ignored` or `mise run test:ignored`
+//! Start one with `docker compose up -d --wait`, then run:
+//! `cargo nextest run -p sabiql --run-ignored ignored-only -E 'test(tests::adapter_postgres)'`
 //!
 //! DSN is read from `SABIQL_TEST_DSN` env var.
-//! Default: `postgres://postgres:postgres@localhost:5432/sabiql_test`
+//! Default: `postgres://dev:dev@localhost:5433/testdb` (matches compose.yml)
 
 use sabiql_app::ports::outbound::{DbOperationError, MetadataProvider, QueryExecutor};
 use sabiql_infra::adapters::postgres::PostgresAdapter;
 
 fn test_dsn() -> String {
     std::env::var("SABIQL_TEST_DSN")
-        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/sabiql_test".to_string())
+        .unwrap_or_else(|_| "postgres://dev:dev@localhost:5433/testdb".to_string())
 }
 
 mod metadata_fetch {


### PR DESCRIPTION
## Problem

The Tier 2 psql integration tests (all `#[ignore]`) never run anywhere: their default DSN doesn't match the environment compose.yml provides, CI has no PostgreSQL, and the doc comment points to a nonexistent `mise` task. The test job also runs the entire workspace suite twice even though feature flags only affect the root package.

## Background

Code-quality review follow-up (docs/code-quality-todo.md task 3; findings 1-4b / 1-13). Restoring this test path is a prerequisite for the CSV result-set boundary rework (task 8).

## Approach

Align the default test DSN with compose.yml so one environment definition serves both local runs and CI, then add a CI job that boots the database with `docker compose up --wait` and runs only the ignored psql integration tests (filtered so local-only benchmarks stay excluded). Narrow the second nextest pass to the root package, since the only effective feature difference (`self-update`) lives there; no-default-features compile health across the workspace remains covered by the clippy job.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * PostgreSQL アダプターの統合テストを強化しました
  * テスト実行パイプラインを最適化し、CI/CD の効率性を向上させました
  * テスト環境の設定を更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->