### PR TITLE
refactor: unify reducer time injection and enforce it via clippy

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,7 @@
 msrv = "1.96"
 allow-dbg-in-tests = true
 too-many-arguments-threshold = 8
+
+disallowed-methods = [
+    { path = "std::time::Instant::now", reason = "reducers must receive `now` as a parameter; read the clock only at the runtime boundary (main loop / effect layer)" },
+]

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -253,6 +253,10 @@ impl EffectRunner {
     ) -> Result<Vec<Action>> {
         match effect {
             Effect::Render => {
+                #[expect(
+                    clippy::disallowed_methods,
+                    reason = "the effect runner is the runtime boundary that reads the clock for rendering"
+                )]
                 let now = Instant::now();
                 let output = tui.draw(state, services, now)?;
                 if !state.ui.is_focus_mode() {

--- a/src/app/lib.rs
+++ b/src/app/lib.rs
@@ -1,3 +1,11 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::disallowed_methods,
+        reason = "tests construct fixtures with real clock readings; purity is enforced on production code via the lib target"
+    )
+)]
+
 pub mod catalog;
 pub mod cmd;
 pub mod model;

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -97,16 +97,8 @@ impl AppState {
         self.render_dirty = false;
     }
 
-    pub fn set_error(&mut self, msg: String) {
-        self.messages.set_error(msg);
-    }
-
-    pub fn set_success(&mut self, msg: String) {
-        self.messages.set_success(msg);
-    }
-
     pub fn clear_expired_timers(&mut self, now: Instant) {
-        self.messages.clear_expired();
+        self.messages.clear_expired_at(now);
         self.query.clear_expired_highlight(now);
         self.result_interaction.clear_expired_flash(now);
         self.flash_timers.clear_expired(now);

--- a/src/app/model/shared/message.rs
+++ b/src/app/model/shared/message.rs
@@ -33,18 +33,6 @@ impl MessageState {
         }
     }
 
-    pub fn set_error(&mut self, msg: String) {
-        self.set_error_at(msg, Instant::now());
-    }
-
-    pub fn set_success(&mut self, msg: String) {
-        self.set_success_at(msg, Instant::now());
-    }
-
-    pub fn clear_expired(&mut self) {
-        self.clear_expired_at(Instant::now());
-    }
-
     pub fn clear(&mut self) {
         self.last_error = None;
         self.last_success = None;

--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::update::action::Action;
@@ -5,7 +7,11 @@ use crate::update::dispatch_result::DispatchResult;
 
 use super::check_er_completion;
 
-pub(super) fn reduce_er_neighbors(state: &mut AppState, action: &Action) -> DispatchResult {
+pub(super) fn reduce_er_neighbors(
+    state: &mut AppState,
+    action: &Action,
+    now: Instant,
+) -> DispatchResult {
     match action {
         Action::ExpandPrefetchWithFkNeighbors => {
             let seed_tables = state.er_preparation.seed_tables.clone();
@@ -19,7 +25,7 @@ pub(super) fn reduce_er_neighbors(state: &mut AppState, action: &Action) -> Disp
 
             if tables.is_empty() {
                 // No new neighbors — proceed to generate with what we have
-                return DispatchResult::handled_with(check_er_completion(state));
+                return DispatchResult::handled_with(check_er_completion(state, now));
             }
 
             for qualified_name in tables {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -11,7 +11,7 @@ use crate::model::er_state::ErStatus;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
+pub(super) fn check_er_completion(state: &mut AppState, now: Instant) -> Vec<Effect> {
     if state.er_preparation.status != ErStatus::Waiting || !state.er_preparation.is_complete() {
         return vec![];
     }
@@ -34,10 +34,13 @@ pub(super) fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
         .iter()
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
-    state.set_error(format!(
-        "ER failed: {} table(s) failed. 'e' to retry.",
-        failed_data.len()
-    ));
+    state.messages.set_error_at(
+        format!(
+            "ER failed: {} table(s) failed. 'e' to retry.",
+            failed_data.len()
+        ),
+        now,
+    );
     vec![Effect::WriteErFailureLog {
         failed_tables: failed_data,
     }]
@@ -45,9 +48,9 @@ pub(super) fn check_er_completion(state: &mut AppState) -> Vec<Effect> {
 
 pub fn dispatch_metadata(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     loading::reduce_loading(state, action, now)
-        .or_else(|| table_detail::reduce_table_detail(state, action))
+        .or_else(|| table_detail::reduce_table_detail(state, action, now))
         .or_else(|| prefetch::reduce_prefetch(state, action, now))
-        .or_else(|| er_neighbors::reduce_er_neighbors(state, action))
+        .or_else(|| er_neighbors::reduce_er_neighbors(state, action, now))
 }
 
 #[cfg(test)]
@@ -876,7 +879,7 @@ mod tests {
             state.er_preparation.fk_expanded = false;
             // pending and fetching are empty → is_complete() = true
 
-            let effects = check_er_completion(&mut state);
+            let effects = check_er_completion(&mut state, Instant::now());
 
             assert!(effects.iter().any(|e| matches!(
                 e,
@@ -891,7 +894,7 @@ mod tests {
             state.er_preparation.status = ErStatus::Waiting;
             state.er_preparation.fk_expanded = true;
 
-            let effects = check_er_completion(&mut state);
+            let effects = check_er_completion(&mut state, Instant::now());
 
             assert!(effects.iter().any(|e| matches!(
                 e,

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -120,7 +120,7 @@ pub(super) fn reduce_prefetch(
                     state
                         .er_preparation
                         .on_table_failed(&qualified_name, entry.error.clone());
-                    let mut effects = check_er_completion(state);
+                    let mut effects = check_er_completion(state, now);
                     // No fetch started → no completion event to re-drive the queue.
                     if effects.is_empty() && state.er_preparation.status == ErStatus::Waiting {
                         effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
@@ -192,7 +192,7 @@ pub(super) fn reduce_prefetch(
                 effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
             }
 
-            effects.extend(check_er_completion(state));
+            effects.extend(check_er_completion(state, now));
 
             DispatchResult::handled_with(effects)
         }
@@ -241,7 +241,7 @@ pub(super) fn reduce_prefetch(
                 delay_secs: backoff_secs_for(prev_count + 1),
             });
 
-            effects.extend(check_er_completion(state));
+            effects.extend(check_er_completion(state, now));
 
             DispatchResult::handled_with(effects)
         }
@@ -271,7 +271,7 @@ pub(super) fn reduce_prefetch(
                 effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
             }
 
-            effects.extend(check_er_completion(state));
+            effects.extend(check_er_completion(state, now));
 
             DispatchResult::handled_with(effects)
         }

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -1,9 +1,15 @@
+use std::time::Instant;
+
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::update::action::{Action, TableTarget};
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn reduce_table_detail(state: &mut AppState, action: &Action) -> DispatchResult {
+pub(super) fn reduce_table_detail(
+    state: &mut AppState,
+    action: &Action,
+    now: Instant,
+) -> DispatchResult {
     match action {
         Action::TableDetailLoaded {
             dsn,
@@ -35,7 +41,7 @@ pub(super) fn reduce_table_detail(state: &mut AppState, action: &Action) -> Disp
             }
 
             if *generation == state.session.selection_generation() {
-                state.set_error(error.user_message());
+                state.messages.set_error_at(error.user_message(), now);
             }
             DispatchResult::handled()
         }

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -186,7 +186,7 @@ pub fn reduce_execution(
                     )));
                 } else {
                     let user_message = error.user_message();
-                    state.set_error(user_message.clone());
+                    state.messages.set_error_at(user_message.clone(), now);
                     state.sql_modal.finish_adhoc_error(user_message);
                 }
             }

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -8,7 +8,7 @@ use crate::update::dispatch_result::DispatchResult;
 pub(super) fn reduce_diagram_lifecycle(
     state: &mut AppState,
     action: &Action,
-    _now: Instant,
+    now: Instant,
 ) -> DispatchResult {
     match action {
         Action::ErDiagramOpened(ErDiagramInfo {
@@ -19,18 +19,21 @@ pub(super) fn reduce_diagram_lifecycle(
             state.er_preparation.mark_idle();
             // Reset so next ErOpenDiagram re-evaluates target_tables from scratch.
             state.sql_modal.invalidate_prefetch();
-            state.set_success(format!(
-                "✓ Opened {path} ({table_count}/{total_tables} tables) — Stale? Press r to reload"
-            ));
+            state.messages.set_success_at(
+                format!(
+                    "✓ Opened {path} ({table_count}/{total_tables} tables) — Stale? Press r to reload"
+                ),
+                now,
+            );
             DispatchResult::handled()
         }
         Action::ErDiagramFailed(error) => {
             state.er_preparation.mark_idle();
-            state.set_error(error.to_string());
+            state.messages.set_error_at(error.to_string(), now);
             DispatchResult::handled()
         }
         Action::ErLogWriteFailed(error) => {
-            state.set_error(error.to_string());
+            state.messages.set_error_at(error.to_string(), now);
             DispatchResult::handled()
         }
         Action::ErOpenDiagram => {
@@ -39,17 +42,23 @@ pub(super) fn reduce_diagram_lifecycle(
             }
 
             let Some(dsn) = state.session.dsn.clone() else {
-                state.set_error("No active connection".to_string());
+                state
+                    .messages
+                    .set_error_at("No active connection".to_string(), now);
                 return DispatchResult::handled();
             };
             if state.session.metadata().is_none() {
-                state.set_error("Metadata not loaded yet".to_string());
+                state
+                    .messages
+                    .set_error_at("Metadata not loaded yet".to_string(), now);
                 return DispatchResult::handled();
             }
 
             state.sql_modal.invalidate_prefetch();
             let run_id = state.er_preparation.begin_smart_refresh();
-            state.set_success("Checking for schema changes...".to_string());
+            state
+                .messages
+                .set_success_at("Checking for schema changes...".to_string(), now);
 
             DispatchResult::handled_with(vec![Effect::SmartErRefresh { dsn, run_id }])
         }

--- a/src/app/update/er/smart_refresh_completed.rs
+++ b/src/app/update/er/smart_refresh_completed.rs
@@ -9,7 +9,7 @@ use crate::update::dispatch_result::DispatchResult;
 pub(super) fn reduce_smart_refresh_completed(
     state: &mut AppState,
     action: &Action,
-    _now: Instant,
+    now: Instant,
 ) -> DispatchResult {
     match action {
         Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -53,8 +53,9 @@ pub(super) fn reduce_smart_refresh_completed(
             refetch.dedup();
 
             if refetch.is_empty() {
-                state.set_success(
+                state.messages.set_success_at(
                     "No schema changes detected, generating ER diagram...".to_string(),
+                    now,
                 );
                 effects.push(Effect::DispatchActions(vec![Action::ErGenerateFromCache]));
             } else {
@@ -63,10 +64,10 @@ pub(super) fn reduce_smart_refresh_completed(
                         tables: stale_tables.clone(),
                     });
                 }
-                state.set_success(format!(
-                    "Refreshing {} table(s) for ER diagram...",
-                    refetch.len()
-                ));
+                state.messages.set_success_at(
+                    format!("Refreshing {} table(s) for ER diagram...", refetch.len()),
+                    now,
+                );
                 effects.push(Effect::DispatchActions(vec![Action::StartPrefetchScoped {
                     tables: refetch,
                 }]));

--- a/src/app/update/er/smart_refresh_failed.rs
+++ b/src/app/update/er/smart_refresh_failed.rs
@@ -9,7 +9,7 @@ use crate::update::dispatch_result::DispatchResult;
 pub(super) fn reduce_smart_refresh_failed(
     state: &mut AppState,
     action: &Action,
-    _now: Instant,
+    now: Instant,
 ) -> DispatchResult {
     match action {
         Action::SmartErRefreshFailed(SmartErRefreshError {
@@ -30,7 +30,9 @@ pub(super) fn reduce_smart_refresh_failed(
 
             let Some(metadata) = &state.session.metadata() else {
                 state.er_preparation.mark_idle();
-                state.set_error("Metadata not loaded yet".to_string());
+                state
+                    .messages
+                    .set_error_at("Metadata not loaded yet".to_string(), now);
                 return DispatchResult::handled();
             };
             let total_table_count = metadata.table_summaries.len();
@@ -41,9 +43,10 @@ pub(super) fn reduce_smart_refresh_failed(
             state.er_preparation.last_signatures.clear();
 
             if is_scoped {
-                state.set_error(format!(
-                    "Smart refresh failed ({error}), falling back to scoped prefetch"
-                ));
+                state.messages.set_error_at(
+                    format!("Smart refresh failed ({error}), falling back to scoped prefetch"),
+                    now,
+                );
                 let scoped_tables = state.er_preparation.target_tables.clone();
                 DispatchResult::handled_with(vec![
                     Effect::ClearCompletionEngineCache,
@@ -52,9 +55,10 @@ pub(super) fn reduce_smart_refresh_failed(
                     }]),
                 ])
             } else {
-                state.set_error(format!(
-                    "Smart refresh failed ({error}), falling back to full refresh"
-                ));
+                state.messages.set_error_at(
+                    format!("Smart refresh failed ({error}), falling back to full refresh"),
+                    now,
+                );
                 DispatchResult::handled_with(vec![
                     Effect::ClearCompletionEngineCache,
                     Effect::DispatchActions(vec![Action::StartPrefetchAll]),

--- a/src/app/update/modal/er_picker.rs
+++ b/src/app/update/modal/er_picker.rs
@@ -9,13 +9,15 @@ use crate::update::dispatch_result::DispatchResult;
 pub(super) fn reduce_er_picker(
     state: &mut AppState,
     action: &Action,
-    _now: Instant,
+    now: Instant,
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::ErTablePicker) => {
             if state.session.metadata().is_none() {
                 state.ui.request_er_picker_after_metadata();
-                state.set_success("Waiting for metadata...".to_string());
+                state
+                    .messages
+                    .set_success_at("Waiting for metadata...".to_string(), now);
                 return DispatchResult::handled();
             }
             state.ui.reset_er_picker_request();
@@ -71,7 +73,9 @@ pub(super) fn reduce_er_picker(
         }
         Action::ErConfirmSelection => {
             if state.ui.er_selected_tables.is_empty() {
-                state.set_error("No tables selected".to_string());
+                state
+                    .messages
+                    .set_error_at("No tables selected".to_string(), now);
                 return DispatchResult::handled();
             }
             state.er_preparation.target_tables =

--- a/src/app/update/modal/settings.rs
+++ b/src/app/update/modal/settings.rs
@@ -10,7 +10,7 @@ use crate::update::dispatch_result::DispatchResult;
 pub(super) fn reduce_settings(
     state: &mut AppState,
     action: &Action,
-    _now: Instant,
+    now: Instant,
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::Settings) => {
@@ -86,11 +86,15 @@ pub(super) fn reduce_settings(
             state
                 .settings
                 .commit_saved(settings.theme_id, settings.er_browser.clone());
-            state.set_success("Settings saved".to_string());
+            state
+                .messages
+                .set_success_at("Settings saved".to_string(), now);
             DispatchResult::handled()
         }
         Action::SettingsSaveFailed(error) => {
-            state.set_error(format!("Failed to save settings: {error}"));
+            state
+                .messages
+                .set_error_at(format!("Failed to save settings: {error}"), now);
             DispatchResult::handled()
         }
         _ => DispatchResult::pass(),

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -1,3 +1,11 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::disallowed_methods,
+        reason = "tests construct fixtures with real clock readings; purity is enforced on production code via the lib target"
+    )
+)]
+
 // Domain models - fields/methods defined to match DB schema
 
 pub mod column;

--- a/src/domain/metadata.rs
+++ b/src/domain/metadata.rs
@@ -12,6 +12,10 @@ pub struct DatabaseMetadata {
 }
 
 impl DatabaseMetadata {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "fetch timestamp is recorded at construction, which happens at the infra I/O boundary"
+    )]
     pub fn new(database_name: String) -> Self {
         Self {
             database_name,

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -22,6 +22,10 @@ pub struct QueryResult {
 }
 
 impl QueryResult {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "execution timestamp is recorded at construction, which happens at the infra I/O boundary"
+    )]
     pub fn success(
         query: String,
         columns: Vec<String>,
@@ -43,6 +47,10 @@ impl QueryResult {
         }
     }
 
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "execution timestamp is recorded at construction, which happens at the infra I/O boundary"
+    )]
     pub fn error(
         query: String,
         error: String,

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -242,6 +242,10 @@ impl PostgresAdapter {
         source: QuerySource,
         read_only: bool,
     ) -> Result<QueryResult, DbOperationError> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures psql execution time at the I/O boundary"
+        )]
         let start = Instant::now();
 
         let output = self.run_psql(dsn, &["--csv"], query, read_only).await?;
@@ -300,6 +304,10 @@ impl PostgresAdapter {
         query: &str,
         read_only: bool,
     ) -> Result<WriteExecutionResult, DbOperationError> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures psql execution time at the I/O boundary"
+        )]
         let start = Instant::now();
 
         let output = self.run_psql(dsn, &[], query, read_only).await?;

--- a/src/infra/lib.rs
+++ b/src/infra/lib.rs
@@ -1,3 +1,11 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::disallowed_methods,
+        reason = "tests construct fixtures with real clock readings; purity is enforced on production code via the lib target"
+    )
+)]
+
 pub mod adapters;
 pub mod config;
 pub mod export;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+#![allow(
+    clippy::disallowed_methods,
+    reason = "the main loop is the time source: it reads the clock and injects `now` into reducers"
+)]
+
 use std::cell::RefCell;
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/src/main.rs
+++ b/src/main.rs
@@ -468,7 +468,7 @@ fn load_service_entries(state: &mut AppState, reader: Option<&dyn PgServiceEntry
         }
         Ok(_) | Err(ServiceFileError::NotFound(_)) => {}
         Err(e) => {
-            state.messages.set_error(e.to_string());
+            state.messages.set_error_at(e.to_string(), Instant::now());
         }
     }
 }

--- a/src/ui/lib.rs
+++ b/src/ui/lib.rs
@@ -1,3 +1,11 @@
+#![cfg_attr(
+    test,
+    allow(
+        clippy::disallowed_methods,
+        reason = "tests construct fixtures with real clock readings; purity is enforced on production code via the lib target"
+    )
+)]
+
 pub mod adapters;
 pub mod event;
 pub mod features;


### PR DESCRIPTION
<!-- Write all PR content in English. -->

## Problem

`reducer.rs` documents that reducers must not call `Instant::now()` (time is passed as `now`), yet 18 call sites under `update/` violated this through the now-embedding `MessageState::set_error/set_success/clear_expired` and their `AppState` wrappers. Nothing enforced the invariant, so the two API flavors kept drifting.

## Background

The `_at(msg, now)` injected variants already exist and newer code uses them consistently — several reducers even received `_now: Instant` unused while calling the now-embedding wrappers, showing the duplicate API was actively inviting violations. (Task 6 of docs/code-quality-todo.md, finding 1-6 / 3-3-1.)

## Approach

- Route the injected `now` through the remaining reducers and delete the now-embedding APIs, leaving `_at` as the only way to set messages. `load_service_entries` in main.rs is the one caller that legitimately reads the clock.
- Register `std::time::Instant::now` in clippy's `disallowed-methods` so future violations fail the build. Legitimate clock readers are opted out explicitly: tests via crate-level `cfg_attr(test, allow)`, main.rs / effect-runner / infra timing / domain timestamp constructors via `reason`-annotated attributes.

Known gap (out of scope): `QueryResult::error()` embeds `executed_at: Instant::now()` and is invoked from two reducers when synthesizing error results, so a clock reading still hides behind that constructor. Injecting the timestamp touches the domain constructor API, which belongs with task 2's `age_seconds` cleanup.

## Review notes

Commits are self-contained and individually revertable:
1. `_at` migration in `update/` (incl. threading `now` into `reduce_table_detail` / `reduce_er_neighbors` / `check_er_completion`)
2. removal of the now-embedding APIs
3. clippy enforcement