### PR TITLE
fix: make psql multi-statement result boundaries deterministic

### DIFF
--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -12,12 +12,8 @@ use super::super::PostgresAdapter;
 use super::error::classify_query_error;
 use super::parser::{ParseCommandTagError, split_sql_statements};
 
-// psql --csv concatenates multiple result sets without separators.
-// Multi-statement input is sent as one -c per statement, each preceded
-// by an `\echo` boundary marker, so result-set boundaries are
-// deterministic instead of inferred from the data shape. Statements
-// stay server-side SQL (never psql script input), so backslash
-// metacommands in user SQL are not interpreted.
+// Keep user SQL server-side: stdin scripts would let psql interpret
+// line-leading backslash metacommands before the server sees them.
 
 fn boundary_marker() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -33,8 +29,7 @@ fn boundary_marker() -> String {
     )
 }
 
-// --single-transaction preserves the all-or-nothing semantics that a
-// single multi-statement -c gets from the implicit transaction.
+// Match the implicit all-or-nothing behavior of a single multi-statement -c.
 fn segmented_query_args(statements: &[&str], marker: &str) -> Vec<String> {
     let echo = format!("\\echo {marker}");
     let mut args = Vec::with_capacity(statements.len() * 4 + 1);
@@ -48,8 +43,6 @@ fn segmented_query_args(statements: &[&str], marker: &str) -> Vec<String> {
     args
 }
 
-// One segment per marker line, marker lines excluded. Text before the
-// first marker is dropped.
 fn split_marker_segments<'a>(stdout: &'a str, marker: &str) -> Vec<&'a str> {
     let mut segments = Vec::new();
     let mut seg_start: Option<usize> = None;
@@ -69,9 +62,6 @@ fn split_marker_segments<'a>(stdout: &'a str, marker: &str) -> Vec<&'a str> {
     segments
 }
 
-// The result set to display is the last segment that is not a bare
-// command-tag block (statements without a result set emit only their
-// command tag, e.g. "UPDATE 3").
 fn select_result_segment<'a>(segments: &[&'a str]) -> Option<&'a str> {
     segments
         .iter()
@@ -223,9 +213,8 @@ impl PostgresAdapter {
             .await
     }
 
-    // Single statement: at most one result set, no boundary handling.
-    // Also keeps non-transaction-capable statements (VACUUM etc.)
-    // outside the --single-transaction wrapping of the segmented path.
+    // Keep non-transaction-capable statements outside the segmented
+    // --single-transaction path.
     async fn execute_single_statement(
         &self,
         dsn: &str,
@@ -293,8 +282,8 @@ impl PostgresAdapter {
         }
 
         let segments = split_marker_segments(&output.stdout, &marker);
-        // psql emits every marker once it exits successfully; a surplus
-        // means a data line collided with the marker. Refuse to guess.
+        // A mismatch implies a marker collision in data; guessing would
+        // reintroduce silent result-set misattribution.
         if segments.len() != statements.len() {
             return Err(DbOperationError::QueryFailed(format!(
                 "result-set boundary mismatch: expected {} segments, found {}",
@@ -628,8 +617,6 @@ mod tests {
 
         #[test]
         fn empty_leading_result_set_returns_last() {
-            // Header-only segment (0-row SELECT) followed by a real result;
-            // the old field-count heuristic could not detect this boundary.
             let segments = vec!["id,name", "age,email\n30,alice@example.com"];
             assert_eq!(
                 select_result_segment(&segments),
@@ -645,8 +632,6 @@ mod tests {
 
         #[test]
         fn data_rows_identical_to_header_stay_in_segment() {
-            // The old heuristic treated a data row equal to a known header
-            // as a new result-set boundary and silently dropped rows.
             let segments = vec!["id,name\n1,Alice", "id,name\nid,name"];
             assert_eq!(select_result_segment(&segments), Some("id,name\nid,name"));
         }

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -6,119 +6,78 @@ use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::app::ports::outbound::DbOperationError;
-use crate::domain::{QueryResult, QuerySource, WriteExecutionResult};
+use crate::domain::{CommandTag, QueryResult, QuerySource, WriteExecutionResult};
 
 use super::super::PostgresAdapter;
 use super::error::classify_query_error;
 use super::parser::{ParseCommandTagError, split_sql_statements};
 
-fn csv_field_count(line: &str) -> usize {
-    let mut count = 1;
-    let mut in_quotes = false;
-    for ch in line.chars() {
-        match ch {
-            '"' => in_quotes = !in_quotes,
-            ',' if !in_quotes => count += 1,
-            _ => {}
-        }
-    }
-    count
+// psql --csv concatenates multiple result sets without separators.
+// Multi-statement input is sent as one -c per statement, each preceded
+// by an `\echo` boundary marker, so result-set boundaries are
+// deterministic instead of inferred from the data shape. Statements
+// stay server-side SQL (never psql script input), so backslash
+// metacommands in user SQL are not interpreted.
+
+fn boundary_marker() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    format!(
+        "__sabiql_boundary_{}_{}_{}__",
+        std::process::id(),
+        nanos,
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    )
 }
 
-fn first_keyword(stmt: &str) -> &str {
-    let bytes = stmt.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        match bytes[i] {
-            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
-                while i < bytes.len() && bytes[i] != b'\n' {
-                    i += 1;
-                }
-            }
-            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
-                i += 2;
-                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    i += 1;
-                }
-                if i + 1 < bytes.len() {
-                    i += 2;
-                }
-            }
-            b if b.is_ascii_alphabetic() => {
-                let start = i;
-                while i < bytes.len() && bytes[i].is_ascii_alphanumeric() {
-                    i += 1;
-                }
-                return &stmt[start..i];
-            }
-            _ => i += 1,
-        }
+// --single-transaction preserves the all-or-nothing semantics that a
+// single multi-statement -c gets from the implicit transaction.
+fn segmented_query_args(statements: &[&str], marker: &str) -> Vec<String> {
+    let echo = format!("\\echo {marker}");
+    let mut args = Vec::with_capacity(statements.len() * 4 + 1);
+    args.push("--single-transaction".to_string());
+    for stmt in statements {
+        args.push("-c".to_string());
+        args.push(echo.clone());
+        args.push("-c".to_string());
+        args.push((*stmt).to_string());
     }
-    ""
+    args
 }
 
-fn count_select_statements(sql: &str) -> usize {
-    split_sql_statements(sql)
+// One segment per marker line, marker lines excluded. Text before the
+// first marker is dropped.
+fn split_marker_segments<'a>(stdout: &'a str, marker: &str) -> Vec<&'a str> {
+    let mut segments = Vec::new();
+    let mut seg_start: Option<usize> = None;
+    let mut offset = 0;
+    for line in stdout.split_inclusive('\n') {
+        if line.trim_end_matches(['\n', '\r']) == marker {
+            if let Some(start) = seg_start {
+                segments.push(stdout[start..offset].trim_matches(['\n', '\r']));
+            }
+            seg_start = Some(offset + line.len());
+        }
+        offset += line.len();
+    }
+    if let Some(start) = seg_start {
+        segments.push(stdout[start..].trim_matches(['\n', '\r']));
+    }
+    segments
+}
+
+// The result set to display is the last segment that is not a bare
+// command-tag block (statements without a result set emit only their
+// command tag, e.g. "UPDATE 3").
+fn select_result_segment<'a>(segments: &[&'a str]) -> Option<&'a str> {
+    segments
         .iter()
-        .filter(|s| {
-            let kw = first_keyword(s);
-            kw.eq_ignore_ascii_case("SELECT") || kw.eq_ignore_ascii_case("WITH")
-        })
-        .count()
-}
-
-// psql --csv concatenates multiple result sets without separators;
-// keep only the last one.
-fn extract_last_csv_block<'a>(stdout: &'a str, sql: &str) -> &'a str {
-    let lines: Vec<&str> = stdout.lines().collect();
-    if lines.len() <= 2 {
-        return stdout;
-    }
-
-    let expected_sets = count_select_statements(sql);
-    let first_header = lines[0];
-    let mut current_fc = csv_field_count(first_header);
-    let mut known_headers: Vec<&str> = vec![first_header];
-    let mut last_header_idx = 0;
-    let mut data_rows_since_header = 0usize;
-
-    for (i, &line) in lines.iter().enumerate().skip(1) {
-        let fc = csv_field_count(line);
-        if fc != current_fc {
-            last_header_idx = i;
-            current_fc = fc;
-            data_rows_since_header = 0;
-            if !known_headers.contains(&line) {
-                known_headers.push(line);
-            }
-        } else if known_headers.contains(&line) {
-            last_header_idx = i;
-            data_rows_since_header = 0;
-        } else if expected_sets > 1
-            && data_rows_since_header >= 1
-            && known_headers.len() < expected_sets
-        {
-            // Require at least one data row before accepting a new header
-            // candidate, bounded by SELECT/WITH count
-            last_header_idx = i;
-            known_headers.push(line);
-            data_rows_since_header = 0;
-        } else {
-            data_rows_since_header += 1;
-        }
-    }
-
-    if last_header_idx == 0 {
-        return stdout;
-    }
-
-    let byte_offset: usize = stdout
-        .lines()
-        .take(last_header_idx)
-        .map(|l| l.len() + 1) // +1 for '\n'
-        .sum();
-
-    &stdout[byte_offset..]
+        .rev()
+        .find(|seg| !seg.trim().is_empty() && !PostgresAdapter::is_command_tags_only(seg))
+        .copied()
 }
 
 struct PsqlOutput {
@@ -137,6 +96,17 @@ impl PostgresAdapter {
         query: &str,
         read_only: bool,
     ) -> Result<PsqlOutput, DbOperationError> {
+        self.run_psql_args(dsn, extra_args, &["-c", query], read_only)
+            .await
+    }
+
+    async fn run_psql_args(
+        &self,
+        dsn: &str,
+        extra_args: &[&str],
+        query_args: &[&str],
+        read_only: bool,
+    ) -> Result<PsqlOutput, DbOperationError> {
         let mut cmd = Command::new("psql");
         if read_only {
             Self::apply_read_only_pgoptions(&mut cmd);
@@ -146,8 +116,9 @@ impl PostgresAdapter {
         for arg in extra_args {
             cmd.arg(arg);
         }
-
-        cmd.arg("-c").arg(query);
+        for arg in query_args {
+            cmd.arg(arg);
+        }
 
         Self::collect_output(&mut cmd, self.timeout_secs).await
     }
@@ -242,6 +213,26 @@ impl PostgresAdapter {
         source: QuerySource,
         read_only: bool,
     ) -> Result<QueryResult, DbOperationError> {
+        let statements = split_sql_statements(query);
+        if statements.len() <= 1 {
+            return self
+                .execute_single_statement(dsn, query, source, read_only)
+                .await;
+        }
+        self.execute_segmented_statements(dsn, query, &statements, source, read_only)
+            .await
+    }
+
+    // Single statement: at most one result set, no boundary handling.
+    // Also keeps non-transaction-capable statements (VACUUM etc.)
+    // outside the --single-transaction wrapping of the segmented path.
+    async fn execute_single_statement(
+        &self,
+        dsn: &str,
+        query: &str,
+        source: QuerySource,
+        read_only: bool,
+    ) -> Result<QueryResult, DbOperationError> {
         let start = Instant::now();
 
         let output = self.run_psql(dsn, &["--csv"], query, read_only).await?;
@@ -252,7 +243,8 @@ impl PostgresAdapter {
             return Err(Self::classify_psql_error(&output.stderr));
         }
 
-        if output.stdout.trim().is_empty() {
+        let stdout_trimmed = output.stdout.trim();
+        if stdout_trimmed.is_empty() {
             return Ok(QueryResult::success(
                 query.to_string(),
                 Vec::new(),
@@ -262,16 +254,84 @@ impl PostgresAdapter {
             ));
         }
 
-        let stdout_trimmed = output.stdout.trim();
         if let Some(tag) = Self::parse_aggregate_command_tag(stdout_trimmed, query) {
-            let row_count = tag.affected_rows().unwrap_or(0) as usize;
-            let mut result =
-                QueryResult::success(query.to_string(), Vec::new(), Vec::new(), elapsed, source);
-            result.row_count = row_count;
-            return Ok(result.with_command_tag(tag));
+            return Ok(Self::command_tag_result(query, tag, elapsed, source));
         }
 
-        let csv_block = extract_last_csv_block(stdout_trimmed, query);
+        Self::csv_result(query, stdout_trimmed, elapsed, source)
+    }
+
+    async fn execute_segmented_statements(
+        &self,
+        dsn: &str,
+        query: &str,
+        statements: &[&str],
+        source: QuerySource,
+        read_only: bool,
+    ) -> Result<QueryResult, DbOperationError> {
+        let start = Instant::now();
+
+        let marker = boundary_marker();
+        let args = segmented_query_args(statements, &marker);
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let output = self
+            .run_psql_args(dsn, &["--csv"], &arg_refs, read_only)
+            .await?;
+
+        let elapsed = start.elapsed().as_millis() as u64;
+
+        if !output.status.success() {
+            return Err(Self::classify_psql_error(&output.stderr));
+        }
+
+        let segments = split_marker_segments(&output.stdout, &marker);
+        // psql emits every marker once it exits successfully; a surplus
+        // means a data line collided with the marker. Refuse to guess.
+        if segments.len() != statements.len() {
+            return Err(DbOperationError::QueryFailed(format!(
+                "result-set boundary mismatch: expected {} segments, found {}",
+                statements.len(),
+                segments.len()
+            )));
+        }
+
+        if let Some(csv_block) = select_result_segment(&segments) {
+            return Self::csv_result(query, csv_block, elapsed, source);
+        }
+
+        let tags = segments.join("\n");
+        if let Some(tag) = Self::parse_aggregate_command_tag(tags.trim(), query) {
+            return Ok(Self::command_tag_result(query, tag, elapsed, source));
+        }
+
+        Ok(QueryResult::success(
+            query.to_string(),
+            Vec::new(),
+            Vec::new(),
+            elapsed,
+            source,
+        ))
+    }
+
+    fn command_tag_result(
+        query: &str,
+        tag: CommandTag,
+        elapsed: u64,
+        source: QuerySource,
+    ) -> QueryResult {
+        let row_count = tag.affected_rows().unwrap_or(0) as usize;
+        let mut result =
+            QueryResult::success(query.to_string(), Vec::new(), Vec::new(), elapsed, source);
+        result.row_count = row_count;
+        result.with_command_tag(tag)
+    }
+
+    fn csv_result(
+        query: &str,
+        csv_block: &str,
+        elapsed: u64,
+        source: QuerySource,
+    ) -> Result<QueryResult, DbOperationError> {
         let mut reader = csv::ReaderBuilder::new()
             .has_headers(true)
             .from_reader(csv_block.as_bytes());
@@ -452,143 +512,137 @@ impl PostgresAdapter {
 mod tests {
     use crate::adapters::postgres::PostgresAdapter;
 
-    mod extract_last_csv_block {
-        use super::super::extract_last_csv_block;
+    mod boundary_marker {
+        use super::super::boundary_marker;
 
         #[test]
-        fn single_result_set_returned_as_is() {
-            let input = "id,name\n1,alice\n2,bob";
-            assert_eq!(extract_last_csv_block(input, "SELECT * FROM t"), input);
+        fn consecutive_markers_are_unique() {
+            assert_ne!(boundary_marker(), boundary_marker());
+        }
+    }
+
+    mod segmented_query_args {
+        use super::super::segmented_query_args;
+
+        #[test]
+        fn interleaves_echo_markers_inside_single_transaction() {
+            let args = segmented_query_args(&["SELECT 1", "SELECT 2"], "M");
+
+            assert_eq!(
+                args,
+                vec![
+                    "--single-transaction",
+                    "-c",
+                    "\\echo M",
+                    "-c",
+                    "SELECT 1",
+                    "-c",
+                    "\\echo M",
+                    "-c",
+                    "SELECT 2",
+                ]
+            );
+        }
+    }
+
+    mod split_marker_segments {
+        use super::super::split_marker_segments;
+
+        #[test]
+        fn splits_segments_between_markers() {
+            let stdout = "M\na\n1\nM\nb,c\n2,3\n";
+            assert_eq!(split_marker_segments(stdout, "M"), vec!["a\n1", "b,c\n2,3"]);
         }
 
         #[test]
-        fn two_selects_same_header_returns_last() {
-            let input = "?column?\n1\n?column?\n2";
+        fn drops_text_before_first_marker() {
+            let stdout = "noise\nM\na\n1\n";
+            assert_eq!(split_marker_segments(stdout, "M"), vec!["a\n1"]);
+        }
+
+        #[test]
+        fn no_marker_returns_empty() {
+            assert!(split_marker_segments("a\n1\n", "M").is_empty());
+        }
+
+        #[test]
+        fn consecutive_markers_yield_empty_segment() {
+            let stdout = "M\nM\nb\n2\n";
+            assert_eq!(split_marker_segments(stdout, "M"), vec!["", "b\n2"]);
+        }
+
+        #[test]
+        fn crlf_marker_line_is_recognized() {
+            let stdout = "M\r\na\r\n1\r\nM\r\nb\r\n2\r\n";
+            assert_eq!(split_marker_segments(stdout, "M"), vec!["a\r\n1", "b\r\n2"]);
+        }
+
+        #[test]
+        fn data_line_containing_marker_substring_is_not_a_boundary() {
+            let stdout = "M\nx\nprefix M suffix\nM\ny\n1\n";
             assert_eq!(
-                extract_last_csv_block(input, "SELECT 1; SELECT 2"),
-                "?column?\n2"
+                split_marker_segments(stdout, "M"),
+                vec!["x\nprefix M suffix", "y\n1"]
+            );
+        }
+    }
+
+    mod select_result_segment {
+        use super::super::select_result_segment;
+
+        #[test]
+        fn tag_then_csv_returns_csv() {
+            let segments = vec!["UPDATE 3", "id,name\n1,Alice"];
+            assert_eq!(select_result_segment(&segments), Some("id,name\n1,Alice"));
+        }
+
+        #[test]
+        fn csv_then_tag_returns_csv() {
+            let segments = vec!["id,name\n1,Alice", "DELETE 2"];
+            assert_eq!(select_result_segment(&segments), Some("id,name\n1,Alice"));
+        }
+
+        #[test]
+        fn two_result_sets_returns_last() {
+            let segments = vec!["a\n1", "b\n2"];
+            assert_eq!(select_result_segment(&segments), Some("b\n2"));
+        }
+
+        #[test]
+        fn tags_only_returns_none() {
+            let segments = vec!["BEGIN", "UPDATE 1", "COMMIT"];
+            assert_eq!(select_result_segment(&segments), None);
+        }
+
+        #[test]
+        fn empty_leading_result_set_returns_last() {
+            // Header-only segment (0-row SELECT) followed by a real result;
+            // the old field-count heuristic could not detect this boundary.
+            let segments = vec!["id,name", "age,email\n30,alice@example.com"];
+            assert_eq!(
+                select_result_segment(&segments),
+                Some("age,email\n30,alice@example.com")
             );
         }
 
         #[test]
-        fn two_selects_different_column_count_returns_last() {
-            let input = "a\n1\nb,c\n2,3";
-            assert_eq!(
-                extract_last_csv_block(input, "SELECT 1 AS a; SELECT 2 AS b, 3 AS c"),
-                "b,c\n2,3"
-            );
+        fn empty_trailing_result_set_is_selected_over_earlier_data() {
+            let segments = vec!["id,name\n1,Alice", "age,email"];
+            assert_eq!(select_result_segment(&segments), Some("age,email"));
         }
 
         #[test]
-        fn three_selects_returns_last() {
-            let input = "?column?\n1\n?column?\n2\n?column?\n3";
-            assert_eq!(
-                extract_last_csv_block(input, "SELECT 1; SELECT 2; SELECT 3"),
-                "?column?\n3"
-            );
+        fn data_rows_identical_to_header_stay_in_segment() {
+            // The old heuristic treated a data row equal to a known header
+            // as a new result-set boundary and silently dropped rows.
+            let segments = vec!["id,name\n1,Alice", "id,name\nid,name"];
+            assert_eq!(select_result_segment(&segments), Some("id,name\nid,name"));
         }
 
         #[test]
-        fn single_result_set_returns_unchanged() {
-            let input = "col\n42";
-            assert_eq!(extract_last_csv_block(input, "SELECT 1"), input);
-        }
-
-        #[test]
-        fn empty_input_returns_empty() {
-            assert_eq!(extract_last_csv_block("", "SELECT 1"), "");
-        }
-
-        #[test]
-        fn header_only_returns_unchanged() {
-            assert_eq!(extract_last_csv_block("col", "SELECT 1"), "col");
-        }
-
-        #[test]
-        fn same_field_count_different_headers_returns_last() {
-            let input = "id,name\n1,Alice\nage,email\n30,alice@example.com";
-            assert_eq!(
-                extract_last_csv_block(
-                    input,
-                    "SELECT id, name FROM users; SELECT age, email FROM contacts"
-                ),
-                "age,email\n30,alice@example.com"
-            );
-        }
-
-        #[test]
-        fn single_statement_falls_back() {
-            let input = "id,name\n1,Alice\n2,Bob";
-            assert_eq!(extract_last_csv_block(input, "SELECT * FROM t"), input);
-        }
-
-        #[test]
-        fn three_different_headers_same_field_count() {
-            let input = "x,y\n1,2\na,b\n3,4\np,q\n5,6";
-            assert_eq!(
-                extract_last_csv_block(
-                    input,
-                    "SELECT 1 AS x, 2 AS y; SELECT 3 AS a, 4 AS b; SELECT 5 AS p, 6 AS q"
-                ),
-                "p,q\n5,6"
-            );
-        }
-
-        #[test]
-        fn non_select_statements_excluded_from_hint() {
-            let input = "id,name\n1,Alice\nage,email\n30,bob@example.com";
-            assert_eq!(
-                extract_last_csv_block(
-                    input,
-                    "SET search_path TO public; SELECT id, name FROM users; SELECT age, email FROM contacts"
-                ),
-                "age,email\n30,bob@example.com"
-            );
-        }
-
-        #[test]
-        fn data_row_not_mistaken_when_single_select() {
-            let input = "x,y\na,b\n1,2";
-            assert_eq!(extract_last_csv_block(input, "SELECT * FROM t"), input);
-        }
-
-        #[test]
-        fn leading_line_comment_does_not_break_hint() {
-            let input = "id,name\n1,Alice\nage,email\n30,bob@example.com";
-            assert_eq!(
-                extract_last_csv_block(
-                    input,
-                    "-- note\nSELECT id, name FROM users; SELECT age, email FROM contacts"
-                ),
-                "age,email\n30,bob@example.com"
-            );
-        }
-
-        #[test]
-        fn leading_block_comment_does_not_break_hint() {
-            let input = "id,name\n1,Alice\nage,email\n30,bob@example.com";
-            assert_eq!(
-                extract_last_csv_block(
-                    input,
-                    "/* note */ SELECT id, name FROM users; SELECT age, email FROM contacts"
-                ),
-                "age,email\n30,bob@example.com"
-            );
-        }
-
-        // Known limitation: when the leading result set has 0 data rows,
-        // the data_rows_since_header guard prevents detecting the next header.
-        // Fixing this requires redesigning how boundary info flows from
-        // parse_aggregate_command_tag, which is out of scope here.
-        #[test]
-        #[ignore = "empty leading result set — needs boundary redesign"]
-        fn empty_leading_result_returns_last_block() {
-            let input = "id,name\nage,email\n30,alice@example.com";
-            let sql = "SELECT id, name FROM users WHERE false; SELECT age, email FROM contacts";
-            assert_eq!(
-                extract_last_csv_block(input, sql),
-                "age,email\n30,alice@example.com"
-            );
+        fn blank_segments_are_skipped() {
+            let segments = vec!["a\n1", ""];
+            assert_eq!(select_result_segment(&segments), Some("a\n1"));
         }
     }
 

--- a/src/infra/adapters/postgres/psql/parser/command_tag.rs
+++ b/src/infra/adapters/postgres/psql/parser/command_tag.rs
@@ -100,6 +100,13 @@ impl PostgresAdapter {
         ) || s == "START TRANSACTION"
     }
 
+    // Distinguishes a command-tag block ("UPDATE 1", "BEGIN", ...) from a
+    // result-set block (CSV header + data rows) in psql output. Empty input
+    // is not a command-tag block.
+    pub(in crate::adapters::postgres) fn is_command_tags_only(block: &str) -> bool {
+        Self::parse_all_tags(block).is_some()
+    }
+
     fn parse_all_tags(stdout: &str) -> Option<Vec<CommandTag>> {
         let mut tags = Vec::new();
         for line in stdout.lines() {
@@ -456,6 +463,30 @@ mod tests {
             assert!(!PostgresAdapter::is_known_tcl_tag("UPDATE 1"));
             assert!(!PostgresAdapter::is_known_tcl_tag("id,name"));
             assert!(!PostgresAdapter::is_known_tcl_tag("VACUUM"));
+        }
+    }
+
+    mod is_command_tags_only {
+        use super::*;
+        use rstest::rstest;
+
+        #[rstest]
+        #[case::single_dml("UPDATE 3")]
+        #[case::ddl("CREATE TABLE")]
+        #[case::txn_sequence("BEGIN\nUPDATE 1\nCOMMIT")]
+        #[case::trailing_newline("INSERT 0 1\n")]
+        fn tag_block_returns_true(#[case] block: &str) {
+            assert!(PostgresAdapter::is_command_tags_only(block));
+        }
+
+        #[rstest]
+        #[case::csv_with_rows("id,name\n1,Alice")]
+        #[case::csv_header_only("id,name")]
+        #[case::single_column_header("count")]
+        #[case::empty("")]
+        #[case::tag_then_csv("UPDATE 1\nid,name\n1,Alice")]
+        fn result_set_or_empty_returns_false(#[case] block: &str) {
+            assert!(!PostgresAdapter::is_command_tags_only(block));
         }
     }
 

--- a/src/infra/adapters/postgres/psql/parser/command_tag.rs
+++ b/src/infra/adapters/postgres/psql/parser/command_tag.rs
@@ -100,9 +100,6 @@ impl PostgresAdapter {
         ) || s == "START TRANSACTION"
     }
 
-    // Distinguishes a command-tag block ("UPDATE 1", "BEGIN", ...) from a
-    // result-set block (CSV header + data rows) in psql output. Empty input
-    // is not a command-tag block.
     pub(in crate::adapters::postgres) fn is_command_tags_only(block: &str) -> bool {
         Self::parse_all_tags(block).is_some()
     }

--- a/src/tests/adapter_postgres.rs
+++ b/src/tests/adapter_postgres.rs
@@ -109,8 +109,6 @@ mod query_execution {
     }
 }
 
-// Result-set boundary contract for multi-statement adhoc SQL:
-// the displayed result is the last statement that produced a result set.
 mod multi_statement_boundaries {
     use super::*;
     use sabiql_domain::CommandTag;
@@ -136,8 +134,6 @@ mod multi_statement_boundaries {
         let adapter = PostgresAdapter::new();
         let dsn = test_dsn();
 
-        // The data row of the second result set spells out "id,name",
-        // identical to its own header and to the first result set's header.
         let sql = "SELECT 1 AS id, 'Alice' AS name; \
                    SELECT 'id' AS id, 'name' AS name";
         let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();

--- a/src/tests/adapter_postgres.rs
+++ b/src/tests/adapter_postgres.rs
@@ -109,6 +109,129 @@ mod query_execution {
     }
 }
 
+// Result-set boundary contract for multi-statement adhoc SQL:
+// the displayed result is the last statement that produced a result set.
+mod multi_statement_boundaries {
+    use super::*;
+    use sabiql_domain::CommandTag;
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL, tracked: #133"]
+    async fn returns_last_result_set() {
+        let adapter = PostgresAdapter::new();
+        let dsn = test_dsn();
+
+        let result = adapter
+            .execute_adhoc(&dsn, "SELECT 1 AS a; SELECT 2 AS b, 3 AS c", false)
+            .await
+            .unwrap();
+
+        assert_eq!(result.columns, vec!["b", "c"]);
+        assert_eq!(result.rows, vec![vec!["2", "3"]]);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL, tracked: #133"]
+    async fn data_rows_identical_to_header_are_preserved() {
+        let adapter = PostgresAdapter::new();
+        let dsn = test_dsn();
+
+        // The data row of the second result set spells out "id,name",
+        // identical to its own header and to the first result set's header.
+        let sql = "SELECT 1 AS id, 'Alice' AS name; \
+                   SELECT 'id' AS id, 'name' AS name";
+        let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
+
+        assert_eq!(result.columns, vec!["id", "name"]);
+        assert_eq!(result.rows, vec![vec!["id", "name"]]);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL, tracked: #133"]
+    async fn empty_leading_result_set_returns_last() {
+        let adapter = PostgresAdapter::new();
+        let dsn = test_dsn();
+
+        let sql = "SELECT 1 AS a WHERE false; SELECT 2 AS b";
+        let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
+
+        assert_eq!(result.columns, vec!["b"]);
+        assert_eq!(result.rows, vec![vec!["2"]]);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL, tracked: #133"]
+    async fn empty_trailing_result_set_returns_zero_rows() {
+        let adapter = PostgresAdapter::new();
+        let dsn = test_dsn();
+
+        let sql = "SELECT 1 AS a; SELECT 2 AS b WHERE false";
+        let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
+
+        assert_eq!(result.columns, vec!["b"]);
+        assert!(result.rows.is_empty());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL, tracked: #133"]
+    async fn statements_share_one_session_and_transaction() {
+        let adapter = PostgresAdapter::new();
+        let dsn = test_dsn();
+
+        // Temp tables are session-local: this only works if all
+        // statements run in a single psql invocation.
+        let sql = "CREATE TEMP TABLE boundary_probe(v int); \
+                   INSERT INTO boundary_probe VALUES (7); \
+                   SELECT v FROM boundary_probe";
+        let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
+
+        assert_eq!(result.columns, vec!["v"]);
+        assert_eq!(result.rows, vec![vec!["7"]]);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL, tracked: #133"]
+    async fn write_only_statements_report_aggregate_tag() {
+        let adapter = PostgresAdapter::new();
+        let dsn = test_dsn();
+
+        let sql = "CREATE TEMP TABLE tag_probe(v int); \
+                   INSERT INTO tag_probe VALUES (1), (2)";
+        let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
+
+        assert!(result.rows.is_empty());
+        assert_eq!(
+            result.command_tag,
+            Some(CommandTag::Create("TABLE".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PostgreSQL, tracked: #133"]
+    async fn error_in_later_statement_rolls_back_earlier_writes() {
+        let adapter = PostgresAdapter::new();
+        let dsn = test_dsn();
+        adapter
+            .execute_adhoc(&dsn, "DROP TABLE IF EXISTS boundary_rollback_probe", false)
+            .await
+            .unwrap();
+
+        let failing = "CREATE TABLE boundary_rollback_probe(v int); SELECT no_such_column";
+        let result = adapter.execute_adhoc(&dsn, failing, false).await;
+        assert!(result.is_err(), "expected mid-script error, got {result:?}");
+
+        let check = adapter
+            .execute_adhoc(
+                &dsn,
+                "SELECT to_regclass('boundary_rollback_probe') IS NULL AS rolled_back",
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(check.rows, vec![vec!["t"]]);
+    }
+}
+
 mod error_paths {
     use super::*;
 


### PR DESCRIPTION
## Problem

Multi-statement adhoc queries pick the displayed result set with a shape-based heuristic (field-count changes + known headers + SELECT count). It can misattribute results: a data row identical to a header is treated as a boundary and silently dropped, and an empty leading result set defeats detection entirely.

## Background

psql `--csv` concatenates result sets with no separator, so boundaries cannot be recovered from the output alone — they have to be injected at execution time.

## Approach

Send each statement as its own server-side `-c`, preceded by `-c '\echo <random marker>'`, so stdout splits deterministically into one segment per statement; the last segment that is not a bare command-tag block is the result to display. `--single-transaction` preserves the implicit all-or-nothing semantics of the old single `-c` (verified against live psql, including that its BEGIN/COMMIT tags don't leak into stdout), and single-statement queries keep the old path untouched. stdin scripting was rejected because psql would interpret backslash metacommands embedded in user SQL.