### PR TITLE
refactor: dedup update/query reducers (task 10: 1-9 / 1-15)

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -213,6 +213,12 @@ impl AppState {
     pub fn can_request_csv_export(&self) -> bool {
         !self.query.is_history_mode() && self.query.visible_result().is_some_and(|r| !r.is_error())
     }
+
+    /// True when a run-scoped async response no longer belongs to the active
+    /// connection and query run, and must be dropped without touching state.
+    pub fn is_stale_query_run(&self, dsn: &str, run_id: u64) -> bool {
+        self.session.dsn.as_deref() != Some(dsn) || !self.query.is_current_run(run_id)
+    }
 }
 
 #[cfg(test)]

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -3,11 +3,11 @@ use std::time::Instant;
 
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
-use crate::model::browse::query_execution::PREVIEW_PAGE_SIZE;
 use crate::model::connection::error::ConnectionErrorInfo;
 use crate::model::er_state::ErStatus;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ModalKind};
+use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn reduce_loading(
@@ -47,24 +47,14 @@ pub(super) fn reduce_loading(
                     state.ui.set_explorer_selection(Some(idx));
                     // Refresh preview and detail: DDL or reload may have changed
                     // data/schema even though the table still exists.
-                    let dsn = dsn.clone();
                     let page = state.query.pagination.current_page;
                     let generation = state.session.selection_generation();
-                    let query_run_id = state.query.begin_running(now);
+                    effects.extend(preview_effect_for_current_table(
+                        state, now, page, generation,
+                    ));
                     let detail_run_id = state.session.begin_table_detail_run();
-                    effects.push(Effect::ExecutePreview {
-                        dsn: dsn.clone(),
-                        schema: state.query.pagination.schema.clone(),
-                        table: state.query.pagination.table.clone(),
-                        generation,
-                        run_id: query_run_id,
-                        limit: PREVIEW_PAGE_SIZE,
-                        offset: page * PREVIEW_PAGE_SIZE,
-                        target_page: page,
-                        read_only: state.session.read_only,
-                    });
                     effects.push(Effect::FetchTableDetail {
-                        dsn,
+                        dsn: dsn.clone(),
                         schema: state.query.pagination.schema.clone(),
                         table: state.query.pagination.table.clone(),
                         generation,

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -10,6 +10,7 @@ use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::AdhocSuccessSnapshot;
 use crate::services::AppServices;
 use crate::update::action::{Action, ModalKind, TableTarget};
+use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::input::command::{command_to_action, parse_command};
 
@@ -39,18 +40,10 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -
         effects.push(Effect::FetchMetadata { dsn, run_id });
     } else if !state.query.pagination.table.is_empty() {
         let page = state.query.pagination.current_page;
-        let run_id = state.query.begin_running(now);
-        effects.push(Effect::ExecutePreview {
-            dsn,
-            schema: state.query.pagination.schema.clone(),
-            table: state.query.pagination.table.clone(),
-            generation: state.session.selection_generation(),
-            run_id,
-            limit: PREVIEW_PAGE_SIZE,
-            offset: page * PREVIEW_PAGE_SIZE,
-            target_page: page,
-            read_only: state.session.read_only,
-        });
+        let generation = state.session.selection_generation();
+        effects.extend(preview_effect_for_current_table(
+            state, now, page, generation,
+        ));
     }
 
     effects
@@ -242,41 +235,35 @@ pub fn reduce_execution(
             table,
             generation,
         }) => {
-            if let Some(dsn) = &state.session.dsn {
-                let run_id = state.query.begin_running(now);
+            if state.session.dsn.is_none() {
+                return DispatchResult::handled();
+            }
 
-                state.query.pagination.reset();
-                state.query.pagination.schema.clone_from(schema);
-                state.query.pagination.table.clone_from(table);
+            state.query.pagination.reset();
+            state.query.pagination.schema.clone_from(schema);
+            state.query.pagination.table.clone_from(table);
 
-                let row_estimate = state
-                    .session
-                    .table_detail()
-                    .and_then(|d| d.row_count_estimate)
-                    .or_else(|| {
-                        state.tables().iter().find_map(|t| {
-                            if t.schema == *schema && t.name == *table {
-                                t.row_count_estimate
-                            } else {
-                                None
-                            }
-                        })
-                    });
-                state.query.pagination.total_rows_estimate = row_estimate;
+            let row_estimate = state
+                .session
+                .table_detail()
+                .and_then(|d| d.row_count_estimate)
+                .or_else(|| {
+                    state.tables().iter().find_map(|t| {
+                        if t.schema == *schema && t.name == *table {
+                            t.row_count_estimate
+                        } else {
+                            None
+                        }
+                    })
+                });
+            state.query.pagination.total_rows_estimate = row_estimate;
 
-                DispatchResult::handled_with(vec![Effect::ExecutePreview {
-                    dsn: dsn.clone(),
-                    schema: schema.clone(),
-                    table: table.clone(),
-                    generation: *generation,
-                    run_id,
-                    limit: PREVIEW_PAGE_SIZE,
-                    offset: 0,
-                    target_page: 0,
-                    read_only: state.session.read_only,
-                }])
-            } else {
-                DispatchResult::handled()
+            // Keep the generation captured at selection time, not the current
+            // one: the selection may have been cleared between dispatch and
+            // now, and such a completion must fail the stale check.
+            match preview_effect_for_current_table(state, now, 0, *generation) {
+                Some(effect) => DispatchResult::handled_with(vec![effect]),
+                None => DispatchResult::handled(),
             }
         }
 

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -293,26 +293,6 @@ mod tests {
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
 
-    fn begin_query_run(state: &mut AppState) -> u64 {
-        state.query.begin_running(Instant::now())
-    }
-
-    fn query_completed_action(
-        state: &mut AppState,
-        result: Arc<QueryResult>,
-        generation: u64,
-        target_page: Option<usize>,
-    ) -> Action {
-        let run_id = begin_query_run(state);
-        Action::QueryCompleted {
-            dsn: "postgres://localhost/test".to_string(),
-            run_id,
-            result,
-            generation,
-            target_page,
-        }
-    }
-
     fn query_failed_action(
         state: &mut AppState,
         error: DbOperationError,

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -71,7 +71,7 @@ pub fn reduce_execution(
             generation,
             target_page,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
             if *generation != 0 && *generation != state.session.selection_generation() {
@@ -151,7 +151,7 @@ pub fn reduce_execution(
             generation,
             source,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
 

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -49,6 +49,14 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -
     effects
 }
 
+fn reset_view_for_new_result(state: &mut AppState, now: Instant) {
+    state.result_interaction.reset_view();
+    state
+        .query
+        .set_result_highlight(now + Duration::from_millis(500));
+    state.query.exit_history();
+}
+
 pub fn reduce_execution(
     state: &mut AppState,
     action: &Action,
@@ -66,51 +74,45 @@ pub fn reduce_execution(
             if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
                 return DispatchResult::handled();
             }
+            if *generation != 0 && *generation != state.session.selection_generation() {
+                return DispatchResult::handled();
+            }
 
-            if *generation == 0 || *generation == state.session.selection_generation() {
-                state.query.mark_idle();
-                let preserved_result_col = state.result_interaction.selection().cell();
-                let preserved_horizontal_offset = state.result_interaction.horizontal_offset;
+            state.query.mark_idle();
 
-                let is_adhoc_error = result.source == QuerySource::Adhoc && result.is_error();
-                if !is_adhoc_error {
-                    state.result_interaction.reset_view();
+            match (result.source, result.is_error()) {
+                // Adhoc errors stay inside the SQL modal; the existing preview
+                // result and its view state are kept untouched.
+                (QuerySource::Adhoc, true) => {
                     state
-                        .query
-                        .set_result_highlight(now + Duration::from_millis(500));
-                    state.query.exit_history();
+                        .sql_modal
+                        .finish_adhoc_error(result.error.clone().unwrap_or_default());
                 }
-
-                if result.source == QuerySource::Adhoc {
-                    if result.is_error() {
-                        state
-                            .sql_modal
-                            .finish_adhoc_error(result.error.clone().unwrap_or_default());
-                    } else {
-                        state.sql_modal.finish_adhoc_success(AdhocSuccessSnapshot {
-                            command_tag: result.command_tag.clone(),
-                            row_count: result.row_count,
-                            execution_time_ms: result.execution_time_ms,
-                        });
-                    }
-                }
-
-                if result.source == QuerySource::Adhoc && !result.is_error() {
+                (QuerySource::Adhoc, false) => {
+                    reset_view_for_new_result(state, now);
+                    state.sql_modal.finish_adhoc_success(AdhocSuccessSnapshot {
+                        command_tag: result.command_tag.clone(),
+                        row_count: result.row_count,
+                        execution_time_ms: result.execution_time_ms,
+                    });
                     state.query.push_history(Arc::clone(result));
-                }
-
-                if let Some(page) = target_page {
-                    state.query.pagination.current_page = *page;
-                    if result.rows.len() < PREVIEW_PAGE_SIZE {
-                        state.query.pagination.reached_end = true;
-                    }
-                }
-
-                if !result.is_error() || result.source != QuerySource::Adhoc {
                     state.query.set_current_result(Arc::clone(result));
                 }
+                // Preview errors arrive as error results and are shown in the
+                // Result pane like any other preview.
+                (QuerySource::Preview, _) => {
+                    let preserved_result_col = state.result_interaction.selection().cell();
+                    let preserved_horizontal_offset = state.result_interaction.horizontal_offset;
+                    reset_view_for_new_result(state, now);
 
-                if result.source == QuerySource::Preview {
+                    if let Some(page) = target_page {
+                        state.query.pagination.current_page = *page;
+                        if result.rows.len() < PREVIEW_PAGE_SIZE {
+                            state.query.pagination.reached_end = true;
+                        }
+                    }
+                    state.query.set_current_result(Arc::clone(result));
+
                     match state.query.post_delete_row_selection() {
                         PostDeleteRowSelection::Keep => {}
                         PostDeleteRowSelection::Clear => {
@@ -138,11 +140,9 @@ pub fn reduce_execution(
                         .query
                         .set_post_delete_selection(PostDeleteRowSelection::Keep);
                 }
-
-                DispatchResult::handled_with(try_adhoc_refresh(state, result, now))
-            } else {
-                DispatchResult::handled()
             }
+
+            DispatchResult::handled_with(try_adhoc_refresh(state, result, now))
         }
         Action::QueryFailed {
             dsn,

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -61,11 +61,32 @@ pub(super) mod tests {
         QuerySource, Table, Trigger, TriggerEvent, TriggerTiming,
     };
     use crate::model::app_state::AppState;
+    use crate::update::action::Action;
 
     pub fn create_test_state() -> AppState {
         let mut state = AppState::new("test_project".to_string());
         state.session.dsn = Some("postgres://localhost/test".to_string());
         state
+    }
+
+    pub fn begin_query_run(state: &mut AppState) -> u64 {
+        state.query.begin_running(Instant::now())
+    }
+
+    pub fn query_completed_action(
+        state: &mut AppState,
+        result: Arc<QueryResult>,
+        generation: u64,
+        target_page: Option<usize>,
+    ) -> Action {
+        let run_id = begin_query_run(state);
+        Action::QueryCompleted {
+            dsn: "postgres://localhost/test".to_string(),
+            run_id,
+            result,
+            generation,
+            target_page,
+        }
     }
 
     pub fn preview_result(row_count: usize) -> Arc<QueryResult> {

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -4,7 +4,9 @@ mod write;
 
 use std::time::Instant;
 
+use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
+use crate::model::browse::query_execution::PREVIEW_PAGE_SIZE;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
@@ -18,6 +20,35 @@ pub fn dispatch_query(
     execution::reduce_execution(state, action, now, services)
         .or_else(|| write::reduce_write(state, action, now, services))
         .or_else(|| pagination::reduce_pagination(state, action, now, services))
+}
+
+/// Builds the preview effect for the table currently held in pagination state,
+/// issuing a fresh run_id. Returns `None` when no connection is active.
+///
+/// `generation` is the selection snapshot the eventual completion is validated
+/// against. Refreshes of the active selection pass
+/// `state.session.selection_generation()`; `Action::ExecutePreview` instead
+/// passes the generation captured at selection time, so that results for a
+/// selection cleared in the meantime (e.g. DROP TABLE + reload) are rejected.
+pub(super) fn preview_effect_for_current_table(
+    state: &mut AppState,
+    now: Instant,
+    target_page: usize,
+    generation: u64,
+) -> Option<Effect> {
+    let dsn = state.session.dsn.clone()?;
+    let run_id = state.query.begin_running(now);
+    Some(Effect::ExecutePreview {
+        dsn,
+        schema: state.query.pagination.schema.clone(),
+        table: state.query.pagination.table.clone(),
+        generation,
+        run_id,
+        limit: PREVIEW_PAGE_SIZE,
+        offset: target_page * PREVIEW_PAGE_SIZE,
+        target_page,
+        read_only: state.session.read_only,
+    })
 }
 
 #[cfg(test)]

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -68,7 +68,7 @@ pub fn reduce_pagination(
             export_query,
             file_name,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
 
@@ -116,7 +116,7 @@ pub fn reduce_pagination(
             file_name,
             row_count,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
 
@@ -136,7 +136,7 @@ pub fn reduce_pagination(
             path,
             row_count,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
 
@@ -153,7 +153,7 @@ pub fn reduce_pagination(
         }
 
         Action::CsvExportFailed { dsn, run_id, error } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
 

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -4,10 +4,10 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::domain::QuerySource;
 use crate::model::app_state::AppState;
-use crate::model::browse::query_execution::PREVIEW_PAGE_SIZE;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
+use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
 
 pub fn reduce_pagination(
@@ -177,23 +177,14 @@ pub fn reduce_pagination(
             if !state.query.pagination.can_next() {
                 return DispatchResult::handled();
             }
-            if let Some(dsn) = state.session.dsn.clone() {
-                let next_page = state.query.pagination.current_page + 1;
-                let run_id = state.query.begin_running(now);
-                state.result_interaction.reset_view();
-                DispatchResult::handled_with(vec![Effect::ExecutePreview {
-                    dsn,
-                    schema: state.query.pagination.schema.clone(),
-                    table: state.query.pagination.table.clone(),
-                    generation: state.session.selection_generation(),
-                    run_id,
-                    limit: PREVIEW_PAGE_SIZE,
-                    offset: next_page * PREVIEW_PAGE_SIZE,
-                    target_page: next_page,
-                    read_only: state.session.read_only,
-                }])
-            } else {
-                DispatchResult::handled()
+            let next_page = state.query.pagination.current_page + 1;
+            let generation = state.session.selection_generation();
+            match preview_effect_for_current_table(state, now, next_page, generation) {
+                Some(effect) => {
+                    state.result_interaction.reset_view();
+                    DispatchResult::handled_with(vec![effect])
+                }
+                None => DispatchResult::handled(),
             }
         }
 
@@ -204,24 +195,15 @@ pub fn reduce_pagination(
             if !state.query.pagination.can_prev() {
                 return DispatchResult::handled();
             }
-            if let Some(dsn) = state.session.dsn.clone() {
-                let prev_page = state.query.pagination.current_page - 1;
-                let run_id = state.query.begin_running(now);
-                state.result_interaction.reset_view();
-                state.query.pagination.reached_end = false;
-                DispatchResult::handled_with(vec![Effect::ExecutePreview {
-                    dsn,
-                    schema: state.query.pagination.schema.clone(),
-                    table: state.query.pagination.table.clone(),
-                    generation: state.session.selection_generation(),
-                    run_id,
-                    limit: PREVIEW_PAGE_SIZE,
-                    offset: prev_page * PREVIEW_PAGE_SIZE,
-                    target_page: prev_page,
-                    read_only: state.session.read_only,
-                }])
-            } else {
-                DispatchResult::handled()
+            let prev_page = state.query.pagination.current_page - 1;
+            let generation = state.session.selection_generation();
+            match preview_effect_for_current_table(state, now, prev_page, generation) {
+                Some(effect) => {
+                    state.result_interaction.reset_view();
+                    state.query.pagination.reached_end = false;
+                    DispatchResult::handled_with(vec![effect])
+                }
+                None => DispatchResult::handled(),
             }
         }
 
@@ -236,7 +218,7 @@ mod tests {
     use crate::ports::outbound::DbOperationError;
     use std::sync::Arc;
 
-    use crate::model::browse::query_execution::PaginationState;
+    use crate::model::browse::query_execution::{PREVIEW_PAGE_SIZE, PaginationState};
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
 

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -222,10 +222,6 @@ mod tests {
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
 
-    fn begin_query_run(state: &mut AppState) -> u64 {
-        state.query.begin_running(Instant::now())
-    }
-
     fn csv_rows_counted_action(
         state: &mut AppState,
         row_count: Option<usize>,

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -256,7 +256,7 @@ pub fn reduce_write(
             run_id,
             affected_rows,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
 
@@ -344,7 +344,7 @@ pub fn reduce_write(
         }
 
         Action::ExecuteWriteFailed { dsn, run_id, error } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
 

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -2,9 +2,7 @@ use std::time::Instant;
 
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
-use crate::model::browse::query_execution::{
-    DeleteRefreshTarget, PREVIEW_PAGE_SIZE, PostDeleteRowSelection,
-};
+use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSelection};
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::json::json_diff::compute_json_diff;
 use crate::policy::write::write_guardrails::{
@@ -15,6 +13,7 @@ use crate::policy::write::write_update::{
 };
 use crate::services::AppServices;
 use crate::update::action::Action;
+use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{
     EditGuardrailError, build_bulk_delete_preview, editable_preview_base,
@@ -284,22 +283,11 @@ pub fn reduce_write(
                     state.result_interaction.clear_cell_edit();
                     state.modal.set_mode(InputMode::Normal);
 
-                    if let Some(dsn) = &state.session.dsn {
-                        let page = state.query.pagination.current_page;
-                        let run_id = state.query.begin_running(now);
-                        DispatchResult::handled_with(vec![Effect::ExecutePreview {
-                            dsn: dsn.clone(),
-                            schema: state.query.pagination.schema.clone(),
-                            table: state.query.pagination.table.clone(),
-                            generation: state.session.selection_generation(),
-                            run_id,
-                            limit: PREVIEW_PAGE_SIZE,
-                            offset: page * PREVIEW_PAGE_SIZE,
-                            target_page: page,
-                            read_only: state.session.read_only,
-                        }])
-                    } else {
-                        DispatchResult::handled()
+                    let page = state.query.pagination.current_page;
+                    let generation = state.session.selection_generation();
+                    match preview_effect_for_current_table(state, now, page, generation) {
+                        Some(effect) => DispatchResult::handled_with(vec![effect]),
+                        None => DispatchResult::handled(),
                     }
                 }
                 WriteOperation::Delete => {
@@ -343,22 +331,13 @@ pub fn reduce_write(
                         PostDeleteRowSelection::Select,
                     ));
 
-                    if let Some(dsn) = &state.session.dsn {
-                        let run_id = state.query.begin_running(now);
-                        state.query.pagination.reached_end = false;
-                        DispatchResult::handled_with(vec![Effect::ExecutePreview {
-                            dsn: dsn.clone(),
-                            schema: state.query.pagination.schema.clone(),
-                            table: state.query.pagination.table.clone(),
-                            generation: state.session.selection_generation(),
-                            run_id,
-                            limit: PREVIEW_PAGE_SIZE,
-                            offset: target_page * PREVIEW_PAGE_SIZE,
-                            target_page,
-                            read_only: state.session.read_only,
-                        }])
-                    } else {
-                        DispatchResult::handled()
+                    let generation = state.session.selection_generation();
+                    match preview_effect_for_current_table(state, now, target_page, generation) {
+                        Some(effect) => {
+                            state.query.pagination.reached_end = false;
+                            DispatchResult::handled_with(vec![effect])
+                        }
+                        None => DispatchResult::handled(),
                     }
                 }
             }
@@ -395,7 +374,7 @@ mod tests {
 
     use crate::domain::QueryResult;
     use crate::model::browse::query_execution::{
-        DeleteRefreshTarget, PostDeleteRowSelection, QueryStatus,
+        DeleteRefreshTarget, PREVIEW_PAGE_SIZE, PostDeleteRowSelection, QueryStatus,
     };
     use crate::policy::write::write_guardrails::{
         GuardrailDecision, RiskLevel, TargetSummary, WriteOperation, WritePreview,

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -370,9 +370,7 @@ pub fn reduce_write(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
 
-    use crate::domain::QueryResult;
     use crate::model::browse::query_execution::{
         DeleteRefreshTarget, PREVIEW_PAGE_SIZE, PostDeleteRowSelection, QueryStatus,
     };
@@ -382,10 +380,6 @@ mod tests {
     use crate::ports::outbound::DbOperationError;
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
-
-    fn begin_query_run(state: &mut AppState) -> u64 {
-        state.query.begin_running(Instant::now())
-    }
 
     fn write_succeeded_action(state: &mut AppState, affected_rows: usize) -> Action {
         let run_id = begin_query_run(state);
@@ -402,22 +396,6 @@ mod tests {
             dsn: "postgres://localhost/test".to_string(),
             run_id,
             error,
-        }
-    }
-
-    fn query_completed_action(
-        state: &mut AppState,
-        result: Arc<QueryResult>,
-        generation: u64,
-        target_page: Option<usize>,
-    ) -> Action {
-        let run_id = begin_query_run(state);
-        Action::QueryCompleted {
-            dsn: "postgres://localhost/test".to_string(),
-            run_id,
-            result,
-            generation,
-            target_page,
         }
     }
 

--- a/src/app/update/explain/output.rs
+++ b/src/app/update/explain/output.rs
@@ -20,7 +20,7 @@ pub(super) fn reduce_output(
             is_analyze,
             execution_time_ms,
         } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_success(
@@ -34,7 +34,7 @@ pub(super) fn reduce_output(
         }
 
         Action::ExplainFailed { dsn, run_id, error } => {
-            if state.session.dsn.as_ref() != Some(dsn) || !state.query.is_current_run(*run_id) {
+            if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_error(state, error.user_message());


### PR DESCRIPTION
<!-- Write all PR content in English. -->

## Problem
The query update reducers had repeated preview-effect construction and scattered stale-run checks, making small behavior-preserving changes harder to review.

This addresses code-quality task 10 for review findings 1-9 and 1-15.

## Background
The cleanup target came from the code-quality TODO list. The original TODO suggested a narrower helper shape, but preview completions still need the selection generation captured when the preview was requested so stale table-selection results are rejected correctly.

## Approach
Centralize preview refresh construction and query-run staleness checks while keeping existing async completion semantics unchanged.

Reshape query completion handling around the source/error matrix, preserving the existing distinction between preview errors shown in the result pane and adhoc errors kept in the SQL modal.

Share query reducer test fixtures so the tests describe the behavior differences instead of duplicating setup.

## Screenshots
N/A
