### PR TITLE
fix: block mixed acknowledge reasons and register statement keywords in lexer

### DIFF
--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -131,6 +131,18 @@ const SQL_KEYWORDS: &[&str] = &[
     "FOLLOWING",
     "CURRENT",
     "ROW",
+    "DO",
+    "GRANT",
+    "REVOKE",
+    "COPY",
+    "CALL",
+    "MERGE",
+    "TRUNCATE",
+    "BEGIN",
+    "COMMIT",
+    "ROLLBACK",
+    "EXPLAIN",
+    "ANALYZE",
 ];
 
 pub struct SqlLexer;
@@ -1019,6 +1031,24 @@ mod tests {
                 })
                 .collect();
             assert_eq!(keywords, vec!["SELECT", "FROM"]);
+        }
+
+        #[test]
+        fn statement_starting_keywords_tokenize_as_keywords() {
+            let l = lexer();
+
+            for kw in [
+                "DO", "GRANT", "REVOKE", "COPY", "CALL", "MERGE", "TRUNCATE", "BEGIN", "COMMIT",
+                "ROLLBACK", "EXPLAIN", "ANALYZE",
+            ] {
+                let sql = format!("{kw} x");
+                let tokens = l.tokenize(&sql, sql.chars().count());
+
+                assert!(
+                    matches!(&tokens[0].kind, TokenKind::Keyword(k) if k == kw),
+                    "{kw} should tokenize as a keyword"
+                );
+            }
         }
 
         #[test]

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -143,6 +143,11 @@ const SQL_KEYWORDS: &[&str] = &[
     "ROLLBACK",
     "EXPLAIN",
     "ANALYZE",
+    "SHOW",
+    "SAVEPOINT",
+    "START",
+    "TRANSACTION",
+    "RELEASE",
 ];
 
 pub struct SqlLexer;
@@ -1034,12 +1039,27 @@ mod tests {
         }
 
         #[test]
-        fn statement_starting_keywords_tokenize_as_keywords() {
+        fn statement_keywords_tokenize_as_keywords() {
             let l = lexer();
 
             for kw in [
-                "DO", "GRANT", "REVOKE", "COPY", "CALL", "MERGE", "TRUNCATE", "BEGIN", "COMMIT",
-                "ROLLBACK", "EXPLAIN", "ANALYZE",
+                "DO",
+                "GRANT",
+                "REVOKE",
+                "COPY",
+                "CALL",
+                "MERGE",
+                "TRUNCATE",
+                "BEGIN",
+                "COMMIT",
+                "ROLLBACK",
+                "EXPLAIN",
+                "ANALYZE",
+                "SHOW",
+                "SAVEPOINT",
+                "START",
+                "TRANSACTION",
+                "RELEASE",
             ] {
                 let sql = format!("{kw} x");
                 let tokens = l.tokenize(&sql, sql.chars().count());

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -228,13 +228,21 @@ pub fn evaluate_multi_statement(sql: &str) -> MultiStatementDecision {
     let has_table_name_input = decisions
         .iter()
         .any(|(_, d)| matches!(d.confirmation, ConfirmationType::TableNameInput { .. }));
-    let has_acknowledge = decisions
+    let ack_reasons: Vec<&AcknowledgeReason> = decisions
         .iter()
-        .any(|(_, d)| matches!(d.confirmation, ConfirmationType::Acknowledge { .. }));
+        .filter_map(|(_, d)| match &d.confirmation {
+            ConfirmationType::Acknowledge { reason, .. } => Some(reason),
+            _ => None,
+        })
+        .collect();
+    let has_acknowledge = !ack_reasons.is_empty();
+    let mixed_ack_reasons = ack_reasons.windows(2).any(|w| w[0] != w[1]);
 
     // One dialog can only carry one consent: a typed-name confirmation must not
-    // silently approve statements that need their own acknowledgment.
-    if has_table_name_input && has_acknowledge {
+    // silently approve statements that need their own acknowledgment, and one
+    // acknowledgment must not cover statements flagged for a different reason
+    // (the dialog would hide the other reason from the user).
+    if (has_table_name_input && has_acknowledge) || mixed_ack_reasons {
         return MultiStatementDecision::Block {
             reason: "Statements require different confirmations; run them separately".to_string(),
         };
@@ -248,18 +256,11 @@ pub fn evaluate_multi_statement(sql: &str) -> MultiStatementDecision {
             .map(|(_, d)| d.confirmation.clone())
             .unwrap()
     } else if has_acknowledge {
-        let max_acknowledged_risk = decisions
-            .iter()
-            .filter(|(_, d)| matches!(d.confirmation, ConfirmationType::Acknowledge { .. }))
-            .map(|(_, d)| d.risk_level)
-            .max()
-            .unwrap();
+        // Mixed reasons are blocked above, so every remaining Acknowledge
+        // carries the same reason; the first one's label is representative.
         decisions
             .iter()
-            .find(|(_, d)| {
-                matches!(d.confirmation, ConfirmationType::Acknowledge { .. })
-                    && d.risk_level == max_acknowledged_risk
-            })
+            .find(|(_, d)| matches!(d.confirmation, ConfirmationType::Acknowledge { .. }))
             .map(|(_, d)| d.confirmation.clone())
             .unwrap()
     } else {
@@ -665,25 +666,43 @@ mod tests {
         #[rstest]
         #[case::do_block_with_drop("DO $$ BEGIN RAISE NOTICE 'hi'; END $$; DROP TABLE users")]
         #[case::drop_with_unextractable_drop("DROP TABLE users; DROP TABLE a, b")]
+        #[case::mixed_acknowledge_reasons("DO $$ BEGIN RAISE NOTICE 'hi'; END $$; DROP TABLE a, b")]
         fn mixed_confirmations_are_blocked(#[case] sql: &str) {
             let result = evaluate_multi_statement(sql);
 
             assert!(matches!(result, MultiStatementDecision::Block { .. }));
         }
 
-        #[test]
-        fn acknowledgments_aggregate_to_highest_risk_reason() {
-            let result =
-                evaluate_multi_statement("DO $$ BEGIN RAISE NOTICE 'hi'; END $$; DROP TABLE a, b");
+        #[rstest]
+        #[case::unknown_risk(
+            "COPY users FROM '/tmp/a.csv'; CALL refresh()",
+            RiskLevel::Low,
+            AcknowledgeReason::UnknownRisk,
+            "COPY"
+        )]
+        #[case::target_name_unavailable(
+            "DROP TABLE a, b; TRUNCATE c, d",
+            RiskLevel::High,
+            AcknowledgeReason::TargetNameUnavailable,
+            "DROP"
+        )]
+        fn same_reason_acknowledgments_allow_single_dialog(
+            #[case] sql: &str,
+            #[case] expected_risk: RiskLevel,
+            #[case] expected_reason: AcknowledgeReason,
+            #[case] expected_label: &str,
+        ) {
+            let result = evaluate_multi_statement(sql);
+
             match result {
                 MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::High);
+                    assert_eq!(risk.risk_level, expected_risk);
                     assert!(matches!(
                         risk.confirmation,
                         ConfirmationType::Acknowledge {
-                            reason: AcknowledgeReason::TargetNameUnavailable,
-                            ..
-                        }
+                            ref reason,
+                            ref label,
+                        } if *reason == expected_reason && label == expected_label
                     ));
                 }
                 _ => panic!("expected Allow"),

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -256,8 +256,7 @@ pub fn evaluate_multi_statement(sql: &str) -> MultiStatementDecision {
             .map(|(_, d)| d.confirmation.clone())
             .unwrap()
     } else if has_acknowledge {
-        // Mixed reasons are blocked above, so every remaining Acknowledge
-        // carries the same reason; the first one's label is representative.
+        // Mixed reasons are blocked above; the first Acknowledge represents all.
         decisions
             .iter()
             .find(|(_, d)| matches!(d.confirmation, ConfirmationType::Acknowledge { .. }))
@@ -686,7 +685,7 @@ mod tests {
             AcknowledgeReason::TargetNameUnavailable,
             "DROP"
         )]
-        fn same_reason_acknowledgments_allow_single_dialog(
+        fn same_reason_acknowledgments_aggregate_with_first_label(
             #[case] sql: &str,
             #[case] expected_risk: RiskLevel,
             #[case] expected_reason: AcknowledgeReason,


### PR DESCRIPTION
## Problem

Two follow-ups from PR #412 (docs/code-quality-todo.md tasks 13, 14):

1. Multi-statement SQL mixing different `AcknowledgeReason`s (e.g. `DO $$...$$; DROP TABLE a, b`) showed only the highest-risk statement's reason in the confirmation dialog, hiding the UNKNOWN RISK statement from the user.
2. Statement-level keywords recognized by the risk classifier (DO / GRANT / REVOKE / COPY / CALL / MERGE / TRUNCATE / BEGIN / COMMIT / ROLLBACK / EXPLAIN / ANALYZE / SHOW / SAVEPOINT / START / TRANSACTION / RELEASE) were missing from the highlight lexer's keyword list, so e.g. TRUNCATE rendered in identifier color despite being a High-risk confirmation target.

## Background

The aggregation picked the single highest-risk Acknowledge confirmation, dropping the other reasons. Not a safety hole (a dialog still appears), but one Enter consented to risks the dialog never described.

## Approach

1. Extend the existing block rule — "one dialog can only carry one consent" — to mixed acknowledge reasons, same as the typed-name × acknowledge mix. Resolved entirely in the policy layer; statements sharing one reason still aggregate into a single dialog. Users run mixed statements separately.
2. Add the missing keywords to `SQL_KEYWORDS`. The lexer is shared with the completion engine, but table/alias extraction accepts `Identifier | Keyword` and all name matching is case-insensitive, so completion behavior is unaffected (verified by the full test suite).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能改善**
  * SQL解析において、17個の追加キーワードの認識を改善しました
  * マルチステートメント処理における承認ロジックを強化し、混在する承認理由の検出精度を向上させました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->