### PR TITLE
[sqlite] fix: route explain SQL by database type

### DIFF
--- a/src/app/ports/outbound/sql_dialect.rs
+++ b/src/app/ports/outbound/sql_dialect.rs
@@ -1,8 +1,9 @@
 use crate::domain::DatabaseType;
 
 pub trait SqlDialect: Send + Sync {
-    fn build_explain_sql(&self, query: &str) -> Option<String>;
-    fn build_explain_analyze_sql(&self, query: &str) -> Option<String>;
+    fn build_explain_sql(&self, database_type: DatabaseType, query: &str) -> Option<String>;
+    fn build_explain_analyze_sql(&self, database_type: DatabaseType, query: &str)
+    -> Option<String>;
     fn build_update_sql(
         &self,
         database_type: DatabaseType,

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -33,12 +33,26 @@ impl AppServices {
 
         struct StubSqlDialect;
         impl SqlDialect for StubSqlDialect {
-            fn build_explain_sql(&self, query: &str) -> Option<String> {
-                Some(format!("EXPLAIN {query}"))
+            fn build_explain_sql(
+                &self,
+                database_type: DatabaseType,
+                query: &str,
+            ) -> Option<String> {
+                match database_type {
+                    DatabaseType::PostgreSQL => Some(format!("EXPLAIN {query}")),
+                    DatabaseType::SQLite => None,
+                }
             }
 
-            fn build_explain_analyze_sql(&self, query: &str) -> Option<String> {
-                Some(format!("EXPLAIN ANALYZE {query}"))
+            fn build_explain_analyze_sql(
+                &self,
+                database_type: DatabaseType,
+                query: &str,
+            ) -> Option<String> {
+                match database_type {
+                    DatabaseType::PostgreSQL => Some(format!("EXPLAIN ANALYZE {query}")),
+                    DatabaseType::SQLite => None,
+                }
             }
 
             fn build_update_sql(

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -70,8 +70,10 @@ pub(super) fn reduce_analyze(
                         .begin_confirming_analyze_risk(content, reason);
                 }
                 ConfirmationType::Immediate => {
-                    let Some(explain_query) =
-                        services.sql_dialect.build_explain_analyze_sql(&content)
+                    let database_type = state.session.active_database_type_or_default();
+                    let Some(explain_query) = services
+                        .sql_dialect
+                        .build_explain_analyze_sql(database_type, &content)
                     else {
                         mark_explain_unavailable(state);
                         return DispatchResult::handled();
@@ -107,7 +109,10 @@ pub(super) fn reduce_analyze(
             if let Some(query) = query
                 && let Some(dsn) = state.session.dsn().map(String::from)
             {
-                let Some(explain_query) = services.sql_dialect.build_explain_analyze_sql(&query)
+                let database_type = state.session.active_database_type_or_default();
+                let Some(explain_query) = services
+                    .sql_dialect
+                    .build_explain_analyze_sql(database_type, &query)
                 else {
                     mark_explain_unavailable(state);
                     return DispatchResult::handled();

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -39,7 +39,11 @@ pub(super) fn reduce_request(
                 return DispatchResult::handled();
             }
 
-            let Some(query) = services.sql_dialect.build_explain_sql(&content) else {
+            let database_type = state.session.active_database_type_or_default();
+            let Some(query) = services
+                .sql_dialect
+                .build_explain_sql(database_type, &content)
+            else {
                 mark_explain_unavailable(state);
                 return DispatchResult::handled();
             };

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -129,11 +129,15 @@ impl DdlGenerator for MySqlAdapter {
 }
 
 impl SqlDialect for MySqlAdapter {
-    fn build_explain_sql(&self, _query: &str) -> Option<String> {
+    fn build_explain_sql(&self, _database_type: DatabaseType, _query: &str) -> Option<String> {
         None
     }
 
-    fn build_explain_analyze_sql(&self, _query: &str) -> Option<String> {
+    fn build_explain_analyze_sql(
+        &self,
+        _database_type: DatabaseType,
+        _query: &str,
+    ) -> Option<String> {
         None
     }
 

--- a/src/infra/adapters/postgres/sql/dialect.rs
+++ b/src/infra/adapters/postgres/sql/dialect.rs
@@ -13,11 +13,15 @@ fn sql_literal_or_null(value: &str) -> String {
 }
 
 impl SqlDialect for PostgresAdapter {
-    fn build_explain_sql(&self, query: &str) -> Option<String> {
+    fn build_explain_sql(&self, _database_type: DatabaseType, query: &str) -> Option<String> {
         Some(format!("EXPLAIN {query}"))
     }
 
-    fn build_explain_analyze_sql(&self, query: &str) -> Option<String> {
+    fn build_explain_analyze_sql(
+        &self,
+        _database_type: DatabaseType,
+        query: &str,
+    ) -> Option<String> {
         Some(format!("EXPLAIN ANALYZE {query}"))
     }
 
@@ -154,7 +158,7 @@ mod tests {
             let adapter = PostgresAdapter::new();
 
             assert_eq!(
-                adapter.build_explain_sql("SELECT 1"),
+                adapter.build_explain_sql(DatabaseType::PostgreSQL, "SELECT 1"),
                 Some("EXPLAIN SELECT 1".to_string())
             );
         }
@@ -164,7 +168,7 @@ mod tests {
             let adapter = PostgresAdapter::new();
 
             assert_eq!(
-                adapter.build_explain_analyze_sql("SELECT 1"),
+                adapter.build_explain_analyze_sql(DatabaseType::PostgreSQL, "SELECT 1"),
                 Some("EXPLAIN ANALYZE SELECT 1".to_string())
             );
         }

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -193,12 +193,24 @@ impl DdlGenerator for DbAdapterRegistry {
 }
 
 impl SqlDialect for DbAdapterRegistry {
-    fn build_explain_sql(&self, query: &str) -> Option<String> {
-        self.postgres.build_explain_sql(query)
+    fn build_explain_sql(&self, database_type: DatabaseType, query: &str) -> Option<String> {
+        match database_type {
+            DatabaseType::PostgreSQL => self.postgres.build_explain_sql(database_type, query),
+            DatabaseType::SQLite => self.sqlite.build_explain_sql(database_type, query),
+        }
     }
 
-    fn build_explain_analyze_sql(&self, query: &str) -> Option<String> {
-        self.postgres.build_explain_analyze_sql(query)
+    fn build_explain_analyze_sql(
+        &self,
+        database_type: DatabaseType,
+        query: &str,
+    ) -> Option<String> {
+        match database_type {
+            DatabaseType::PostgreSQL => self
+                .postgres
+                .build_explain_analyze_sql(database_type, query),
+            DatabaseType::SQLite => self.sqlite.build_explain_analyze_sql(database_type, query),
+        }
     }
 
     fn build_update_sql(
@@ -373,6 +385,34 @@ mod tests {
         assert_eq!(delete_sql, "DELETE FROM \"users\"\nWHERE \"id\" IN ('1');");
         assert!(ddl.contains("CREATE TABLE \"users\""));
         assert!(!ddl.contains("\"main\".\"users\""));
+    }
+
+    #[test]
+    fn postgres_explain_generation_uses_postgres_dialect() {
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+
+        assert_eq!(
+            registry.build_explain_sql(DatabaseType::PostgreSQL, "SELECT 1"),
+            Some("EXPLAIN SELECT 1".to_string())
+        );
+        assert_eq!(
+            registry.build_explain_analyze_sql(DatabaseType::PostgreSQL, "SELECT 1"),
+            Some("EXPLAIN ANALYZE SELECT 1".to_string())
+        );
+    }
+
+    #[test]
+    fn sqlite_explain_generation_is_unsupported() {
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+
+        assert_eq!(
+            registry.build_explain_sql(DatabaseType::SQLite, "SELECT 1"),
+            None
+        );
+        assert_eq!(
+            registry.build_explain_analyze_sql(DatabaseType::SQLite, "SELECT 1"),
+            None
+        );
     }
 
     #[tokio::test]

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -122,11 +122,15 @@ impl DdlGenerator for SqliteAdapter {
 }
 
 impl SqlDialect for SqliteAdapter {
-    fn build_explain_sql(&self, _query: &str) -> Option<String> {
+    fn build_explain_sql(&self, _database_type: DatabaseType, _query: &str) -> Option<String> {
         None
     }
 
-    fn build_explain_analyze_sql(&self, _query: &str) -> Option<String> {
+    fn build_explain_analyze_sql(
+        &self,
+        _database_type: DatabaseType,
+        _query: &str,
+    ) -> Option<String> {
         None
     }
 
@@ -257,6 +261,20 @@ mod tests {
     fn user_tables_query_uses_compatible_schema_table() {
         assert!(user_tables_query().contains("FROM sqlite_master"));
         assert!(user_tables_query().contains("name NOT LIKE 'sqlite_%'"));
+    }
+
+    #[test]
+    fn explain_generation_is_unsupported() {
+        let adapter = SqliteAdapter::new();
+
+        assert_eq!(
+            adapter.build_explain_sql(DatabaseType::SQLite, "SELECT 1"),
+            None
+        );
+        assert_eq!(
+            adapter.build_explain_analyze_sql(DatabaseType::SQLite, "SELECT 1"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem
Task 3: EXPLAIN SQL generation could still fall back to the PostgreSQL dialect outside the UI capability gate.

## Background
The SQLite review called out EXPLAIN as the remaining `SqlDialect` builder that did not receive the active database type, unlike update/delete SQL generation.

## Approach
Route EXPLAIN SQL generation through the same database-type-aware dialect boundary used by other generated SQL, and keep SQLite unsupported at the adapter boundary while leaving the UI capability gate in place.

## Screenshots
N/A

## Verification
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
