### PR TITLE
refactor: deduplicate connection setup UI

### DIFF
--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -256,29 +256,11 @@ impl ConnectionSetupState {
     }
 
     pub fn focused_input(&self) -> Option<&TextInputState> {
-        match self.focused_field {
-            ConnectionField::DatabaseType | ConnectionField::SslMode => None,
-            ConnectionField::Name => Some(&self.name),
-            ConnectionField::SqlitePath => Some(&self.sqlite_path),
-            ConnectionField::Host => Some(&self.host),
-            ConnectionField::Port => Some(&self.port),
-            ConnectionField::Database => Some(&self.database),
-            ConnectionField::User => Some(&self.user),
-            ConnectionField::Password => Some(&self.password),
-        }
+        self.input(self.focused_field)
     }
 
     pub fn focused_input_mut(&mut self) -> Option<&mut TextInputState> {
-        match self.focused_field {
-            ConnectionField::DatabaseType | ConnectionField::SslMode => None,
-            ConnectionField::Name => Some(&mut self.name),
-            ConnectionField::SqlitePath => Some(&mut self.sqlite_path),
-            ConnectionField::Host => Some(&mut self.host),
-            ConnectionField::Port => Some(&mut self.port),
-            ConnectionField::Database => Some(&mut self.database),
-            ConnectionField::User => Some(&mut self.user),
-            ConnectionField::Password => Some(&mut self.password),
-        }
+        self.input_mut(self.focused_field)
     }
 
     pub fn clear_errors(&mut self) {

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -1,4 +1,5 @@
 use crate::domain::QueryResult;
+use crate::domain::connection::SqliteConnectionConfig;
 use crate::model::app_state::AppState;
 use crate::model::connection::setup::{ConnectionField, ConnectionSetupState};
 use crate::policy::write::write_guardrails::{
@@ -204,44 +205,35 @@ pub fn char_to_byte_index(s: &str, char_idx: usize) -> usize {
         .map_or(s.len(), |(byte_idx, _)| byte_idx)
 }
 
+fn text_input_content(state: &ConnectionSetupState, field: ConnectionField) -> &str {
+    state
+        .input(field)
+        .expect("connection field is a text input")
+        .content()
+}
+
+fn require_non_empty(state: &mut ConnectionSetupState, field: ConnectionField, message: &str) {
+    if text_input_content(state, field).trim().is_empty() {
+        state.set_validation_error(field, message);
+    }
+}
+
 pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) {
     state.clear_validation_error(field);
 
     match field {
         ConnectionField::SqlitePath => {
-            match crate::domain::connection::SqliteConnectionConfig::new(
-                state
-                    .input(ConnectionField::SqlitePath)
-                    .expect("sqlite path is a text input")
-                    .content()
-                    .to_string(),
-            ) {
+            let path = text_input_content(state, ConnectionField::SqlitePath).to_string();
+            match SqliteConnectionConfig::new(path) {
                 Ok(_) => {}
-                Err(crate::domain::connection::SqliteConnectionConfigError::EmptyPath) => {
-                    state.set_validation_error(field, "Required");
-                }
-                Err(crate::domain::connection::SqliteConnectionConfigError::UnsupportedPath) => {
-                    state.set_validation_error(field, "Unsupported characters");
-                }
+                Err(error) => state.record_sqlite_config_error(error),
             }
         }
-        ConnectionField::Host => {
-            if state
-                .input(ConnectionField::Host)
-                .expect("host is a text input")
-                .content()
-                .trim()
-                .is_empty()
-            {
-                state.set_validation_error(field, "Required");
-            }
+        ConnectionField::Host | ConnectionField::Database | ConnectionField::User => {
+            require_non_empty(state, field, "Required");
         }
         ConnectionField::Port => {
-            let port = state
-                .input(ConnectionField::Port)
-                .expect("port is a text input")
-                .content()
-                .trim();
+            let port = text_input_content(state, field).trim();
             if port.is_empty() {
                 state.set_validation_error(field, "Required");
             } else {
@@ -256,35 +248,8 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
                 }
             }
         }
-        ConnectionField::Database => {
-            if state
-                .input(ConnectionField::Database)
-                .expect("database is a text input")
-                .content()
-                .trim()
-                .is_empty()
-            {
-                state.set_validation_error(field, "Required");
-            }
-        }
-        ConnectionField::User => {
-            if state
-                .input(ConnectionField::User)
-                .expect("user is a text input")
-                .content()
-                .trim()
-                .is_empty()
-            {
-                state.set_validation_error(field, "Required");
-            }
-        }
         ConnectionField::Name => {
-            let name = state
-                .input(ConnectionField::Name)
-                .expect("name is a text input")
-                .content()
-                .trim()
-                .to_string();
+            let name = text_input_content(state, field).trim().to_string();
             if name.is_empty() {
                 state.set_validation_error(field, "Name is required");
             } else if name.chars().count() > 50 {

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -227,8 +227,6 @@ impl Inspector {
         table: &'a Table,
         theme: &ThemePalette,
     ) -> Line<'a> {
-        let label_style = Style::default().add_modifier(Modifier::BOLD);
-
         match field {
             InspectorInfoField::Owner => Self::optional_info_line(
                 "Owner:   ",
@@ -247,13 +245,12 @@ impl Inspector {
                 Self::optional_info_line("Rows:    ", value, theme)
             }
             InspectorInfoField::Schema => Line::from(vec![
-                Span::styled("Schema:  ", label_style),
+                Self::info_label("Schema:  "),
                 Span::raw(&table.schema),
             ]),
-            InspectorInfoField::TableName => Line::from(vec![
-                Span::styled("Table:   ", label_style),
-                Span::raw(&table.name),
-            ]),
+            InspectorInfoField::TableName => {
+                Line::from(vec![Self::info_label("Table:   "), Span::raw(&table.name)])
+            }
         }
     }
 
@@ -262,17 +259,17 @@ impl Inspector {
         value: Option<Cow<'a, str>>,
         theme: &ThemePalette,
     ) -> Line<'a> {
-        let label_style = Style::default().add_modifier(Modifier::BOLD);
         let none_style = Style::default().fg(theme.semantic.text.placeholder);
         let (value, style) = match value {
             Some(value) => (value, Style::default()),
             None => (Cow::Borrowed("(none)"), none_style),
         };
 
-        Line::from(vec![
-            Span::styled(label, label_style),
-            Span::styled(value, style),
-        ])
+        Line::from(vec![Self::info_label(label), Span::styled(value, style)])
+    }
+
+    fn info_label(label: &'static str) -> Span<'static> {
+        Span::styled(label, Style::default().add_modifier(Modifier::BOLD))
     }
 
     fn render_columns(

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::time::Instant;
 
 use ratatui::Frame;
@@ -227,46 +228,23 @@ impl Inspector {
         theme: &ThemePalette,
     ) -> Line<'a> {
         let label_style = Style::default().add_modifier(Modifier::BOLD);
-        let none_style = Style::default().fg(theme.semantic.text.placeholder);
 
         match field {
-            InspectorInfoField::Owner => {
-                let value = table.owner.as_deref().unwrap_or("(none)");
-                let style = if table.owner.is_some() {
-                    Style::default()
-                } else {
-                    none_style
-                };
-                Line::from(vec![
-                    Span::styled("Owner:   ", label_style),
-                    Span::styled(value, style),
-                ])
-            }
-            InspectorInfoField::Comment => {
-                let value = table.comment.as_deref().unwrap_or("(none)");
-                let style = if table.comment.is_some() {
-                    Style::default()
-                } else {
-                    none_style
-                };
-                Line::from(vec![
-                    Span::styled("Comment: ", label_style),
-                    Span::styled(value, style),
-                ])
-            }
+            InspectorInfoField::Owner => Self::optional_info_line(
+                "Owner:   ",
+                table.owner.as_deref().map(Cow::Borrowed),
+                theme,
+            ),
+            InspectorInfoField::Comment => Self::optional_info_line(
+                "Comment: ",
+                table.comment.as_deref().map(Cow::Borrowed),
+                theme,
+            ),
             InspectorInfoField::RowCount => {
                 let value = table
                     .row_count_estimate
-                    .map_or_else(|| "(none)".to_string(), |n| format!("~{n}"));
-                let style = if table.row_count_estimate.is_some() {
-                    Style::default()
-                } else {
-                    none_style
-                };
-                Line::from(vec![
-                    Span::styled("Rows:    ", label_style),
-                    Span::styled(value, style),
-                ])
+                    .map(|n| Cow::Owned(format!("~{n}")));
+                Self::optional_info_line("Rows:    ", value, theme)
             }
             InspectorInfoField::Schema => Line::from(vec![
                 Span::styled("Schema:  ", label_style),
@@ -277,6 +255,24 @@ impl Inspector {
                 Span::raw(&table.name),
             ]),
         }
+    }
+
+    fn optional_info_line<'a>(
+        label: &'static str,
+        value: Option<Cow<'a, str>>,
+        theme: &ThemePalette,
+    ) -> Line<'a> {
+        let label_style = Style::default().add_modifier(Modifier::BOLD);
+        let none_style = Style::default().fg(theme.semantic.text.placeholder);
+        let (value, style) = match value {
+            Some(value) => (value, Style::default()),
+            None => (Cow::Borrowed("(none)"), none_style),
+        };
+
+        Line::from(vec![
+            Span::styled(label, label_style),
+            Span::styled(value, style),
+        ])
     }
 
     fn render_columns(

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -78,7 +78,7 @@ impl ConnectionSetup {
                     frame,
                     chunks[idx],
                     field.label(),
-                    &form_state.ssl_mode().to_string(),
+                    ssl_mode_label(form_state.ssl_mode()),
                     form_state.focused_field() == ConnectionField::SslMode,
                     theme,
                 ),

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -99,48 +99,52 @@ impl ConnectionSetup {
         frame.render_widget(notice_para, chunks[field_count + 1]);
 
         if form_state.database_type_dropdown().is_open()
-            && let Some(field_area) = Self::field_area(
+            && let Some(field_area) = Self::open_dropdown_field_area(
                 chunks.as_ref(),
                 visible_fields,
                 ConnectionField::DatabaseType,
             )
         {
-            let items: Vec<String> = DatabaseType::all()
-                .iter()
-                .map(ToString::to_string)
-                .collect();
             Self::render_dropdown_list(
                 frame,
                 field_area,
-                &items,
+                DatabaseType::all()
+                    .iter()
+                    .map(|database_type| database_type.label()),
                 form_state.database_type_dropdown().selected_index(),
                 theme,
             );
         } else if form_state.ssl_dropdown().is_open()
-            && let Some(field_area) =
-                Self::field_area(chunks.as_ref(), visible_fields, ConnectionField::SslMode)
+            && let Some(field_area) = Self::open_dropdown_field_area(
+                chunks.as_ref(),
+                visible_fields,
+                ConnectionField::SslMode,
+            )
         {
-            let items: Vec<String> = SslMode::all_variants()
-                .iter()
-                .map(ToString::to_string)
-                .collect();
             Self::render_dropdown_list(
                 frame,
                 field_area,
-                &items,
+                SslMode::all_variants()
+                    .iter()
+                    .map(|ssl_mode| ssl_mode_label(*ssl_mode)),
                 form_state.ssl_dropdown().selected_index(),
                 theme,
             );
         }
     }
 
-    fn field_area(
+    fn open_dropdown_field_area(
         chunks: &[Rect],
         visible_fields: &[ConnectionField],
         target: ConnectionField,
     ) -> Option<Rect> {
-        let idx = visible_fields.iter().position(|field| *field == target)?;
-        chunks.get(idx).copied()
+        let area = visible_fields
+            .iter()
+            .position(|field| *field == target)
+            .and_then(|idx| chunks.get(idx))
+            .copied();
+        debug_assert!(area.is_some(), "open dropdown field must be visible");
+        area
     }
 
     fn render_text_field(
@@ -269,7 +273,7 @@ impl ConnectionSetup {
     fn render_dropdown_list(
         frame: &mut Frame,
         field_area: Rect,
-        items: &[String],
+        items: impl ExactSizeIterator<Item = &'static str>,
         selected_index: usize,
         theme: &ThemePalette,
     ) {
@@ -297,7 +301,7 @@ impl ConnectionSetup {
 
         let inner = dropdown_area.inner(Margin::new(1, 1));
 
-        for (i, item) in items.iter().enumerate() {
+        for (i, item) in items.enumerate() {
             let item_area = Rect {
                 x: inner.x,
                 y: inner.y + i as u16,
@@ -312,8 +316,19 @@ impl ConnectionSetup {
                 Style::default().fg(theme.semantic.text.secondary)
             };
 
-            let item_para = Paragraph::new(item.as_str()).style(item_style);
+            let item_para = Paragraph::new(item).style(item_style);
             frame.render_widget(item_para, item_area);
         }
+    }
+}
+
+fn ssl_mode_label(mode: SslMode) -> &'static str {
+    match mode {
+        SslMode::Disable => "disable",
+        SslMode::Allow => "allow",
+        SslMode::Prefer => "prefer",
+        SslMode::Require => "require",
+        SslMode::VerifyCa => "verify-ca",
+        SslMode::VerifyFull => "verify-full",
     }
 }

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -16,8 +16,6 @@ const INPUT_WIDTH: u16 = CONNECTION_INPUT_WIDTH;
 const ERROR_WIDTH: u16 = 12;
 const FIELD_HEIGHT: u16 = 1;
 const MODAL_VERTICAL_CHROME: u16 = 6;
-const SSL_DROPDOWN_ITEM_COUNT: usize = 6;
-const DB_TYPE_DROPDOWN_ITEM_COUNT: usize = DatabaseType::all().len();
 
 fn bracketed_input(content: &str, border_style: Style, theme: &ThemePalette) -> Line<'static> {
     Line::from(vec![
@@ -68,17 +66,19 @@ impl ConnectionSetup {
 
         for (idx, field) in visible_fields.iter().enumerate() {
             match field {
-                ConnectionField::DatabaseType => Self::render_database_type_field(
+                ConnectionField::DatabaseType => Self::render_dropdown_field(
                     frame,
                     chunks[idx],
-                    form_state.database_type(),
+                    field.label(),
+                    &form_state.database_type().to_string(),
                     form_state.focused_field() == ConnectionField::DatabaseType,
                     theme,
                 ),
-                ConnectionField::SslMode => Self::render_ssl_field(
+                ConnectionField::SslMode => Self::render_dropdown_field(
                     frame,
                     chunks[idx],
-                    form_state.ssl_mode(),
+                    field.label(),
+                    &form_state.ssl_mode().to_string(),
                     form_state.focused_field() == ConnectionField::SslMode,
                     theme,
                 ),
@@ -98,25 +98,49 @@ impl ConnectionSetup {
             Paragraph::new(notice).style(Style::default().fg(theme.component.feedback.note_text));
         frame.render_widget(notice_para, chunks[field_count + 1]);
 
-        if form_state.database_type_dropdown().is_open() {
-            Self::render_database_type_dropdown(
+        if form_state.database_type_dropdown().is_open()
+            && let Some(field_area) = Self::field_area(
+                chunks.as_ref(),
+                visible_fields,
+                ConnectionField::DatabaseType,
+            )
+        {
+            let items: Vec<String> = DatabaseType::all()
+                .iter()
+                .map(ToString::to_string)
+                .collect();
+            Self::render_dropdown_list(
                 frame,
-                chunks[0],
+                field_area,
+                &items,
                 form_state.database_type_dropdown().selected_index(),
                 theme,
             );
-        } else if form_state.ssl_dropdown().is_open() {
-            let ssl_idx = visible_fields
+        } else if form_state.ssl_dropdown().is_open()
+            && let Some(field_area) =
+                Self::field_area(chunks.as_ref(), visible_fields, ConnectionField::SslMode)
+        {
+            let items: Vec<String> = SslMode::all_variants()
                 .iter()
-                .position(|field| *field == ConnectionField::SslMode)
-                .unwrap_or(0);
-            Self::render_dropdown(
+                .map(ToString::to_string)
+                .collect();
+            Self::render_dropdown_list(
                 frame,
-                chunks[ssl_idx],
+                field_area,
+                &items,
                 form_state.ssl_dropdown().selected_index(),
                 theme,
             );
         }
+    }
+
+    fn field_area(
+        chunks: &[Rect],
+        visible_fields: &[ConnectionField],
+        target: ConnectionField,
+    ) -> Option<Rect> {
+        let idx = visible_fields.iter().position(|field| *field == target)?;
+        chunks.get(idx).copied()
     }
 
     fn render_text_field(
@@ -210,10 +234,11 @@ impl ConnectionSetup {
         }
     }
 
-    fn render_ssl_field(
+    fn render_dropdown_field(
         frame: &mut Frame,
         area: Rect,
-        ssl_mode: SslMode,
+        label: &str,
+        value: &str,
         is_focused: bool,
         theme: &ThemePalette,
     ) {
@@ -224,19 +249,16 @@ impl ConnectionSetup {
         ])
         .split(area);
 
-        // Label: gray (like Explorer content), bold when focused
         let label_style = if is_focused {
             Style::default().fg(theme.semantic.text.secondary).bold()
         } else {
             Style::default().fg(theme.semantic.text.secondary)
         };
-        let label_para = Paragraph::new("SSL Mode:").style(label_style);
+        let label_para = Paragraph::new(label).style(label_style);
         frame.render_widget(label_para, chunks[0]);
 
-        // Value: white (emphasized), same width as text fields
         let content_width = CONNECTION_INPUT_VISIBLE_WIDTH;
-        let ssl_mode_str = ssl_mode.to_string();
-        let display_content = format!("{:<1$} ▼", ssl_mode_str, content_width - 2);
+        let display_content = format!("{:<1$} ▼", value, content_width - 2);
 
         let border_style = theme.modal_input_border_style(is_focused, false);
 
@@ -244,41 +266,10 @@ impl ConnectionSetup {
         frame.render_widget(input_para, chunks[1]);
     }
 
-    fn render_database_type_field(
-        frame: &mut Frame,
-        area: Rect,
-        database_type: DatabaseType,
-        is_focused: bool,
-        theme: &ThemePalette,
-    ) {
-        let chunks = Layout::horizontal([
-            Constraint::Length(LABEL_WIDTH),
-            Constraint::Length(INPUT_WIDTH),
-            Constraint::Length(ERROR_WIDTH),
-        ])
-        .split(area);
-
-        let label_style = if is_focused {
-            Style::default().fg(theme.semantic.text.secondary).bold()
-        } else {
-            Style::default().fg(theme.semantic.text.secondary)
-        };
-        frame.render_widget(Paragraph::new("Type:").style(label_style), chunks[0]);
-
-        let content_width = CONNECTION_INPUT_VISIBLE_WIDTH;
-        let value = database_type.to_string();
-        let display_content = format!("{:<1$} ▼", value, content_width - 2);
-        let border_style = theme.modal_input_border_style(is_focused, false);
-
-        frame.render_widget(
-            Paragraph::new(bracketed_input(&display_content, border_style, theme)),
-            chunks[1],
-        );
-    }
-
-    fn render_database_type_dropdown(
+    fn render_dropdown_list(
         frame: &mut Frame,
         field_area: Rect,
+        items: &[String],
         selected_index: usize,
         theme: &ThemePalette,
     ) {
@@ -293,51 +284,7 @@ impl ConnectionSetup {
             x: chunks[1].x,
             y: chunks[1].y + 1,
             width: INPUT_WIDTH,
-            height: DB_TYPE_DROPDOWN_ITEM_COUNT as u16 + 2,
-        };
-
-        frame.render_widget(Clear, dropdown_area);
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_style(theme.modal_border_style())
-            .style(Style::default());
-        frame.render_widget(block, dropdown_area);
-
-        let inner = dropdown_area.inner(Margin::new(1, 1));
-        for (i, variant) in DatabaseType::all().iter().enumerate() {
-            let item_area = Rect {
-                x: inner.x,
-                y: inner.y + i as u16,
-                width: inner.width,
-                height: 1,
-            };
-            let style = if i == selected_index {
-                theme.picker_selected_style()
-            } else {
-                Style::default().fg(theme.semantic.text.secondary)
-            };
-            frame.render_widget(Paragraph::new(variant.to_string()).style(style), item_area);
-        }
-    }
-
-    fn render_dropdown(
-        frame: &mut Frame,
-        ssl_field_area: Rect,
-        selected_index: usize,
-        theme: &ThemePalette,
-    ) {
-        let chunks = Layout::horizontal([
-            Constraint::Length(LABEL_WIDTH),
-            Constraint::Length(INPUT_WIDTH),
-            Constraint::Length(ERROR_WIDTH),
-        ])
-        .split(ssl_field_area);
-
-        let dropdown_area = Rect {
-            x: chunks[1].x,
-            y: chunks[1].y + 1,
-            width: INPUT_WIDTH,
-            height: SSL_DROPDOWN_ITEM_COUNT as u16 + 2,
+            height: items.len() as u16 + 2,
         };
 
         frame.render_widget(Clear, dropdown_area);
@@ -349,12 +296,8 @@ impl ConnectionSetup {
         frame.render_widget(block, dropdown_area);
 
         let inner = dropdown_area.inner(Margin::new(1, 1));
-        let variants = SslMode::all_variants();
 
-        for (i, variant) in variants.iter().enumerate() {
-            if i >= SSL_DROPDOWN_ITEM_COUNT {
-                break;
-            }
+        for (i, item) in items.iter().enumerate() {
             let item_area = Rect {
                 x: inner.x,
                 y: inner.y + i as u16,
@@ -369,7 +312,7 @@ impl ConnectionSetup {
                 Style::default().fg(theme.semantic.text.secondary)
             };
 
-            let item_para = Paragraph::new(variant.to_string()).style(item_style);
+            let item_para = Paragraph::new(item.as_str()).style(item_style);
             frame.render_widget(item_para, item_area);
         }
     }

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -138,10 +138,9 @@ impl Footer {
                     list
                 } else {
                     // Actions → Navigation → Help → Close/Cancel → Quit
-                    let active_inspector_tab = state
-                        .session
-                        .active_db_capabilities()
-                        .normalize_inspector_tab(state.ui.inspector_tab());
+                    let capabilities = state.session.active_db_capabilities();
+                    let active_inspector_tab =
+                        capabilities.normalize_inspector_tab(state.ui.inspector_tab());
                     let mut list = vec![
                         global::RELOAD.as_hint(),
                         global::SQL.as_hint(),
@@ -182,12 +181,7 @@ impl Footer {
                         }
                     }
                     if state.ui.focused_pane() == FocusedPane::Inspector
-                        && state
-                            .session
-                            .active_db_capabilities()
-                            .supported_inspector_tabs()
-                            .len()
-                            > 1
+                        && capabilities.supported_inspector_tabs().len() > 1
                     {
                         list.push(global::INSPECTOR_TABS.as_hint());
                     }


### PR DESCRIPTION
## Problem
Task 6 tracks duplicated connection setup validation and rendering logic introduced while adding SQLite support.

## Background
The duplicated paths made SQLite path errors, focused input lookup, dropdown rendering, and capability-driven footer hints harder to keep aligned as more database types are added.

## Approach
Consolidate validation through the connection setup aggregate, reuse field-to-input lookup for focused inputs, and share dropdown/info/footer rendering helpers without changing the rendered snapshots.

## Screenshots
N/A

Validation:
- cargo fmt
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * コネクション設定の入力フィールド処理を統一し、検証ロジックを簡潔に改善
  * インスペクタの情報表示において、オプショナルフィールドの表示方式を最適化
  * データベース種別とSSLモード選択のドロップダウン描画を共通化し、UI処理を統一
  * フッターの機能判定処理を効率化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->