### PR TITLE
fix: harden SQL safety policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sabiql treats the SQL modal as SQL-only input. CLI meta-commands such as psql ba
 
 Read-only mode combines app-level write blocking with the database client guard available for the active adapter. PostgreSQL uses a read-only session option; SQLite uses sqlite3's read-only mode.
 
-PostgreSQL multi-statement SQL runs in one transaction. SQLite multi-statement DML is wrapped in an explicit transaction unless the input already contains transaction control statements.
+PostgreSQL multi-statement SQL runs in one transaction. SQLite multi-statement write SQL is wrapped in an explicit transaction unless the input already contains transaction control statements.
 
 ## Features
 ![hero_1000_20fps](https://github.com/user-attachments/assets/06e1900d-b044-4f29-a2a8-7d7bab5bd3a1)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Destructive operations are guarded. Inline edits and row deletions always show a
 
 Built in Rust for minimal memory footprint and near-zero idle CPU. A full-featured alternative to GUI tools like DBeaver or DataGrip, without ever leaving the terminal.
 
+## Query Safety
+
+sabiql treats the SQL modal as SQL-only input. CLI meta-commands such as psql backslash commands and sqlite3 dot commands are rejected instead of being passed to the underlying client.
+
+Read-only mode combines app-level write blocking with the database client guard available for the active adapter. PostgreSQL uses a read-only session option; SQLite uses sqlite3's read-only mode.
+
+PostgreSQL multi-statement SQL runs in one transaction. SQLite multi-statement DML is wrapped in an explicit transaction unless the input already contains transaction control statements.
+
 ## Features
 ![hero_1000_20fps](https://github.com/user-attachments/assets/06e1900d-b044-4f29-a2a8-7d7bab5bd3a1)
 

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -46,7 +46,7 @@ pub enum MultiStatementDecision {
     },
 }
 
-pub fn contains_cli_meta_command(sql: &str) -> bool {
+fn contains_cli_meta_command(sql: &str) -> bool {
     let chars: Vec<(usize, char)> = sql.char_indices().collect();
     let mut i = 0;
     let mut in_string = false;

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -697,6 +697,8 @@ mod tests {
         #[case::dot_inside_string("SELECT '.shell echo ok'")]
         #[case::backslash_inside_string("SELECT '\\\\! echo ok'")]
         #[case::dot_inside_comment("-- .shell ignored\nSELECT 1")]
+        #[case::backslash_inside_block_comment("SELECT /* \\! ignored */ 1")]
+        #[case::backslash_inside_quoted_identifier(r#"SELECT "table\!name" FROM "table\!name""#)]
         #[case::dot_inside_dollar_quote("SELECT $tag$\n.shell ignored\n$tag$")]
         fn cli_meta_command_like_text_is_allowed(#[case] sql: &str) {
             let result = evaluate_multi_statement(sql);

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -46,6 +46,71 @@ pub enum MultiStatementDecision {
     },
 }
 
+pub fn contains_cli_meta_command(sql: &str) -> bool {
+    let chars: Vec<(usize, char)> = sql.char_indices().collect();
+    let mut i = 0;
+    let mut in_string = false;
+    let mut line_leading = true;
+
+    while i < chars.len() {
+        let (byte_pos, ch) = chars[i];
+
+        if in_string {
+            if let Some(next_i) = advance_single_quote(&chars, i, ch, &mut in_string) {
+                i = next_i;
+                continue;
+            }
+            if ch == '\n' {
+                line_leading = true;
+            }
+            i += 1;
+            continue;
+        }
+
+        if ch == '\n' {
+            line_leading = true;
+            i += 1;
+            continue;
+        }
+        if line_leading && ch.is_whitespace() {
+            i += 1;
+            continue;
+        }
+        if let Some(next_i) = skip_line_comment(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_block_comment(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = advance_single_quote(&chars, i, ch, &mut in_string) {
+            line_leading = false;
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_double_quoted_identifier(&chars, i, ch) {
+            line_leading = false;
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_dollar_quoted_string(sql, &chars, i, byte_pos, ch) {
+            line_leading = false;
+            i = next_i;
+            continue;
+        }
+
+        if line_leading && matches!(ch, '.' | '\\') {
+            return true;
+        }
+
+        line_leading = false;
+        i += 1;
+    }
+
+    false
+}
+
 pub fn split_statements(sql: &str) -> Vec<String> {
     // Use sql's own char_indices so byte offsets remain valid for slicing sql.
     // to_lowercase() can change byte lengths (e.g. İ → i̇), which would corrupt offsets.
@@ -209,6 +274,12 @@ pub fn evaluate_sql_risk(kind: &StatementKind, sql: &str) -> SqlRiskDecision {
 }
 
 pub fn evaluate_multi_statement(sql: &str) -> MultiStatementDecision {
+    if contains_cli_meta_command(sql) {
+        return MultiStatementDecision::Block {
+            reason: "CLI meta-commands are not supported in SQL input".to_string(),
+        };
+    }
+
     let statements = split_statements(sql);
 
     if statements.is_empty() {
@@ -605,6 +676,32 @@ mod tests {
         fn empty_input_blocked() {
             let result = evaluate_multi_statement("");
             assert!(matches!(result, MultiStatementDecision::Block { .. }));
+        }
+
+        #[rstest]
+        #[case::sqlite_shell(".shell echo injected")]
+        #[case::sqlite_open_after_select("SELECT 1;\n.open writable.db")]
+        #[case::psql_shell("\\! echo injected")]
+        #[case::indented_meta_command("  .output /tmp/out.csv")]
+        fn cli_meta_commands_are_blocked(#[case] sql: &str) {
+            let result = evaluate_multi_statement(sql);
+
+            assert!(matches!(
+                result,
+                MultiStatementDecision::Block { reason }
+                    if reason == "CLI meta-commands are not supported in SQL input"
+            ));
+        }
+
+        #[rstest]
+        #[case::dot_inside_string("SELECT '.shell echo ok'")]
+        #[case::backslash_inside_string("SELECT '\\\\! echo ok'")]
+        #[case::dot_inside_comment("-- .shell ignored\nSELECT 1")]
+        #[case::dot_inside_dollar_quote("SELECT $tag$\n.shell ignored\n$tag$")]
+        fn cli_meta_command_like_text_is_allowed(#[case] sql: &str) {
+            let result = evaluate_multi_statement(sql);
+
+            assert!(matches!(result, MultiStatementDecision::Allow { .. }));
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -396,13 +396,6 @@ impl SqliteAdapter {
     }
 }
 
-fn append_changes_query(query: &str) -> String {
-    let trimmed = query.trim_end();
-    // The standalone separator also terminates a trailing line comment before
-    // appending the changes() probe.
-    format!("{trimmed}\n;\nSELECT changes() AS affected_rows;")
-}
-
 fn is_ident_char(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || byte == b'_'
 }
@@ -492,13 +485,90 @@ fn contains_keyword(sql: &str, expected: &str) -> bool {
     false
 }
 
+fn split_sqlite_statements(sql: &str) -> Vec<&str> {
+    let bytes = sql.as_bytes();
+    let mut statements = Vec::new();
+    let mut start = 0;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                if i + 1 < bytes.len() {
+                    i += 2;
+                }
+            }
+            b'\'' | b'"' | b'`' => {
+                i = skip_quoted(bytes, i, bytes[i]);
+            }
+            b'[' => {
+                i = skip_bracket_quoted(bytes, i);
+            }
+            b';' => {
+                let statement = sql[start..i].trim();
+                if !statement.is_empty() {
+                    statements.push(statement);
+                }
+                i += 1;
+                start = i;
+            }
+            _ => i += 1,
+        }
+    }
+
+    let tail = sql[start..].trim();
+    if !tail.is_empty() {
+        statements.push(tail);
+    }
+
+    statements
+}
+
 fn count_select_statements(sql: &str) -> usize {
-    sql.split(';')
+    split_sqlite_statements(sql)
+        .into_iter()
         .filter(|stmt| {
             let keyword = first_keyword(stmt);
             keyword.eq_ignore_ascii_case("SELECT") || keyword.eq_ignore_ascii_case("WITH")
         })
         .count()
+}
+
+fn is_transaction_control(statement: &str) -> bool {
+    matches!(
+        first_keyword(statement).to_ascii_uppercase().as_str(),
+        "BEGIN" | "COMMIT" | "ROLLBACK" | "SAVEPOINT" | "RELEASE"
+    )
+}
+
+fn should_wrap_dml_transaction(query: &str) -> bool {
+    let statements = split_sqlite_statements(query);
+    statements.len() > 1 && !statements.iter().any(|stmt| is_transaction_control(stmt))
+}
+
+fn sqlite_transaction_block(query: &str) -> String {
+    let trimmed = query.trim_end().trim_end_matches(';').trim_end();
+    format!("BEGIN;\n{trimmed}\n;\nCOMMIT")
+}
+
+fn append_changes_query(query: &str) -> String {
+    let body = if should_wrap_dml_transaction(query) {
+        sqlite_transaction_block(query)
+    } else {
+        query.trim_end().to_string()
+    };
+    // The standalone separator also terminates a trailing line comment before
+    // appending the changes() probe.
+    format!("{body}\n;\nSELECT changes() AS affected_rows;")
 }
 
 fn extract_last_csv_block<'a>(stdout: &'a str, sql: &str) -> &'a str {
@@ -883,6 +953,45 @@ mod tests {
         (dir, format!("sqlite://{}", path.display()))
     }
 
+    #[test]
+    fn split_sqlite_statements_ignores_semicolons_in_literals_and_comments() {
+        let statements = split_sqlite_statements(
+            "INSERT INTO logs(message) VALUES ('a;b'); -- ; ignored\nSELECT ';' AS value;",
+        );
+
+        assert_eq!(
+            statements,
+            vec![
+                "INSERT INTO logs(message) VALUES ('a;b')",
+                "-- ; ignored\nSELECT ';' AS value"
+            ]
+        );
+    }
+
+    #[test]
+    fn append_changes_wraps_multi_statement_dml_without_explicit_transaction() {
+        let query = "INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2);";
+
+        let wrapped = append_changes_query(query);
+
+        assert_eq!(
+            wrapped,
+            "BEGIN;\nINSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)\n;\nCOMMIT\n;\nSELECT changes() AS affected_rows;"
+        );
+    }
+
+    #[test]
+    fn append_changes_keeps_explicit_transaction_control() {
+        let query = "BEGIN; INSERT INTO users(id) VALUES (1); COMMIT";
+
+        let wrapped = append_changes_query(query);
+
+        assert_eq!(
+            wrapped,
+            "BEGIN; INSERT INTO users(id) VALUES (1); COMMIT\n;\nSELECT changes() AS affected_rows;"
+        );
+    }
+
     #[tokio::test]
     async fn preview_returns_columns_rows_and_respects_pagination() {
         let (_dir, dsn) = make_db(
@@ -1029,6 +1138,27 @@ mod tests {
 
         assert_eq!(result.row_count, 1);
         assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
+    }
+
+    #[tokio::test]
+    async fn adhoc_multi_statement_dml_rolls_back_when_later_statement_fails() {
+        let (_dir, dsn) = make_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(
+                &dsn,
+                "INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
+                false,
+            )
+            .await;
+
+        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+        let rows = adapter
+            .execute_adhoc(&dsn, "SELECT id FROM users", true)
+            .await
+            .unwrap();
+        assert!(rows.rows.is_empty());
     }
 
     #[tokio::test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -564,7 +564,7 @@ fn count_select_statements(sql: &str) -> usize {
 fn is_transaction_control(statement: &str) -> bool {
     matches!(
         first_keyword(statement).to_ascii_uppercase().as_str(),
-        "BEGIN" | "COMMIT" | "ROLLBACK" | "SAVEPOINT" | "RELEASE"
+        "BEGIN" | "COMMIT" | "END" | "ROLLBACK" | "SAVEPOINT" | "RELEASE"
     )
 }
 
@@ -1025,7 +1025,7 @@ mod tests {
     }
 
     #[test]
-    fn append_changes_keeps_explicit_transaction_control() {
+    fn append_changes_keeps_explicit_begin_commit_transaction_control() {
         let query = "BEGIN; INSERT INTO users(id) VALUES (1); COMMIT";
 
         let wrapped = append_changes_query(query);
@@ -1033,6 +1033,18 @@ mod tests {
         assert_eq!(
             wrapped,
             "BEGIN; INSERT INTO users(id) VALUES (1); COMMIT\n;\nSELECT changes() AS affected_rows;"
+        );
+    }
+
+    #[test]
+    fn append_changes_keeps_explicit_begin_end_transaction_control() {
+        let query = "BEGIN; INSERT INTO users(id) VALUES (1); END";
+
+        let wrapped = append_changes_query(query);
+
+        assert_eq!(
+            wrapped,
+            "BEGIN; INSERT INTO users(id) VALUES (1); END\n;\nSELECT changes() AS affected_rows;"
         );
     }
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::time::Instant;
 
@@ -162,14 +163,31 @@ impl SqliteAdapter {
         source: QuerySource,
         read_only: bool,
     ) -> Result<QueryResult, DbOperationError> {
+        self.execute_csv_query_with_display_query(path, query, query, source, read_only)
+            .await
+    }
+
+    async fn execute_csv_query_with_display_query(
+        &self,
+        path: &str,
+        execution_query: &str,
+        display_query: &str,
+        source: QuerySource,
+        read_only: bool,
+    ) -> Result<QueryResult, DbOperationError> {
         #[expect(
             clippy::disallowed_methods,
             reason = "infra measures sqlite3 execution time at the I/O boundary"
         )]
         let start = Instant::now();
-        let stdout = self.cli.execute_csv(path, query, read_only).await?;
+        let stdout = self
+            .cli
+            .execute_csv(path, execution_query, read_only)
+            .await?;
         let elapsed = start.elapsed().as_millis() as u64;
-        csv_to_query_result(query, &stdout, source, elapsed)
+        let mut result = csv_to_query_result(execution_query, &stdout, source, elapsed)?;
+        result.query = display_query.to_string();
+        Ok(result)
     }
 
     async fn execute_changes_query(
@@ -550,9 +568,18 @@ fn is_transaction_control(statement: &str) -> bool {
     )
 }
 
-fn should_wrap_dml_transaction(query: &str) -> bool {
+fn is_write_statement(statement: &str) -> bool {
+    matches!(
+        first_keyword(statement).to_ascii_uppercase().as_str(),
+        "INSERT" | "UPDATE" | "DELETE" | "CREATE" | "ALTER" | "DROP" | "TRUNCATE"
+    )
+}
+
+fn should_wrap_transaction(query: &str) -> bool {
     let statements = split_sqlite_statements(query);
-    statements.len() > 1 && !statements.iter().any(|stmt| is_transaction_control(stmt))
+    statements.len() > 1
+        && statements.iter().any(|stmt| is_write_statement(stmt))
+        && !statements.iter().any(|stmt| is_transaction_control(stmt))
 }
 
 fn sqlite_transaction_block(query: &str) -> String {
@@ -560,12 +587,16 @@ fn sqlite_transaction_block(query: &str) -> String {
     format!("BEGIN;\n{trimmed}\n;\nCOMMIT")
 }
 
-fn append_changes_query(query: &str) -> String {
-    let body = if should_wrap_dml_transaction(query) {
-        sqlite_transaction_block(query)
+fn sqlite_execution_query(query: &str) -> Cow<'_, str> {
+    if should_wrap_transaction(query) {
+        Cow::Owned(sqlite_transaction_block(query))
     } else {
-        query.trim_end().to_string()
-    };
+        Cow::Borrowed(query)
+    }
+}
+
+fn append_changes_query(query: &str) -> String {
+    let body = sqlite_execution_query(query).trim_end().to_string();
     // The standalone separator also terminates a trailing line comment before
     // appending the changes() probe.
     format!("{body}\n;\nSELECT changes() AS affected_rows;")
@@ -839,13 +870,20 @@ impl QueryExecutor for SqliteAdapter {
     ) -> Result<QueryResult, DbOperationError> {
         let path = Self::path_from_dsn(dsn)?;
         let keyword = first_keyword(query);
+        let execution_query = sqlite_execution_query(query);
         if keyword.eq_ignore_ascii_case("INSERT")
             || keyword.eq_ignore_ascii_case("UPDATE")
             || keyword.eq_ignore_ascii_case("DELETE")
         {
             if contains_keyword(query, "RETURNING") {
                 let mut result = self
-                    .execute_csv_query(path, query, QuerySource::Adhoc, read_only)
+                    .execute_csv_query_with_display_query(
+                        path,
+                        &execution_query,
+                        query,
+                        QuerySource::Adhoc,
+                        read_only,
+                    )
                     .await?;
                 let affected_rows = result.row_count as u64;
                 let tag = if keyword.eq_ignore_ascii_case("INSERT") {
@@ -880,7 +918,13 @@ impl QueryExecutor for SqliteAdapter {
         }
 
         let mut result = self
-            .execute_csv_query(path, query, QuerySource::Adhoc, read_only)
+            .execute_csv_query_with_display_query(
+                path,
+                &execution_query,
+                query,
+                QuerySource::Adhoc,
+                read_only,
+            )
             .await?;
         if let Some(tag) = ddl_tag(query) {
             result = result.with_command_tag(tag);
@@ -969,7 +1013,7 @@ mod tests {
     }
 
     #[test]
-    fn append_changes_wraps_multi_statement_dml_without_explicit_transaction() {
+    fn append_changes_wraps_multi_statement_write_without_explicit_transaction() {
         let query = "INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2);";
 
         let wrapped = append_changes_query(query);
@@ -1149,6 +1193,44 @@ mod tests {
             .execute_adhoc(
                 &dsn,
                 "INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
+                false,
+            )
+            .await;
+
+        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+        let rows = adapter
+            .execute_adhoc(&dsn, "SELECT id FROM users", true)
+            .await
+            .unwrap();
+        assert!(rows.rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn adhoc_returning_dml_rolls_back_when_later_statement_fails() {
+        let (_dir, dsn) = make_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let adapter = SqliteAdapter::new();
+        let query =
+            "INSERT INTO users(id) VALUES (1) RETURNING id; INSERT INTO missing(id) VALUES (2)";
+
+        let result = adapter.execute_adhoc(&dsn, query, false).await;
+
+        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+        let rows = adapter
+            .execute_adhoc(&dsn, "SELECT id FROM users", true)
+            .await
+            .unwrap();
+        assert!(rows.rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn adhoc_select_then_dml_rolls_back_when_later_statement_fails() {
+        let (_dir, dsn) = make_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let adapter = SqliteAdapter::new();
+
+        let result = adapter
+            .execute_adhoc(
+                &dsn,
+                "SELECT 1 AS marker; INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
                 false,
             )
             .await;


### PR DESCRIPTION
## Problem
Task 7 calls for a cross-adapter safety decision around SQLite multi-statement DML and CLI meta-command handling. Leaving the behavior implicit made SQLite read-only guarantees and PostgreSQL parity hard to review.

## Background
SQLite executes multi-statement scripts through sqlite3, while PostgreSQL already uses transaction-scoped execution for multi-statement SQL. Both adapters can also expose client meta-command behavior if non-SQL input reaches the CLI.

## Approach
Reject CLI meta-commands at the SQL policy boundary, document the shared safety contract, and wrap SQLite multi-statement DML in an explicit transaction unless the user already supplied transaction control.

## Screenshots
N/A

Task: memo/sqlite/task.md Task 7

Validation:
- cargo fmt
- cargo test -p sabiql-app cli_meta
- cargo test -p sabiql-infra sqlite::tests
- cargo clippy --workspace --all-targets --all-features -- -D warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * SQLクエリでCLIメタコマンド（バックスラッシュコマンド、ドットコマンド）の実行をブロックするセーフティゲートを追加
  * SQLiteの複数ステートメント実行時にトランザクションを自動的にラップし、エラー時のロールバック機構を強化

* **ドキュメント**
  * クエリ安全性に関する仕様（読み取り専用モード、トランザクション処理）をREADMEに明記

<!-- end of auto-generated comment: release notes by coderabbit.ai -->