### PR TITLE
Refactor app model connection invariants

### DIFF
--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -537,7 +537,7 @@ mod tests {
             let (tx, mut rx) = mpsc::channel::<Action>(16);
             let runner = make_runner_with_dsn_builder(tx);
 
-            let profile = ConnectionProfile::new(
+            let profile = ConnectionProfile::new_postgres(
                 "My DB",
                 "db.example.com",
                 5432,

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -300,7 +300,7 @@ mod tests {
     }
 
     fn use_postgres_connection(state: &mut AppState, dsn: &str) {
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
             "postgres",
             DatabaseType::PostgreSQL,

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -788,7 +788,7 @@ mod tests {
         use crate::model::connection::list::ConnectionListItem;
 
         fn make_profile(name: &str) -> ConnectionProfile {
-            ConnectionProfile::new(
+            ConnectionProfile::new_postgres(
                 name,
                 "localhost",
                 5432,

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -135,7 +135,7 @@ impl BrowseSession {
         self.begin_metadata_run()
     }
 
-    pub fn set_active_connection_with_dsn(
+    pub fn activate_connection_with_dsn(
         &mut self,
         id: &ConnectionId,
         name: &str,
@@ -170,7 +170,7 @@ impl BrowseSession {
 
     #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
-    pub fn set_active_database_type_for_test(&mut self, database_type: DatabaseType) {
+    pub fn set_active_db_capabilities_for_test(&mut self, database_type: DatabaseType) {
         self.active_db_capabilities = DbCapabilities::for_database_type(database_type);
     }
 
@@ -288,7 +288,7 @@ impl BrowseSession {
         dsn: &str,
     ) {
         self.restore_from_cache(cache, query);
-        self.set_active_connection_with_dsn(id, name, database_type, dsn);
+        self.activate_connection_with_dsn(id, name, database_type, dsn);
     }
 
     // Caller must also call `result_interaction.reset_view()` and restore UI state.
@@ -597,7 +597,7 @@ mod tests {
         #[test]
         fn mark_connecting_sets_pair_without_changing_dsn() {
             let mut session = BrowseSession::default();
-            session.set_active_connection_with_dsn(
+            session.activate_connection_with_dsn(
                 &ConnectionId::new(),
                 "postgres",
                 DatabaseType::PostgreSQL,
@@ -782,7 +782,7 @@ mod tests {
         fn clears_session_and_query_state() {
             let mut session = BrowseSession::default();
             session.mark_connected(make_metadata("db"));
-            session.set_active_connection_with_dsn(
+            session.activate_connection_with_dsn(
                 &ConnectionId::new(),
                 "mydb",
                 DatabaseType::PostgreSQL,

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -11,6 +11,13 @@ use crate::model::shared::async_run::AsyncRun;
 use crate::model::shared::db_capabilities::DbCapabilities;
 use crate::model::shared::inspector_tab::InspectorTab;
 
+#[derive(Debug, Clone)]
+struct ActiveConnection {
+    id: ConnectionId,
+    name: String,
+    database_type: DatabaseType,
+}
+
 // # Invariants
 //
 // - `connection_state` and `metadata_state` always transition as a pair
@@ -44,9 +51,7 @@ pub struct BrowseSession {
 
     // -- co-dependent: connection identity / lifecycle --
     dsn: Option<String>,
-    active_connection_id: Option<ConnectionId>,
-    active_connection_name: Option<String>,
-    active_database_type: Option<DatabaseType>,
+    active_connection: Option<ActiveConnection>,
     active_db_capabilities: DbCapabilities,
     read_only: bool,
     is_reloading: bool,
@@ -64,9 +69,7 @@ impl Default for BrowseSession {
             metadata_run: AsyncRun::default(),
             table_detail_run: AsyncRun::default(),
             dsn: None,
-            active_connection_id: None,
-            active_connection_name: None,
-            active_database_type: None,
+            active_connection: None,
             active_db_capabilities: DbCapabilities::disconnected(),
             read_only: false,
             is_reloading: false,
@@ -139,11 +142,14 @@ impl BrowseSession {
         database_type: DatabaseType,
         dsn: &str,
     ) {
-        self.active_connection_id = Some(id.clone());
-        self.active_connection_name = Some(name.to_string());
-        self.active_database_type = Some(database_type);
+        self.active_connection = Some(ActiveConnection {
+            id: id.clone(),
+            name: name.to_string(),
+            database_type,
+        });
         self.active_db_capabilities = DbCapabilities::for_database_type(database_type);
         self.dsn = Some(dsn.to_string());
+        self.read_only = false;
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -154,24 +160,23 @@ impl BrowseSession {
         name: &str,
         database_type: DatabaseType,
     ) {
-        self.active_connection_id = Some(id.clone());
-        self.active_connection_name = Some(name.to_string());
-        self.active_database_type = Some(database_type);
+        self.active_connection = Some(ActiveConnection {
+            id: id.clone(),
+            name: name.to_string(),
+            database_type,
+        });
         self.active_db_capabilities = DbCapabilities::for_database_type(database_type);
     }
 
     #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn set_active_database_type_for_test(&mut self, database_type: DatabaseType) {
-        self.active_database_type = Some(database_type);
         self.active_db_capabilities = DbCapabilities::for_database_type(database_type);
     }
 
     pub fn clear_connection(&mut self) {
         self.dsn = None;
-        self.active_connection_id = None;
-        self.active_connection_name = None;
-        self.active_database_type = None;
+        self.active_connection = None;
         self.active_db_capabilities = DbCapabilities::disconnected();
     }
 
@@ -284,7 +289,6 @@ impl BrowseSession {
     ) {
         self.restore_from_cache(cache, query);
         self.set_active_connection_with_dsn(id, name, database_type, dsn);
-        self.disable_read_only();
     }
 
     // Caller must also call `result_interaction.reset_view()` and restore UI state.
@@ -347,19 +351,25 @@ impl BrowseSession {
     }
 
     pub fn active_connection_id(&self) -> Option<&ConnectionId> {
-        self.active_connection_id.as_ref()
+        self.active_connection
+            .as_ref()
+            .map(|connection| &connection.id)
     }
 
     pub fn active_connection_name(&self) -> Option<&str> {
-        self.active_connection_name.as_deref()
+        self.active_connection
+            .as_ref()
+            .map(|connection| connection.name.as_str())
     }
 
     pub fn active_database_type(&self) -> Option<DatabaseType> {
-        self.active_database_type
+        self.active_connection
+            .as_ref()
+            .map(|connection| connection.database_type)
     }
 
     pub fn active_database_type_or_default(&self) -> DatabaseType {
-        self.active_database_type.unwrap_or_default()
+        self.active_database_type().unwrap_or_default()
     }
 
     pub fn active_db_capabilities(&self) -> &DbCapabilities {

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -612,6 +612,29 @@ mod tests {
         }
 
         #[test]
+        fn activate_connection_with_dsn_disables_read_only() {
+            let mut session = BrowseSession::default();
+            let id = ConnectionId::new();
+            session.enable_read_only();
+
+            session.activate_connection_with_dsn(
+                &id,
+                "postgres",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
+
+            assert!(!session.is_read_only());
+            assert_eq!(session.dsn(), Some("postgres://localhost/test"));
+            assert_eq!(session.active_connection_id(), Some(&id));
+            assert_eq!(session.active_connection_name(), Some("postgres"));
+            assert_eq!(
+                session.active_database_type(),
+                Some(DatabaseType::PostgreSQL)
+            );
+        }
+
+        #[test]
         fn mark_connected_sets_pair_and_metadata() {
             let mut session = BrowseSession::default();
             let metadata = make_metadata("test_db");

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -1,9 +1,10 @@
+use std::collections::HashMap;
+
 use crate::domain::connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, DatabaseType, SqliteConnectionConfigError,
     SslMode,
 };
 use crate::model::shared::text_input::TextInputState;
-use std::collections::HashMap;
 
 pub const CONNECTION_INPUT_WIDTH: u16 = 30;
 pub const CONNECTION_INPUT_VISIBLE_WIDTH: usize = (CONNECTION_INPUT_WIDTH - 4) as usize;

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -1,11 +1,9 @@
-use std::collections::HashMap;
-use std::path::Path;
-
 use crate::domain::connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, DatabaseType, SqliteConnectionConfigError,
     SslMode,
 };
 use crate::model::shared::text_input::TextInputState;
+use std::collections::HashMap;
 
 pub const CONNECTION_INPUT_WIDTH: u16 = 30;
 pub const CONNECTION_INPUT_VISIBLE_WIDTH: usize = (CONNECTION_INPUT_WIDTH - 4) as usize;
@@ -24,20 +22,6 @@ pub enum ConnectionField {
 }
 
 impl ConnectionField {
-    pub fn all() -> &'static [Self] {
-        &[
-            Self::DatabaseType,
-            Self::Name,
-            Self::SqlitePath,
-            Self::Host,
-            Self::Port,
-            Self::Database,
-            Self::User,
-            Self::Password,
-            Self::SslMode,
-        ]
-    }
-
     pub fn fields_for(database_type: DatabaseType) -> &'static [Self] {
         match database_type {
             DatabaseType::PostgreSQL => &[
@@ -125,7 +109,7 @@ pub struct ConnectionSetupState {
     pub(crate) ssl_dropdown: SslModeDropdown,
     pub(crate) validation_errors: HashMap<ConnectionField, String>,
 
-    pub(crate) is_first_run: bool,
+    is_first_run: bool,
 
     pub(crate) editing_id: Option<ConnectionId>,
 }
@@ -237,48 +221,12 @@ impl ConnectionSetupState {
         &mut self.port
     }
 
-    pub fn default_name(&self) -> String {
-        match self.database_type {
-            DatabaseType::PostgreSQL => {
-                if self.database.content().is_empty() {
-                    self.host.content().to_string()
-                } else {
-                    format!("{}@{}", self.database.content(), self.host.content())
-                }
-            }
-            DatabaseType::SQLite => self
-                .sqlite_path
-                .content()
-                .file_name_for_display()
-                .unwrap_or("SQLite")
-                .to_string(),
-        }
-    }
-
     pub fn focused_input(&self) -> Option<&TextInputState> {
-        match self.focused_field {
-            ConnectionField::DatabaseType | ConnectionField::SslMode => None,
-            ConnectionField::Name => Some(&self.name),
-            ConnectionField::SqlitePath => Some(&self.sqlite_path),
-            ConnectionField::Host => Some(&self.host),
-            ConnectionField::Port => Some(&self.port),
-            ConnectionField::Database => Some(&self.database),
-            ConnectionField::User => Some(&self.user),
-            ConnectionField::Password => Some(&self.password),
-        }
+        self.input(self.focused_field)
     }
 
     pub fn focused_input_mut(&mut self) -> Option<&mut TextInputState> {
-        match self.focused_field {
-            ConnectionField::DatabaseType | ConnectionField::SslMode => None,
-            ConnectionField::Name => Some(&mut self.name),
-            ConnectionField::SqlitePath => Some(&mut self.sqlite_path),
-            ConnectionField::Host => Some(&mut self.host),
-            ConnectionField::Port => Some(&mut self.port),
-            ConnectionField::Database => Some(&mut self.database),
-            ConnectionField::User => Some(&mut self.user),
-            ConnectionField::Password => Some(&mut self.password),
-        }
+        self.input_mut(self.focused_field)
     }
 
     pub fn clear_errors(&mut self) {
@@ -447,19 +395,6 @@ fn base_from_profile(profile: &ConnectionProfile) -> ConnectionSetupState {
     }
 }
 
-trait PathDisplayName {
-    fn file_name_for_display(&self) -> Option<&str>;
-}
-
-impl PathDisplayName for str {
-    fn file_name_for_display(&self) -> Option<&str> {
-        Path::new(self)
-            .file_name()
-            .and_then(|name| name.to_str())
-            .filter(|name| !name.is_empty())
-    }
-}
-
 fn next_visible_field(
     fields: &[ConnectionField],
     current: ConnectionField,
@@ -526,14 +461,6 @@ mod tests {
         ) {
             assert_eq!(field.is_required(), expected);
         }
-
-        #[test]
-        fn all_returns_fields_in_order() {
-            let all = ConnectionField::all();
-            assert_eq!(all.len(), 9);
-            assert_eq!(all[0], ConnectionField::DatabaseType);
-            assert_eq!(all[8], ConnectionField::SslMode);
-        }
     }
 
     mod connection_setup_state {
@@ -550,32 +477,8 @@ mod tests {
             assert!(state.password.content().is_empty());
             assert_eq!(state.ssl_mode, SslMode::Prefer);
             assert_eq!(state.focused_field, ConnectionField::DatabaseType);
-            assert!(state.is_first_run);
+            assert!(state.is_first_run());
             assert!(state.editing_id.is_none());
-        }
-
-        #[test]
-        fn default_name_without_database() {
-            let state = ConnectionSetupState::default();
-            assert_eq!(state.default_name(), "localhost");
-        }
-
-        #[test]
-        fn default_name_with_database() {
-            let mut state = ConnectionSetupState::default();
-            state.database.set_content("mydb".to_string());
-            assert_eq!(state.default_name(), "mydb@localhost");
-        }
-
-        #[test]
-        fn sqlite_default_name_uses_path_file_name() {
-            let mut state = ConnectionSetupState {
-                database_type: DatabaseType::SQLite,
-                ..ConnectionSetupState::default()
-            };
-            state.sqlite_path.set_content("/tmp/app.db".to_string());
-
-            assert_eq!(state.default_name(), "app.db");
         }
 
         #[test]
@@ -623,7 +526,7 @@ mod tests {
 
         #[test]
         fn from_profile_populates_all_fields() {
-            let profile = ConnectionProfile::new(
+            let profile = ConnectionProfile::new_postgres(
                 "Test DB",
                 "db.example.com",
                 5433,
@@ -644,7 +547,7 @@ mod tests {
             assert_eq!(state.password.content(), "secret");
             assert_eq!(state.ssl_mode, SslMode::Require);
             assert_eq!(state.editing_id, Some(profile.id));
-            assert!(!state.is_first_run);
+            assert!(!state.is_first_run());
         }
 
         #[test]
@@ -655,7 +558,7 @@ mod tests {
 
         #[test]
         fn is_edit_mode_returns_true_for_edit() {
-            let profile = ConnectionProfile::new(
+            let profile = ConnectionProfile::new_postgres(
                 "Test",
                 "localhost",
                 5432,

--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -171,7 +171,9 @@ impl ErPreparationState {
         self.status = ErStatus::Idle;
     }
 
-    pub fn mark_waiting(&mut self) {
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn mark_waiting_for_test(&mut self) {
         self.status = ErStatus::Waiting;
     }
 

--- a/src/app/model/explain_context.rs
+++ b/src/app/model/explain_context.rs
@@ -146,10 +146,6 @@ impl ExplainContext {
         self.scroll_offset = 0;
     }
 
-    pub fn reset_confirm_scroll(&mut self) {
-        self.confirm_scroll_offset = 0;
-    }
-
     pub fn set_compare_viewport_height(&mut self, height: u16) {
         self.compare_viewport_height = Some(height);
     }
@@ -164,10 +160,6 @@ impl ExplainContext {
 
     pub fn scroll_compare_to(&mut self, offset: usize) {
         self.compare_scroll_offset = offset;
-    }
-
-    pub fn right_full_query(&self) -> Option<&str> {
-        self.right.as_ref().map(|slot| slot.full_query.as_str())
     }
 
     pub fn reset_for_new_run(&mut self) {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -61,7 +61,7 @@ mod tests {
 
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
             "postgres",
             DatabaseType::PostgreSQL,

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -304,7 +304,7 @@ mod tests {
         fn retry_limit_exceeded_as_last_table_triggers_er_completion() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
             // Only table remaining; retry limit exceeded
@@ -341,7 +341,7 @@ mod tests {
         fn retry_limit_exceeded_with_queue_remaining_redrives_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let failed = "public.users".to_string();
             let remaining = "public.posts".to_string();
@@ -558,7 +558,7 @@ mod tests {
         fn transient_failure_then_success_clears_er_failure_state() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let qualified = "public.users".to_string();
             state.sql_modal.mark_prefetching(qualified.clone());
@@ -859,7 +859,7 @@ mod tests {
         #[test]
         fn complete_not_fk_expanded_dispatches_expand() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_unexpanded();
             // pending and fetching are empty → is_complete() = true
 
@@ -875,7 +875,7 @@ mod tests {
         #[test]
         fn complete_fk_expanded_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
 
             let effects = check_er_completion(&mut state, Instant::now());
@@ -897,7 +897,7 @@ mod tests {
         fn empty_neighbors_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -918,7 +918,7 @@ mod tests {
         fn non_empty_neighbors_adds_to_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -953,7 +953,7 @@ mod tests {
         #[test]
         fn stale_neighbors_without_active_run_do_not_mutate_state() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
 
             let effects = dispatch_metadata(
                 &mut state,
@@ -974,7 +974,7 @@ mod tests {
         fn duplicate_neighbors_are_not_requeued() {
             let mut state = state_with_dsn("postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state
                 .er_preparation
                 .queue_pending_table("public.posts".to_string());
@@ -1022,7 +1022,7 @@ mod tests {
             // All Phase 2 tables fail → completion must still fire
             let mut state = state_with_dsn("postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_expanded();
             let neighbor = "public.posts".to_string();
             state.er_preparation.queue_pending_table(neighbor.clone());

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -111,7 +111,7 @@ mod tests {
     use crate::update::browse::navigation::dispatch_navigation;
 
     fn create_test_profile(name: &str) -> ConnectionProfile {
-        ConnectionProfile::new(
+        ConnectionProfile::new_postgres(
             name,
             "localhost",
             5432,
@@ -306,7 +306,7 @@ mod tests {
         use super::*;
 
         fn create_test_profile_with_id(name: &str, id: ConnectionId) -> ConnectionProfile {
-            ConnectionProfile::with_id(
+            ConnectionProfile::with_id_postgres(
                 id,
                 name,
                 "localhost",

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -329,7 +329,7 @@ mod tests {
                 create_test_profile_with_id("active", active_id.clone()),
                 create_test_profile_with_id("other", other_id),
             ]);
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &active_id,
                 "active",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -363,7 +363,7 @@ mod tests {
                 "active",
                 active_id.clone(),
             )]);
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &active_id,
                 "active",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -407,7 +407,7 @@ mod tests {
                 create_test_profile_with_id("active", active_id.clone()),
                 create_test_profile_with_id("other", other_id),
             ]);
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &active_id,
                 "active",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -439,7 +439,7 @@ mod tests {
                 "active",
                 active_id.clone(),
             )]);
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &active_id,
                 "active",
                 crate::domain::DatabaseType::PostgreSQL,

--- a/src/app/update/browse/navigation/focus.rs
+++ b/src/app/update/browse/navigation/focus.rs
@@ -114,7 +114,7 @@ mod tests {
         use super::*;
 
         fn use_sqlite_connection(state: &mut AppState) {
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &ConnectionId::new(),
                 "sqlite",
                 DatabaseType::SQLite,

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -121,7 +121,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.ui.set_inspector_pane_height(10);
             state.ui.set_inspector_tab(InspectorTab::Columns);
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &ConnectionId::new(),
                 "postgres",
                 DatabaseType::PostgreSQL,
@@ -275,7 +275,7 @@ mod tests {
         }
 
         fn use_sqlite_tabs(state: &mut AppState) {
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &ConnectionId::new(),
                 "sqlite",
                 DatabaseType::SQLite,

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -70,7 +70,7 @@ pub(super) mod tests {
     }
 
     pub fn use_postgres_connection(state: &mut AppState, dsn: &str) {
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
             "postgres",
             DatabaseType::PostgreSQL,

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -523,7 +523,7 @@ mod tests {
         #[test]
         fn sqlite_active_database_type_uses_sqlite_update_preview() {
             let mut state = editable_state();
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
                 "sqlite",
                 DatabaseType::SQLite,

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -94,7 +94,7 @@ mod tests {
     use crate::domain::{ConnectionId, DatabaseType};
 
     fn use_postgres_connection(state: &mut AppState, dsn: &str) {
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
             "postgres",
             DatabaseType::PostgreSQL,
@@ -142,7 +142,7 @@ mod tests {
         #[test]
         fn blocked_for_service_connection() {
             let mut state = AppState::new("test".to_string());
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &ConnectionId::new(),
                 "service",
                 DatabaseType::PostgreSQL,

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -1,6 +1,6 @@
-use crate::domain::connection::{ConnectionId, DatabaseType};
 use crate::model::app_state::AppState;
 use crate::model::connection::cache::ConnectionCache;
+use crate::update::action::ConnectionTarget;
 
 pub(super) fn save_current_cache(state: &AppState) -> ConnectionCache {
     state.session.to_cache(
@@ -14,18 +14,15 @@ pub(super) fn save_current_cache(state: &AppState) -> ConnectionCache {
 pub(super) fn restore_cache(
     state: &mut AppState,
     cache: &ConnectionCache,
-    id: &ConnectionId,
-    name: &str,
-    database_type: DatabaseType,
-    dsn: &str,
+    target: &ConnectionTarget,
 ) {
     state.session.restore_from_cache_for_connection(
         cache,
         &mut state.query,
-        id,
-        name,
-        database_type,
-        dsn,
+        &target.id,
+        &target.name,
+        target.database_type,
+        &target.dsn,
     );
     state.ui.set_inspector_tab(
         state

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -21,7 +21,7 @@ fn reset_for_new_connection(
     state.ui.set_explorer_selection(None);
     state
         .session
-        .set_active_connection_with_dsn(id, name, database_type, dsn);
+        .activate_connection_with_dsn(id, name, database_type, dsn);
 }
 
 pub fn reduce_connection_lifecycle(
@@ -112,7 +112,7 @@ mod tests {
         let current_id = ConnectionId::new();
         let new_id = ConnectionId::new();
 
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &current_id,
             "current",
             DatabaseType::PostgreSQL,
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn sqlite_try_connect_fetches_metadata() {
         let mut state = AppState::new("test".to_string());
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::from_string("sqlite-test"),
             "sqlite",
             DatabaseType::SQLite,

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -22,7 +22,6 @@ fn reset_for_new_connection(
     state
         .session
         .set_active_connection_with_dsn(id, name, database_type, dsn);
-    state.session.disable_read_only();
 }
 
 pub fn reduce_connection_lifecycle(
@@ -47,19 +46,20 @@ pub fn reduce_connection_lifecycle(
             }
         }
 
-        Action::SwitchConnection(ConnectionTarget {
-            id,
-            dsn,
-            name,
-            database_type,
-        }) => {
+        Action::SwitchConnection(target) => {
+            let ConnectionTarget {
+                id,
+                dsn,
+                name,
+                database_type,
+            } = target;
             if let Some(current_id) = state.session.active_connection_id().cloned() {
                 let cache = save_current_cache(state);
                 state.connection_caches.save(&current_id, cache);
             }
 
             if let Some(cached) = state.connection_caches.get(id).cloned() {
-                restore_cache(state, &cached, id, name, *database_type, dsn);
+                restore_cache(state, &cached, target);
                 DispatchResult::handled_with(vec![Effect::ClearCompletionEngineCache])
             } else {
                 // No cache: reset and fetch metadata

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -190,7 +190,7 @@ mod tests {
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
             state.ui.set_connection_list_selected_raw(0);
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &profile_id,
                 "Production",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -303,7 +303,7 @@ mod tests {
             let profile = create_profile("Production");
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &profile_id,
                 "Production",
                 crate::domain::DatabaseType::PostgreSQL,
@@ -330,7 +330,7 @@ mod tests {
             let profile = create_profile("Production");
             let profile_id = profile.id.clone();
             state.set_connections(vec![profile]);
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &profile_id,
                 "Production",
                 crate::domain::DatabaseType::PostgreSQL,

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -109,7 +109,7 @@ mod tests {
     use crate::model::connection::list::build_connection_list;
 
     fn create_profile(name: &str) -> ConnectionProfile {
-        ConnectionProfile::new(
+        ConnectionProfile::new_postgres(
             name.to_string(),
             "localhost".to_string(),
             5432,

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -199,7 +199,7 @@ pub fn reduce_connection_setup(
             state.modal.set_mode(InputMode::Normal);
             state
                 .session
-                .set_active_connection_with_dsn(id, name, *database_type, dsn);
+                .activate_connection_with_dsn(id, name, *database_type, dsn);
             let run_id = state.session.begin_connecting(dsn);
             DispatchResult::handled_with(vec![Effect::FetchMetadata {
                 dsn: dsn.clone(),
@@ -242,7 +242,7 @@ mod tests {
     }
 
     fn use_postgres_connection(state: &mut AppState, dsn: &str) {
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
             "postgres",
             DatabaseType::PostgreSQL,

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -200,7 +200,6 @@ pub fn reduce_connection_setup(
             state
                 .session
                 .set_active_connection_with_dsn(id, name, *database_type, dsn);
-            state.session.disable_read_only();
             let run_id = state.session.begin_connecting(dsn);
             DispatchResult::handled_with(vec![Effect::FetchMetadata {
                 dsn: dsn.clone(),
@@ -230,7 +229,7 @@ mod tests {
     }
 
     fn create_profile(name: &str) -> ConnectionProfile {
-        ConnectionProfile::new(
+        ConnectionProfile::new_postgres(
             name.to_string(),
             "localhost".to_string(),
             5432,

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -143,7 +143,7 @@ mod tests {
         #[test]
         fn waiting_status_returns_empty_effects() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
                 .into_effects()
@@ -230,7 +230,7 @@ mod tests {
         fn no_changes_dispatches_generate_from_cache() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -259,7 +259,7 @@ mod tests {
         fn stale_tables_trigger_evict_and_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -293,7 +293,7 @@ mod tests {
         fn added_tables_trigger_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -322,7 +322,7 @@ mod tests {
         fn removed_tables_trigger_evict() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -351,7 +351,7 @@ mod tests {
         fn missing_in_cache_triggers_scoped_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
@@ -380,7 +380,7 @@ mod tests {
         fn mismatched_run_id_returns_empty_for_completed() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 5);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
 
             let action = Action::SmartErRefreshCompleted(SmartErRefreshResult {
                 dsn: "postgres://localhost/test".to_string(),
@@ -404,7 +404,7 @@ mod tests {
         fn updates_metadata_and_signatures() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.session.set_metadata(Some(make_metadata(0)));
 
             let new_sigs: HashMap<String, String> =
@@ -457,7 +457,7 @@ mod tests {
         fn falls_back_to_full_prefetch() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.session.set_metadata(Some(make_metadata(5)));
             state.er_preparation.apply_refresh_metadata(
                 HashMap::from([("public.old".to_string(), "sig".to_string())]),
@@ -501,7 +501,7 @@ mod tests {
         fn falls_back_to_scoped_prefetch_when_targets_set() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.session.set_metadata(Some(make_metadata(10)));
             state
                 .er_preparation
@@ -543,7 +543,7 @@ mod tests {
         fn mismatched_run_id_returns_empty_for_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 5);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.session.set_metadata(Some(make_metadata(5)));
 
             let effects = reduce_er(
@@ -565,7 +565,7 @@ mod tests {
         fn mismatched_dsn_returns_empty_for_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.session.set_metadata(Some(make_metadata(5)));
 
             let effects = reduce_er(
@@ -590,7 +590,7 @@ mod tests {
         fn no_metadata_sets_idle_and_error() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
 
             let effects = reduce_er(
                 &mut state,
@@ -613,7 +613,7 @@ mod tests {
         fn new_metadata_applied_before_fallback() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.session.set_metadata(Some(make_metadata(3)));
 
             let effects = reduce_er(

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -33,7 +33,7 @@ mod tests {
 
     fn state_with_dsn(dsn: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
             "postgres",
             DatabaseType::PostgreSQL,

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -52,7 +52,7 @@ mod tests {
     }
 
     fn use_postgres_connection_with_dsn(state: &mut AppState, dsn: &str) {
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::from_string("postgres-test"),
             "postgres",
             DatabaseType::PostgreSQL,
@@ -61,7 +61,7 @@ mod tests {
     }
 
     fn use_sqlite_connection(state: &mut AppState) {
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::from_string("sqlite-test"),
             "sqlite",
             DatabaseType::SQLite,

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -482,7 +482,7 @@ mod tests {
                 DatabaseType::PostgreSQL => "postgres://localhost/test",
                 DatabaseType::SQLite => "sqlite:///tmp/app.db",
             };
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("test-connection"),
                 "test",
                 database_type,

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -122,7 +122,7 @@ mod tests {
                 .sql_modal
                 .set_active_tab(crate::model::sql_editor::modal::SqlModalTab::Plan);
 
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
                 "sqlite",
                 crate::domain::DatabaseType::SQLite,

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -101,7 +101,7 @@ pub(super) fn reduce_confirm_dialog(
             if matches!(intent, Some(ConfirmIntent::QuitNoConnection)) {
                 state.connection_setup.reset();
                 if !state.connections().is_empty() || state.session.dsn().is_some() {
-                    state.connection_setup.is_first_run = false;
+                    state.connection_setup.set_first_run(false);
                 }
                 state.modal.pop_mode_override(InputMode::ConnectionSetup);
                 DispatchResult::handled()

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -41,7 +41,7 @@ mod tests {
     }
 
     fn use_postgres_connection(state: &mut AppState, dsn: &str) {
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
             "postgres",
             DatabaseType::PostgreSQL,
@@ -836,7 +836,7 @@ mod tests {
 
         fn connected_state() -> AppState {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &ConnectionId::from_string("test-conn"),
                 "test",
                 DatabaseType::PostgreSQL,

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -194,7 +194,7 @@ mod tests {
     }
 
     fn use_postgres_connection(state: &mut AppState, dsn: &str) {
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
             "postgres",
             DatabaseType::PostgreSQL,
@@ -1306,7 +1306,7 @@ mod tests {
         #[test]
         fn reload_then_metadata_loaded_shows_reloaded_message() {
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("test-connection"),
                 "test",
                 DatabaseType::PostgreSQL,
@@ -2104,7 +2104,7 @@ mod tests {
             // When already connected, metadata failure should preserve connection state
             // (metadata-only failure, e.g., permission denied on schema)
             let mut state = create_test_state();
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &crate::domain::connection::ConnectionId::from_string("test-connection"),
                 "test",
                 DatabaseType::PostgreSQL,
@@ -2232,7 +2232,7 @@ mod tests {
             let conn_a = ConnectionId::new();
             let conn_b = ConnectionId::new();
 
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &conn_a,
                 "conn-a",
                 DatabaseType::PostgreSQL,
@@ -2278,7 +2278,7 @@ mod tests {
             let conn_a = ConnectionId::new();
             let conn_b = ConnectionId::new();
 
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &conn_a,
                 "conn-a",
                 DatabaseType::PostgreSQL,

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1450,7 +1450,7 @@ mod tests {
         #[test]
         fn metadata_failed_resets_er_waiting_to_idle() {
             let mut state = create_test_state();
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             let now = Instant::now();
             use_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
@@ -1670,7 +1670,7 @@ mod tests {
         fn save_completed_sets_dsn_and_returns_fetch_effect() {
             let mut state = create_test_state();
             state.modal.set_mode(InputMode::ConnectionSetup);
-            state.connection_setup.is_first_run = true;
+            state.connection_setup.set_first_run(true);
             state
                 .connection_setup
                 .host
@@ -1694,7 +1694,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert!(!state.connection_setup.is_first_run);
+            assert!(!state.connection_setup.is_first_run());
             assert_eq!(state.session.dsn(), Some("postgres://db.example.com/mydb"));
             assert_eq!(
                 state.session.active_connection_name(),
@@ -1728,7 +1728,7 @@ mod tests {
         fn cancel_on_first_run_opens_confirm_dialog() {
             let mut state = create_test_state();
             state.modal.set_mode(InputMode::ConnectionSetup);
-            state.connection_setup.is_first_run = true;
+            state.connection_setup.set_first_run(true);
             let now = Instant::now();
 
             let effects = reduce(
@@ -1750,7 +1750,7 @@ mod tests {
         fn cancel_after_save_returns_to_normal_and_dispatches_try_connect() {
             let mut state = create_test_state();
             state.modal.set_mode(InputMode::ConnectionSetup);
-            state.connection_setup.is_first_run = false;
+            state.connection_setup.set_first_run(false);
             let now = Instant::now();
 
             let effects = reduce(
@@ -2545,7 +2545,7 @@ mod tests {
             let mut state = state_with_metadata();
             use_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.er_preparation.begin_full_prefetch(1);
             state.er_preparation.mark_fk_expanded();
             state
@@ -2579,7 +2579,7 @@ mod tests {
             let mut state = state_with_metadata();
             use_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
-            state.er_preparation.mark_waiting();
+            state.er_preparation.mark_waiting_for_test();
             state.er_preparation.begin_full_prefetch(2);
             state.er_preparation.mark_fk_expanded();
             state

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -45,7 +45,7 @@ mod tests {
     }
 
     fn use_postgres_connection(state: &mut AppState, dsn: &str) {
-        state.session.set_active_connection_with_dsn(
+        state.session.activate_connection_with_dsn(
             &ConnectionId::from_string("postgres-test"),
             "postgres",
             DatabaseType::PostgreSQL,

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -32,7 +32,7 @@ impl PostgresConnectionConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct SqliteConnectionConfig {
     path: String,
 }
@@ -58,6 +58,21 @@ impl SqliteConnectionConfig {
 
     pub fn path(&self) -> &str {
         &self.path
+    }
+}
+
+impl<'de> Deserialize<'de> for SqliteConnectionConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawSqliteConnectionConfig {
+            path: String,
+        }
+
+        let raw = RawSqliteConnectionConfig::deserialize(deserializer)?;
+        Self::new(raw.path).map_err(serde::de::Error::custom)
     }
 }
 
@@ -96,6 +111,38 @@ impl ConnectionConfig {
         match self {
             Self::SQLite(config) => Some(config),
             Self::PostgreSQL(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod sqlite_deserialize {
+        use super::*;
+
+        #[test]
+        fn accepts_valid_path() {
+            let config: SqliteConnectionConfig =
+                serde_json::from_str(r#"{ "path": "/tmp/app.db" }"#).unwrap();
+
+            assert_eq!(config.path(), "/tmp/app.db");
+        }
+
+        #[test]
+        fn rejects_empty_path() {
+            let result = serde_json::from_str::<SqliteConnectionConfig>(r#"{ "path": "   " }"#);
+
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn rejects_control_characters() {
+            let result =
+                serde_json::from_str::<SqliteConnectionConfig>(r#"{ "path": "/tmp/app\n.db" }"#);
+
+            assert!(result.is_err());
         }
     }
 }

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -52,10 +52,6 @@ impl SqliteConnectionConfig {
         Ok(Self { path })
     }
 
-    pub(crate) fn validate(&self) -> Result<(), SqliteConnectionConfigError> {
-        validate_sqlite_path(&self.path)
-    }
-
     pub fn path(&self) -> &str {
         &self.path
     }

--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -102,9 +102,6 @@ impl ConnectionProfile {
         name: impl Into<String>,
         config: ConnectionConfig,
     ) -> Result<Self, ConnectionProfileError> {
-        if let ConnectionConfig::SQLite(sqlite) = &config {
-            sqlite.validate()?;
-        }
         Ok(Self {
             id,
             name: ConnectionName::new(name)?,

--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -37,27 +37,6 @@ pub struct ConnectionProfile {
 }
 
 impl ConnectionProfile {
-    pub fn new(
-        name: impl Into<String>,
-        host: impl Into<String>,
-        port: u16,
-        database: impl Into<String>,
-        username: impl Into<String>,
-        password: impl Into<String>,
-        ssl_mode: SslMode,
-    ) -> Result<Self, ConnectionNameError> {
-        Self::new_postgres(name, host, port, database, username, password, ssl_mode).map_err(|e| {
-            match e {
-                ConnectionProfileError::Name(e) => e,
-                ConnectionProfileError::EmptySqlitePath
-                | ConnectionProfileError::InvalidSqlitePath
-                | ConnectionProfileError::MissingPostgresField(_) => {
-                    unreachable!("postgres constructor")
-                }
-            }
-        })
-    }
-
     pub fn new_postgres(
         name: impl Into<String>,
         host: impl Into<String>,
@@ -85,27 +64,6 @@ impl ConnectionProfile {
             name: ConnectionName::new(name)?,
             config: ConnectionConfig::SQLite(SqliteConnectionConfig::new(path)?),
         })
-    }
-
-    pub fn with_id(
-        id: ConnectionId,
-        name: impl Into<String>,
-        host: impl Into<String>,
-        port: u16,
-        database: impl Into<String>,
-        username: impl Into<String>,
-        password: impl Into<String>,
-        ssl_mode: SslMode,
-    ) -> Result<Self, ConnectionNameError> {
-        Self::with_id_postgres(id, name, host, port, database, username, password, ssl_mode)
-            .map_err(|e| match e {
-                ConnectionProfileError::Name(e) => e,
-                ConnectionProfileError::EmptySqlitePath
-                | ConnectionProfileError::InvalidSqlitePath
-                | ConnectionProfileError::MissingPostgresField(_) => {
-                    unreachable!("postgres constructor")
-                }
-            })
     }
 
     pub fn with_id_postgres(
@@ -176,7 +134,7 @@ mod tests {
     use super::*;
 
     fn make_test_profile() -> ConnectionProfile {
-        ConnectionProfile::new(
+        ConnectionProfile::new_postgres(
             "Test Connection",
             "localhost",
             5432,
@@ -200,7 +158,7 @@ mod tests {
 
         #[test]
         fn empty_name_returns_error() {
-            let result = ConnectionProfile::new(
+            let result = ConnectionProfile::new_postgres(
                 "",
                 "localhost",
                 5432,

--- a/src/infra/adapters/connection_store.rs
+++ b/src/infra/adapters/connection_store.rs
@@ -138,7 +138,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn make_test_profile(name: &str) -> ConnectionProfile {
-        ConnectionProfile::new(
+        ConnectionProfile::new_postgres(
             name,
             "localhost",
             5432,

--- a/src/infra/adapters/postgres/dsn.rs
+++ b/src/infra/adapters/postgres/dsn.rs
@@ -49,7 +49,7 @@ mod tests {
     use crate::domain::connection::SslMode;
 
     fn make_test_profile() -> ConnectionProfile {
-        ConnectionProfile::new(
+        ConnectionProfile::new_postgres(
             "Test Connection",
             "localhost",
             5432,
@@ -81,7 +81,7 @@ mod tests {
         #[test]
         fn encodes_special_chars_in_credentials() {
             let adapter = PostgresAdapter::new();
-            let profile = ConnectionProfile::new(
+            let profile = ConnectionProfile::new_postgres(
                 "Test",
                 "localhost",
                 5432,

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn builds_postgres_dsn_from_postgres_profile() {
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
-        let profile = ConnectionProfile::new(
+        let profile = ConnectionProfile::new_postgres(
             "Test",
             "localhost",
             5432,

--- a/src/tests/render_snapshots/connection_management.rs
+++ b/src/tests/render_snapshots/connection_management.rs
@@ -6,7 +6,7 @@ use sabiql_domain::connection::{ConnectionId, ConnectionProfile, SslMode};
 fn three_connections() -> (ConnectionId, Vec<ConnectionProfile>) {
     let active_id = ConnectionId::new();
     let profiles = vec![
-        ConnectionProfile::with_id(
+        ConnectionProfile::with_id_postgres(
             active_id.clone(),
             "Production",
             "prod.example.com",
@@ -17,7 +17,7 @@ fn three_connections() -> (ConnectionId, Vec<ConnectionProfile>) {
             SslMode::Require,
         )
         .unwrap(),
-        ConnectionProfile::new(
+        ConnectionProfile::new_postgres(
             "Staging",
             "staging.example.com",
             5432,
@@ -27,7 +27,7 @@ fn three_connections() -> (ConnectionId, Vec<ConnectionProfile>) {
             SslMode::Prefer,
         )
         .unwrap(),
-        ConnectionProfile::new(
+        ConnectionProfile::new_postgres(
             "Local Dev",
             "localhost",
             5432,

--- a/src/tests/render_snapshots/initial_state.rs
+++ b/src/tests/render_snapshots/initial_state.rs
@@ -16,7 +16,7 @@ fn explorer_shows_not_connected_when_no_active_connection() {
     state.session.clear_connection();
     state
         .session
-        .set_active_database_type_for_test(sabiql_domain::DatabaseType::PostgreSQL);
+        .set_active_db_capabilities_for_test(sabiql_domain::DatabaseType::PostgreSQL);
     let mut terminal = create_test_terminal();
 
     let output = render_to_string(&mut terminal, &mut state);

--- a/src/tests/render_snapshots/inspector.rs
+++ b/src/tests/render_snapshots/inspector.rs
@@ -172,7 +172,7 @@ fn inspector_info_tab_for_sqlite_hides_postgres_only_fields() {
     table.rls = None;
     table.triggers = vec![];
     let _ = state.session.set_table_detail(table, 0);
-    state.session.set_active_connection_with_dsn(
+    state.session.activate_connection_with_dsn(
         &ConnectionId::from_string("sqlite-test"),
         "app.db",
         DatabaseType::SQLite,

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -387,7 +387,7 @@ mod tests {
     ) {
         let mut state = inspector_state();
         if let Some(database_type) = database_type {
-            state.session.set_active_connection_with_dsn(
+            state.session.activate_connection_with_dsn(
                 &ConnectionId::new(),
                 "database",
                 database_type,


### PR DESCRIPTION
## Problem
Task 5 left app model APIs in a half-migrated state: connection identity fields were still split, read-only reset was caller-owned, and several test-only or unused helpers remained in production-facing model APIs.

## Background
SQLite support expanded the connection model, which made existing PostgreSQL-only helper surfaces and connection-state invariants easier to misuse from new paths.

## Approach
- Move active-connection identity into a single aggregate-owned value and make connection activation reset read-only state.
- Remove stale/test-only model APIs from production-facing surfaces and migrate fixtures to explicit PostgreSQL constructors.
- Validate SQLite config deserialization through the same path validation used by normal construction.

## Screenshots
N/A

Validation:
- `cargo fmt`
- `cargo test --workspace -- --nocapture`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal refactoring of session and connection management methods for improved code organization and maintainability. API consolidation for connection profile generation. No user-facing feature changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->