### PR TITLE
Add read-only cell detail modal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2671,6 +2671,7 @@ dependencies = [
  "sabiql-domain",
  "tokio",
  "tokio-util",
+ "unicode-casefold",
  "unicode-width",
 ]
 

--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -261,6 +261,8 @@ fn current_section(origin: HelpOrigin) -> HelpSection {
         HelpOrigin::QueryHistoryPicker => rows_from_mode_rows(QUERY_HISTORY_PICKER_ROWS),
         HelpOrigin::JsonbDetail { mode } => jsonb_current_rows(mode),
         HelpOrigin::JsonbEdit => rows_from_mode_rows(JSONB_EDIT_ROWS),
+        HelpOrigin::CellDetail { searching: true } => rows_from_bindings(CELL_DETAIL_SEARCH_KEYS),
+        HelpOrigin::CellDetail { searching: false } => rows_from_mode_rows(CELL_DETAIL_ROWS),
     };
 
     HelpSection {

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -162,9 +162,9 @@ impl AppState {
             self.ui.set_jsonb_detail_editor_visible_rows(visible_rows);
             self.jsonb_detail.editor_mut().update_scroll(visible_rows);
         }
-        if let Some((visible_rows, viewport_width)) = output.cell_detail_viewport {
+        if let Some(viewport) = output.cell_detail_viewport {
             self.cell_detail
-                .set_viewport_metrics(visible_rows, viewport_width);
+                .set_viewport_metrics(viewport.visible_rows, viewport.viewport_width);
         }
         self.confirm_dialog.apply_preview_metrics(
             output.confirm_preview_viewport_height,

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -4,6 +4,7 @@ use super::explain_context::ExplainContext;
 use super::runtime_state::RuntimeState;
 use crate::domain::TableSummary;
 use crate::domain::connection::{ConnectionProfile, ServiceEntry};
+use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::browse::jsonb_detail::JsonbDetailState;
 use crate::model::browse::query_execution::QueryExecution;
 use crate::model::browse::result_interaction::ResultInteraction;
@@ -41,6 +42,7 @@ pub struct AppState {
     pub connection_error: ConnectionErrorState,
     pub confirm_dialog: ConfirmDialogState,
     pub result_interaction: ResultInteraction,
+    pub cell_detail: CellDetailState,
     pub jsonb_detail: JsonbDetailState,
     pub query_history_picker: QueryHistoryPickerState,
     pub settings: SettingsState,
@@ -71,6 +73,7 @@ impl AppState {
             connection_error: ConnectionErrorState::default(),
             confirm_dialog: ConfirmDialogState::default(),
             result_interaction: ResultInteraction::default(),
+            cell_detail: CellDetailState::default(),
             jsonb_detail: JsonbDetailState::default(),
             query_history_picker: QueryHistoryPickerState::default(),
             settings: SettingsState::default(),
@@ -158,6 +161,10 @@ impl AppState {
         if let Some(visible_rows) = output.jsonb_detail_editor_visible_rows {
             self.ui.set_jsonb_detail_editor_visible_rows(visible_rows);
             self.jsonb_detail.editor_mut().update_scroll(visible_rows);
+        }
+        if let Some((visible_rows, viewport_width)) = output.cell_detail_viewport {
+            self.cell_detail
+                .set_viewport_metrics(visible_rows, viewport_width);
         }
         self.confirm_dialog.apply_preview_metrics(
             output.confirm_preview_viewport_height,

--- a/src/app/model/browse/cell_detail.rs
+++ b/src/app/model/browse/cell_detail.rs
@@ -77,7 +77,8 @@ pub struct CellDetailState {
     row: usize,
     col: usize,
     column_name: String,
-    content: String,
+    original_content: String,
+    display_content: String,
     scroll_offset: usize,
     visible_rows: usize,
     viewport_width: usize,
@@ -91,7 +92,8 @@ impl Default for CellDetailState {
             row: 0,
             col: 0,
             column_name: String::new(),
-            content: String::new(),
+            original_content: String::new(),
+            display_content: String::new(),
             scroll_offset: 0,
             visible_rows: DEFAULT_VISIBLE_ROWS,
             viewport_width: DEFAULT_VIEWPORT_WIDTH,
@@ -102,12 +104,19 @@ impl Default for CellDetailState {
 }
 
 impl CellDetailState {
-    pub fn open(row: usize, col: usize, column_name: String, content: String) -> Self {
+    pub fn open(
+        row: usize,
+        col: usize,
+        column_name: String,
+        original_content: String,
+        display_content: String,
+    ) -> Self {
         Self {
             row,
             col,
             column_name,
-            content,
+            original_content,
+            display_content,
             active: true,
             ..Self::default()
         }
@@ -134,7 +143,11 @@ impl CellDetailState {
     }
 
     pub fn content(&self) -> &str {
-        &self.content
+        &self.display_content
+    }
+
+    pub fn original_content(&self) -> &str {
+        &self.original_content
     }
 
     pub fn scroll_offset(&self) -> usize {
@@ -189,7 +202,7 @@ impl CellDetailState {
             return;
         };
         self.scroll_offset =
-            visual_row_for_char_offset(&self.content, match_pos, self.viewport_width)
+            visual_row_for_char_offset(&self.display_content, match_pos, self.viewport_width)
                 .min(self.max_scroll_offset());
     }
 
@@ -198,7 +211,8 @@ impl CellDetailState {
     }
 
     fn max_scroll_offset(&self) -> usize {
-        visual_line_count(&self.content, self.viewport_width).saturating_sub(self.visible_rows)
+        visual_line_count(&self.display_content, self.viewport_width)
+            .saturating_sub(self.visible_rows)
     }
 }
 
@@ -263,7 +277,9 @@ mod tests {
 
         #[test]
         fn long_single_line_uses_wrapped_visual_rows_for_max_scroll() {
-            let mut state = CellDetailState::open(0, 0, "body".to_string(), "a".repeat(100));
+            let content = "a".repeat(100);
+            let mut state =
+                CellDetailState::open(0, 0, "body".to_string(), content.clone(), content);
             state.set_viewport_metrics(3, 10);
 
             state.scroll(ScrollDirection::Down, ScrollAmount::ToEnd);
@@ -273,12 +289,9 @@ mod tests {
 
         #[test]
         fn search_match_scrolls_to_wrapped_visual_row() {
-            let mut state = CellDetailState::open(
-                0,
-                0,
-                "body".to_string(),
-                format!("{}needle", "a".repeat(35)),
-            );
+            let content = format!("{}needle", "a".repeat(35));
+            let mut state =
+                CellDetailState::open(0, 0, "body".to_string(), content.clone(), content);
             state.set_viewport_metrics(3, 10);
             state.search_mut().set_matches(vec![35]);
 

--- a/src/app/model/browse/cell_detail.rs
+++ b/src/app/model/browse/cell_detail.rs
@@ -1,9 +1,8 @@
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthChar;
 
 use crate::model::shared::text_input::TextInputState;
 use crate::update::action::{ScrollAmount, ScrollDirection};
 
-const CELL_DETAIL_MIN_DISPLAY_WIDTH: usize = 60;
 const DEFAULT_VIEWPORT_WIDTH: usize = 80;
 const DEFAULT_VISIBLE_ROWS: usize = 8;
 
@@ -203,14 +202,6 @@ impl CellDetailState {
     }
 }
 
-pub fn is_cell_detail_candidate(value: &str) -> bool {
-    if value.is_empty() || value == "NULL" {
-        return false;
-    }
-
-    value.contains('\n') || UnicodeWidthStr::width(value) >= CELL_DETAIL_MIN_DISPLAY_WIDTH
-}
-
 fn visual_line_count(content: &str, width: usize) -> usize {
     content
         .split('\n')
@@ -266,33 +257,6 @@ fn visual_row_for_char_offset(content: &str, target: usize, width: usize) -> usi
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    mod detail_candidate {
-        use super::*;
-
-        #[test]
-        fn excludes_empty_and_null_values() {
-            assert!(!is_cell_detail_candidate(""));
-            assert!(!is_cell_detail_candidate("NULL"));
-        }
-
-        #[test]
-        fn includes_multiline_values() {
-            assert!(is_cell_detail_candidate("hello\nworld"));
-        }
-
-        #[test]
-        fn includes_single_line_values_at_display_width_threshold() {
-            let value = "a".repeat(CELL_DETAIL_MIN_DISPLAY_WIDTH);
-
-            assert!(is_cell_detail_candidate(&value));
-        }
-
-        #[test]
-        fn excludes_short_single_line_values() {
-            assert!(!is_cell_detail_candidate("short text"));
-        }
-    }
 
     mod scrolling {
         use super::*;

--- a/src/app/model/browse/cell_detail.rs
+++ b/src/app/model/browse/cell_detail.rs
@@ -1,0 +1,326 @@
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::model::shared::text_input::TextInputState;
+use crate::update::action::{ScrollAmount, ScrollDirection};
+
+const CELL_DETAIL_MIN_DISPLAY_WIDTH: usize = 60;
+const DEFAULT_VIEWPORT_WIDTH: usize = 80;
+const DEFAULT_VISIBLE_ROWS: usize = 8;
+
+#[derive(Debug, Clone, Default)]
+pub struct CellDetailSearchState {
+    input: TextInputState,
+    matches: Vec<usize>,
+    current_match: usize,
+    active: bool,
+}
+
+impl CellDetailSearchState {
+    pub fn input(&self) -> &TextInputState {
+        &self.input
+    }
+
+    pub fn input_mut(&mut self) -> &mut TextInputState {
+        &mut self.input
+    }
+
+    pub fn matches(&self) -> &[usize] {
+        &self.matches
+    }
+
+    pub fn current_match(&self) -> usize {
+        self.current_match
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub fn set_matches(&mut self, matches: Vec<usize>) {
+        self.matches = matches;
+        self.current_match = 0;
+    }
+
+    pub fn advance_to_next_match(&mut self) {
+        if !self.matches.is_empty() {
+            self.current_match = (self.current_match + 1) % self.matches.len();
+        }
+    }
+
+    pub fn advance_to_prev_match(&mut self) {
+        if self.matches.is_empty() {
+            return;
+        }
+        self.current_match = if self.current_match == 0 {
+            self.matches.len() - 1
+        } else {
+            self.current_match - 1
+        };
+    }
+
+    pub fn reset(&mut self) {
+        self.input.clear();
+        self.matches.clear();
+        self.current_match = 0;
+    }
+
+    pub fn activate(&mut self) {
+        self.active = true;
+    }
+
+    pub fn deactivate(&mut self) {
+        self.active = false;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CellDetailState {
+    row: usize,
+    col: usize,
+    column_name: String,
+    content: String,
+    scroll_offset: usize,
+    visible_rows: usize,
+    viewport_width: usize,
+    search: CellDetailSearchState,
+    active: bool,
+}
+
+impl Default for CellDetailState {
+    fn default() -> Self {
+        Self {
+            row: 0,
+            col: 0,
+            column_name: String::new(),
+            content: String::new(),
+            scroll_offset: 0,
+            visible_rows: DEFAULT_VISIBLE_ROWS,
+            viewport_width: DEFAULT_VIEWPORT_WIDTH,
+            search: CellDetailSearchState::default(),
+            active: false,
+        }
+    }
+}
+
+impl CellDetailState {
+    pub fn open(row: usize, col: usize, column_name: String, content: String) -> Self {
+        Self {
+            row,
+            col,
+            column_name,
+            content,
+            active: true,
+            ..Self::default()
+        }
+    }
+
+    pub fn close(&mut self) {
+        *self = Self::default();
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    pub fn row(&self) -> usize {
+        self.row
+    }
+
+    pub fn col(&self) -> usize {
+        self.col
+    }
+
+    pub fn column_name(&self) -> &str {
+        &self.column_name
+    }
+
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    pub fn scroll_offset(&self) -> usize {
+        self.scroll_offset
+    }
+
+    pub fn search(&self) -> &CellDetailSearchState {
+        &self.search
+    }
+
+    pub fn search_mut(&mut self) -> &mut CellDetailSearchState {
+        &mut self.search
+    }
+
+    pub fn set_viewport_metrics(&mut self, visible_rows: usize, viewport_width: usize) {
+        self.visible_rows = visible_rows.max(1);
+        self.viewport_width = viewport_width.max(1);
+        self.clamp_scroll();
+    }
+
+    pub fn enter_search(&mut self) {
+        self.search.reset();
+        self.search.activate();
+    }
+
+    pub fn exit_search(&mut self) {
+        self.search.deactivate();
+    }
+
+    pub fn scroll(&mut self, direction: ScrollDirection, amount: ScrollAmount) {
+        let delta = match amount {
+            ScrollAmount::Line => 1,
+            ScrollAmount::HalfPage => (self.visible_rows / 2).max(1),
+            ScrollAmount::FullPage => self.visible_rows,
+            ScrollAmount::ToStart => {
+                self.scroll_offset = 0;
+                return;
+            }
+            ScrollAmount::ToEnd => {
+                self.scroll_offset = self.max_scroll_offset();
+                return;
+            }
+            _ => return,
+        };
+
+        self.scroll_offset =
+            direction.clamp_vertical_offset(self.scroll_offset, self.max_scroll_offset(), delta);
+    }
+
+    pub fn scroll_to_match(&mut self) {
+        let Some(&match_pos) = self.search.matches.get(self.search.current_match) else {
+            return;
+        };
+        self.scroll_offset =
+            visual_row_for_char_offset(&self.content, match_pos, self.viewport_width)
+                .min(self.max_scroll_offset());
+    }
+
+    fn clamp_scroll(&mut self) {
+        self.scroll_offset = self.scroll_offset.min(self.max_scroll_offset());
+    }
+
+    fn max_scroll_offset(&self) -> usize {
+        visual_line_count(&self.content, self.viewport_width).saturating_sub(self.visible_rows)
+    }
+}
+
+pub fn is_cell_detail_candidate(value: &str) -> bool {
+    if value.is_empty() || value == "NULL" {
+        return false;
+    }
+
+    value.contains('\n') || UnicodeWidthStr::width(value) >= CELL_DETAIL_MIN_DISPLAY_WIDTH
+}
+
+fn visual_line_count(content: &str, width: usize) -> usize {
+    content
+        .split('\n')
+        .map(|line| visual_rows_for_line(line, width))
+        .sum::<usize>()
+        .max(1)
+}
+
+fn visual_rows_for_line(line: &str, width: usize) -> usize {
+    if width == 0 {
+        return 1;
+    }
+
+    let mut rows = 1;
+    let mut current_width = 0;
+    for ch in line.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if current_width > 0 && current_width + ch_width > width {
+            rows += 1;
+            current_width = 0;
+        }
+        current_width += ch_width;
+    }
+    rows
+}
+
+fn visual_row_for_char_offset(content: &str, target: usize, width: usize) -> usize {
+    if width == 0 {
+        return 0;
+    }
+
+    let mut visual_row = 0;
+    let mut current_width = 0;
+    for (char_offset, ch) in content.chars().enumerate() {
+        if char_offset >= target {
+            break;
+        }
+        if ch == '\n' {
+            visual_row += 1;
+            current_width = 0;
+            continue;
+        }
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if current_width > 0 && current_width + ch_width > width {
+            visual_row += 1;
+            current_width = 0;
+        }
+        current_width += ch_width;
+    }
+    visual_row
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod detail_candidate {
+        use super::*;
+
+        #[test]
+        fn excludes_empty_and_null_values() {
+            assert!(!is_cell_detail_candidate(""));
+            assert!(!is_cell_detail_candidate("NULL"));
+        }
+
+        #[test]
+        fn includes_multiline_values() {
+            assert!(is_cell_detail_candidate("hello\nworld"));
+        }
+
+        #[test]
+        fn includes_single_line_values_at_display_width_threshold() {
+            let value = "a".repeat(CELL_DETAIL_MIN_DISPLAY_WIDTH);
+
+            assert!(is_cell_detail_candidate(&value));
+        }
+
+        #[test]
+        fn excludes_short_single_line_values() {
+            assert!(!is_cell_detail_candidate("short text"));
+        }
+    }
+
+    mod scrolling {
+        use super::*;
+
+        #[test]
+        fn long_single_line_uses_wrapped_visual_rows_for_max_scroll() {
+            let mut state = CellDetailState::open(0, 0, "body".to_string(), "a".repeat(100));
+            state.set_viewport_metrics(3, 10);
+
+            state.scroll(ScrollDirection::Down, ScrollAmount::ToEnd);
+
+            assert_eq!(state.scroll_offset(), 7);
+        }
+
+        #[test]
+        fn search_match_scrolls_to_wrapped_visual_row() {
+            let mut state = CellDetailState::open(
+                0,
+                0,
+                "body".to_string(),
+                format!("{}needle", "a".repeat(35)),
+            );
+            state.set_viewport_metrics(3, 10);
+            state.search_mut().set_matches(vec![35]);
+
+            state.scroll_to_match();
+
+            assert_eq!(state.scroll_offset(), 2);
+        }
+    }
+}

--- a/src/app/model/browse/mod.rs
+++ b/src/app/model/browse/mod.rs
@@ -1,3 +1,4 @@
+pub mod cell_detail;
 pub mod cell_edit;
 pub mod jsonb_detail;
 pub mod query_execution;

--- a/src/app/model/shared/flash_timer.rs
+++ b/src/app/model/shared/flash_timer.rs
@@ -8,6 +8,7 @@ pub enum FlashId {
     SqlModal,
     Ddl,
     JsonbDetail,
+    CellDetail,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/app/model/shared/help.rs
+++ b/src/app/model/shared/help.rs
@@ -117,6 +117,9 @@ pub enum HelpOrigin {
         mode: JsonbHelpMode,
     },
     JsonbEdit,
+    CellDetail {
+        searching: bool,
+    },
 }
 
 impl HelpOrigin {
@@ -137,7 +140,8 @@ impl HelpOrigin {
             | Self::ConnectionSelector
             | Self::QueryHistoryPicker
             | Self::JsonbDetail { .. }
-            | Self::JsonbEdit => KeymapPreset::Default,
+            | Self::JsonbEdit
+            | Self::CellDetail { .. } => KeymapPreset::Default,
         }
     }
 
@@ -172,6 +176,9 @@ impl HelpOrigin {
                 mode: JsonbHelpMode::from_state(state),
             },
             InputMode::JsonbEdit => Self::JsonbEdit,
+            InputMode::CellDetail => Self::CellDetail {
+                searching: state.cell_detail.search().is_active(),
+            },
         }
     }
 
@@ -204,6 +211,8 @@ impl HelpOrigin {
             Self::QueryHistoryPicker => "Query History Picker",
             Self::JsonbDetail { mode } => mode.label(),
             Self::JsonbEdit => "JSONB Edit",
+            Self::CellDetail { searching: true } => "Cell Detail Search",
+            Self::CellDetail { searching: false } => "Cell Detail",
         }
     }
 }

--- a/src/app/model/shared/input_mode.rs
+++ b/src/app/model/shared/input_mode.rs
@@ -17,4 +17,5 @@ pub enum InputMode {
     QueryHistoryPicker,
     JsonbDetail,
     JsonbEdit,
+    CellDetail,
 }

--- a/src/app/model/shared/render_output.rs
+++ b/src/app/model/shared/render_output.rs
@@ -21,6 +21,7 @@ pub struct RenderOutput {
     pub query_history_picker_pane_height: Option<u16>,
     pub query_history_picker_filter_visible_width: Option<usize>,
     pub jsonb_detail_editor_visible_rows: Option<usize>,
+    pub cell_detail_viewport: Option<(usize, usize)>,
     pub confirm_preview_viewport_height: Option<u16>,
     pub confirm_preview_content_height: Option<u16>,
     pub confirm_preview_scroll: u16,

--- a/src/app/model/shared/render_output.rs
+++ b/src/app/model/shared/render_output.rs
@@ -1,5 +1,11 @@
 use crate::model::shared::viewport::{ColumnWidthsCache, ViewportPlan};
 
+#[derive(Clone, Copy)]
+pub struct CellDetailViewport {
+    pub visible_rows: usize,
+    pub viewport_width: usize,
+}
+
 /// Pane geometry measured during a draw. Owned by the model so state
 /// write-back (`AppState::apply_render_output`) stays port-agnostic; the
 /// renderer port re-exports this type as its output.
@@ -21,7 +27,7 @@ pub struct RenderOutput {
     pub query_history_picker_pane_height: Option<u16>,
     pub query_history_picker_filter_visible_width: Option<usize>,
     pub jsonb_detail_editor_visible_rows: Option<usize>,
-    pub cell_detail_viewport: Option<(usize, usize)>,
+    pub cell_detail_viewport: Option<CellDetailViewport>,
     pub confirm_preview_viewport_height: Option<u16>,
     pub confirm_preview_content_height: Option<u16>,
     pub confirm_preview_scroll: u16,

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -32,7 +32,7 @@ pub use folder_opener::{FolderOpenError, FolderOpener};
 pub use metadata::MetadataProvider;
 pub use query_executor::QueryExecutor;
 pub use query_history::{QueryHistoryError, QueryHistoryStore};
-pub use renderer::{RenderError, RenderOutput, RenderResult, Renderer};
+pub use renderer::{CellDetailViewport, RenderError, RenderOutput, RenderResult, Renderer};
 pub use service_file::{PgServiceEntryReader, ServiceFileError};
 pub use settings_store::{AppSettings, SettingsStore, SettingsStoreError};
 pub use sql_dialect::SqlDialect;

--- a/src/app/ports/outbound/renderer.rs
+++ b/src/app/ports/outbound/renderer.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use crate::model::app_state::AppState;
 use crate::services::AppServices;
 
-pub use crate::model::shared::render_output::RenderOutput;
+pub use crate::model::shared::render_output::{CellDetailViewport, RenderOutput};
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum RenderError {

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -64,6 +64,7 @@ pub enum ScrollTarget {
     ExplainConfirm,
     Explorer,
     JsonbDetail,
+    CellDetail,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -137,6 +138,7 @@ pub enum InputTarget {
     QueryHistoryFilter,
     JsonbEdit,
     JsonbSearch,
+    CellDetailSearch,
     HelpFilter,
 }
 
@@ -185,6 +187,7 @@ pub enum ModalKind {
     ErTablePicker,
     QueryHistoryPicker,
     JsonbDetail,
+    CellDetail,
     ConnectionSetup,
     ConnectionSelector,
 }
@@ -510,6 +513,7 @@ pub enum Action {
     ClearStagedDeletes,
     RequestDeleteActiveRow,
     ResultEnterCellEdit,
+    ResultOpenCellDetail,
     ResultCancelCellEdit,
     ResultDiscardCellEdit,
     SubmitCellEditWrite,
@@ -567,6 +571,15 @@ pub enum Action {
     JsonbSearchNext,
     JsonbSearchPrev,
     JsonbSearchSubmit,
+
+    // Cell detail
+    CellDetailYankAll,
+    CellDetailYankSuccess,
+    CellDetailEnterSearch,
+    CellDetailExitSearch,
+    CellDetailSearchNext,
+    CellDetailSearchPrev,
+    CellDetailSearchSubmit,
 
     // ER diagrams
     ErToggleSelection,

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -29,7 +29,8 @@ pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -
             };
 
             let display_value = cell_detail_display_value(&cell_value, data_type.as_deref());
-            state.cell_detail = CellDetailState::open(row_idx, col_idx, column_name, display_value);
+            state.cell_detail =
+                CellDetailState::open(row_idx, col_idx, column_name, cell_value, display_value);
             state.modal.push_mode(InputMode::CellDetail);
             DispatchResult::handled()
         }
@@ -39,7 +40,7 @@ pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -
             DispatchResult::handled()
         }
         Action::CellDetailYankAll => DispatchResult::handled_with(vec![Effect::CopyToClipboard {
-            content: state.cell_detail.content().to_string(),
+            content: state.cell_detail.original_content().to_string(),
             on_success: Some(Box::new(Action::CellDetailYankSuccess)),
             on_failure: Some(Box::new(Action::CopyFailed(ClipboardError::Unavailable(
                 "Clipboard unavailable".into(),
@@ -309,6 +310,7 @@ mod tests {
 
         assert_eq!(state.input_mode(), InputMode::CellDetail);
         assert_eq!(state.cell_detail.content(), "{\n  \"a\": 1,\n  \"b\": 2\n}");
+        assert_eq!(state.cell_detail.original_content(), r#"{"b":2,"a":1}"#);
     }
 
     #[test]
@@ -322,6 +324,23 @@ mod tests {
             state.cell_detail.content(),
             "{\n  \"items\": [\n    \"admin\",\n    \"writer\"\n  ]\n}"
         );
+        assert_eq!(
+            state.cell_detail.original_content(),
+            r#"{"items":["admin","writer"]}"#
+        );
+    }
+
+    #[test]
+    fn yank_all_copies_original_cell_value() {
+        let mut state = state_with_cell("json", r#"{"b":2,"a":1}"#);
+        reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        let result = reduce_cell_detail(&mut state, &Action::CellDetailYankAll, Instant::now());
+
+        assert!(matches!(
+            result.expect("yank should copy").as_slice(),
+            [Effect::CopyToClipboard { content, .. }] if content == r#"{"b":2,"a":1}"#
+        ));
     }
 
     #[test]

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -1,0 +1,316 @@
+use std::time::Instant;
+
+use unicode_casefold::UnicodeCaseFold;
+
+use crate::cmd::effect::Effect;
+#[cfg(test)]
+use crate::domain::ColumnAttributes;
+use crate::model::app_state::AppState;
+use crate::model::browse::cell_detail::{CellDetailState, is_cell_detail_candidate};
+use crate::model::shared::flash_timer::FlashId;
+use crate::model::shared::input_mode::InputMode;
+use crate::ports::outbound::ClipboardError;
+use crate::update::action::{Action, InputTarget, ModalKind, ScrollDirection, ScrollTarget};
+use crate::update::dispatch_result::DispatchResult;
+
+pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
+    match action {
+        Action::ResultOpenCellDetail => {
+            if selected_column_is_jsonb(state) {
+                return DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
+                    Action::OpenModal(ModalKind::JsonbDetail),
+                ])]);
+            }
+
+            let Some((row_idx, col_idx, column_name, cell_value)) = selected_cell_value(state)
+            else {
+                return DispatchResult::handled();
+            };
+            if !is_cell_detail_candidate(&cell_value) {
+                return DispatchResult::handled();
+            }
+
+            state.cell_detail = CellDetailState::open(row_idx, col_idx, column_name, cell_value);
+            state.modal.push_mode(InputMode::CellDetail);
+            DispatchResult::handled()
+        }
+        Action::CloseModal(ModalKind::CellDetail) => {
+            state.cell_detail.close();
+            state.modal.pop_mode();
+            DispatchResult::handled()
+        }
+        Action::CellDetailYankAll => DispatchResult::handled_with(vec![Effect::CopyToClipboard {
+            content: state.cell_detail.content().to_string(),
+            on_success: Some(Box::new(Action::CellDetailYankSuccess)),
+            on_failure: Some(Box::new(Action::CopyFailed(ClipboardError::Unavailable(
+                "Clipboard unavailable".into(),
+            )))),
+        }]),
+        Action::CellDetailYankSuccess => {
+            state.flash_timers.set(FlashId::CellDetail, now);
+            DispatchResult::handled()
+        }
+        Action::CellDetailEnterSearch => {
+            state.cell_detail.enter_search();
+            DispatchResult::handled()
+        }
+        Action::CellDetailExitSearch => {
+            state.cell_detail.exit_search();
+            DispatchResult::handled()
+        }
+        Action::CellDetailSearchSubmit => {
+            state.cell_detail.exit_search();
+            state.cell_detail.scroll_to_match();
+            DispatchResult::handled()
+        }
+        Action::CellDetailSearchNext => {
+            state.cell_detail.search_mut().advance_to_next_match();
+            state.cell_detail.scroll_to_match();
+            DispatchResult::handled()
+        }
+        Action::CellDetailSearchPrev => {
+            state.cell_detail.search_mut().advance_to_prev_match();
+            state.cell_detail.scroll_to_match();
+            DispatchResult::handled()
+        }
+        Action::TextInput {
+            target: InputTarget::CellDetailSearch,
+            ch,
+        } => {
+            state.cell_detail.search_mut().input_mut().insert_char(*ch);
+            update_search_matches(state);
+            DispatchResult::handled()
+        }
+        Action::TextBackspace {
+            target: InputTarget::CellDetailSearch,
+        } => {
+            state.cell_detail.search_mut().input_mut().backspace();
+            update_search_matches(state);
+            DispatchResult::handled()
+        }
+        Action::TextDelete {
+            target: InputTarget::CellDetailSearch,
+        } => {
+            state.cell_detail.search_mut().input_mut().delete();
+            update_search_matches(state);
+            DispatchResult::handled()
+        }
+        Action::TextMoveCursor {
+            target: InputTarget::CellDetailSearch,
+            direction,
+        } => {
+            state
+                .cell_detail
+                .search_mut()
+                .input_mut()
+                .move_cursor(*direction);
+            DispatchResult::handled()
+        }
+        Action::Paste(text)
+            if state.input_mode() == InputMode::CellDetail
+                && state.cell_detail.search().is_active() =>
+        {
+            let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+            state
+                .cell_detail
+                .search_mut()
+                .input_mut()
+                .insert_str(&clean);
+            update_search_matches(state);
+            DispatchResult::handled()
+        }
+        Action::Scroll {
+            target: ScrollTarget::CellDetail,
+            direction: direction @ (ScrollDirection::Down | ScrollDirection::Up),
+            amount,
+        } => {
+            state.cell_detail.scroll(*direction, *amount);
+            DispatchResult::handled()
+        }
+        _ => DispatchResult::pass(),
+    }
+}
+
+fn selected_cell_value(state: &AppState) -> Option<(usize, usize, String, String)> {
+    let result = state.query.visible_result().filter(|r| !r.is_error())?;
+    let row_idx = state.result_interaction.selection().row()?;
+    let col_idx = state.result_interaction.selection().cell()?;
+    let column_name = result.columns.get(col_idx)?.clone();
+    let cell_value = result.rows.get(row_idx)?.get(col_idx)?.clone();
+    Some((row_idx, col_idx, column_name, cell_value))
+}
+
+fn selected_column_is_jsonb(state: &AppState) -> bool {
+    let Some(col_idx) = state.result_interaction.selection().cell() else {
+        return false;
+    };
+    let Some(td) = state.session.table_detail() else {
+        return false;
+    };
+    if td.schema != state.query.pagination.schema() || td.name != state.query.pagination.table() {
+        return false;
+    }
+    td.columns
+        .get(col_idx)
+        .is_some_and(|column| column.data_type == "jsonb")
+}
+
+fn update_search_matches(state: &mut AppState) {
+    let query = state.cell_detail.search().input().content().to_string();
+    let matches = find_text_matches(state.cell_detail.content(), &query);
+    state.cell_detail.search_mut().set_matches(matches);
+}
+
+fn find_text_matches(content: &str, query: &str) -> Vec<usize> {
+    if query.is_empty() {
+        return Vec::new();
+    }
+
+    let query_folded = query.case_fold().collect::<String>();
+    let mut matches = Vec::new();
+    let mut offset = 0;
+
+    for segment in content.split_inclusive('\n') {
+        let line = segment.strip_suffix('\n').unwrap_or(segment);
+        let (folded, offset_map) = casefold_with_char_offsets(line);
+        let mut search_from = 0;
+        while let Some(rel_idx) = folded[search_from..].find(&query_folded) {
+            let match_idx = search_from + rel_idx;
+            matches.push(offset + original_char_offset_for_folded_byte(&offset_map, match_idx));
+            search_from = match_idx + query_folded.len();
+        }
+        offset += segment.chars().count();
+    }
+
+    matches
+}
+
+fn casefold_with_char_offsets(text: &str) -> (String, Vec<(usize, usize)>) {
+    let mut folded = String::new();
+    let mut offset_map = Vec::new();
+
+    for (original_char_offset, ch) in text.chars().enumerate() {
+        for folded_char in ch.case_fold() {
+            offset_map.push((folded.len(), original_char_offset));
+            folded.push(folded_char);
+        }
+    }
+
+    offset_map.push((folded.len(), text.chars().count()));
+    (folded, offset_map)
+}
+
+fn original_char_offset_for_folded_byte(
+    offset_map: &[(usize, usize)],
+    folded_byte_offset: usize,
+) -> usize {
+    let idx = offset_map.partition_point(|(byte_offset, _)| *byte_offset <= folded_byte_offset);
+    offset_map[idx.saturating_sub(1)].1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::column::Column;
+    use crate::domain::{QueryResult, QuerySource, Table};
+    use std::sync::Arc;
+
+    fn state_with_cell(data_type: &str, cell_value: &str) -> AppState {
+        let mut state = AppState::new("test".to_string());
+        state
+            .query
+            .set_current_result(Arc::new(QueryResult::success(
+                String::new(),
+                vec!["id".to_string(), "body".to_string()],
+                vec![vec!["1".to_string(), cell_value.to_string()]],
+                1,
+                QuerySource::Preview,
+            )));
+        state.query.pagination.reset_for_table("public", "notes");
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "public".to_string(),
+            name: "notes".to_string(),
+            owner: None,
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "integer".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::PRIMARY_KEY,
+                    comment: None,
+                    ordinal_position: 1,
+                },
+                Column {
+                    name: "body".to_string(),
+                    data_type: data_type.to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::NULLABLE,
+                    comment: None,
+                    ordinal_position: 2,
+                },
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            foreign_keys: vec![],
+            indexes: vec![],
+            rls: None,
+            triggers: vec![],
+            row_count_estimate: None,
+            comment: None,
+        }));
+        state.result_interaction.activate_cell(0, 1);
+        state
+    }
+
+    #[test]
+    fn long_text_cell_opens_read_only_detail() {
+        let mut state = state_with_cell("text", &"a".repeat(60));
+
+        reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        assert_eq!(state.input_mode(), InputMode::CellDetail);
+        assert!(state.cell_detail.is_active());
+        assert_eq!(state.cell_detail.column_name(), "body");
+    }
+
+    #[test]
+    fn short_text_cell_does_not_open_detail() {
+        let mut state = state_with_cell("text", "short");
+
+        reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        assert_eq!(state.input_mode(), InputMode::Normal);
+        assert!(!state.cell_detail.is_active());
+    }
+
+    #[test]
+    fn jsonb_cell_dispatches_to_existing_jsonb_modal() {
+        let mut state = state_with_cell("jsonb", r#"{"a":1}"#);
+
+        let result = reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        assert!(matches!(
+            result.expect("jsonb dispatch should be handled").as_slice(),
+            [Effect::DispatchActions(actions)]
+                if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonbDetail)])
+        ));
+        assert!(!state.cell_detail.is_active());
+    }
+
+    #[test]
+    fn search_input_tracks_matches_case_insensitively() {
+        let mut state = state_with_cell("text", "Alpha\nalpha");
+        reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+        reduce_cell_detail(&mut state, &Action::CellDetailEnterSearch, Instant::now());
+
+        reduce_cell_detail(
+            &mut state,
+            &Action::TextInput {
+                target: InputTarget::CellDetailSearch,
+                ch: 'p',
+            },
+            Instant::now(),
+        );
+
+        assert_eq!(state.cell_detail.search().matches(), &[2, 8]);
+    }
+}

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -6,7 +6,7 @@ use crate::cmd::effect::Effect;
 #[cfg(test)]
 use crate::domain::ColumnAttributes;
 use crate::model::app_state::AppState;
-use crate::model::browse::cell_detail::{CellDetailState, is_cell_detail_candidate};
+use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
 use crate::ports::outbound::ClipboardError;
@@ -22,15 +22,14 @@ pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -
                 ])]);
             }
 
-            let Some((row_idx, col_idx, column_name, cell_value)) = selected_cell_value(state)
+            let Some((row_idx, col_idx, column_name, cell_value, data_type)) =
+                selected_cell_value(state)
             else {
                 return DispatchResult::handled();
             };
-            if !is_cell_detail_candidate(&cell_value) {
-                return DispatchResult::handled();
-            }
 
-            state.cell_detail = CellDetailState::open(row_idx, col_idx, column_name, cell_value);
+            let display_value = cell_detail_display_value(&cell_value, data_type.as_deref());
+            state.cell_detail = CellDetailState::open(row_idx, col_idx, column_name, display_value);
             state.modal.push_mode(InputMode::CellDetail);
             DispatchResult::handled()
         }
@@ -131,28 +130,48 @@ pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -
     }
 }
 
-fn selected_cell_value(state: &AppState) -> Option<(usize, usize, String, String)> {
+fn selected_cell_value(state: &AppState) -> Option<(usize, usize, String, String, Option<String>)> {
     let result = state.query.visible_result().filter(|r| !r.is_error())?;
     let row_idx = state.result_interaction.selection().row()?;
     let col_idx = state.result_interaction.selection().cell()?;
     let column_name = result.columns.get(col_idx)?.clone();
     let cell_value = result.rows.get(row_idx)?.get(col_idx)?.clone();
-    Some((row_idx, col_idx, column_name, cell_value))
+    let data_type = selected_column_data_type(state, col_idx).map(ToString::to_string);
+    Some((row_idx, col_idx, column_name, cell_value, data_type))
 }
 
 fn selected_column_is_jsonb(state: &AppState) -> bool {
     let Some(col_idx) = state.result_interaction.selection().cell() else {
         return false;
     };
-    let Some(td) = state.session.table_detail() else {
-        return false;
-    };
+    selected_column_data_type(state, col_idx).is_some_and(|data_type| data_type == "jsonb")
+}
+
+fn selected_column_data_type(state: &AppState, col_idx: usize) -> Option<&str> {
+    let td = state.session.table_detail()?;
     if td.schema != state.query.pagination.schema() || td.name != state.query.pagination.table() {
-        return false;
+        return None;
     }
     td.columns
         .get(col_idx)
-        .is_some_and(|column| column.data_type == "jsonb")
+        .map(|column| column.data_type.as_str())
+}
+
+fn cell_detail_display_value(value: &str, data_type: Option<&str>) -> String {
+    let should_pretty_print_json = data_type == Some("json") || looks_like_json_container(value);
+    if !should_pretty_print_json {
+        return value.to_string();
+    }
+
+    serde_json::from_str::<serde_json::Value>(value)
+        .ok()
+        .and_then(|json| serde_json::to_string_pretty(&json).ok())
+        .unwrap_or_else(|| value.to_string())
+}
+
+fn looks_like_json_container(value: &str) -> bool {
+    let trimmed = value.trim_start();
+    trimmed.starts_with('{') || trimmed.starts_with('[')
 }
 
 fn update_search_matches(state: &mut AppState) {
@@ -273,13 +292,36 @@ mod tests {
     }
 
     #[test]
-    fn short_text_cell_does_not_open_detail() {
+    fn short_text_cell_opens_detail() {
         let mut state = state_with_cell("text", "short");
 
         reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
 
-        assert_eq!(state.input_mode(), InputMode::Normal);
-        assert!(!state.cell_detail.is_active());
+        assert_eq!(state.input_mode(), InputMode::CellDetail);
+        assert_eq!(state.cell_detail.content(), "short");
+    }
+
+    #[test]
+    fn json_column_opens_read_only_pretty_detail() {
+        let mut state = state_with_cell("json", r#"{"b":2,"a":1}"#);
+
+        reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        assert_eq!(state.input_mode(), InputMode::CellDetail);
+        assert_eq!(state.cell_detail.content(), "{\n  \"a\": 1,\n  \"b\": 2\n}");
+    }
+
+    #[test]
+    fn text_json_container_opens_read_only_pretty_detail() {
+        let mut state = state_with_cell("text", r#"{"items":["admin","writer"]}"#);
+
+        reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        assert_eq!(state.input_mode(), InputMode::CellDetail);
+        assert_eq!(
+            state.cell_detail.content(),
+            "{\n  \"items\": [\n    \"admin\",\n    \"writer\"\n  ]\n}"
+        );
     }
 
     #[test]

--- a/src/app/update/browse/result/mod.rs
+++ b/src/app/update/browse/result/mod.rs
@@ -1,3 +1,4 @@
+mod cell_detail;
 mod edit;
 mod jsonb;
 mod scroll;
@@ -21,6 +22,7 @@ pub fn dispatch_result(
         .or_else(|| selection::reduce_selection(state, action, now))
         .or_else(|| edit::reduce_edit(state, action, now))
         .or_else(|| yank::reduce_yank(state, action, services, now))
+        .or_else(|| cell_detail::reduce_cell_detail(state, action, now))
         .or_else(|| jsonb::reduce_jsonb(state, action, now))
 }
 

--- a/src/app/update/input/handlers/cell_detail.rs
+++ b/src/app/update/input/handlers/cell_detail.rs
@@ -1,5 +1,7 @@
 use crate::update::action::{Action, CursorMove, InputTarget};
-use crate::update::input::keybindings::{CELL_DETAIL, CELL_DETAIL_SEARCH_KEYS, Key, KeyCombo};
+use crate::update::input::keybindings::{
+    CELL_DETAIL, CELL_DETAIL_SEARCH_KEYS, Key, KeyCombo, Modifiers,
+};
 use crate::update::input::keymap;
 
 pub fn handle_cell_detail_keys(combo: KeyCombo, is_searching: bool) -> Action {
@@ -13,6 +15,10 @@ pub fn handle_cell_detail_keys(combo: KeyCombo, is_searching: bool) -> Action {
 fn handle_search_input(combo: KeyCombo) -> Action {
     if let Some(action) = keymap::resolve(&combo, CELL_DETAIL_SEARCH_KEYS) {
         return action;
+    }
+
+    if combo.modifiers.intersects(Modifiers::CTRL | Modifiers::ALT) {
+        return Action::None;
     }
 
     match combo.key {
@@ -55,11 +61,29 @@ mod tests {
         KeyCombo::plain(k)
     }
 
+    fn modified_combo(k: Key, modifiers: Modifiers) -> KeyCombo {
+        KeyCombo { key: k, modifiers }
+    }
+
     #[test]
     fn enter_confirms_active_search() {
         let result = handle_cell_detail_keys(combo(Key::Enter), true);
 
         assert!(matches!(result, Action::CellDetailSearchSubmit));
+    }
+
+    #[test]
+    fn ctrl_char_is_not_inserted_into_search() {
+        let result = handle_cell_detail_keys(modified_combo(Key::Char('n'), Modifiers::CTRL), true);
+
+        assert!(matches!(result, Action::None));
+    }
+
+    #[test]
+    fn alt_char_is_not_inserted_into_search() {
+        let result = handle_cell_detail_keys(modified_combo(Key::Char('n'), Modifiers::ALT), true);
+
+        assert!(matches!(result, Action::None));
     }
 
     #[test]

--- a/src/app/update/input/handlers/cell_detail.rs
+++ b/src/app/update/input/handlers/cell_detail.rs
@@ -1,0 +1,85 @@
+use crate::update::action::{Action, CursorMove, InputTarget};
+use crate::update::input::keybindings::{CELL_DETAIL, CELL_DETAIL_SEARCH_KEYS, Key, KeyCombo};
+use crate::update::input::keymap;
+
+pub fn handle_cell_detail_keys(combo: KeyCombo, is_searching: bool) -> Action {
+    if is_searching {
+        return handle_search_input(combo);
+    }
+
+    CELL_DETAIL.resolve(&combo).unwrap_or(Action::None)
+}
+
+fn handle_search_input(combo: KeyCombo) -> Action {
+    if let Some(action) = keymap::resolve(&combo, CELL_DETAIL_SEARCH_KEYS) {
+        return action;
+    }
+
+    match combo.key {
+        Key::Char(c) => Action::TextInput {
+            target: InputTarget::CellDetailSearch,
+            ch: c,
+        },
+        Key::Backspace => Action::TextBackspace {
+            target: InputTarget::CellDetailSearch,
+        },
+        Key::Delete => Action::TextDelete {
+            target: InputTarget::CellDetailSearch,
+        },
+        Key::Left => Action::TextMoveCursor {
+            target: InputTarget::CellDetailSearch,
+            direction: CursorMove::Left,
+        },
+        Key::Right => Action::TextMoveCursor {
+            target: InputTarget::CellDetailSearch,
+            direction: CursorMove::Right,
+        },
+        Key::Home => Action::TextMoveCursor {
+            target: InputTarget::CellDetailSearch,
+            direction: CursorMove::Home,
+        },
+        Key::End => Action::TextMoveCursor {
+            target: InputTarget::CellDetailSearch,
+            direction: CursorMove::End,
+        },
+        _ => Action::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::update::action::{ScrollAmount, ScrollDirection, ScrollTarget};
+
+    fn combo(k: Key) -> KeyCombo {
+        KeyCombo::plain(k)
+    }
+
+    #[test]
+    fn enter_confirms_active_search() {
+        let result = handle_cell_detail_keys(combo(Key::Enter), true);
+
+        assert!(matches!(result, Action::CellDetailSearchSubmit));
+    }
+
+    #[test]
+    fn j_scrolls_down_when_not_searching() {
+        let result = handle_cell_detail_keys(combo(Key::Char('j')), false);
+
+        assert!(matches!(
+            result,
+            Action::Scroll {
+                target: ScrollTarget::CellDetail,
+                direction: ScrollDirection::Down,
+                amount: ScrollAmount::Line,
+            }
+        ));
+    }
+
+    #[test]
+    fn slash_enters_search_when_not_searching() {
+        let result = handle_cell_detail_keys(combo(Key::Char('/')), false);
+
+        assert!(matches!(result, Action::CellDetailEnterSearch));
+    }
+}

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -1,3 +1,4 @@
+mod cell_detail;
 mod connections;
 mod editors;
 mod jsonb;
@@ -30,7 +31,8 @@ fn handle_paste_event(text: String, state: &AppState) -> Action {
         | InputMode::SqlModal
         | InputMode::QueryHistoryPicker
         | InputMode::JsonbEdit
-        | InputMode::JsonbDetail => Action::Paste(text),
+        | InputMode::JsonbDetail
+        | InputMode::CellDetail => Action::Paste(text),
         _ => Action::None,
     }
 }
@@ -74,6 +76,10 @@ fn handle_key_event(combo: KeyCombo, state: &AppState) -> Action {
             )
         }
         InputMode::JsonbEdit => jsonb::handle_jsonb_edit_keys(combo),
+        InputMode::CellDetail => {
+            let is_searching = state.cell_detail.search().is_active();
+            cell_detail::handle_cell_detail_keys(combo, is_searching)
+        }
     }
 }
 

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -140,6 +140,15 @@ mod tests {
 
             assert!(matches!(result, Action::SqlModalEnterInsert));
         }
+
+        #[test]
+        fn cell_detail_mode_routes_to_cell_detail_handler() {
+            let state = make_state(InputMode::CellDetail);
+
+            let result = handle_key_event(combo(Key::Char('/')), &state);
+
+            assert!(matches!(result, Action::CellDetailEnterSearch));
+        }
     }
 
     mod paste_event {
@@ -185,6 +194,15 @@ mod tests {
             let result = handle_paste_event("users".to_string(), &state);
 
             assert!(matches!(result, Action::Paste(t) if t == "users"));
+        }
+
+        #[test]
+        fn cell_detail_pastes_text() {
+            let state = make_state(InputMode::CellDetail);
+
+            let result = handle_paste_event("needle".to_string(), &state);
+
+            assert!(matches!(result, Action::Paste(t) if t == "needle"));
         }
 
         #[test]

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -487,6 +487,17 @@ mod tests {
 
                 assert!(matches!(result, Action::ResultActivateCell));
             }
+
+            #[test]
+            fn enter_opens_cell_detail_when_result_cell_is_active() {
+                let mut state = browse_state();
+                state.ui.set_focused_pane(FocusedPane::Result);
+                state.result_interaction.activate_cell(0, 0);
+
+                let result = handle_normal_mode(combo(Key::Enter), &state);
+
+                assert!(matches!(result, Action::ResultOpenCellDetail));
+            }
         }
 
         mod pane_switch_and_tabs {

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -89,6 +89,9 @@ pub const JSONB_DETAIL: ModeBindings = ModeBindings {
 pub const JSONB_EDIT: ModeBindings = ModeBindings {
     rows: JSONB_EDIT_ROWS,
 };
+pub const CELL_DETAIL: ModeBindings = ModeBindings {
+    rows: CELL_DETAIL_ROWS,
+};
 
 pub const ALL_MODE_BINDINGS: &[(&str, &ModeBindings)] = &[
     ("HELP", &HELP),
@@ -101,6 +104,7 @@ pub const ALL_MODE_BINDINGS: &[(&str, &ModeBindings)] = &[
     ("CONNECTION_SELECTOR", &CONNECTION_SELECTOR),
     ("JSONB_DETAIL", &JSONB_DETAIL),
     ("JSONB_EDIT", &JSONB_EDIT),
+    ("CELL_DETAIL", &CELL_DETAIL),
 ];
 
 pub const HELP_KEY_INDENT_WIDTH: usize = 2;
@@ -555,7 +559,7 @@ mod tests {
 
             #[test]
             fn all_mode_bindings_count() {
-                assert_eq!(ALL_MODE_BINDINGS.len(), 10);
+                assert_eq!(ALL_MODE_BINDINGS.len(), 11);
             }
         }
     }

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -269,6 +269,7 @@ mod tests {
                 check_non_none_have_combos(COMMAND_LINE_KEYS, "COMMAND_LINE_KEYS");
                 check_non_none_have_combos(CELL_EDIT_KEYS, "CELL_EDIT_KEYS");
                 check_non_none_have_combos(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
+                check_non_none_have_combos(CELL_DETAIL_SEARCH_KEYS, "CELL_DETAIL_SEARCH_KEYS");
             }
 
             fn check_mode_rows_exec_valid(rows: &[ModeRow], name: &str) {
@@ -334,6 +335,10 @@ mod tests {
                 );
                 check_none_action_entries_have_no_combos(RESULT_ACTIVE_KEYS, "RESULT_ACTIVE_KEYS");
                 check_none_action_entries_have_no_combos(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
+                check_none_action_entries_have_no_combos(
+                    CELL_DETAIL_SEARCH_KEYS,
+                    "CELL_DETAIL_SEARCH_KEYS",
+                );
             }
         }
 
@@ -398,6 +403,7 @@ mod tests {
                 check_no_duplicate_combos(CONFIRM_DIALOG_KEYS, "CONFIRM_DIALOG_KEYS");
                 check_no_duplicate_combos(COMMAND_LINE_KEYS, "COMMAND_LINE_KEYS");
                 check_no_duplicate_combos(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
+                check_no_duplicate_combos(CELL_DETAIL_SEARCH_KEYS, "CELL_DETAIL_SEARCH_KEYS");
                 check_no_conflicting_combos(GLOBAL_KEYS, "GLOBAL_KEYS");
                 check_no_conflicting_combos(IDE_GLOBAL_KEYS, "IDE_GLOBAL_KEYS");
                 for (name, mb) in ALL_MODE_BINDINGS {
@@ -454,6 +460,7 @@ mod tests {
                 check_keymap_roundtrip(CONFIRM_DIALOG_KEYS, "CONFIRM_DIALOG_KEYS");
                 check_keymap_roundtrip(COMMAND_LINE_KEYS, "COMMAND_LINE_KEYS");
                 check_keymap_roundtrip(JSONB_SEARCH_KEYS, "JSONB_SEARCH_KEYS");
+                check_keymap_roundtrip(CELL_DETAIL_SEARCH_KEYS, "CELL_DETAIL_SEARCH_KEYS");
                 check_keymap_roundtrip(GLOBAL_KEYS, "GLOBAL_KEYS");
                 check_keymap_roundtrip(IDE_GLOBAL_KEYS, "IDE_GLOBAL_KEYS");
                 for (name, mb) in ALL_MODE_BINDINGS {

--- a/src/app/update/input/keybindings/normal.rs
+++ b/src/app/update/input/keybindings/normal.rs
@@ -613,7 +613,6 @@ pub mod result_active {
 }
 
 pub const RESULT_ACTIVE_KEYS: &[KeyBinding] = &[
-    result_active::ENTER_DEEPEN,
     result_active::DETAIL,
     result_active::YANK,
     result_active::STAGE_DELETE,

--- a/src/app/update/input/keybindings/normal.rs
+++ b/src/app/update/input/keybindings/normal.rs
@@ -512,6 +512,15 @@ pub mod result_active {
         combos: &[KeyCombo::plain(Key::Enter)],
     };
 
+    pub const DETAIL: KeyBinding = KeyBinding {
+        key_short: "Enter",
+        key: "Enter",
+        desc_short: "Detail",
+        description: "Open active cell detail",
+        action: Action::ResultOpenCellDetail,
+        combos: &[KeyCombo::plain(Key::Enter)],
+    };
+
     pub const YANK: KeyBinding = KeyBinding {
         key_short: "Y",
         key: "Y",
@@ -605,6 +614,7 @@ pub mod result_active {
 
 pub const RESULT_ACTIVE_KEYS: &[KeyBinding] = &[
     result_active::ENTER_DEEPEN,
+    result_active::DETAIL,
     result_active::YANK,
     result_active::STAGE_DELETE,
     result_active::UNSTAGE_DELETE,

--- a/src/app/update/input/keybindings/overlays.rs
+++ b/src/app/update/input/keybindings/overlays.rs
@@ -1080,6 +1080,174 @@ pub const JSONB_DETAIL_ROWS: &[ModeRow] = &[
 ];
 
 // =============================================================================
+// Cell Detail
+// =============================================================================
+
+pub mod cell_detail {
+    use crate::update::action::{Action, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget};
+    use crate::update::input::keybindings::{ExecBinding, Key, KeyCombo, ModeRow};
+
+    pub const YANK: ModeRow = ModeRow {
+        key_short: "y",
+        key: "y",
+        desc_short: "Copy",
+        description: "Copy full cell text",
+        bindings: &[ExecBinding {
+            action: Action::CellDetailYankAll,
+            combos: &[KeyCombo::plain(Key::Char('y'))],
+        }],
+    };
+
+    pub const SEARCH: ModeRow = ModeRow {
+        key_short: "/",
+        key: "/",
+        desc_short: "Search",
+        description: "Search cell text",
+        bindings: &[ExecBinding {
+            action: Action::CellDetailEnterSearch,
+            combos: &[KeyCombo::plain(Key::Char('/'))],
+        }],
+    };
+
+    pub const NEXT_PREV: ModeRow = ModeRow {
+        key_short: "n/N",
+        key: "n / N",
+        desc_short: "Next/Prev",
+        description: "Jump to next / previous search result",
+        bindings: &[
+            ExecBinding {
+                action: Action::CellDetailSearchNext,
+                combos: &[KeyCombo::plain(Key::Char('n'))],
+            },
+            ExecBinding {
+                action: Action::CellDetailSearchPrev,
+                combos: &[KeyCombo::plain(Key::Char('N'))],
+            },
+        ],
+    };
+
+    pub const SCROLL: ModeRow = ModeRow {
+        key_short: "j/k/↑↓",
+        key: "j / k / Ctrl+N / Ctrl+P / ↑ / ↓",
+        desc_short: "Scroll",
+        description: "Scroll text down / up",
+        bindings: &[
+            ExecBinding {
+                action: Action::Scroll {
+                    target: ScrollTarget::CellDetail,
+                    direction: ScrollDirection::Down,
+                    amount: ScrollAmount::Line,
+                },
+                combos: &[
+                    KeyCombo::plain(Key::Char('j')),
+                    KeyCombo::ctrl(Key::Char('n')),
+                    KeyCombo::plain(Key::Down),
+                ],
+            },
+            ExecBinding {
+                action: Action::Scroll {
+                    target: ScrollTarget::CellDetail,
+                    direction: ScrollDirection::Up,
+                    amount: ScrollAmount::Line,
+                },
+                combos: &[
+                    KeyCombo::plain(Key::Char('k')),
+                    KeyCombo::ctrl(Key::Char('p')),
+                    KeyCombo::plain(Key::Up),
+                ],
+            },
+        ],
+    };
+
+    pub const PAGE: ModeRow = ModeRow {
+        key_short: "^D/^U Pg",
+        key: "Ctrl+D / Ctrl+U / PageDown / PageUp",
+        desc_short: "Page",
+        description: "Scroll by page",
+        bindings: &[
+            ExecBinding {
+                action: Action::Scroll {
+                    target: ScrollTarget::CellDetail,
+                    direction: ScrollDirection::Down,
+                    amount: ScrollAmount::HalfPage,
+                },
+                combos: &[KeyCombo::ctrl(Key::Char('d'))],
+            },
+            ExecBinding {
+                action: Action::Scroll {
+                    target: ScrollTarget::CellDetail,
+                    direction: ScrollDirection::Up,
+                    amount: ScrollAmount::HalfPage,
+                },
+                combos: &[KeyCombo::ctrl(Key::Char('u'))],
+            },
+            ExecBinding {
+                action: Action::Scroll {
+                    target: ScrollTarget::CellDetail,
+                    direction: ScrollDirection::Down,
+                    amount: ScrollAmount::FullPage,
+                },
+                combos: &[KeyCombo::plain(Key::PageDown)],
+            },
+            ExecBinding {
+                action: Action::Scroll {
+                    target: ScrollTarget::CellDetail,
+                    direction: ScrollDirection::Up,
+                    amount: ScrollAmount::FullPage,
+                },
+                combos: &[KeyCombo::plain(Key::PageUp)],
+            },
+        ],
+    };
+
+    pub const TOP_BOTTOM: ModeRow = ModeRow {
+        key_short: "Home/End",
+        key: "Home / End",
+        desc_short: "Top/Btm",
+        description: "Jump to top / bottom",
+        bindings: &[
+            ExecBinding {
+                action: Action::Scroll {
+                    target: ScrollTarget::CellDetail,
+                    direction: ScrollDirection::Up,
+                    amount: ScrollAmount::ToStart,
+                },
+                combos: &[KeyCombo::plain(Key::Home)],
+            },
+            ExecBinding {
+                action: Action::Scroll {
+                    target: ScrollTarget::CellDetail,
+                    direction: ScrollDirection::Down,
+                    amount: ScrollAmount::ToEnd,
+                },
+                combos: &[KeyCombo::plain(Key::End)],
+            },
+        ],
+    };
+
+    pub const CLOSE: ModeRow = ModeRow {
+        key_short: "Esc",
+        key: "Esc / q",
+        desc_short: "Close",
+        description: "Close cell detail",
+        bindings: &[ExecBinding {
+            action: Action::CloseModal(ModalKind::CellDetail),
+            combos: &[KeyCombo::plain(Key::Esc), KeyCombo::plain(Key::Char('q'))],
+        }],
+    };
+}
+
+pub const CELL_DETAIL_ROWS: &[ModeRow] = &[
+    cell_detail::YANK,
+    cell_detail::SEARCH,
+    cell_detail::NEXT_PREV,
+    cell_detail::SCROLL,
+    cell_detail::PAGE,
+    cell_detail::TOP_BOTTOM,
+    cell_detail::CLOSE,
+];
+
+// =============================================================================
 // JSONB Search (active search input)
 // =============================================================================
 
@@ -1119,6 +1287,44 @@ pub const JSONB_SEARCH_KEYS: &[KeyBinding] = &[
     jsonb_search::TYPE_SEARCH,
     jsonb_search::CONFIRM,
     jsonb_search::CANCEL,
+];
+
+pub mod cell_detail_search {
+    use crate::update::action::Action;
+    use crate::update::input::keybindings::{Key, KeyBinding, KeyCombo};
+
+    pub const TYPE_SEARCH: KeyBinding = KeyBinding {
+        key_short: "type",
+        key: "type",
+        desc_short: "Search",
+        description: "Type to search",
+        action: Action::None,
+        combos: &[],
+    };
+
+    pub const CONFIRM: KeyBinding = KeyBinding {
+        key_short: "Enter",
+        key: "Enter",
+        desc_short: "Confirm",
+        description: "Confirm search",
+        action: Action::CellDetailSearchSubmit,
+        combos: &[KeyCombo::plain(Key::Enter)],
+    };
+
+    pub const CANCEL: KeyBinding = KeyBinding {
+        key_short: "Esc",
+        key: "Esc",
+        desc_short: "Cancel",
+        description: "Cancel search",
+        action: Action::CellDetailExitSearch,
+        combos: &[KeyCombo::plain(Key::Esc)],
+    };
+}
+
+pub const CELL_DETAIL_SEARCH_KEYS: &[KeyBinding] = &[
+    cell_detail_search::TYPE_SEARCH,
+    cell_detail_search::CONFIRM,
+    cell_detail_search::CANCEL,
 ];
 
 // =============================================================================

--- a/src/app/update/input/vim/actions/browse.rs
+++ b/src/app/update/input/vim/actions/browse.rs
@@ -46,7 +46,7 @@ pub(in crate::update::input::vim) fn mode_transition(
         (VimModeTransition::ConfirmOrEnter, BrowseVimContext::Result(result_ctx)) => {
             match result_ctx.mode {
                 ResultNavMode::Scroll => Action::ResultActivateCell,
-                ResultNavMode::CellActive => Action::None,
+                ResultNavMode::CellActive => Action::ResultOpenCellDetail,
             }
         }
         (VimModeTransition::Insert, BrowseVimContext::Result(result_ctx))

--- a/src/app/update/input/vim/actions/browse.rs
+++ b/src/app/update/input/vim/actions/browse.rs
@@ -323,6 +323,16 @@ mod tests {
     }
 
     #[test]
+    fn result_cell_enter_opens_cell_detail() {
+        let action = action_for_command(
+            VimCommand::ModeTransition(VimModeTransition::ConfirmOrEnter),
+            browse_result(result_ctx(ResultNavMode::CellActive)),
+        );
+
+        assert!(matches!(action, Some(Action::ResultOpenCellDetail)));
+    }
+
+    #[test]
     fn result_scroll_mode_move_down_resolves_to_result_line_scroll() {
         let action = action_for_command(
             VimCommand::Navigation(VimNavigation::MoveDown),

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -48,6 +48,26 @@ fn jsonb_detail_state() -> (AppState, std::time::Instant) {
     (state, now)
 }
 
+fn cell_detail_state() -> (AppState, std::time::Instant) {
+    let now = test_instant();
+    let mut state = table_detail_loaded_state();
+    state
+        .query
+        .set_current_result(Arc::new(QueryResult::success(
+            "SELECT id, body FROM notes".to_string(),
+            vec!["id".to_string(), "body".to_string()],
+            vec![vec![
+                "1".to_string(),
+                "Prompt:\nSummarize the incident timeline and include the operator notes.\n\nMemory:\n- User prefers concise status updates\n- Keep markdown bullets intact".to_string(),
+            ]],
+            1,
+            QuerySource::Preview,
+        )));
+    state.ui.set_focused_pane(FocusedPane::Result);
+    state.result_interaction.activate_cell(0, 1);
+    (state, now)
+}
+
 #[test]
 fn result_pane_scrolled_past_wide_column_fills_width() {
     let mut state = table_detail_loaded_state();
@@ -336,6 +356,24 @@ fn result_pane_jsonb_detail_mode() {
         now,
     );
     assert_eq!(state.input_mode(), InputMode::JsonbDetail);
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn result_pane_cell_detail_mode() {
+    let (mut state, now) = cell_detail_state();
+    let mut terminal = create_test_terminal();
+
+    dispatch_result(
+        &mut state,
+        &Action::ResultOpenCellDetail,
+        &AppServices::stub(),
+        now,
+    );
+    assert_eq!(state.input_mode(), InputMode::CellDetail);
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_active_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_active_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tests/render_snapshots/result_pane.rs
+assertion_line: 224
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -51,4 +52,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-i:Edit  Y:Yank Cell  yy:Yank Row  dd:Stage Del  ?:Help  Esc:Back  q:Quit
+Enter:Detail  i:Edit  Y:Yank Cell  yy:Yank Row  dd:Stage Del  ?:Help  Esc:Back  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_detail_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_detail_mode.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/render_snapshots/result_pane.rs
+assertion_line: 380
+expression: output
+---
+test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
+│> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  public.posts                         ││Owner:   postgres                                                                                                         │
+│  public.comments                      ││Comment: User accounts                                                                                                    │
+│                                       ││Rows:    ~100                                                                                                             │
+│                                       ││Schema:  public                                                                                                           │
+│                                       ││Table:   users                                                                                                            │
+│                ╭ Cell Detail ── body──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮               │
+│                │Prompt:                                                                                                                           │               │
+│                │Summarize the incident timeline and include the operator notes.                                                                   │               │
+│                │                                                                                                                                  │               │
+│                │Memory:                                                                                                                           │               │
+│                │- User prefers concise status updates                                                                                             │               │
+│                │- Keep markdown bullets intact                                                                                                    │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │───────────────┘
+│                │                                                                                                                                  │───────────────┐
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │                                                                                                                                  │               │
+│                │149 chars                                                                                                                         │               │
+│                ╰ y: Copy │ /: Search │ Esc: Close ────────────────────────────────────────────────────────────────────────────────────────────────╯               │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+└───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+y:Copy  /:Search  n/N:Next/Prev  j/k/↑↓:Scroll  Esc:Close

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_first_cell_active_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_first_cell_active_mode.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tests/render_snapshots/result_pane.rs
+assertion_line: 210
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -51,4 +52,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-i:Edit  Y:Yank Cell  yy:Yank Row  dd:Stage Del  ?:Help  Esc:Back  q:Quit
+Enter:Detail  i:Edit  Y:Yank Cell  yy:Yank Row  dd:Stage Del  ?:Help  Esc:Back  q:Quit

--- a/src/ui/Cargo.toml
+++ b/src/ui/Cargo.toml
@@ -20,6 +20,7 @@ futures.workspace = true
 ratatui.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+unicode-casefold.workspace = true
 unicode-width.workspace = true
 sabiql-app.workspace = true
 sabiql-domain.workspace = true

--- a/src/ui/adapters/tui_adapter.rs
+++ b/src/ui/adapters/tui_adapter.rs
@@ -55,6 +55,7 @@ fn uses_insert_cursor(state: &AppState) -> bool {
     match state.input_mode() {
         InputMode::JsonbEdit => true,
         InputMode::JsonbDetail => state.jsonb_detail.search().is_active(),
+        InputMode::CellDetail => state.cell_detail.search().is_active(),
         InputMode::SqlModal => matches!(
             state.sql_modal.status(),
             crate::app::model::sql_editor::modal::SqlModalStatus::Editing

--- a/src/ui/features/browse/cell_detail.rs
+++ b/src/ui/features/browse/cell_detail.rs
@@ -1,0 +1,268 @@
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Paragraph, Wrap};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::app::model::app_state::AppState;
+use crate::app::model::shared::flash_timer::FlashId;
+use crate::primitives::atoms::{
+    CursorKind, apply_yank_flash, set_terminal_cursor, text_cursor_spans_with_kind,
+};
+use crate::primitives::molecules::{FooterHintBar, render_modal};
+use crate::theme::ThemePalette;
+
+pub struct CellDetailRenderMetrics {
+    pub visible_rows: usize,
+    pub viewport_width: usize,
+}
+
+pub struct CellDetail;
+
+impl CellDetail {
+    pub fn render(
+        frame: &mut Frame,
+        state: &AppState,
+        now: std::time::Instant,
+        theme: &ThemePalette,
+    ) -> Option<CellDetailRenderMetrics> {
+        if !state.cell_detail.is_active() {
+            return None;
+        }
+
+        let title = format!(
+            " Cell Detail \u{2500}\u{2500} {}",
+            state.cell_detail.column_name()
+        );
+        let hints = vec![("y", "Copy"), ("/", "Search"), ("Esc", "Close")];
+        let (_area, inner) = render_modal(
+            frame,
+            Constraint::Percentage(80),
+            Constraint::Percentage(70),
+            &title,
+            FooterHintBar::new(hints),
+            theme,
+        );
+
+        let (content_area, status_area, search_area) = if state.cell_detail.search().is_active() {
+            let [content_area, status_area, search_area] = Layout::vertical([
+                Constraint::Min(1),
+                Constraint::Length(1),
+                Constraint::Length(1),
+            ])
+            .areas(inner);
+            (content_area, status_area, Some(search_area))
+        } else {
+            let [content_area, status_area] =
+                Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(inner);
+            (content_area, status_area, None)
+        };
+
+        Self::render_content(frame, content_area, state, now, theme);
+        Self::render_status(frame, status_area, state, theme);
+        if let Some(search_area) = search_area {
+            Self::render_search(frame, search_area, state, theme);
+        }
+
+        Some(CellDetailRenderMetrics {
+            visible_rows: content_area.height as usize,
+            viewport_width: content_area.width as usize,
+        })
+    }
+
+    fn render_content(
+        frame: &mut Frame,
+        area: Rect,
+        state: &AppState,
+        now: std::time::Instant,
+        theme: &ThemePalette,
+    ) {
+        let mut lines = content_lines(state, theme);
+        let flash_active = state.flash_timers.is_active(FlashId::CellDetail, now);
+        apply_yank_flash(&mut lines, flash_active, theme);
+
+        frame.render_widget(
+            Paragraph::new(lines)
+                .wrap(Wrap { trim: false })
+                .scroll((state.cell_detail.scroll_offset() as u16, 0))
+                .style(Style::default().fg(theme.semantic.text.primary)),
+            area,
+        );
+    }
+
+    fn render_status(frame: &mut Frame, area: Rect, state: &AppState, theme: &ThemePalette) {
+        let search = state.cell_detail.search();
+        let status = if search.is_active() {
+            if search.matches().is_empty() {
+                "0/0".to_string()
+            } else {
+                format!("{}/{}", search.current_match() + 1, search.matches().len())
+            }
+        } else {
+            format!("{} chars", state.cell_detail.content().chars().count())
+        };
+
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                status,
+                Style::default().fg(theme.semantic.text.muted),
+            ))),
+            area,
+        );
+    }
+
+    fn render_search(frame: &mut Frame, area: Rect, state: &AppState, theme: &ThemePalette) {
+        let search = state.cell_detail.search();
+        let input = search.input().content();
+        let cursor = search.input().cursor();
+        let match_info = if search.matches().is_empty() {
+            "0/0".to_string()
+        } else {
+            format!("{}/{}", search.current_match() + 1, search.matches().len())
+        };
+        let suffix = format!("  {match_info}");
+        let visible_width = area
+            .width
+            .saturating_sub((1 + UnicodeWidthStr::width(suffix.as_str())) as u16)
+            as usize;
+        let viewport_offset = search_viewport_offset(input, cursor, visible_width);
+        let visible_input = slice_chars_fitting_width(input, viewport_offset, visible_width);
+        let relative_cursor = cursor.saturating_sub(viewport_offset);
+
+        let mut spans = vec![Span::styled(
+            "/",
+            Style::default().fg(theme.semantic.text.accent),
+        )];
+        spans.extend(text_cursor_spans_with_kind(
+            &visible_input,
+            relative_cursor,
+            0,
+            visible_input.chars().count(),
+            CursorKind::Insert,
+            theme,
+        ));
+        spans.push(Span::styled(
+            suffix,
+            Style::default().fg(theme.semantic.text.muted),
+        ));
+
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+        set_terminal_cursor(frame, area, &visible_input, 0, relative_cursor, 0, 1);
+    }
+}
+
+fn content_lines(state: &AppState, theme: &ThemePalette) -> Vec<Line<'static>> {
+    let content = state.cell_detail.content();
+    if content.is_empty() {
+        return vec![Line::from(Span::styled(
+            "No content",
+            Style::default().fg(theme.semantic.text.placeholder),
+        ))];
+    }
+
+    let current_match = state
+        .cell_detail
+        .search()
+        .matches()
+        .get(state.cell_detail.search().current_match())
+        .copied();
+    let query_len = state.cell_detail.search().input().content().chars().count();
+    let mut char_offset = 0;
+
+    content
+        .split('\n')
+        .map(|line| {
+            let line_len = line.chars().count();
+            let line_start = char_offset;
+            let line_end = line_start + line_len;
+            char_offset = line_end + 1;
+
+            match current_match {
+                Some(pos) if query_len > 0 && pos >= line_start && pos < line_end => {
+                    highlighted_line(line, pos - line_start, query_len, theme)
+                }
+                _ => Line::from(Span::raw(line.to_string())),
+            }
+        })
+        .collect()
+}
+
+fn highlighted_line(
+    line: &str,
+    match_start: usize,
+    match_len: usize,
+    theme: &ThemePalette,
+) -> Line<'static> {
+    let mut before = String::new();
+    let mut matched = String::new();
+    let mut after = String::new();
+
+    for (idx, ch) in line.chars().enumerate() {
+        if idx < match_start {
+            before.push(ch);
+        } else if idx < match_start + match_len {
+            matched.push(ch);
+        } else {
+            after.push(ch);
+        }
+    }
+
+    Line::from(vec![
+        Span::raw(before),
+        Span::styled(
+            matched,
+            Style::default()
+                .fg(theme.semantic.text.primary)
+                .bg(theme.semantic.text.accent)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(after),
+    ])
+}
+
+fn search_viewport_offset(input: &str, cursor: usize, visible_width: usize) -> usize {
+    if visible_width == 0 {
+        return cursor;
+    }
+
+    let chars: Vec<char> = input.chars().collect();
+    let mut viewport_offset = 0;
+    let mut width_before_cursor = display_width(&chars[..cursor.min(chars.len())]);
+
+    while width_before_cursor >= visible_width && viewport_offset < cursor {
+        width_before_cursor =
+            width_before_cursor.saturating_sub(char_width(chars[viewport_offset]));
+        viewport_offset += 1;
+    }
+
+    viewport_offset
+}
+
+fn slice_chars_fitting_width(input: &str, start: usize, visible_width: usize) -> String {
+    if visible_width == 0 {
+        return String::new();
+    }
+
+    let mut width = 0;
+    let mut visible = String::new();
+
+    for ch in input.chars().skip(start) {
+        let ch_width = char_width(ch);
+        if width + ch_width > visible_width {
+            break;
+        }
+        width += ch_width;
+        visible.push(ch);
+    }
+
+    visible
+}
+
+fn display_width(chars: &[char]) -> usize {
+    chars.iter().map(|&ch| char_width(ch)).sum()
+}
+
+fn char_width(ch: char) -> usize {
+    UnicodeWidthChar::width(ch).unwrap_or(0)
+}

--- a/src/ui/features/browse/cell_detail.rs
+++ b/src/ui/features/browse/cell_detail.rs
@@ -3,6 +3,7 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Paragraph, Wrap};
+use unicode_casefold::UnicodeCaseFold;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::model::app_state::AppState;
@@ -167,7 +168,7 @@ fn content_lines(state: &AppState, theme: &ThemePalette) -> Vec<Line<'static>> {
         .matches()
         .get(state.cell_detail.search().current_match())
         .copied();
-    let query_len = state.cell_detail.search().input().content().chars().count();
+    let query = state.cell_detail.search().input().content().to_string();
     let mut char_offset = 0;
 
     content
@@ -179,8 +180,8 @@ fn content_lines(state: &AppState, theme: &ThemePalette) -> Vec<Line<'static>> {
             char_offset = line_end + 1;
 
             match current_match {
-                Some(pos) if query_len > 0 && pos >= line_start && pos < line_end => {
-                    highlighted_line(line, pos - line_start, query_len, theme)
+                Some(pos) if !query.is_empty() && pos >= line_start && pos < line_end => {
+                    highlighted_line(line, pos - line_start, &query, theme)
                 }
                 _ => Line::from(Span::raw(line.to_string())),
             }
@@ -191,9 +192,10 @@ fn content_lines(state: &AppState, theme: &ThemePalette) -> Vec<Line<'static>> {
 fn highlighted_line(
     line: &str,
     match_start: usize,
-    match_len: usize,
+    query: &str,
     theme: &ThemePalette,
 ) -> Line<'static> {
+    let match_len = folded_match_len(line, match_start, query);
     let mut before = String::new();
     let mut matched = String::new();
     let mut after = String::new();
@@ -219,6 +221,22 @@ fn highlighted_line(
         ),
         Span::raw(after),
     ])
+}
+
+fn folded_match_len(line: &str, match_start: usize, query: &str) -> usize {
+    let target_len = query.case_fold().collect::<String>().chars().count();
+    let mut folded_len = 0;
+    let mut original_len = 0;
+
+    for ch in line.chars().skip(match_start) {
+        folded_len += ch.case_fold().count();
+        original_len += 1;
+        if folded_len >= target_len {
+            break;
+        }
+    }
+
+    original_len
 }
 
 fn search_viewport_offset(input: &str, cursor: usize, visible_width: usize) -> usize {
@@ -265,4 +283,19 @@ fn display_width(chars: &[char]) -> usize {
 
 fn char_width(ch: char) -> usize {
     UnicodeWidthChar::width(ch).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn folded_match_len_keeps_sharp_s_to_one_original_char() {
+        assert_eq!(folded_match_len("straße", 4, "ss"), 1);
+    }
+
+    #[test]
+    fn folded_match_len_keeps_ascii_query_length() {
+        assert_eq!(folded_match_len("alphabet", 2, "pha"), 3);
+    }
 }

--- a/src/ui/features/browse/mod.rs
+++ b/src/ui/features/browse/mod.rs
@@ -1,3 +1,4 @@
+pub mod cell_detail;
 pub mod explorer;
 pub mod inspector;
 pub mod jsonb_detail;

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -12,11 +12,12 @@ use crate::app::model::shared::settings::KeymapPreset;
 use crate::app::model::shared::ui_state::ResultNavMode;
 use crate::app::model::sql_editor::modal::SqlModalStatus;
 use crate::app::update::input::keybindings::{
-    cell_edit, command_palette, command_palette as command_palette_key, connection_error,
-    connection_selector, connection_setup, connection_setup_save, csv_export, er_picker,
-    er_picker_select_all, exit_read_only, footer_nav, global, help, inspector_ddl, jsonb_detail,
-    jsonb_edit, jsonb_search, overlay, query_history, query_history_picker, read_only,
-    result_active, settings, sql_modal, sql_modal_confirming, sql_modal_plan, table_picker,
+    cell_detail, cell_detail_search, cell_edit, command_palette,
+    command_palette as command_palette_key, connection_error, connection_selector,
+    connection_setup, connection_setup_save, csv_export, er_picker, er_picker_select_all,
+    exit_read_only, footer_nav, global, help, inspector_ddl, jsonb_detail, jsonb_edit,
+    jsonb_search, overlay, query_history, query_history_picker, read_only, result_active, settings,
+    sql_modal, sql_modal_confirming, sql_modal_plan, table_picker,
     table_picker as table_picker_key,
 };
 use crate::features::settings::hints::settings_hints;
@@ -97,6 +98,7 @@ impl Footer {
                         ]
                     } else if state.result_interaction.staged_delete_rows().is_empty() {
                         vec![
+                            result_active::DETAIL.as_hint(),
                             result_active::EDIT.as_hint(),
                             result_active::YANK.as_hint(),
                             result_active::ROW_YANK.as_hint(),
@@ -320,6 +322,23 @@ impl Footer {
                 jsonb_edit::MOVE.as_hint(),
                 jsonb_edit::HOME_END.as_hint(),
             ],
+            InputMode::CellDetail => {
+                if state.cell_detail.search().is_active() {
+                    vec![
+                        cell_detail_search::TYPE_SEARCH.as_hint(),
+                        cell_detail_search::CONFIRM.as_hint(),
+                        cell_detail_search::CANCEL.as_hint(),
+                    ]
+                } else {
+                    vec![
+                        cell_detail::YANK.as_hint(),
+                        cell_detail::SEARCH.as_hint(),
+                        cell_detail::NEXT_PREV.as_hint(),
+                        cell_detail::SCROLL.as_hint(),
+                        cell_detail::CLOSE.as_hint(),
+                    ]
+                }
+            }
             InputMode::ConnectionSelector => {
                 use connection_selector as cs;
                 let is_service_selected = crate::app::model::connection::list::is_service_selected(

--- a/src/ui/shell/layout.rs
+++ b/src/ui/shell/layout.rs
@@ -7,7 +7,7 @@ use crate::app::model::app_state::AppState;
 use crate::app::model::shared::input_mode::InputMode;
 use crate::app::model::shared::ui_state::explorer_content_width_from_pane_width;
 use crate::app::model::shared::viewport::ViewportPlan;
-use crate::app::ports::outbound::RenderOutput;
+use crate::app::ports::outbound::{CellDetailViewport, RenderOutput};
 use crate::app::services::AppServices;
 use crate::features::browse::cell_detail::{CellDetail, CellDetailRenderMetrics};
 use crate::features::browse::explorer::Explorer;
@@ -157,7 +157,10 @@ impl MainLayout {
                 |CellDetailRenderMetrics {
                      visible_rows,
                      viewport_width,
-                 }| (visible_rows, viewport_width),
+                 }| CellDetailViewport {
+                    visible_rows,
+                    viewport_width,
+                },
             ),
             _ => None,
         };

--- a/src/ui/shell/layout.rs
+++ b/src/ui/shell/layout.rs
@@ -9,6 +9,7 @@ use crate::app::model::shared::ui_state::explorer_content_width_from_pane_width;
 use crate::app::model::shared::viewport::ViewportPlan;
 use crate::app::ports::outbound::RenderOutput;
 use crate::app::services::AppServices;
+use crate::features::browse::cell_detail::{CellDetail, CellDetailRenderMetrics};
 use crate::features::browse::explorer::Explorer;
 use crate::features::browse::inspector::Inspector;
 use crate::features::browse::jsonb_detail::{JsonbDetail, JsonbDetailRenderMetrics};
@@ -151,6 +152,16 @@ impl MainLayout {
             _ => None,
         };
 
+        let cell_detail_viewport = match state.input_mode() {
+            InputMode::CellDetail => CellDetail::render(frame, state, now, theme).map(
+                |CellDetailRenderMetrics {
+                     visible_rows,
+                     viewport_width,
+                 }| (visible_rows, viewport_width),
+            ),
+            _ => None,
+        };
+
         match state.input_mode() {
             InputMode::CommandPalette => CommandPalette::render(frame, state, theme),
             InputMode::Settings => SettingsOverlay::render(frame, state, theme),
@@ -170,6 +181,7 @@ impl MainLayout {
             query_history_picker_pane_height,
             query_history_picker_filter_visible_width,
             jsonb_detail_editor_visible_rows,
+            cell_detail_viewport,
             confirm_preview_viewport_height,
             confirm_preview_content_height,
             confirm_preview_scroll,


### PR DESCRIPTION
## Summary
- add a read-only Cell Detail modal for long text cells opened explicitly from an active result cell
- keep JSONB cells routed to the existing JSONB detail flow
- preserve grid truncation while adding search, copy, wrapping, and vertical scroll for long text bodies

## Validation
- env RUSTC_WRAPPER= cargo test --workspace -- --nocapture
- env RUSTC_WRAPPER= cargo clippy --workspace --all-targets --all-features -- -D warnings
- env RUSTC_WRAPPER= cargo clippy --workspace --all-targets --no-default-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 結果パネルでセルを選択し、Enter でセル詳細表示を開けるようになりました。
  * セル詳細内で `/` により検索を開始し、大文字小文字を区別せず一致箇所をハイライトします。
  * 検索の次/前移動、行/ページ単位のスクロール、全文コピーに対応しました。
* **Bug Fixes**
  * 折り返し表示を考慮した一致位置への移動・スクロールを改善しました。
* **Tests**
  * セル詳細のレンダリング、検索、コピー、JSON整形の動作を追加で検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->