### PR TITLE
Use comma for settings shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Built in Rust for minimal memory footprint and near-zero idle CPU. A full-featur
 
 - **Fuzzy Search** (`/`) — Incremental table filtering
 - **Focus Mode** (`f`) — Expand any pane to full screen
-- **Settings** (`Ctrl+K`) — Theme, keymap, and ER diagram preferences
+- **Settings** (`,`) — Theme, keymap, and ER diagram preferences
 - **Command Palette** (`F1`, `:palette`) — Searchable command list
 
 ## Installation
@@ -82,9 +82,9 @@ On first run, enter your connection details. They are saved to your platform con
 
 Press `?` for help.
 
-Open Settings with `Ctrl+K` to switch themes, keymap presets, and the ER diagram browser command.
+Open Settings with `,` to switch themes, keymap presets, and the ER diagram browser command.
 
-> **Note:** If you use sabiql inside an IDE terminal, some default keybindings may conflict with the IDE. Open Settings and switch the keymap preset to make sabiql work comfortably inside your IDE.
+> **Note:** If you use sabiql inside an IDE terminal, some default keybindings may conflict with the IDE. Open Settings with `,` and switch the keymap preset to make sabiql work comfortably inside your IDE.
 
 ## Requirements
 

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -29,9 +29,6 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
     // Ctrl combos
     if combo.modifiers.contains(Modifiers::CTRL) {
         match combo.key {
-            Key::Char('k') if kb::settings(keymap_preset).combos.contains(&combo) => {
-                return Action::OpenModal(ModalKind::Settings);
-            }
             Key::Char('r') if kb::read_only(keymap_preset).combos.contains(&combo) => {
                 return Action::ToggleReadOnly;
             }
@@ -212,33 +209,42 @@ mod tests {
             }
 
             #[test]
-            fn ctrl_k_opens_settings() {
+            fn comma_opens_settings() {
                 let state = browse_state();
 
-                let result = handle_normal_mode(combo_ctrl(Key::Char('k')), &state);
+                let result = handle_normal_mode(combo(Key::Char(',')), &state);
 
                 assert!(matches!(result, Action::OpenModal(ModalKind::Settings)));
             }
 
             #[test]
-            fn default_s_also_opens_settings() {
+            fn default_s_no_longer_opens_settings() {
                 let state = browse_state();
 
                 let result = handle_normal_mode(combo(Key::Char('S')), &state);
 
-                assert!(matches!(result, Action::OpenModal(ModalKind::Settings)));
+                assert!(matches!(result, Action::None));
+            }
+
+            #[test]
+            fn default_ctrl_k_no_longer_opens_settings() {
+                let state = browse_state();
+
+                let result = handle_normal_mode(combo_ctrl(Key::Char('k')), &state);
+
+                assert!(matches!(result, Action::None));
             }
 
             #[rstest]
             #[case(combo_ctrl(Key::Char('p')), Action::OpenModal(ModalKind::TablePicker))]
-            #[case(combo_ctrl(Key::Char('k')), Action::OpenModal(ModalKind::Settings))]
+            #[case(combo(Key::Char(',')), Action::OpenModal(ModalKind::Settings))]
             #[case(combo(Key::F(1)), Action::OpenModal(ModalKind::CommandPalette))]
             #[case(combo_ctrl(Key::Char('r')), Action::ToggleReadOnly)]
             #[case(
                 combo_ctrl(Key::Char('o')),
                 Action::OpenModal(ModalKind::QueryHistoryPicker)
             )]
-            fn default_preset_keeps_ctrl_and_function_keys(
+            fn default_preset_uses_declared_global_keys(
                 #[case] input: KeyCombo,
                 #[case] expected: Action,
             ) {
@@ -251,14 +257,14 @@ mod tests {
 
             #[rstest]
             #[case(combo(Key::Char('T')), Action::OpenModal(ModalKind::TablePicker))]
-            #[case(combo(Key::Char('S')), Action::OpenModal(ModalKind::Settings))]
+            #[case(combo(Key::Char(',')), Action::OpenModal(ModalKind::Settings))]
             #[case(combo(Key::Char('P')), Action::OpenModal(ModalKind::CommandPalette))]
             #[case(combo(Key::Char('R')), Action::ToggleReadOnly)]
             #[case(
                 combo(Key::Char('O')),
                 Action::OpenModal(ModalKind::QueryHistoryPicker)
             )]
-            fn ide_preset_uses_plain_uppercase_keys(
+            fn ide_preset_uses_declared_replacement_keys(
                 #[case] input: KeyCombo,
                 #[case] expected: Action,
             ) {
@@ -273,21 +279,14 @@ mod tests {
             #[case(combo(Key::F(1)))]
             #[case(combo_ctrl(Key::Char('r')))]
             #[case(combo_ctrl(Key::Char('o')))]
+            #[case(combo_ctrl(Key::Char('k')))]
+            #[case(combo(Key::Char('S')))]
             fn ide_preset_disables_replaced_keys(#[case] input: KeyCombo) {
                 let state = browse_state_with_preset(KeymapPreset::Ide);
 
                 let result = handle_normal_mode(input, &state);
 
                 assert!(matches!(result, Action::None));
-            }
-
-            #[test]
-            fn ide_preset_keeps_ctrl_k_settings_alias() {
-                let state = browse_state_with_preset(KeymapPreset::Ide);
-
-                let result = handle_normal_mode(combo_ctrl(Key::Char('k')), &state);
-
-                assert!(matches!(result, Action::OpenModal(ModalKind::Settings)));
             }
 
             #[test]

--- a/src/app/update/input/keybindings/normal.rs
+++ b/src/app/update/input/keybindings/normal.rs
@@ -48,15 +48,12 @@ pub mod global {
     };
 
     pub const SETTINGS: KeyBinding = KeyBinding {
-        key_short: "S/^K",
-        key: "S / Ctrl+K",
+        key_short: ",",
+        key: ",",
         desc_short: "Settings",
         description: "Open Settings",
         action: Action::OpenModal(ModalKind::Settings),
-        combos: &[
-            KeyCombo::plain(Key::Char('S')),
-            KeyCombo::ctrl(Key::Char('k')),
-        ],
+        combos: &[KeyCombo::plain(Key::Char(','))],
     };
 
     pub const COMMAND_LINE: KeyBinding = KeyBinding {

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__footer_shows_success_message.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__footer_shows_success_message.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
-assertion_line: 181
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
@@ -52,4 +51,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-✓ Reconnected!  r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+✓ Reconnected!  r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__explorer_shows_not_connected_when_no_active_connection.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__explorer_shows_not_connected_when_no_active_connection.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/initial_state.rs
-assertion_line: 21
 expression: output
 ---
 test_project | - | - | no dsn | -                                                                                                                                    
@@ -52,4 +51,4 @@ test_project | - | - | no dsn | -
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__initial_state_no_metadata.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__initial_state_no_metadata.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/initial_state.rs
-assertion_line: 10
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
@@ -52,4 +51,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/inspector.rs
-assertion_line: 92
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_with_data.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/inspector.rs
-assertion_line: 79
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_shows_owner_and_comment.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_shows_owner_and_comment.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/inspector.rs
-assertion_line: 134
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_with_no_metadata.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_with_no_metadata.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/inspector.rs
-assertion_line: 152
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_empty.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_empty.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/inspector.rs
-assertion_line: 121
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_with_data.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/inspector.rs
-assertion_line: 105
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_palette_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_palette_overlay.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 457
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -20,7 +19,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││  q                  Quit application                                            │                                        │
 │                                       ││  ?                  Toggle help                                                 │                                        │
 │                                       ││  Ctrl+P             Open Table Picker                                           │                                        │
-│                                       ││  S / Ctrl+K         Open Settings                                               │                                        │
+│                                       ││  ,                  Open Settings                                               │                                        │
 │                                       ││  f                  Toggle Focus mode                                           │                                        │
 │                                       ││  r                  Reload metadata                                             │                                        │
 │                                       ││  s                  Open SQL Editor                                             │                                        │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 398
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -19,7 +18,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                        │▸ Common                                                                                                        ┃│                        │
 │                        │  ?                                    Toggle help                                                              ┃│                        │
 │                        │  q                                    Quit application                                                         ┃│                        │
-│                        │  S / Ctrl+K                           Open Settings                                                            ┃│                        │
+│                        │  ,                                    Open Settings                                                            ┃│                        │
 │                        │  F1                                   Open Command Palette                                                     ││                        │
 │                        │  :                                    Enter command line                                                       ││                        │
 │                        │  f                                    Toggle Focus mode                                                        ││                        │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_right_edge_peeks_truncated_previous_column.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_right_edge_peeks_truncated_previous_column.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/result_pane.rs
-assertion_line: 138
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││ col 100% ◀︎─════════════════════════════════════════════════════════════════════════════════════════════════════════════▶︎ │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_scrolled_past_wide_column_fills_width.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_scrolled_past_wide_column_fills_width.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/result_pane.rs
-assertion_line: 94
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││ col 100% ◀︎─════════════════════════════════════════════════════════════════════════════════════════════════════════════▶︎ │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__empty_query_result.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__empty_query_result.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/table_explorer.rs
-assertion_line: 72
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_mode_fullscreen_result.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_mode_fullscreen_result.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/table_explorer.rs
-assertion_line: 44
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                                                                                                                                                   │
 │                                                                                                                                                                   │
 └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-Enter:Select  ^E:Export  ]/[:Page  ?:Help  S/^K:Settings  f:Exit Focus  q:Quit
+Enter:Select  ^E:Export  ]/[:Page  ?:Help  ,:Settings  f:Exit Focus  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_on_result_pane.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_on_result_pane.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/table_explorer.rs
-assertion_line: 29
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  Enter:Select  ]/[:Page  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__table_selection_with_preview.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__table_selection_with_preview.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/table_explorer.rs
-assertion_line: 14
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +51,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  ?:Help  F1:Palette  S/^K:Settings  q:Quit
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  ^E:Export  ?:Help  F1:Palette  ,:Settings  q:Quit


### PR DESCRIPTION
## Problem
`Ctrl+K` is a common IDE shortcut prefix, so using it as the Settings entry point makes the IDE-friendly keymap story less consistent.

## Background
The keymap preset feature is meant to make sabiql comfortable inside IDE terminals. Keeping Settings on a shortcut that editors often reserve undermines that escape hatch.

## Approach
Use `,` as the single Settings shortcut across presets, remove the `S` and `Ctrl+K` aliases, and update the user-facing docs and snapshots to match.

## Screenshots
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Settings（設定）を開くキーバインディングが `Ctrl+K` から `,`（コンマ）に変更されました。
  * README および IDE ターミナル環境向けの注意書きを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->