### PR TITLE
Block CSV export for mutating result queries

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -22,6 +22,7 @@ use crate::model::shared::settings::SettingsState;
 use crate::model::shared::ui_state::{UiState, scroll_max_offset};
 use crate::model::sql_editor::modal::SqlModalContext;
 use crate::model::sql_editor::query_history::QueryHistoryPickerState;
+use crate::policy::sql::export::can_rerun_for_csv_export;
 
 pub struct AppState {
     pub should_quit: bool,
@@ -260,7 +261,9 @@ impl AppState {
     }
 
     pub fn can_request_csv_export(&self) -> bool {
-        self.query.visible_result().is_some_and(|r| !r.is_error())
+        self.query
+            .visible_result()
+            .is_some_and(|r| !r.is_error() && can_rerun_for_csv_export(&r.query))
     }
 
     /// True when a run-scoped async response no longer belongs to the active
@@ -682,6 +685,21 @@ mod tests {
                 .set_current_result(make_query_result(QuerySource::Preview));
 
             assert!(state.can_request_csv_export());
+        }
+
+        #[test]
+        fn csv_export_blocked_for_mutating_result_query() {
+            let mut state = make_state();
+            let result = crate::domain::QueryResult::success(
+                "UPDATE users SET name = 'b' WHERE id = 1 RETURNING id".to_string(),
+                vec!["id".to_string()],
+                vec![vec!["1".to_string()]],
+                10,
+                QuerySource::Adhoc,
+            );
+            state.query.set_current_result(Arc::new(result));
+
+            assert!(!state.can_request_csv_export());
         }
     }
 

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -279,9 +279,7 @@ mod tests {
     use std::time::Instant;
 
     use super::*;
-    use crate::domain::DatabaseMetadata;
-    use crate::domain::QuerySource;
-    use crate::domain::Table;
+    use crate::domain::{DatabaseMetadata, QueryResult, QuerySource, Table};
     use crate::model::er_state::ErStatus;
     use crate::model::shared::focused_pane::FocusedPane;
     use crate::update::action::Action;
@@ -291,8 +289,8 @@ mod tests {
         AppState::new("test".to_string())
     }
 
-    fn make_query_result(source: QuerySource) -> Arc<crate::domain::QueryResult> {
-        Arc::new(crate::domain::QueryResult::success(
+    fn make_query_result(source: QuerySource) -> Arc<QueryResult> {
+        Arc::new(QueryResult::success(
             "SELECT 1".to_string(),
             vec!["col".to_string()],
             vec![vec!["val".to_string()]],
@@ -690,7 +688,7 @@ mod tests {
         #[test]
         fn csv_export_blocked_for_mutating_result_query() {
             let mut state = make_state();
-            let result = crate::domain::QueryResult::success(
+            let result = QueryResult::success(
                 "UPDATE users SET name = 'b' WHERE id = 1 RETURNING id".to_string(),
                 vec!["id".to_string()],
                 vec![vec!["1".to_string()]],

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -22,7 +22,7 @@ use crate::model::shared::settings::SettingsState;
 use crate::model::shared::ui_state::{UiState, scroll_max_offset};
 use crate::model::sql_editor::modal::SqlModalContext;
 use crate::model::sql_editor::query_history::QueryHistoryPickerState;
-use crate::policy::sql::export::can_rerun_for_csv_export;
+use crate::policy::sql::result_query::is_rerunnable_select;
 
 pub struct AppState {
     pub should_quit: bool,
@@ -263,7 +263,7 @@ impl AppState {
     pub fn can_request_csv_export(&self) -> bool {
         self.query
             .visible_result()
-            .is_some_and(|r| !r.is_error() && can_rerun_for_csv_export(&r.query))
+            .is_some_and(|r| !r.is_error() && is_rerunnable_select(&r.query))
     }
 
     /// True when a run-scoped async response no longer belongs to the active

--- a/src/app/policy/sql/export.rs
+++ b/src/app/policy/sql/export.rs
@@ -1,0 +1,31 @@
+use super::statement_classifier::{self, StatementKind};
+
+pub fn can_rerun_for_csv_export(sql: &str) -> bool {
+    matches!(statement_classifier::classify(sql), StatementKind::Select)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::select("SELECT * FROM users")]
+    #[case::show("SHOW search_path")]
+    fn allows_read_only_result_queries(#[case] sql: &str) {
+        assert!(can_rerun_for_csv_export(sql));
+    }
+
+    #[rstest]
+    #[case::insert_returning("INSERT INTO users(name) VALUES ('a') RETURNING id")]
+    #[case::update_returning("UPDATE users SET name = 'b' WHERE id = 1 RETURNING id")]
+    #[case::delete_returning("DELETE FROM users WHERE id = 1 RETURNING id")]
+    #[case::cte_update_returning(
+        "WITH changed AS (SELECT 1) UPDATE users SET name = 'b' RETURNING id"
+    )]
+    #[case::multi_statement("SELECT 1; DELETE FROM users RETURNING id")]
+    #[case::explain_analyze_update("EXPLAIN ANALYZE UPDATE users SET name = 'b' RETURNING id")]
+    fn blocks_queries_that_could_mutate_on_rerun(#[case] sql: &str) {
+        assert!(!can_rerun_for_csv_export(sql));
+    }
+}

--- a/src/app/policy/sql/mod.rs
+++ b/src/app/policy/sql/mod.rs
@@ -1,2 +1,3 @@
+pub mod export;
 pub mod lexer;
 pub mod statement_classifier;

--- a/src/app/policy/sql/mod.rs
+++ b/src/app/policy/sql/mod.rs
@@ -1,3 +1,3 @@
-pub mod export;
 pub mod lexer;
+pub mod result_query;
 pub mod statement_classifier;

--- a/src/app/policy/sql/result_query.rs
+++ b/src/app/policy/sql/result_query.rs
@@ -2,6 +2,7 @@ use super::statement_classifier::{self, StatementKind};
 
 pub fn is_rerunnable_select(sql: &str) -> bool {
     matches!(statement_classifier::classify(sql), StatementKind::Select)
+        && !statement_classifier::has_executed_data_modifying_cte(sql)
 }
 
 #[cfg(test)]
@@ -23,9 +24,29 @@ mod tests {
     #[case::cte_update_returning(
         "WITH changed AS (SELECT 1) UPDATE users SET name = 'b' RETURNING id"
     )]
+    #[case::select_from_update_cte(
+        "WITH moved AS (UPDATE users SET name = 'a' RETURNING *) SELECT * FROM moved"
+    )]
+    #[case::select_from_insert_cte(
+        "WITH inserted AS (INSERT INTO users(name) VALUES ('a') RETURNING *) SELECT * FROM inserted"
+    )]
+    #[case::select_from_delete_cte(
+        "WITH deleted AS (DELETE FROM users WHERE id = 1 RETURNING *) SELECT * FROM deleted"
+    )]
+    #[case::explain_analyze_update_cte(
+        "EXPLAIN ANALYZE WITH moved AS (UPDATE users SET name = 'a' RETURNING *) SELECT * FROM moved"
+    )]
     #[case::multi_statement("SELECT 1; DELETE FROM users RETURNING id")]
     #[case::explain_analyze_update("EXPLAIN ANALYZE UPDATE users SET name = 'b' RETURNING id")]
     fn blocks_queries_that_could_mutate_on_rerun(#[case] sql: &str) {
         assert!(!is_rerunnable_select(sql));
+    }
+
+    #[test]
+    fn allows_plain_explain_with_data_modifying_cte() {
+        let sql =
+            "EXPLAIN WITH moved AS (UPDATE users SET name = 'a' RETURNING *) SELECT * FROM moved";
+
+        assert!(is_rerunnable_select(sql));
     }
 }

--- a/src/app/policy/sql/result_query.rs
+++ b/src/app/policy/sql/result_query.rs
@@ -1,6 +1,6 @@
 use super::statement_classifier::{self, StatementKind};
 
-pub fn can_rerun_for_csv_export(sql: &str) -> bool {
+pub fn is_rerunnable_select(sql: &str) -> bool {
     matches!(statement_classifier::classify(sql), StatementKind::Select)
 }
 
@@ -13,7 +13,7 @@ mod tests {
     #[case::select("SELECT * FROM users")]
     #[case::show("SHOW search_path")]
     fn allows_read_only_result_queries(#[case] sql: &str) {
-        assert!(can_rerun_for_csv_export(sql));
+        assert!(is_rerunnable_select(sql));
     }
 
     #[rstest]
@@ -26,6 +26,6 @@ mod tests {
     #[case::multi_statement("SELECT 1; DELETE FROM users RETURNING id")]
     #[case::explain_analyze_update("EXPLAIN ANALYZE UPDATE users SET name = 'b' RETURNING id")]
     fn blocks_queries_that_could_mutate_on_rerun(#[case] sql: &str) {
-        assert!(!can_rerun_for_csv_export(sql));
+        assert!(!is_rerunnable_select(sql));
     }
 }

--- a/src/app/policy/sql/statement_classifier.rs
+++ b/src/app/policy/sql/statement_classifier.rs
@@ -28,6 +28,138 @@ pub fn classify(sql: &str) -> StatementKind {
     classify_inner(&lower, &chars)
 }
 
+pub fn has_executed_data_modifying_cte(sql: &str) -> bool {
+    let lower = sql.trim().to_lowercase();
+    if lower.is_empty() {
+        return false;
+    }
+    let chars: Vec<(usize, char)> = lower.char_indices().collect();
+    if matches!(
+        explain_executes_inner_statement(&lower, &chars),
+        Some(false)
+    ) {
+        return false;
+    }
+
+    let mut i = 0;
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut in_cte = false;
+
+    while i < chars.len() {
+        let (byte_pos, ch) = chars[i];
+
+        if let Some(next_i) = skip_line_comment(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_block_comment(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = advance_single_quote(&chars, i, ch, &mut in_string) {
+            i = next_i;
+            continue;
+        }
+        if in_string {
+            i += 1;
+            continue;
+        }
+        if let Some(next_i) = skip_double_quoted_identifier(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_dollar_quoted_string(&lower, &chars, i, byte_pos, ch) {
+            i = next_i;
+            continue;
+        }
+
+        update_parentheses_depth(ch, &mut depth);
+
+        if (ch.is_alphabetic() || ch == '_') && is_word_start(&chars, i) {
+            let rest = &lower[byte_pos..];
+            if depth == 0 && is_keyword(rest, "with") {
+                in_cte = true;
+            } else if in_cte && depth == 0 && match_keyword(rest).is_some() {
+                return false;
+            } else if in_cte && depth > 0 && is_data_modifying_keyword(rest) {
+                return true;
+            }
+        }
+
+        i += 1;
+    }
+
+    false
+}
+
+fn explain_executes_inner_statement(lower: &str, chars: &[(usize, char)]) -> Option<bool> {
+    let mut i = 0;
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut is_explain = false;
+
+    while i < chars.len() {
+        let (byte_pos, ch) = chars[i];
+
+        if let Some(next_i) = skip_line_comment(chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_block_comment(chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = advance_single_quote(chars, i, ch, &mut in_string) {
+            i = next_i;
+            continue;
+        }
+        if in_string {
+            i += 1;
+            continue;
+        }
+        if let Some(next_i) = skip_double_quoted_identifier(chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_dollar_quoted_string(lower, chars, i, byte_pos, ch) {
+            i = next_i;
+            continue;
+        }
+
+        update_parentheses_depth(ch, &mut depth);
+
+        if (ch.is_alphabetic() || ch == '_') && is_word_start(chars, i) {
+            let rest = &lower[byte_pos..];
+            if !is_explain {
+                if depth == 0 && is_keyword(rest, "explain") {
+                    is_explain = true;
+                    i += 1;
+                    continue;
+                }
+                return None;
+            }
+            if (depth == 0 || depth == 1) && is_keyword(rest, "analyze") {
+                return Some(true);
+            }
+            if depth == 0 && match_keyword(rest).is_some() {
+                return Some(false);
+            }
+        }
+
+        i += 1;
+    }
+
+    None
+}
+
+fn is_data_modifying_keyword(rest: &str) -> bool {
+    is_keyword(rest, "insert")
+        || is_keyword(rest, "update")
+        || is_keyword(rest, "delete")
+        || is_keyword(rest, "merge")
+}
+
 pub fn drop_subtype(sql: &str) -> Option<String> {
     let trimmed = sql.trim();
     let chars: Vec<(usize, char)> = trimmed.char_indices().collect();

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -856,7 +856,7 @@ mod tests {
         #[test]
         fn no_command_tag_emits_no_effects() {
             let mut state = state_with_table("public", "users");
-            let result = Arc::new(crate::domain::QueryResult::success(
+            let result = Arc::new(QueryResult::success(
                 "SELECT 1".to_string(),
                 vec!["?column?".to_string()],
                 vec![vec!["1".to_string()]],

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -503,6 +503,7 @@ mod tests {
         use super::*;
         use crate::domain::QueryResult;
         use crate::ports::outbound::DbOperationError;
+        use rstest::rstest;
 
         fn export_test_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
@@ -565,6 +566,34 @@ mod tests {
                 }
                 other => panic!("expected CountRowsForExport, got {other:?}"),
             }
+        }
+
+        #[rstest]
+        #[case::insert("INSERT INTO users(name) VALUES ('a') RETURNING id")]
+        #[case::update("UPDATE users SET name = 'b' WHERE id = 1 RETURNING id")]
+        #[case::delete("DELETE FROM users WHERE id = 1 RETURNING id")]
+        fn request_with_mutating_returning_result_is_noop(#[case] query: &str) {
+            let mut state = create_test_state();
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success(
+                    query.to_string(),
+                    vec!["id".to_string()],
+                    vec![vec!["1".to_string()]],
+                    10,
+                    QuerySource::Adhoc,
+                )));
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::RequestCsvExport,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert!(!state.query.is_running());
         }
 
         #[test]

--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -256,6 +256,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::domain::{QueryResult, QuerySource};
     use crate::model::shared::key_sequence::Prefix;
 
     fn state_with_result_rows(rows: usize, pane_height: u16) -> AppState {
@@ -264,12 +265,12 @@ mod tests {
         let result_rows: Vec<Vec<String>> = (0..rows).map(|i| vec![format!("{}", i)]).collect();
         state
             .query
-            .set_current_result(Arc::new(crate::domain::QueryResult::success(
+            .set_current_result(Arc::new(QueryResult::success(
                 String::new(),
                 vec!["id".to_string()],
                 result_rows,
                 1,
-                crate::domain::QuerySource::Preview,
+                QuerySource::Preview,
             )));
         state
     }

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use crate::cmd::effect::Effect;
 #[cfg(test)]
-use crate::domain::ColumnAttributes;
+use crate::domain::{ColumnAttributes, QueryResult, QuerySource};
 use crate::model::app_state::AppState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::inspector_tab::InspectorTab;
@@ -151,12 +151,12 @@ mod tests {
                 .collect();
             state
                 .query
-                .set_current_result(Arc::new(crate::domain::QueryResult::success(
+                .set_current_result(Arc::new(QueryResult::success(
                     String::new(),
                     columns,
                     result_rows,
                     1,
-                    crate::domain::QuerySource::Preview,
+                    QuerySource::Preview,
                 )));
             state
         }
@@ -286,12 +286,12 @@ mod tests {
             let rows = vec![values.iter().map(ToString::to_string).collect()];
             state
                 .query
-                .set_current_result(Arc::new(crate::domain::QueryResult::success(
+                .set_current_result(Arc::new(QueryResult::success(
                     String::new(),
                     columns,
                     rows,
                     1,
-                    crate::domain::QuerySource::Preview,
+                    QuerySource::Preview,
                 )));
             state
         }


### PR DESCRIPTION
## Problem
CSV export can re-run the SQL behind the visible result. For mutating statements that return rows, this can execute the write again during export.

## Background
The shared export flow counted and exported by sending the stored query back through the adapter, so PostgreSQL and SQLite would inherit the same risk.

## Approach
Limit query re-run CSV export to statements classified as read-only result queries. Mutating RETURNING results now stop before row counting or export effects are emitted.

## Screenshots
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * CSVエクスポートを、エラーでない表示結果かつ「再実行可能なSELECT」の場合にのみ許可するように変更しました。
  * 更新系（`INSERT/UPDATE/DELETE … RETURNING`）や、データ変更が起こり得るCTEを含むケースはブロックします（`EXPLAIN ANALYZE` 等も対象）。
* **テスト**
  * 許可/拒否の判定、および該当時に処理が開始されないことを検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->