### PR TITLE
Preserve SQLite value fidelity across results and writes

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -162,7 +162,7 @@ pub async fn run(
                 match executor.execute_adhoc(&dsn, &query, read_only).await {
                     Ok(result) => {
                         let plan_text = result
-                            .rows
+                            .rows()
                             .iter()
                             .filter_map(|row| row.first())
                             .cloned()

--- a/src/app/model/connection/cache.rs
+++ b/src/app/model/connection/cache.rs
@@ -166,6 +166,6 @@ mod tests {
         assert!(retrieved.query_result.is_some());
         let retrieved_result = retrieved.query_result.as_ref().unwrap();
         assert_eq!(retrieved_result.query, "SELECT * FROM users");
-        assert_eq!(retrieved_result.row_count, 1);
+        assert_eq!(retrieved_result.row_count(), 1);
     }
 }

--- a/src/app/policy/write/write_guardrails.rs
+++ b/src/app/policy/write/write_guardrails.rs
@@ -1,3 +1,4 @@
+use crate::domain::QueryValue;
 use crate::policy::sql::statement_classifier::StatementKind;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,7 +29,7 @@ impl RiskLevel {
 pub struct TargetSummary {
     pub schema: String,
     pub table: String,
-    pub key_values: Vec<(String, String)>,
+    pub key_values: Vec<(String, QueryValue)>,
 }
 
 impl TargetSummary {
@@ -36,7 +37,7 @@ impl TargetSummary {
         let key_str = self
             .key_values
             .iter()
-            .map(|(k, v)| format!("{k}={v}"))
+            .map(|(k, v)| format!("{k}={}", v.display_value()))
             .collect::<Vec<_>>()
             .join(", ");
         format!("{}.{} ({})", self.schema, self.table, key_str)
@@ -153,7 +154,7 @@ mod tests {
             let target = TargetSummary {
                 schema: "public".to_string(),
                 table: "users".to_string(),
-                key_values: vec![("id".to_string(), "42".to_string())],
+                key_values: vec![("id".to_string(), QueryValue::text("42"))],
             };
             let decision = evaluate_guardrails(true, true, Some(target));
             assert_eq!(decision.risk_level, RiskLevel::Low);
@@ -165,7 +166,7 @@ mod tests {
             let target = TargetSummary {
                 schema: "public".to_string(),
                 table: "users".to_string(),
-                key_values: vec![("id".to_string(), "42".to_string())],
+                key_values: vec![("id".to_string(), QueryValue::text("42"))],
             };
             assert_eq!(target.format_compact(), "public.users (id=42)");
         }

--- a/src/app/policy/write/write_update.rs
+++ b/src/app/policy/write/write_update.rs
@@ -1,3 +1,5 @@
+use crate::domain::QueryValue;
+
 /// Normalize a cell value for diff display.
 /// If the value is valid JSON, re-serialize it so both before/after
 /// share the same key ordering and formatting.
@@ -28,9 +30,9 @@ pub fn preview_value_expr(value: &str) -> String {
 
 pub fn build_pk_pairs(
     columns: &[String],
-    row: &[String],
+    row: &[QueryValue],
     pk_columns: &[String],
-) -> Option<Vec<(String, String)>> {
+) -> Option<Vec<(String, QueryValue)>> {
     let mut pairs = Vec::with_capacity(pk_columns.len());
     for pk_col in pk_columns {
         let idx = columns.iter().position(|c| c == pk_col)?;
@@ -84,15 +86,15 @@ mod tests {
         #[test]
         fn existing_pk_columns_returns_pk_pairs() {
             let columns = vec!["id".to_string(), "name".to_string()];
-            let row = vec!["1".to_string(), "alice".to_string()];
+            let row = vec![QueryValue::text("1"), QueryValue::text("alice")];
             let pairs = build_pk_pairs(&columns, &row, &["id".to_string()]).unwrap();
-            assert_eq!(pairs, vec![("id".to_string(), "1".to_string())]);
+            assert_eq!(pairs, vec![("id".to_string(), QueryValue::text("1"))]);
         }
 
         #[test]
         fn missing_pk_column_returns_none() {
             let columns = vec!["name".to_string()];
-            let row = vec!["alice".to_string()];
+            let row = vec![QueryValue::text("alice")];
             let pairs = build_pk_pairs(&columns, &row, &["id".to_string()]);
             assert!(pairs.is_none());
         }

--- a/src/app/policy/write/write_update.rs
+++ b/src/app/policy/write/write_update.rs
@@ -16,18 +16,6 @@ pub fn escape_preview_value(value: &str) -> String {
         .replace('\n', "\\n")
 }
 
-fn preview_quote_literal(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
-}
-
-pub fn preview_value_expr(value: &str) -> String {
-    if value == "NULL" {
-        "NULL".to_string()
-    } else {
-        preview_quote_literal(value)
-    }
-}
-
 pub fn build_pk_pairs(
     columns: &[String],
     row: &[QueryValue],
@@ -45,18 +33,9 @@ pub fn build_pk_pairs(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rstest::rstest;
 
-    mod value_expr {
+    mod value_preview {
         use super::*;
-
-        #[rstest]
-        #[case("NULL", "NULL")]
-        #[case("alice", "'alice'")]
-        #[case("O'Reilly", "'O''Reilly'")]
-        fn formats_input_as_sql_expr(#[case] input: &str, #[case] expected: &str) {
-            assert_eq!(preview_value_expr(input), expected);
-        }
 
         #[test]
         fn value_with_control_chars_returns_escaped_preview_value() {

--- a/src/app/ports/outbound/sql_dialect.rs
+++ b/src/app/ports/outbound/sql_dialect.rs
@@ -1,4 +1,4 @@
-use crate::domain::DatabaseType;
+use crate::domain::{DatabaseType, QueryValue};
 
 pub trait SqlDialect: Send + Sync {
     fn build_explain_sql(&self, database_type: DatabaseType, query: &str) -> Option<String>;
@@ -10,14 +10,14 @@ pub trait SqlDialect: Send + Sync {
         schema: &str,
         table: &str,
         column: &str,
-        new_value: &str,
-        pk_pairs: &[(String, String)],
+        new_value: &QueryValue,
+        pk_pairs: &[(String, QueryValue)],
     ) -> String;
     fn build_bulk_delete_sql(
         &self,
         database_type: DatabaseType,
         schema: &str,
         table: &str,
-        pk_pairs_per_row: &[Vec<(String, String)>],
+        pk_pairs_per_row: &[Vec<(String, QueryValue)>],
     ) -> String;
 }

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -1,7 +1,9 @@
+#[cfg(any(test, feature = "test-support"))]
+use std::fmt::Write as _;
 use std::sync::Arc;
 
 #[cfg(any(test, feature = "test-support"))]
-use crate::domain::DatabaseType;
+use crate::domain::{DatabaseType, QueryValue};
 
 use super::ports::outbound::{DdlGenerator, SqlDialect};
 pub struct AppServices {
@@ -13,6 +15,39 @@ impl AppServices {
     #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn stub() -> Self {
+        fn quote_literal(value: &str) -> String {
+            format!("'{}'", value.replace('\'', "''"))
+        }
+
+        fn sql_literal(database_type: DatabaseType, value: &QueryValue) -> String {
+            match value {
+                QueryValue::Null => "NULL".to_string(),
+                QueryValue::Text(value) => quote_literal(value),
+                QueryValue::SqlLiteral(value) => value.clone(),
+                QueryValue::Blob(bytes) => {
+                    let mut hex = String::with_capacity(bytes.len() * 2);
+                    for byte in bytes {
+                        let _ = write!(hex, "{byte:02x}");
+                    }
+                    match database_type {
+                        DatabaseType::PostgreSQL => format!("'\\x{hex}'"),
+                        DatabaseType::SQLite => format!("X'{}'", hex.to_uppercase()),
+                    }
+                }
+            }
+        }
+
+        fn equality_predicate(
+            database_type: DatabaseType,
+            key: &str,
+            value: &QueryValue,
+        ) -> String {
+            match value {
+                QueryValue::Null => format!("\"{key}\" IS NULL"),
+                _ => format!("\"{key}\" = {}", sql_literal(database_type, value)),
+            }
+        }
+
         struct StubDdlGenerator;
         impl DdlGenerator for StubDdlGenerator {
             fn generate_ddl(
@@ -64,10 +99,11 @@ impl AppServices {
                 new_value: &crate::domain::QueryValue,
                 pk_pairs: &[(String, crate::domain::QueryValue)],
             ) -> String {
-                let set_clause = format!("\"{column}\" = '{}'", new_value.display_value());
+                let set_clause =
+                    format!("\"{column}\" = {}", sql_literal(database_type, new_value));
                 let where_clause = pk_pairs
                     .iter()
-                    .map(|(key, value)| format!("\"{key}\" = '{}'", value.display_value()))
+                    .map(|(key, value)| equality_predicate(database_type, key, value))
                     .collect::<Vec<_>>()
                     .join(" AND ");
                 match database_type {
@@ -93,7 +129,7 @@ impl AppServices {
                     .map(|pk_pairs| {
                         pk_pairs
                             .iter()
-                            .map(|(key, value)| format!("\"{key}\" = '{}'", value.display_value()))
+                            .map(|(key, value)| equality_predicate(database_type, key, value))
                             .collect::<Vec<_>>()
                             .join(" AND ")
                     })
@@ -112,5 +148,40 @@ impl AppServices {
             ddl_generator: Arc::new(StubDdlGenerator),
             sql_dialect: Arc::new(StubSqlDialect),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::QueryValue;
+
+    #[test]
+    fn stub_sql_dialect_formats_typed_values() {
+        let services = AppServices::stub();
+
+        let update = services.sql_dialect.build_update_sql(
+            DatabaseType::PostgreSQL,
+            "public",
+            "files",
+            "payload",
+            &QueryValue::Blob(vec![0, 255]),
+            &[("deleted_at".to_string(), QueryValue::Null)],
+        );
+        let delete = services.sql_dialect.build_bulk_delete_sql(
+            DatabaseType::SQLite,
+            "main",
+            "files",
+            &[vec![(
+                "payload".to_string(),
+                QueryValue::Blob(vec![0, 255]),
+            )]],
+        );
+
+        assert_eq!(
+            update,
+            "UPDATE \"public\".\"files\" SET \"payload\" = '\\x00ff' WHERE \"deleted_at\" IS NULL"
+        );
+        assert_eq!(delete, "DELETE FROM \"files\" WHERE \"payload\" = X'00FF'");
     }
 }

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -3,7 +3,7 @@ use std::fmt::Write as _;
 use std::sync::Arc;
 
 #[cfg(any(test, feature = "test-support"))]
-use crate::domain::{DatabaseType, QueryValue};
+use crate::domain::{DatabaseType, QueryValue, Table};
 
 use super::ports::outbound::{DdlGenerator, SqlDialect};
 pub struct AppServices {
@@ -50,18 +50,10 @@ impl AppServices {
 
         struct StubDdlGenerator;
         impl DdlGenerator for StubDdlGenerator {
-            fn generate_ddl(
-                &self,
-                _database_type: DatabaseType,
-                _table: &crate::domain::Table,
-            ) -> String {
+            fn generate_ddl(&self, _database_type: DatabaseType, _table: &Table) -> String {
                 unimplemented!("inject a real DdlGenerator via AppServices")
             }
-            fn ddl_line_count(
-                &self,
-                _database_type: DatabaseType,
-                _table: &crate::domain::Table,
-            ) -> usize {
+            fn ddl_line_count(&self, _database_type: DatabaseType, _table: &Table) -> usize {
                 0
             }
         }
@@ -96,8 +88,8 @@ impl AppServices {
                 schema: &str,
                 table: &str,
                 column: &str,
-                new_value: &crate::domain::QueryValue,
-                pk_pairs: &[(String, crate::domain::QueryValue)],
+                new_value: &QueryValue,
+                pk_pairs: &[(String, QueryValue)],
             ) -> String {
                 let set_clause =
                     format!("\"{column}\" = {}", sql_literal(database_type, new_value));
@@ -122,7 +114,7 @@ impl AppServices {
                 database_type: DatabaseType,
                 schema: &str,
                 table: &str,
-                pk_pairs_per_row: &[Vec<(String, crate::domain::QueryValue)>],
+                pk_pairs_per_row: &[Vec<(String, QueryValue)>],
             ) -> String {
                 let where_clause = pk_pairs_per_row
                     .iter()

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -61,13 +61,13 @@ impl AppServices {
                 schema: &str,
                 table: &str,
                 column: &str,
-                new_value: &str,
-                pk_pairs: &[(String, String)],
+                new_value: &crate::domain::QueryValue,
+                pk_pairs: &[(String, crate::domain::QueryValue)],
             ) -> String {
-                let set_clause = format!("\"{column}\" = '{new_value}'");
+                let set_clause = format!("\"{column}\" = '{}'", new_value.display_value());
                 let where_clause = pk_pairs
                     .iter()
-                    .map(|(key, value)| format!("\"{key}\" = '{value}'"))
+                    .map(|(key, value)| format!("\"{key}\" = '{}'", value.display_value()))
                     .collect::<Vec<_>>()
                     .join(" AND ");
                 match database_type {
@@ -86,14 +86,14 @@ impl AppServices {
                 database_type: DatabaseType,
                 schema: &str,
                 table: &str,
-                pk_pairs_per_row: &[Vec<(String, String)>],
+                pk_pairs_per_row: &[Vec<(String, crate::domain::QueryValue)>],
             ) -> String {
                 let where_clause = pk_pairs_per_row
                     .iter()
                     .map(|pk_pairs| {
                         pk_pairs
                             .iter()
-                            .map(|(key, value)| format!("\"{key}\" = '{value}'"))
+                            .map(|(key, value)| format!("\"{key}\" = '{}'", value.display_value()))
                             .collect::<Vec<_>>()
                             .join(" AND ")
                     })

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -91,7 +91,7 @@ pub fn reduce_execution(
                     reset_view_for_new_result(state, now);
                     state.sql_modal.finish_adhoc_success(AdhocSuccessSnapshot {
                         command_tag: result.command_tag.clone(),
-                        row_count: result.row_count,
+                        row_count: result.row_count(),
                         execution_time_ms: result.execution_time_ms,
                     });
                     state.query.push_history(Arc::clone(result));
@@ -108,7 +108,7 @@ pub fn reduce_execution(
                         state
                             .query
                             .pagination
-                            .set_page_result(*page, result.rows.len() < PREVIEW_PAGE_SIZE);
+                            .set_page_result(*page, result.rows().len() < PREVIEW_PAGE_SIZE);
                     }
                     state.query.set_current_result(Arc::clone(result));
 
@@ -118,8 +118,8 @@ pub fn reduce_execution(
                             state.result_interaction.reset_interaction();
                         }
                         PostDeleteRowSelection::Select(row) => {
-                            if !result.rows.is_empty() && !result.columns.is_empty() {
-                                let clamped = row.min(result.rows.len() - 1);
+                            if !result.rows().is_empty() && !result.columns.is_empty() {
+                                let clamped = row.min(result.rows().len() - 1);
                                 let max_col = result.columns.len() - 1;
                                 let col = preserved_result_col
                                     .unwrap_or(preserved_horizontal_offset)
@@ -902,7 +902,7 @@ mod tests {
 
             let stored = state.query.current_result().unwrap();
             assert_eq!(stored.source, QuerySource::Preview);
-            assert_eq!(stored.row_count, 5);
+            assert_eq!(stored.row_count(), 5);
         }
 
         #[test]

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -195,9 +195,11 @@ pub(super) mod tests {
 
     // Mirrors the executor's command-tag path: affected rows become row_count
     pub fn adhoc_result_with_tag(tag: CommandTag) -> Arc<QueryResult> {
-        let mut result = QueryResult::success(String::new(), vec![], vec![], 5, QuerySource::Adhoc);
-        result.row_count = tag.affected_rows().unwrap_or(0) as usize;
-        Arc::new(result.with_command_tag(tag))
+        Arc::new(
+            QueryResult::success(String::new(), vec![], vec![], 5, QuerySource::Adhoc)
+                .with_row_count(tag.affected_rows().unwrap_or(0) as usize)
+                .with_command_tag(tag),
+        )
     }
 
     pub fn adhoc_error_result() -> Arc<QueryResult> {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -7,7 +7,7 @@ use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSe
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::json::json_diff::compute_json_diff;
 use crate::policy::write::write_guardrails::{
-    ColumnDiff, RiskLevel, WriteOperation, WritePreview, evaluate_guardrails,
+    ColumnDiff, RiskLevel, TargetSummary, WriteOperation, WritePreview, evaluate_guardrails,
 };
 use crate::policy::write::write_update::{
     build_pk_pairs, escape_preview_value, normalize_for_diff,
@@ -68,7 +68,7 @@ fn build_update_preview(
     if let Some(pairs) = pk_pairs.as_deref() {
         reject_sqlite_null_pk(state.session.active_database_type_or_default(), pairs)?;
     }
-    let target = crate::policy::write::write_guardrails::TargetSummary {
+    let target = TargetSummary {
         schema: state.query.pagination.schema().to_string(),
         table: state.query.pagination.table().to_string(),
         key_values: pk_pairs.clone().unwrap_or_default(),
@@ -384,6 +384,7 @@ pub fn reduce_write(
 mod tests {
     use super::*;
 
+    use crate::domain::connection::ConnectionId;
     use crate::domain::{DatabaseType, QueryResult, QuerySource};
     use crate::model::browse::query_execution::{
         DeleteRefreshTarget, PREVIEW_PAGE_SIZE, PostDeleteRowSelection, QueryStatus,
@@ -580,7 +581,7 @@ mod tests {
         fn sqlite_active_database_type_uses_sqlite_update_preview() {
             let mut state = editable_state();
             state.session.activate_connection_with_dsn(
-                &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
+                &ConnectionId::from_string("sqlite-test"),
                 "sqlite",
                 DatabaseType::SQLite,
                 "sqlite:///tmp/app.db",
@@ -617,7 +618,7 @@ mod tests {
         fn sqlite_update_rejects_null_primary_key_value() {
             let mut state = editable_state();
             state.session.activate_connection_with_dsn(
-                &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
+                &ConnectionId::from_string("sqlite-test"),
                 "sqlite",
                 DatabaseType::SQLite,
                 "sqlite:///tmp/app.db",

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -17,7 +17,7 @@ use crate::update::action::Action;
 use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{
-    EditGuardrailError, build_bulk_delete_preview, editable_preview_base,
+    EditGuardrailError, build_bulk_delete_preview, editable_preview_base, reject_sqlite_null_pk,
 };
 
 fn build_update_preview(
@@ -65,6 +65,9 @@ fn build_update_preview(
     };
 
     let pk_pairs = build_pk_pairs(&result.columns, row_values, pk_cols);
+    if let Some(pairs) = pk_pairs.as_deref() {
+        reject_sqlite_null_pk(state.session.active_database_type_or_default(), pairs)?;
+    }
     let target = crate::policy::write::write_guardrails::TargetSummary {
         schema: state.query.pagination.schema().to_string(),
         table: state.query.pagination.table().to_string(),
@@ -392,6 +395,7 @@ mod tests {
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
     use crate::update::test_support::activate_postgres_connection;
+    use rstest::rstest;
     use std::sync::Arc;
 
     fn write_succeeded_action(state: &mut AppState, affected_rows: usize) -> Action {
@@ -506,21 +510,27 @@ mod tests {
             );
         }
 
-        #[test]
-        fn submit_rejects_non_text_active_cell_edit() {
+        #[rstest]
+        #[case(QueryValue::Null, "NULL")]
+        #[case(QueryValue::Blob(vec![0, 255]), "BLOB (2 bytes) 00 FF")]
+        #[case(QueryValue::SqlLiteral("42".to_string()), "42")]
+        fn submit_rejects_non_text_active_cell_edit(
+            #[case] cell_value: QueryValue,
+            #[case] draft: &str,
+        ) {
             let mut state = editable_state();
             state
                 .query
                 .set_current_result(Arc::new(QueryResult::success_with_values(
                     String::new(),
                     vec!["id".to_string(), "name".to_string()],
-                    vec![vec![QueryValue::text("1"), QueryValue::Null]],
+                    vec![vec![QueryValue::text("1"), cell_value]],
                     1,
                     QuerySource::Preview,
                 )));
             state
                 .result_interaction
-                .begin_cell_edit(0, 1, "NULL".to_string());
+                .begin_cell_edit(0, 1, draft.to_string());
 
             let effects = dispatch_query(
                 &mut state,
@@ -601,6 +611,55 @@ mod tests {
                 }
                 other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
             }
+        }
+
+        #[test]
+        fn sqlite_update_rejects_null_primary_key_value() {
+            let mut state = editable_state();
+            state.session.activate_connection_with_dsn(
+                &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
+            let mut detail = users_table_detail();
+            detail.schema = "main".to_string();
+            state.session.set_table_detail_raw(Some(detail));
+            state.query.pagination.reset_for_table("main", "users");
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    String::new(),
+                    vec!["id".to_string(), "name".to_string()],
+                    vec![vec![QueryValue::Null, QueryValue::text("Alice")]],
+                    1,
+                    QuerySource::Preview,
+                )));
+            state
+                .result_interaction
+                .begin_cell_edit(0, 1, "Alice".to_string());
+            state
+                .result_interaction
+                .cell_edit_input_mut()
+                .set_content("Bob".to_string());
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(
+                effects
+                    .into_effects()
+                    .expect("reducer should handle action")
+                    .is_empty()
+            );
+            assert_eq!(
+                state.messages.last_error.as_deref(),
+                Some("SQLite writes require non-NULL primary key values")
+            );
         }
 
         fn editable_state_with_jsonb() -> AppState {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -54,6 +54,15 @@ fn build_update_preview(
     if pk_cols.iter().any(|pk| pk == &column_name) {
         return Err(EditGuardrailError::PrimaryKeyColumnsReadOnly);
     }
+    let new_value = match row_values
+        .get(col_idx)
+        .ok_or(EditGuardrailError::CellIndexOutOfBounds)?
+    {
+        QueryValue::Text(_) => QueryValue::text(state.result_interaction.cell_edit().draft_value()),
+        QueryValue::Null | QueryValue::Blob(_) | QueryValue::SqlLiteral(_) => {
+            return Err(EditGuardrailError::NonTextInlineEdit);
+        }
+    };
 
     let pk_pairs = build_pk_pairs(&result.columns, row_values, pk_cols);
     let target = crate::policy::write::write_guardrails::TargetSummary {
@@ -76,7 +85,7 @@ fn build_update_preview(
         &target.schema,
         &target.table,
         &column_name,
-        &QueryValue::text(state.result_interaction.cell_edit().draft_value()),
+        &new_value,
         &target.key_values,
     );
     let preview = WritePreview {
@@ -372,7 +381,7 @@ pub fn reduce_write(
 mod tests {
     use super::*;
 
-    use crate::domain::DatabaseType;
+    use crate::domain::{DatabaseType, QueryResult, QuerySource};
     use crate::model::browse::query_execution::{
         DeleteRefreshTarget, PREVIEW_PAGE_SIZE, PostDeleteRowSelection, QueryStatus,
     };
@@ -383,6 +392,7 @@ mod tests {
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
     use crate::update::test_support::activate_postgres_connection;
+    use std::sync::Arc;
 
     fn write_succeeded_action(state: &mut AppState, affected_rows: usize) -> Action {
         let run_id = begin_query_run(state);
@@ -493,6 +503,41 @@ mod tests {
             assert_eq!(
                 state.messages.last_error.as_deref(),
                 Some("Table metadata does not match current preview target")
+            );
+        }
+
+        #[test]
+        fn submit_rejects_non_text_active_cell_edit() {
+            let mut state = editable_state();
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    String::new(),
+                    vec!["id".to_string(), "name".to_string()],
+                    vec![vec![QueryValue::text("1"), QueryValue::Null]],
+                    1,
+                    QuerySource::Preview,
+                )));
+            state
+                .result_interaction
+                .begin_cell_edit(0, 1, "NULL".to_string());
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(
+                effects
+                    .into_effects()
+                    .expect("reducer should handle action")
+                    .is_empty()
+            );
+            assert_eq!(
+                state.messages.last_error.as_deref(),
+                Some("Only text cells can be edited inline")
             );
         }
 

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -42,7 +42,7 @@ fn build_update_preview(
         .ok_or(EditGuardrailError::NoColumnSelectedForEdit)?;
 
     let row_values = result
-        .values
+        .values()
         .get(row_idx)
         .ok_or(EditGuardrailError::RowIndexOutOfBounds)?;
     let column_name = result

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::QueryValue;
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSelection};
 use crate::model::shared::input_mode::InputMode;
@@ -40,8 +41,8 @@ fn build_update_preview(
         .col
         .ok_or(EditGuardrailError::NoColumnSelectedForEdit)?;
 
-    let row = result
-        .rows
+    let row_values = result
+        .values
         .get(row_idx)
         .ok_or(EditGuardrailError::RowIndexOutOfBounds)?;
     let column_name = result
@@ -54,7 +55,7 @@ fn build_update_preview(
         return Err(EditGuardrailError::PrimaryKeyColumnsReadOnly);
     }
 
-    let pk_pairs = build_pk_pairs(&result.columns, row, pk_cols);
+    let pk_pairs = build_pk_pairs(&result.columns, row_values, pk_cols);
     let target = crate::policy::write::write_guardrails::TargetSummary {
         schema: state.query.pagination.schema().to_string(),
         table: state.query.pagination.table().to_string(),
@@ -75,7 +76,7 @@ fn build_update_preview(
         &target.schema,
         &target.table,
         &column_name,
-        state.result_interaction.cell_edit().draft_value(),
+        &QueryValue::text(state.result_interaction.cell_edit().draft_value()),
         &target.key_values,
     );
     let preview = WritePreview {
@@ -760,7 +761,7 @@ mod tests {
                 target_summary: TargetSummary {
                     schema: "public".to_string(),
                     table: "users".to_string(),
-                    key_values: vec![("id".to_string(), "2".to_string())],
+                    key_values: vec![("id".to_string(), QueryValue::text("2"))],
                 },
                 diff: vec![],
                 guardrail: GuardrailDecision {

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -135,7 +135,7 @@ fn selected_cell_value(state: &AppState) -> Option<(usize, usize, String, String
     let row_idx = state.result_interaction.selection().row()?;
     let col_idx = state.result_interaction.selection().cell()?;
     let column_name = result.columns.get(col_idx)?.clone();
-    let cell_value = result.rows.get(row_idx)?.get(col_idx)?.clone();
+    let cell_value = result.rows().get(row_idx)?.get(col_idx)?.clone();
     let data_type = selected_column_data_type(state, col_idx).map(ToString::to_string);
     Some((row_idx, col_idx, column_name, cell_value, data_type))
 }

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 #[cfg(test)]
 use crate::domain::ColumnAttributes;
+use crate::domain::QueryValue;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::write::write_update::build_pk_pairs;
@@ -57,10 +58,15 @@ fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), Edi
         return Err(EditGuardrailError::StableKeyColumnsMissing);
     }
 
-    let cell_value = result
+    let cell_value = match result
         .value_at(row_idx, col_idx)
         .ok_or(EditGuardrailError::CellIndexOutOfBounds)?
-        .display_value();
+    {
+        QueryValue::Text(value) => value.clone(),
+        QueryValue::Null | QueryValue::Blob(_) | QueryValue::SqlLiteral(_) => {
+            return Err(EditGuardrailError::NonTextInlineEdit);
+        }
+    };
 
     Ok((row_idx, col_idx, cell_value))
 }
@@ -154,7 +160,7 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{QueryResult, QuerySource, Table};
+    use crate::domain::{QueryResult, QuerySource, QueryValue, Table};
     use crate::update::action::CursorMove;
     use std::sync::Arc;
 
@@ -240,6 +246,36 @@ mod tests {
             assert_eq!(state.input_mode(), InputMode::CellEdit);
             assert_eq!(state.result_interaction.cell_edit().col(), Some(1));
             assert_eq!(state.result_interaction.cell_edit().draft_value(), "alice");
+        }
+
+        #[test]
+        fn non_text_cell_blocks_cell_edit_entry() {
+            let mut state = AppState::new("test".to_string());
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    String::new(),
+                    vec!["id".to_string(), "payload".to_string()],
+                    vec![vec![QueryValue::text("1"), QueryValue::Null]],
+                    1,
+                    QuerySource::Preview,
+                )));
+            state.query.pagination.reset_for_table("public", "users");
+            state.result_interaction.activate_cell(0, 1);
+            state
+                .session
+                .set_table_detail_raw(Some(minimal_users_table()));
+
+            let effects = reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            assert!(effects.is_empty());
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert_eq!(
+                state.messages.last_error(),
+                Some("Only text cells can be edited inline")
+            );
         }
 
         #[test]

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -162,6 +162,7 @@ mod tests {
     use super::*;
     use crate::domain::{QueryResult, QuerySource, QueryValue, Table};
     use crate::update::action::CursorMove;
+    use rstest::rstest;
     use std::sync::Arc;
 
     mod cell_edit_entry_guardrails {
@@ -248,15 +249,18 @@ mod tests {
             assert_eq!(state.result_interaction.cell_edit().draft_value(), "alice");
         }
 
-        #[test]
-        fn non_text_cell_blocks_cell_edit_entry() {
+        #[rstest]
+        #[case(QueryValue::Null)]
+        #[case(QueryValue::Blob(vec![0, 255]))]
+        #[case(QueryValue::SqlLiteral("42".to_string()))]
+        fn non_text_cell_blocks_cell_edit_entry(#[case] cell_value: QueryValue) {
             let mut state = AppState::new("test".to_string());
             state
                 .query
                 .set_current_result(Arc::new(QueryResult::success_with_values(
                     String::new(),
                     vec!["id".to_string(), "payload".to_string()],
-                    vec![vec![QueryValue::text("1"), QueryValue::Null]],
+                    vec![vec![QueryValue::text("1"), cell_value]],
                     1,
                     QuerySource::Preview,
                 )));

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -50,7 +50,7 @@ fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), Edi
     }
 
     let row = result
-        .values
+        .values()
         .get(row_idx)
         .ok_or(EditGuardrailError::RowIndexOutOfBounds)?;
     if build_pk_pairs(&result.columns, row, pk_cols).is_none() {
@@ -58,7 +58,7 @@ fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), Edi
     }
 
     let cell_value = result
-        .rows
+        .rows()
         .get(row_idx)
         .ok_or(EditGuardrailError::RowIndexOutOfBounds)?
         .get(col_idx)

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -58,12 +58,9 @@ fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), Edi
     }
 
     let cell_value = result
-        .rows()
-        .get(row_idx)
-        .ok_or(EditGuardrailError::RowIndexOutOfBounds)?
-        .get(col_idx)
+        .value_at(row_idx, col_idx)
         .ok_or(EditGuardrailError::CellIndexOutOfBounds)?
-        .clone();
+        .display_value();
 
     Ok((row_idx, col_idx, cell_value))
 }

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -50,14 +50,17 @@ fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), Edi
     }
 
     let row = result
-        .rows
+        .values
         .get(row_idx)
         .ok_or(EditGuardrailError::RowIndexOutOfBounds)?;
     if build_pk_pairs(&result.columns, row, pk_cols).is_none() {
         return Err(EditGuardrailError::StableKeyColumnsMissing);
     }
 
-    let cell_value = row
+    let cell_value = result
+        .rows
+        .get(row_idx)
+        .ok_or(EditGuardrailError::RowIndexOutOfBounds)?
         .get(col_idx)
         .ok_or(EditGuardrailError::CellIndexOutOfBounds)?
         .clone();

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -45,7 +45,7 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 _ => return DispatchResult::handled(),
             };
 
-            let cell_value = match result.rows.get(row_idx).and_then(|r| r.get(col_idx)) {
+            let cell_value = match result.rows().get(row_idx).and_then(|r| r.get(col_idx)) {
                 Some(v) if !v.is_empty() => v,
                 _ => return DispatchResult::handled(),
             };
@@ -316,7 +316,7 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
         let original_cell = state
             .query
             .visible_result()
-            .and_then(|r| r.rows.get(row).and_then(|r| r.get(col)).cloned())
+            .and_then(|r| r.rows().get(row).and_then(|r| r.get(col)).cloned())
             .unwrap_or_default();
         state
             .result_interaction

--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -7,7 +7,7 @@ use crate::update::action::{
 use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn result_row_count(state: &AppState) -> usize {
-    state.query.visible_result().map_or(0, |r| r.rows.len())
+    state.query.visible_result().map_or(0, |r| r.rows().len())
 }
 
 pub(super) fn result_col_count(state: &AppState) -> usize {

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -27,7 +27,7 @@ pub fn reduce_yank(
                 let content = state
                     .query
                     .visible_result()
-                    .and_then(|r| r.rows.get(row_idx))
+                    .and_then(|r| r.rows().get(row_idx))
                     .and_then(|row| row.get(col_idx))
                     .cloned();
                 if let Some(value) = content {
@@ -73,7 +73,7 @@ pub fn reduce_yank(
                 let content = state
                     .query
                     .visible_result()
-                    .and_then(|r| r.rows.get(row_idx))
+                    .and_then(|r| r.rows().get(row_idx))
                     .map(|row| {
                         row.iter()
                             .map(|v| {

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -1,5 +1,6 @@
 use unicode_casefold::UnicodeCaseFold;
 
+use crate::domain::DatabaseType;
 use crate::domain::connection::SqliteConnectionConfig;
 use crate::domain::{QueryResult, QueryValue};
 use crate::model::app_state::AppState;
@@ -56,6 +57,8 @@ pub enum EditGuardrailError {
     CellIndexOutOfBounds,
     #[error("Only text cells can be edited inline")]
     NonTextInlineEdit,
+    #[error("SQLite writes require non-NULL primary key values")]
+    SqliteNullPrimaryKey,
     #[error("{0}")]
     GuardrailBlocked(String),
 }
@@ -64,6 +67,20 @@ pub struct BulkDeletePreviewResult {
     pub preview: WritePreview,
     pub target_page: usize,
     pub target_row: Option<usize>,
+}
+
+pub fn reject_sqlite_null_pk(
+    database_type: DatabaseType,
+    pk_pairs: &[(String, QueryValue)],
+) -> Result<(), EditGuardrailError> {
+    if database_type == DatabaseType::SQLite
+        && pk_pairs
+            .iter()
+            .any(|(_, value)| matches!(value, QueryValue::Null))
+    {
+        return Err(EditGuardrailError::SqliteNullPrimaryKey);
+    }
+    Ok(())
 }
 
 // Entry checks in navigation and submit-time checks in query should both use this.
@@ -134,6 +151,7 @@ pub fn build_bulk_delete_preview(
             .ok_or(EditGuardrailError::StagedRowIndexOutOfBounds(row_idx))?;
         let pairs = build_pk_pairs(&result.columns, row, pk_cols)
             .ok_or(EditGuardrailError::StableKeyColumnsMissing)?;
+        reject_sqlite_null_pk(state.session.active_database_type_or_default(), &pairs)?;
         pk_pairs_per_row.push(pairs);
     }
 
@@ -627,6 +645,27 @@ mod tests {
                 result.preview.sql,
                 "DELETE FROM \"users\" WHERE \"id\" = '1'"
             );
+        }
+
+        #[test]
+        fn sqlite_database_type_rejects_null_primary_key_value() {
+            let mut state = editable_state(DatabaseType::SQLite);
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    "SELECT * FROM users".to_string(),
+                    vec!["id".to_string(), "name".to_string()],
+                    vec![vec![QueryValue::Null, QueryValue::text("Alice")]],
+                    10,
+                    QuerySource::Preview,
+                )));
+
+            let result = build_bulk_delete_preview(&state, &AppServices::stub());
+
+            assert!(matches!(
+                result,
+                Err(EditGuardrailError::SqliteNullPrimaryKey)
+            ));
         }
     }
 }

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -127,7 +127,7 @@ pub fn build_bulk_delete_preview(
     let mut pk_pairs_per_row: Vec<Vec<(String, QueryValue)>> = Vec::new();
     for &row_idx in state.result_interaction.staged_delete_rows() {
         let row = result
-            .values
+            .values()
             .get(row_idx)
             .ok_or(EditGuardrailError::StagedRowIndexOutOfBounds(row_idx))?;
         let pairs = build_pk_pairs(&result.columns, row, pk_cols)
@@ -150,7 +150,7 @@ pub fn build_bulk_delete_preview(
         .next()
         .unwrap();
     let (target_page, target_row) = deletion_refresh_target_bulk(
-        result.rows.len(),
+        result.rows().len(),
         staged_count,
         first_deleted_idx,
         state.query.pagination.current_page(),

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -411,6 +411,7 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
+    use crate::domain::connection::ConnectionId;
     use crate::domain::{Column, ColumnAttributes, DatabaseType, QuerySource, Table};
     use rstest::rstest;
 
@@ -586,7 +587,7 @@ mod tests {
                 DatabaseType::SQLite => "sqlite:///tmp/app.db",
             };
             state.session.activate_connection_with_dsn(
-                &crate::domain::connection::ConnectionId::from_string("test-connection"),
+                &ConnectionId::from_string("test-connection"),
                 "test",
                 database_type,
                 dsn,

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -54,6 +54,8 @@ pub enum EditGuardrailError {
     NoActiveCell,
     #[error("Cell index out of bounds")]
     CellIndexOutOfBounds,
+    #[error("Only text cells can be edited inline")]
+    NonTextInlineEdit,
     #[error("{0}")]
     GuardrailBlocked(String),
 }

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -1,7 +1,7 @@
 use unicode_casefold::UnicodeCaseFold;
 
-use crate::domain::QueryResult;
 use crate::domain::connection::SqliteConnectionConfig;
+use crate::domain::{QueryResult, QueryValue};
 use crate::model::app_state::AppState;
 use crate::model::connection::setup::{ConnectionField, ConnectionSetupState};
 use crate::policy::write::write_guardrails::{
@@ -124,10 +124,10 @@ pub fn build_bulk_delete_preview(
         other => other,
     })?;
 
-    let mut pk_pairs_per_row: Vec<Vec<(String, String)>> = Vec::new();
+    let mut pk_pairs_per_row: Vec<Vec<(String, QueryValue)>> = Vec::new();
     for &row_idx in state.result_interaction.staged_delete_rows() {
         let row = result
-            .rows
+            .values
             .get(row_idx)
             .ok_or(EditGuardrailError::StagedRowIndexOutOfBounds(row_idx))?;
         let pairs = build_pk_pairs(&result.columns, row, pk_cols)

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1823,7 +1823,7 @@ mod tests {
                 target_summary: TargetSummary {
                     schema: "public".to_string(),
                     table: "users".to_string(),
-                    key_values: vec![("id".to_string(), "2".to_string())],
+                    key_values: vec![("id".to_string(), crate::domain::QueryValue::text("2"))],
                 },
                 diff: vec![],
                 guardrail: GuardrailDecision {

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -24,7 +24,7 @@ pub use er::ErTableInfo;
 pub use foreign_key::{FkAction, ForeignKey};
 pub use index::{Index, IndexAttributes, IndexType};
 pub use metadata::{DatabaseMetadata, MetadataState};
-pub use query_result::{QueryResult, QuerySource};
+pub use query_result::{QueryResult, QuerySource, QueryValue};
 pub use rls::{RlsCommand, RlsInfo, RlsPolicy};
 pub use schema::Schema;
 pub use table::{Table, TableSignature, TableSummary};

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -38,6 +38,18 @@ impl QueryValue {
     }
 }
 
+impl From<String> for QueryValue {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<&str> for QueryValue {
+    fn from(value: &str) -> Self {
+        Self::Text(value.to_string())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QuerySource {
     Preview,

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -7,7 +7,7 @@ pub enum QueryValue {
     Null,
     Text(String),
     Blob(Vec<u8>),
-    /// Raw SQL literal emitted by a trusted database adapter parser.
+    /// Unquoted SQL literal emitted by a trusted database adapter parser.
     SqlLiteral(String),
 }
 
@@ -37,6 +37,14 @@ impl QueryValue {
                     format!("BLOB ({} bytes) {preview}", bytes.len())
                 }
             }
+        }
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Self::Text(value) | Self::SqlLiteral(value) => Some(value),
+            Self::Null | Self::Blob(_) => None,
         }
     }
 }
@@ -145,22 +153,27 @@ impl QueryResult {
         self
     }
 
+    #[must_use]
     pub fn is_error(&self) -> bool {
         self.error.is_some()
     }
 
+    #[must_use]
     pub fn rows(&self) -> &[Vec<String>] {
         &self.rows
     }
 
+    #[must_use]
     pub fn values(&self) -> &[Vec<QueryValue>] {
         &self.values
     }
 
+    #[must_use]
     pub fn row_count(&self) -> usize {
         self.row_count
     }
 
+    #[must_use]
     pub fn row_count_display(&self) -> String {
         if self.row_count == 1 {
             "1 row".to_string()
@@ -169,6 +182,7 @@ impl QueryResult {
         }
     }
 
+    #[must_use]
     pub fn value_at(&self, row: usize, col: usize) -> Option<&QueryValue> {
         self.values.get(row)?.get(col)
     }

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -1,10 +1,13 @@
 use super::CommandTag;
 
+const BLOB_PREVIEW_BYTES: usize = 8;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum QueryValue {
     Null,
     Text(String),
     Blob(Vec<u8>),
+    /// Raw SQL literal emitted by a trusted database adapter parser.
     SqlLiteral(String),
 }
 
@@ -22,31 +25,19 @@ impl QueryValue {
             Self::Blob(bytes) => {
                 let preview = bytes
                     .iter()
-                    .take(8)
+                    .take(BLOB_PREVIEW_BYTES)
                     .map(|byte| format!("{byte:02X}"))
                     .collect::<Vec<_>>()
                     .join(" ");
                 if preview.is_empty() {
                     "BLOB (0 bytes)".to_string()
-                } else if bytes.len() > 8 {
+                } else if bytes.len() > BLOB_PREVIEW_BYTES {
                     format!("BLOB ({} bytes) {preview} ...", bytes.len())
                 } else {
                     format!("BLOB ({} bytes) {preview}", bytes.len())
                 }
             }
         }
-    }
-}
-
-impl From<String> for QueryValue {
-    fn from(value: String) -> Self {
-        Self::Text(value)
-    }
-}
-
-impl From<&str> for QueryValue {
-    fn from(value: &str) -> Self {
-        Self::Text(value.to_string())
     }
 }
 

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -1,5 +1,43 @@
 use super::CommandTag;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryValue {
+    Null,
+    Text(String),
+    Blob(Vec<u8>),
+    SqlLiteral(String),
+}
+
+impl QueryValue {
+    #[must_use]
+    pub fn text(value: impl Into<String>) -> Self {
+        Self::Text(value.into())
+    }
+
+    #[must_use]
+    pub fn display_value(&self) -> String {
+        match self {
+            Self::Null => "NULL".to_string(),
+            Self::Text(value) | Self::SqlLiteral(value) => value.clone(),
+            Self::Blob(bytes) => {
+                let preview = bytes
+                    .iter()
+                    .take(8)
+                    .map(|byte| format!("{byte:02X}"))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                if preview.is_empty() {
+                    "BLOB (0 bytes)".to_string()
+                } else if bytes.len() > 8 {
+                    format!("BLOB ({} bytes) {preview} ...", bytes.len())
+                } else {
+                    format!("BLOB ({} bytes) {preview}", bytes.len())
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QuerySource {
     Preview,
@@ -11,6 +49,7 @@ pub struct QueryResult {
     pub query: String,
     pub columns: Vec<String>,
     pub rows: Vec<Vec<String>>,
+    pub values: Vec<Vec<QueryValue>>,
     pub row_count: usize,
     pub execution_time_ms: u64,
     pub source: QuerySource,
@@ -28,10 +67,41 @@ impl QueryResult {
         source: QuerySource,
     ) -> Self {
         let row_count = rows.len();
+        let values = rows
+            .iter()
+            .map(|row| row.iter().cloned().map(QueryValue::Text).collect())
+            .collect();
         Self {
             query,
             columns,
             rows,
+            values,
+            row_count,
+            execution_time_ms,
+            source,
+            error: None,
+            command_tag: None,
+        }
+    }
+
+    #[must_use]
+    pub fn success_with_values(
+        query: String,
+        columns: Vec<String>,
+        values: Vec<Vec<QueryValue>>,
+        execution_time_ms: u64,
+        source: QuerySource,
+    ) -> Self {
+        let rows = values
+            .iter()
+            .map(|row| row.iter().map(QueryValue::display_value).collect())
+            .collect();
+        let row_count = values.len();
+        Self {
+            query,
+            columns,
+            rows,
+            values,
             row_count,
             execution_time_ms,
             source,
@@ -51,6 +121,7 @@ impl QueryResult {
             query,
             columns: Vec::new(),
             rows: Vec::new(),
+            values: Vec::new(),
             row_count: 0,
             execution_time_ms,
             source,
@@ -75,6 +146,10 @@ impl QueryResult {
         } else {
             format!("{} rows", self.row_count)
         }
+    }
+
+    pub fn value_at(&self, row: usize, col: usize) -> Option<&QueryValue> {
+        self.values.get(row)?.get(col)
     }
 }
 

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -51,13 +51,13 @@ pub enum QuerySource {
 pub struct QueryResult {
     pub query: String,
     pub columns: Vec<String>,
-    pub rows: Vec<Vec<String>>,
-    pub values: Vec<Vec<QueryValue>>,
-    pub row_count: usize,
     pub execution_time_ms: u64,
     pub source: QuerySource,
     pub error: Option<String>,
     pub command_tag: Option<CommandTag>,
+    rows: Vec<Vec<String>>,
+    values: Vec<Vec<QueryValue>>,
+    row_count: usize,
 }
 
 impl QueryResult {
@@ -139,8 +139,26 @@ impl QueryResult {
         self
     }
 
+    #[must_use]
+    pub fn with_row_count(mut self, row_count: usize) -> Self {
+        self.row_count = row_count;
+        self
+    }
+
     pub fn is_error(&self) -> bool {
         self.error.is_some()
+    }
+
+    pub fn rows(&self) -> &[Vec<String>] {
+        &self.rows
+    }
+
+    pub fn values(&self) -> &[Vec<QueryValue>] {
+        &self.values
+    }
+
+    pub fn row_count(&self) -> usize {
+        self.row_count
     }
 
     pub fn row_count_display(&self) -> String {
@@ -176,8 +194,8 @@ mod tests {
 
             assert_eq!(result.query, "SELECT 1");
             assert_eq!(result.columns, vec!["id"]);
-            assert_eq!(result.rows, vec![vec!["1"]]);
-            assert_eq!(result.row_count, 1);
+            assert_eq!(result.rows(), vec![vec!["1"]]);
+            assert_eq!(result.row_count(), 1);
             assert_eq!(result.execution_time_ms, 42);
             assert_eq!(result.source, QuerySource::Adhoc);
             assert!(result.error.is_none());
@@ -195,7 +213,7 @@ mod tests {
                 QuerySource::Preview,
             );
 
-            assert_eq!(result.row_count, 3);
+            assert_eq!(result.row_count(), 3);
         }
     }
 
@@ -214,8 +232,8 @@ mod tests {
             assert!(result.is_error());
             assert_eq!(result.error.as_deref(), Some("syntax error"));
             assert!(result.columns.is_empty());
-            assert!(result.rows.is_empty());
-            assert_eq!(result.row_count, 0);
+            assert!(result.rows().is_empty());
+            assert_eq!(result.row_count(), 0);
         }
     }
 
@@ -240,9 +258,9 @@ mod tests {
         #[case(1, "1 row")]
         #[case(5, "5 rows")]
         fn formats_row_count_display(#[case] count: usize, #[case] expected: &str) {
-            let mut result =
-                QueryResult::success("SELECT".to_string(), vec![], vec![], 0, QuerySource::Adhoc);
-            result.row_count = count;
+            let result =
+                QueryResult::success("SELECT".to_string(), vec![], vec![], 0, QuerySource::Adhoc)
+                    .with_row_count(count);
 
             assert_eq!(result.row_count_display(), expected);
         }

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -4,7 +4,9 @@ use crate::app::ports::outbound::{
     DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor, SqlDialect,
 };
 use crate::domain::connection::{ConnectionProfile, DatabaseType};
-use crate::domain::{DatabaseMetadata, QueryResult, Table, TableSignature, WriteExecutionResult};
+use crate::domain::{
+    DatabaseMetadata, QueryResult, QueryValue, Table, TableSignature, WriteExecutionResult,
+};
 
 pub struct MySqlAdapter;
 
@@ -147,8 +149,8 @@ impl SqlDialect for MySqlAdapter {
         _schema: &str,
         _table: &str,
         _column: &str,
-        _new_value: &str,
-        _pk_pairs: &[(String, String)],
+        _new_value: &QueryValue,
+        _pk_pairs: &[(String, QueryValue)],
     ) -> String {
         unimplemented!("MySQL adapter not yet implemented")
     }
@@ -158,7 +160,7 @@ impl SqlDialect for MySqlAdapter {
         _database_type: DatabaseType,
         _schema: &str,
         _table: &str,
-        _pk_pairs_per_row: &[Vec<(String, String)>],
+        _pk_pairs_per_row: &[Vec<(String, QueryValue)>],
     ) -> String {
         unimplemented!("MySQL adapter not yet implemented")
     }

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -317,10 +317,9 @@ impl PostgresAdapter {
         source: QuerySource,
     ) -> QueryResult {
         let row_count = tag.affected_rows().unwrap_or(0) as usize;
-        let mut result =
-            QueryResult::success(query.to_string(), Vec::new(), Vec::new(), elapsed, source);
-        result.row_count = row_count;
-        result.with_command_tag(tag)
+        QueryResult::success(query.to_string(), Vec::new(), Vec::new(), elapsed, source)
+            .with_row_count(row_count)
+            .with_command_tag(tag)
     }
 
     fn csv_result(

--- a/src/infra/adapters/postgres/sql/dialect.rs
+++ b/src/infra/adapters/postgres/sql/dialect.rs
@@ -13,6 +13,38 @@ fn sql_literal(value: &QueryValue) -> String {
     }
 }
 
+fn equality_predicate(column: &str, value: &QueryValue) -> String {
+    let column = quote_ident(column);
+    match value {
+        QueryValue::Null => format!("{column} IS NULL"),
+        _ => format!("{column} = {}", sql_literal(value)),
+    }
+}
+
+fn row_predicate(pk_pairs: &[(String, QueryValue)]) -> String {
+    pk_pairs
+        .iter()
+        .map(|(col, val)| equality_predicate(col, val))
+        .collect::<Vec<_>>()
+        .join(" AND ")
+}
+
+fn rows_predicate(pk_pairs_per_row: &[Vec<(String, QueryValue)>]) -> String {
+    let predicates = pk_pairs_per_row
+        .iter()
+        .map(|pairs| row_predicate(pairs))
+        .collect::<Vec<_>>();
+    if predicates.len() == 1 {
+        predicates[0].clone()
+    } else {
+        predicates
+            .into_iter()
+            .map(|predicate| format!("({predicate})"))
+            .collect::<Vec<_>>()
+            .join(" OR ")
+    }
+}
+
 impl SqlDialect for PostgresAdapter {
     fn build_explain_sql(&self, _database_type: DatabaseType, query: &str) -> Option<String> {
         Some(format!("EXPLAIN {query}"))
@@ -37,7 +69,7 @@ impl SqlDialect for PostgresAdapter {
     ) -> String {
         let where_clause = pk_pairs
             .iter()
-            .map(|(col, val)| format!("{} = {}", quote_ident(col), sql_literal(val)))
+            .map(|(col, val)| equality_predicate(col, val))
             .collect::<Vec<_>>()
             .join(" AND ");
 
@@ -63,36 +95,7 @@ impl SqlDialect for PostgresAdapter {
             "pk_pairs_per_row must not be empty"
         );
 
-        let pk_count = pk_pairs_per_row[0].len();
-
-        let where_clause = if pk_count == 1 {
-            let col = quote_ident(&pk_pairs_per_row[0][0].0);
-            let values = pk_pairs_per_row
-                .iter()
-                .map(|pairs| sql_literal(&pairs[0].1))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("{col} IN ({values})")
-        } else {
-            let cols = pk_pairs_per_row[0]
-                .iter()
-                .map(|(col, _)| quote_ident(col))
-                .collect::<Vec<_>>()
-                .join(", ");
-            let rows = pk_pairs_per_row
-                .iter()
-                .map(|pairs| {
-                    let vals = pairs
-                        .iter()
-                        .map(|(_, val)| sql_literal(val))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    format!("({vals})")
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("({cols}) IN ({rows})")
-        };
+        let where_clause = rows_predicate(pk_pairs_per_row);
 
         format!(
             "DELETE FROM {}.{}\nWHERE {};",
@@ -281,21 +284,18 @@ mod tests {
         use super::*;
 
         #[test]
-        fn single_pk_single_row_returns_in_clause() {
+        fn single_pk_single_row_returns_predicate() {
             let adapter = PostgresAdapter::new();
             let rows = vec![vec![("id".to_string(), QueryValue::text("1"))]];
 
             let sql =
                 adapter.build_bulk_delete_sql(DatabaseType::PostgreSQL, "public", "users", &rows);
 
-            assert_eq!(
-                sql,
-                "DELETE FROM \"public\".\"users\"\nWHERE \"id\" IN ('1');"
-            );
+            assert_eq!(sql, "DELETE FROM \"public\".\"users\"\nWHERE \"id\" = '1';");
         }
 
         #[test]
-        fn single_pk_multiple_rows_returns_in_clause_with_all_values() {
+        fn single_pk_multiple_rows_returns_or_predicates() {
             let adapter = PostgresAdapter::new();
             let rows = vec![
                 vec![("id".to_string(), QueryValue::text("1"))],
@@ -308,12 +308,12 @@ mod tests {
 
             assert_eq!(
                 sql,
-                "DELETE FROM \"public\".\"users\"\nWHERE \"id\" IN ('1', '2', '3');"
+                "DELETE FROM \"public\".\"users\"\nWHERE (\"id\" = '1') OR (\"id\" = '2') OR (\"id\" = '3');"
             );
         }
 
         #[test]
-        fn composite_pk_returns_row_constructor_in_clause() {
+        fn composite_pk_returns_or_predicates() {
             let adapter = PostgresAdapter::new();
             let rows = vec![
                 vec![
@@ -330,18 +330,37 @@ mod tests {
 
             assert_eq!(
                 sql,
-                "DELETE FROM \"s\".\"t\"\nWHERE (\"id\", \"tenant_id\") IN (('1', 'a'), ('2', 'b'));"
+                "DELETE FROM \"s\".\"t\"\nWHERE (\"id\" = '1' AND \"tenant_id\" = 'a') OR (\"id\" = '2' AND \"tenant_id\" = 'b');"
             );
         }
 
         #[test]
-        fn null_pk_value_uses_null_literal() {
+        fn null_pk_value_uses_is_null_predicate() {
             let adapter = PostgresAdapter::new();
             let rows = vec![vec![("id".to_string(), QueryValue::Null)]];
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::PostgreSQL, "public", "t", &rows);
 
-            assert_eq!(sql, "DELETE FROM \"public\".\"t\"\nWHERE \"id\" IN (NULL);");
+            assert_eq!(sql, "DELETE FROM \"public\".\"t\"\nWHERE \"id\" IS NULL;");
+        }
+
+        #[test]
+        fn update_null_pk_value_uses_is_null_predicate() {
+            let adapter = PostgresAdapter::new();
+
+            let sql = adapter.build_update_sql(
+                DatabaseType::PostgreSQL,
+                "public",
+                "users",
+                "name",
+                &QueryValue::text("new"),
+                &[("id".into(), QueryValue::Null)],
+            );
+
+            assert_eq!(
+                sql,
+                "UPDATE \"public\".\"users\"\nSET \"name\" = 'new'\nWHERE \"id\" IS NULL;"
+            );
         }
 
         #[test]
@@ -353,7 +372,7 @@ mod tests {
 
             assert_eq!(
                 sql,
-                "DELETE FROM \"public\".\"t\"\nWHERE \"id\" IN ('O''Reilly');"
+                "DELETE FROM \"public\".\"t\"\nWHERE \"id\" = 'O''Reilly';"
             );
         }
 
@@ -364,7 +383,7 @@ mod tests {
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::PostgreSQL, "public", "t", &rows);
 
-            assert_eq!(sql, "DELETE FROM \"public\".\"t\"\nWHERE \"id\" IN ('');");
+            assert_eq!(sql, "DELETE FROM \"public\".\"t\"\nWHERE \"id\" = '';");
         }
 
         #[test]
@@ -376,7 +395,7 @@ mod tests {
 
             assert_eq!(
                 sql,
-                "DELETE FROM \"public\".\"t\"\nWHERE \"my\"\"pk\" IN ('1');"
+                "DELETE FROM \"public\".\"t\"\nWHERE \"my\"\"pk\" = '1';"
             );
         }
     }

--- a/src/infra/adapters/postgres/sql/dialect.rs
+++ b/src/infra/adapters/postgres/sql/dialect.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use crate::app::ports::outbound::SqlDialect;
 use crate::domain::{DatabaseType, QueryValue};
 
@@ -9,7 +11,13 @@ fn sql_literal(value: &QueryValue) -> String {
         QueryValue::Null => "NULL".to_string(),
         QueryValue::Text(value) => quote_literal(value),
         QueryValue::SqlLiteral(value) => value.clone(),
-        QueryValue::Blob(bytes) => quote_literal(&String::from_utf8_lossy(bytes)),
+        QueryValue::Blob(bytes) => {
+            let mut hex = String::with_capacity(bytes.len() * 2);
+            for byte in bytes {
+                let _ = write!(hex, "{byte:02x}");
+            }
+            format!("'\\x{hex}'")
+        }
     }
 }
 
@@ -419,7 +427,10 @@ mod tests {
         #[test]
         fn formats_non_text_query_values() {
             assert_eq!(sql_literal(&QueryValue::Null), "NULL");
-            assert_eq!(sql_literal(&QueryValue::Blob(vec![65, 66])), "'AB'");
+            assert_eq!(
+                sql_literal(&QueryValue::Blob(vec![0, 255, 65])),
+                "'\\x00ff41'"
+            );
             assert_eq!(sql_literal(&QueryValue::SqlLiteral("42".to_string())), "42");
         }
     }

--- a/src/infra/adapters/postgres/sql/dialect.rs
+++ b/src/infra/adapters/postgres/sql/dialect.rs
@@ -4,10 +4,11 @@ use crate::domain::{DatabaseType, QueryValue};
 use super::super::PostgresAdapter;
 use super::{quote_ident, quote_literal};
 
-fn sql_literal_or_null(value: &QueryValue) -> String {
+fn sql_literal(value: &QueryValue) -> String {
     match value {
         QueryValue::Null => "NULL".to_string(),
-        QueryValue::Text(value) | QueryValue::SqlLiteral(value) => quote_literal(value),
+        QueryValue::Text(value) => quote_literal(value),
+        QueryValue::SqlLiteral(value) => value.clone(),
         QueryValue::Blob(bytes) => quote_literal(&String::from_utf8_lossy(bytes)),
     }
 }
@@ -36,7 +37,7 @@ impl SqlDialect for PostgresAdapter {
     ) -> String {
         let where_clause = pk_pairs
             .iter()
-            .map(|(col, val)| format!("{} = {}", quote_ident(col), sql_literal_or_null(val)))
+            .map(|(col, val)| format!("{} = {}", quote_ident(col), sql_literal(val)))
             .collect::<Vec<_>>()
             .join(" AND ");
 
@@ -45,7 +46,7 @@ impl SqlDialect for PostgresAdapter {
             quote_ident(schema),
             quote_ident(table),
             quote_ident(column),
-            sql_literal_or_null(new_value),
+            sql_literal(new_value),
             where_clause
         )
     }
@@ -68,7 +69,7 @@ impl SqlDialect for PostgresAdapter {
             let col = quote_ident(&pk_pairs_per_row[0][0].0);
             let values = pk_pairs_per_row
                 .iter()
-                .map(|pairs| sql_literal_or_null(&pairs[0].1))
+                .map(|pairs| sql_literal(&pairs[0].1))
                 .collect::<Vec<_>>()
                 .join(", ");
             format!("{col} IN ({values})")
@@ -83,7 +84,7 @@ impl SqlDialect for PostgresAdapter {
                 .map(|pairs| {
                     let vals = pairs
                         .iter()
-                        .map(|(_, val)| sql_literal_or_null(val))
+                        .map(|(_, val)| sql_literal(val))
                         .collect::<Vec<_>>()
                         .join(", ");
                     format!("({vals})")
@@ -380,8 +381,8 @@ mod tests {
         }
     }
 
-    mod sql_literal_or_null_tests {
-        use super::super::sql_literal_or_null;
+    mod sql_literal_tests {
+        use super::super::sql_literal;
         use crate::domain::QueryValue;
         use rstest::rstest;
 
@@ -392,18 +393,15 @@ mod tests {
         #[case("hello", "'hello'")]
         #[case("it's", "'it''s'")]
         #[case("NULL ", "'NULL '")]
-        fn formats_sql_literal_or_null(#[case] input: &str, #[case] expected: &str) {
-            assert_eq!(sql_literal_or_null(&QueryValue::text(input)), expected);
+        fn formats_sql_literal(#[case] input: &str, #[case] expected: &str) {
+            assert_eq!(sql_literal(&QueryValue::text(input)), expected);
         }
 
         #[test]
         fn formats_non_text_query_values() {
-            assert_eq!(sql_literal_or_null(&QueryValue::Null), "NULL");
-            assert_eq!(sql_literal_or_null(&QueryValue::Blob(vec![65, 66])), "'AB'");
-            assert_eq!(
-                sql_literal_or_null(&QueryValue::SqlLiteral("42".to_string())),
-                "'42'"
-            );
+            assert_eq!(sql_literal(&QueryValue::Null), "NULL");
+            assert_eq!(sql_literal(&QueryValue::Blob(vec![65, 66])), "'AB'");
+            assert_eq!(sql_literal(&QueryValue::SqlLiteral("42".to_string())), "42");
         }
     }
 }

--- a/src/infra/adapters/postgres/sql/dialect.rs
+++ b/src/infra/adapters/postgres/sql/dialect.rs
@@ -7,7 +7,6 @@ use super::{quote_ident, quote_literal};
 fn sql_literal_or_null(value: &QueryValue) -> String {
     match value {
         QueryValue::Null => "NULL".to_string(),
-        QueryValue::Text(value) if value == "NULL" => "NULL".to_string(),
         QueryValue::Text(value) | QueryValue::SqlLiteral(value) => quote_literal(value),
         QueryValue::Blob(bytes) => quote_literal(&String::from_utf8_lossy(bytes)),
     }
@@ -122,7 +121,7 @@ mod tests {
                 "users",
                 "name",
                 &QueryValue::text("O'Reilly"),
-                &[("id".into(), "42".into())],
+                &[("id".into(), QueryValue::text("42"))],
             );
 
             assert_eq!(
@@ -141,7 +140,10 @@ mod tests {
                 "t",
                 "name",
                 &QueryValue::text("new"),
-                &[("id".into(), "1".into()), ("tenant_id".into(), "7".into())],
+                &[
+                    ("id".into(), QueryValue::text("1")),
+                    ("tenant_id".into(), QueryValue::text("7")),
+                ],
             );
 
             assert_eq!(
@@ -187,13 +189,32 @@ mod tests {
                 "public",
                 "users",
                 "name",
-                &QueryValue::text("NULL"),
-                &[("id".into(), "1".into())],
+                &QueryValue::Null,
+                &[("id".into(), QueryValue::text("1"))],
             );
 
             assert_eq!(
                 sql,
                 "UPDATE \"public\".\"users\"\nSET \"name\" = NULL\nWHERE \"id\" = '1';"
+            );
+        }
+
+        #[test]
+        fn text_null_value_generates_quoted_text() {
+            let adapter = PostgresAdapter::new();
+
+            let sql = adapter.build_update_sql(
+                DatabaseType::PostgreSQL,
+                "public",
+                "users",
+                "name",
+                &QueryValue::text("NULL"),
+                &[("id".into(), QueryValue::text("1"))],
+            );
+
+            assert_eq!(
+                sql,
+                "UPDATE \"public\".\"users\"\nSET \"name\" = 'NULL'\nWHERE \"id\" = '1';"
             );
         }
 
@@ -207,7 +228,7 @@ mod tests {
                 "users",
                 "name",
                 &QueryValue::text(""),
-                &[("id".into(), "1".into())],
+                &[("id".into(), QueryValue::text("1"))],
             );
 
             assert_eq!(
@@ -226,7 +247,7 @@ mod tests {
                 "users",
                 "my\"col",
                 &QueryValue::text("val"),
-                &[("id".into(), "1".into())],
+                &[("id".into(), QueryValue::text("1"))],
             );
 
             assert_eq!(
@@ -245,7 +266,7 @@ mod tests {
                 "users",
                 "path",
                 &QueryValue::text("C:\\Users\\test"),
-                &[("id".into(), "1".into())],
+                &[("id".into(), QueryValue::text("1"))],
             );
 
             assert_eq!(
@@ -315,7 +336,7 @@ mod tests {
         #[test]
         fn null_pk_value_uses_null_literal() {
             let adapter = PostgresAdapter::new();
-            let rows = vec![vec![("id".to_string(), QueryValue::text("NULL"))]];
+            let rows = vec![vec![("id".to_string(), QueryValue::Null)]];
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::PostgreSQL, "public", "t", &rows);
 
@@ -365,7 +386,7 @@ mod tests {
         use rstest::rstest;
 
         #[rstest]
-        #[case("NULL", "NULL")]
+        #[case("NULL", "'NULL'")]
         #[case("null", "'null'")]
         #[case("", "''")]
         #[case("hello", "'hello'")]
@@ -373,6 +394,16 @@ mod tests {
         #[case("NULL ", "'NULL '")]
         fn formats_sql_literal_or_null(#[case] input: &str, #[case] expected: &str) {
             assert_eq!(sql_literal_or_null(&QueryValue::text(input)), expected);
+        }
+
+        #[test]
+        fn formats_non_text_query_values() {
+            assert_eq!(sql_literal_or_null(&QueryValue::Null), "NULL");
+            assert_eq!(sql_literal_or_null(&QueryValue::Blob(vec![65, 66])), "'AB'");
+            assert_eq!(
+                sql_literal_or_null(&QueryValue::SqlLiteral("42".to_string())),
+                "'42'"
+            );
         }
     }
 }

--- a/src/infra/adapters/postgres/sql/dialect.rs
+++ b/src/infra/adapters/postgres/sql/dialect.rs
@@ -1,14 +1,15 @@
 use crate::app::ports::outbound::SqlDialect;
-use crate::domain::DatabaseType;
+use crate::domain::{DatabaseType, QueryValue};
 
 use super::super::PostgresAdapter;
 use super::{quote_ident, quote_literal};
 
-fn sql_literal_or_null(value: &str) -> String {
-    if value == "NULL" {
-        "NULL".to_string()
-    } else {
-        quote_literal(value)
+fn sql_literal_or_null(value: &QueryValue) -> String {
+    match value {
+        QueryValue::Null => "NULL".to_string(),
+        QueryValue::Text(value) if value == "NULL" => "NULL".to_string(),
+        QueryValue::Text(value) | QueryValue::SqlLiteral(value) => quote_literal(value),
+        QueryValue::Blob(bytes) => quote_literal(&String::from_utf8_lossy(bytes)),
     }
 }
 
@@ -31,12 +32,12 @@ impl SqlDialect for PostgresAdapter {
         schema: &str,
         table: &str,
         column: &str,
-        new_value: &str,
-        pk_pairs: &[(String, String)],
+        new_value: &QueryValue,
+        pk_pairs: &[(String, QueryValue)],
     ) -> String {
         let where_clause = pk_pairs
             .iter()
-            .map(|(col, val)| format!("{} = {}", quote_ident(col), quote_literal(val)))
+            .map(|(col, val)| format!("{} = {}", quote_ident(col), sql_literal_or_null(val)))
             .collect::<Vec<_>>()
             .join(" AND ");
 
@@ -55,7 +56,7 @@ impl SqlDialect for PostgresAdapter {
         _database_type: DatabaseType,
         schema: &str,
         table: &str,
-        pk_pairs_per_row: &[Vec<(String, String)>],
+        pk_pairs_per_row: &[Vec<(String, QueryValue)>],
     ) -> String {
         assert!(
             !pk_pairs_per_row.is_empty(),
@@ -106,7 +107,7 @@ impl SqlDialect for PostgresAdapter {
 mod tests {
     use crate::adapters::postgres::PostgresAdapter;
     use crate::app::ports::outbound::SqlDialect;
-    use crate::domain::DatabaseType;
+    use crate::domain::{DatabaseType, QueryValue};
 
     mod sql_dialect_update {
         use super::*;
@@ -120,7 +121,7 @@ mod tests {
                 "public",
                 "users",
                 "name",
-                "O'Reilly",
+                &QueryValue::text("O'Reilly"),
                 &[("id".into(), "42".into())],
             );
 
@@ -139,7 +140,7 @@ mod tests {
                 "s",
                 "t",
                 "name",
-                "new",
+                &QueryValue::text("new"),
                 &[("id".into(), "1".into()), ("tenant_id".into(), "7".into())],
             );
 
@@ -186,7 +187,7 @@ mod tests {
                 "public",
                 "users",
                 "name",
-                "NULL",
+                &QueryValue::text("NULL"),
                 &[("id".into(), "1".into())],
             );
 
@@ -205,7 +206,7 @@ mod tests {
                 "public",
                 "users",
                 "name",
-                "",
+                &QueryValue::text(""),
                 &[("id".into(), "1".into())],
             );
 
@@ -224,7 +225,7 @@ mod tests {
                 "public",
                 "users",
                 "my\"col",
-                "val",
+                &QueryValue::text("val"),
                 &[("id".into(), "1".into())],
             );
 
@@ -243,7 +244,7 @@ mod tests {
                 "public",
                 "users",
                 "path",
-                "C:\\Users\\test",
+                &QueryValue::text("C:\\Users\\test"),
                 &[("id".into(), "1".into())],
             );
 
@@ -260,7 +261,7 @@ mod tests {
         #[test]
         fn single_pk_single_row_returns_in_clause() {
             let adapter = PostgresAdapter::new();
-            let rows = vec![vec![("id".to_string(), "1".to_string())]];
+            let rows = vec![vec![("id".to_string(), QueryValue::text("1"))]];
 
             let sql =
                 adapter.build_bulk_delete_sql(DatabaseType::PostgreSQL, "public", "users", &rows);
@@ -275,9 +276,9 @@ mod tests {
         fn single_pk_multiple_rows_returns_in_clause_with_all_values() {
             let adapter = PostgresAdapter::new();
             let rows = vec![
-                vec![("id".to_string(), "1".to_string())],
-                vec![("id".to_string(), "2".to_string())],
-                vec![("id".to_string(), "3".to_string())],
+                vec![("id".to_string(), QueryValue::text("1"))],
+                vec![("id".to_string(), QueryValue::text("2"))],
+                vec![("id".to_string(), QueryValue::text("3"))],
             ];
 
             let sql =
@@ -294,12 +295,12 @@ mod tests {
             let adapter = PostgresAdapter::new();
             let rows = vec![
                 vec![
-                    ("id".to_string(), "1".to_string()),
-                    ("tenant_id".to_string(), "a".to_string()),
+                    ("id".to_string(), QueryValue::text("1")),
+                    ("tenant_id".to_string(), QueryValue::text("a")),
                 ],
                 vec![
-                    ("id".to_string(), "2".to_string()),
-                    ("tenant_id".to_string(), "b".to_string()),
+                    ("id".to_string(), QueryValue::text("2")),
+                    ("tenant_id".to_string(), QueryValue::text("b")),
                 ],
             ];
 
@@ -314,7 +315,7 @@ mod tests {
         #[test]
         fn null_pk_value_uses_null_literal() {
             let adapter = PostgresAdapter::new();
-            let rows = vec![vec![("id".to_string(), "NULL".to_string())]];
+            let rows = vec![vec![("id".to_string(), QueryValue::text("NULL"))]];
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::PostgreSQL, "public", "t", &rows);
 
@@ -324,7 +325,7 @@ mod tests {
         #[test]
         fn pk_value_with_quotes_is_escaped() {
             let adapter = PostgresAdapter::new();
-            let rows = vec![vec![("id".to_string(), "O'Reilly".to_string())]];
+            let rows = vec![vec![("id".to_string(), QueryValue::text("O'Reilly"))]];
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::PostgreSQL, "public", "t", &rows);
 
@@ -337,7 +338,7 @@ mod tests {
         #[test]
         fn empty_string_pk_value_returns_empty_literal() {
             let adapter = PostgresAdapter::new();
-            let rows = vec![vec![("id".to_string(), String::new())]];
+            let rows = vec![vec![("id".to_string(), QueryValue::text(""))]];
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::PostgreSQL, "public", "t", &rows);
 
@@ -347,7 +348,7 @@ mod tests {
         #[test]
         fn build_bulk_delete_sql_escapes_column_name() {
             let adapter = PostgresAdapter::new();
-            let rows = vec![vec![("my\"pk".to_string(), "1".to_string())]];
+            let rows = vec![vec![("my\"pk".to_string(), QueryValue::text("1"))]];
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::PostgreSQL, "public", "t", &rows);
 
@@ -360,6 +361,7 @@ mod tests {
 
     mod sql_literal_or_null_tests {
         use super::super::sql_literal_or_null;
+        use crate::domain::QueryValue;
         use rstest::rstest;
 
         #[rstest]
@@ -370,7 +372,7 @@ mod tests {
         #[case("it's", "'it''s'")]
         #[case("NULL ", "'NULL '")]
         fn formats_sql_literal_or_null(#[case] input: &str, #[case] expected: &str) {
-            assert_eq!(sql_literal_or_null(input), expected);
+            assert_eq!(sql_literal_or_null(&QueryValue::text(input)), expected);
         }
     }
 }

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -346,7 +346,7 @@ mod tests {
         );
         assert_eq!(
             delete_sql,
-            "DELETE FROM \"public\".\"users\"\nWHERE \"id\" IN ('1');"
+            "DELETE FROM \"public\".\"users\"\nWHERE \"id\" = '1';"
         );
         assert!(ddl.contains("CREATE TABLE \"main\".\"users\""));
     }
@@ -372,7 +372,7 @@ mod tests {
             update_sql,
             "UPDATE \"users\"\nSET \"name\" = 'Bob'\nWHERE \"id\" = '1';"
         );
-        assert_eq!(delete_sql, "DELETE FROM \"users\"\nWHERE \"id\" IN ('1');");
+        assert_eq!(delete_sql, "DELETE FROM \"users\"\nWHERE \"id\" = '1';");
         assert!(ddl.contains("CREATE TABLE \"users\""));
         assert!(!ddl.contains("\"main\".\"users\""));
     }

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -459,7 +459,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.columns, vec!["value"]);
-        assert_eq!(result.rows, vec![vec!["1".to_string()]]);
+        assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
     }
 
     #[tokio::test]

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -5,7 +5,9 @@ use crate::app::ports::outbound::{
     DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor, SqlDialect,
 };
 use crate::domain::connection::{ConnectionProfile, DatabaseType};
-use crate::domain::{DatabaseMetadata, QueryResult, Table, TableSignature, WriteExecutionResult};
+use crate::domain::{
+    DatabaseMetadata, QueryResult, QueryValue, Table, TableSignature, WriteExecutionResult,
+};
 use async_trait::async_trait;
 
 use super::postgres::PostgresAdapter;
@@ -219,8 +221,8 @@ impl SqlDialect for DbAdapterRegistry {
         schema: &str,
         table: &str,
         column: &str,
-        new_value: &str,
-        pk_pairs: &[(String, String)],
+        new_value: &QueryValue,
+        pk_pairs: &[(String, QueryValue)],
     ) -> String {
         match database_type {
             DatabaseType::PostgreSQL => self.postgres.build_update_sql(
@@ -247,7 +249,7 @@ impl SqlDialect for DbAdapterRegistry {
         database_type: DatabaseType,
         schema: &str,
         table: &str,
-        pk_pairs_per_row: &[Vec<(String, String)>],
+        pk_pairs_per_row: &[Vec<(String, QueryValue)>],
     ) -> String {
         match database_type {
             DatabaseType::PostgreSQL => {
@@ -267,7 +269,7 @@ mod tests {
     use super::*;
     use crate::adapters::test_support::make_sqlite_db;
     use crate::domain::connection::SslMode;
-    use crate::domain::{Column, ColumnAttributes};
+    use crate::domain::{Column, ColumnAttributes, QueryValue};
 
     fn make_table() -> Table {
         Table {
@@ -324,14 +326,14 @@ mod tests {
     #[test]
     fn postgres_sql_generation_keeps_schema_qualified_sql() {
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
-        let rows = vec![vec![("id".to_string(), "1".to_string())]];
+        let rows = vec![vec![("id".to_string(), QueryValue::text("1"))]];
 
         let update_sql = registry.build_update_sql(
             DatabaseType::PostgreSQL,
             "public",
             "users",
             "name",
-            "Bob",
+            &QueryValue::text("Bob"),
             &[("id".into(), "1".into())],
         );
         let delete_sql =
@@ -352,14 +354,14 @@ mod tests {
     #[test]
     fn sqlite_sql_generation_omits_schema_qualification() {
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
-        let rows = vec![vec![("id".to_string(), "1".to_string())]];
+        let rows = vec![vec![("id".to_string(), QueryValue::text("1"))]];
 
         let update_sql = registry.build_update_sql(
             DatabaseType::SQLite,
             "main",
             "users",
             "name",
-            "Bob",
+            &QueryValue::text("Bob"),
             &[("id".into(), "1".into())],
         );
         let delete_sql =

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -334,7 +334,7 @@ mod tests {
             "users",
             "name",
             &QueryValue::text("Bob"),
-            &[("id".into(), "1".into())],
+            &[("id".into(), QueryValue::text("1"))],
         );
         let delete_sql =
             registry.build_bulk_delete_sql(DatabaseType::PostgreSQL, "public", "users", &rows);
@@ -362,7 +362,7 @@ mod tests {
             "users",
             "name",
             &QueryValue::text("Bob"),
-            &[("id".into(), "1".into())],
+            &[("id".into(), QueryValue::text("1"))],
         );
         let delete_sql =
             registry.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);

--- a/src/infra/adapters/sqlite/cli.rs
+++ b/src/infra/adapters/sqlite/cli.rs
@@ -57,6 +57,23 @@ impl SqliteCli {
         Ok(output.stdout)
     }
 
+    pub(super) async fn execute_quote(
+        &self,
+        path: &str,
+        sql: &str,
+        read_only: bool,
+    ) -> Result<String, DbOperationError> {
+        let mut args = vec!["-batch", "-bail", "-quote", "-header"];
+        if read_only {
+            args.push("-readonly");
+        }
+        let output = self.run(path, &args, sql).await?;
+        if !output.status.success() {
+            return Err(DbOperationError::QueryFailed(output.stderr));
+        }
+        Ok(output.stdout)
+    }
+
     pub(super) async fn export_csv(
         &self,
         path: &str,

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -812,6 +812,12 @@ fn parse_quoted_value(value: &str) -> Result<QueryValue, DbOperationError> {
             &value[2..value.len() - 1],
         )?));
     }
+    if value == "Inf" {
+        return Ok(QueryValue::SqlLiteral("1e999".to_string()));
+    }
+    if value == "-Inf" {
+        return Ok(QueryValue::SqlLiteral("-1e999".to_string()));
+    }
     Ok(QueryValue::SqlLiteral(value.to_string()))
 }
 
@@ -1563,6 +1569,24 @@ mod tests {
             assert_eq!(
                 result.value_at(0, 3),
                 Some(&QueryValue::Blob(vec![0, 255, 65]))
+            );
+        }
+
+        #[test]
+        fn quoted_to_query_result_normalizes_infinite_numeric_literals() {
+            let quoted = "'pos','neg'\nInf,-Inf\n";
+
+            let result =
+                quoted_to_query_result("SELECT 1e999, -1e999", quoted, QuerySource::Adhoc, 1)
+                    .unwrap();
+
+            assert_eq!(
+                result.value_at(0, 0),
+                Some(&QueryValue::SqlLiteral("1e999".to_string()))
+            );
+            assert_eq!(
+                result.value_at(0, 1),
+                Some(&QueryValue::SqlLiteral("-1e999".to_string()))
             );
         }
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -9,8 +9,8 @@ use serde::Deserialize;
 use crate::app::ports::outbound::{DbOperationError, MetadataProvider, QueryExecutor};
 use crate::domain::{
     Column, ColumnAttributes, CommandTag, DatabaseMetadata, FkAction, ForeignKey, Index,
-    IndexAttributes, IndexType, QueryResult, QuerySource, Schema, Table, TableSignature,
-    TableSummary, WriteExecutionResult,
+    IndexAttributes, IndexType, QueryResult, QuerySource, QueryValue, Schema, Table,
+    TableSignature, TableSummary, WriteExecutionResult,
 };
 
 mod cli;
@@ -164,11 +164,11 @@ impl SqliteAdapter {
         source: QuerySource,
         read_only: bool,
     ) -> Result<QueryResult, DbOperationError> {
-        self.execute_csv_query_with_display_query(path, query, query, source, read_only)
+        self.execute_quoted_query_with_display_query(path, query, query, source, read_only)
             .await
     }
 
-    async fn execute_csv_query_with_display_query(
+    async fn execute_quoted_query_with_display_query(
         &self,
         path: &str,
         execution_query: &str,
@@ -183,10 +183,10 @@ impl SqliteAdapter {
         let start = Instant::now();
         let stdout = self
             .cli
-            .execute_csv(path, execution_query, read_only)
+            .execute_quote(path, execution_query, read_only)
             .await?;
         let elapsed = start.elapsed().as_millis() as u64;
-        let mut result = csv_to_query_result(execution_query, &stdout, source, elapsed)?;
+        let mut result = quoted_to_query_result(execution_query, &stdout, source, elapsed)?;
         result.query = display_query.to_string();
         Ok(result)
     }
@@ -704,43 +704,146 @@ fn count_result_statements(sql: &str) -> usize {
         .count()
 }
 
-fn extract_last_csv_block<'a>(stdout: &'a str, sql: &str) -> &'a str {
-    let mut reader = csv::ReaderBuilder::new()
-        .has_headers(false)
-        .flexible(true)
-        .from_reader(stdout.as_bytes());
-    let mut record = csv::ByteRecord::new();
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QuotedRecord {
+    offset: usize,
+    values: Vec<QueryValue>,
+}
+
+fn split_quoted_records(stdout: &str) -> Vec<(usize, String)> {
     let mut records = Vec::new();
-    loop {
-        let position = reader.position().clone();
-        match reader.read_byte_record(&mut record) {
-            Ok(true) => records.push((position.byte() as usize, record.clone())),
-            Ok(false) => break,
-            Err(_) => return stdout,
+    let mut start = 0usize;
+    let mut in_quote = false;
+    let bytes = stdout.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' if in_quote && i + 1 < bytes.len() && bytes[i + 1] == b'\'' => {
+                i += 2;
+            }
+            b'\'' => {
+                in_quote = !in_quote;
+                i += 1;
+            }
+            b'\n' if !in_quote => {
+                records.push((start, stdout[start..i].trim_end_matches('\r').to_string()));
+                start = i + 1;
+                i += 1;
+            }
+            _ => i += 1,
         }
     }
+    if start < stdout.len() {
+        records.push((start, stdout[start..].trim_end_matches('\r').to_string()));
+    }
+    records.retain(|(_, record)| !record.is_empty());
+    records
+}
 
+fn split_quoted_fields(record: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut start = 0usize;
+    let mut in_quote = false;
+    let bytes = record.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\'' if in_quote && i + 1 < bytes.len() && bytes[i + 1] == b'\'' => {
+                i += 2;
+            }
+            b'\'' => {
+                in_quote = !in_quote;
+                i += 1;
+            }
+            b',' if !in_quote => {
+                fields.push(record[start..i].to_string());
+                start = i + 1;
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    fields.push(record[start..].to_string());
+    fields
+}
+
+fn unquote_sql_text(value: &str) -> String {
+    value[1..value.len() - 1].replace("''", "'")
+}
+
+fn decode_hex_bytes(hex: &str) -> Result<Vec<u8>, DbOperationError> {
+    if !hex.len().is_multiple_of(2) {
+        return Err(DbOperationError::MetadataParseFailed(
+            "invalid SQLite BLOB hex literal".to_string(),
+        ));
+    }
+    let mut bytes = Vec::with_capacity(hex.len() / 2);
+    let mut chars = hex.as_bytes().chunks_exact(2);
+    for pair in &mut chars {
+        let raw = std::str::from_utf8(pair)
+            .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
+        let byte = u8::from_str_radix(raw, 16)
+            .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
+        bytes.push(byte);
+    }
+    Ok(bytes)
+}
+
+fn parse_quoted_value(value: &str) -> Result<QueryValue, DbOperationError> {
+    if value == "NULL" {
+        return Ok(QueryValue::Null);
+    }
+    if value.starts_with('\'') && value.ends_with('\'') && value.len() >= 2 {
+        return Ok(QueryValue::Text(unquote_sql_text(value)));
+    }
+    if value.len() >= 3
+        && value.as_bytes()[1] == b'\''
+        && value.ends_with('\'')
+        && value.as_bytes()[0].eq_ignore_ascii_case(&b'X')
+    {
+        return Ok(QueryValue::Blob(decode_hex_bytes(
+            &value[2..value.len() - 1],
+        )?));
+    }
+    Ok(QueryValue::SqlLiteral(value.to_string()))
+}
+
+fn parse_quoted_records(stdout: &str) -> Result<Vec<QuotedRecord>, DbOperationError> {
+    split_quoted_records(stdout)
+        .into_iter()
+        .map(|(offset, record)| {
+            split_quoted_fields(&record)
+                .into_iter()
+                .map(|field| parse_quoted_value(&field))
+                .collect::<Result<Vec<_>, _>>()
+                .map(|values| QuotedRecord { offset, values })
+        })
+        .collect()
+}
+
+fn extract_last_quoted_block<'a>(stdout: &'a str, sql: &str) -> Result<&'a str, DbOperationError> {
+    let records = parse_quoted_records(stdout)?;
     if records.len() <= 2 {
-        return stdout;
+        return Ok(stdout);
     }
 
     let expected_sets = count_result_statements(sql);
-    let first_header = &records[0].1;
+    let first_header = &records[0].values;
     let mut current_fc = first_header.len();
     let mut known_headers = vec![first_header.clone()];
     let mut last_header_idx = 0;
     let mut data_rows_since_header = 0usize;
 
-    for (i, (_, record)) in records.iter().enumerate().skip(1) {
-        let fc = record.len();
+    for (i, record) in records.iter().enumerate().skip(1) {
+        let fc = record.values.len();
         if fc != current_fc {
             last_header_idx = i;
             current_fc = fc;
             data_rows_since_header = 0;
-            if !known_headers.contains(record) {
-                known_headers.push(record.clone());
+            if !known_headers.contains(&record.values) {
+                known_headers.push(record.values.clone());
             }
-        } else if known_headers.contains(record) {
+        } else if known_headers.contains(&record.values) {
             last_header_idx = i;
             data_rows_since_header = 0;
         } else if expected_sets > 1
@@ -748,7 +851,7 @@ fn extract_last_csv_block<'a>(stdout: &'a str, sql: &str) -> &'a str {
             && known_headers.len() < expected_sets
         {
             last_header_idx = i;
-            known_headers.push(record.clone());
+            known_headers.push(record.values.clone());
             data_rows_since_header = 0;
         } else {
             data_rows_since_header += 1;
@@ -756,13 +859,13 @@ fn extract_last_csv_block<'a>(stdout: &'a str, sql: &str) -> &'a str {
     }
 
     if last_header_idx == 0 {
-        return stdout;
+        return Ok(stdout);
     }
 
-    &stdout[records[last_header_idx].0..]
+    Ok(&stdout[records[last_header_idx].offset..])
 }
 
-fn csv_to_query_result(
+fn quoted_to_query_result(
     query: &str,
     stdout: &str,
     source: QuerySource,
@@ -779,24 +882,32 @@ fn csv_to_query_result(
         ));
     }
 
-    let csv_block = if count_result_statements(query) <= 1 {
+    let quoted_block = if count_result_statements(query) <= 1 {
         stdout
     } else {
-        extract_last_csv_block(stdout, query)
+        extract_last_quoted_block(stdout, query)?
     };
-    let mut reader = csv::ReaderBuilder::new()
-        .has_headers(true)
-        .from_reader(csv_block.as_bytes());
-    let columns = reader.headers()?.iter().map(ToString::to_string).collect();
-    let mut rows = Vec::new();
-    for result in reader.records() {
-        rows.push(result?.iter().map(ToString::to_string).collect());
-    }
+    let mut records = parse_quoted_records(quoted_block)?;
+    let Some(header) = records.first() else {
+        return Ok(QueryResult::success(
+            query.to_string(),
+            Vec::new(),
+            Vec::new(),
+            execution_time_ms,
+            source,
+        ));
+    };
+    let columns = header
+        .values
+        .iter()
+        .map(QueryValue::display_value)
+        .collect();
+    let values = records.drain(1..).map(|record| record.values).collect();
 
-    Ok(QueryResult::success(
+    Ok(QueryResult::success_with_values(
         query.to_string(),
         columns,
-        rows,
+        values,
         execution_time_ms,
         source,
     ))
@@ -811,15 +922,8 @@ fn strip_sqlite_probes(
     }
 
     let (stmt_col, changes_col) = sqlite_probe_columns(marker);
-    let mut reader = csv::ReaderBuilder::new()
-        .has_headers(false)
-        .flexible(true)
-        .from_reader(stdout.as_bytes());
-    let mut record = csv::ByteRecord::new();
-    let mut records = Vec::new();
-    while reader.read_byte_record(&mut record)? {
-        records.push(record.clone());
-    }
+    let raw_records = split_quoted_records(stdout);
+    let records = parse_quoted_records(stdout)?;
 
     let mut changes = HashMap::new();
     let mut kept = Vec::new();
@@ -827,9 +931,9 @@ fn strip_sqlite_probes(
     let mut index = 0;
     while index < records.len() {
         let record = &records[index];
-        if record.len() == 2
-            && record.get(0) == Some(stmt_col.as_bytes())
-            && record.get(1) == Some(changes_col.as_bytes())
+        if record.values.len() == 2
+            && record.values[0].display_value() == stmt_col
+            && record.values[1].display_value() == changes_col
         {
             removed_probe = true;
             let value = records.get(index + 1).ok_or_else(|| {
@@ -838,18 +942,18 @@ fn strip_sqlite_probes(
                 )
             })?;
             let stmt_index = value
-                .get(0)
-                .and_then(|raw| std::str::from_utf8(raw).ok())
-                .and_then(|raw| raw.parse::<usize>().ok())
+                .values
+                .first()
+                .and_then(|raw| raw.display_value().parse::<usize>().ok())
                 .ok_or_else(|| {
                     DbOperationError::CommandTagParseFailed(
                         "invalid SQLite statement probe index".to_string(),
                     )
                 })?;
             let affected_rows = value
+                .values
                 .get(1)
-                .and_then(|raw| std::str::from_utf8(raw).ok())
-                .and_then(|raw| raw.parse::<usize>().ok())
+                .and_then(|raw| raw.display_value().parse::<usize>().ok())
                 .ok_or_else(|| {
                     DbOperationError::CommandTagParseFailed(
                         "invalid SQLite statement probe changes".to_string(),
@@ -858,7 +962,7 @@ fn strip_sqlite_probes(
             changes.insert(stmt_index, affected_rows);
             index += 2;
         } else {
-            kept.push(record.clone());
+            kept.push(raw_records[index].1.clone());
             index += 1;
         }
     }
@@ -867,19 +971,7 @@ fn strip_sqlite_probes(
         return Ok((stdout.to_string(), changes));
     }
 
-    let mut writer = csv::WriterBuilder::new()
-        .has_headers(false)
-        .flexible(true)
-        .from_writer(Vec::new());
-    for record in kept {
-        writer.write_byte_record(&record)?;
-    }
-    let bytes = writer.into_inner().map_err(|error| {
-        DbOperationError::QueryFailed(format!("Failed to write filtered SQLite CSV: {error}"))
-    })?;
-    String::from_utf8(bytes)
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
-        .map(|filtered| (filtered, changes))
+    Ok((kept.join("\n"), changes))
 }
 
 fn first_csv_cell(stdout: &str) -> Result<String, DbOperationError> {
@@ -1224,7 +1316,7 @@ impl QueryExecutor for SqliteAdapter {
         let start = Instant::now();
         let stdout = self
             .cli
-            .execute_csv(path, &execution_query, read_only)
+            .execute_quote(path, &execution_query, read_only)
             .await?;
         let elapsed = start.elapsed().as_millis() as u64;
         let (stdout, changes) = strip_sqlite_probes(&stdout, &marker)?;
@@ -1243,7 +1335,7 @@ impl QueryExecutor for SqliteAdapter {
             ));
         }
 
-        let mut result = csv_to_query_result(query, &stdout, QuerySource::Adhoc, elapsed)?;
+        let mut result = quoted_to_query_result(query, &stdout, QuerySource::Adhoc, elapsed)?;
         if let Some(tag) = tag {
             result = result.with_command_tag(tag);
         } else if statements.iter().any(|stmt| statement_returns_rows(stmt)) {
@@ -1393,28 +1485,12 @@ mod tests {
         use super::*;
 
         #[test]
-        fn csv_to_query_result_preserves_quoted_newline_for_single_statement() {
-            let csv = "body,marker\n\"line 1\nline 2\",ok\n";
+        fn quoted_to_query_result_preserves_newline_for_single_statement() {
+            let quoted = "'body','marker'\n'line 1\nline 2','ok'\n";
 
-            let result =
-                csv_to_query_result("SELECT body, marker FROM notes", csv, QuerySource::Adhoc, 1)
-                    .unwrap();
-
-            assert_eq!(result.columns, vec!["body", "marker"]);
-            assert_eq!(
-                result.rows,
-                vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
-            );
-        }
-
-        #[test]
-        fn csv_to_query_result_uses_last_result_set_for_multi_select() {
-            let sqlite_csv_with_ignored_first_result_set =
-                "ignored\n1\nbody,marker\n\"line 1\nline 2\",ok\n";
-
-            let result = csv_to_query_result(
-                "SELECT 1 AS ignored; SELECT body, marker FROM notes",
-                sqlite_csv_with_ignored_first_result_set,
+            let result = quoted_to_query_result(
+                "SELECT body, marker FROM notes",
+                quoted,
                 QuerySource::Adhoc,
                 1,
             )
@@ -1428,6 +1504,58 @@ mod tests {
         }
 
         #[test]
+        fn quoted_to_query_result_uses_last_result_set_for_multi_select() {
+            let sqlite_output_with_ignored_first_result_set =
+                "'ignored'\n1\n'body','marker'\n'line 1\nline 2','ok'\n";
+
+            let result = quoted_to_query_result(
+                "SELECT 1 AS ignored; SELECT body, marker FROM notes",
+                sqlite_output_with_ignored_first_result_set,
+                QuerySource::Adhoc,
+                1,
+            )
+            .unwrap();
+
+            assert_eq!(result.columns, vec!["body", "marker"]);
+            assert_eq!(
+                result.rows,
+                vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
+            );
+        }
+
+        #[test]
+        fn quoted_to_query_result_preserves_sqlite_value_kinds() {
+            let quoted = "'a','b','c','d'\nNULL,'','NULL',X'00FF41'\n";
+
+            let result =
+                quoted_to_query_result("SELECT a, b, c, d FROM t", quoted, QuerySource::Adhoc, 1)
+                    .unwrap();
+
+            assert_eq!(
+                result.rows,
+                vec![vec![
+                    "NULL".to_string(),
+                    String::new(),
+                    "NULL".to_string(),
+                    "BLOB (3 bytes) 00 FF 41".to_string()
+                ]]
+            );
+            assert!(matches!(result.value_at(0, 0), Some(QueryValue::Null)));
+            assert_eq!(
+                result.value_at(0, 1),
+                Some(&QueryValue::Text(String::new()))
+            );
+            assert_eq!(
+                result.value_at(0, 2),
+                Some(&QueryValue::Text("NULL".to_string()))
+            );
+            assert_eq!(
+                result.value_at(0, 3),
+                Some(&QueryValue::Blob(vec![0, 255, 65]))
+            );
+        }
+
+        #[test]
         fn parse_affected_rows_reads_trailing_changes_cell() {
             assert_eq!(parse_affected_rows("changes()\n3\n").unwrap(), 3);
         }
@@ -1435,12 +1563,12 @@ mod tests {
         #[test]
         fn strip_sqlite_probes_removes_probe_result_sets() {
             let marker = "probe";
-            let stdout = "id,name\n1,Alice\nprobe_stmt,probe_changes\n0,2\nvalue\n42\n";
+            let stdout = "'id','name'\n1,'Alice'\n'probe_stmt','probe_changes'\n0,2\n'value'\n42\n";
 
             let (filtered, changes) = strip_sqlite_probes(stdout, marker).unwrap();
 
             assert_eq!(changes.get(&0), Some(&2));
-            assert_eq!(filtered, "id,name\n1,Alice\nvalue\n42\n");
+            assert_eq!(filtered, "'id','name'\n1,'Alice'\n'value'\n42");
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -157,7 +157,7 @@ impl SqliteAdapter {
             .unwrap_or_default()
     }
 
-    async fn execute_csv_query(
+    async fn execute_quoted_query(
         &self,
         path: &str,
         query: &str,
@@ -710,11 +710,11 @@ struct QuotedRecord {
     values: Vec<QueryValue>,
 }
 
-fn split_quoted_records(stdout: &str) -> Vec<(usize, String)> {
-    let mut records = Vec::new();
+fn split_outside_sqlite_quotes(input: &str, delimiter: u8) -> Vec<(usize, String)> {
+    let mut segments = Vec::new();
     let mut start = 0usize;
     let mut in_quote = false;
-    let bytes = stdout.as_bytes();
+    let bytes = input.as_bytes();
     let mut i = 0usize;
     while i < bytes.len() {
         match bytes[i] {
@@ -725,46 +725,32 @@ fn split_quoted_records(stdout: &str) -> Vec<(usize, String)> {
                 in_quote = !in_quote;
                 i += 1;
             }
-            b'\n' if !in_quote => {
-                records.push((start, stdout[start..i].trim_end_matches('\r').to_string()));
+            byte if byte == delimiter && !in_quote => {
+                segments.push((start, input[start..i].to_string()));
                 start = i + 1;
                 i += 1;
             }
             _ => i += 1,
         }
     }
-    if start < stdout.len() {
-        records.push((start, stdout[start..].trim_end_matches('\r').to_string()));
-    }
+    segments.push((start, input[start..].to_string()));
+    segments
+}
+
+fn split_quoted_records(stdout: &str) -> Vec<(usize, String)> {
+    let mut records = split_outside_sqlite_quotes(stdout, b'\n')
+        .into_iter()
+        .map(|(offset, record)| (offset, record.trim_end_matches('\r').to_string()))
+        .collect::<Vec<_>>();
     records.retain(|(_, record)| !record.is_empty());
     records
 }
 
 fn split_quoted_fields(record: &str) -> Vec<String> {
-    let mut fields = Vec::new();
-    let mut start = 0usize;
-    let mut in_quote = false;
-    let bytes = record.as_bytes();
-    let mut i = 0usize;
-    while i < bytes.len() {
-        match bytes[i] {
-            b'\'' if in_quote && i + 1 < bytes.len() && bytes[i + 1] == b'\'' => {
-                i += 2;
-            }
-            b'\'' => {
-                in_quote = !in_quote;
-                i += 1;
-            }
-            b',' if !in_quote => {
-                fields.push(record[start..i].to_string());
-                start = i + 1;
-                i += 1;
-            }
-            _ => i += 1,
-        }
-    }
-    fields.push(record[start..].to_string());
-    fields
+    split_outside_sqlite_quotes(record, b',')
+        .into_iter()
+        .map(|(_, field)| field)
+        .collect()
 }
 
 fn unquote_sql_text(value: &str) -> String {
@@ -1294,7 +1280,7 @@ impl QueryExecutor for SqliteAdapter {
         let path = Self::path_from_dsn(dsn)?;
         let order_columns = self.preview_order_columns(path, table).await;
         let query = sql::build_preview_query(table, &order_columns, limit, offset);
-        self.execute_csv_query(path, &query, QuerySource::Preview, read_only)
+        self.execute_quoted_query(path, &query, QuerySource::Preview, read_only)
             .await
     }
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -710,7 +710,16 @@ struct QuotedRecord {
     values: Vec<QueryValue>,
 }
 
-fn split_outside_sqlite_quotes(input: &str, delimiter: u8) -> Vec<(usize, String)> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SplitSegment {
+    offset: usize,
+    text: String,
+}
+
+fn split_outside_sqlite_quotes(
+    input: &str,
+    delimiter: u8,
+) -> Result<Vec<SplitSegment>, DbOperationError> {
     let mut segments = Vec::new();
     let mut start = 0usize;
     let mut in_quote = false;
@@ -726,31 +735,43 @@ fn split_outside_sqlite_quotes(input: &str, delimiter: u8) -> Vec<(usize, String
                 i += 1;
             }
             byte if byte == delimiter && !in_quote => {
-                segments.push((start, input[start..i].to_string()));
+                segments.push(SplitSegment {
+                    offset: start,
+                    text: input[start..i].to_string(),
+                });
                 start = i + 1;
                 i += 1;
             }
             _ => i += 1,
         }
     }
-    segments.push((start, input[start..].to_string()));
-    segments
+    if in_quote {
+        return Err(DbOperationError::MetadataParseFailed(
+            "unterminated SQLite quoted output".to_string(),
+        ));
+    }
+    segments.push(SplitSegment {
+        offset: start,
+        text: input[start..].to_string(),
+    });
+    Ok(segments)
 }
 
-fn split_quoted_records(stdout: &str) -> Vec<(usize, String)> {
-    let mut records = split_outside_sqlite_quotes(stdout, b'\n')
+fn split_quoted_records(stdout: &str) -> Result<Vec<SplitSegment>, DbOperationError> {
+    let mut records = split_outside_sqlite_quotes(stdout, b'\n')?
         .into_iter()
-        .map(|(offset, record)| (offset, record.trim_end_matches('\r').to_string()))
+        .map(|segment| SplitSegment {
+            offset: segment.offset,
+            text: segment.text.trim_end_matches('\r').to_string(),
+        })
         .collect::<Vec<_>>();
-    records.retain(|(_, record)| !record.is_empty());
-    records
+    records.retain(|segment| !segment.text.is_empty());
+    Ok(records)
 }
 
-fn split_quoted_fields(record: &str) -> Vec<String> {
+fn split_quoted_fields(record: &str) -> Result<Vec<String>, DbOperationError> {
     split_outside_sqlite_quotes(record, b',')
-        .into_iter()
-        .map(|(_, field)| field)
-        .collect()
+        .map(|segments| segments.into_iter().map(|segment| segment.text).collect())
 }
 
 fn unquote_sql_text(value: &str) -> String {
@@ -795,14 +816,17 @@ fn parse_quoted_value(value: &str) -> Result<QueryValue, DbOperationError> {
 }
 
 fn parse_quoted_records(stdout: &str) -> Result<Vec<QuotedRecord>, DbOperationError> {
-    split_quoted_records(stdout)
+    split_quoted_records(stdout)?
         .into_iter()
-        .map(|(offset, record)| {
-            split_quoted_fields(&record)
+        .map(|segment| {
+            split_quoted_fields(&segment.text)?
                 .into_iter()
                 .map(|field| parse_quoted_value(&field))
                 .collect::<Result<Vec<_>, _>>()
-                .map(|values| QuotedRecord { offset, values })
+                .map(|values| QuotedRecord {
+                    offset: segment.offset,
+                    values,
+                })
         })
         .collect()
 }
@@ -908,7 +932,7 @@ fn strip_sqlite_probes(
     }
 
     let (stmt_col, changes_col) = sqlite_probe_columns(marker);
-    let raw_records = split_quoted_records(stdout);
+    let raw_records = split_quoted_records(stdout)?;
     let records = parse_quoted_records(stdout)?;
 
     let mut changes = HashMap::new();
@@ -918,8 +942,8 @@ fn strip_sqlite_probes(
     while index < records.len() {
         let record = &records[index];
         if record.values.len() == 2
-            && record.values[0].display_value() == stmt_col
-            && record.values[1].display_value() == changes_col
+            && record.values[0].as_str() == Some(stmt_col.as_str())
+            && record.values[1].as_str() == Some(changes_col.as_str())
         {
             removed_probe = true;
             let value = records.get(index + 1).ok_or_else(|| {
@@ -930,7 +954,8 @@ fn strip_sqlite_probes(
             let stmt_index = value
                 .values
                 .first()
-                .and_then(|raw| raw.display_value().parse::<usize>().ok())
+                .and_then(QueryValue::as_str)
+                .and_then(|raw| raw.parse::<usize>().ok())
                 .ok_or_else(|| {
                     DbOperationError::CommandTagParseFailed(
                         "invalid SQLite statement probe index".to_string(),
@@ -939,7 +964,8 @@ fn strip_sqlite_probes(
             let affected_rows = value
                 .values
                 .get(1)
-                .and_then(|raw| raw.display_value().parse::<usize>().ok())
+                .and_then(QueryValue::as_str)
+                .and_then(|raw| raw.parse::<usize>().ok())
                 .ok_or_else(|| {
                     DbOperationError::CommandTagParseFailed(
                         "invalid SQLite statement probe changes".to_string(),
@@ -948,7 +974,7 @@ fn strip_sqlite_probes(
             changes.insert(stmt_index, affected_rows);
             index += 2;
         } else {
-            kept.push(raw_records[index].1.clone());
+            kept.push(raw_records[index].text.clone());
             index += 1;
         }
     }
@@ -1538,6 +1564,22 @@ mod tests {
                 result.value_at(0, 3),
                 Some(&QueryValue::Blob(vec![0, 255, 65]))
             );
+        }
+
+        #[test]
+        fn quoted_to_query_result_rejects_unterminated_quote() {
+            let result = quoted_to_query_result(
+                "SELECT body FROM notes",
+                "'body'\n'unclosed\nnext",
+                QuerySource::Adhoc,
+                1,
+            );
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::MetadataParseFailed(message))
+                    if message == "unterminated SQLite quoted output"
+            ));
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1193,10 +1193,9 @@ fn command_tag_result(
     elapsed: u64,
     source: QuerySource,
 ) -> QueryResult {
-    let mut result =
-        QueryResult::success(query.to_string(), Vec::new(), Vec::new(), elapsed, source);
-    result.row_count = tag.affected_rows().unwrap_or(0) as usize;
-    result.with_command_tag(tag)
+    QueryResult::success(query.to_string(), Vec::new(), Vec::new(), elapsed, source)
+        .with_row_count(tag.affected_rows().unwrap_or(0) as usize)
+        .with_command_tag(tag)
 }
 
 fn parse_fk_action(action: &str) -> Result<FkAction, DbOperationError> {
@@ -1325,7 +1324,7 @@ impl QueryExecutor for SqliteAdapter {
         if let Some(tag) = tag {
             result = result.with_command_tag(tag);
         } else if statements.iter().any(|stmt| statement_returns_rows(stmt)) {
-            let row_count = result.row_count as u64;
+            let row_count = result.row_count() as u64;
             result = result.with_command_tag(CommandTag::Select(row_count));
         }
         Ok(result)
@@ -1451,7 +1450,7 @@ mod tests {
 
             assert_eq!(result.source, QuerySource::Preview);
             assert_eq!(result.columns, vec!["id", "name"]);
-            assert_eq!(result.rows, vec![vec!["2".to_string(), "b".to_string()]]);
+            assert_eq!(result.rows(), vec![vec!["2".to_string(), "b".to_string()]]);
         }
 
         #[tokio::test]
@@ -1484,7 +1483,7 @@ mod tests {
 
             assert_eq!(result.columns, vec!["body", "marker"]);
             assert_eq!(
-                result.rows,
+                result.rows(),
                 vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
             );
         }
@@ -1504,7 +1503,7 @@ mod tests {
 
             assert_eq!(result.columns, vec!["body", "marker"]);
             assert_eq!(
-                result.rows,
+                result.rows(),
                 vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
             );
         }
@@ -1518,7 +1517,7 @@ mod tests {
                     .unwrap();
 
             assert_eq!(
-                result.rows,
+                result.rows(),
                 vec![vec![
                     "NULL".to_string(),
                     String::new(),
@@ -1578,7 +1577,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(result.columns, vec!["value"]);
-            assert_eq!(result.rows, vec![vec!["1".to_string()]]);
+            assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
             assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
         }
 
@@ -1599,7 +1598,7 @@ mod tests {
 
             assert_eq!(result.columns, vec!["body", "marker"]);
             assert_eq!(
-                result.rows,
+                result.rows(),
                 vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
             );
             assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
@@ -1621,7 +1620,7 @@ mod tests {
 
             assert_eq!(result.columns, vec!["body", "marker"]);
             assert_eq!(
-                result.rows,
+                result.rows(),
                 vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
             );
             assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
@@ -1642,7 +1641,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(result.row_count, 1);
+            assert_eq!(result.row_count(), 1);
             assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
         }
 
@@ -1665,7 +1664,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(result.row_count, 1);
+            assert_eq!(result.row_count(), 1);
             assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
         }
 
@@ -1689,7 +1688,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(result.columns, vec!["name"]);
-            assert_eq!(result.rows, vec![vec!["x".to_string()]]);
+            assert_eq!(result.rows(), vec![vec!["x".to_string()]]);
             assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
         }
 
@@ -1714,7 +1713,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(result.row_count, 1);
+            assert_eq!(result.row_count(), 1);
             assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
         }
 
@@ -1737,7 +1736,7 @@ mod tests {
                 result.command_tag,
                 Some(CommandTag::Create("TABLE".to_string()))
             );
-            assert_eq!(result.row_count, 0);
+            assert_eq!(result.row_count(), 0);
         }
 
         #[tokio::test]
@@ -1759,7 +1758,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(result.command_tag, Some(CommandTag::Rollback));
-            assert!(rows.rows.is_empty());
+            assert!(rows.rows().is_empty());
         }
 
         #[tokio::test]
@@ -1785,7 +1784,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(result.command_tag, Some(CommandTag::Rollback));
-            assert!(rows.rows.is_empty());
+            assert!(rows.rows().is_empty());
         }
 
         #[tokio::test]
@@ -1812,7 +1811,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-            assert_eq!(rows.rows, vec![vec!["1".to_string()]]);
+            assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
         }
 
         #[tokio::test]
@@ -1841,7 +1840,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-            assert_eq!(rows.rows, vec![vec!["1".to_string()]]);
+            assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
         }
 
         #[tokio::test]
@@ -1870,7 +1869,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-            assert_eq!(rows.rows, vec![vec!["1".to_string()]]);
+            assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
         }
 
         #[tokio::test]
@@ -1888,7 +1887,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(result.row_count, 2);
+            assert_eq!(result.row_count(), 2);
             assert_eq!(result.command_tag, Some(CommandTag::Insert(2)));
         }
 
@@ -1910,7 +1909,7 @@ mod tests {
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
                 .unwrap();
-            assert!(rows.rows.is_empty());
+            assert!(rows.rows().is_empty());
         }
 
         #[tokio::test]
@@ -1927,7 +1926,7 @@ mod tests {
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
                 .unwrap();
-            assert!(rows.rows.is_empty());
+            assert!(rows.rows().is_empty());
         }
 
         #[tokio::test]
@@ -1948,7 +1947,7 @@ mod tests {
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
                 .unwrap();
-            assert!(rows.rows.is_empty());
+            assert!(rows.rows().is_empty());
         }
 
         #[tokio::test]
@@ -1970,7 +1969,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(result.row_count, 1);
+            assert_eq!(result.row_count(), 1);
             assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
         }
 
@@ -1990,7 +1989,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(result.columns, vec!["id", "name"]);
-            assert_eq!(result.rows, vec![vec!["1".to_string(), "a".to_string()]]);
+            assert_eq!(result.rows(), vec![vec!["1".to_string(), "a".to_string()]]);
             assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
         }
 
@@ -2013,7 +2012,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(result.rows.len(), 2);
+            assert_eq!(result.rows().len(), 2);
             assert_eq!(result.command_tag, Some(CommandTag::Update(2)));
         }
 
@@ -2036,7 +2035,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(result.rows, vec![vec!["1".to_string(), "a".to_string()]]);
+            assert_eq!(result.rows(), vec![vec!["1".to_string(), "a".to_string()]]);
             assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
         }
 
@@ -2051,7 +2050,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(result.row_count, 1);
+            assert_eq!(result.row_count(), 1);
             assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
         }
 
@@ -2066,7 +2065,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(result.row_count, 1);
+            assert_eq!(result.row_count(), 1);
             assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
         }
 
@@ -2081,7 +2080,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert_eq!(result.row_count, 1);
+            assert_eq!(result.row_count(), 1);
             assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
         }
 
@@ -2436,7 +2435,7 @@ mod tests {
                 .await;
 
             let result = result.unwrap();
-            assert_eq!(result.rows, vec![vec!["1".to_string()]]);
+            assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
         }
 
         #[tokio::test]

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -31,7 +31,7 @@ fn sql_literal(value: &QueryValue) -> String {
 fn equality_predicate(column: &str, value: &QueryValue) -> String {
     let column = quote_ident(column);
     match value {
-        QueryValue::Null => format!("{column} IS NULL"),
+        QueryValue::Null => panic!("SQLite write predicates require non-NULL primary key values"),
         _ => format!("{column} = {}", sql_literal(value)),
     }
 }
@@ -482,10 +482,11 @@ mod tests {
         }
 
         #[test]
-        fn update_null_pk_value_uses_is_null_predicate() {
+        #[should_panic(expected = "SQLite write predicates require non-NULL primary key values")]
+        fn update_null_pk_value_panics_before_unsafe_predicate() {
             let adapter = SqliteAdapter::new();
 
-            let sql = adapter.build_update_sql(
+            let _ = adapter.build_update_sql(
                 DatabaseType::SQLite,
                 "main",
                 "users",
@@ -493,37 +494,27 @@ mod tests {
                 &QueryValue::text("new"),
                 &[("id".into(), QueryValue::Null)],
             );
-
-            assert_eq!(
-                sql,
-                "UPDATE \"users\"\nSET \"name\" = 'new'\nWHERE \"id\" IS NULL;"
-            );
         }
 
         #[test]
-        fn null_pk_value_uses_is_null_predicate() {
+        #[should_panic(expected = "SQLite write predicates require non-NULL primary key values")]
+        fn null_pk_value_panics_before_unsafe_predicate() {
             let adapter = SqliteAdapter::new();
             let rows = vec![vec![("id".to_string(), QueryValue::Null)]];
 
-            let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
-
-            assert_eq!(sql, "DELETE FROM \"users\"\nWHERE \"id\" IS NULL;");
+            let _ = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
         }
 
         #[test]
-        fn composite_pk_null_value_uses_is_null_predicate() {
+        #[should_panic(expected = "SQLite write predicates require non-NULL primary key values")]
+        fn composite_pk_null_value_panics_before_unsafe_predicate() {
             let adapter = SqliteAdapter::new();
             let rows = vec![vec![
                 ("id".to_string(), QueryValue::Null),
                 ("tenant_id".to_string(), QueryValue::text("10")),
             ]];
 
-            let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
-
-            assert_eq!(
-                sql,
-                "DELETE FROM \"users\"\nWHERE \"id\" IS NULL AND \"tenant_id\" = '10';"
-            );
+            let _ = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -28,6 +28,38 @@ fn sql_literal(value: &QueryValue) -> String {
     }
 }
 
+fn equality_predicate(column: &str, value: &QueryValue) -> String {
+    let column = quote_ident(column);
+    match value {
+        QueryValue::Null => format!("{column} IS NULL"),
+        _ => format!("{column} = {}", sql_literal(value)),
+    }
+}
+
+fn row_predicate(pk_pairs: &[(String, QueryValue)]) -> String {
+    pk_pairs
+        .iter()
+        .map(|(col, val)| equality_predicate(col, val))
+        .collect::<Vec<_>>()
+        .join(" AND ")
+}
+
+fn rows_predicate(pk_pairs_per_row: &[Vec<(String, QueryValue)>]) -> String {
+    let predicates = pk_pairs_per_row
+        .iter()
+        .map(|pairs| row_predicate(pairs))
+        .collect::<Vec<_>>();
+    if predicates.len() == 1 {
+        predicates[0].clone()
+    } else {
+        predicates
+            .into_iter()
+            .map(|predicate| format!("({predicate})"))
+            .collect::<Vec<_>>()
+            .join(" OR ")
+    }
+}
+
 pub(super) fn user_tables_query() -> &'static str {
     r"
     WITH fts5_tables AS (
@@ -175,7 +207,7 @@ impl SqlDialect for SqliteAdapter {
     ) -> String {
         let where_clause = pk_pairs
             .iter()
-            .map(|(col, val)| format!("{} = {}", quote_ident(col), sql_literal(val)))
+            .map(|(col, val)| equality_predicate(col, val))
             .collect::<Vec<_>>()
             .join(" AND ");
 
@@ -200,35 +232,7 @@ impl SqlDialect for SqliteAdapter {
             "pk_pairs_per_row must not be empty"
         );
 
-        let pk_count = pk_pairs_per_row[0].len();
-        let where_clause = if pk_count == 1 {
-            let col = quote_ident(&pk_pairs_per_row[0][0].0);
-            let values = pk_pairs_per_row
-                .iter()
-                .map(|pairs| sql_literal(&pairs[0].1))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("{col} IN ({values})")
-        } else {
-            let cols = pk_pairs_per_row[0]
-                .iter()
-                .map(|(col, _)| quote_ident(col))
-                .collect::<Vec<_>>()
-                .join(", ");
-            let rows = pk_pairs_per_row
-                .iter()
-                .map(|pairs| {
-                    let vals = pairs
-                        .iter()
-                        .map(|(_, val)| sql_literal(val))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    format!("({vals})")
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("({cols}) IN ({rows})")
-        };
+        let where_clause = rows_predicate(pk_pairs_per_row);
 
         format!(
             "DELETE FROM {}\nWHERE {};",
@@ -287,6 +291,10 @@ mod tests {
         assert_eq!(sql_literal(&QueryValue::text("null")), "'null'");
         assert_eq!(sql_literal(&QueryValue::Blob(vec![0, 255])), "X'00FF'");
         assert_eq!(sql_literal(&QueryValue::SqlLiteral("42".to_string())), "42");
+        assert_eq!(
+            sql_literal(&QueryValue::SqlLiteral("1e999".to_string())),
+            "1e999"
+        );
     }
 
     #[test]
@@ -436,7 +444,7 @@ mod tests {
         use super::*;
 
         #[test]
-        fn single_pk_multiple_rows_returns_in_clause() {
+        fn single_pk_multiple_rows_returns_or_predicates() {
             let adapter = SqliteAdapter::new();
             let rows = vec![
                 vec![("id".to_string(), QueryValue::text("1"))],
@@ -445,11 +453,14 @@ mod tests {
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
 
-            assert_eq!(sql, "DELETE FROM \"users\"\nWHERE \"id\" IN ('1', '2');");
+            assert_eq!(
+                sql,
+                "DELETE FROM \"users\"\nWHERE (\"id\" = '1') OR (\"id\" = '2');"
+            );
         }
 
         #[test]
-        fn composite_pk_returns_row_value_in_clause() {
+        fn composite_pk_returns_or_predicates() {
             let adapter = SqliteAdapter::new();
             let rows = vec![
                 vec![
@@ -466,22 +477,41 @@ mod tests {
 
             assert_eq!(
                 sql,
-                "DELETE FROM \"users\"\nWHERE (\"id\", \"tenant_id\") IN (('1', '10'), ('2', '20'));"
+                "DELETE FROM \"users\"\nWHERE (\"id\" = '1' AND \"tenant_id\" = '10') OR (\"id\" = '2' AND \"tenant_id\" = '20');"
             );
         }
 
         #[test]
-        fn null_pk_value_uses_null_literal() {
+        fn update_null_pk_value_uses_is_null_predicate() {
+            let adapter = SqliteAdapter::new();
+
+            let sql = adapter.build_update_sql(
+                DatabaseType::SQLite,
+                "main",
+                "users",
+                "name",
+                &QueryValue::text("new"),
+                &[("id".into(), QueryValue::Null)],
+            );
+
+            assert_eq!(
+                sql,
+                "UPDATE \"users\"\nSET \"name\" = 'new'\nWHERE \"id\" IS NULL;"
+            );
+        }
+
+        #[test]
+        fn null_pk_value_uses_is_null_predicate() {
             let adapter = SqliteAdapter::new();
             let rows = vec![vec![("id".to_string(), QueryValue::Null)]];
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
 
-            assert_eq!(sql, "DELETE FROM \"users\"\nWHERE \"id\" IN (NULL);");
+            assert_eq!(sql, "DELETE FROM \"users\"\nWHERE \"id\" IS NULL;");
         }
 
         #[test]
-        fn composite_pk_null_value_uses_null_literal() {
+        fn composite_pk_null_value_uses_is_null_predicate() {
             let adapter = SqliteAdapter::new();
             let rows = vec![vec![
                 ("id".to_string(), QueryValue::Null),
@@ -492,7 +522,7 @@ mod tests {
 
             assert_eq!(
                 sql,
-                "DELETE FROM \"users\"\nWHERE (\"id\", \"tenant_id\") IN ((NULL, '10'));"
+                "DELETE FROM \"users\"\nWHERE \"id\" IS NULL AND \"tenant_id\" = '10';"
             );
         }
 
@@ -503,7 +533,7 @@ mod tests {
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
 
-            assert_eq!(sql, "DELETE FROM \"users\"\nWHERE \"id\" IN (X'00FF41');");
+            assert_eq!(sql, "DELETE FROM \"users\"\nWHERE \"id\" = X'00FF41';");
         }
     }
 

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write as _;
 
 use crate::app::ports::outbound::{DdlGenerator, SqlDialect};
-use crate::domain::{DatabaseType, Table};
+use crate::domain::{DatabaseType, QueryValue, Table};
 
 use super::SqliteAdapter;
 
@@ -13,11 +13,18 @@ fn quote_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
-fn sql_literal_or_null(value: &str) -> String {
-    if value == "NULL" {
-        "NULL".to_string()
-    } else {
-        quote_literal(value)
+fn sql_literal(value: &QueryValue) -> String {
+    match value {
+        QueryValue::Null => "NULL".to_string(),
+        QueryValue::Text(value) => quote_literal(value),
+        QueryValue::SqlLiteral(value) => value.clone(),
+        QueryValue::Blob(bytes) => {
+            let mut hex = String::with_capacity(bytes.len() * 2);
+            for byte in bytes {
+                let _ = write!(hex, "{byte:02X}");
+            }
+            format!("X'{hex}'")
+        }
     }
 }
 
@@ -163,12 +170,12 @@ impl SqlDialect for SqliteAdapter {
         _schema: &str,
         table: &str,
         column: &str,
-        new_value: &str,
-        pk_pairs: &[(String, String)],
+        new_value: &QueryValue,
+        pk_pairs: &[(String, QueryValue)],
     ) -> String {
         let where_clause = pk_pairs
             .iter()
-            .map(|(col, val)| format!("{} = {}", quote_ident(col), quote_literal(val)))
+            .map(|(col, val)| format!("{} = {}", quote_ident(col), sql_literal(val)))
             .collect::<Vec<_>>()
             .join(" AND ");
 
@@ -176,7 +183,7 @@ impl SqlDialect for SqliteAdapter {
             "UPDATE {}\nSET {} = {}\nWHERE {};",
             quote_ident(table),
             quote_ident(column),
-            sql_literal_or_null(new_value),
+            sql_literal(new_value),
             where_clause
         )
     }
@@ -186,7 +193,7 @@ impl SqlDialect for SqliteAdapter {
         _database_type: DatabaseType,
         _schema: &str,
         table: &str,
-        pk_pairs_per_row: &[Vec<(String, String)>],
+        pk_pairs_per_row: &[Vec<(String, QueryValue)>],
     ) -> String {
         assert!(
             !pk_pairs_per_row.is_empty(),
@@ -198,7 +205,7 @@ impl SqlDialect for SqliteAdapter {
             let col = quote_ident(&pk_pairs_per_row[0][0].0);
             let values = pk_pairs_per_row
                 .iter()
-                .map(|pairs| sql_literal_or_null(&pairs[0].1))
+                .map(|pairs| sql_literal(&pairs[0].1))
                 .collect::<Vec<_>>()
                 .join(", ");
             format!("{col} IN ({values})")
@@ -213,7 +220,7 @@ impl SqlDialect for SqliteAdapter {
                 .map(|pairs| {
                     let vals = pairs
                         .iter()
-                        .map(|(_, val)| sql_literal_or_null(val))
+                        .map(|(_, val)| sql_literal(val))
                         .collect::<Vec<_>>()
                         .join(", ");
                     format!("({vals})")
@@ -274,10 +281,12 @@ mod tests {
     }
 
     #[test]
-    fn sql_literal_or_null_preserves_only_uppercase_null_as_null() {
-        assert_eq!(sql_literal_or_null("NULL"), "NULL");
-        assert_eq!(sql_literal_or_null("null"), "'null'");
-        assert_eq!(sql_literal_or_null("NULL "), "'NULL '");
+    fn sql_literal_preserves_typed_values() {
+        assert_eq!(sql_literal(&QueryValue::Null), "NULL");
+        assert_eq!(sql_literal(&QueryValue::text("NULL")), "'NULL'");
+        assert_eq!(sql_literal(&QueryValue::text("null")), "'null'");
+        assert_eq!(sql_literal(&QueryValue::Blob(vec![0, 255])), "X'00FF'");
+        assert_eq!(sql_literal(&QueryValue::SqlLiteral("42".to_string())), "42");
     }
 
     #[test]
@@ -352,8 +361,8 @@ mod tests {
                 "main",
                 "users",
                 "name",
-                "O'Reilly",
-                &[("id".into(), "42".into())],
+                &QueryValue::text("O'Reilly"),
+                &[("id".into(), QueryValue::text("42"))],
             );
 
             assert_eq!(
@@ -371,8 +380,11 @@ mod tests {
                 "main",
                 "users",
                 "name",
-                "new",
-                &[("id".into(), "1".into()), ("tenant_id".into(), "7".into())],
+                &QueryValue::text("new"),
+                &[
+                    ("id".into(), QueryValue::text("1")),
+                    ("tenant_id".into(), QueryValue::text("7")),
+                ],
             );
 
             assert_eq!(
@@ -390,13 +402,32 @@ mod tests {
                 "main",
                 "users",
                 "name",
-                "NULL",
-                &[("id".into(), "1".into())],
+                &QueryValue::Null,
+                &[("id".into(), QueryValue::text("1"))],
             );
 
             assert_eq!(
                 sql,
                 "UPDATE \"users\"\nSET \"name\" = NULL\nWHERE \"id\" = '1';"
+            );
+        }
+
+        #[test]
+        fn text_null_value_generates_quoted_text() {
+            let adapter = SqliteAdapter::new();
+
+            let sql = adapter.build_update_sql(
+                DatabaseType::SQLite,
+                "main",
+                "users",
+                "name",
+                &QueryValue::text("NULL"),
+                &[("id".into(), QueryValue::text("1"))],
+            );
+
+            assert_eq!(
+                sql,
+                "UPDATE \"users\"\nSET \"name\" = 'NULL'\nWHERE \"id\" = '1';"
             );
         }
     }
@@ -408,8 +439,8 @@ mod tests {
         fn single_pk_multiple_rows_returns_in_clause() {
             let adapter = SqliteAdapter::new();
             let rows = vec![
-                vec![("id".to_string(), "1".to_string())],
-                vec![("id".to_string(), "2".to_string())],
+                vec![("id".to_string(), QueryValue::text("1"))],
+                vec![("id".to_string(), QueryValue::text("2"))],
             ];
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
@@ -422,12 +453,12 @@ mod tests {
             let adapter = SqliteAdapter::new();
             let rows = vec![
                 vec![
-                    ("id".to_string(), "1".to_string()),
-                    ("tenant_id".to_string(), "10".to_string()),
+                    ("id".to_string(), QueryValue::text("1")),
+                    ("tenant_id".to_string(), QueryValue::text("10")),
                 ],
                 vec![
-                    ("id".to_string(), "2".to_string()),
-                    ("tenant_id".to_string(), "20".to_string()),
+                    ("id".to_string(), QueryValue::text("2")),
+                    ("tenant_id".to_string(), QueryValue::text("20")),
                 ],
             ];
 
@@ -442,7 +473,7 @@ mod tests {
         #[test]
         fn null_pk_value_uses_null_literal() {
             let adapter = SqliteAdapter::new();
-            let rows = vec![vec![("id".to_string(), "NULL".to_string())]];
+            let rows = vec![vec![("id".to_string(), QueryValue::Null)]];
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
 
@@ -453,8 +484,8 @@ mod tests {
         fn composite_pk_null_value_uses_null_literal() {
             let adapter = SqliteAdapter::new();
             let rows = vec![vec![
-                ("id".to_string(), "NULL".to_string()),
-                ("tenant_id".to_string(), "10".to_string()),
+                ("id".to_string(), QueryValue::Null),
+                ("tenant_id".to_string(), QueryValue::text("10")),
             ]];
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
@@ -463,6 +494,16 @@ mod tests {
                 sql,
                 "DELETE FROM \"users\"\nWHERE (\"id\", \"tenant_id\") IN ((NULL, '10'));"
             );
+        }
+
+        #[test]
+        fn blob_pk_value_uses_blob_literal() {
+            let adapter = SqliteAdapter::new();
+            let rows = vec![vec![("id".to_string(), QueryValue::Blob(vec![0, 255, 65]))]];
+
+            let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
+
+            assert_eq!(sql, "DELETE FROM \"users\"\nWHERE \"id\" IN (X'00FF41');");
         }
     }
 

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -31,6 +31,8 @@ fn sql_literal(value: &QueryValue) -> String {
 fn equality_predicate(column: &str, value: &QueryValue) -> String {
     let column = quote_ident(column);
     match value {
+        // App-layer write flows reject SQLite NULL primary keys before SQL generation.
+        // Reaching this branch means a caller bypassed that guardrail.
         QueryValue::Null => panic!("SQLite write predicates require non-NULL primary key values"),
         _ => format!("{column} = {}", sql_literal(value)),
     }

--- a/src/tests/adapter_postgres.rs
+++ b/src/tests/adapter_postgres.rs
@@ -104,8 +104,8 @@ mod query_execution {
             .unwrap();
 
         assert_eq!(result.columns, vec!["value"]);
-        assert_eq!(result.rows.len(), 1);
-        assert_eq!(result.rows[0], vec!["1"]);
+        assert_eq!(result.rows().len(), 1);
+        assert_eq!(result.rows()[0], vec!["1"]);
     }
 }
 
@@ -125,7 +125,7 @@ mod multi_statement_boundaries {
             .unwrap();
 
         assert_eq!(result.columns, vec!["b", "c"]);
-        assert_eq!(result.rows, vec![vec!["2", "3"]]);
+        assert_eq!(result.rows(), vec![vec!["2", "3"]]);
     }
 
     #[tokio::test]
@@ -139,7 +139,7 @@ mod multi_statement_boundaries {
         let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
 
         assert_eq!(result.columns, vec!["id", "name"]);
-        assert_eq!(result.rows, vec![vec!["id", "name"]]);
+        assert_eq!(result.rows(), vec![vec!["id", "name"]]);
     }
 
     #[tokio::test]
@@ -152,7 +152,7 @@ mod multi_statement_boundaries {
         let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
 
         assert_eq!(result.columns, vec!["b"]);
-        assert_eq!(result.rows, vec![vec!["2"]]);
+        assert_eq!(result.rows(), vec![vec!["2"]]);
     }
 
     #[tokio::test]
@@ -165,7 +165,7 @@ mod multi_statement_boundaries {
         let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
 
         assert_eq!(result.columns, vec!["b"]);
-        assert!(result.rows.is_empty());
+        assert!(result.rows().is_empty());
     }
 
     #[tokio::test]
@@ -182,7 +182,7 @@ mod multi_statement_boundaries {
         let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
 
         assert_eq!(result.columns, vec!["v"]);
-        assert_eq!(result.rows, vec![vec!["7"]]);
+        assert_eq!(result.rows(), vec![vec!["7"]]);
     }
 
     #[tokio::test]
@@ -195,7 +195,7 @@ mod multi_statement_boundaries {
                    INSERT INTO tag_probe VALUES (1), (2)";
         let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
 
-        assert!(result.rows.is_empty());
+        assert!(result.rows().is_empty());
         assert_eq!(
             result.command_tag,
             Some(CommandTag::Create("TABLE".to_string()))
@@ -224,7 +224,7 @@ mod multi_statement_boundaries {
             )
             .await
             .unwrap();
-        assert_eq!(check.rows, vec![vec!["t"]]);
+        assert_eq!(check.rows(), vec![vec!["t"]]);
     }
 }
 

--- a/src/tests/render_snapshots/confirm_dialogs.rs
+++ b/src/tests/render_snapshots/confirm_dialogs.rs
@@ -1,5 +1,6 @@
 use super::*;
 use harness::connected_state;
+use sabiql_app::domain::QueryValue;
 use sabiql_app::model::app_state::AppState;
 use sabiql_app::model::shared::confirm_dialog::ConfirmIntent;
 
@@ -14,7 +15,7 @@ fn make_update_preview_with_key(diff: Vec<ColumnDiff>, sql: String, id: &str) ->
         target_summary: TargetSummary {
             schema: "public".to_string(),
             table: "users".to_string(),
-            key_values: vec![("id".to_string(), id.to_string())],
+            key_values: vec![("id".to_string(), QueryValue::text(id))],
         },
         diff,
         guardrail: GuardrailDecision {
@@ -132,7 +133,7 @@ fn confirm_dialog_delete_preview_low_risk() {
         target_summary: TargetSummary {
             schema: "public".to_string(),
             table: "users".to_string(),
-            key_values: vec![("id".to_string(), "3".to_string())],
+            key_values: vec![("id".to_string(), QueryValue::text("3"))],
         },
         diff: vec![],
         guardrail: GuardrailDecision {

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -281,17 +281,17 @@ fn sql_modal_success_dml_with_command_tag() {
         execution_time_ms: 12,
     });
     // DML: row_count carries affected rows, not result rows (executor's command-tag path)
-    let mut result = QueryResult::success(
-        "DELETE FROM users WHERE id = 1".to_string(),
-        vec![],
-        vec![],
-        12,
-        QuerySource::Adhoc,
-    );
-    result.row_count = 3;
-    state
-        .query
-        .set_current_result(Arc::new(result.with_command_tag(CommandTag::Delete(3))));
+    state.query.set_current_result(Arc::new(
+        QueryResult::success(
+            "DELETE FROM users WHERE id = 1".to_string(),
+            vec![],
+            vec![],
+            12,
+            QuerySource::Adhoc,
+        )
+        .with_row_count(3)
+        .with_command_tag(CommandTag::Delete(3)),
+    ));
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -70,7 +70,7 @@ impl ResultPane {
             if result.is_error() {
                 Self::render_error(frame, area, result, block, theme);
                 default_result()
-            } else if result.rows.is_empty() {
+            } else if result.rows().is_empty() {
                 Self::render_empty(frame, area, block, theme);
                 default_result()
             } else {
@@ -201,7 +201,7 @@ impl ResultPane {
                 &stored_cache.header_min_widths[..],
             )
         } else {
-            fresh_ideal = calculate_ideal_widths(&result.columns, &result.rows);
+            fresh_ideal = calculate_ideal_widths(&result.columns, result.rows());
             fresh_min = calculate_header_min_widths(&result.columns);
             (&fresh_ideal[..], &fresh_min[..])
         };
@@ -266,7 +266,7 @@ impl ResultPane {
         let yank_flash_active = yank_flash.is_some_and(|f| now < f.until);
 
         let rows: Vec<Row> = result
-            .rows
+            .rows()
             .iter()
             .enumerate()
             .skip(scroll_offset)
@@ -364,7 +364,7 @@ impl ResultPane {
         frame.render_widget(table, inner);
 
         // Scroll indicators (pass inner area, not outer with border)
-        let total_rows = result.rows.len();
+        let total_rows = result.rows().len();
         let total_cols = result.columns.len();
 
         use crate::primitives::atoms::scroll_indicator::{

--- a/src/ui/features/overlays/confirm_dialog.rs
+++ b/src/ui/features/overlays/confirm_dialog.rs
@@ -180,7 +180,7 @@ impl ConfirmDialog {
                             Style::default().fg(theme.semantic.text.secondary),
                         ),
                         Span::styled(
-                            format!("\"{}\"", escape_preview_value(value)),
+                            format!("\"{}\"", escape_preview_value(&value.display_value())),
                             Style::default().fg(theme.semantic.text.primary),
                         ),
                     ]));


### PR DESCRIPTION
## Problem
SQLite values were flattened into display strings before reaching result interaction and write generation, so SQL NULL, text `NULL`, empty strings, and BLOB values could become ambiguous.

## Background
This matters most for edit/delete predicates: a value that looks right in the table can still produce the wrong SQL if its original SQLite type was lost.

## Approach
Carry typed result values alongside display rows for SQLite query output, render BLOBs as binary previews, and build SQLite update/delete SQL from typed values instead of display strings.

## Screenshots
N/A

Validation:
- `env RUSTC_WRAPPER= cargo test --workspace -- --nocapture`
- `env RUSTC_WRAPPER= cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `env RUSTC_WRAPPER= cargo clippy --workspace --all-targets --no-default-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * テキストセルのみインライン編集を許可し、非テキスト入力はガードレールでブロック

* **バグ修正**
  * SQLiteの結果表示と更新/削除プレビューをquoted出力ベースに更新し、NULL・BLOBなどの値の扱いとエスケープを改善
  * SQLiteでPRIMARY KEYがNULLのケースはプレビュー生成をエラーに

* **改善**
  * プレビュー表示のキー値を QueryValue 表現に合わせて更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->