### PR TITLE
Fix SQLite multi-result parsing

### DIFF
--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -649,7 +649,7 @@ fn sqlite_adhoc_execution_query(query: &str, marker: &str) -> String {
         if is_dml_statement(statement) {
             parts.push(sqlite_changes_probe(marker, index));
         }
-        if statement_returns_rows(statement) {
+        if statement_emits_result_set(statement) {
             parts.push(sqlite_result_probe(marker, index));
         }
     }
@@ -701,7 +701,7 @@ fn is_dml_statement(statement: &str) -> bool {
     dml_keyword(statement).is_some()
 }
 
-fn statement_returns_rows(statement: &str) -> bool {
+fn statement_emits_result_set(statement: &str) -> bool {
     let keyword = first_keyword(statement);
     if keyword.eq_ignore_ascii_case("SELECT")
         || keyword.eq_ignore_ascii_case("PRAGMA")
@@ -714,6 +714,11 @@ fn statement_returns_rows(statement: &str) -> bool {
         return contains_keyword(statement, "RETURNING");
     }
     keyword.eq_ignore_ascii_case("WITH")
+}
+
+fn statement_counts_as_select_tag(statement: &str) -> bool {
+    let keyword = first_keyword(statement);
+    keyword.eq_ignore_ascii_case("SELECT") || keyword.eq_ignore_ascii_case("WITH")
 }
 
 fn csv_to_query_result(
@@ -880,19 +885,7 @@ fn strip_sqlite_probes(
         return Ok((stdout.to_string(), changes));
     }
 
-    let mut writer = csv::WriterBuilder::new()
-        .has_headers(false)
-        .flexible(true)
-        .from_writer(Vec::new());
-    for record in kept {
-        writer.write_byte_record(&record)?;
-    }
-    let bytes = writer.into_inner().map_err(|error| {
-        DbOperationError::QueryFailed(format!("Failed to write filtered SQLite CSV: {error}"))
-    })?;
-    String::from_utf8(bytes)
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
-        .map(|filtered| (filtered, changes))
+    csv_from_byte_records(&kept).map(|filtered| (filtered, changes))
 }
 
 fn first_csv_cell(stdout: &str) -> Result<String, DbOperationError> {
@@ -1255,7 +1248,10 @@ impl QueryExecutor for SqliteAdapter {
                 elapsed,
                 QuerySource::Adhoc,
             );
-            if statements.iter().any(|stmt| statement_returns_rows(stmt)) {
+            if statements
+                .iter()
+                .any(|stmt| statement_counts_as_select_tag(stmt))
+            {
                 result = result.with_command_tag(CommandTag::Select(0));
             }
             return Ok(result);
@@ -1264,7 +1260,10 @@ impl QueryExecutor for SqliteAdapter {
         let mut result = csv_to_query_result(query, &stdout, QuerySource::Adhoc, elapsed)?;
         if let Some(tag) = tag {
             result = result.with_command_tag(tag);
-        } else if statements.iter().any(|stmt| statement_returns_rows(stmt)) {
+        } else if statements
+            .iter()
+            .any(|stmt| statement_counts_as_select_tag(stmt))
+        {
             let row_count = result.row_count as u64;
             result = result.with_command_tag(CommandTag::Select(row_count));
         }
@@ -1566,6 +1565,37 @@ mod tests {
             assert!(result.columns.is_empty());
             assert!(result.rows.is_empty());
             assert_eq!(result.command_tag, Some(CommandTag::Select(0)));
+        }
+
+        #[tokio::test]
+        async fn pragma_result_does_not_get_select_command_tag() {
+            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(&dsn, "PRAGMA table_info(users)", true)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                result.columns,
+                vec!["cid", "name", "type", "notnull", "dflt_value", "pk"]
+            );
+            assert_eq!(result.command_tag, None);
+        }
+
+        #[tokio::test]
+        async fn values_result_does_not_get_select_command_tag() {
+            let (_dir, dsn) = make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(&dsn, "VALUES (1)", true)
+                .await
+                .unwrap();
+
+            assert_eq!(result.rows, vec![vec!["1".to_string()]]);
+            assert_eq!(result.command_tag, None);
         }
 
         #[tokio::test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -621,6 +621,18 @@ fn sqlite_changes_probe(marker: &str, index: usize) -> String {
     format!("SELECT {index} AS \"{stmt_col}\", changes() AS \"{changes_col}\"")
 }
 
+fn sqlite_result_probe_columns(marker: &str) -> (String, String) {
+    (
+        format!("{marker}_result_stmt"),
+        format!("{marker}_result_marker"),
+    )
+}
+
+fn sqlite_result_probe(marker: &str, index: usize) -> String {
+    let (stmt_col, marker_col) = sqlite_result_probe_columns(marker);
+    format!("SELECT {index} AS \"{stmt_col}\", '{marker}' AS \"{marker_col}\"")
+}
+
 fn sqlite_adhoc_execution_query(query: &str, marker: &str) -> String {
     let statements = split_sqlite_statements(query);
     if statements.is_empty() {
@@ -636,6 +648,9 @@ fn sqlite_adhoc_execution_query(query: &str, marker: &str) -> String {
         parts.push((*statement).to_string());
         if is_dml_statement(statement) {
             parts.push(sqlite_changes_probe(marker, index));
+        }
+        if statement_returns_rows(statement) {
+            parts.push(sqlite_result_probe(marker, index));
         }
     }
     if wrap {
@@ -688,78 +703,17 @@ fn is_dml_statement(statement: &str) -> bool {
 
 fn statement_returns_rows(statement: &str) -> bool {
     let keyword = first_keyword(statement);
-    if keyword.eq_ignore_ascii_case("SELECT") {
+    if keyword.eq_ignore_ascii_case("SELECT")
+        || keyword.eq_ignore_ascii_case("PRAGMA")
+        || keyword.eq_ignore_ascii_case("EXPLAIN")
+        || keyword.eq_ignore_ascii_case("VALUES")
+    {
         return true;
     }
     if is_dml_statement(statement) {
         return contains_keyword(statement, "RETURNING");
     }
     keyword.eq_ignore_ascii_case("WITH")
-}
-
-fn count_result_statements(sql: &str) -> usize {
-    split_sqlite_statements(sql)
-        .into_iter()
-        .filter(|stmt| statement_returns_rows(stmt))
-        .count()
-}
-
-fn extract_last_csv_block<'a>(stdout: &'a str, sql: &str) -> &'a str {
-    let mut reader = csv::ReaderBuilder::new()
-        .has_headers(false)
-        .flexible(true)
-        .from_reader(stdout.as_bytes());
-    let mut record = csv::ByteRecord::new();
-    let mut records = Vec::new();
-    loop {
-        let position = reader.position().clone();
-        match reader.read_byte_record(&mut record) {
-            Ok(true) => records.push((position.byte() as usize, record.clone())),
-            Ok(false) => break,
-            Err(_) => return stdout,
-        }
-    }
-
-    if records.len() <= 2 {
-        return stdout;
-    }
-
-    let expected_sets = count_result_statements(sql);
-    let first_header = &records[0].1;
-    let mut current_fc = first_header.len();
-    let mut known_headers = vec![first_header.clone()];
-    let mut last_header_idx = 0;
-    let mut data_rows_since_header = 0usize;
-
-    for (i, (_, record)) in records.iter().enumerate().skip(1) {
-        let fc = record.len();
-        if fc != current_fc {
-            last_header_idx = i;
-            current_fc = fc;
-            data_rows_since_header = 0;
-            if !known_headers.contains(record) {
-                known_headers.push(record.clone());
-            }
-        } else if known_headers.contains(record) {
-            last_header_idx = i;
-            data_rows_since_header = 0;
-        } else if expected_sets > 1
-            && data_rows_since_header >= 1
-            && known_headers.len() < expected_sets
-        {
-            last_header_idx = i;
-            known_headers.push(record.clone());
-            data_rows_since_header = 0;
-        } else {
-            data_rows_since_header += 1;
-        }
-    }
-
-    if last_header_idx == 0 {
-        return stdout;
-    }
-
-    &stdout[records[last_header_idx].0..]
 }
 
 fn csv_to_query_result(
@@ -779,14 +733,9 @@ fn csv_to_query_result(
         ));
     }
 
-    let csv_block = if count_result_statements(query) <= 1 {
-        stdout
-    } else {
-        extract_last_csv_block(stdout, query)
-    };
     let mut reader = csv::ReaderBuilder::new()
         .has_headers(true)
-        .from_reader(csv_block.as_bytes());
+        .from_reader(stdout.as_bytes());
     let columns = reader.headers()?.iter().map(ToString::to_string).collect();
     let mut rows = Vec::new();
     for result in reader.records() {
@@ -800,6 +749,70 @@ fn csv_to_query_result(
         execution_time_ms,
         source,
     ))
+}
+
+fn csv_from_byte_records(records: &[csv::ByteRecord]) -> Result<String, DbOperationError> {
+    let mut writer = csv::WriterBuilder::new()
+        .has_headers(false)
+        .flexible(true)
+        .from_writer(Vec::new());
+    for record in records {
+        writer.write_byte_record(record)?;
+    }
+    let bytes = writer.into_inner().map_err(|error| {
+        DbOperationError::QueryFailed(format!("Failed to write filtered SQLite CSV: {error}"))
+    })?;
+    String::from_utf8(bytes).map_err(|error| DbOperationError::QueryFailed(error.to_string()))
+}
+
+fn last_sqlite_result_set(stdout: &str, marker: &str) -> Result<Option<String>, DbOperationError> {
+    let (stmt_col, marker_col) = sqlite_result_probe_columns(marker);
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .flexible(true)
+        .from_reader(stdout.as_bytes());
+    let mut record = csv::ByteRecord::new();
+    let mut records = Vec::new();
+    while reader.read_byte_record(&mut record)? {
+        records.push(record.clone());
+    }
+
+    let mut last_result = None;
+    let mut result_start = 0;
+    let mut index = 0;
+    while index < records.len() {
+        let record = &records[index];
+        if record.len() == 2
+            && record.get(0) == Some(stmt_col.as_bytes())
+            && record.get(1) == Some(marker_col.as_bytes())
+        {
+            let value = records.get(index + 1).ok_or_else(|| {
+                DbOperationError::CommandTagParseFailed(
+                    "missing SQLite result marker row".to_string(),
+                )
+            })?;
+            let marker_value = value
+                .get(1)
+                .and_then(|raw| std::str::from_utf8(raw).ok())
+                .ok_or_else(|| {
+                    DbOperationError::CommandTagParseFailed(
+                        "invalid SQLite result marker".to_string(),
+                    )
+                })?;
+            if marker_value != marker {
+                return Err(DbOperationError::CommandTagParseFailed(
+                    "mismatched SQLite result marker".to_string(),
+                ));
+            }
+            last_result = Some(csv_from_byte_records(&records[result_start..index])?);
+            index += 2;
+            result_start = index;
+        } else {
+            index += 1;
+        }
+    }
+
+    Ok(last_result)
 }
 
 fn strip_sqlite_probes(
@@ -1228,19 +1241,24 @@ impl QueryExecutor for SqliteAdapter {
             .await?;
         let elapsed = start.elapsed().as_millis() as u64;
         let (stdout, changes) = strip_sqlite_probes(&stdout, &marker)?;
+        let stdout = last_sqlite_result_set(&stdout, &marker)?.unwrap_or(stdout);
         let tag = aggregate_sqlite_command_tag(&sqlite_statement_tags(&statements, &changes));
 
         if stdout.trim().is_empty() {
             if let Some(tag) = tag {
                 return Ok(command_tag_result(query, tag, elapsed, QuerySource::Adhoc));
             }
-            return Ok(QueryResult::success(
+            let mut result = QueryResult::success(
                 query.to_string(),
                 Vec::new(),
                 Vec::new(),
                 elapsed,
                 QuerySource::Adhoc,
-            ));
+            );
+            if statements.iter().any(|stmt| statement_returns_rows(stmt)) {
+                result = result.with_command_tag(CommandTag::Select(0));
+            }
+            return Ok(result);
         }
 
         let mut result = csv_to_query_result(query, &stdout, QuerySource::Adhoc, elapsed)?;
@@ -1408,13 +1426,16 @@ mod tests {
         }
 
         #[test]
-        fn csv_to_query_result_uses_last_result_set_for_multi_select() {
-            let sqlite_csv_with_ignored_first_result_set =
-                "ignored\n1\nbody,marker\n\"line 1\nline 2\",ok\n";
+        fn last_sqlite_result_set_uses_marker_boundaries() {
+            let marker = "probe";
+            let sqlite_csv_with_ignored_first_result_set = "ignored\n1\nprobe_result_stmt,probe_result_marker\n0,probe\nbody,marker\n\"line 1\nline 2\",ok\nprobe_result_stmt,probe_result_marker\n1,probe\n";
 
+            let csv = last_sqlite_result_set(sqlite_csv_with_ignored_first_result_set, marker)
+                .unwrap()
+                .unwrap();
             let result = csv_to_query_result(
                 "SELECT 1 AS ignored; SELECT body, marker FROM notes",
-                sqlite_csv_with_ignored_first_result_set,
+                &csv,
                 QuerySource::Adhoc,
                 1,
             )
@@ -1511,6 +1532,40 @@ mod tests {
                 vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
             );
             assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
+        }
+
+        #[tokio::test]
+        async fn multi_select_does_not_treat_data_row_as_next_header() {
+            let (_dir, dsn) = make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(
+                    &dsn,
+                    "SELECT 1 AS a, 2 AS b UNION ALL SELECT 3, 4; SELECT 5 AS c, 6 AS d",
+                    true,
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(result.columns, vec!["c", "d"]);
+            assert_eq!(result.rows, vec![vec!["5".to_string(), "6".to_string()]]);
+            assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
+        }
+
+        #[tokio::test]
+        async fn multi_select_empty_trailing_result_returns_empty_result() {
+            let (_dir, dsn) = make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(&dsn, "SELECT 1 AS a; SELECT 2 AS b WHERE false", true)
+                .await
+                .unwrap();
+
+            assert!(result.columns.is_empty());
+            assert!(result.rows.is_empty());
+            assert_eq!(result.command_tag, Some(CommandTag::Select(0)));
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Problem
SQLite ad-hoc execution inferred multi-result-set boundaries from CSV shape, so a data row in an earlier result could be mistaken for the next header.

## Background
`sqlite3 -csv -header` concatenates result sets without an explicit separator. SAB-277 tracks making that boundary deterministic while preserving the last non-command result set and existing command-tag aggregation behavior.

## Approach
Inject a per-execution result marker after statements that can return rows, then select the last marked result set after removing affected-row probes. This keeps read result boundaries independent from user data shape and leaves rollback/savepoint aggregation on the existing probe path.

When the final SQLite result set is empty, `sqlite3 -csv -header` emits no header for that result set. The adapter can now select that empty trailing result deterministically, but its columns remain empty; preserving those column names is left as a separate SQLite CLI fidelity gap.

## Screenshots
N/A

Validation:
- `env RUSTC_WRAPPER= cargo test --workspace -- --nocapture`
- `env RUSTC_WRAPPER= cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `env RUSTC_WRAPPER= cargo clippy --workspace --all-targets --no-default-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * SQLiteクエリ実行における結果セット検出ロジックを改善し、より正確な結果抽出を実現しました。
  * 複数のSELECT、PRAGMA、VALUES文を含む複雑なクエリの結果処理の信頼性を向上させました。
  * 空の結果セットが返される場合の動作を修正しました。

* **Tests**
  * 結果セット抽出精度とエッジケースの正確性に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->