### PR TITLE
SAB-278 Harden SQLite execution sessions

### DIFF
--- a/src/infra/adapters/sqlite/cli.rs
+++ b/src/infra/adapters/sqlite/cli.rs
@@ -8,6 +8,8 @@ use tokio::time::timeout;
 
 use crate::app::ports::outbound::DbOperationError;
 
+pub(super) const BUSY_TIMEOUT_MS: u64 = 5_000;
+
 #[derive(Debug, Clone)]
 pub(super) struct SqliteCli {
     timeout_secs: u64,
@@ -29,7 +31,7 @@ impl SqliteCli {
         path: &str,
         sql: &str,
     ) -> Result<T, DbOperationError> {
-        let output = self.run(path, &["-readonly", "-json"], sql).await?;
+        let output = self.run(path, &["-json"], sql, true).await?;
         if !output.status.success() {
             return Err(DbOperationError::QueryFailed(output.stderr));
         }
@@ -46,11 +48,14 @@ impl SqliteCli {
         sql: &str,
         read_only: bool,
     ) -> Result<String, DbOperationError> {
-        let mut args = vec!["-batch", "-bail", "-csv", "-header"];
-        if read_only {
-            args.push("-readonly");
-        }
-        let output = self.run(path, &args, sql).await?;
+        let output = self
+            .run(
+                path,
+                &["-batch", "-bail", "-csv", "-header"],
+                sql,
+                read_only,
+            )
+            .await?;
         if !output.status.success() {
             return Err(DbOperationError::QueryFailed(output.stderr));
         }
@@ -63,11 +68,14 @@ impl SqliteCli {
         sql: &str,
         read_only: bool,
     ) -> Result<String, DbOperationError> {
-        let mut args = vec!["-batch", "-bail", "-quote", "-header"];
-        if read_only {
-            args.push("-readonly");
-        }
-        let output = self.run(path, &args, sql).await?;
+        let output = self
+            .run(
+                path,
+                &["-batch", "-bail", "-quote", "-header"],
+                sql,
+                read_only,
+            )
+            .await?;
         if !output.status.success() {
             return Err(DbOperationError::QueryFailed(output.stderr));
         }
@@ -82,10 +90,8 @@ impl SqliteCli {
         read_only: bool,
     ) -> Result<usize, DbOperationError> {
         let mut cmd = Command::new("sqlite3");
+        Self::apply_session_options(&mut cmd, read_only);
         cmd.arg("-batch").arg("-bail").arg("-csv").arg("-header");
-        if read_only {
-            cmd.arg("-readonly");
-        }
         cmd.arg("--").arg(path).arg(sql);
 
         let mut child = cmd
@@ -151,13 +157,28 @@ impl SqliteCli {
         path: &str,
         args: &[&str],
         sql: &str,
+        read_only: bool,
     ) -> Result<SqliteOutput, DbOperationError> {
         let mut cmd = Command::new("sqlite3");
+        Self::apply_session_options(&mut cmd, read_only);
         for arg in args {
             cmd.arg(arg);
         }
         cmd.arg("--").arg(path).arg(sql);
         Self::collect_output(&mut cmd, self.timeout_secs).await
+    }
+
+    fn apply_session_options(cmd: &mut Command, read_only: bool) {
+        if read_only {
+            cmd.arg("-readonly");
+        }
+        cmd.arg("-cmd")
+            .arg(format!(".timeout {BUSY_TIMEOUT_MS}"))
+            .arg("-cmd")
+            .arg("PRAGMA foreign_keys=ON");
+        if read_only {
+            cmd.arg("-cmd").arg("PRAGMA query_only=ON");
+        }
     }
 
     async fn collect_output(

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1938,6 +1938,45 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn enables_foreign_keys_before_user_sql() {
+            let (_dir, dsn) = make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(&dsn, "PRAGMA foreign_keys", false)
+                .await
+                .unwrap();
+
+            assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+        }
+
+        #[tokio::test]
+        async fn read_only_session_enables_query_only_before_user_sql() {
+            let (_dir, dsn) = make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(&dsn, "PRAGMA query_only", true)
+                .await
+                .unwrap();
+
+            assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+        }
+
+        #[tokio::test]
+        async fn applies_busy_timeout_before_user_sql() {
+            let (_dir, dsn) = make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(&dsn, "PRAGMA busy_timeout", true)
+                .await
+                .unwrap();
+
+            assert_eq!(result.rows(), vec![vec![cli::BUSY_TIMEOUT_MS.to_string()]]);
+        }
+
+        #[tokio::test]
         async fn values_result_does_not_get_select_command_tag() {
             let (_dir, dsn) = make_sqlite_db("");
             let adapter = SqliteAdapter::new();
@@ -2428,6 +2467,63 @@ mod tests {
 
     mod write_execution {
         use super::*;
+
+        #[tokio::test]
+        async fn foreign_key_restrict_rejects_parent_delete_with_child_row() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE orgs(id INTEGER PRIMARY KEY);
+            CREATE TABLE users(
+                id INTEGER PRIMARY KEY,
+                org_id INTEGER REFERENCES orgs(id) ON DELETE RESTRICT
+            );
+            INSERT INTO orgs(id) VALUES (1);
+            INSERT INTO users(id, org_id) VALUES (1, 1);
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_write(&dsn, "DELETE FROM orgs WHERE id = 1", false)
+                .await;
+            let children = adapter
+                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .await
+                .unwrap();
+
+            assert!(
+                matches!(result, Err(DbOperationError::QueryFailed(message)) if message.contains("FOREIGN KEY constraint failed"))
+            );
+            assert_eq!(children.rows(), vec![vec!["1".to_string()]]);
+        }
+
+        #[tokio::test]
+        async fn foreign_key_cascade_applies_to_parent_delete() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE orgs(id INTEGER PRIMARY KEY);
+            CREATE TABLE users(
+                id INTEGER PRIMARY KEY,
+                org_id INTEGER REFERENCES orgs(id) ON DELETE CASCADE
+            );
+            INSERT INTO orgs(id) VALUES (1);
+            INSERT INTO users(id, org_id) VALUES (1, 1);
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_write(&dsn, "DELETE FROM orgs WHERE id = 1", false)
+                .await
+                .unwrap();
+            let children = adapter
+                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .await
+                .unwrap();
+
+            assert_eq!(result.affected_rows, 1);
+            assert!(children.rows().is_empty());
+        }
 
         #[tokio::test]
         async fn returns_affected_rows() {


### PR DESCRIPTION
## Problem
SQLite execution starts a fresh sqlite3 process per operation, so connection-local safety settings were not guaranteed before user SQL ran.

## Background
SQLite leaves foreign key enforcement disabled by default, and read-only file opening is separate from rejecting writes on the connection.

## Approach
Apply safety session options at the sqlite3 CLI boundary before user SQL: enable foreign keys for every execution, enable query-only mode for read-only executions, and set a busy timeout for lock handling.

## Screenshots
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * SQLiteセッション設定の処理を統一し、読み取り専用モード時のタイムアウトおよび制約設定を確実に適用するようにしました。

* **Tests**
  * 外部キー制約とカスケード削除の動作検証、セッション設定の確認テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->