### PR TITLE
SAB-279 Add SQLite-specific SQL risk classification

### DIFF
--- a/src/app/policy/sql/statement_classifier.rs
+++ b/src/app/policy/sql/statement_classifier.rs
@@ -410,7 +410,10 @@ fn has_non_whitespace_after(lower: &str, byte_pos: usize) -> bool {
         .is_some_and(|tail| !tail.trim().is_empty())
 }
 
-fn collect_top_level_tokens(original: &str, chars: &[(usize, char)]) -> Vec<(usize, String)> {
+pub(crate) fn collect_top_level_tokens(
+    original: &str,
+    chars: &[(usize, char)],
+) -> Vec<(usize, String)> {
     let mut tokens = Vec::new();
     let mut i = 0;
     let mut depth: i32 = 0;

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1,8 +1,9 @@
 use super::write_guardrails::{self, RiskLevel};
+use crate::domain::DatabaseType;
 use crate::policy::sql::statement_classifier::{
-    StatementKind, advance_single_quote, classify, drop_subtype, extract_target_name,
-    first_keyword, skip_block_comment, skip_dollar_quoted_string, skip_double_quoted_identifier,
-    skip_line_comment,
+    StatementKind, advance_single_quote, classify, collect_top_level_tokens, drop_subtype,
+    extract_target_name, first_keyword, skip_block_comment, skip_dollar_quoted_string,
+    skip_double_quoted_identifier, skip_line_comment,
 };
 
 // Why the statement cannot be confirmed via typed target name.
@@ -33,6 +34,7 @@ pub enum ConfirmationType {
 pub struct SqlRiskDecision {
     pub risk_level: RiskLevel,
     pub confirmation: ConfirmationType,
+    pub read_only_allowed: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -206,6 +208,7 @@ fn low_immediate() -> SqlRiskDecision {
     SqlRiskDecision {
         risk_level: RiskLevel::Low,
         confirmation: ConfirmationType::Immediate,
+        read_only_allowed: true,
     }
 }
 
@@ -219,15 +222,32 @@ fn high_acknowledge(kind: &StatementKind) -> SqlRiskDecision {
             reason: AcknowledgeReason::TargetNameUnavailable,
             label: write_guardrails::evaluate_sql_risk(kind).label.to_string(),
         },
+        read_only_allowed: false,
     }
 }
 
 pub fn evaluate_sql_risk(kind: &StatementKind, sql: &str) -> SqlRiskDecision {
+    evaluate_sql_risk_for_database(DatabaseType::PostgreSQL, kind, sql)
+}
+
+pub fn evaluate_sql_risk_for_database(
+    database_type: DatabaseType,
+    kind: &StatementKind,
+    sql: &str,
+) -> SqlRiskDecision {
+    if database_type == DatabaseType::SQLite
+        && let Some(decision) = evaluate_sqlite_specific_risk(sql)
+    {
+        return decision;
+    }
+
     match kind {
-        StatementKind::Select
-        | StatementKind::Transaction
-        | StatementKind::Insert
-        | StatementKind::Create => low_immediate(),
+        StatementKind::Select | StatementKind::Transaction => low_immediate(),
+        StatementKind::Insert | StatementKind::Create => SqlRiskDecision {
+            risk_level: RiskLevel::Low,
+            confirmation: ConfirmationType::Immediate,
+            read_only_allowed: false,
+        },
         StatementKind::Unsupported | StatementKind::Other => {
             // Empty / comment-only input has nothing to execute; gating it
             // would show a confirm dialog for a no-op.
@@ -240,6 +260,7 @@ pub fn evaluate_sql_risk(kind: &StatementKind, sql: &str) -> SqlRiskDecision {
                     reason: AcknowledgeReason::UnknownRisk,
                     label: first_keyword(sql).unwrap_or_else(|| "SQL".to_string()),
                 },
+                read_only_allowed: false,
             }
         }
         StatementKind::Update { has_where: true }
@@ -247,6 +268,7 @@ pub fn evaluate_sql_risk(kind: &StatementKind, sql: &str) -> SqlRiskDecision {
         | StatementKind::Alter => SqlRiskDecision {
             risk_level: RiskLevel::Medium,
             confirmation: ConfirmationType::Immediate,
+            read_only_allowed: false,
         },
         StatementKind::Drop => {
             if matches!(drop_subtype(sql).as_deref(), Some("table" | "database")) {
@@ -254,11 +276,16 @@ pub fn evaluate_sql_risk(kind: &StatementKind, sql: &str) -> SqlRiskDecision {
                     Some(name) => SqlRiskDecision {
                         risk_level: RiskLevel::High,
                         confirmation: ConfirmationType::TableNameInput { target: name },
+                        read_only_allowed: false,
                     },
                     None => high_acknowledge(kind),
                 }
             } else {
-                low_immediate()
+                SqlRiskDecision {
+                    risk_level: RiskLevel::Low,
+                    confirmation: ConfirmationType::Immediate,
+                    read_only_allowed: false,
+                }
             }
         }
         StatementKind::Update { has_where: false }
@@ -267,6 +294,7 @@ pub fn evaluate_sql_risk(kind: &StatementKind, sql: &str) -> SqlRiskDecision {
             Some(name) => SqlRiskDecision {
                 risk_level: RiskLevel::High,
                 confirmation: ConfirmationType::TableNameInput { target: name },
+                read_only_allowed: false,
             },
             None => high_acknowledge(kind),
         },
@@ -274,6 +302,13 @@ pub fn evaluate_sql_risk(kind: &StatementKind, sql: &str) -> SqlRiskDecision {
 }
 
 pub fn evaluate_multi_statement(sql: &str) -> MultiStatementDecision {
+    evaluate_multi_statement_for_database(DatabaseType::PostgreSQL, sql)
+}
+
+pub fn evaluate_multi_statement_for_database(
+    database_type: DatabaseType,
+    sql: &str,
+) -> MultiStatementDecision {
     if contains_cli_meta_command(sql) {
         return MultiStatementDecision::Block {
             reason: "CLI meta-commands are not supported in SQL input".to_string(),
@@ -292,7 +327,7 @@ pub fn evaluate_multi_statement(sql: &str) -> MultiStatementDecision {
 
     for stmt in &statements {
         let kind = classify(stmt);
-        let decision = evaluate_sql_risk(&kind, stmt);
+        let decision = evaluate_sql_risk_for_database(database_type, &kind, stmt);
         decisions.push((stmt.clone(), decision));
     }
 
@@ -342,7 +377,162 @@ pub fn evaluate_multi_statement(sql: &str) -> MultiStatementDecision {
         risk: SqlRiskDecision {
             risk_level: max_risk,
             confirmation,
+            read_only_allowed: decisions.iter().all(|(_, d)| d.read_only_allowed),
         },
+    }
+}
+
+fn high_acknowledge_label(label: &str) -> SqlRiskDecision {
+    SqlRiskDecision {
+        risk_level: RiskLevel::High,
+        confirmation: ConfirmationType::Acknowledge {
+            reason: AcknowledgeReason::TargetNameUnavailable,
+            label: label.to_string(),
+        },
+        read_only_allowed: false,
+    }
+}
+
+fn high_acknowledge_keyword(keyword: &str) -> SqlRiskDecision {
+    high_acknowledge_label(&keyword.to_uppercase())
+}
+
+fn sqlite_replace_target(sql: &str) -> Option<String> {
+    let tokens = top_level_tokens(sql);
+    let lowers: Vec<String> = tokens.iter().map(|token| token.to_lowercase()).collect();
+    let replace_into = lowers.first().is_some_and(|token| token == "replace")
+        && lowers.get(1).is_some_and(|token| token == "into");
+    if replace_into {
+        return tokens.get(2).cloned();
+    }
+    let insert_or_replace = lowers.first().is_some_and(|token| token == "insert")
+        && lowers.get(1).is_some_and(|token| token == "or")
+        && lowers.get(2).is_some_and(|token| token == "replace")
+        && lowers.get(3).is_some_and(|token| token == "into");
+    insert_or_replace.then(|| tokens.get(4).cloned()).flatten()
+}
+
+fn top_level_tokens(sql: &str) -> Vec<String> {
+    let trimmed = sql.trim();
+    let chars: Vec<(usize, char)> = trimmed.char_indices().collect();
+    collect_top_level_tokens(trimmed, &chars)
+        .into_iter()
+        .map(|(_, token)| token)
+        .collect()
+}
+
+fn top_level_token_lowers(sql: &str) -> Vec<String> {
+    top_level_tokens(sql)
+        .into_iter()
+        .map(|token| token.to_lowercase())
+        .collect()
+}
+
+fn top_level_contains_char(sql: &str, target: char) -> bool {
+    let chars: Vec<(usize, char)> = sql.char_indices().collect();
+    let mut i = 0;
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+
+    while i < chars.len() {
+        let (byte_pos, ch) = chars[i];
+
+        if let Some(next_i) = skip_line_comment(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_block_comment(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = advance_single_quote(&chars, i, ch, &mut in_string) {
+            i = next_i;
+            continue;
+        }
+        if in_string {
+            i += 1;
+            continue;
+        }
+        if let Some(next_i) = skip_double_quoted_identifier(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_dollar_quoted_string(sql, &chars, i, byte_pos, ch) {
+            i = next_i;
+            continue;
+        }
+
+        if ch == '(' {
+            depth += 1;
+        } else if ch == ')' {
+            depth -= 1;
+        } else if depth == 0 && ch == target {
+            return true;
+        }
+        i += 1;
+    }
+
+    false
+}
+
+fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
+    let tokens = top_level_token_lowers(sql);
+    let name = tokens.get(1)?;
+    let pragma_name = name.rsplit('.').next().unwrap_or(name);
+    let has_assignment = top_level_contains_char(sql, '=') || tokens.len() > 2;
+
+    if !has_assignment {
+        return Some(low_immediate());
+    }
+
+    let value = tokens.get(2).map(String::as_str);
+    let dangerous = matches!(
+        pragma_name,
+        "writable_schema" | "journal_mode" | "locking_mode"
+    ) || (pragma_name == "foreign_keys"
+        && matches!(value, Some("off" | "0" | "false")));
+
+    Some(SqlRiskDecision {
+        risk_level: if dangerous {
+            RiskLevel::High
+        } else {
+            RiskLevel::Medium
+        },
+        confirmation: if dangerous {
+            ConfirmationType::Acknowledge {
+                reason: AcknowledgeReason::TargetNameUnavailable,
+                label: "PRAGMA".to_string(),
+            }
+        } else {
+            ConfirmationType::Immediate
+        },
+        read_only_allowed: false,
+    })
+}
+
+fn evaluate_sqlite_specific_risk(sql: &str) -> Option<SqlRiskDecision> {
+    let tokens = top_level_token_lowers(sql);
+    match tokens.first().map(String::as_str)? {
+        "pragma" => sqlite_pragma_risk(sql),
+        "attach" | "detach" | "vacuum" | "reindex" | "analyze" => {
+            Some(high_acknowledge_keyword(&tokens[0]))
+        }
+        "replace" => sqlite_replace_target(sql).map_or_else(
+            || Some(high_acknowledge_label("REPLACE")),
+            |target| {
+                Some(SqlRiskDecision {
+                    risk_level: RiskLevel::High,
+                    confirmation: ConfirmationType::TableNameInput { target },
+                    read_only_allowed: false,
+                })
+            },
+        ),
+        "insert" => sqlite_replace_target(sql).map(|target| SqlRiskDecision {
+            risk_level: RiskLevel::High,
+            confirmation: ConfirmationType::TableNameInput { target },
+            read_only_allowed: false,
+        }),
+        _ => None,
     }
 }
 
@@ -560,6 +750,79 @@ mod tests {
             let result = evaluate_sql_risk(&StatementKind::Drop, sql);
             assert_eq!(result.risk_level, RiskLevel::Low);
             assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+        }
+
+        #[test]
+        fn sqlite_read_only_pragma_returns_low_immediate() {
+            let sql = "PRAGMA table_info(users)";
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::Low);
+            assert!(result.read_only_allowed);
+            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+        }
+
+        #[rstest]
+        #[case::writable_schema("PRAGMA writable_schema = ON")]
+        #[case::foreign_keys_off("PRAGMA foreign_keys = OFF")]
+        #[case::journal_mode("PRAGMA journal_mode = WAL")]
+        #[case::locking_mode("PRAGMA locking_mode = EXCLUSIVE")]
+        fn sqlite_dangerous_pragma_requires_acknowledgment(#[case] sql: &str) {
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::High);
+            assert!(!result.read_only_allowed);
+            assert!(matches!(
+                result.confirmation,
+                ConfirmationType::Acknowledge {
+                    reason: AcknowledgeReason::TargetNameUnavailable,
+                    ref label,
+                } if label == "PRAGMA"
+            ));
+        }
+
+        #[test]
+        fn sqlite_non_dangerous_pragma_assignment_is_medium_write() {
+            let sql = "PRAGMA user_version = 3";
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::Medium);
+            assert!(!result.read_only_allowed);
+            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+        }
+
+        #[rstest]
+        #[case::attach("ATTACH DATABASE 'other.db' AS other", "ATTACH")]
+        #[case::detach("DETACH DATABASE other", "DETACH")]
+        #[case::vacuum("VACUUM INTO 'copy.db'", "VACUUM")]
+        #[case::reindex("REINDEX users_name_idx", "REINDEX")]
+        #[case::analyze("ANALYZE users", "ANALYZE")]
+        fn sqlite_high_risk_statements_require_acknowledgment(
+            #[case] sql: &str,
+            #[case] expected_label: &str,
+        ) {
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::High);
+            assert!(!result.read_only_allowed);
+            assert!(matches!(
+                result.confirmation,
+                ConfirmationType::Acknowledge { ref label, .. } if label == expected_label
+            ));
+        }
+
+        #[rstest]
+        #[case::insert_or_replace("INSERT OR REPLACE INTO users(id) VALUES (1)")]
+        #[case::replace("REPLACE INTO users(id) VALUES (1)")]
+        fn sqlite_replace_requires_table_name_input(#[case] sql: &str) {
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::High);
+            assert!(!result.read_only_allowed);
+            assert!(matches!(
+                result.confirmation,
+                ConfirmationType::TableNameInput { ref target } if target == "users"
+            ));
         }
     }
 
@@ -856,6 +1119,36 @@ mod tests {
                 MultiStatementDecision::Allow { risk, .. } => {
                     assert_eq!(risk.risk_level, RiskLevel::Low);
                     assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                }
+                _ => panic!("expected Allow"),
+            }
+        }
+
+        #[test]
+        fn sqlite_safe_pragma_is_read_only_allowed() {
+            let result =
+                evaluate_multi_statement_for_database(DatabaseType::SQLite, "PRAGMA table_info(t)");
+
+            match result {
+                MultiStatementDecision::Allow { risk, .. } => {
+                    assert_eq!(risk.risk_level, RiskLevel::Low);
+                    assert!(risk.read_only_allowed);
+                }
+                _ => panic!("expected Allow"),
+            }
+        }
+
+        #[test]
+        fn sqlite_dangerous_pragma_blocks_read_only() {
+            let result = evaluate_multi_statement_for_database(
+                DatabaseType::SQLite,
+                "PRAGMA foreign_keys = OFF",
+            );
+
+            match result {
+                MultiStatementDecision::Allow { risk, .. } => {
+                    assert_eq!(risk.risk_level, RiskLevel::High);
+                    assert!(!risk.read_only_allowed);
                 }
                 _ => panic!("expected Allow"),
             }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -398,24 +398,37 @@ fn high_acknowledge_keyword(keyword: &str) -> SqlRiskDecision {
 }
 
 fn sqlite_replace_target(sql: &str) -> Option<String> {
-    let tokens = top_level_tokens(sql);
-    let lowers: Vec<String> = tokens.iter().map(|token| token.to_lowercase()).collect();
+    let trimmed = sql.trim();
+    let tokens = top_level_token_pairs(trimmed);
+    let lowers: Vec<String> = tokens
+        .iter()
+        .map(|(_, token)| token.to_lowercase())
+        .collect();
     let replace_into = lowers.first().is_some_and(|token| token == "replace")
         && lowers.get(1).is_some_and(|token| token == "into");
     if replace_into {
-        return tokens.get(2).cloned();
+        let into = tokens.get(1)?;
+        return sqlite_identifier_after(trimmed, into.0 + into.1.len());
     }
     let insert_or_replace = lowers.first().is_some_and(|token| token == "insert")
         && lowers.get(1).is_some_and(|token| token == "or")
         && lowers.get(2).is_some_and(|token| token == "replace")
         && lowers.get(3).is_some_and(|token| token == "into");
-    insert_or_replace.then(|| tokens.get(4).cloned()).flatten()
+    if insert_or_replace {
+        let into = tokens.get(3)?;
+        return sqlite_identifier_after(trimmed, into.0 + into.1.len());
+    }
+    None
 }
 
-fn top_level_tokens(sql: &str) -> Vec<String> {
+fn top_level_token_pairs(sql: &str) -> Vec<(usize, String)> {
     let trimmed = sql.trim();
     let chars: Vec<(usize, char)> = trimmed.char_indices().collect();
     collect_top_level_tokens(trimmed, &chars)
+}
+
+fn top_level_tokens(sql: &str) -> Vec<String> {
+    top_level_token_pairs(sql)
         .into_iter()
         .map(|(_, token)| token)
         .collect()
@@ -441,6 +454,74 @@ pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
         "insert" if sqlite_replace_target(sql).is_some() => Some("REPLACE"),
         _ => None,
     }
+}
+
+fn skip_whitespace(sql: &str, mut cursor: usize) -> usize {
+    while cursor < sql.len() {
+        let Some(ch) = sql[cursor..].chars().next() else {
+            break;
+        };
+        if !ch.is_whitespace() {
+            break;
+        }
+        cursor += ch.len_utf8();
+    }
+    cursor
+}
+
+fn sqlite_identifier_part(sql: &str, cursor: usize) -> Option<(String, usize)> {
+    let ch = sql[cursor..].chars().next()?;
+    let close_quote = match ch {
+        '"' => Some('"'),
+        '`' => Some('`'),
+        '[' => Some(']'),
+        _ => None,
+    };
+    if let Some(close) = close_quote {
+        let mut value = String::new();
+        let mut next = cursor + ch.len_utf8();
+        while next < sql.len() {
+            let c = sql[next..].chars().next()?;
+            next += c.len_utf8();
+            if c == close {
+                if sql[next..].starts_with(close) {
+                    value.push(close);
+                    next += close.len_utf8();
+                    continue;
+                }
+                return Some((value, next));
+            }
+            value.push(c);
+        }
+        return None;
+    }
+
+    let mut end = cursor;
+    while end < sql.len() {
+        let c = sql[end..].chars().next()?;
+        if c.is_whitespace() || matches!(c, '.' | '(' | ',' | ';') {
+            break;
+        }
+        end += c.len_utf8();
+    }
+    (end > cursor).then(|| (sql[cursor..end].to_string(), end))
+}
+
+fn sqlite_identifier_after(sql: &str, start: usize) -> Option<String> {
+    let mut cursor = skip_whitespace(sql, start);
+    let mut parts = Vec::new();
+
+    loop {
+        let (part, next) = sqlite_identifier_part(sql, cursor)?;
+        parts.push(part);
+        cursor = skip_whitespace(sql, next);
+        if !sql[cursor..].starts_with('.') {
+            break;
+        }
+        cursor = skip_whitespace(sql, cursor + 1);
+    }
+
+    Some(parts.join("."))
 }
 
 fn top_level_char_index(sql: &str, target: char) -> Option<usize> {
@@ -504,17 +585,41 @@ fn parenthesized_pragma_value(sql: &str) -> Option<String> {
         .map(str::to_lowercase)
 }
 
+fn sqlite_read_only_parameterized_pragma(name: &str) -> bool {
+    matches!(
+        name,
+        "table_info"
+            | "table_xinfo"
+            | "index_info"
+            | "index_xinfo"
+            | "index_list"
+            | "foreign_key_list"
+            | "database_list"
+            | "table_list"
+            | "pragma_list"
+            | "function_list"
+            | "module_list"
+            | "collation_list"
+            | "integrity_check"
+            | "quick_check"
+            | "column_info"
+    )
+}
+
 fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
     let tokens = top_level_token_lowers(sql);
     let name = tokens.get(1)?;
     let pragma_name = name.rsplit('.').next().unwrap_or(name);
     let has_assignment = top_level_contains_char(sql, '=') || tokens.len() > 2;
     let has_parenthesized_value = top_level_contains_char(sql, '(');
-    let has_side_effect_without_assignment = matches!(
-        pragma_name,
-        "optimize" | "incremental_vacuum" | "wal_checkpoint"
-    ) || (pragma_name == "foreign_keys"
-        && has_parenthesized_value);
+    let is_read_only_parameterized =
+        has_parenthesized_value && sqlite_read_only_parameterized_pragma(pragma_name);
+    let has_side_effect_without_assignment = (has_parenthesized_value
+        && !is_read_only_parameterized)
+        || matches!(
+            pragma_name,
+            "optimize" | "incremental_vacuum" | "wal_checkpoint"
+        );
 
     if !has_assignment && !has_side_effect_without_assignment {
         return Some(low_immediate());
@@ -806,11 +911,23 @@ mod tests {
             assert!(matches!(result.confirmation, ConfirmationType::Immediate));
         }
 
+        #[test]
+        fn sqlite_allowlisted_parameterized_pragma_returns_low_immediate() {
+            let sql = "PRAGMA index_info(users_name_idx)";
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::Low);
+            assert!(result.read_only_allowed);
+            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+        }
+
         #[rstest]
         #[case::writable_schema("PRAGMA writable_schema = ON")]
+        #[case::writable_schema_call("PRAGMA writable_schema(ON)")]
         #[case::foreign_keys_off("PRAGMA foreign_keys = OFF")]
         #[case::foreign_keys_call_off("PRAGMA foreign_keys(OFF)")]
         #[case::journal_mode("PRAGMA journal_mode = WAL")]
+        #[case::journal_mode_call("PRAGMA journal_mode(WAL)")]
         #[case::locking_mode("PRAGMA locking_mode = EXCLUSIVE")]
         #[case::optimize("PRAGMA optimize")]
         #[case::incremental_vacuum("PRAGMA incremental_vacuum")]
@@ -839,6 +956,16 @@ mod tests {
             assert!(matches!(result.confirmation, ConfirmationType::Immediate));
         }
 
+        #[test]
+        fn sqlite_non_allowlisted_parameterized_pragma_is_medium_write() {
+            let sql = "PRAGMA user_version(3)";
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::Medium);
+            assert!(!result.read_only_allowed);
+            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+        }
+
         #[rstest]
         #[case::attach("ATTACH DATABASE 'other.db' AS other", "ATTACH")]
         #[case::detach("DETACH DATABASE other", "DETACH")]
@@ -860,16 +987,26 @@ mod tests {
         }
 
         #[rstest]
-        #[case::insert_or_replace("INSERT OR REPLACE INTO users(id) VALUES (1)")]
-        #[case::replace("REPLACE INTO users(id) VALUES (1)")]
-        fn sqlite_replace_requires_table_name_input(#[case] sql: &str) {
+        #[case::insert_or_replace("INSERT OR REPLACE INTO users(id) VALUES (1)", "users")]
+        #[case::replace("REPLACE INTO users(id) VALUES (1)", "users")]
+        #[case::bracket_quoted("REPLACE INTO [my table](id) VALUES (1)", "my table")]
+        #[case::backtick_quoted("REPLACE INTO `my table`(id) VALUES (1)", "my table")]
+        #[case::double_quoted(r#"REPLACE INTO "my table"(id) VALUES (1)"#, "my table")]
+        #[case::schema_qualified(
+            "INSERT OR REPLACE INTO main.[my table](id) VALUES (1)",
+            "main.my table"
+        )]
+        fn sqlite_replace_requires_table_name_input(
+            #[case] sql: &str,
+            #[case] expected_target: &str,
+        ) {
             let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
 
             assert_eq!(result.risk_level, RiskLevel::High);
             assert!(!result.read_only_allowed);
             assert!(matches!(
                 result.confirmation,
-                ConfirmationType::TableNameInput { ref target } if target == "users"
+                ConfirmationType::TableNameInput { ref target } if target == expected_target
             ));
         }
 

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -428,7 +428,22 @@ fn top_level_token_lowers(sql: &str) -> Vec<String> {
         .collect()
 }
 
-fn top_level_contains_char(sql: &str, target: char) -> bool {
+pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
+    let tokens = top_level_token_lowers(sql);
+    match tokens.first().map(String::as_str)? {
+        "pragma" => Some("PRAGMA"),
+        "attach" => Some("ATTACH"),
+        "detach" => Some("DETACH"),
+        "vacuum" => Some("VACUUM"),
+        "reindex" => Some("REINDEX"),
+        "analyze" => Some("ANALYZE"),
+        "replace" => Some("REPLACE"),
+        "insert" if sqlite_replace_target(sql).is_some() => Some("REPLACE"),
+        _ => None,
+    }
+}
+
+fn top_level_char_index(sql: &str, target: char) -> Option<usize> {
     let chars: Vec<(usize, char)> = sql.char_indices().collect();
     let mut i = 0;
     let mut depth: i32 = 0;
@@ -462,17 +477,31 @@ fn top_level_contains_char(sql: &str, target: char) -> bool {
             continue;
         }
 
+        if depth == 0 && ch == target {
+            return Some(byte_pos);
+        }
         if ch == '(' {
             depth += 1;
         } else if ch == ')' {
             depth -= 1;
-        } else if depth == 0 && ch == target {
-            return true;
         }
         i += 1;
     }
 
-    false
+    None
+}
+
+fn top_level_contains_char(sql: &str, target: char) -> bool {
+    top_level_char_index(sql, target).is_some()
+}
+
+fn parenthesized_pragma_value(sql: &str) -> Option<String> {
+    let open = top_level_char_index(sql, '(')?;
+    let close = sql[open + 1..].find(')')? + open + 1;
+    sql[open + 1..close]
+        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
+        .find(|part| !part.is_empty())
+        .map(str::to_lowercase)
 }
 
 fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
@@ -480,15 +509,30 @@ fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
     let name = tokens.get(1)?;
     let pragma_name = name.rsplit('.').next().unwrap_or(name);
     let has_assignment = top_level_contains_char(sql, '=') || tokens.len() > 2;
+    let has_parenthesized_value = top_level_contains_char(sql, '(');
+    let has_side_effect_without_assignment = matches!(
+        pragma_name,
+        "optimize" | "incremental_vacuum" | "wal_checkpoint"
+    ) || (pragma_name == "foreign_keys"
+        && has_parenthesized_value);
 
-    if !has_assignment {
+    if !has_assignment && !has_side_effect_without_assignment {
         return Some(low_immediate());
     }
 
-    let value = tokens.get(2).map(String::as_str);
+    let parenthesized_value = parenthesized_pragma_value(sql);
+    let value = tokens
+        .get(2)
+        .map(String::as_str)
+        .or(parenthesized_value.as_deref());
     let dangerous = matches!(
         pragma_name,
-        "writable_schema" | "journal_mode" | "locking_mode"
+        "writable_schema"
+            | "journal_mode"
+            | "locking_mode"
+            | "optimize"
+            | "incremental_vacuum"
+            | "wal_checkpoint"
     ) || (pragma_name == "foreign_keys"
         && matches!(value, Some("off" | "0" | "false")));
 
@@ -765,8 +809,12 @@ mod tests {
         #[rstest]
         #[case::writable_schema("PRAGMA writable_schema = ON")]
         #[case::foreign_keys_off("PRAGMA foreign_keys = OFF")]
+        #[case::foreign_keys_call_off("PRAGMA foreign_keys(OFF)")]
         #[case::journal_mode("PRAGMA journal_mode = WAL")]
         #[case::locking_mode("PRAGMA locking_mode = EXCLUSIVE")]
+        #[case::optimize("PRAGMA optimize")]
+        #[case::incremental_vacuum("PRAGMA incremental_vacuum")]
+        #[case::wal_checkpoint("PRAGMA wal_checkpoint")]
         fn sqlite_dangerous_pragma_requires_acknowledgment(#[case] sql: &str) {
             let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
 
@@ -823,6 +871,13 @@ mod tests {
                 result.confirmation,
                 ConfirmationType::TableNameInput { ref target } if target == "users"
             ));
+        }
+
+        #[test]
+        fn sqlite_specific_label_detects_commented_insert_or_replace() {
+            let sql = "-- upsert\nINSERT OR REPLACE INTO users(id) VALUES (1)";
+
+            assert_eq!(sqlite_specific_label(sql), Some("REPLACE"));
         }
     }
 

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -484,7 +484,7 @@ fn sqlite_identifier_part(sql: &str, cursor: usize) -> Option<(String, usize)> {
             let c = sql[next..].chars().next()?;
             next += c.len_utf8();
             if c == close {
-                if sql[next..].starts_with(close) {
+                if close != ']' && sql[next..].starts_with(close) {
                     value.push(close);
                     next += close.len_utf8();
                     continue;
@@ -992,6 +992,12 @@ mod tests {
         #[case::bracket_quoted("REPLACE INTO [my table](id) VALUES (1)", "my table")]
         #[case::backtick_quoted("REPLACE INTO `my table`(id) VALUES (1)", "my table")]
         #[case::double_quoted(r#"REPLACE INTO "my table"(id) VALUES (1)"#, "my table")]
+        #[case::double_quoted_escaped(r#"REPLACE INTO "my""table"(id) VALUES (1)"#, r#"my"table"#)]
+        #[case::backtick_quoted_escaped("REPLACE INTO `my``table`(id) VALUES (1)", "my`table")]
+        #[case::bracket_doubled_close_is_not_escape(
+            "REPLACE INTO [my]]table](id) VALUES (1)",
+            "my"
+        )]
         #[case::schema_qualified(
             "INSERT OR REPLACE INTO main.[my table](id) VALUES (1)",
             "main.my table"

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -4,8 +4,8 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
-use crate::policy::sql::statement_classifier::{self, StatementKind};
-use crate::policy::write::sql_risk::{ConfirmationType, evaluate_sql_risk};
+use crate::policy::sql::statement_classifier;
+use crate::policy::write::sql_risk::{ConfirmationType, evaluate_sql_risk_for_database};
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
@@ -44,11 +44,10 @@ pub(super) fn reduce_analyze(
                 return DispatchResult::handled();
             }
             let kind = statement_classifier::classify(&content);
-            let risk = evaluate_sql_risk(&kind, &content);
+            let database_type = state.session.active_database_type_or_default();
+            let risk = evaluate_sql_risk_for_database(database_type, &kind, &content);
 
-            let is_dml = !matches!(kind, StatementKind::Select | StatementKind::Transaction);
-
-            if state.session.is_read_only() && is_dml {
+            if state.session.is_read_only() && !risk.read_only_allowed {
                 show_explain_error_on_plan(
                     state,
                     "Read-only mode: EXPLAIN ANALYZE is blocked for DML statements.",
@@ -70,7 +69,6 @@ pub(super) fn reduce_analyze(
                         .begin_confirming_analyze_risk(content, reason);
                 }
                 ConfirmationType::Immediate => {
-                    let database_type = state.session.active_database_type_or_default();
                     let Some(explain_query) = services
                         .sql_dialect
                         .build_explain_analyze_sql(database_type, &content)

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -710,7 +710,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("PRAGMA table_info(users)".to_string());
-            activate_sqlite_connection(&mut state, "sqlite:/tmp/test.db");
+            activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
@@ -729,7 +729,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("PRAGMA foreign_keys = OFF".to_string());
-            activate_sqlite_connection(&mut state, "sqlite:/tmp/test.db");
+            activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -42,7 +42,7 @@ mod tests {
         state.modal.set_mode(InputMode::SqlModal);
         state
     }
-    use crate::update::test_support::activate_postgres_connection;
+    use crate::update::test_support::{activate_postgres_connection, activate_sqlite_connection};
 
     mod paste {
         use super::*;
@@ -700,6 +700,48 @@ mod tests {
 
             assert!(!effects.is_empty());
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
+        }
+
+        #[test]
+        fn sqlite_read_only_allows_read_only_pragma() {
+            let mut state = AppState::new("test".to_string());
+            state.modal.set_mode(InputMode::SqlModal);
+            state
+                .sql_modal
+                .editor
+                .set_content("PRAGMA table_info(users)".to_string());
+            activate_sqlite_connection(&mut state, "sqlite:/tmp/test.db");
+            state.session.enable_read_only();
+
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            assert!(!effects.is_empty());
+            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
+        }
+
+        #[test]
+        fn sqlite_read_only_blocks_dangerous_pragma() {
+            let mut state = AppState::new("test".to_string());
+            state.modal.set_mode(InputMode::SqlModal);
+            state
+                .sql_modal
+                .editor
+                .set_content("PRAGMA foreign_keys = OFF".to_string());
+            activate_sqlite_connection(&mut state, "sqlite:/tmp/test.db");
+            state.session.enable_read_only();
+
+            let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            assert!(effects.is_empty());
+            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Error);
+            assert_eq!(
+                state.sql_modal.last_adhoc_error(),
+                Some("Read-only mode: write operations are disabled")
+            );
         }
     }
 

--- a/src/app/update/sql_editor/submit.rs
+++ b/src/app/update/sql_editor/submit.rs
@@ -1,10 +1,11 @@
 use std::time::Instant;
 
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
-use crate::policy::sql::statement_classifier::{self, StatementKind};
+use crate::policy::sql::statement_classifier::{self, first_keyword};
 use crate::policy::write::sql_risk::{
-    ConfirmationType, MultiStatementDecision, evaluate_multi_statement,
+    ConfirmationType, MultiStatementDecision, evaluate_multi_statement_for_database,
 };
 use crate::policy::write::write_guardrails::{AdhocRiskDecision, RiskLevel, evaluate_sql_risk};
 use crate::update::action::Action;
@@ -12,16 +13,40 @@ use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::start_adhoc_if_connected;
 
-fn multi_statement_label(sql: &str) -> &'static str {
+fn sqlite_statement_label(sql: &str) -> Option<&'static str> {
+    let keyword = first_keyword(sql)?;
+    match keyword.as_str() {
+        "PRAGMA" | "ATTACH" | "DETACH" | "VACUUM" | "REINDEX" | "ANALYZE" | "REPLACE" => {
+            Some(match keyword.as_str() {
+                "PRAGMA" => "PRAGMA",
+                "ATTACH" => "ATTACH",
+                "DETACH" => "DETACH",
+                "VACUUM" => "VACUUM",
+                "REINDEX" => "REINDEX",
+                "ANALYZE" => "ANALYZE",
+                "REPLACE" => "REPLACE",
+                _ => "SQL",
+            })
+        }
+        "INSERT" if sql.to_ascii_lowercase().starts_with("insert or replace") => Some("REPLACE"),
+        _ => None,
+    }
+}
+
+fn multi_statement_label(database_type: DatabaseType, sql: &str) -> &'static str {
     use crate::policy::write::sql_risk::split_statements;
     let mut worst_level = RiskLevel::Low;
     let mut worst_label = "SQL";
     for stmt in split_statements(sql) {
+        let sqlite_label = (database_type == DatabaseType::SQLite)
+            .then(|| sqlite_statement_label(&stmt))
+            .flatten();
         let kind = statement_classifier::classify(&stmt);
         let d = evaluate_sql_risk(&kind);
-        if d.risk_level > worst_level || (d.risk_level == worst_level && d.label != "SQL") {
+        let label = sqlite_label.unwrap_or(d.label);
+        if d.risk_level > worst_level || (d.risk_level == worst_level && label != "SQL") {
             worst_level = d.risk_level;
-            worst_label = d.label;
+            worst_label = label;
         }
     }
     worst_label
@@ -35,26 +60,20 @@ pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant)
             }
             state.sql_modal.dismiss_completion();
 
-            match evaluate_multi_statement(&query) {
+            let database_type = state.session.active_database_type_or_default();
+
+            match evaluate_multi_statement_for_database(database_type, &query) {
                 MultiStatementDecision::Block { reason } => {
                     state.sql_modal.finish_adhoc_error(reason);
                     DispatchResult::handled()
                 }
-                MultiStatementDecision::Allow {
-                    risk,
-                    ref statements,
-                } => {
-                    let label = multi_statement_label(&query);
+                MultiStatementDecision::Allow { risk, .. } => {
+                    let label = multi_statement_label(database_type, &query);
                     let decision = AdhocRiskDecision {
                         risk_level: risk.risk_level,
                         label,
                     };
-                    // In read-only mode, block if any statement is a write operation
-                    let has_write = statements.iter().any(|s| {
-                        let kind = statement_classifier::classify(s);
-                        !matches!(kind, StatementKind::Select | StatementKind::Transaction)
-                    });
-                    if state.session.is_read_only() && has_write {
+                    if state.session.is_read_only() && !risk.read_only_allowed {
                         state.sql_modal.finish_adhoc_error(
                             "Read-only mode: write operations are disabled".to_string(),
                         );

--- a/src/app/update/sql_editor/submit.rs
+++ b/src/app/update/sql_editor/submit.rs
@@ -3,9 +3,10 @@ use std::time::Instant;
 use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
-use crate::policy::sql::statement_classifier::{self, first_keyword};
+use crate::policy::sql::statement_classifier;
 use crate::policy::write::sql_risk::{
     ConfirmationType, MultiStatementDecision, evaluate_multi_statement_for_database,
+    sqlite_specific_label,
 };
 use crate::policy::write::write_guardrails::{AdhocRiskDecision, RiskLevel, evaluate_sql_risk};
 use crate::update::action::Action;
@@ -13,33 +14,13 @@ use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::start_adhoc_if_connected;
 
-fn sqlite_statement_label(sql: &str) -> Option<&'static str> {
-    let keyword = first_keyword(sql)?;
-    match keyword.as_str() {
-        "PRAGMA" | "ATTACH" | "DETACH" | "VACUUM" | "REINDEX" | "ANALYZE" | "REPLACE" => {
-            Some(match keyword.as_str() {
-                "PRAGMA" => "PRAGMA",
-                "ATTACH" => "ATTACH",
-                "DETACH" => "DETACH",
-                "VACUUM" => "VACUUM",
-                "REINDEX" => "REINDEX",
-                "ANALYZE" => "ANALYZE",
-                "REPLACE" => "REPLACE",
-                _ => "SQL",
-            })
-        }
-        "INSERT" if sql.to_ascii_lowercase().starts_with("insert or replace") => Some("REPLACE"),
-        _ => None,
-    }
-}
-
 fn multi_statement_label(database_type: DatabaseType, sql: &str) -> &'static str {
     use crate::policy::write::sql_risk::split_statements;
     let mut worst_level = RiskLevel::Low;
     let mut worst_label = "SQL";
     for stmt in split_statements(sql) {
         let sqlite_label = (database_type == DatabaseType::SQLite)
-            .then(|| sqlite_statement_label(&stmt))
+            .then(|| sqlite_specific_label(&stmt))
             .flatten();
         let kind = statement_classifier::classify(&stmt);
         let d = evaluate_sql_risk(&kind);

--- a/src/domain/command_tag.rs
+++ b/src/domain/command_tag.rs
@@ -21,6 +21,7 @@ impl CommandTag {
 
     pub fn is_schema_modifying(&self) -> bool {
         matches!(self, Self::Create(_) | Self::Drop(_) | Self::Alter(_))
+            || matches!(self, Self::Other(tag) if matches!(tag.as_str(), "ATTACH" | "DETACH"))
     }
 
     pub fn needs_refresh(&self) -> bool {
@@ -33,6 +34,13 @@ impl CommandTag {
                 | Self::Drop(_)
                 | Self::Alter(_)
                 | Self::Truncate
+        ) || matches!(
+            self,
+            Self::Other(tag)
+                if matches!(
+                    tag.as_str(),
+                    "ANALYZE" | "ATTACH" | "DETACH" | "REINDEX" | "VACUUM"
+                )
         )
     }
 
@@ -165,6 +173,12 @@ mod tests {
     }
 
     #[test]
+    fn is_schema_modifying_true_for_sqlite_attachment_changes() {
+        assert!(CommandTag::Other("ATTACH".to_string()).is_schema_modifying());
+        assert!(CommandTag::Other("DETACH".to_string()).is_schema_modifying());
+    }
+
+    #[test]
     fn needs_refresh_true_for_dml_and_ddl() {
         assert!(CommandTag::Insert(1).needs_refresh());
         assert!(CommandTag::Update(1).needs_refresh());
@@ -181,6 +195,13 @@ mod tests {
         assert!(!CommandTag::Begin.needs_refresh());
         assert!(!CommandTag::Commit.needs_refresh());
         assert!(!CommandTag::Rollback.needs_refresh());
-        assert!(!CommandTag::Other("VACUUM".to_string()).needs_refresh());
+        assert!(!CommandTag::Other("SAVEPOINT".to_string()).needs_refresh());
+    }
+
+    #[test]
+    fn needs_refresh_true_for_sqlite_side_effects() {
+        for tag in ["ANALYZE", "ATTACH", "DETACH", "REINDEX", "VACUUM"] {
+            assert!(CommandTag::Other(tag.to_string()).needs_refresh());
+        }
     }
 }

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -698,7 +698,7 @@ fn is_transaction_control(statement: &str) -> bool {
 fn is_write_statement(statement: &str) -> bool {
     matches!(
         first_keyword(statement).to_ascii_uppercase().as_str(),
-        "INSERT" | "UPDATE" | "DELETE" | "CREATE" | "ALTER" | "DROP" | "TRUNCATE"
+        "INSERT" | "REPLACE" | "UPDATE" | "DELETE" | "CREATE" | "ALTER" | "DROP" | "TRUNCATE"
     )
 }
 
@@ -1601,6 +1601,18 @@ mod tests {
         assert_eq!(
             wrapped,
             "BEGIN;\nINSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)\n;\nCOMMIT\n;\nSELECT changes() AS affected_rows;"
+        );
+    }
+
+    #[test]
+    fn append_changes_wraps_multi_statement_replace_without_explicit_transaction() {
+        let query = "REPLACE INTO users(id) VALUES (1); SELECT * FROM missing";
+
+        let wrapped = append_changes_query(query);
+
+        assert_eq!(
+            wrapped,
+            "BEGIN;\nREPLACE INTO users(id) VALUES (1); SELECT * FROM missing\n;\nCOMMIT\n;\nSELECT changes() AS affected_rows;"
         );
     }
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -794,6 +794,9 @@ fn dml_keyword(statement: &str) -> Option<&'static str> {
     if keyword.eq_ignore_ascii_case("INSERT") {
         return Some("INSERT");
     }
+    if keyword.eq_ignore_ascii_case("REPLACE") {
+        return Some("INSERT");
+    }
     if keyword.eq_ignore_ascii_case("UPDATE") {
         return Some("UPDATE");
     }
@@ -807,6 +810,9 @@ fn dml_keyword(statement: &str) -> Option<&'static str> {
     let mut offset = 0;
     while let Some((keyword, end)) = next_keyword_from(statement, offset) {
         if keyword.eq_ignore_ascii_case("INSERT") {
+            return Some("INSERT");
+        }
+        if keyword.eq_ignore_ascii_case("REPLACE") {
             return Some("INSERT");
         }
         if keyword.eq_ignore_ascii_case("UPDATE") {
@@ -2005,6 +2011,25 @@ mod tests {
 
             assert_eq!(result.row_count(), 1);
             assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
+        }
+
+        #[tokio::test]
+        async fn replace_into_returns_insert_refresh_tag() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            INSERT INTO users(id, name) VALUES (1, 'a');
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(&dsn, "REPLACE INTO users(id, name) VALUES (1, 'z')", false)
+                .await
+                .unwrap();
+
+            assert_eq!(result.row_count(), 1);
+            assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
         }
 
         #[tokio::test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1248,6 +1248,14 @@ fn dml_tag(query: &str, affected_rows: usize) -> Option<CommandTag> {
     }
 }
 
+fn sqlite_side_effect_tag(query: &str) -> Option<CommandTag> {
+    let keyword = first_keyword(query).to_ascii_uppercase();
+    match keyword.as_str() {
+        "ANALYZE" | "ATTACH" | "DETACH" | "REINDEX" | "VACUUM" => Some(CommandTag::Other(keyword)),
+        _ => None,
+    }
+}
+
 fn sqlite_statement_tags(statements: &[&str], changes: &HashMap<usize, usize>) -> Vec<CommandTag> {
     statements
         .iter()
@@ -1256,6 +1264,7 @@ fn sqlite_statement_tags(statements: &[&str], changes: &HashMap<usize, usize>) -
             dml_tag(statement, *changes.get(&index).unwrap_or(&0))
                 .or_else(|| ddl_tag(statement))
                 .or_else(|| transaction_control_tag(statement))
+                .or_else(|| sqlite_side_effect_tag(statement))
         })
         .collect()
 }
@@ -1611,6 +1620,34 @@ mod tests {
             wrapped,
             "BEGIN; INSERT INTO users(id) VALUES (1); END\n;\nSELECT changes() AS affected_rows;"
         );
+    }
+
+    #[test]
+    fn sqlite_side_effect_statements_emit_refresh_tags() {
+        let changes = HashMap::new();
+
+        let tags = sqlite_statement_tags(
+            &[
+                "ANALYZE users",
+                "ATTACH DATABASE 'other.db' AS other",
+                "DETACH DATABASE other",
+                "REINDEX users_name_idx",
+                "VACUUM",
+            ],
+            &changes,
+        );
+
+        assert_eq!(
+            tags,
+            vec![
+                CommandTag::Other("ANALYZE".to_string()),
+                CommandTag::Other("ATTACH".to_string()),
+                CommandTag::Other("DETACH".to_string()),
+                CommandTag::Other("REINDEX".to_string()),
+                CommandTag::Other("VACUUM".to_string()),
+            ]
+        );
+        assert!(tags.iter().all(CommandTag::needs_refresh));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add SQLite-specific SQL risk handling for PRAGMA, ATTACH/DETACH, VACUUM, REINDEX, ANALYZE, and REPLACE forms.
- Route SQL modal and EXPLAIN ANALYZE read-only checks through dialect-aware risk decisions.
- Mark SQLite side-effect statements with refresh-aware command tags so metadata or table views update after execution.

## Validation

- `env RUSTC_WRAPPER= cargo test --workspace`
- `env RUSTC_WRAPPER= cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `env RUSTC_WRAPPER= cargo clippy --workspace --all-targets --no-default-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * データベース種別ごとのSQLリスク評価を導入し、SQLite向けのラベル/危険度判定を改善（マルチステートメントにも対応）。
* **バグ修正**
  * 読み取り専用モード時の実行可否判定を全体的に見直し（SQL実行・EXPLAIN ANALYZE・エラー表示）。
  * SQLiteでのスキーマ変更/更新要判定を調整（ATTACH/DETACH、REPLACEの扱いを含む）。
* **テスト**
  * SQLiteの読み取り専用モードやラベル/判定、スキーマ変更・更新要タグ、REPLACE挙動の検証を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->