### PR TITLE
SAB-283 Keep SSL mode connect action visible

### DIFF
--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -1,6 +1,7 @@
 use unicode_width::UnicodeWidthStr;
 
 use crate::model::app_state::AppState;
+use crate::model::connection::setup::ConnectionField;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::help::{HelpOrigin, JsonbHelpMode, SqlHelpMode};
 use crate::model::shared::settings::KeymapPreset;
@@ -243,15 +244,10 @@ fn current_section(origin: HelpOrigin) -> HelpSection {
             mode,
             keymap_preset,
         } => sql_current_rows(mode, keymap_preset),
-        HelpOrigin::ConnectionSetup { keymap_preset } => rows_from_binding_refs(&[
-            &connection_setup::TAB_NAV,
-            &connection_setup::TAB_NEXT,
-            &connection_setup::TAB_PREV,
-            connection_setup_save(keymap_preset),
-            &connection_setup::ESC_CANCEL,
-            &connection_setup::ENTER_DROPDOWN,
-            &connection_setup::DROPDOWN_NAV,
-        ]),
+        HelpOrigin::ConnectionSetup {
+            keymap_preset,
+            focused_field,
+        } => connection_setup_current_rows(keymap_preset, focused_field),
         HelpOrigin::ConnectionError => rows_from_mode_rows(CONNECTION_ERROR_ROWS),
         HelpOrigin::ConfirmDialog => rows_from_bindings(CONFIRM_DIALOG_KEYS),
         HelpOrigin::ConnectionSelector => rows_from_mode_rows(CONNECTION_SELECTOR_ROWS),
@@ -415,6 +411,34 @@ fn sql_current_rows(mode: SqlHelpMode, keymap_preset: KeymapPreset) -> Vec<HelpR
         ]),
         SqlHelpMode::Confirm => rows_from_bindings(SQL_MODAL_CONFIRMING_KEYS),
     }
+}
+
+fn connection_setup_current_rows(
+    keymap_preset: KeymapPreset,
+    focused_field: ConnectionField,
+) -> Vec<HelpRow> {
+    let submit = if focused_field == ConnectionField::SslMode {
+        &connection_setup::ENTER_DROPDOWN
+    } else {
+        connection_setup_save(keymap_preset)
+    };
+    let mut rows = rows_from_binding_refs(&[
+        &connection_setup::TAB_NAV,
+        &connection_setup::TAB_NEXT,
+        &connection_setup::TAB_PREV,
+        submit,
+    ]);
+    if focused_field == ConnectionField::SslMode {
+        rows.push(HelpRow::new(
+            connection_setup::SAVE.key,
+            connection_setup::SAVE.description,
+        ));
+    }
+    rows.extend(rows_from_binding_refs(&[
+        &connection_setup::ESC_CANCEL,
+        &connection_setup::DROPDOWN_NAV,
+    ]));
+    rows
 }
 
 fn jsonb_current_rows(mode: JsonbHelpMode) -> Vec<HelpRow> {
@@ -655,5 +679,30 @@ mod tests {
             jsonb_document.sections()[0].title(),
             "Current: JSONB Search"
         );
+    }
+
+    #[test]
+    fn connection_setup_help_matches_ssl_field_actions() {
+        let document = HelpDocument::new(
+            HelpOrigin::ConnectionSetup {
+                keymap_preset: KeymapPreset::Ide,
+                focused_field: ConnectionField::SslMode,
+            },
+            "",
+        );
+        let current_rows = document.sections()[0].rows();
+
+        assert!(current_rows.iter().any(|row| {
+            row.key() == connection_setup::ENTER_DROPDOWN.key
+                && row.description() == connection_setup::ENTER_DROPDOWN.description
+        }));
+        assert!(current_rows.iter().any(|row| {
+            row.key() == connection_setup::SAVE.key
+                && row.description() == connection_setup::SAVE.description
+        }));
+        assert!(!current_rows.iter().any(|row| {
+            row.key() == connection_setup::SAVE_IDE.key
+                && row.description() == connection_setup::SAVE_IDE.description
+        }));
     }
 }

--- a/src/app/model/shared/help.rs
+++ b/src/app/model/shared/help.rs
@@ -1,5 +1,6 @@
 use crate::model::app_state::AppState;
 use crate::model::browse::jsonb_detail::JsonbDetailMode;
+use crate::model::connection::setup::ConnectionField;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::settings::KeymapPreset;
@@ -105,6 +106,7 @@ pub enum HelpOrigin {
     },
     ConnectionSetup {
         keymap_preset: KeymapPreset,
+        focused_field: ConnectionField,
     },
     ConnectionError,
     ConfirmDialog,
@@ -124,7 +126,7 @@ impl HelpOrigin {
         match self {
             Self::Normal { keymap_preset, .. }
             | Self::SqlModal { keymap_preset, .. }
-            | Self::ConnectionSetup { keymap_preset }
+            | Self::ConnectionSetup { keymap_preset, .. }
             | Self::ErTablePicker { keymap_preset } => keymap_preset,
             Self::CommandLine
             | Self::CellEdit
@@ -160,6 +162,7 @@ impl HelpOrigin {
             },
             InputMode::ConnectionSetup => Self::ConnectionSetup {
                 keymap_preset: state.settings.saved_keymap_preset(),
+                focused_field: state.connection_setup.focused_field,
             },
             InputMode::ConnectionError => Self::ConnectionError,
             InputMode::ConfirmDialog => Self::ConfirmDialog,

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -164,12 +164,7 @@ pub(super) fn reduce_connection_setup(
         }
         Action::ConnectionSetupDropdownConfirm => {
             let setup = &mut state.connection_setup;
-            if setup.ssl_dropdown.is_open {
-                if let Some(mode) = SslMode::all_variants().get(setup.ssl_dropdown.selected_index) {
-                    setup.ssl_mode = *mode;
-                }
-                setup.ssl_dropdown.is_open = false;
-            }
+            confirm_ssl_dropdown_selection(setup);
             DispatchResult::handled()
         }
         Action::ConnectionSetupDropdownCancel => {
@@ -178,6 +173,7 @@ pub(super) fn reduce_connection_setup(
         }
         Action::ConnectionSetupSave => {
             let setup = &mut state.connection_setup;
+            confirm_ssl_dropdown_selection(setup);
             validate_all(setup);
             if setup.validation_errors.is_empty() {
                 let port = setup.port.content().parse().unwrap_or(5432);
@@ -233,6 +229,15 @@ pub(super) fn reduce_connection_setup(
         }
 
         _ => DispatchResult::pass(),
+    }
+}
+
+fn confirm_ssl_dropdown_selection(setup: &mut ConnectionSetupState) {
+    if setup.ssl_dropdown.is_open {
+        if let Some(mode) = SslMode::all_variants().get(setup.ssl_dropdown.selected_index) {
+            setup.ssl_mode = *mode;
+        }
+        setup.ssl_dropdown.is_open = false;
     }
 }
 
@@ -400,6 +405,32 @@ mod tests {
                 ConnectionState::Connecting
             );
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
+        }
+
+        #[test]
+        fn save_confirms_open_ssl_dropdown_selection() {
+            let mut state = AppState::new("test".to_string());
+            fill_valid_form(&mut state);
+            state.connection_setup.ssl_mode = SslMode::Prefer;
+            state.connection_setup.ssl_dropdown.is_open = true;
+            state.connection_setup.ssl_dropdown.selected_index = SslMode::all_variants()
+                .iter()
+                .position(|mode| *mode == SslMode::Require)
+                .unwrap();
+
+            let effects =
+                reduce_connection_setup(&mut state, &Action::ConnectionSetupSave, Instant::now())
+                    .unwrap();
+
+            assert_eq!(state.connection_setup.ssl_mode, SslMode::Require);
+            assert!(!state.connection_setup.ssl_dropdown.is_open);
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::SaveAndConnect {
+                    ssl_mode: SslMode::Require,
+                    ..
+                }]
+            ));
         }
 
         #[test]

--- a/src/app/update/input/handlers/connections.rs
+++ b/src/app/update/input/handlers/connections.rs
@@ -1,4 +1,5 @@
 use crate::model::app_state::AppState;
+use crate::model::shared::settings::KeymapPreset;
 use crate::update::action::{Action, InputTarget};
 use crate::update::input::keybindings::{self, Key, KeyCombo, Modifiers};
 
@@ -13,8 +14,7 @@ pub fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) -> Action
     let ctrl_only = ctrl && !alt && !shift;
 
     let primary_save = keybindings::connection_setup_save(state.settings.saved_keymap_preset());
-    let auxiliary_save = state.settings.saved_keymap_preset()
-        == crate::model::shared::settings::KeymapPreset::Ide
+    let auxiliary_save = state.settings.saved_keymap_preset() == KeymapPreset::Ide
         && keybindings::connection_setup::SAVE.combos.contains(&combo);
     if (primary_save.combos.contains(&combo) || auxiliary_save)
         && !(combo.key == Key::Enter
@@ -92,7 +92,6 @@ pub fn handle_connection_selector_keys(combo: KeyCombo) -> Action {
 mod tests {
     use super::*;
     use crate::model::shared::input_mode::InputMode;
-    use crate::model::shared::settings::KeymapPreset;
     use crate::update::action::{
         ListMotion, ListTarget, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget,
     };

--- a/src/app/update/input/handlers/connections.rs
+++ b/src/app/update/input/handlers/connections.rs
@@ -12,6 +12,17 @@ pub fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) -> Action
     let shift = combo.modifiers.contains(Modifiers::SHIFT);
     let ctrl_only = ctrl && !alt && !shift;
 
+    let primary_save = keybindings::connection_setup_save(state.settings.saved_keymap_preset());
+    let auxiliary_save = state.settings.saved_keymap_preset()
+        == crate::model::shared::settings::KeymapPreset::Ide
+        && keybindings::connection_setup::SAVE.combos.contains(&combo);
+    if (primary_save.combos.contains(&combo) || auxiliary_save)
+        && !(combo.key == Key::Enter
+            && state.connection_setup.focused_field == ConnectionField::SslMode)
+    {
+        return Action::ConnectionSetupSave;
+    }
+
     if dropdown_open {
         return match combo.key {
             Key::Up => Action::ConnectionSetupDropdownPrev,
@@ -22,15 +33,6 @@ pub fn handle_connection_setup_keys(combo: KeyCombo, state: &AppState) -> Action
             Key::Esc => Action::ConnectionSetupDropdownCancel,
             _ => Action::None,
         };
-    }
-
-    if keybindings::connection_setup_save(state.settings.saved_keymap_preset())
-        .combos
-        .contains(&combo)
-        && !(combo.key == Key::Enter
-            && state.connection_setup.focused_field == ConnectionField::SslMode)
-    {
-        return Action::ConnectionSetupSave;
     }
 
     match combo.key {
@@ -172,12 +174,22 @@ mod tests {
         }
 
         #[test]
-        fn ide_ctrl_s_is_ignored() {
+        fn ide_ctrl_s_saves() {
             let state = setup_state_with_preset(KeymapPreset::Ide);
 
             let result = handle_connection_setup_keys(combo_ctrl(Key::Char('s')), &state);
 
-            assert!(matches!(result, Action::None));
+            assert!(matches!(result, Action::ConnectionSetupSave));
+        }
+
+        #[test]
+        fn ide_ctrl_s_saves_on_ssl_field() {
+            let mut state = setup_state_with_preset(KeymapPreset::Ide);
+            state.connection_setup.focused_field = ConnectionField::SslMode;
+
+            let result = handle_connection_setup_keys(combo_ctrl(Key::Char('s')), &state);
+
+            assert!(matches!(result, Action::ConnectionSetupSave));
         }
 
         #[test]

--- a/src/app/update/input/keybindings/connections.rs
+++ b/src/app/update/input/keybindings/connections.rs
@@ -13,7 +13,7 @@ pub mod connection_setup {
     pub const TAB_NAV: KeyBinding = KeyBinding {
         key_short: "Tab/⇧Tab",
         key: "Tab/⇧Tab",
-        desc_short: "Next/Prev",
+        desc_short: "Field",
         description: "Next/Previous field",
         action: Action::None,
         combos: &[],

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -1,4 +1,5 @@
 use super::*;
+use sabiql_app::model::shared::settings::KeymapPreset;
 
 #[test]
 fn connection_setup_form() {
@@ -59,6 +60,20 @@ fn connection_setup_cursor_at_tail() {
         .connection_setup
         .host
         .set_content("db.example.com".to_string());
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn connection_setup_ssl_mode_ide_hint() {
+    let mut state = create_test_state();
+    let mut terminal = create_test_terminal();
+
+    state.modal.set_mode(InputMode::ConnectionSetup);
+    state.settings.load_keymap_preset(KeymapPreset::Ide);
+    state.connection_setup.focused_field = ConnectionField::SslMode;
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 35
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
@@ -33,7 +34,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          ╰ Tab: Next │ Shift+Tab: Prev │ Ctrl+S: Connect │ Esc: Cancel╯                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ Ctrl+S: Connect │ Esc: Cancel ───────────╯                                                  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
@@ -51,4 +52,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-^S:Connect  Tab:Next  ⇧Tab:Prev  Esc:Cancel
+^S:Connect  Tab/⇧Tab:Field  Esc:Cancel

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
@@ -34,7 +34,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          ╰ Tab/⇧Tab: Field │ Ctrl+S: Connect │ Esc: Cancel ───────────╯                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
@@ -34,7 +34,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          ╰ Tab/⇧Tab: Field │ Ctrl+S: Connect │ Esc: Cancel ───────────╯                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 49
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
@@ -33,7 +34,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          ╰ Tab: Next │ Shift+Tab: Prev │ Ctrl+S: Connect │ Esc: Cancel╯                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ Ctrl+S: Connect │ Esc: Cancel ───────────╯                                                  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
@@ -51,4 +52,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-^S:Connect  Tab:Next  ⇧Tab:Prev  Esc:Cancel
+^S:Connect  Tab/⇧Tab:Field  Esc:Cancel

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
@@ -34,7 +34,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          ╰ Tab/⇧Tab: Field │ Ctrl+S: Connect │ Esc: Cancel ───────────╯                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 66
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
@@ -33,7 +34,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          ╰ Tab: Next │ Shift+Tab: Prev │ Ctrl+S: Connect │ Esc: Cancel╯                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ Ctrl+S: Connect │ Esc: Cancel ───────────╯                                                  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
@@ -51,4 +52,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-^S:Connect  Tab:Next  ⇧Tab:Prev  Esc:Cancel
+^S:Connect  Tab/⇧Tab:Field  Esc:Cancel

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 21
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
@@ -33,7 +34,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          ╰ Tab: Next │ Shift+Tab: Prev │ Ctrl+S: Connect │ Esc: Cancel╯                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ Ctrl+S: Connect │ Esc: Cancel ───────────╯                                                  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
@@ -51,4 +52,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-^S:Connect  Tab:Next  ⇧Tab:Prev  Esc:Cancel
+^S:Connect  Tab/⇧Tab:Field  Esc:Cancel

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
@@ -34,7 +34,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          ╰ Tab/⇧Tab: Field │ Ctrl+S: Connect │ Esc: Cancel ───────────╯                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 80
+expression: output
+---
+test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
+│ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                       ││(select a table)                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││   ╭ New Connection ─────────────────────────────────────────────────────────╮                                            │
+│                                       ││   │                                                                         │                                            │
+│                                       ││   │  Name:       [                            ]                             │                                            │
+│                                       ││   │  Host:       [ localhost                  ]                             │                                            │
+│                                       ││   │  Port:       [ 5432                       ]                             │                                            │
+│                                       │└───│  Database:   [                            ]                             │────────────────────────────────────────────┘
+│                                       │┌ [3│  User:       [                            ]                             │────────────────────────────────────────────┐
+│                                       ││(se│  Password:   [                            ]                             │                                            │
+│                                       ││   │  SSL Mode:   [ prefer                   ▼ ]                             │                                            │
+│                                       ││   │                                                                         │                                            │
+│                                       ││   │  Note: Connection info is stored locally in plain text                  │                                            │
+│                                       ││   │                                                                         │                                            │
+│                                       ││   ╰ Tab: Next │ Shift+Tab: Prev │ Enter: Toggle │ ^S: Connect │ Esc: Cancel ╯                                            │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+└───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+Enter:Toggle  ^S:Connect  Tab:Next  ⇧Tab:Prev  Esc:Cancel

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
@@ -22,19 +22,19 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││   ╭ New Connection ─────────────────────────────────────────────────────────╮                                            │
-│                                       ││   │                                                                         │                                            │
-│                                       ││   │  Name:       [                            ]                             │                                            │
-│                                       ││   │  Host:       [ localhost                  ]                             │                                            │
-│                                       ││   │  Port:       [ 5432                       ]                             │                                            │
-│                                       │└───│  Database:   [                            ]                             │────────────────────────────────────────────┘
-│                                       │┌ [3│  User:       [                            ]                             │────────────────────────────────────────────┐
-│                                       ││(se│  Password:   [                            ]                             │                                            │
-│                                       ││   │  SSL Mode:   [ prefer                   ▼ ]                             │                                            │
-│                                       ││   │                                                                         │                                            │
-│                                       ││   │  Note: Connection info is stored locally in plain text                  │                                            │
-│                                       ││   │                                                                         │                                            │
-│                                       ││   ╰ Tab: Next │ Shift+Tab: Prev │ Enter: Toggle │ ^S: Connect │ Esc: Cancel ╯                                            │
+│                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  Name:       [                            ]                │                                                  │
+│                                       ││          │  Host:       [ localhost                  ]                │                                                  │
+│                                       ││          │  Port:       [ 5432                       ]                │                                                  │
+│                                       │└──────────│  Database:   [                            ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  User:       [                            ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  Password:   [                            ]                │                                                  │
+│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ Enter: Toggle │ ^S: Connect │ Esc: Cancel╯                                                  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
@@ -52,4 +52,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-Enter:Toggle  ^S:Connect  Tab:Next  ⇧Tab:Prev  Esc:Cancel
+Enter:Toggle  ^S:Connect  Tab/⇧Tab:Field  Esc:Cancel

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_with_validation_errors.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_with_validation_errors.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
+assertion_line: 107
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
@@ -33,7 +34,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          ╰ Tab: Next │ Shift+Tab: Prev │ Ctrl+S: Connect │ Esc: Cancel╯                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ Ctrl+S: Connect │ Esc: Cancel ───────────╯                                                  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
@@ -51,4 +52,4 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-^S:Connect  Tab:Next  ⇧Tab:Prev  Esc:Cancel
+^S:Connect  Tab/⇧Tab:Field  Esc:Cancel

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_with_validation_errors.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_with_validation_errors.snap
@@ -34,7 +34,7 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          ╰ Tab/⇧Tab: Field │ Ctrl+S: Connect │ Esc: Cancel ───────────╯                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -154,7 +154,7 @@ impl ConnectionSetup {
             ]
         } else {
             vec![(
-                connection_setup_save(state.settings.saved_keymap_preset()).key,
+                connection_setup_save(state.settings.saved_keymap_preset()).key_short,
                 submit_desc,
             )]
         }
@@ -368,6 +368,17 @@ mod tests {
         assert_eq!(
             ConnectionSetup::submit_hints(&state, &form_state, "Connect"),
             vec![("Enter", "Connect")]
+        );
+    }
+
+    #[test]
+    fn submit_hints_use_short_default_save_key_off_ssl_field() {
+        let state = AppState::new("test".to_string());
+        let form_state = ConnectionSetupState::default();
+
+        assert_eq!(
+            ConnectionSetup::submit_hints(&state, &form_state, "Connect"),
+            vec![("^S", "Connect")]
         );
     }
 }

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -6,7 +6,7 @@ use crate::app::model::app_state::AppState;
 use crate::app::model::connection::setup::{
     CONNECTION_INPUT_VISIBLE_WIDTH, CONNECTION_INPUT_WIDTH, ConnectionField, ConnectionSetupState,
 };
-use crate::app::update::input::keybindings::connection_setup_save;
+use crate::app::update::input::keybindings::{connection_setup, connection_setup_save};
 use crate::domain::connection::SslMode;
 use crate::primitives::atoms::text_cursor_spans;
 use crate::primitives::molecules::{FooterHintBar, render_modal};
@@ -35,26 +35,30 @@ impl ConnectionSetup {
     pub fn render(frame: &mut Frame, state: &AppState, theme: &ThemePalette) {
         let form_state = &state.connection_setup;
 
-        let modal_width = LABEL_WIDTH + INPUT_WIDTH + ERROR_WIDTH + 8;
-        let modal_height = 13;
-
         let (title, submit_desc) = if form_state.is_edit_mode() {
             (" Edit Connection ", "Save")
         } else {
             (" New Connection ", "Connect")
         };
-        let (submit_key, submit_desc) = Self::submit_hint(state, form_state, submit_desc);
+        let submit_hints = Self::submit_hints(state, form_state, submit_desc);
+        let mut footer_hints = vec![("Tab", "Next"), ("Shift+Tab", "Prev")];
+        footer_hints.extend(submit_hints);
+        footer_hints.push(("Esc", "Cancel"));
+        let footer = FooterHintBar::new(footer_hints);
+
+        let base_modal_width = LABEL_WIDTH + INPUT_WIDTH + ERROR_WIDTH + 8;
+        let modal_width = if form_state.focused_field == ConnectionField::SslMode {
+            base_modal_width.max(footer.width() + 2)
+        } else {
+            base_modal_width
+        };
+        let modal_height = 13;
         let (_, modal_inner) = render_modal(
             frame,
             Constraint::Length(modal_width),
             Constraint::Length(modal_height),
             title,
-            FooterHintBar::new([
-                ("Tab", "Next"),
-                ("Shift+Tab", "Prev"),
-                (submit_key, submit_desc),
-                ("Esc", "Cancel"),
-            ]),
+            footer,
             theme,
         );
 
@@ -143,18 +147,21 @@ impl ConnectionSetup {
         }
     }
 
-    fn submit_hint(
+    fn submit_hints(
         state: &AppState,
         form_state: &ConnectionSetupState,
         submit_desc: &'static str,
-    ) -> (&'static str, &'static str) {
+    ) -> Vec<(&'static str, &'static str)> {
         if form_state.focused_field == ConnectionField::SslMode {
-            ("Enter", "Toggle")
+            vec![
+                connection_setup::ENTER_DROPDOWN.as_hint(),
+                (connection_setup::SAVE.key_short, submit_desc),
+            ]
         } else {
-            (
+            vec![(
                 connection_setup_save(state.settings.saved_keymap_preset()).key,
                 submit_desc,
-            )
+            )]
         }
     }
 
@@ -344,7 +351,7 @@ mod tests {
     use crate::app::model::shared::settings::KeymapPreset;
 
     #[test]
-    fn submit_hint_uses_toggle_on_ssl_field() {
+    fn submit_hints_include_toggle_and_save_on_ssl_field() {
         let state = AppState::new("test".to_string());
         let form_state = ConnectionSetupState {
             focused_field: ConnectionField::SslMode,
@@ -352,20 +359,20 @@ mod tests {
         };
 
         assert_eq!(
-            ConnectionSetup::submit_hint(&state, &form_state, "Connect"),
-            ("Enter", "Toggle")
+            ConnectionSetup::submit_hints(&state, &form_state, "Connect"),
+            vec![("Enter", "Toggle"), ("^S", "Connect")]
         );
     }
 
     #[test]
-    fn submit_hint_uses_preset_save_key_off_ssl_field() {
+    fn submit_hints_use_preset_save_key_off_ssl_field() {
         let mut state = AppState::new("test".to_string());
         state.settings.load_keymap_preset(KeymapPreset::Ide);
         let form_state = ConnectionSetupState::default();
 
         assert_eq!(
-            ConnectionSetup::submit_hint(&state, &form_state, "Connect"),
-            ("Enter", "Connect")
+            ConnectionSetup::submit_hints(&state, &form_state, "Connect"),
+            vec![("Enter", "Connect")]
         );
     }
 }

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -41,17 +41,12 @@ impl ConnectionSetup {
             (" New Connection ", "Connect")
         };
         let submit_hints = Self::submit_hints(state, form_state, submit_desc);
-        let mut footer_hints = vec![("Tab", "Next"), ("Shift+Tab", "Prev")];
+        let mut footer_hints = vec![connection_setup::TAB_NAV.as_hint()];
         footer_hints.extend(submit_hints);
         footer_hints.push(("Esc", "Cancel"));
         let footer = FooterHintBar::new(footer_hints);
 
-        let base_modal_width = LABEL_WIDTH + INPUT_WIDTH + ERROR_WIDTH + 8;
-        let modal_width = if form_state.focused_field == ConnectionField::SslMode {
-            base_modal_width.max(footer.width() + 2)
-        } else {
-            base_modal_width
-        };
+        let modal_width = LABEL_WIDTH + INPUT_WIDTH + ERROR_WIDTH + 8;
         let modal_height = 13;
         let (_, modal_inner) = render_modal(
             frame,

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -275,8 +275,7 @@ impl Footer {
                     vec![connection_setup_save(state.settings.saved_keymap_preset()).as_hint()]
                 };
                 hints.extend([
-                    connection_setup::TAB_NEXT.as_hint(),
-                    connection_setup::TAB_PREV.as_hint(),
+                    connection_setup::TAB_NAV.as_hint(),
                     connection_setup::ESC_CANCEL.as_hint(),
                 ]);
                 hints

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -265,18 +265,21 @@ impl Footer {
                 }
             }
             InputMode::ConnectionSetup => {
-                let submit_hint =
-                    if state.connection_setup.focused_field == ConnectionField::SslMode {
-                        connection_setup::ENTER_DROPDOWN.as_hint()
-                    } else {
-                        connection_setup_save(state.settings.saved_keymap_preset()).as_hint()
-                    };
-                vec![
-                    submit_hint,
+                let mut hints = if state.connection_setup.focused_field == ConnectionField::SslMode
+                {
+                    vec![
+                        connection_setup::ENTER_DROPDOWN.as_hint(),
+                        connection_setup::SAVE.as_hint(),
+                    ]
+                } else {
+                    vec![connection_setup_save(state.settings.saved_keymap_preset()).as_hint()]
+                };
+                hints.extend([
                     connection_setup::TAB_NEXT.as_hint(),
                     connection_setup::TAB_PREV.as_hint(),
                     connection_setup::ESC_CANCEL.as_hint(),
-                ]
+                ]);
+                hints
             }
             InputMode::ConnectionError => {
                 let first = if state.session.is_service_connection() {
@@ -463,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn connection_setup_footer_shows_toggle_on_ssl_field() {
+    fn connection_setup_footer_shows_toggle_and_connect_on_ssl_field() {
         let mut state = AppState::new("test".to_string());
         let services = AppServices::stub();
         state.modal.set_mode(InputMode::ConnectionSetup);
@@ -472,6 +475,7 @@ mod tests {
         let hints = Footer::get_context_hints(&state, &services);
 
         assert!(hints.contains(&connection_setup::ENTER_DROPDOWN.as_hint()));
+        assert!(hints.contains(&connection_setup::SAVE.as_hint()));
         assert!(!hints.contains(&("Enter", "Connect")));
     }
 }


### PR DESCRIPTION
## Problem
The connection setup modal lost a visible and executable Connect path when the SSL Mode field had focus.

## Background
IDE keymap users rely on Enter to connect, but SSL Mode also uses Enter to open the dropdown. That made the footer and the actual input behavior diverge at the end of the form.

## Approach
Keep Enter dedicated to SSL Mode dropdown behavior in that context, and expose Ctrl+S as the auxiliary Connect action there. The footer, modal hint, current Help view, and tests now share that contract.

## Screenshots
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 接続設定のヘルプコンテンツがフォーカス中のフィールドに応じて動的に変わるようになりました。
  * フッター表示のキーボードヒントが文脈に応じて最適化され、SSLモードではドロップダウン操作と保存の両方のキーが表示されるようになりました。
  * タブナビゲーションのラベルを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->