### PR TITLE
SAB-265 Add PostgreSQL integration fixture harness

### DIFF
--- a/src/tests/adapter_postgres.rs
+++ b/src/tests/adapter_postgres.rs
@@ -6,14 +6,12 @@
 //!
 //! DSN is read from `SABIQL_TEST_DSN` env var.
 //! Default: `postgres://dev:dev@localhost:5433/testdb` (matches compose.yml)
+//! The database user must be able to create and drop schemas.
 
 use sabiql_app::ports::outbound::{DbOperationError, MetadataProvider, QueryExecutor};
 use sabiql_infra::adapters::postgres::PostgresAdapter;
 
-fn test_dsn() -> String {
-    std::env::var("SABIQL_TEST_DSN")
-        .unwrap_or_else(|_| "postgres://dev:dev@localhost:5433/testdb".to_string())
-}
+use crate::tests::harness::postgres::{PostgresTestDb, postgres_bad_dsn, postgres_test_dsn};
 
 mod metadata_fetch {
     use super::*;
@@ -21,45 +19,45 @@ mod metadata_fetch {
     #[tokio::test]
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn fetch_metadata_returns_schemas() {
-        let adapter = PostgresAdapter::new();
-        let dsn = test_dsn();
+        let db = PostgresTestDb::setup().await.unwrap();
 
-        let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
+        let metadata = db.adapter().fetch_metadata(db.dsn()).await.unwrap();
 
         assert!(
-            !metadata.schemas.is_empty(),
-            "Expected at least one schema (public)"
+            metadata.schemas.iter().any(|s| s.name == db.schema()),
+            "expected fixture schema '{}' in metadata",
+            db.schema()
         );
         assert!(
-            metadata.schemas.iter().any(|s| s.name == "public"),
-            "Expected public schema"
+            metadata
+                .table_summaries
+                .iter()
+                .any(|table| { table.schema == db.schema() && table.name == db.table() }),
+            "expected fixture table '{}.{}' in metadata",
+            db.schema(),
+            db.table()
         );
+
+        db.cleanup().await.unwrap();
     }
 
     #[tokio::test]
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn fetch_table_detail_returns_columns() {
-        let adapter = PostgresAdapter::new();
-        let dsn = test_dsn();
+        let db = PostgresTestDb::setup().await.unwrap();
 
-        let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
-
-        assert!(
-            !metadata.table_summaries.is_empty(),
-            "Test DB must have at least one table; create one before running integration tests"
-        );
-
-        let first_table = &metadata.table_summaries[0];
-        let detail = adapter
-            .fetch_table_detail(&dsn, &first_table.schema, &first_table.name)
+        let detail = db
+            .adapter()
+            .fetch_table_detail(db.dsn(), db.schema(), db.table())
             .await
             .unwrap();
 
         assert!(
             !detail.columns.is_empty(),
-            "Expected at least one column for table '{}'",
-            first_table.name
+            "expected at least one column for fixture table"
         );
+
+        db.cleanup().await.unwrap();
     }
 }
 
@@ -69,34 +67,27 @@ mod query_execution {
     #[tokio::test]
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn execute_preview_returns_columns() {
-        let adapter = PostgresAdapter::new();
-        let dsn = test_dsn();
+        let db = PostgresTestDb::setup().await.unwrap();
 
-        let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
-
-        assert!(
-            !metadata.table_summaries.is_empty(),
-            "Test DB must have at least one table; create one before running integration tests"
-        );
-
-        let table = &metadata.table_summaries[0];
-        let result = adapter
-            .execute_preview(&dsn, &table.schema, &table.name, 10, 0, false)
+        let result = db
+            .adapter()
+            .execute_preview(db.dsn(), db.schema(), db.table(), 10, 0, false)
             .await
             .unwrap();
 
         assert!(
             !result.columns.is_empty(),
-            "Expected columns for table '{}'",
-            table.name
+            "expected columns for fixture table preview"
         );
+
+        db.cleanup().await.unwrap();
     }
 
     #[tokio::test]
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn execute_adhoc_select_returns_query_result() {
         let adapter = PostgresAdapter::new();
-        let dsn = test_dsn();
+        let dsn = postgres_test_dsn();
 
         let result = adapter
             .execute_adhoc(&dsn, "SELECT 1 AS value", false)
@@ -117,7 +108,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn returns_last_result_set() {
         let adapter = PostgresAdapter::new();
-        let dsn = test_dsn();
+        let dsn = postgres_test_dsn();
 
         let result = adapter
             .execute_adhoc(&dsn, "SELECT 1 AS a; SELECT 2 AS b, 3 AS c", false)
@@ -132,7 +123,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn data_rows_identical_to_header_are_preserved() {
         let adapter = PostgresAdapter::new();
-        let dsn = test_dsn();
+        let dsn = postgres_test_dsn();
 
         let sql = "SELECT 1 AS id, 'Alice' AS name; \
                    SELECT 'id' AS id, 'name' AS name";
@@ -146,7 +137,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn empty_leading_result_set_returns_last() {
         let adapter = PostgresAdapter::new();
-        let dsn = test_dsn();
+        let dsn = postgres_test_dsn();
 
         let sql = "SELECT 1 AS a WHERE false; SELECT 2 AS b";
         let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
@@ -159,7 +150,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn empty_trailing_result_set_returns_zero_rows() {
         let adapter = PostgresAdapter::new();
-        let dsn = test_dsn();
+        let dsn = postgres_test_dsn();
 
         let sql = "SELECT 1 AS a; SELECT 2 AS b WHERE false";
         let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
@@ -172,7 +163,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn statements_share_one_session_and_transaction() {
         let adapter = PostgresAdapter::new();
-        let dsn = test_dsn();
+        let dsn = postgres_test_dsn();
 
         // Temp tables are session-local: this only works if all
         // statements run in a single psql invocation.
@@ -189,7 +180,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn write_only_statements_report_aggregate_tag() {
         let adapter = PostgresAdapter::new();
-        let dsn = test_dsn();
+        let dsn = postgres_test_dsn();
 
         let sql = "CREATE TEMP TABLE tag_probe(v int); \
                    INSERT INTO tag_probe VALUES (1), (2)";
@@ -205,26 +196,30 @@ mod multi_statement_boundaries {
     #[tokio::test]
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn error_in_later_statement_rolls_back_earlier_writes() {
-        let adapter = PostgresAdapter::new();
-        let dsn = test_dsn();
-        adapter
-            .execute_adhoc(&dsn, "DROP TABLE IF EXISTS boundary_rollback_probe", false)
-            .await
-            .unwrap();
+        let db = PostgresTestDb::setup().await.unwrap();
 
-        let failing = "CREATE TABLE boundary_rollback_probe(v int); SELECT no_such_column";
-        let result = adapter.execute_adhoc(&dsn, failing, false).await;
+        let failing = format!(
+            "CREATE TABLE \"{}\".boundary_rollback_probe(v int); SELECT no_such_column",
+            db.schema()
+        );
+        let result = db.adapter().execute_adhoc(db.dsn(), &failing, false).await;
         assert!(result.is_err(), "expected mid-script error, got {result:?}");
 
-        let check = adapter
+        let check = db
+            .adapter()
             .execute_adhoc(
-                &dsn,
-                "SELECT to_regclass('boundary_rollback_probe') IS NULL AS rolled_back",
+                db.dsn(),
+                &format!(
+                    "SELECT to_regclass('{}.boundary_rollback_probe') IS NULL AS rolled_back",
+                    db.schema()
+                ),
                 false,
             )
             .await
             .unwrap();
         assert_eq!(check.rows(), vec![vec!["t"]]);
+
+        db.cleanup().await.unwrap();
     }
 }
 
@@ -235,9 +230,8 @@ mod error_paths {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn bad_dsn_returns_connection_or_query_error() {
         let adapter = PostgresAdapter::new();
-        let bad_dsn = "postgres://nobody:wrong@127.0.0.1:59999/nonexistent";
 
-        let result = adapter.fetch_metadata(bad_dsn).await;
+        let result = adapter.fetch_metadata(postgres_bad_dsn()).await;
 
         assert!(result.is_err(), "Expected error for bad DSN");
     }
@@ -246,7 +240,7 @@ mod error_paths {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn timeout_with_pg_sleep_returns_timeout_error() {
         let adapter = PostgresAdapter::with_timeout(1);
-        let dsn = test_dsn();
+        let dsn = postgres_test_dsn();
 
         let result = adapter
             .execute_adhoc(&dsn, "SELECT pg_sleep(5)", false)

--- a/src/tests/adapter_postgres.rs
+++ b/src/tests/adapter_postgres.rs
@@ -11,7 +11,9 @@
 use sabiql_app::ports::outbound::{DbOperationError, MetadataProvider, QueryExecutor};
 use sabiql_infra::adapters::postgres::PostgresAdapter;
 
-use crate::tests::harness::postgres::{PostgresTestDb, postgres_bad_dsn, postgres_test_dsn};
+use crate::tests::harness::postgres::{
+    postgres_bad_dsn, postgres_integration_dsn, with_postgres_test_db,
+};
 
 mod metadata_fetch {
     use super::*;
@@ -19,45 +21,55 @@ mod metadata_fetch {
     #[tokio::test]
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn fetch_metadata_returns_schemas() {
-        let db = PostgresTestDb::setup().await.unwrap();
+        with_postgres_test_db(|db| {
+            Box::pin(async move {
+                let metadata = db
+                    .adapter()
+                    .fetch_metadata(db.dsn())
+                    .await
+                    .map_err(|err| err.to_string())?;
 
-        let metadata = db.adapter().fetch_metadata(db.dsn()).await.unwrap();
-
-        assert!(
-            metadata.schemas.iter().any(|s| s.name == db.schema()),
-            "expected fixture schema '{}' in metadata",
-            db.schema()
-        );
-        assert!(
-            metadata
-                .table_summaries
-                .iter()
-                .any(|table| { table.schema == db.schema() && table.name == db.table() }),
-            "expected fixture table '{}.{}' in metadata",
-            db.schema(),
-            db.table()
-        );
-
-        db.cleanup().await.unwrap();
+                if !metadata.schemas.iter().any(|s| s.name == db.schema()) {
+                    return Err(format!(
+                        "expected fixture schema '{}' in metadata",
+                        db.schema()
+                    ));
+                }
+                if !metadata
+                    .table_summaries
+                    .iter()
+                    .any(|table| table.schema == db.schema() && table.name == db.table())
+                {
+                    return Err(format!(
+                        "expected fixture table '{}.{}' in metadata",
+                        db.schema(),
+                        db.table()
+                    ));
+                }
+                Ok(())
+            })
+        })
+        .await;
     }
 
     #[tokio::test]
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn fetch_table_detail_returns_columns() {
-        let db = PostgresTestDb::setup().await.unwrap();
+        with_postgres_test_db(|db| {
+            Box::pin(async move {
+                let detail = db
+                    .adapter()
+                    .fetch_table_detail(db.dsn(), db.schema(), db.table())
+                    .await
+                    .map_err(|err| err.to_string())?;
 
-        let detail = db
-            .adapter()
-            .fetch_table_detail(db.dsn(), db.schema(), db.table())
-            .await
-            .unwrap();
-
-        assert!(
-            !detail.columns.is_empty(),
-            "expected at least one column for fixture table"
-        );
-
-        db.cleanup().await.unwrap();
+                if detail.columns.is_empty() {
+                    return Err("expected at least one column for fixture table".to_string());
+                }
+                Ok(())
+            })
+        })
+        .await;
     }
 }
 
@@ -67,27 +79,28 @@ mod query_execution {
     #[tokio::test]
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn execute_preview_returns_columns() {
-        let db = PostgresTestDb::setup().await.unwrap();
+        with_postgres_test_db(|db| {
+            Box::pin(async move {
+                let result = db
+                    .adapter()
+                    .execute_preview(db.dsn(), db.schema(), db.table(), 10, 0, false)
+                    .await
+                    .map_err(|err| err.to_string())?;
 
-        let result = db
-            .adapter()
-            .execute_preview(db.dsn(), db.schema(), db.table(), 10, 0, false)
-            .await
-            .unwrap();
-
-        assert!(
-            !result.columns.is_empty(),
-            "expected columns for fixture table preview"
-        );
-
-        db.cleanup().await.unwrap();
+                if result.columns.is_empty() {
+                    return Err("expected columns for fixture table preview".to_string());
+                }
+                Ok(())
+            })
+        })
+        .await;
     }
 
     #[tokio::test]
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn execute_adhoc_select_returns_query_result() {
         let adapter = PostgresAdapter::new();
-        let dsn = postgres_test_dsn();
+        let dsn = postgres_integration_dsn();
 
         let result = adapter
             .execute_adhoc(&dsn, "SELECT 1 AS value", false)
@@ -108,7 +121,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn returns_last_result_set() {
         let adapter = PostgresAdapter::new();
-        let dsn = postgres_test_dsn();
+        let dsn = postgres_integration_dsn();
 
         let result = adapter
             .execute_adhoc(&dsn, "SELECT 1 AS a; SELECT 2 AS b, 3 AS c", false)
@@ -123,7 +136,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn data_rows_identical_to_header_are_preserved() {
         let adapter = PostgresAdapter::new();
-        let dsn = postgres_test_dsn();
+        let dsn = postgres_integration_dsn();
 
         let sql = "SELECT 1 AS id, 'Alice' AS name; \
                    SELECT 'id' AS id, 'name' AS name";
@@ -137,7 +150,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn empty_leading_result_set_returns_last() {
         let adapter = PostgresAdapter::new();
-        let dsn = postgres_test_dsn();
+        let dsn = postgres_integration_dsn();
 
         let sql = "SELECT 1 AS a WHERE false; SELECT 2 AS b";
         let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
@@ -150,7 +163,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn empty_trailing_result_set_returns_zero_rows() {
         let adapter = PostgresAdapter::new();
-        let dsn = postgres_test_dsn();
+        let dsn = postgres_integration_dsn();
 
         let sql = "SELECT 1 AS a; SELECT 2 AS b WHERE false";
         let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
@@ -163,7 +176,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn statements_share_one_session_and_transaction() {
         let adapter = PostgresAdapter::new();
-        let dsn = postgres_test_dsn();
+        let dsn = postgres_integration_dsn();
 
         // Temp tables are session-local: this only works if all
         // statements run in a single psql invocation.
@@ -180,7 +193,7 @@ mod multi_statement_boundaries {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn write_only_statements_report_aggregate_tag() {
         let adapter = PostgresAdapter::new();
-        let dsn = postgres_test_dsn();
+        let dsn = postgres_integration_dsn();
 
         let sql = "CREATE TEMP TABLE tag_probe(v int); \
                    INSERT INTO tag_probe VALUES (1), (2)";
@@ -196,30 +209,36 @@ mod multi_statement_boundaries {
     #[tokio::test]
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn error_in_later_statement_rolls_back_earlier_writes() {
-        let db = PostgresTestDb::setup().await.unwrap();
-
-        let failing = format!(
-            "CREATE TABLE \"{}\".boundary_rollback_probe(v int); SELECT no_such_column",
-            db.schema()
-        );
-        let result = db.adapter().execute_adhoc(db.dsn(), &failing, false).await;
-        assert!(result.is_err(), "expected mid-script error, got {result:?}");
-
-        let check = db
-            .adapter()
-            .execute_adhoc(
-                db.dsn(),
-                &format!(
-                    "SELECT to_regclass('{}.boundary_rollback_probe') IS NULL AS rolled_back",
+        with_postgres_test_db(|db| {
+            Box::pin(async move {
+                let failing = format!(
+                    "CREATE TABLE \"{}\".boundary_rollback_probe(v int); SELECT no_such_column",
                     db.schema()
-                ),
-                false,
-            )
-            .await
-            .unwrap();
-        assert_eq!(check.rows(), vec![vec!["t"]]);
+                );
+                let result = db.adapter().execute_adhoc(db.dsn(), &failing, false).await;
+                if result.is_ok() {
+                    return Err("expected mid-script error".to_string());
+                }
 
-        db.cleanup().await.unwrap();
+                let check = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!(
+                            "SELECT to_regclass('{}.boundary_rollback_probe') IS NULL AS rolled_back",
+                            db.schema()
+                        ),
+                        false,
+                    )
+                    .await
+                    .map_err(|err| err.to_string())?;
+                if check.rows() != vec![vec!["t"]] {
+                    return Err(format!("expected rollback marker, got {:?}", check.rows()));
+                }
+                Ok(())
+            })
+        })
+        .await;
     }
 }
 
@@ -240,7 +259,7 @@ mod error_paths {
     #[ignore = "requires PostgreSQL, tracked: #133"]
     async fn timeout_with_pg_sleep_returns_timeout_error() {
         let adapter = PostgresAdapter::with_timeout(1);
-        let dsn = postgres_test_dsn();
+        let dsn = postgres_integration_dsn();
 
         let result = adapter
             .execute_adhoc(&dsn, "SELECT pg_sleep(5)", false)

--- a/src/tests/harness/mod.rs
+++ b/src/tests/harness/mod.rs
@@ -1,4 +1,5 @@
 pub mod fixtures;
+pub mod postgres;
 
 use std::sync::Arc;
 use std::time::Instant;

--- a/src/tests/harness/postgres.rs
+++ b/src/tests/harness/postgres.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use sabiql_app::ports::outbound::{DbOperationError, QueryExecutor};
@@ -13,11 +15,13 @@ pub struct PostgresTestDb {
     schema: String,
 }
 
+type PostgresFixtureTest<'db> = Pin<Box<dyn Future<Output = Result<(), String>> + 'db>>;
+
 impl PostgresTestDb {
     pub async fn setup() -> Result<Self, DbOperationError> {
         let db = Self {
             adapter: PostgresAdapter::new(),
-            dsn: postgres_test_dsn(),
+            dsn: postgres_integration_dsn(),
             schema: unique_schema_name(),
         };
         db.create_fixture_schema().await?;
@@ -71,7 +75,21 @@ impl PostgresTestDb {
     }
 }
 
-pub fn postgres_test_dsn() -> String {
+pub async fn with_postgres_test_db<F>(test: F)
+where
+    F: for<'db> FnOnce(&'db PostgresTestDb) -> PostgresFixtureTest<'db>,
+{
+    let db = PostgresTestDb::setup().await.unwrap();
+    let test_result = test(&db).await;
+    let cleanup_result = db.cleanup().await;
+
+    if let Err(err) = test_result {
+        panic!("{err}");
+    }
+    cleanup_result.unwrap();
+}
+
+pub fn postgres_integration_dsn() -> String {
     std::env::var(TEST_DSN_ENV).unwrap_or_else(|_| DEFAULT_TEST_DSN.to_string())
 }
 

--- a/src/tests/harness/postgres.rs
+++ b/src/tests/harness/postgres.rs
@@ -83,10 +83,14 @@ where
     let test_result = test(&db).await;
     let cleanup_result = db.cleanup().await;
 
-    if let Err(err) = test_result {
-        panic!("{err}");
+    match (test_result, cleanup_result) {
+        (Ok(()), Ok(())) => {}
+        (Err(test_err), Ok(())) => panic!("{test_err}"),
+        (Ok(()), Err(cleanup_err)) => panic!("cleanup failed: {cleanup_err}"),
+        (Err(test_err), Err(cleanup_err)) => {
+            panic!("test failed: {test_err}; cleanup failed: {cleanup_err}")
+        }
     }
-    cleanup_result.unwrap();
 }
 
 pub fn postgres_integration_dsn() -> String {

--- a/src/tests/harness/postgres.rs
+++ b/src/tests/harness/postgres.rs
@@ -1,0 +1,93 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use sabiql_app::ports::outbound::{DbOperationError, QueryExecutor};
+use sabiql_infra::adapters::postgres::PostgresAdapter;
+
+const DEFAULT_TEST_DSN: &str = "postgres://dev:dev@localhost:5433/testdb";
+const TEST_DSN_ENV: &str = "SABIQL_TEST_DSN";
+const FIXTURE_TABLE: &str = "fixture_people";
+
+pub struct PostgresTestDb {
+    adapter: PostgresAdapter,
+    dsn: String,
+    schema: String,
+}
+
+impl PostgresTestDb {
+    pub async fn setup() -> Result<Self, DbOperationError> {
+        let db = Self {
+            adapter: PostgresAdapter::new(),
+            dsn: postgres_test_dsn(),
+            schema: unique_schema_name(),
+        };
+        db.create_fixture_schema().await?;
+        Ok(db)
+    }
+
+    pub fn adapter(&self) -> &PostgresAdapter {
+        &self.adapter
+    }
+
+    pub fn dsn(&self) -> &str {
+        &self.dsn
+    }
+
+    pub fn schema(&self) -> &str {
+        &self.schema
+    }
+
+    pub fn table(&self) -> &str {
+        FIXTURE_TABLE
+    }
+
+    pub async fn cleanup(&self) -> Result<(), DbOperationError> {
+        self.adapter
+            .execute_adhoc(
+                &self.dsn,
+                &format!("DROP SCHEMA IF EXISTS \"{}\" CASCADE", self.schema),
+                false,
+            )
+            .await
+            .map(|_| ())
+    }
+
+    async fn create_fixture_schema(&self) -> Result<(), DbOperationError> {
+        let schema = &self.schema;
+        let sql = format!(
+            r#"
+            CREATE SCHEMA "{schema}";
+            CREATE TABLE "{schema}"."{FIXTURE_TABLE}" (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL
+            );
+            INSERT INTO "{schema}"."{FIXTURE_TABLE}" (id, name)
+            VALUES (1, 'Ada'), (2, 'Grace');
+            "#
+        );
+        self.adapter
+            .execute_adhoc(&self.dsn, &sql, false)
+            .await
+            .map(|_| ())
+    }
+}
+
+pub fn postgres_test_dsn() -> String {
+    std::env::var(TEST_DSN_ENV).unwrap_or_else(|_| DEFAULT_TEST_DSN.to_string())
+}
+
+pub fn postgres_bad_dsn() -> &'static str {
+    "postgres://nobody:wrong@127.0.0.1:59999/nonexistent"
+}
+
+fn unique_schema_name() -> String {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    format!(
+        "sabiql_it_{}_{}_{}",
+        std::process::id(),
+        nanos,
+        SEQ.fetch_add(1, Ordering::Relaxed)
+    )
+}


### PR DESCRIPTION
## Summary

- Add a PostgreSQL integration test harness for shared DSN handling and isolated fixture schemas.
- Rework PostgreSQL adapter integration tests to use deterministic fixture tables instead of whichever table appears first in the seed database.
- Keep bad-DSN and simple query tests on the shared DSN helpers while preserving the ignored-test workflow.

## Validation

- `cargo fmt`
- `env RUSTC_WRAPPER= cargo test --workspace -- --nocapture`
- `env RUSTC_WRAPPER= cargo nextest run -p sabiql --run-ignored ignored-only -E 'test(tests::adapter_postgres)' --hide-progress-bar`
- `env RUSTC_WRAPPER= cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `env RUSTC_WRAPPER= cargo clippy --workspace --all-targets --no-default-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * PostgreSQL統合テストのテストインフラストラクチャを整理し、共有テストハーネスに移行しました。
  * テスト実行の初期化・後処理を一元化し、テストの保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->