### PR TITLE
Safely handle SQLite TEXT values with embedded NUL bytes

### DIFF
--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -18,14 +18,6 @@ impl QueryValue {
     }
 
     #[must_use]
-    pub fn contains_nul(&self) -> bool {
-        match self {
-            Self::Text(value) | Self::SqlLiteral(value) => value.contains('\0'),
-            Self::Null | Self::Blob(_) => false,
-        }
-    }
-
-    #[must_use]
     pub fn display_value(&self) -> String {
         match self {
             Self::Null => "NULL".to_string(),
@@ -302,13 +294,6 @@ mod tests {
 
     mod nul_text {
         use super::*;
-
-        #[test]
-        fn contains_nul_detects_embedded_nul_byte() {
-            assert!(QueryValue::text("a\0bc").contains_nul());
-            assert!(!QueryValue::text("abc").contains_nul());
-            assert!(!QueryValue::Null.contains_nul());
-        }
 
         #[test]
         fn display_value_escapes_embedded_nul_byte() {

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -18,10 +18,18 @@ impl QueryValue {
     }
 
     #[must_use]
+    pub fn contains_nul(&self) -> bool {
+        match self {
+            Self::Text(value) | Self::SqlLiteral(value) => value.contains('\0'),
+            Self::Null | Self::Blob(_) => false,
+        }
+    }
+
+    #[must_use]
     pub fn display_value(&self) -> String {
         match self {
             Self::Null => "NULL".to_string(),
-            Self::Text(value) | Self::SqlLiteral(value) => value.clone(),
+            Self::Text(value) | Self::SqlLiteral(value) => escape_display_text(value),
             Self::Blob(bytes) => {
                 let preview = bytes
                     .iter()
@@ -47,6 +55,18 @@ impl QueryValue {
             Self::Null | Self::Blob(_) => None,
         }
     }
+}
+
+fn escape_display_text(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if ch == '\0' {
+            escaped.push_str("\\0");
+        } else {
+            escaped.push(ch);
+        }
+    }
+    escaped
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -277,6 +297,22 @@ mod tests {
                     .with_row_count(count);
 
             assert_eq!(result.row_count_display(), expected);
+        }
+    }
+
+    mod nul_text {
+        use super::*;
+
+        #[test]
+        fn contains_nul_detects_embedded_nul_byte() {
+            assert!(QueryValue::text("a\0bc").contains_nul());
+            assert!(!QueryValue::text("abc").contains_nul());
+            assert!(!QueryValue::Null.contains_nul());
+        }
+
+        #[test]
+        fn display_value_escapes_embedded_nul_byte() {
+            assert_eq!(QueryValue::text("a\0bc").display_value(), "a\\0bc");
         }
     }
 }

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -954,32 +954,50 @@ fn parse_unistr_literal(value: &str) -> Result<String, DbOperationError> {
     let mut decoded = String::new();
     let mut chars = inner.chars();
     while let Some(ch) = chars.next() {
-        if ch == '\\' {
-            let escape = chars.next().ok_or_else(|| {
-                DbOperationError::MetadataParseFailed(
-                    "invalid SQLite unistr escape sequence".to_string(),
-                )
-            })?;
-            if escape == 'u' {
-                let hex: String = chars.by_ref().take(4).collect();
-                if hex.len() != 4 {
-                    return Err(DbOperationError::MetadataParseFailed(
-                        "invalid SQLite unistr unicode escape".to_string(),
-                    ));
-                }
-                let code = u32::from_str_radix(&hex, 16)
-                    .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
-                let decoded_char = char::from_u32(code).ok_or_else(|| {
+        match ch {
+            '\'' => {
+                let next = chars.next().ok_or_else(|| {
                     DbOperationError::MetadataParseFailed(
-                        "invalid SQLite unistr unicode code point".to_string(),
+                        "invalid SQLite unistr SQL string quote".to_string(),
                     )
                 })?;
-                decoded.push(decoded_char);
-            } else {
-                decoded.push(escape);
+                if next != '\'' {
+                    return Err(DbOperationError::MetadataParseFailed(
+                        "invalid SQLite unistr SQL string quote".to_string(),
+                    ));
+                }
+                decoded.push('\'');
             }
-        } else {
-            decoded.push(ch);
+            '\\' => {
+                let next = chars.next().ok_or_else(|| {
+                    DbOperationError::MetadataParseFailed(
+                        "invalid SQLite unistr escape sequence".to_string(),
+                    )
+                })?;
+                if next == 'u' {
+                    let hex: String = chars.by_ref().take(4).collect();
+                    if hex.len() != 4 {
+                        return Err(DbOperationError::MetadataParseFailed(
+                            "invalid SQLite unistr unicode escape".to_string(),
+                        ));
+                    }
+                    let code = u32::from_str_radix(&hex, 16).map_err(|error| {
+                        DbOperationError::MetadataParseFailed(error.to_string())
+                    })?;
+                    let decoded_char = char::from_u32(code).ok_or_else(|| {
+                        DbOperationError::MetadataParseFailed(
+                            "invalid SQLite unistr unicode code point".to_string(),
+                        )
+                    })?;
+                    decoded.push(decoded_char);
+                } else if next == '\\' {
+                    decoded.push('\\');
+                } else {
+                    decoded.push('\\');
+                    decoded.push(next);
+                }
+            }
+            ch => decoded.push(ch),
         }
     }
     Ok(decoded)
@@ -2061,6 +2079,40 @@ mod tests {
                 Err(DbOperationError::MetadataParseFailed(message))
                     if message == "unterminated SQLite quoted output"
             ));
+        }
+
+        #[test]
+        fn parse_unistr_literal_unescapes_sql_string_quotes_and_backslashes() {
+            assert_eq!(
+                parse_unistr_literal("unistr('\\u0001O''Reilly')").unwrap(),
+                "\x01O'Reilly"
+            );
+            assert_eq!(
+                parse_unistr_literal("unistr('\\u0001back\\slash')").unwrap(),
+                "\x01back\\slash"
+            );
+            assert_eq!(
+                parse_unistr_literal("unistr('\\u0001a\\\\b')").unwrap(),
+                "\x01a\\b"
+            );
+        }
+
+        #[test]
+        fn quoted_to_query_result_decodes_unistr_adhoc_text_with_sql_escapes() {
+            let quoted = "'value'\nunistr('\\u0001O''Reilly')\n";
+
+            let result = quoted_to_query_result(
+                "SELECT char(1) || 'O''Reilly'",
+                quoted,
+                QuerySource::Adhoc,
+                1,
+            )
+            .unwrap();
+
+            assert_eq!(
+                result.value_at(0, 0),
+                Some(&QueryValue::Text("\x01O'Reilly".to_string()))
+            );
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -919,6 +919,75 @@ fn unquote_sql_text(value: &str) -> String {
     value[1..value.len() - 1].replace("''", "'")
 }
 
+pub(super) const SQLITE_NUL_TEXT_SENTINEL: &str = "\x01SABIQL_HEX:";
+
+fn decode_sqlite_nul_text_transport(value: String) -> String {
+    let Some(hex) = value.strip_prefix(SQLITE_NUL_TEXT_SENTINEL) else {
+        return value;
+    };
+    match decode_hex_bytes(hex) {
+        Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+        Err(_) => value,
+    }
+}
+
+fn parse_unistr_literal(value: &str) -> Result<String, DbOperationError> {
+    let inner = value
+        .strip_prefix("unistr(")
+        .and_then(|rest| rest.strip_suffix(')'))
+        .ok_or_else(|| {
+            DbOperationError::MetadataParseFailed("invalid SQLite unistr literal".to_string())
+        })?;
+    let inner = inner
+        .strip_prefix('\'')
+        .and_then(|rest| rest.strip_suffix('\''))
+        .ok_or_else(|| {
+            DbOperationError::MetadataParseFailed("invalid SQLite unistr literal".to_string())
+        })?;
+
+    let mut decoded = String::new();
+    let mut chars = inner.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            let escape = chars.next().ok_or_else(|| {
+                DbOperationError::MetadataParseFailed(
+                    "invalid SQLite unistr escape sequence".to_string(),
+                )
+            })?;
+            if escape == 'u' {
+                let hex: String = chars.by_ref().take(4).collect();
+                if hex.len() != 4 {
+                    return Err(DbOperationError::MetadataParseFailed(
+                        "invalid SQLite unistr unicode escape".to_string(),
+                    ));
+                }
+                let code = u32::from_str_radix(&hex, 16)
+                    .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
+                let decoded_char = char::from_u32(code).ok_or_else(|| {
+                    DbOperationError::MetadataParseFailed(
+                        "invalid SQLite unistr unicode code point".to_string(),
+                    )
+                })?;
+                decoded.push(decoded_char);
+            } else {
+                decoded.push(escape);
+            }
+        } else {
+            decoded.push(ch);
+        }
+    }
+    Ok(decoded)
+}
+
+fn parse_sqlite_text_value(value: &str) -> Result<String, DbOperationError> {
+    let decoded = if value.starts_with("unistr(") {
+        parse_unistr_literal(value)?
+    } else {
+        unquote_sql_text(value)
+    };
+    Ok(decode_sqlite_nul_text_transport(decoded))
+}
+
 fn decode_hex_bytes(hex: &str) -> Result<Vec<u8>, DbOperationError> {
     if !hex.len().is_multiple_of(2) {
         return Err(DbOperationError::MetadataParseFailed(
@@ -942,7 +1011,10 @@ fn parse_quoted_value(value: &str) -> Result<QueryValue, DbOperationError> {
         return Ok(QueryValue::Null);
     }
     if value.starts_with('\'') && value.ends_with('\'') && value.len() >= 2 {
-        return Ok(QueryValue::Text(unquote_sql_text(value)));
+        return Ok(QueryValue::Text(parse_sqlite_text_value(value)?));
+    }
+    if value.starts_with("unistr(") && value.ends_with(')') {
+        return Ok(QueryValue::Text(parse_sqlite_text_value(value)?));
     }
     if value.len() >= 3
         && value.as_bytes()[1] == b'\''
@@ -1465,7 +1537,17 @@ impl QueryExecutor for SqliteAdapter {
         Self::validate_main_schema(schema)?;
         let path = Self::path_from_dsn(dsn)?;
         let order_columns = self.preview_order_columns(path, table).await;
-        let query = sql::build_preview_query(table, &order_columns, limit, offset);
+        let columns = self
+            .columns(path, table)
+            .await
+            .map(|raw_columns| {
+                raw_columns
+                    .into_iter()
+                    .map(|column| column.name)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let query = sql::build_preview_query(table, &columns, &order_columns, limit, offset);
         self.execute_quoted_query(path, &query, QuerySource::Preview, read_only)
             .await
     }
@@ -1572,7 +1654,7 @@ impl QueryExecutor for SqliteAdapter {
 #[cfg(test)]
 mod tests {
     use crate::adapters::test_support::make_sqlite_db;
-    use crate::app::ports::outbound::{DdlGenerator, MetadataProvider, QueryExecutor};
+    use crate::app::ports::outbound::{DdlGenerator, MetadataProvider, QueryExecutor, SqlDialect};
     use crate::domain::{CommandTag, DatabaseType, QuerySource};
 
     use super::*;
@@ -1741,6 +1823,53 @@ mod tests {
 
             assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
         }
+
+        #[tokio::test]
+        async fn preserves_nul_text_primary_key_for_preview_and_delete() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id TEXT PRIMARY KEY, name TEXT);
+            INSERT INTO users(id, name) VALUES ('a' || char(0) || 'bc', 'target'), ('only', 'other');
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let preview = adapter
+                .execute_preview(&dsn, "main", "users", 10, 0, true)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                preview.value_at(0, 0),
+                Some(&QueryValue::Text("a\0bc".to_string()))
+            );
+            assert_eq!(preview.rows()[0][0], "a\\0bc");
+
+            let delete_sql = adapter.build_bulk_delete_sql(
+                DatabaseType::SQLite,
+                "main",
+                "users",
+                &[vec![(
+                    "id".to_string(),
+                    QueryValue::Text("a\0bc".to_string()),
+                )]],
+            );
+            let write = adapter
+                .execute_write(&dsn, &delete_sql, false)
+                .await
+                .unwrap();
+            assert_eq!(write.affected_rows, 1);
+
+            let remaining = adapter
+                .execute_preview(&dsn, "main", "users", 10, 0, true)
+                .await
+                .unwrap();
+            assert_eq!(remaining.row_count(), 1);
+            assert_eq!(
+                remaining.value_at(0, 0),
+                Some(&QueryValue::Text("only".to_string()))
+            );
+        }
     }
 
     mod parsing {
@@ -1853,6 +1982,20 @@ mod tests {
                 Err(DbOperationError::MetadataParseFailed(message))
                     if message == "unterminated SQLite quoted output"
             ));
+        }
+
+        #[test]
+        fn parse_sqlite_text_value_decodes_unistr_transport() {
+            let value = parse_sqlite_text_value("unistr('\\u0001SABIQL_HEX:61006263')").unwrap();
+
+            assert_eq!(value, "a\0bc");
+        }
+
+        #[test]
+        fn parse_quoted_value_decodes_nul_text_transport() {
+            let value = parse_quoted_value("unistr('\\u0001SABIQL_HEX:61006263')").unwrap();
+
+            assert_eq!(value, QueryValue::Text("a\0bc".to_string()));
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -984,12 +984,18 @@ fn parse_unistr_literal(value: &str) -> Result<String, DbOperationError> {
                     let code = u32::from_str_radix(&hex, 16).map_err(|error| {
                         DbOperationError::MetadataParseFailed(error.to_string())
                     })?;
-                    let decoded_char = char::from_u32(code).ok_or_else(|| {
-                        DbOperationError::MetadataParseFailed(
-                            "invalid SQLite unistr unicode code point".to_string(),
-                        )
-                    })?;
-                    decoded.push(decoded_char);
+                    if code <= 0x1F {
+                        let decoded_char = char::from_u32(code).ok_or_else(|| {
+                            DbOperationError::MetadataParseFailed(
+                                "invalid SQLite unistr unicode code point".to_string(),
+                            )
+                        })?;
+                        decoded.push(decoded_char);
+                    } else {
+                        decoded.push('\\');
+                        decoded.push('u');
+                        decoded.push_str(&hex);
+                    }
                 } else if next == '\\' {
                     decoded.push('\\');
                 } else {
@@ -2094,6 +2100,28 @@ mod tests {
             assert_eq!(
                 parse_unistr_literal("unistr('\\u0001a\\\\b')").unwrap(),
                 "\x01a\\b"
+            );
+            assert_eq!(
+                parse_unistr_literal("unistr('\\u0001\\u0041')").unwrap(),
+                "\x01\\u0041"
+            );
+        }
+
+        #[test]
+        fn quoted_to_query_result_preserves_literal_backslash_u_sequences_in_adhoc() {
+            let quoted = "'value'\nunistr('\\u0001\\u0041')\n";
+
+            let result = quoted_to_query_result(
+                "SELECT char(1) || char(92) || 'u0041'",
+                quoted,
+                QuerySource::Adhoc,
+                1,
+            )
+            .unwrap();
+
+            assert_eq!(
+                result.value_at(0, 0),
+                Some(&QueryValue::Text("\x01\\u0041".to_string()))
             );
         }
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -927,17 +927,12 @@ fn unquote_sql_text(value: &str) -> String {
     value[1..value.len() - 1].replace("''", "'")
 }
 
-fn decode_sqlite_nul_text_transport(value: String) -> String {
-    let sentinel = sql::sqlite_nul_text_sentinel();
-    if let Some(hex) = value.strip_prefix(&sentinel)
-        && let Ok(bytes) = decode_hex_bytes(hex)
-    {
-        return String::from_utf8_lossy(&bytes).into_owned();
-    }
-    value
+fn decode_hex_text(hex: &str) -> Result<String, DbOperationError> {
+    let bytes = decode_hex_bytes(hex)?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
 }
 
-fn parse_unistr_literal(value: &str) -> Result<String, DbOperationError> {
+fn parse_unistr_inner_sql_escapes(value: &str) -> Result<String, DbOperationError> {
     let inner = value
         .strip_prefix("unistr(")
         .and_then(|rest| rest.strip_suffix(')'))
@@ -974,29 +969,7 @@ fn parse_unistr_literal(value: &str) -> Result<String, DbOperationError> {
                         "invalid SQLite unistr escape sequence".to_string(),
                     )
                 })?;
-                if next == 'u' {
-                    let hex: String = chars.by_ref().take(4).collect();
-                    if hex.len() != 4 {
-                        return Err(DbOperationError::MetadataParseFailed(
-                            "invalid SQLite unistr unicode escape".to_string(),
-                        ));
-                    }
-                    let code = u32::from_str_radix(&hex, 16).map_err(|error| {
-                        DbOperationError::MetadataParseFailed(error.to_string())
-                    })?;
-                    if code <= 0x1F {
-                        let decoded_char = char::from_u32(code).ok_or_else(|| {
-                            DbOperationError::MetadataParseFailed(
-                                "invalid SQLite unistr unicode code point".to_string(),
-                            )
-                        })?;
-                        decoded.push(decoded_char);
-                    } else {
-                        decoded.push('\\');
-                        decoded.push('u');
-                        decoded.push_str(&hex);
-                    }
-                } else if next == '\\' {
+                if next == '\\' {
                     decoded.push('\\');
                 } else {
                     decoded.push('\\');
@@ -1009,16 +982,15 @@ fn parse_unistr_literal(value: &str) -> Result<String, DbOperationError> {
     Ok(decoded)
 }
 
-fn parse_sqlite_text_value(value: &str, source: QuerySource) -> Result<String, DbOperationError> {
-    let decoded = if value.starts_with("unistr(") {
-        parse_unistr_literal(value)?
-    } else {
-        unquote_sql_text(value)
-    };
-    Ok(match source {
-        QuerySource::Preview => decode_sqlite_nul_text_transport(decoded),
-        QuerySource::Adhoc => decoded,
-    })
+fn decode_preview_transport_unistr(value: &str) -> Result<Option<String>, DbOperationError> {
+    let inner = parse_unistr_inner_sql_escapes(value)?;
+    if let Some(hex) = inner.strip_prefix(sql::PREVIEW_TRANSPORT_UNISTR_PREFIX) {
+        return decode_hex_text(hex).map(Some);
+    }
+    if let Some(hex) = inner.strip_prefix(&sql::sqlite_nul_text_sentinel()) {
+        return decode_hex_text(hex).map(Some);
+    }
+    Ok(None)
 }
 
 fn decode_hex_bytes(hex: &str) -> Result<Vec<u8>, DbOperationError> {
@@ -1044,10 +1016,15 @@ fn parse_quoted_value(value: &str, source: QuerySource) -> Result<QueryValue, Db
         return Ok(QueryValue::Null);
     }
     if value.starts_with('\'') && value.ends_with('\'') && value.len() >= 2 {
-        return Ok(QueryValue::Text(parse_sqlite_text_value(value, source)?));
+        return Ok(QueryValue::Text(unquote_sql_text(value)));
     }
     if value.starts_with("unistr(") && value.ends_with(')') {
-        return Ok(QueryValue::Text(parse_sqlite_text_value(value, source)?));
+        if source == QuerySource::Preview
+            && let Some(text) = decode_preview_transport_unistr(value)?
+        {
+            return Ok(QueryValue::Text(text));
+        }
+        return Ok(QueryValue::SqlLiteral(value.to_string()));
     }
     if value.len() >= 3
         && value.as_bytes()[1] == b'\''
@@ -1925,6 +1902,32 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn preserves_distinct_c0_text_values_in_preview() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, value TEXT);
+            INSERT INTO users(value) VALUES (char(1) || char(1));
+            INSERT INTO users(value) VALUES (char(1) || char(92) || 'u0001');
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_preview(&dsn, "main", "users", 10, 0, true)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                result.value_at(0, 1),
+                Some(&QueryValue::Text("\x01\x01".to_string()))
+            );
+            assert_eq!(
+                result.value_at(1, 1),
+                Some(&QueryValue::Text("\x01\\u0001".to_string()))
+            );
+        }
+
+        #[tokio::test]
         async fn preserves_sentinel_like_text_without_nul_in_preview() {
             let (_dir, dsn) = make_sqlite_db(
                 r"
@@ -2088,74 +2091,53 @@ mod tests {
         }
 
         #[test]
-        fn parse_unistr_literal_unescapes_sql_string_quotes_and_backslashes() {
+        fn parse_unistr_inner_sql_escapes_does_not_decode_unicode_sequences() {
             assert_eq!(
-                parse_unistr_literal("unistr('\\u0001O''Reilly')").unwrap(),
-                "\x01O'Reilly"
+                parse_unistr_inner_sql_escapes("unistr('\\u0001\\u0001')").unwrap(),
+                "\\u0001\\u0001"
             );
             assert_eq!(
-                parse_unistr_literal("unistr('\\u0001back\\slash')").unwrap(),
-                "\x01back\\slash"
-            );
-            assert_eq!(
-                parse_unistr_literal("unistr('\\u0001a\\\\b')").unwrap(),
-                "\x01a\\b"
-            );
-            assert_eq!(
-                parse_unistr_literal("unistr('\\u0001\\u0041')").unwrap(),
-                "\x01\\u0041"
+                parse_unistr_inner_sql_escapes("unistr('\\u0001O''Reilly')").unwrap(),
+                "\\u0001O'Reilly"
             );
         }
 
         #[test]
-        fn quoted_to_query_result_preserves_literal_backslash_u_sequences_in_adhoc() {
-            let quoted = "'value'\nunistr('\\u0001\\u0041')\n";
-
-            let result = quoted_to_query_result(
-                "SELECT char(1) || char(92) || 'u0041'",
-                quoted,
-                QuerySource::Adhoc,
-                1,
-            )
-            .unwrap();
-
+        fn decode_preview_transport_unistr_decodes_hex_payload() {
             assert_eq!(
-                result.value_at(0, 0),
-                Some(&QueryValue::Text("\x01\\u0041".to_string()))
+                decode_preview_transport_unistr("unistr('\\u0001SABIQL_HEX:61006263')")
+                    .unwrap()
+                    .as_deref(),
+                Some("a\0bc")
+            );
+            assert_eq!(
+                decode_preview_transport_unistr("unistr('\\u0001SABIQL_HEX:0101')")
+                    .unwrap()
+                    .as_deref(),
+                Some("\x01\x01")
+            );
+            assert_eq!(
+                decode_preview_transport_unistr("unistr('\\u0001SABIQL_HEX:015C7530303031')")
+                    .unwrap()
+                    .as_deref(),
+                Some("\x01\\u0001")
             );
         }
 
         #[test]
-        fn quoted_to_query_result_decodes_unistr_adhoc_text_with_sql_escapes() {
-            let quoted = "'value'\nunistr('\\u0001O''Reilly')\n";
-
-            let result = quoted_to_query_result(
-                "SELECT char(1) || 'O''Reilly'",
-                quoted,
-                QuerySource::Adhoc,
-                1,
-            )
-            .unwrap();
-
+        fn parse_quoted_value_keeps_unrecoverable_adhoc_unistr_as_sql_literal() {
             assert_eq!(
-                result.value_at(0, 0),
-                Some(&QueryValue::Text("\x01O'Reilly".to_string()))
+                parse_quoted_value("unistr('\\u0001\\u0001')", QuerySource::Adhoc).unwrap(),
+                QueryValue::SqlLiteral("unistr('\\u0001\\u0001')".to_string())
+            );
+            assert_eq!(
+                parse_quoted_value("unistr('\\u0001O''Reilly')", QuerySource::Adhoc).unwrap(),
+                QueryValue::SqlLiteral("unistr('\\u0001O''Reilly')".to_string())
             );
         }
 
         #[test]
-        fn parse_sqlite_text_value_decodes_unistr_transport_for_preview() {
-            let value = parse_sqlite_text_value(
-                "unistr('\\u0001SABIQL_HEX:61006263')",
-                QuerySource::Preview,
-            )
-            .unwrap();
-
-            assert_eq!(value, "a\0bc");
-        }
-
-        #[test]
-        fn parse_quoted_value_decodes_nul_text_transport_for_preview() {
+        fn parse_quoted_value_decodes_preview_transport_unistr() {
             let value =
                 parse_quoted_value("unistr('\\u0001SABIQL_HEX:61006263')", QuerySource::Preview)
                     .unwrap();
@@ -2164,30 +2146,19 @@ mod tests {
         }
 
         #[test]
-        fn parse_quoted_value_preserves_transport_prefix_for_adhoc() {
-            let value =
-                parse_quoted_value("unistr('\\u0001SABIQL_HEX:4142')", QuerySource::Adhoc).unwrap();
+        fn quoted_to_query_result_keeps_unrecoverable_adhoc_unistr_as_sql_literal() {
+            let quoted = "'value'\nunistr('\\u0001\\u0001')\n";
+
+            let result =
+                quoted_to_query_result("SELECT char(1) || char(1)", quoted, QuerySource::Adhoc, 1)
+                    .unwrap();
 
             assert_eq!(
-                value,
-                QueryValue::Text(format!("{}4142", sql::sqlite_nul_text_sentinel()))
+                result.value_at(0, 0),
+                Some(&QueryValue::SqlLiteral(
+                    "unistr('\\u0001\\u0001')".to_string()
+                ))
             );
-        }
-
-        #[test]
-        fn quoted_to_query_result_preserves_sentinel_like_adhoc_text() {
-            let quoted = "'value'\nunistr('\\u0001SABIQL_HEX:4142')\n";
-            let expected = format!("{}4142", sql::sqlite_nul_text_sentinel());
-
-            let result = quoted_to_query_result(
-                "SELECT char(1) || 'SABIQL_HEX:4142'",
-                quoted,
-                QuerySource::Adhoc,
-                1,
-            )
-            .unwrap();
-
-            assert_eq!(result.value_at(0, 0), Some(&QueryValue::Text(expected)));
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -982,15 +982,19 @@ fn parse_unistr_inner_sql_escapes(value: &str) -> Result<String, DbOperationErro
     Ok(decoded)
 }
 
-fn decode_preview_transport_unistr(value: &str) -> Result<Option<String>, DbOperationError> {
-    let inner = parse_unistr_inner_sql_escapes(value)?;
-    if let Some(hex) = inner.strip_prefix(sql::PREVIEW_TRANSPORT_UNISTR_PREFIX) {
+fn decode_sqlite_nul_text_transport(text: &str) -> Result<Option<String>, DbOperationError> {
+    if let Some(hex) = text.strip_prefix(&sql::sqlite_nul_text_sentinel()) {
         return decode_hex_text(hex).map(Some);
     }
-    if let Some(hex) = inner.strip_prefix(&sql::sqlite_nul_text_sentinel()) {
+    if let Some(hex) = text.strip_prefix(sql::PREVIEW_TRANSPORT_UNISTR_PREFIX) {
         return decode_hex_text(hex).map(Some);
     }
     Ok(None)
+}
+
+fn decode_preview_transport_unistr(value: &str) -> Result<Option<String>, DbOperationError> {
+    let inner = parse_unistr_inner_sql_escapes(value)?;
+    decode_sqlite_nul_text_transport(&inner)
 }
 
 fn decode_hex_bytes(hex: &str) -> Result<Vec<u8>, DbOperationError> {
@@ -1016,7 +1020,13 @@ fn parse_quoted_value(value: &str, source: QuerySource) -> Result<QueryValue, Db
         return Ok(QueryValue::Null);
     }
     if value.starts_with('\'') && value.ends_with('\'') && value.len() >= 2 {
-        return Ok(QueryValue::Text(unquote_sql_text(value)));
+        let text = unquote_sql_text(value);
+        if source == QuerySource::Preview
+            && let Some(decoded) = decode_sqlite_nul_text_transport(&text)?
+        {
+            return Ok(QueryValue::Text(decoded));
+        }
+        return Ok(QueryValue::Text(text));
     }
     if value.starts_with("unistr(") && value.ends_with(')') {
         if source == QuerySource::Preview
@@ -2143,6 +2153,25 @@ mod tests {
                     .unwrap();
 
             assert_eq!(value, QueryValue::Text("a\0bc".to_string()));
+        }
+
+        #[test]
+        fn parse_quoted_value_decodes_preview_transport_plain_quoted() {
+            let sentinel = sql::sqlite_nul_text_sentinel();
+            let quoted = format!("'{sentinel}68656C6C6F'");
+            let value = parse_quoted_value(&quoted, QuerySource::Preview).unwrap();
+
+            assert_eq!(value, QueryValue::Text("hello".to_string()));
+        }
+
+        #[test]
+        fn parse_quoted_value_keeps_plain_quoted_transport_as_text_for_adhoc() {
+            let sentinel = sql::sqlite_nul_text_sentinel();
+            let transport = format!("{sentinel}68656C6C6F");
+            let quoted = format!("'{transport}'");
+            let value = parse_quoted_value(&quoted, QuerySource::Adhoc).unwrap();
+
+            assert_eq!(value, QueryValue::Text(transport));
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1015,13 +1015,18 @@ fn decode_hex_bytes(hex: &str) -> Result<Vec<u8>, DbOperationError> {
     Ok(bytes)
 }
 
-fn parse_quoted_value(value: &str, source: QuerySource) -> Result<QueryValue, DbOperationError> {
+fn parse_quoted_value(
+    value: &str,
+    source: QuerySource,
+    decode_preview_transport: bool,
+) -> Result<QueryValue, DbOperationError> {
     if value == "NULL" {
         return Ok(QueryValue::Null);
     }
     if value.starts_with('\'') && value.ends_with('\'') && value.len() >= 2 {
         let text = unquote_sql_text(value);
         if source == QuerySource::Preview
+            && decode_preview_transport
             && let Some(decoded) = decode_sqlite_nul_text_transport(&text)?
         {
             return Ok(QueryValue::Text(decoded));
@@ -1030,6 +1035,7 @@ fn parse_quoted_value(value: &str, source: QuerySource) -> Result<QueryValue, Db
     }
     if value.starts_with("unistr(") && value.ends_with(')') {
         if source == QuerySource::Preview
+            && decode_preview_transport
             && let Some(text) = decode_preview_transport_unistr(value)?
         {
             return Ok(QueryValue::Text(text));
@@ -1060,10 +1066,12 @@ fn parse_quoted_records(
 ) -> Result<Vec<QuotedRecord>, DbOperationError> {
     split_quoted_records(stdout)?
         .into_iter()
-        .map(|segment| {
+        .enumerate()
+        .map(|(index, segment)| {
+            let decode_preview_transport = source == QuerySource::Preview && index > 0;
             split_quoted_fields(&segment.text)?
                 .into_iter()
-                .map(|field| parse_quoted_value(&field, source))
+                .map(|field| parse_quoted_value(&field, source, decode_preview_transport))
                 .collect::<Result<Vec<_>, _>>()
                 .map(|values| QuotedRecord {
                     offset: segment.offset,
@@ -2137,20 +2145,23 @@ mod tests {
         #[test]
         fn parse_quoted_value_keeps_unrecoverable_adhoc_unistr_as_sql_literal() {
             assert_eq!(
-                parse_quoted_value("unistr('\\u0001\\u0001')", QuerySource::Adhoc).unwrap(),
+                parse_quoted_value("unistr('\\u0001\\u0001')", QuerySource::Adhoc, true).unwrap(),
                 QueryValue::SqlLiteral("unistr('\\u0001\\u0001')".to_string())
             );
             assert_eq!(
-                parse_quoted_value("unistr('\\u0001O''Reilly')", QuerySource::Adhoc).unwrap(),
+                parse_quoted_value("unistr('\\u0001O''Reilly')", QuerySource::Adhoc, true).unwrap(),
                 QueryValue::SqlLiteral("unistr('\\u0001O''Reilly')".to_string())
             );
         }
 
         #[test]
         fn parse_quoted_value_decodes_preview_transport_unistr() {
-            let value =
-                parse_quoted_value("unistr('\\u0001SABIQL_HEX:61006263')", QuerySource::Preview)
-                    .unwrap();
+            let value = parse_quoted_value(
+                "unistr('\\u0001SABIQL_HEX:61006263')",
+                QuerySource::Preview,
+                true,
+            )
+            .unwrap();
 
             assert_eq!(value, QueryValue::Text("a\0bc".to_string()));
         }
@@ -2159,7 +2170,7 @@ mod tests {
         fn parse_quoted_value_decodes_preview_transport_plain_quoted() {
             let sentinel = sql::sqlite_nul_text_sentinel();
             let quoted = format!("'{sentinel}68656C6C6F'");
-            let value = parse_quoted_value(&quoted, QuerySource::Preview).unwrap();
+            let value = parse_quoted_value(&quoted, QuerySource::Preview, true).unwrap();
 
             assert_eq!(value, QueryValue::Text("hello".to_string()));
         }
@@ -2169,9 +2180,35 @@ mod tests {
             let sentinel = sql::sqlite_nul_text_sentinel();
             let transport = format!("{sentinel}68656C6C6F");
             let quoted = format!("'{transport}'");
-            let value = parse_quoted_value(&quoted, QuerySource::Adhoc).unwrap();
+            let value = parse_quoted_value(&quoted, QuerySource::Adhoc, true).unwrap();
 
             assert_eq!(value, QueryValue::Text(transport));
+        }
+
+        #[test]
+        fn parse_quoted_value_skips_preview_transport_decode_for_column_names() {
+            let sentinel = sql::sqlite_nul_text_sentinel();
+            let transport = format!("{sentinel}68656C6C6F");
+            let quoted = format!("'{transport}'");
+            let value = parse_quoted_value(&quoted, QuerySource::Preview, false).unwrap();
+
+            assert_eq!(value, QueryValue::Text(transport));
+        }
+
+        #[test]
+        fn quoted_to_query_result_keeps_transport_like_column_name() {
+            let sentinel = sql::sqlite_nul_text_sentinel();
+            let column = format!("{sentinel}4142");
+            let data = format!("'{sentinel}68656C6C6F'");
+            let quoted = format!("'{column}'\n{data}\n");
+            let result =
+                quoted_to_query_result("SELECT 1", &quoted, QuerySource::Preview, 1).unwrap();
+
+            assert_eq!(result.columns, vec![column]);
+            assert_eq!(
+                result.value_at(0, 0),
+                Some(&QueryValue::Text("hello".to_string()))
+            );
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -143,6 +143,14 @@ impl SqliteAdapter {
         }
     }
 
+    fn preview_visible_column_names(raw_columns: Vec<RawColumn>) -> Vec<String> {
+        raw_columns
+            .into_iter()
+            .filter(|column| column.hidden != 1)
+            .map(|column| column.name)
+            .collect()
+    }
+
     fn extract_primary_key(columns: &[RawColumn]) -> Vec<String> {
         let mut primary_key: Vec<(i64, String)> = columns
             .iter()
@@ -919,16 +927,14 @@ fn unquote_sql_text(value: &str) -> String {
     value[1..value.len() - 1].replace("''", "'")
 }
 
-pub(super) const SQLITE_NUL_TEXT_SENTINEL: &str = "\x01SABIQL_HEX:";
-
 fn decode_sqlite_nul_text_transport(value: String) -> String {
-    let Some(hex) = value.strip_prefix(SQLITE_NUL_TEXT_SENTINEL) else {
-        return value;
-    };
-    match decode_hex_bytes(hex) {
-        Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
-        Err(_) => value,
+    let sentinel = sql::sqlite_nul_text_sentinel();
+    if let Some(hex) = value.strip_prefix(&sentinel)
+        && let Ok(bytes) = decode_hex_bytes(hex)
+    {
+        return String::from_utf8_lossy(&bytes).into_owned();
     }
+    value
 }
 
 fn parse_unistr_literal(value: &str) -> Result<String, DbOperationError> {
@@ -979,13 +985,16 @@ fn parse_unistr_literal(value: &str) -> Result<String, DbOperationError> {
     Ok(decoded)
 }
 
-fn parse_sqlite_text_value(value: &str) -> Result<String, DbOperationError> {
+fn parse_sqlite_text_value(value: &str, source: QuerySource) -> Result<String, DbOperationError> {
     let decoded = if value.starts_with("unistr(") {
         parse_unistr_literal(value)?
     } else {
         unquote_sql_text(value)
     };
-    Ok(decode_sqlite_nul_text_transport(decoded))
+    Ok(match source {
+        QuerySource::Preview => decode_sqlite_nul_text_transport(decoded),
+        QuerySource::Adhoc => decoded,
+    })
 }
 
 fn decode_hex_bytes(hex: &str) -> Result<Vec<u8>, DbOperationError> {
@@ -1006,15 +1015,15 @@ fn decode_hex_bytes(hex: &str) -> Result<Vec<u8>, DbOperationError> {
     Ok(bytes)
 }
 
-fn parse_quoted_value(value: &str) -> Result<QueryValue, DbOperationError> {
+fn parse_quoted_value(value: &str, source: QuerySource) -> Result<QueryValue, DbOperationError> {
     if value == "NULL" {
         return Ok(QueryValue::Null);
     }
     if value.starts_with('\'') && value.ends_with('\'') && value.len() >= 2 {
-        return Ok(QueryValue::Text(parse_sqlite_text_value(value)?));
+        return Ok(QueryValue::Text(parse_sqlite_text_value(value, source)?));
     }
     if value.starts_with("unistr(") && value.ends_with(')') {
-        return Ok(QueryValue::Text(parse_sqlite_text_value(value)?));
+        return Ok(QueryValue::Text(parse_sqlite_text_value(value, source)?));
     }
     if value.len() >= 3
         && value.as_bytes()[1] == b'\''
@@ -1034,13 +1043,16 @@ fn parse_quoted_value(value: &str) -> Result<QueryValue, DbOperationError> {
     Ok(QueryValue::SqlLiteral(value.to_string()))
 }
 
-fn parse_quoted_records(stdout: &str) -> Result<Vec<QuotedRecord>, DbOperationError> {
+fn parse_quoted_records(
+    stdout: &str,
+    source: QuerySource,
+) -> Result<Vec<QuotedRecord>, DbOperationError> {
     split_quoted_records(stdout)?
         .into_iter()
         .map(|segment| {
             split_quoted_fields(&segment.text)?
                 .into_iter()
-                .map(|field| parse_quoted_value(&field))
+                .map(|field| parse_quoted_value(&field, source))
                 .collect::<Result<Vec<_>, _>>()
                 .map(|values| QuotedRecord {
                     offset: segment.offset,
@@ -1072,7 +1084,7 @@ fn quoted_to_query_result(
         ));
     }
 
-    let mut records = parse_quoted_records(stdout)?;
+    let mut records = parse_quoted_records(stdout, source)?;
     let Some(header) = records.first() else {
         return Ok(QueryResult::success(
             query.to_string(),
@@ -1100,7 +1112,7 @@ fn quoted_to_query_result(
 fn last_sqlite_result_set(stdout: &str, marker: &str) -> Result<Option<String>, DbOperationError> {
     let (stmt_col, marker_col) = sqlite_result_probe_columns(marker);
     let raw_records = split_quoted_records(stdout)?;
-    let records = parse_quoted_records(stdout)?;
+    let records = parse_quoted_records(stdout, QuerySource::Adhoc)?;
 
     let mut last_result = None;
     let mut result_start = 0;
@@ -1157,7 +1169,7 @@ fn strip_sqlite_probes(
 
     let (stmt_col, changes_col) = sqlite_probe_columns(marker);
     let raw_records = split_quoted_records(stdout)?;
-    let records = parse_quoted_records(stdout)?;
+    let records = parse_quoted_records(stdout, QuerySource::Adhoc)?;
 
     let mut changes = HashMap::new();
     let mut kept = Vec::new();
@@ -1540,12 +1552,7 @@ impl QueryExecutor for SqliteAdapter {
         let columns = self
             .columns(path, table)
             .await
-            .map(|raw_columns| {
-                raw_columns
-                    .into_iter()
-                    .map(|column| column.name)
-                    .collect::<Vec<_>>()
-            })
+            .map(Self::preview_visible_column_names)
             .unwrap_or_default();
         let query = sql::build_preview_query(table, &columns, &order_columns, limit, offset);
         self.execute_quoted_query(path, &query, QuerySource::Preview, read_only)
@@ -1870,6 +1877,78 @@ mod tests {
                 Some(&QueryValue::Text("only".to_string()))
             );
         }
+
+        #[tokio::test]
+        async fn excludes_hidden_columns_from_preview_select_list() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE VIRTUAL TABLE notes_fts USING fts5(body);
+            INSERT INTO notes_fts(body) VALUES ('hello');
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_preview(&dsn, "main", "notes_fts", 10, 0, true)
+                .await
+                .unwrap();
+
+            assert_eq!(result.columns, vec!["body"]);
+            assert_eq!(
+                result.value_at(0, 0),
+                Some(&QueryValue::Text("hello".to_string()))
+            );
+        }
+
+        #[tokio::test]
+        async fn preserves_sentinel_like_text_without_nul_in_preview() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, token TEXT);
+            INSERT INTO users(token) VALUES (char(1) || 'SABIQL_HEX:4142');
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_preview(&dsn, "main", "users", 10, 0, true)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                result.value_at(0, 1),
+                Some(&QueryValue::Text(format!(
+                    "{}4142",
+                    sql::sqlite_nul_text_sentinel()
+                )))
+            );
+        }
+
+        #[tokio::test]
+        async fn keeps_generated_columns_in_preview_select_list() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(
+                id INTEGER PRIMARY KEY,
+                name TEXT,
+                name_upper TEXT GENERATED ALWAYS AS (upper(name)) STORED
+            );
+            INSERT INTO users(name) VALUES ('alice');
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_preview(&dsn, "main", "users", 10, 0, true)
+                .await
+                .unwrap();
+
+            assert_eq!(result.columns, vec!["id", "name", "name_upper"]);
+            assert_eq!(
+                result.value_at(0, 2),
+                Some(&QueryValue::Text("ALICE".to_string()))
+            );
+        }
     }
 
     mod parsing {
@@ -1985,17 +2064,50 @@ mod tests {
         }
 
         #[test]
-        fn parse_sqlite_text_value_decodes_unistr_transport() {
-            let value = parse_sqlite_text_value("unistr('\\u0001SABIQL_HEX:61006263')").unwrap();
+        fn parse_sqlite_text_value_decodes_unistr_transport_for_preview() {
+            let value = parse_sqlite_text_value(
+                "unistr('\\u0001SABIQL_HEX:61006263')",
+                QuerySource::Preview,
+            )
+            .unwrap();
 
             assert_eq!(value, "a\0bc");
         }
 
         #[test]
-        fn parse_quoted_value_decodes_nul_text_transport() {
-            let value = parse_quoted_value("unistr('\\u0001SABIQL_HEX:61006263')").unwrap();
+        fn parse_quoted_value_decodes_nul_text_transport_for_preview() {
+            let value =
+                parse_quoted_value("unistr('\\u0001SABIQL_HEX:61006263')", QuerySource::Preview)
+                    .unwrap();
 
             assert_eq!(value, QueryValue::Text("a\0bc".to_string()));
+        }
+
+        #[test]
+        fn parse_quoted_value_preserves_transport_prefix_for_adhoc() {
+            let value =
+                parse_quoted_value("unistr('\\u0001SABIQL_HEX:4142')", QuerySource::Adhoc).unwrap();
+
+            assert_eq!(
+                value,
+                QueryValue::Text(format!("{}4142", sql::sqlite_nul_text_sentinel()))
+            );
+        }
+
+        #[test]
+        fn quoted_to_query_result_preserves_sentinel_like_adhoc_text() {
+            let quoted = "'value'\nunistr('\\u0001SABIQL_HEX:4142')\n";
+            let expected = format!("{}4142", sql::sqlite_nul_text_sentinel());
+
+            let result = quoted_to_query_result(
+                "SELECT char(1) || 'SABIQL_HEX:4142'",
+                quoted,
+                QuerySource::Adhoc,
+                1,
+            )
+            .unwrap();
+
+            assert_eq!(result.value_at(0, 0), Some(&QueryValue::Text(expected)));
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -123,11 +123,12 @@ pub(super) fn row_count_query(table: &str) -> String {
     format!("SELECT COUNT(*) AS count FROM {}", quote_ident(table))
 }
 
+pub(super) const PREVIEW_TRANSPORT_UNISTR_PREFIX: &str = "\\u0001SABIQL_HEX:";
+
 pub(super) fn encode_preview_column_expr(column: &str) -> String {
     let ident = quote_ident(column);
     format!(
-        "CASE WHEN typeof({ident}) = 'text' AND (instr({ident}, char(0)) > 0 \
-         OR {ident} LIKE char(1) || '{SQLITE_NUL_TEXT_TRANSPORT_TAG}%') \
+        "CASE WHEN typeof({ident}) = 'text' \
          THEN char(1) || '{SQLITE_NUL_TEXT_TRANSPORT_TAG}' || hex({ident}) \
          ELSE {ident} END AS {ident}"
     )
@@ -401,11 +402,9 @@ mod tests {
                 20
             ),
             concat!(
-                r#"SELECT CASE WHEN typeof("id") = 'text' AND (instr("id", char(0)) > 0 "#,
-                r#"OR "id" LIKE char(1) || 'SABIQL_HEX:%') "#,
+                r#"SELECT CASE WHEN typeof("id") = 'text' "#,
                 r#"THEN char(1) || 'SABIQL_HEX:' || hex("id") ELSE "id" END AS "id", "#,
-                r#"CASE WHEN typeof("name") = 'text' AND (instr("name", char(0)) > 0 "#,
-                r#"OR "name" LIKE char(1) || 'SABIQL_HEX:%') "#,
+                r#"CASE WHEN typeof("name") = 'text' "#,
                 r#"THEN char(1) || 'SABIQL_HEX:' || hex("name") ELSE "name" END AS "name" "#,
                 r#"FROM "users" ORDER BY "id" LIMIT 10 OFFSET 20"#
             )

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -5,6 +5,21 @@ use crate::domain::{DatabaseType, QueryValue, Table};
 
 use super::SqliteAdapter;
 
+pub(super) const SQLITE_NUL_TEXT_TRANSPORT_TAG: &str = "SABIQL_HEX:";
+
+pub(super) fn sqlite_nul_text_sentinel() -> String {
+    format!("\x01{SQLITE_NUL_TEXT_TRANSPORT_TAG}")
+}
+
+pub(super) fn encode_bytes_as_sql_hex(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .fold(String::with_capacity(bytes.len() * 2), |mut hex, byte| {
+            let _ = write!(hex, "{byte:02X}");
+            hex
+        })
+}
+
 fn quote_ident(value: &str) -> String {
     format!("\"{}\"", value.replace('"', "\"\""))
 }
@@ -13,16 +28,16 @@ fn quote_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
+fn blob_sql_literal(bytes: &[u8]) -> String {
+    format!("X'{}'", encode_bytes_as_sql_hex(bytes))
+}
+
 fn text_sql_literal(value: &str) -> String {
     if value.contains('\0') {
-        let hex = value
-            .as_bytes()
-            .iter()
-            .fold(String::new(), |mut hex, byte| {
-                let _ = write!(hex, "{byte:02X}");
-                hex
-            });
-        format!("CAST(X'{hex}' AS TEXT)")
+        format!(
+            "CAST(X'{}' AS TEXT)",
+            encode_bytes_as_sql_hex(value.as_bytes())
+        )
     } else {
         quote_literal(value)
     }
@@ -33,13 +48,7 @@ fn sql_literal(value: &QueryValue) -> String {
         QueryValue::Null => "NULL".to_string(),
         QueryValue::Text(value) => text_sql_literal(value),
         QueryValue::SqlLiteral(value) => value.clone(),
-        QueryValue::Blob(bytes) => {
-            let mut hex = String::with_capacity(bytes.len() * 2);
-            for byte in bytes {
-                let _ = write!(hex, "{byte:02X}");
-            }
-            format!("X'{hex}'")
-        }
+        QueryValue::Blob(bytes) => blob_sql_literal(bytes),
     }
 }
 
@@ -117,8 +126,9 @@ pub(super) fn row_count_query(table: &str) -> String {
 pub(super) fn encode_preview_column_expr(column: &str) -> String {
     let ident = quote_ident(column);
     format!(
-        "CASE WHEN typeof({ident}) = 'text' AND instr({ident}, char(0)) > 0 \
-         THEN char(1) || 'SABIQL_HEX:' || hex({ident}) \
+        "CASE WHEN typeof({ident}) = 'text' AND (instr({ident}, char(0)) > 0 \
+         OR {ident} LIKE char(1) || '{SQLITE_NUL_TEXT_TRANSPORT_TAG}%') \
+         THEN char(1) || '{SQLITE_NUL_TEXT_TRANSPORT_TAG}' || hex({ident}) \
          ELSE {ident} END AS {ident}"
     )
 }
@@ -391,9 +401,11 @@ mod tests {
                 20
             ),
             concat!(
-                r#"SELECT CASE WHEN typeof("id") = 'text' AND instr("id", char(0)) > 0 "#,
+                r#"SELECT CASE WHEN typeof("id") = 'text' AND (instr("id", char(0)) > 0 "#,
+                r#"OR "id" LIKE char(1) || 'SABIQL_HEX:%') "#,
                 r#"THEN char(1) || 'SABIQL_HEX:' || hex("id") ELSE "id" END AS "id", "#,
-                r#"CASE WHEN typeof("name") = 'text' AND instr("name", char(0)) > 0 "#,
+                r#"CASE WHEN typeof("name") = 'text' AND (instr("name", char(0)) > 0 "#,
+                r#"OR "name" LIKE char(1) || 'SABIQL_HEX:%') "#,
                 r#"THEN char(1) || 'SABIQL_HEX:' || hex("name") ELSE "name" END AS "name" "#,
                 r#"FROM "users" ORDER BY "id" LIMIT 10 OFFSET 20"#
             )

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -13,10 +13,25 @@ fn quote_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
+fn text_sql_literal(value: &str) -> String {
+    if value.contains('\0') {
+        let hex = value
+            .as_bytes()
+            .iter()
+            .fold(String::new(), |mut hex, byte| {
+                let _ = write!(hex, "{byte:02X}");
+                hex
+            });
+        format!("CAST(X'{hex}' AS TEXT)")
+    } else {
+        quote_literal(value)
+    }
+}
+
 fn sql_literal(value: &QueryValue) -> String {
     match value {
         QueryValue::Null => "NULL".to_string(),
-        QueryValue::Text(value) => quote_literal(value),
+        QueryValue::Text(value) => text_sql_literal(value),
         QueryValue::SqlLiteral(value) => value.clone(),
         QueryValue::Blob(bytes) => {
             let mut hex = String::with_capacity(bytes.len() * 2);
@@ -99,12 +114,31 @@ pub(super) fn row_count_query(table: &str) -> String {
     format!("SELECT COUNT(*) AS count FROM {}", quote_ident(table))
 }
 
+pub(super) fn encode_preview_column_expr(column: &str) -> String {
+    let ident = quote_ident(column);
+    format!(
+        "CASE WHEN typeof({ident}) = 'text' AND instr({ident}, char(0)) > 0 \
+         THEN char(1) || 'SABIQL_HEX:' || hex({ident}) \
+         ELSE {ident} END AS {ident}"
+    )
+}
+
 pub(super) fn build_preview_query(
     table: &str,
+    columns: &[String],
     order_columns: &[String],
     limit: usize,
     offset: usize,
 ) -> String {
+    let select_list = if columns.is_empty() {
+        "*".to_string()
+    } else {
+        columns
+            .iter()
+            .map(|column| encode_preview_column_expr(column))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
     let order_clause = if order_columns.is_empty() {
         String::new()
     } else {
@@ -117,7 +151,7 @@ pub(super) fn build_preview_query(
     };
 
     format!(
-        "SELECT * FROM {}{} LIMIT {} OFFSET {}",
+        "SELECT {select_list} FROM {}{} LIMIT {} OFFSET {}",
         quote_ident(table),
         order_clause,
         limit,
@@ -349,8 +383,36 @@ mod tests {
     #[test]
     fn build_preview_query_orders_by_primary_key_columns_when_available() {
         assert_eq!(
-            build_preview_query("users", &["id".to_string()], 10, 20),
+            build_preview_query(
+                "users",
+                &["id".to_string(), "name".to_string()],
+                &["id".to_string()],
+                10,
+                20
+            ),
+            concat!(
+                r#"SELECT CASE WHEN typeof("id") = 'text' AND instr("id", char(0)) > 0 "#,
+                r#"THEN char(1) || 'SABIQL_HEX:' || hex("id") ELSE "id" END AS "id", "#,
+                r#"CASE WHEN typeof("name") = 'text' AND instr("name", char(0)) > 0 "#,
+                r#"THEN char(1) || 'SABIQL_HEX:' || hex("name") ELSE "name" END AS "name" "#,
+                r#"FROM "users" ORDER BY "id" LIMIT 10 OFFSET 20"#
+            )
+        );
+    }
+
+    #[test]
+    fn build_preview_query_falls_back_to_star_without_columns() {
+        assert_eq!(
+            build_preview_query("users", &[], &["id".to_string()], 10, 20),
             r#"SELECT * FROM "users" ORDER BY "id" LIMIT 10 OFFSET 20"#
+        );
+    }
+
+    #[test]
+    fn text_sql_literal_uses_cast_for_embedded_nul_byte() {
+        assert_eq!(
+            sql_literal(&QueryValue::text("a\0bc")),
+            "CAST(X'61006263' AS TEXT)"
         );
     }
 
@@ -546,6 +608,22 @@ mod tests {
             let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
 
             assert_eq!(sql, "DELETE FROM \"users\"\nWHERE \"id\" = X'00FF41';");
+        }
+
+        #[test]
+        fn nul_text_pk_value_uses_cast_literal() {
+            let adapter = SqliteAdapter::new();
+            let rows = vec![vec![(
+                "id".to_string(),
+                QueryValue::Text("a\0bc".to_string()),
+            )]];
+
+            let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "users", &rows);
+
+            assert_eq!(
+                sql,
+                "DELETE FROM \"users\"\nWHERE \"id\" = CAST(X'61006263' AS TEXT);"
+            );
         }
     }
 


### PR DESCRIPTION
## Problem
SQLite TEXT can contain embedded NUL bytes, but `sqlite3 -quote` truncates output at the first NUL. When those values are used for row identity, preview/edit/delete can target the wrong row.

## Background
SAB-275 already preserved typed `QueryValue`s for writes, but the SQLite quoted-output path still dropped bytes after NUL before those values reached the app. Display truncation alone would be annoying; using the truncated value in write predicates is unsafe.

## Approach
Encode NUL-bearing TEXT in preview queries with a transport prefix and hex payload so quoted output stays lossless, decode `unistr(...)` transport back into typed TEXT values, render embedded NUL as `\0` in display strings only, and generate write predicates with `CAST(X'..')` instead of quoted literals or CLI arguments containing NUL.

## Screenshots
N/A

Validation:
- `cargo nextest run --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

Closes SAB-284