### PR TITLE
fix(sqlite): exclude shadow tables from normal browsing (SAB-289)

### DIFF
--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -9,6 +9,7 @@ pub enum ConnectionErrorKind {
     DatabaseNotFound,
     ConnectionLost,
     Timeout,
+    SqliteVersionTooOld,
     #[default]
     Unknown,
 }
@@ -68,6 +69,7 @@ impl ConnectionErrorKind {
             Self::DatabaseNotFound => "Database does not exist",
             Self::ConnectionLost => "Connection lost during operation",
             Self::Timeout => "Connection timed out",
+            Self::SqliteVersionTooOld => "SQLite 3.37 or later required",
             Self::Unknown => "Connection failed",
         }
     }
@@ -80,6 +82,9 @@ impl ConnectionErrorKind {
             Self::DatabaseNotFound => "Check database name",
             Self::ConnectionLost => "Reconnect and retry the operation",
             Self::Timeout => "Check network connectivity",
+            Self::SqliteVersionTooOld => {
+                "Upgrade sqlite3, or open a database without virtual tables"
+            }
             Self::Unknown => "See details for more information",
         }
     }
@@ -119,6 +124,11 @@ impl ConnectionErrorInfo {
             DbOperationError::CommandNotFound(_) => ConnectionErrorKind::CliNotFound,
             DbOperationError::ConnectionLost(_) => ConnectionErrorKind::ConnectionLost,
             DbOperationError::Timeout(_) => ConnectionErrorKind::Timeout,
+            DbOperationError::UnsupportedOperation(details)
+                if details.contains("SQLITE_TABLE_LIST_REQUIRED") =>
+            {
+                ConnectionErrorKind::SqliteVersionTooOld
+            }
             DbOperationError::ConnectionFailed(_) => ConnectionErrorKind::classify(&raw_details),
             _ => ConnectionErrorKind::Unknown,
         };
@@ -245,6 +255,7 @@ mod tests {
         #[case(ConnectionErrorKind::DatabaseNotFound)]
         #[case(ConnectionErrorKind::ConnectionLost)]
         #[case(ConnectionErrorKind::Timeout)]
+        #[case(ConnectionErrorKind::SqliteVersionTooOld)]
         #[case(ConnectionErrorKind::Unknown)]
         fn has_non_empty_summary_and_hint(#[case] kind: ConnectionErrorKind) {
             assert!(!kind.summary().is_empty());
@@ -288,6 +299,18 @@ mod tests {
             );
 
             assert_eq!(info.kind, ConnectionErrorKind::ConnectionLost);
+        }
+
+        #[test]
+        fn from_db_operation_error_classifies_sqlite_table_list_requirement() {
+            let info = ConnectionErrorInfo::from_db_operation_error(
+                &DbOperationError::UnsupportedOperation(
+                    "SQLITE_TABLE_LIST_REQUIRED: upgrade sqlite3".to_string(),
+                ),
+            );
+
+            assert_eq!(info.kind, ConnectionErrorKind::SqliteVersionTooOld);
+            assert_eq!(info.summary(), "SQLite 3.37 or later required");
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -105,7 +105,17 @@ impl SqliteAdapter {
     }
 
     async fn list_tables(&self, path: &str) -> Result<Vec<RawTable>, DbOperationError> {
-        self.cli.execute_json(path, sql::user_tables_query()).await
+        match self.cli.execute_json(path, sql::user_tables_query()).await {
+            Ok(tables) => Ok(tables),
+            Err(DbOperationError::QueryFailed(message))
+                if sql::is_table_list_unavailable(&message) =>
+            {
+                self.cli
+                    .execute_json(path, sql::legacy_user_tables_query())
+                    .await
+            }
+            Err(error) => Err(error),
+        }
     }
 
     async fn row_count(&self, path: &str, table: &str) -> Option<i64> {
@@ -2706,29 +2716,6 @@ mod tests {
                 r"
             CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);
             CREATE VIRTUAL TABLE notes_fts USING fts5(body);
-            ",
-            );
-            let adapter = SqliteAdapter::new();
-
-            let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
-            let table_names: Vec<_> = metadata
-                .table_summaries
-                .iter()
-                .map(|summary| summary.name.as_str())
-                .collect();
-
-            assert_eq!(table_names, vec!["notes", "notes_fts"]);
-        }
-
-        #[tokio::test]
-        async fn hides_fts5_shadow_tables_with_wrapped_virtual_table_ddl() {
-            let (_dir, dsn) = make_sqlite_db(
-                r"
-            CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);
-            CREATE VIRTUAL
-            TABLE notes_fts
-            USING
-            	fts5(body);
             ",
             );
             let adapter = SqliteAdapter::new();

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -2742,6 +2742,30 @@ mod tests {
 
             assert_eq!(table_names, vec!["notes", "notes_fts"]);
         }
+
+        #[tokio::test]
+        async fn hides_rtree_shadow_tables_from_normal_table_list() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE places(id INTEGER PRIMARY KEY, name TEXT);
+            CREATE VIRTUAL TABLE places_geo USING rtree(
+                id,
+                minX, maxX,
+                minY, maxY
+            );
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
+            let table_names: Vec<_> = metadata
+                .table_summaries
+                .iter()
+                .map(|summary| summary.name.as_str())
+                .collect();
+
+            assert_eq!(table_names, vec!["places", "places_geo"]);
+        }
     }
 
     mod table_detail {

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -104,12 +104,23 @@ impl SqliteAdapter {
             .to_string()
     }
 
+    async fn has_virtual_tables(&self, path: &str) -> Result<bool, DbOperationError> {
+        let rows: Vec<RawRowCount> = self
+            .cli
+            .execute_json(path, sql::has_virtual_tables_query())
+            .await?;
+        Ok(rows.into_iter().next().is_some_and(|row| row.count > 0))
+    }
+
     async fn list_tables(&self, path: &str) -> Result<Vec<RawTable>, DbOperationError> {
         match self.cli.execute_json(path, sql::user_tables_query()).await {
             Ok(tables) => Ok(tables),
             Err(DbOperationError::QueryFailed(message))
                 if sql::is_table_list_unavailable(&message) =>
             {
+                if self.has_virtual_tables(path).await? {
+                    return Err(sql::table_list_required_error());
+                }
                 self.cli
                     .execute_json(path, sql::legacy_user_tables_query())
                     .await
@@ -2752,6 +2763,24 @@ mod tests {
                 .collect();
 
             assert_eq!(table_names, vec!["places", "places_geo"]);
+        }
+
+        #[tokio::test]
+        async fn detects_virtual_tables_in_schema() {
+            let (_dir, dsn) = make_sqlite_db("CREATE VIRTUAL TABLE notes_fts USING fts5(body);");
+            let adapter = SqliteAdapter::new();
+            let path = SqliteAdapter::path_from_dsn(&dsn).unwrap();
+
+            assert!(adapter.has_virtual_tables(path).await.unwrap());
+        }
+
+        #[tokio::test]
+        async fn simple_schema_has_no_virtual_tables() {
+            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let adapter = SqliteAdapter::new();
+            let path = SqliteAdapter::path_from_dsn(&dsn).unwrap();
+
+            assert!(!adapter.has_virtual_tables(path).await.unwrap());
         }
     }
 

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -64,34 +64,15 @@ fn rows_predicate(pk_pairs_per_row: &[Vec<(String, QueryValue)>]) -> String {
 
 pub(super) fn user_tables_query() -> &'static str {
     r"
-    WITH fts5_tables AS (
-        SELECT name
-        FROM sqlite_master
-        WHERE type = 'table'
-          AND replace(
-                  replace(
-                      replace(lower(sql), char(13), ' '),
-                      char(10), ' '
-                  ),
-                  char(9), ' '
-              ) LIKE 'create%virtual%table%using%fts5%'
-    )
-    SELECT m.name, m.sql
-    FROM sqlite_master m
-    WHERE m.type = 'table'
-      AND m.name NOT LIKE 'sqlite_%'
-      AND NOT EXISTS (
-          SELECT 1
-          FROM fts5_tables f
-          WHERE m.name IN (
-              f.name || '_data',
-              f.name || '_idx',
-              f.name || '_content',
-              f.name || '_docsize',
-              f.name || '_config'
-          )
-      )
-    ORDER BY name
+    SELECT tl.name, m.sql
+    FROM pragma_table_list() AS tl
+    LEFT JOIN sqlite_master AS m
+      ON m.type = 'table'
+     AND m.name = tl.name
+    WHERE tl.schema = 'main'
+      AND tl.type IN ('table', 'virtual')
+      AND tl.name NOT LIKE 'sqlite_%'
+    ORDER BY tl.name
     "
 }
 
@@ -319,8 +300,10 @@ mod tests {
     }
 
     #[test]
-    fn user_tables_query_uses_compatible_schema_table() {
-        assert!(user_tables_query().contains("FROM sqlite_master"));
+    fn user_tables_query_uses_table_list_and_excludes_shadow_tables() {
+        assert!(user_tables_query().contains("pragma_table_list()"));
+        assert!(user_tables_query().contains("tl.schema = 'main'"));
+        assert!(user_tables_query().contains("tl.type IN ('table', 'virtual')"));
         assert!(user_tables_query().contains("name NOT LIKE 'sqlite_%'"));
     }
 

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -76,6 +76,43 @@ pub(super) fn user_tables_query() -> &'static str {
     "
 }
 
+pub(super) fn legacy_user_tables_query() -> &'static str {
+    r"
+    WITH fts5_tables AS (
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table'
+          AND replace(
+                  replace(
+                      replace(lower(sql), char(13), ' '),
+                      char(10), ' '
+                  ),
+                  char(9), ' '
+              ) LIKE 'create%virtual%table%using%fts5%'
+    )
+    SELECT m.name, m.sql
+    FROM sqlite_master m
+    WHERE m.type = 'table'
+      AND m.name NOT LIKE 'sqlite_%'
+      AND NOT EXISTS (
+          SELECT 1
+          FROM fts5_tables f
+          WHERE m.name IN (
+              f.name || '_data',
+              f.name || '_idx',
+              f.name || '_content',
+              f.name || '_docsize',
+              f.name || '_config'
+          )
+      )
+    ORDER BY name
+    "
+}
+
+pub(super) fn is_table_list_unavailable(error: &str) -> bool {
+    error.to_ascii_lowercase().contains("pragma_table_list")
+}
+
 pub(super) fn row_count_query(table: &str) -> String {
     format!("SELECT COUNT(*) AS count FROM {}", quote_ident(table))
 }
@@ -305,6 +342,21 @@ mod tests {
         assert!(user_tables_query().contains("tl.schema = 'main'"));
         assert!(user_tables_query().contains("tl.type IN ('table', 'virtual')"));
         assert!(user_tables_query().contains("name NOT LIKE 'sqlite_%'"));
+    }
+
+    #[test]
+    fn legacy_user_tables_query_excludes_fts5_shadow_tables() {
+        assert!(legacy_user_tables_query().contains("FROM sqlite_master"));
+        assert!(legacy_user_tables_query().contains("fts5_tables"));
+        assert!(legacy_user_tables_query().contains("name NOT LIKE 'sqlite_%'"));
+    }
+
+    #[test]
+    fn is_table_list_unavailable_detects_missing_pragma() {
+        assert!(is_table_list_unavailable(
+            "Error: in prepare, no such table: main.pragma_table_list"
+        ));
+        assert!(!is_table_list_unavailable("FOREIGN KEY constraint failed"));
     }
 
     #[test]

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as _;
 
-use crate::app::ports::outbound::{DdlGenerator, SqlDialect};
+use crate::app::ports::outbound::{DbOperationError, DdlGenerator, SqlDialect};
 use crate::domain::{DatabaseType, QueryValue, Table};
 
 use super::SqliteAdapter;
@@ -62,6 +62,8 @@ fn rows_predicate(pk_pairs_per_row: &[Vec<(String, QueryValue)>]) -> String {
     }
 }
 
+pub(super) const TABLE_LIST_REQUIRED_MARKER: &str = "SQLITE_TABLE_LIST_REQUIRED";
+
 pub(super) fn user_tables_query() -> &'static str {
     r"
     SELECT tl.name, m.sql
@@ -78,35 +80,36 @@ pub(super) fn user_tables_query() -> &'static str {
 
 pub(super) fn legacy_user_tables_query() -> &'static str {
     r"
-    WITH fts5_tables AS (
-        SELECT name
-        FROM sqlite_master
-        WHERE type = 'table'
-          AND replace(
-                  replace(
-                      replace(lower(sql), char(13), ' '),
-                      char(10), ' '
-                  ),
-                  char(9), ' '
-              ) LIKE 'create%virtual%table%using%fts5%'
-    )
-    SELECT m.name, m.sql
-    FROM sqlite_master m
-    WHERE m.type = 'table'
-      AND m.name NOT LIKE 'sqlite_%'
-      AND NOT EXISTS (
-          SELECT 1
-          FROM fts5_tables f
-          WHERE m.name IN (
-              f.name || '_data',
-              f.name || '_idx',
-              f.name || '_content',
-              f.name || '_docsize',
-              f.name || '_config'
-          )
-      )
+    SELECT name, sql
+    FROM sqlite_master
+    WHERE type = 'table'
+      AND name NOT LIKE 'sqlite_%'
     ORDER BY name
     "
+}
+
+pub(super) fn has_virtual_tables_query() -> &'static str {
+    r"
+    SELECT COUNT(*) AS count
+    FROM sqlite_master
+    WHERE type = 'table'
+      AND sql IS NOT NULL
+      AND replace(
+              replace(
+                  replace(lower(sql), char(13), ' '),
+                  char(10), ' '
+              ),
+              char(9), ' '
+          ) LIKE 'create%virtual%table%'
+    "
+}
+
+pub(super) fn table_list_required_error() -> DbOperationError {
+    DbOperationError::UnsupportedOperation(format!(
+        "{TABLE_LIST_REQUIRED_MARKER}: This database contains virtual tables (such as FTS or RTree). \
+         Upgrade sqlite3 to version 3.37.0 or later to browse it safely. \
+         Databases with only regular tables can still be opened with older sqlite3 versions."
+    ))
 }
 
 pub(super) fn is_table_list_unavailable(error: &str) -> bool {
@@ -345,10 +348,23 @@ mod tests {
     }
 
     #[test]
-    fn legacy_user_tables_query_excludes_fts5_shadow_tables() {
+    fn legacy_user_tables_query_lists_regular_tables_only() {
         assert!(legacy_user_tables_query().contains("FROM sqlite_master"));
-        assert!(legacy_user_tables_query().contains("fts5_tables"));
+        assert!(!legacy_user_tables_query().contains("fts5_tables"));
         assert!(legacy_user_tables_query().contains("name NOT LIKE 'sqlite_%'"));
+    }
+
+    #[test]
+    fn has_virtual_tables_query_detects_virtual_table_ddl() {
+        assert!(has_virtual_tables_query().contains("create%virtual%table%"));
+    }
+
+    #[test]
+    fn table_list_required_error_includes_marker_and_upgrade_guidance() {
+        let error = table_list_required_error();
+        let message = error.user_message();
+        assert!(message.contains(TABLE_LIST_REQUIRED_MARKER));
+        assert!(message.contains("3.37.0"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Internal shadow tables from virtual table extensions were listed as normal user tables.

## Background

Only FTS5 shadows were filtered via DDL heuristics; RTree and others remained visible.

## Approach

Identify shadow objects via pragma_table_list and exclude them from metadata-driven table navigation while keeping virtual tables browsable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Bug Fixes**
  * SQLiteデータベースのテーブル一覧取得時の互換性を向上しました。対応していないバージョンを自動検出し、代替方法にフォールバックするようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->