### PR TITLE
fix: prevent SQLite CSV export from re-executing write SQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -8,6 +8,7 @@ use tokio::sync::mpsc;
 use crate::cmd::effect::Effect;
 use crate::domain::ConnectionId;
 use crate::domain::QuerySource;
+use crate::domain::QueryValue;
 use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{DbOperationError, QueryExecutor, QueryHistoryStore};
@@ -92,7 +93,7 @@ fn resolve_export_path(file_name: &str) -> PathBuf {
 fn write_cached_result_csv(
     path: &Path,
     columns: &[String],
-    rows: &[Vec<String>],
+    values: &[Vec<QueryValue>],
 ) -> Result<usize, DbOperationError> {
     let file = std::fs::File::create(path)
         .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
@@ -100,15 +101,16 @@ fn write_cached_result_csv(
     writer
         .write_record(columns)
         .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    for row in rows {
+    for row in values {
+        let record: Vec<String> = row.iter().map(QueryValue::csv_field).collect();
         writer
-            .write_record(row)
+            .write_record(&record)
             .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
     }
     writer
         .flush()
         .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    Ok(rows.len())
+    Ok(values.len())
 }
 
 #[allow(
@@ -417,14 +419,14 @@ pub async fn run(
             run_id,
             file_name,
             columns,
-            rows,
+            values,
             row_count,
         } => {
             let tx = action_tx.clone();
             let path = resolve_export_path(&file_name);
 
             tokio::spawn(async move {
-                match write_cached_result_csv(&path, &columns, &rows) {
+                match write_cached_result_csv(&path, &columns, &values) {
                     Ok(_) => {
                         tx.send(Action::CsvExportSucceeded {
                             dsn,

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -90,6 +90,21 @@ fn resolve_export_path(file_name: &str) -> PathBuf {
     dir.join(file_stem)
 }
 
+fn cached_csv_cell(value: &QueryValue) -> String {
+    match value {
+        QueryValue::Null => String::new(),
+        QueryValue::Text(text) | QueryValue::SqlLiteral(text) => text.clone(),
+        QueryValue::Blob(bytes) => {
+            let mut hex = String::with_capacity(bytes.len() * 2);
+            for byte in bytes {
+                use std::fmt::Write as _;
+                let _ = write!(hex, "{byte:02X}");
+            }
+            hex
+        }
+    }
+}
+
 fn write_cached_result_csv(
     path: &Path,
     columns: &[String],
@@ -102,7 +117,7 @@ fn write_cached_result_csv(
         .write_record(columns)
         .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
     for row in values {
-        let record: Vec<String> = row.iter().map(QueryValue::csv_field).collect();
+        let record: Vec<String> = row.iter().map(cached_csv_cell).collect();
         writer
             .write_record(&record)
             .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
@@ -499,6 +514,34 @@ mod tests {
                 Path::new(file_name)
                     .extension()
                     .is_some_and(|ext: &std::ffi::OsStr| ext.eq_ignore_ascii_case("csv"))
+            );
+        }
+    }
+
+    mod cached_csv_cell_tests {
+        use super::super::cached_csv_cell;
+        use crate::domain::QueryValue;
+
+        #[test]
+        fn null_is_empty_field() {
+            assert_eq!(cached_csv_cell(&QueryValue::Null), "");
+        }
+
+        #[test]
+        fn blob_is_uppercase_hex() {
+            assert_eq!(cached_csv_cell(&QueryValue::Blob(vec![0xAB, 0xCD])), "ABCD");
+        }
+
+        #[test]
+        fn text_preserves_embedded_nul_byte() {
+            assert_eq!(cached_csv_cell(&QueryValue::text("a\0bc")), "a\0bc");
+        }
+
+        #[test]
+        fn text_is_not_display_form() {
+            assert_ne!(
+                cached_csv_cell(&QueryValue::Null),
+                QueryValue::Null.display_value()
             );
         }
     }

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -10,7 +10,7 @@ use crate::domain::ConnectionId;
 use crate::domain::QuerySource;
 use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
 use crate::model::app_state::AppState;
-use crate::ports::outbound::{QueryExecutor, QueryHistoryStore};
+use crate::ports::outbound::{DbOperationError, QueryExecutor, QueryHistoryStore};
 use crate::update::action::Action;
 
 fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
@@ -87,6 +87,28 @@ fn resolve_export_path(file_name: &str) -> PathBuf {
         .or_else(dirs::home_dir)
         .unwrap_or_else(|| PathBuf::from("."));
     dir.join(file_stem)
+}
+
+fn write_cached_result_csv(
+    path: &Path,
+    columns: &[String],
+    rows: &[Vec<String>],
+) -> Result<usize, DbOperationError> {
+    let file = std::fs::File::create(path)
+        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    let mut writer = csv::WriterBuilder::new().from_writer(file);
+    writer
+        .write_record(columns)
+        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    for row in rows {
+        writer
+            .write_record(row)
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    }
+    writer
+        .flush()
+        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    Ok(rows.len())
 }
 
 #[allow(
@@ -384,6 +406,39 @@ pub async fn run(
                         })
                         .await
                         .ok();
+                    }
+                }
+            });
+            Ok(())
+        }
+
+        Effect::ExportCsvFromCache {
+            dsn,
+            run_id,
+            file_name,
+            columns,
+            rows,
+            row_count,
+        } => {
+            let tx = action_tx.clone();
+            let path = resolve_export_path(&file_name);
+
+            tokio::spawn(async move {
+                match write_cached_result_csv(&path, &columns, &rows) {
+                    Ok(_) => {
+                        tx.send(Action::CsvExportSucceeded {
+                            dsn,
+                            run_id,
+                            path: path.display().to_string(),
+                            row_count,
+                        })
+                        .await
+                        .ok();
+                    }
+                    Err(error) => {
+                        tx.send(Action::CsvExportFailed { dsn, run_id, error })
+                            .await
+                            .ok();
                     }
                 }
             });

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -441,7 +441,15 @@ pub async fn run(
             let path = resolve_export_path(&file_name);
 
             tokio::spawn(async move {
-                match write_cached_result_csv(&path, &columns, &values) {
+                let export_path = path.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    write_cached_result_csv(&export_path, &columns, &values)
+                })
+                .await
+                .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
+                .and_then(|inner| inner);
+
+                match result {
                     Ok(_) => {
                         tx.send(Action::CsvExportSucceeded {
                             dsn,
@@ -543,6 +551,129 @@ mod tests {
                 cached_csv_cell(&QueryValue::Null),
                 QueryValue::Null.display_value()
             );
+        }
+    }
+
+    mod cached_csv_export_effect {
+        use std::cell::RefCell;
+        use std::sync::Arc;
+
+        use tokio::sync::mpsc;
+
+        use crate::cmd::cache::TtlCache;
+        use crate::cmd::completion_engine::CompletionEngine;
+        use crate::cmd::effect::Effect;
+        use crate::cmd::test_support::*;
+        use crate::domain::QueryValue;
+        use crate::model::app_state::AppState;
+        use crate::ports::outbound::connection_store::MockConnectionStore;
+        use crate::ports::outbound::metadata::MockMetadataProvider;
+        use crate::ports::outbound::query_executor::MockQueryExecutor;
+        use crate::ports::outbound::{RenderOutput, RenderResult, Renderer};
+        use crate::services::AppServices;
+        use crate::update::action::Action;
+
+        struct NoopRenderer;
+        impl Renderer for NoopRenderer {
+            fn draw(
+                &mut self,
+                _state: &AppState,
+                _services: &AppServices,
+                _now: std::time::Instant,
+            ) -> RenderResult<RenderOutput> {
+                Ok(RenderOutput::default())
+            }
+        }
+
+        fn test_file_name(label: &str) -> String {
+            format!("cached_{label}_{}", std::process::id())
+        }
+
+        #[tokio::test]
+        async fn writes_file_and_dispatches_success() {
+            let cache = TtlCache::new(300);
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = make_runner(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                cache,
+                tx,
+            );
+            let mut state = AppState::new("test".to_string());
+            let ce = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .run(
+                    vec![Effect::ExportCsvFromCache {
+                        dsn: "sqlite:///tmp/test.db".to_string(),
+                        run_id: 7,
+                        file_name: test_file_name("success"),
+                        columns: vec!["id".to_string(), "payload".to_string()],
+                        values: vec![vec![
+                            QueryValue::SqlLiteral("1".to_string()),
+                            QueryValue::Blob(vec![0xAB, 0xCD]),
+                        ]],
+                        row_count: Some(1),
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &ce,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            let action = rx.recv().await.unwrap();
+            let Action::CsvExportSucceeded {
+                path, row_count, ..
+            } = action
+            else {
+                panic!("expected CSV export success action");
+            };
+            let csv = std::fs::read_to_string(&path).unwrap();
+            let _ = std::fs::remove_file(&path);
+
+            assert_eq!(row_count, Some(1));
+            assert_eq!(csv, "id,payload\n1,ABCD\n");
+        }
+
+        #[tokio::test]
+        async fn dispatches_failure_when_file_cannot_be_created() {
+            let cache = TtlCache::new(300);
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = make_runner(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                cache,
+                tx,
+            );
+            let mut state = AppState::new("test".to_string());
+            let ce = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .run(
+                    vec![Effect::ExportCsvFromCache {
+                        dsn: "sqlite:///tmp/test.db".to_string(),
+                        run_id: 8,
+                        file_name: format!("{}/child", test_file_name("missing_parent")),
+                        columns: vec!["id".to_string()],
+                        values: vec![vec![QueryValue::SqlLiteral("1".to_string())]],
+                        row_count: Some(1),
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &ce,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            let action = rx.recv().await.unwrap();
+            assert!(matches!(action, Action::CsvExportFailed { run_id: 8, .. }));
         }
     }
 

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -557,6 +557,7 @@ mod tests {
     mod cached_csv_export_effect {
         use std::cell::RefCell;
         use std::sync::Arc;
+        use std::time::Duration;
 
         use tokio::sync::mpsc;
 
@@ -625,7 +626,10 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = rx.recv().await.unwrap();
+            let action = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+                .await
+                .expect("action timeout")
+                .expect("channel closed");
             let Action::CsvExportSucceeded {
                 path, row_count, ..
             } = action
@@ -672,7 +676,10 @@ mod tests {
                 .await
                 .unwrap();
 
-            let action = rx.recv().await.unwrap();
+            let action = tokio::time::timeout(Duration::from_millis(500), rx.recv())
+                .await
+                .expect("action timeout")
+                .expect("channel closed");
             assert!(matches!(action, Action::CsvExportFailed { run_id: 8, .. }));
         }
     }

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -97,6 +97,14 @@ pub enum Effect {
         row_count: Option<usize>,
         read_only: bool,
     },
+    ExportCsvFromCache {
+        dsn: String,
+        run_id: u64,
+        file_name: String,
+        columns: Vec<String>,
+        rows: Vec<Vec<String>>,
+        row_count: Option<usize>,
+    },
 
     CacheTableInCompletionEngine {
         qualified_name: String,

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -1,5 +1,5 @@
-use crate::domain::Table;
 use crate::domain::connection::{ConnectionConfig, ConnectionId};
+use crate::domain::{QueryValue, Table};
 use crate::ports::outbound::AppSettings;
 use crate::update::action::Action;
 
@@ -102,7 +102,7 @@ pub enum Effect {
         run_id: u64,
         file_name: String,
         columns: Vec<String>,
-        rows: Vec<Vec<String>>,
+        values: Vec<Vec<QueryValue>>,
         row_count: Option<usize>,
     },
 

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -202,7 +202,8 @@ impl EffectRunner {
             | Effect::ExecuteExplain { .. }
             | Effect::ExecuteWrite { .. }
             | Effect::CountRowsForExport { .. }
-            | Effect::ExportCsv { .. }) => {
+            | Effect::ExportCsv { .. }
+            | Effect::ExportCsvFromCache { .. }) => {
                 cmd_browse::query::run(
                     e,
                     &self.action_tx,

--- a/src/app/model/shared/confirm_dialog.rs
+++ b/src/app/model/shared/confirm_dialog.rs
@@ -1,4 +1,10 @@
-use crate::domain::ConnectionId;
+use crate::domain::{ConnectionId, QueryValue};
+
+#[derive(Debug, Clone)]
+pub struct CsvExportCacheSnapshot {
+    pub columns: Vec<String>,
+    pub values: Vec<Vec<QueryValue>>,
+}
 
 #[derive(Debug, Clone)]
 pub enum ConfirmIntent {
@@ -14,7 +20,7 @@ pub enum ConfirmIntent {
         export_query: String,
         file_name: String,
         row_count: Option<usize>,
-        use_cached_result: bool,
+        cached_export: Option<CsvExportCacheSnapshot>,
     },
     DisableReadOnly,
 }

--- a/src/app/model/shared/confirm_dialog.rs
+++ b/src/app/model/shared/confirm_dialog.rs
@@ -14,6 +14,7 @@ pub enum ConfirmIntent {
         export_query: String,
         file_name: String,
         row_count: Option<usize>,
+        use_cached_result: bool,
     },
     DisableReadOnly,
 }

--- a/src/app/model/shared/confirm_dialog.rs
+++ b/src/app/model/shared/confirm_dialog.rs
@@ -14,13 +14,19 @@ pub enum ConfirmIntent {
         sql: String,
         blocked: bool,
     },
-    CsvExport {
+    CsvExportRerunnable {
         dsn: String,
         run_id: u64,
         export_query: String,
         file_name: String,
         row_count: Option<usize>,
-        cached_export: Option<CsvExportCacheSnapshot>,
+    },
+    CsvExportCached {
+        dsn: String,
+        run_id: u64,
+        file_name: String,
+        row_count: Option<usize>,
+        snapshot: CsvExportCacheSnapshot,
     },
     DisableReadOnly,
 }

--- a/src/app/policy/sql/mod.rs
+++ b/src/app/policy/sql/mod.rs
@@ -1,2 +1,3 @@
 pub mod lexer;
+pub mod sqlite_export;
 pub mod statement_classifier;

--- a/src/app/policy/sql/sqlite_export.rs
+++ b/src/app/policy/sql/sqlite_export.rs
@@ -133,6 +133,7 @@ fn next_keyword_from(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     mod rerunnable {
         use super::*;
@@ -191,6 +192,14 @@ mod tests {
             assert!(!is_sqlite_rerunnable_export_query(
                 "PRAGMA foreign_keys = OFF"
             ));
+        }
+
+        #[rstest]
+        #[case::no_space_assignment("PRAGMA foreign_keys=OFF")]
+        #[case::journal_mode("PRAGMA journal_mode=WAL")]
+        #[case::parenthesized_checkpoint("PRAGMA wal_checkpoint(TRUNCATE)")]
+        fn dangerous_pragma_variants_are_not_rerunnable(#[case] sql: &str) {
+            assert!(!is_sqlite_rerunnable_export_query(sql));
         }
     }
 

--- a/src/app/policy/sql/sqlite_export.rs
+++ b/src/app/policy/sql/sqlite_export.rs
@@ -1,0 +1,227 @@
+use crate::domain::DatabaseType;
+use crate::policy::sql::statement_classifier::{classify, first_keyword};
+use crate::policy::write::sql_risk::{
+    evaluate_multi_statement_for_database, evaluate_sql_risk_for_database,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SqliteExportPlan {
+    RerunnableQuery { query: String },
+    CachedResult { row_count: usize },
+    NotExportable { reason: String },
+}
+
+pub fn sqlite_export_plan(query: &str, columns: &[String], row_count: usize) -> SqliteExportPlan {
+    if is_sqlite_rerunnable_export_query(query) {
+        return SqliteExportPlan::RerunnableQuery {
+            query: query.to_string(),
+        };
+    }
+    if columns.is_empty() {
+        return SqliteExportPlan::NotExportable {
+            reason: "Cannot export: query contains write or DDL statements and produced no tabular result".to_string(),
+        };
+    }
+    SqliteExportPlan::CachedResult { row_count }
+}
+
+pub fn is_sqlite_rerunnable_export_query(query: &str) -> bool {
+    match evaluate_multi_statement_for_database(DatabaseType::SQLite, query) {
+        crate::policy::write::sql_risk::MultiStatementDecision::Block { .. } => false,
+        crate::policy::write::sql_risk::MultiStatementDecision::Allow { statements, .. } => {
+            statements
+                .iter()
+                .all(|statement| is_sqlite_rerunnable_export_statement(statement))
+        }
+    }
+}
+
+fn is_sqlite_rerunnable_export_statement(statement: &str) -> bool {
+    if is_write_statement(statement)
+        || is_dml_statement(statement)
+        || is_transaction_control(statement)
+    {
+        return false;
+    }
+    let kind = classify(statement);
+    evaluate_sql_risk_for_database(DatabaseType::SQLite, &kind, statement).read_only_allowed
+}
+
+fn is_write_statement(statement: &str) -> bool {
+    matches!(
+        first_keyword(statement).as_deref(),
+        Some("INSERT" | "REPLACE" | "UPDATE" | "DELETE" | "CREATE" | "ALTER" | "DROP" | "TRUNCATE")
+    )
+}
+
+fn is_transaction_control(statement: &str) -> bool {
+    matches!(
+        first_keyword(statement).as_deref(),
+        Some("BEGIN" | "COMMIT" | "END" | "ROLLBACK" | "SAVEPOINT" | "RELEASE")
+    )
+}
+
+fn is_dml_statement(statement: &str) -> bool {
+    dml_keyword(statement).is_some()
+}
+
+fn dml_keyword(statement: &str) -> Option<&'static str> {
+    let keyword = first_keyword(statement)?;
+    if keyword.eq_ignore_ascii_case("INSERT") {
+        return Some("INSERT");
+    }
+    if keyword.eq_ignore_ascii_case("REPLACE") {
+        return Some("INSERT");
+    }
+    if keyword.eq_ignore_ascii_case("UPDATE") {
+        return Some("UPDATE");
+    }
+    if keyword.eq_ignore_ascii_case("DELETE") {
+        return Some("DELETE");
+    }
+    if !keyword.eq_ignore_ascii_case("WITH") {
+        return None;
+    }
+
+    let lower = statement.to_lowercase();
+    let chars: Vec<(usize, char)> = lower.char_indices().collect();
+    let mut offset = 0usize;
+    while let Some((next_keyword, end)) = next_keyword_from(&lower, &chars, offset) {
+        if next_keyword.eq_ignore_ascii_case("INSERT") {
+            return Some("INSERT");
+        }
+        if next_keyword.eq_ignore_ascii_case("REPLACE") {
+            return Some("INSERT");
+        }
+        if next_keyword.eq_ignore_ascii_case("UPDATE") {
+            return Some("UPDATE");
+        }
+        if next_keyword.eq_ignore_ascii_case("DELETE") {
+            return Some("DELETE");
+        }
+        offset = end;
+    }
+    None
+}
+
+fn next_keyword_from(
+    lower: &str,
+    chars: &[(usize, char)],
+    start: usize,
+) -> Option<(String, usize)> {
+    let mut i = 0usize;
+    while i < chars.len() {
+        if chars[i].0 < start {
+            i += 1;
+            continue;
+        }
+        if chars[i].1.is_ascii_alphabetic() {
+            let keyword_start = chars[i].0;
+            let mut j = i + 1;
+            while j < chars.len() && (chars[j].1.is_ascii_alphanumeric() || chars[j].1 == '_') {
+                j += 1;
+            }
+            let keyword = lower[keyword_start..chars[j - 1].0 + chars[j - 1].1.len_utf8()]
+                .to_ascii_uppercase();
+            return Some((keyword, chars[j - 1].0 + chars[j - 1].1.len_utf8()));
+        }
+        i += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod rerunnable {
+        use super::*;
+
+        #[test]
+        fn plain_select_is_rerunnable() {
+            assert!(is_sqlite_rerunnable_export_query("SELECT id FROM users"));
+        }
+
+        #[test]
+        fn multi_select_is_rerunnable() {
+            assert!(is_sqlite_rerunnable_export_query("SELECT 1; SELECT 2"));
+        }
+
+        #[test]
+        fn read_only_pragma_is_rerunnable() {
+            assert!(is_sqlite_rerunnable_export_query(
+                "PRAGMA table_info(users)"
+            ));
+        }
+    }
+
+    mod not_rerunnable {
+        use super::*;
+
+        #[test]
+        fn insert_is_not_rerunnable() {
+            assert!(!is_sqlite_rerunnable_export_query(
+                "INSERT INTO users(id) VALUES (1)"
+            ));
+        }
+
+        #[test]
+        fn mixed_write_and_select_is_not_rerunnable() {
+            assert!(!is_sqlite_rerunnable_export_query(
+                "INSERT INTO users(id) VALUES (1); SELECT * FROM users"
+            ));
+        }
+
+        #[test]
+        fn with_dml_is_not_rerunnable() {
+            assert!(!is_sqlite_rerunnable_export_query(
+                "WITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload"
+            ));
+        }
+
+        #[test]
+        fn ddl_is_not_rerunnable() {
+            assert!(!is_sqlite_rerunnable_export_query(
+                "CREATE TABLE backup AS SELECT * FROM users"
+            ));
+        }
+
+        #[test]
+        fn write_pragma_is_not_rerunnable() {
+            assert!(!is_sqlite_rerunnable_export_query(
+                "PRAGMA foreign_keys = OFF"
+            ));
+        }
+    }
+
+    mod export_plan {
+        use super::*;
+
+        #[test]
+        fn write_only_without_rows_is_not_exportable() {
+            let plan = sqlite_export_plan("INSERT INTO users(id) VALUES (1)", &[], 0);
+            assert_eq!(
+                plan,
+                SqliteExportPlan::NotExportable {
+                    reason: "Cannot export: query contains write or DDL statements and produced no tabular result".to_string(),
+                }
+            );
+        }
+
+        #[test]
+        fn mixed_query_with_rows_uses_cached_result() {
+            let plan = sqlite_export_plan(
+                "INSERT INTO users(id) VALUES (1); SELECT id FROM users",
+                &["id".to_string()],
+                1,
+            );
+            assert_eq!(plan, SqliteExportPlan::CachedResult { row_count: 1 });
+        }
+
+        #[test]
+        fn select_uses_rerunnable_query() {
+            let plan = sqlite_export_plan("SELECT id FROM users", &["id".to_string()], 1);
+            assert!(matches!(plan, SqliteExportPlan::RerunnableQuery { .. }));
+        }
+    }
+}

--- a/src/app/policy/sql/sqlite_export.rs
+++ b/src/app/policy/sql/sqlite_export.rs
@@ -29,9 +29,10 @@ pub fn is_sqlite_rerunnable_export_query(query: &str) -> bool {
     match evaluate_multi_statement_for_database(DatabaseType::SQLite, query) {
         crate::policy::write::sql_risk::MultiStatementDecision::Block { .. } => false,
         crate::policy::write::sql_risk::MultiStatementDecision::Allow { statements, .. } => {
-            statements
-                .iter()
-                .all(|statement| is_sqlite_rerunnable_export_statement(statement))
+            statements.len() == 1
+                && statements
+                    .iter()
+                    .all(|statement| is_sqlite_rerunnable_export_statement(statement))
         }
     }
 }
@@ -144,8 +145,8 @@ mod tests {
         }
 
         #[test]
-        fn multi_select_is_rerunnable() {
-            assert!(is_sqlite_rerunnable_export_query("SELECT 1; SELECT 2"));
+        fn multi_select_is_not_rerunnable() {
+            assert!(!is_sqlite_rerunnable_export_query("SELECT 1; SELECT 2"));
         }
 
         #[test]

--- a/src/app/policy/sql/sqlite_export.rs
+++ b/src/app/policy/sql/sqlite_export.rs
@@ -1,7 +1,7 @@
 use crate::domain::DatabaseType;
 use crate::policy::sql::statement_classifier::{classify, first_keyword};
 use crate::policy::write::sql_risk::{
-    evaluate_multi_statement_for_database, evaluate_sql_risk_for_database,
+    MultiStatementDecision, evaluate_multi_statement_for_database, evaluate_sql_risk_for_database,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,8 +27,8 @@ pub fn sqlite_export_plan(query: &str, columns: &[String], row_count: usize) -> 
 
 pub fn is_sqlite_rerunnable_export_query(query: &str) -> bool {
     match evaluate_multi_statement_for_database(DatabaseType::SQLite, query) {
-        crate::policy::write::sql_risk::MultiStatementDecision::Block { .. } => false,
-        crate::policy::write::sql_risk::MultiStatementDecision::Allow { statements, .. } => {
+        MultiStatementDecision::Block { .. } => false,
+        MultiStatementDecision::Allow { statements, .. } => {
             statements.len() == 1
                 && statements
                     .iter()

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::{DatabaseType, QuerySource};
+use crate::domain::{DatabaseType, QuerySource, QueryValue};
 use crate::model::app_state::AppState;
 use crate::model::shared::confirm_dialog::{ConfirmIntent, CsvExportCacheSnapshot};
 use crate::model::shared::input_mode::InputMode;
@@ -39,7 +39,7 @@ fn dispatch_cached_csv_export(
     run_id: u64,
     file_name: String,
     columns: Vec<String>,
-    values: Vec<Vec<crate::domain::QueryValue>>,
+    values: Vec<Vec<QueryValue>>,
     row_count: Option<usize>,
 ) -> DispatchResult {
     let needs_confirm = row_count.is_some_and(|count| count > LARGE_EXPORT_THRESHOLD);

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -2,13 +2,96 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::QuerySource;
+use crate::domain::{DatabaseType, QuerySource};
 use crate::model::app_state::AppState;
+use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::input_mode::InputMode;
+use crate::policy::sql::sqlite_export::{SqliteExportPlan, sqlite_export_plan};
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
+
+const LARGE_EXPORT_THRESHOLD: usize = 100_000;
+
+fn csv_export_file_name(state: &AppState, source: QuerySource) -> String {
+    match source {
+        QuerySource::Preview => {
+            let table = state.query.pagination.table();
+            table
+                .chars()
+                .map(|c| {
+                    if c.is_ascii_alphanumeric() || c == '_' {
+                        c
+                    } else {
+                        '_'
+                    }
+                })
+                .collect()
+        }
+        QuerySource::Adhoc => "adhoc".to_string(),
+    }
+}
+
+fn dispatch_cached_csv_export(
+    state: &mut AppState,
+    dsn: String,
+    run_id: u64,
+    file_name: String,
+    columns: Vec<String>,
+    rows: Vec<Vec<String>>,
+    row_count: Option<usize>,
+) -> DispatchResult {
+    let needs_confirm = row_count.is_some_and(|count| count > LARGE_EXPORT_THRESHOLD);
+    if needs_confirm {
+        let msg = match row_count {
+            Some(n) => format!("Export {n} rows to CSV? This may take a while."),
+            None => "Export to CSV?".to_string(),
+        };
+        state.confirm_dialog.open(
+            "Confirm CSV Export",
+            msg,
+            ConfirmIntent::CsvExport {
+                dsn,
+                run_id,
+                export_query: String::new(),
+                file_name,
+                row_count,
+                use_cached_result: true,
+            },
+        );
+        state.modal.push_mode(InputMode::ConfirmDialog);
+        DispatchResult::handled()
+    } else {
+        DispatchResult::handled_with(vec![Effect::ExportCsvFromCache {
+            dsn,
+            run_id,
+            file_name,
+            columns,
+            rows,
+            row_count,
+        }])
+    }
+}
+
+fn dispatch_rerunnable_csv_export(
+    state: &AppState,
+    dsn: String,
+    run_id: u64,
+    export_query: String,
+    file_name: String,
+) -> DispatchResult {
+    let stripped = export_query.trim_end().trim_end_matches(';').to_string();
+    let count_query = format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count");
+    DispatchResult::handled_with(vec![Effect::CountRowsForExport {
+        dsn,
+        run_id,
+        count_query,
+        export_query,
+        file_name,
+        read_only: state.session.is_read_only(),
+    }])
+}
 
 pub fn reduce_pagination(
     state: &mut AppState,
@@ -29,35 +112,39 @@ pub fn reduce_pagination(
             };
 
             let export_query = result.query.clone();
-            let file_name = match result.source {
-                QuerySource::Preview => {
-                    let table = state.query.pagination.table();
-                    table
-                        .chars()
-                        .map(|c| {
-                            if c.is_ascii_alphanumeric() || c == '_' {
-                                c
-                            } else {
-                                '_'
-                            }
-                        })
-                        .collect()
-                }
-                QuerySource::Adhoc => "adhoc".to_string(),
-            };
-
-            let stripped = export_query.trim_end().trim_end_matches(';').to_string();
-            let count_query = format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count");
+            let file_name = csv_export_file_name(state, result.source);
+            let columns = result.columns.clone();
+            let rows = result.rows().to_vec();
+            let row_count = result.row_count();
             let run_id = state.query.begin_running(now);
 
-            DispatchResult::handled_with(vec![Effect::CountRowsForExport {
-                dsn,
-                run_id,
-                count_query,
-                export_query,
-                file_name,
-                read_only: state.session.is_read_only(),
-            }])
+            if state.session.active_database_type() == Some(DatabaseType::SQLite) {
+                match sqlite_export_plan(&export_query, &columns, row_count) {
+                    SqliteExportPlan::RerunnableQuery { query } => {
+                        return dispatch_rerunnable_csv_export(
+                            state, dsn, run_id, query, file_name,
+                        );
+                    }
+                    SqliteExportPlan::CachedResult { row_count } => {
+                        return dispatch_cached_csv_export(
+                            state,
+                            dsn,
+                            run_id,
+                            file_name,
+                            columns,
+                            rows,
+                            Some(row_count),
+                        );
+                    }
+                    SqliteExportPlan::NotExportable { reason } => {
+                        state.query.mark_idle();
+                        state.messages.set_error_at(reason, now);
+                        return DispatchResult::handled();
+                    }
+                }
+            }
+
+            dispatch_rerunnable_csv_export(state, dsn, run_id, export_query, file_name)
         }
 
         Action::CsvExportRowsCounted {
@@ -70,8 +157,6 @@ pub fn reduce_pagination(
             if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }
-
-            const LARGE_EXPORT_THRESHOLD: usize = 100_000;
 
             let needs_confirm = match row_count {
                 Some(n) => *n > LARGE_EXPORT_THRESHOLD,
@@ -86,12 +171,13 @@ pub fn reduce_pagination(
                 state.confirm_dialog.open(
                     "Confirm CSV Export",
                     msg,
-                    crate::model::shared::confirm_dialog::ConfirmIntent::CsvExport {
+                    ConfirmIntent::CsvExport {
                         dsn: dsn.clone(),
                         run_id: *run_id,
                         export_query: export_query.clone(),
                         file_name: file_name.clone(),
                         row_count: *row_count,
+                        use_cached_result: false,
                     },
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
@@ -702,6 +788,99 @@ mod tests {
             .unwrap();
 
             assert!(effects.is_empty());
+        }
+
+        mod sqlite {
+            use super::*;
+            use crate::update::test_support::activate_sqlite_connection;
+
+            fn sqlite_state() -> AppState {
+                let mut state = AppState::new("test_project".to_string());
+                activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
+                state
+            }
+
+            #[test]
+            fn write_only_query_shows_not_exportable_error() {
+                let mut state = sqlite_state();
+                state
+                    .query
+                    .set_current_result(Arc::new(QueryResult::success(
+                        "INSERT INTO users(id) VALUES (1)".to_string(),
+                        vec![],
+                        vec![],
+                        1,
+                        QuerySource::Adhoc,
+                    )));
+
+                let effects = dispatch_query(
+                    &mut state,
+                    &Action::RequestCsvExport,
+                    Instant::now(),
+                    &AppServices::stub(),
+                )
+                .unwrap();
+
+                assert!(effects.is_empty());
+                assert!(
+                    state
+                        .messages
+                        .last_error
+                        .as_deref()
+                        .unwrap()
+                        .contains("Cannot export")
+                );
+            }
+
+            #[test]
+            fn mixed_query_exports_cached_rows_without_count_effect() {
+                let mut state = sqlite_state();
+                state
+                    .query
+                    .set_current_result(Arc::new(QueryResult::success(
+                        "INSERT INTO users(id) VALUES (1); SELECT id FROM users".to_string(),
+                        vec!["id".to_string()],
+                        vec![vec!["1".to_string()]],
+                        1,
+                        QuerySource::Adhoc,
+                    )));
+
+                let effects = dispatch_query(
+                    &mut state,
+                    &Action::RequestCsvExport,
+                    Instant::now(),
+                    &AppServices::stub(),
+                )
+                .unwrap();
+
+                assert_eq!(effects.len(), 1);
+                assert!(matches!(&effects[0], Effect::ExportCsvFromCache { .. }));
+            }
+
+            #[test]
+            fn select_still_uses_count_effect() {
+                let mut state = sqlite_state();
+                state
+                    .query
+                    .set_current_result(Arc::new(QueryResult::success(
+                        "SELECT id FROM users".to_string(),
+                        vec!["id".to_string()],
+                        vec![vec!["1".to_string()]],
+                        1,
+                        QuerySource::Adhoc,
+                    )));
+
+                let effects = dispatch_query(
+                    &mut state,
+                    &Action::RequestCsvExport,
+                    Instant::now(),
+                    &AppServices::stub(),
+                )
+                .unwrap();
+
+                assert_eq!(effects.len(), 1);
+                assert!(matches!(&effects[0], Effect::CountRowsForExport { .. }));
+            }
         }
     }
 }

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::domain::{DatabaseType, QuerySource};
 use crate::model::app_state::AppState;
-use crate::model::shared::confirm_dialog::ConfirmIntent;
+use crate::model::shared::confirm_dialog::{ConfirmIntent, CsvExportCacheSnapshot};
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::sql::sqlite_export::{SqliteExportPlan, sqlite_export_plan};
 use crate::services::AppServices;
@@ -39,7 +39,7 @@ fn dispatch_cached_csv_export(
     run_id: u64,
     file_name: String,
     columns: Vec<String>,
-    rows: Vec<Vec<String>>,
+    values: Vec<Vec<crate::domain::QueryValue>>,
     row_count: Option<usize>,
 ) -> DispatchResult {
     let needs_confirm = row_count.is_some_and(|count| count > LARGE_EXPORT_THRESHOLD);
@@ -57,7 +57,7 @@ fn dispatch_cached_csv_export(
                 export_query: String::new(),
                 file_name,
                 row_count,
-                use_cached_result: true,
+                cached_export: Some(CsvExportCacheSnapshot { columns, values }),
             },
         );
         state.modal.push_mode(InputMode::ConfirmDialog);
@@ -68,7 +68,7 @@ fn dispatch_cached_csv_export(
             run_id,
             file_name,
             columns,
-            rows,
+            values,
             row_count,
         }])
     }
@@ -113,37 +113,38 @@ pub fn reduce_pagination(
 
             let export_query = result.query.clone();
             let file_name = csv_export_file_name(state, result.source);
-            let columns = result.columns.clone();
-            let rows = result.rows().to_vec();
             let row_count = result.row_count();
-            let run_id = state.query.begin_running(now);
 
             if state.session.active_database_type() == Some(DatabaseType::SQLite) {
-                match sqlite_export_plan(&export_query, &columns, row_count) {
+                match sqlite_export_plan(&export_query, &result.columns, row_count) {
+                    SqliteExportPlan::NotExportable { reason } => {
+                        state.messages.set_error_at(reason, now);
+                        return DispatchResult::handled();
+                    }
                     SqliteExportPlan::RerunnableQuery { query } => {
+                        let run_id = state.query.begin_running(now);
                         return dispatch_rerunnable_csv_export(
                             state, dsn, run_id, query, file_name,
                         );
                     }
                     SqliteExportPlan::CachedResult { row_count } => {
+                        let columns = result.columns.clone();
+                        let values = result.values().to_vec();
+                        let run_id = state.query.begin_running(now);
                         return dispatch_cached_csv_export(
                             state,
                             dsn,
                             run_id,
                             file_name,
                             columns,
-                            rows,
+                            values,
                             Some(row_count),
                         );
-                    }
-                    SqliteExportPlan::NotExportable { reason } => {
-                        state.query.mark_idle();
-                        state.messages.set_error_at(reason, now);
-                        return DispatchResult::handled();
                     }
                 }
             }
 
+            let run_id = state.query.begin_running(now);
             dispatch_rerunnable_csv_export(state, dsn, run_id, export_query, file_name)
         }
 
@@ -177,7 +178,7 @@ pub fn reduce_pagination(
                         export_query: export_query.clone(),
                         file_name: file_name.clone(),
                         row_count: *row_count,
-                        use_cached_result: false,
+                        cached_export: None,
                     },
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -51,13 +51,12 @@ fn dispatch_cached_csv_export(
         state.confirm_dialog.open(
             "Confirm CSV Export",
             msg,
-            ConfirmIntent::CsvExport {
+            ConfirmIntent::CsvExportCached {
                 dsn,
                 run_id,
-                export_query: String::new(),
                 file_name,
                 row_count,
-                cached_export: Some(CsvExportCacheSnapshot { columns, values }),
+                snapshot: CsvExportCacheSnapshot { columns, values },
             },
         );
         state.modal.push_mode(InputMode::ConfirmDialog);
@@ -172,13 +171,12 @@ pub fn reduce_pagination(
                 state.confirm_dialog.open(
                     "Confirm CSV Export",
                     msg,
-                    ConfirmIntent::CsvExport {
+                    ConfirmIntent::CsvExportRerunnable {
                         dsn: dsn.clone(),
                         run_id: *run_id,
                         export_query: export_query.clone(),
                         file_name: file_name.clone(),
                         row_count: *row_count,
-                        cached_export: None,
                     },
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -68,36 +68,46 @@ pub(super) fn reduce_confirm_dialog(
                     state.session.disable_read_only();
                     DispatchResult::handled()
                 }
-                Some(ConfirmIntent::CsvExport {
+                Some(ConfirmIntent::CsvExportRerunnable {
                     dsn,
                     run_id,
                     export_query,
                     file_name,
                     row_count,
-                    cached_export,
                 }) => {
                     if state.session.dsn() == Some(dsn.as_str())
                         && state.query.is_current_run(run_id)
                     {
-                        if let Some(snapshot) = cached_export {
-                            DispatchResult::handled_with(vec![Effect::ExportCsvFromCache {
-                                dsn,
-                                run_id,
-                                file_name,
-                                columns: snapshot.columns,
-                                values: snapshot.values,
-                                row_count,
-                            }])
-                        } else {
-                            DispatchResult::handled_with(vec![Effect::ExportCsv {
-                                dsn,
-                                run_id,
-                                query: export_query,
-                                file_name,
-                                row_count,
-                                read_only: state.session.is_read_only(),
-                            }])
-                        }
+                        DispatchResult::handled_with(vec![Effect::ExportCsv {
+                            dsn,
+                            run_id,
+                            query: export_query,
+                            file_name,
+                            row_count,
+                            read_only: state.session.is_read_only(),
+                        }])
+                    } else {
+                        DispatchResult::handled()
+                    }
+                }
+                Some(ConfirmIntent::CsvExportCached {
+                    dsn,
+                    run_id,
+                    file_name,
+                    row_count,
+                    snapshot,
+                }) => {
+                    if state.session.dsn() == Some(dsn.as_str())
+                        && state.query.is_current_run(run_id)
+                    {
+                        DispatchResult::handled_with(vec![Effect::ExportCsvFromCache {
+                            dsn,
+                            run_id,
+                            file_name,
+                            columns: snapshot.columns,
+                            values: snapshot.values,
+                            row_count,
+                        }])
                     } else {
                         DispatchResult::handled()
                     }

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -74,21 +74,18 @@ pub(super) fn reduce_confirm_dialog(
                     export_query,
                     file_name,
                     row_count,
-                    use_cached_result,
+                    cached_export,
                 }) => {
                     if state.session.dsn() == Some(dsn.as_str())
                         && state.query.is_current_run(run_id)
                     {
-                        if use_cached_result {
-                            let Some(result) = state.query.visible_result() else {
-                                return DispatchResult::handled();
-                            };
+                        if let Some(snapshot) = cached_export {
                             DispatchResult::handled_with(vec![Effect::ExportCsvFromCache {
                                 dsn,
                                 run_id,
                                 file_name,
-                                columns: result.columns.clone(),
-                                rows: result.rows().to_vec(),
+                                columns: snapshot.columns,
+                                values: snapshot.values,
                                 row_count,
                             }])
                         } else {

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -74,18 +74,33 @@ pub(super) fn reduce_confirm_dialog(
                     export_query,
                     file_name,
                     row_count,
+                    use_cached_result,
                 }) => {
                     if state.session.dsn() == Some(dsn.as_str())
                         && state.query.is_current_run(run_id)
                     {
-                        DispatchResult::handled_with(vec![Effect::ExportCsv {
-                            dsn,
-                            run_id,
-                            query: export_query,
-                            file_name,
-                            row_count,
-                            read_only: state.session.is_read_only(),
-                        }])
+                        if use_cached_result {
+                            let Some(result) = state.query.visible_result() else {
+                                return DispatchResult::handled();
+                            };
+                            DispatchResult::handled_with(vec![Effect::ExportCsvFromCache {
+                                dsn,
+                                run_id,
+                                file_name,
+                                columns: result.columns.clone(),
+                                rows: result.rows().to_vec(),
+                                row_count,
+                            }])
+                        } else {
+                            DispatchResult::handled_with(vec![Effect::ExportCsv {
+                                dsn,
+                                run_id,
+                                query: export_query,
+                                file_name,
+                                row_count,
+                                read_only: state.session.is_read_only(),
+                            }])
+                        }
                     } else {
                         DispatchResult::handled()
                     }

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -118,8 +118,10 @@ pub(super) fn reduce_confirm_dialog(
         Action::ConfirmDialogCancel => {
             let intent = state.confirm_dialog.take_intent();
             let canceling_current_csv_export = match &intent {
-                Some(ConfirmIntent::CsvExportRerunnable { dsn, run_id, .. })
-                | Some(ConfirmIntent::CsvExportCached { dsn, run_id, .. }) => {
+                Some(
+                    ConfirmIntent::CsvExportRerunnable { dsn, run_id, .. }
+                    | ConfirmIntent::CsvExportCached { dsn, run_id, .. },
+                ) => {
                     state.session.dsn() == Some(dsn.as_str()) && state.query.is_current_run(*run_id)
                 }
                 _ => false,

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -117,8 +117,18 @@ pub(super) fn reduce_confirm_dialog(
         }
         Action::ConfirmDialogCancel => {
             let intent = state.confirm_dialog.take_intent();
+            let canceling_current_csv_export = match &intent {
+                Some(ConfirmIntent::CsvExportRerunnable { dsn, run_id, .. })
+                | Some(ConfirmIntent::CsvExportCached { dsn, run_id, .. }) => {
+                    state.session.dsn() == Some(dsn.as_str()) && state.query.is_current_run(*run_id)
+                }
+                _ => false,
+            };
             state.result_interaction.clear_write_preview();
             state.query.clear_delete_refresh_target();
+            if canceling_current_csv_export {
+                state.query.mark_idle();
+            }
 
             if matches!(intent, Some(ConfirmIntent::QuitNoConnection)) {
                 state.connection_setup.reset();

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -538,7 +538,7 @@ mod tests {
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
-                        use_cached_result: false,
+                        cached_export: None,
                     },
                 );
 
@@ -570,7 +570,7 @@ mod tests {
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
-                        use_cached_result: false,
+                        cached_export: None,
                     },
                 );
 
@@ -599,7 +599,7 @@ mod tests {
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
-                        use_cached_result: false,
+                        cached_export: None,
                     },
                 );
 

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -538,6 +538,7 @@ mod tests {
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
+                        use_cached_result: false,
                     },
                 );
 
@@ -569,6 +570,7 @@ mod tests {
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
+                        use_cached_result: false,
                     },
                 );
 
@@ -597,6 +599,7 @@ mod tests {
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
+                        use_cached_result: false,
                     },
                 );
 

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -361,6 +361,83 @@ mod tests {
             state.modal.push_mode(InputMode::ConfirmDialog);
         }
 
+        const CSV_TEST_DSN: &str = "postgres://localhost/test";
+        const CSV_TEST_FILE: &str = "test.csv";
+
+        fn csv_state_with_current_run() -> (AppState, u64) {
+            let mut state = create_test_state();
+            enter_confirm_dialog(&mut state, InputMode::Normal);
+            activate_postgres_connection(&mut state, CSV_TEST_DSN);
+            let run_id = state.query.begin_running(Instant::now());
+            (state, run_id)
+        }
+
+        fn csv_state_with_stale_run() -> (AppState, u64, u64) {
+            let (mut state, stale_run_id) = csv_state_with_current_run();
+            let current_run_id = state.query.begin_running(Instant::now());
+            (state, stale_run_id, current_run_id)
+        }
+
+        fn rerunnable_csv_intent(run_id: u64) -> ConfirmIntent {
+            ConfirmIntent::CsvExportRerunnable {
+                dsn: CSV_TEST_DSN.to_string(),
+                run_id,
+                export_query: "SELECT 1".to_string(),
+                file_name: CSV_TEST_FILE.to_string(),
+                row_count: Some(200_000),
+            }
+        }
+
+        fn cached_csv_intent(run_id: u64) -> ConfirmIntent {
+            ConfirmIntent::CsvExportCached {
+                dsn: CSV_TEST_DSN.to_string(),
+                run_id,
+                file_name: CSV_TEST_FILE.to_string(),
+                row_count: Some(2),
+                snapshot: CsvExportCacheSnapshot {
+                    columns: vec!["id".to_string()],
+                    values: vec![vec![QueryValue::text("1")]],
+                },
+            }
+        }
+
+        fn open_confirm_intent(state: &mut AppState, intent: ConfirmIntent) {
+            state.confirm_dialog.open("", "", intent);
+        }
+
+        fn confirm_effects(state: &mut AppState) -> Vec<Effect> {
+            dispatch_modal(state, &Action::ConfirmDialogConfirm, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action")
+        }
+
+        fn cancel_effects(state: &mut AppState) -> Vec<Effect> {
+            dispatch_modal(state, &Action::ConfirmDialogCancel, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action")
+        }
+
+        fn assert_cached_export_effect(effect: &Effect, run_id: u64) {
+            let Effect::ExportCsvFromCache {
+                dsn,
+                run_id: effect_run_id,
+                file_name,
+                columns,
+                values,
+                row_count,
+            } = effect
+            else {
+                panic!("expected cached CSV export effect");
+            };
+
+            assert_eq!(dsn, CSV_TEST_DSN);
+            assert_eq!(*effect_run_id, run_id);
+            assert_eq!(file_name, CSV_TEST_FILE);
+            assert_eq!(columns, &vec!["id".to_string()]);
+            assert_eq!(values, &vec![vec![QueryValue::text("1")]]);
+            assert_eq!(*row_count, Some(2));
+        }
+
         mod confirm {
             use super::*;
 
@@ -525,78 +602,22 @@ mod tests {
 
             #[test]
             fn csv_export_returns_export_effect() {
-                let mut state = create_test_state();
-                enter_confirm_dialog(&mut state, InputMode::Normal);
-                activate_postgres_connection(&mut state, "postgres://localhost/test");
-                let _ = state.query.begin_running(Instant::now());
-                state.confirm_dialog.open(
-                    "",
-                    "",
-                    ConfirmIntent::CsvExportRerunnable {
-                        dsn: "postgres://localhost/test".to_string(),
-                        run_id: 1,
-                        export_query: "SELECT 1".to_string(),
-                        file_name: "test.csv".to_string(),
-                        row_count: Some(200_000),
-                    },
-                );
+                let (mut state, run_id) = csv_state_with_current_run();
+                open_confirm_intent(&mut state, rerunnable_csv_intent(run_id));
 
-                let effects = super::dispatch_modal(
-                    &mut state,
-                    &Action::ConfirmDialogConfirm,
-                    Instant::now(),
-                )
-                .unwrap();
-
+                let effects = confirm_effects(&mut state);
                 assert_eq!(effects.len(), 1);
                 assert!(matches!(&effects[0], Effect::ExportCsv { .. }));
             }
 
             #[test]
             fn cached_csv_export_returns_export_from_cache_effect() {
-                let mut state = create_test_state();
-                enter_confirm_dialog(&mut state, InputMode::Normal);
-                activate_postgres_connection(&mut state, "postgres://localhost/test");
-                let run_id = state.query.begin_running(Instant::now());
-                state.confirm_dialog.open(
-                    "",
-                    "",
-                    ConfirmIntent::CsvExportCached {
-                        dsn: "postgres://localhost/test".to_string(),
-                        run_id,
-                        file_name: "test.csv".to_string(),
-                        row_count: Some(2),
-                        snapshot: CsvExportCacheSnapshot {
-                            columns: vec!["id".to_string()],
-                            values: vec![vec![QueryValue::text("1")]],
-                        },
-                    },
-                );
+                let (mut state, run_id) = csv_state_with_current_run();
+                open_confirm_intent(&mut state, cached_csv_intent(run_id));
 
-                let effects = super::dispatch_modal(
-                    &mut state,
-                    &Action::ConfirmDialogConfirm,
-                    Instant::now(),
-                )
-                .unwrap();
-
+                let effects = confirm_effects(&mut state);
                 assert_eq!(effects.len(), 1);
-                assert!(matches!(
-                    &effects[0],
-                    Effect::ExportCsvFromCache {
-                        dsn,
-                        run_id: effect_run_id,
-                        file_name,
-                        columns,
-                        values,
-                        row_count,
-                    } if dsn == "postgres://localhost/test"
-                        && *effect_run_id == run_id
-                        && file_name == "test.csv"
-                        && columns == &vec!["id".to_string()]
-                        && values == &vec![vec![QueryValue::text("1")]]
-                        && *row_count == Some(2)
-                ));
+                assert_cached_export_effect(&effects[0], run_id);
             }
 
             #[test]
@@ -631,60 +652,19 @@ mod tests {
 
             #[test]
             fn csv_export_ignores_mismatched_run_id() {
-                let mut state = create_test_state();
-                enter_confirm_dialog(&mut state, InputMode::Normal);
-                activate_postgres_connection(&mut state, "postgres://localhost/test");
-                let _ = state.query.begin_running(Instant::now());
-                state.confirm_dialog.open(
-                    "",
-                    "",
-                    ConfirmIntent::CsvExportRerunnable {
-                        dsn: "postgres://localhost/test".to_string(),
-                        run_id: 2,
-                        export_query: "SELECT 1".to_string(),
-                        file_name: "test.csv".to_string(),
-                        row_count: Some(200_000),
-                    },
-                );
+                let (mut state, _) = csv_state_with_current_run();
+                open_confirm_intent(&mut state, rerunnable_csv_intent(2));
 
-                let effects = super::dispatch_modal(
-                    &mut state,
-                    &Action::ConfirmDialogConfirm,
-                    Instant::now(),
-                )
-                .unwrap();
-
+                let effects = confirm_effects(&mut state);
                 assert!(effects.is_empty());
             }
 
             #[test]
             fn cached_csv_export_ignores_mismatched_run_id() {
-                let mut state = create_test_state();
-                enter_confirm_dialog(&mut state, InputMode::Normal);
-                activate_postgres_connection(&mut state, "postgres://localhost/test");
-                let _ = state.query.begin_running(Instant::now());
-                state.confirm_dialog.open(
-                    "",
-                    "",
-                    ConfirmIntent::CsvExportCached {
-                        dsn: "postgres://localhost/test".to_string(),
-                        run_id: 2,
-                        file_name: "test.csv".to_string(),
-                        row_count: Some(2),
-                        snapshot: CsvExportCacheSnapshot {
-                            columns: vec!["id".to_string()],
-                            values: vec![vec![QueryValue::text("1")]],
-                        },
-                    },
-                );
+                let (mut state, _) = csv_state_with_current_run();
+                open_confirm_intent(&mut state, cached_csv_intent(2));
 
-                let effects = super::dispatch_modal(
-                    &mut state,
-                    &Action::ConfirmDialogConfirm,
-                    Instant::now(),
-                )
-                .unwrap();
-
+                let effects = confirm_effects(&mut state);
                 assert!(effects.is_empty());
             }
 
@@ -880,85 +860,30 @@ mod tests {
 
             #[test]
             fn current_csv_export_cancel_marks_query_idle() {
-                let mut state = create_test_state();
-                enter_confirm_dialog(&mut state, InputMode::Normal);
-                activate_postgres_connection(&mut state, "postgres://localhost/test");
-                let run_id = state.query.begin_running(Instant::now());
-                state.confirm_dialog.open(
-                    "",
-                    "",
-                    ConfirmIntent::CsvExportRerunnable {
-                        dsn: "postgres://localhost/test".to_string(),
-                        run_id,
-                        export_query: "SELECT 1".to_string(),
-                        file_name: "test.csv".to_string(),
-                        row_count: Some(200_000),
-                    },
-                );
+                let (mut state, run_id) = csv_state_with_current_run();
+                open_confirm_intent(&mut state, rerunnable_csv_intent(run_id));
 
-                let effects =
-                    super::dispatch_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now())
-                        .into_effects()
-                        .expect("reducer should handle action");
-
+                let effects = cancel_effects(&mut state);
                 assert!(effects.is_empty());
                 assert!(!state.query.is_running());
             }
 
             #[test]
             fn current_cached_csv_export_cancel_marks_query_idle() {
-                let mut state = create_test_state();
-                enter_confirm_dialog(&mut state, InputMode::Normal);
-                activate_postgres_connection(&mut state, "postgres://localhost/test");
-                let run_id = state.query.begin_running(Instant::now());
-                state.confirm_dialog.open(
-                    "",
-                    "",
-                    ConfirmIntent::CsvExportCached {
-                        dsn: "postgres://localhost/test".to_string(),
-                        run_id,
-                        file_name: "test.csv".to_string(),
-                        row_count: Some(200_000),
-                        snapshot: CsvExportCacheSnapshot {
-                            columns: vec![],
-                            values: vec![],
-                        },
-                    },
-                );
+                let (mut state, run_id) = csv_state_with_current_run();
+                open_confirm_intent(&mut state, cached_csv_intent(run_id));
 
-                let effects =
-                    super::dispatch_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now())
-                        .into_effects()
-                        .expect("reducer should handle action");
-
+                let effects = cancel_effects(&mut state);
                 assert!(effects.is_empty());
                 assert!(!state.query.is_running());
             }
 
             #[test]
             fn stale_csv_export_cancel_keeps_current_run() {
-                let mut state = create_test_state();
-                enter_confirm_dialog(&mut state, InputMode::Normal);
-                activate_postgres_connection(&mut state, "postgres://localhost/test");
-                let stale_run_id = state.query.begin_running(Instant::now());
-                let current_run_id = state.query.begin_running(Instant::now());
-                state.confirm_dialog.open(
-                    "",
-                    "",
-                    ConfirmIntent::CsvExportRerunnable {
-                        dsn: "postgres://localhost/test".to_string(),
-                        run_id: stale_run_id,
-                        export_query: "SELECT 1".to_string(),
-                        file_name: "test.csv".to_string(),
-                        row_count: Some(200_000),
-                    },
-                );
+                let (mut state, stale_run_id, current_run_id) = csv_state_with_stale_run();
+                open_confirm_intent(&mut state, rerunnable_csv_intent(stale_run_id));
 
-                let effects =
-                    super::dispatch_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now())
-                        .into_effects()
-                        .expect("reducer should handle action");
-
+                let effects = cancel_effects(&mut state);
                 assert!(effects.is_empty());
                 assert!(state.query.is_running());
                 assert!(state.query.is_current_run(current_run_id));
@@ -966,31 +891,10 @@ mod tests {
 
             #[test]
             fn stale_cached_csv_export_cancel_keeps_current_run() {
-                let mut state = create_test_state();
-                enter_confirm_dialog(&mut state, InputMode::Normal);
-                activate_postgres_connection(&mut state, "postgres://localhost/test");
-                let stale_run_id = state.query.begin_running(Instant::now());
-                let current_run_id = state.query.begin_running(Instant::now());
-                state.confirm_dialog.open(
-                    "",
-                    "",
-                    ConfirmIntent::CsvExportCached {
-                        dsn: "postgres://localhost/test".to_string(),
-                        run_id: stale_run_id,
-                        file_name: "test.csv".to_string(),
-                        row_count: Some(200_000),
-                        snapshot: CsvExportCacheSnapshot {
-                            columns: vec![],
-                            values: vec![],
-                        },
-                    },
-                );
+                let (mut state, stale_run_id, current_run_id) = csv_state_with_stale_run();
+                open_confirm_intent(&mut state, cached_csv_intent(stale_run_id));
 
-                let effects =
-                    super::dispatch_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now())
-                        .into_effects()
-                        .expect("reducer should handle action");
-
+                let effects = cancel_effects(&mut state);
                 assert!(effects.is_empty());
                 assert!(state.query.is_running());
                 assert!(state.query.is_current_run(current_run_id));

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -27,7 +27,7 @@ mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
     use crate::domain::{ConnectionId, DatabaseType};
-    use crate::model::shared::confirm_dialog::ConfirmIntent;
+    use crate::model::shared::confirm_dialog::{ConfirmIntent, CsvExportCacheSnapshot};
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::settings::KeymapPreset;
     use crate::ports::outbound::AppSettings;
@@ -828,6 +828,36 @@ mod tests {
             }
 
             #[test]
+            fn current_cached_csv_export_cancel_marks_query_idle() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                activate_postgres_connection(&mut state, "postgres://localhost/test");
+                let run_id = state.query.begin_running(Instant::now());
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::CsvExportCached {
+                        dsn: "postgres://localhost/test".to_string(),
+                        run_id,
+                        file_name: "test.csv".to_string(),
+                        row_count: Some(200_000),
+                        snapshot: CsvExportCacheSnapshot {
+                            columns: vec![],
+                            values: vec![],
+                        },
+                    },
+                );
+
+                let effects =
+                    super::dispatch_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now())
+                        .into_effects()
+                        .expect("reducer should handle action");
+
+                assert!(effects.is_empty());
+                assert!(!state.query.is_running());
+            }
+
+            #[test]
             fn stale_csv_export_cancel_keeps_current_run() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
@@ -843,6 +873,38 @@ mod tests {
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
+                    },
+                );
+
+                let effects =
+                    super::dispatch_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now())
+                        .into_effects()
+                        .expect("reducer should handle action");
+
+                assert!(effects.is_empty());
+                assert!(state.query.is_running());
+                assert!(state.query.is_current_run(current_run_id));
+            }
+
+            #[test]
+            fn stale_cached_csv_export_cancel_keeps_current_run() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                activate_postgres_connection(&mut state, "postgres://localhost/test");
+                let stale_run_id = state.query.begin_running(Instant::now());
+                let current_run_id = state.query.begin_running(Instant::now());
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::CsvExportCached {
+                        dsn: "postgres://localhost/test".to_string(),
+                        run_id: stale_run_id,
+                        file_name: "test.csv".to_string(),
+                        row_count: Some(200_000),
+                        snapshot: CsvExportCacheSnapshot {
+                            columns: vec![],
+                            values: vec![],
+                        },
                     },
                 );
 

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -801,6 +801,62 @@ mod tests {
             }
 
             #[test]
+            fn current_csv_export_cancel_marks_query_idle() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                activate_postgres_connection(&mut state, "postgres://localhost/test");
+                let run_id = state.query.begin_running(Instant::now());
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::CsvExportRerunnable {
+                        dsn: "postgres://localhost/test".to_string(),
+                        run_id,
+                        export_query: "SELECT 1".to_string(),
+                        file_name: "test.csv".to_string(),
+                        row_count: Some(200_000),
+                    },
+                );
+
+                let effects =
+                    super::dispatch_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now())
+                        .into_effects()
+                        .expect("reducer should handle action");
+
+                assert!(effects.is_empty());
+                assert!(!state.query.is_running());
+            }
+
+            #[test]
+            fn stale_csv_export_cancel_keeps_current_run() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                activate_postgres_connection(&mut state, "postgres://localhost/test");
+                let stale_run_id = state.query.begin_running(Instant::now());
+                let current_run_id = state.query.begin_running(Instant::now());
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::CsvExportRerunnable {
+                        dsn: "postgres://localhost/test".to_string(),
+                        run_id: stale_run_id,
+                        export_query: "SELECT 1".to_string(),
+                        file_name: "test.csv".to_string(),
+                        row_count: Some(200_000),
+                    },
+                );
+
+                let effects =
+                    super::dispatch_modal(&mut state, &Action::ConfirmDialogCancel, Instant::now())
+                        .into_effects()
+                        .expect("reducer should handle action");
+
+                assert!(effects.is_empty());
+                assert!(state.query.is_running());
+                assert!(state.query.is_current_run(current_run_id));
+            }
+
+            #[test]
             fn none_intent_cancel_does_not_panic() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -532,13 +532,12 @@ mod tests {
                 state.confirm_dialog.open(
                     "",
                     "",
-                    ConfirmIntent::CsvExport {
+                    ConfirmIntent::CsvExportRerunnable {
                         dsn: "postgres://localhost/test".to_string(),
                         run_id: 1,
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
-                        cached_export: None,
                     },
                 );
 
@@ -564,13 +563,12 @@ mod tests {
                 state.confirm_dialog.open(
                     "",
                     "",
-                    ConfirmIntent::CsvExport {
+                    ConfirmIntent::CsvExportRerunnable {
                         dsn: "postgres://localhost/stale".to_string(),
                         run_id: 1,
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
-                        cached_export: None,
                     },
                 );
 
@@ -593,13 +591,12 @@ mod tests {
                 state.confirm_dialog.open(
                     "",
                     "",
-                    ConfirmIntent::CsvExport {
+                    ConfirmIntent::CsvExportRerunnable {
                         dsn: "postgres://localhost/test".to_string(),
                         run_id: 2,
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
-                        cached_export: None,
                     },
                 );
 

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -26,7 +26,7 @@ mod tests {
 
     use super::*;
     use crate::cmd::effect::Effect;
-    use crate::domain::{ConnectionId, DatabaseType};
+    use crate::domain::{ConnectionId, DatabaseType, QueryValue};
     use crate::model::shared::confirm_dialog::{ConfirmIntent, CsvExportCacheSnapshot};
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::settings::KeymapPreset;
@@ -553,6 +553,53 @@ mod tests {
             }
 
             #[test]
+            fn cached_csv_export_returns_export_from_cache_effect() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                activate_postgres_connection(&mut state, "postgres://localhost/test");
+                let run_id = state.query.begin_running(Instant::now());
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::CsvExportCached {
+                        dsn: "postgres://localhost/test".to_string(),
+                        run_id,
+                        file_name: "test.csv".to_string(),
+                        row_count: Some(2),
+                        snapshot: CsvExportCacheSnapshot {
+                            columns: vec!["id".to_string()],
+                            values: vec![vec![QueryValue::text("1")]],
+                        },
+                    },
+                );
+
+                let effects = super::dispatch_modal(
+                    &mut state,
+                    &Action::ConfirmDialogConfirm,
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert_eq!(effects.len(), 1);
+                assert!(matches!(
+                    &effects[0],
+                    Effect::ExportCsvFromCache {
+                        dsn,
+                        run_id: effect_run_id,
+                        file_name,
+                        columns,
+                        values,
+                        row_count,
+                    } if dsn == "postgres://localhost/test"
+                        && *effect_run_id == run_id
+                        && file_name == "test.csv"
+                        && columns == &vec!["id".to_string()]
+                        && values == &vec![vec![QueryValue::text("1")]]
+                        && *row_count == Some(2)
+                ));
+            }
+
+            #[test]
             fn csv_export_ignores_mismatched_dsn() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
@@ -597,6 +644,37 @@ mod tests {
                         export_query: "SELECT 1".to_string(),
                         file_name: "test.csv".to_string(),
                         row_count: Some(200_000),
+                    },
+                );
+
+                let effects = super::dispatch_modal(
+                    &mut state,
+                    &Action::ConfirmDialogConfirm,
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert!(effects.is_empty());
+            }
+
+            #[test]
+            fn cached_csv_export_ignores_mismatched_run_id() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                activate_postgres_connection(&mut state, "postgres://localhost/test");
+                let _ = state.query.begin_running(Instant::now());
+                state.confirm_dialog.open(
+                    "",
+                    "",
+                    ConfirmIntent::CsvExportCached {
+                        dsn: "postgres://localhost/test".to_string(),
+                        run_id: 2,
+                        file_name: "test.csv".to_string(),
+                        row_count: Some(2),
+                        snapshot: CsvExportCacheSnapshot {
+                            columns: vec!["id".to_string()],
+                            values: vec![vec![QueryValue::text("1")]],
+                        },
                     },
                 );
 

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -47,22 +47,6 @@ impl QueryValue {
             Self::Null | Self::Blob(_) => None,
         }
     }
-
-    #[must_use]
-    pub fn csv_field(&self) -> String {
-        match self {
-            Self::Null => String::new(),
-            Self::Text(value) | Self::SqlLiteral(value) => value.clone(),
-            Self::Blob(bytes) => {
-                let mut hex = String::with_capacity(bytes.len() * 2);
-                for byte in bytes {
-                    use std::fmt::Write as _;
-                    let _ = write!(hex, "{byte:02X}");
-                }
-                hex
-            }
-        }
-    }
 }
 
 fn escape_display_text(value: &str) -> String {
@@ -314,33 +298,6 @@ mod tests {
         #[test]
         fn display_value_escapes_embedded_nul_byte() {
             assert_eq!(QueryValue::text("a\0bc").display_value(), "a\\0bc");
-        }
-
-        #[test]
-        fn csv_field_preserves_embedded_nul_byte() {
-            assert_eq!(QueryValue::text("a\0bc").csv_field(), "a\0bc");
-        }
-    }
-
-    mod csv_field {
-        use super::*;
-
-        #[test]
-        fn null_is_empty_field() {
-            assert_eq!(QueryValue::Null.csv_field(), "");
-        }
-
-        #[test]
-        fn blob_is_uppercase_hex() {
-            assert_eq!(QueryValue::Blob(vec![0xAB, 0xCD]).csv_field(), "ABCD");
-        }
-
-        #[test]
-        fn text_is_not_display_form() {
-            assert_ne!(
-                QueryValue::Null.csv_field(),
-                QueryValue::Null.display_value()
-            );
         }
     }
 }

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -47,6 +47,22 @@ impl QueryValue {
             Self::Null | Self::Blob(_) => None,
         }
     }
+
+    #[must_use]
+    pub fn csv_field(&self) -> String {
+        match self {
+            Self::Null => String::new(),
+            Self::Text(value) | Self::SqlLiteral(value) => value.clone(),
+            Self::Blob(bytes) => {
+                let mut hex = String::with_capacity(bytes.len() * 2);
+                for byte in bytes {
+                    use std::fmt::Write as _;
+                    let _ = write!(hex, "{byte:02X}");
+                }
+                hex
+            }
+        }
+    }
 }
 
 fn escape_display_text(value: &str) -> String {
@@ -298,6 +314,33 @@ mod tests {
         #[test]
         fn display_value_escapes_embedded_nul_byte() {
             assert_eq!(QueryValue::text("a\0bc").display_value(), "a\\0bc");
+        }
+
+        #[test]
+        fn csv_field_preserves_embedded_nul_byte() {
+            assert_eq!(QueryValue::text("a\0bc").csv_field(), "a\0bc");
+        }
+    }
+
+    mod csv_field {
+        use super::*;
+
+        #[test]
+        fn null_is_empty_field() {
+            assert_eq!(QueryValue::Null.csv_field(), "");
+        }
+
+        #[test]
+        fn blob_is_uppercase_hex() {
+            assert_eq!(QueryValue::Blob(vec![0xAB, 0xCD]).csv_field(), "ABCD");
+        }
+
+        #[test]
+        fn text_is_not_display_form() {
+            assert_ne!(
+                QueryValue::Null.csv_field(),
+                QueryValue::Null.display_value()
+            );
         }
     }
 }

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -731,70 +731,7 @@ fn is_write_statement(statement: &str) -> bool {
     )
 }
 
-fn is_rerunnable_sqlite_export_query(query: &str) -> bool {
-    split_sqlite_statements(query)
-        .iter()
-        .all(|statement| is_rerunnable_sqlite_export_statement(statement))
-}
-
-fn is_rerunnable_sqlite_export_statement(statement: &str) -> bool {
-    if is_write_statement(statement)
-        || is_dml_statement(statement)
-        || is_transaction_control(statement)
-    {
-        return false;
-    }
-    match first_keyword(statement).to_ascii_uppercase().as_str() {
-        "SELECT" | "EXPLAIN" | "VALUES" | "WITH" => true,
-        "PRAGMA" => is_read_only_sqlite_export_pragma(statement),
-        _ => false,
-    }
-}
-
-fn is_read_only_sqlite_export_pragma(statement: &str) -> bool {
-    let lower = statement.to_lowercase();
-    let name = lower
-        .split_whitespace()
-        .nth(1)
-        .and_then(|token| token.split('.').next_back())
-        .unwrap_or("");
-    let has_assignment = lower.contains('=');
-    let has_parenthesized_value = lower.contains('(');
-    let side_effect_without_assignment = has_parenthesized_value
-        && !matches!(
-            name,
-            "table_info"
-                | "index_info"
-                | "index_list"
-                | "database_list"
-                | "compile_options"
-                | "function_list"
-                | "module_list"
-                | "collation_list"
-                | "integrity_check"
-                | "quick_check"
-                | "column_info"
-        )
-        || matches!(name, "optimize" | "incremental_vacuum" | "wal_checkpoint");
-    if !has_assignment && !side_effect_without_assignment {
-        return true;
-    }
-    !(matches!(
-        name,
-        "writable_schema"
-            | "journal_mode"
-            | "locking_mode"
-            | "optimize"
-            | "incremental_vacuum"
-            | "wal_checkpoint"
-    ) || (name == "foreign_keys"
-        && lower.split('=').nth(1).is_some_and(|value| {
-            matches!(
-                value.trim(),
-                "off" | "0" | "false" | "OFF" | "FALSE" | "Off" | "False"
-            )
-        })))
-}
+use crate::app::policy::sql::sqlite_export::is_sqlite_rerunnable_export_query;
 
 fn sqlite_export_not_rerunnable_error() -> DbOperationError {
     DbOperationError::UnsupportedOperation(
@@ -1764,7 +1701,7 @@ impl QueryExecutor for SqliteAdapter {
         path: &std::path::Path,
         read_only: bool,
     ) -> Result<usize, DbOperationError> {
-        if !is_rerunnable_sqlite_export_query(query) {
+        if !is_sqlite_rerunnable_export_query(query) {
             return Err(sqlite_export_not_rerunnable_error());
         }
         self.cli

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -3116,6 +3116,25 @@ mod tests {
             assert_eq!(count, 3);
         }
 
+        #[test]
+        fn export_guard_rejects_non_rerunnable_sql() {
+            for sql in [
+                "SELECT 1; SELECT 2",
+                "WITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload",
+                "PRAGMA foreign_keys=OFF",
+                "PRAGMA wal_checkpoint(TRUNCATE)",
+            ] {
+                assert!(!is_sqlite_rerunnable_export_query(sql), "{sql}");
+            }
+        }
+
+        #[test]
+        fn export_guard_allows_read_only_sql() {
+            for sql in ["SELECT 1", "PRAGMA table_info(users)"] {
+                assert!(is_sqlite_rerunnable_export_query(sql), "{sql}");
+            }
+        }
+
         #[tokio::test]
         async fn export_to_csv_writes_rows_and_returns_row_count() {
             let (dir, dsn) = make_sqlite_db(

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -731,7 +731,83 @@ fn is_write_statement(statement: &str) -> bool {
     )
 }
 
-use crate::app::policy::sql::sqlite_export::is_sqlite_rerunnable_export_query;
+fn is_sqlite_rerunnable_export_query(query: &str) -> bool {
+    let statements = split_sqlite_statements(query);
+    statements.len() == 1
+        && statements
+            .iter()
+            .all(|statement| is_sqlite_rerunnable_export_statement(statement))
+}
+
+fn is_sqlite_rerunnable_export_statement(statement: &str) -> bool {
+    if is_write_statement(statement)
+        || is_dml_statement(statement)
+        || is_transaction_control(statement)
+    {
+        return false;
+    }
+    match first_keyword(statement).to_ascii_uppercase().as_str() {
+        "SELECT" | "EXPLAIN" | "VALUES" => true,
+        "WITH" => !is_dml_statement(statement),
+        "PRAGMA" => is_read_only_sqlite_export_pragma(statement),
+        _ => false,
+    }
+}
+
+fn sqlite_pragma_name(statement: &str) -> Option<String> {
+    let (_, pragma_end) = next_keyword_from(statement, 0)?;
+    let tail = statement.get(pragma_end..)?.trim_start();
+    let name: String = tail
+        .chars()
+        .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_' || *ch == '.')
+        .collect();
+    if name.is_empty() {
+        None
+    } else {
+        Some(
+            name.rsplit('.')
+                .next()
+                .unwrap_or(name.as_str())
+                .to_ascii_lowercase(),
+        )
+    }
+}
+
+fn is_read_only_parameterized_pragma(name: &str) -> bool {
+    matches!(
+        name,
+        "table_info"
+            | "table_xinfo"
+            | "index_info"
+            | "index_xinfo"
+            | "index_list"
+            | "foreign_key_list"
+            | "database_list"
+            | "table_list"
+            | "pragma_list"
+            | "function_list"
+            | "module_list"
+            | "collation_list"
+            | "integrity_check"
+            | "quick_check"
+            | "column_info"
+    )
+}
+
+fn is_read_only_sqlite_export_pragma(statement: &str) -> bool {
+    let Some(name) = sqlite_pragma_name(statement) else {
+        return false;
+    };
+    let has_assignment = statement.contains('=');
+    let has_parenthesized_value = statement.contains('(');
+    let side_effect_without_assignment = (has_parenthesized_value
+        && !is_read_only_parameterized_pragma(&name))
+        || matches!(
+            name.as_str(),
+            "optimize" | "incremental_vacuum" | "wal_checkpoint"
+        );
+    !has_assignment && !side_effect_without_assignment
+}
 
 fn sqlite_export_not_rerunnable_error() -> DbOperationError {
     DbOperationError::UnsupportedOperation(
@@ -3063,8 +3139,8 @@ mod tests {
 
         #[tokio::test]
         async fn export_to_csv_rejects_write_sql() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let path = std::env::temp_dir().join("sabiql_write_export.csv");
+            let (dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let path = dir.path().join("write_export.csv");
             let adapter = SqliteAdapter::new();
 
             let result = adapter

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -731,6 +731,78 @@ fn is_write_statement(statement: &str) -> bool {
     )
 }
 
+fn is_rerunnable_sqlite_export_query(query: &str) -> bool {
+    split_sqlite_statements(query)
+        .iter()
+        .all(|statement| is_rerunnable_sqlite_export_statement(statement))
+}
+
+fn is_rerunnable_sqlite_export_statement(statement: &str) -> bool {
+    if is_write_statement(statement)
+        || is_dml_statement(statement)
+        || is_transaction_control(statement)
+    {
+        return false;
+    }
+    match first_keyword(statement).to_ascii_uppercase().as_str() {
+        "SELECT" | "EXPLAIN" | "VALUES" | "WITH" => true,
+        "PRAGMA" => is_read_only_sqlite_export_pragma(statement),
+        _ => false,
+    }
+}
+
+fn is_read_only_sqlite_export_pragma(statement: &str) -> bool {
+    let lower = statement.to_lowercase();
+    let name = lower
+        .split_whitespace()
+        .nth(1)
+        .and_then(|token| token.split('.').next_back())
+        .unwrap_or("");
+    let has_assignment = lower.contains('=');
+    let has_parenthesized_value = lower.contains('(');
+    let side_effect_without_assignment = has_parenthesized_value
+        && !matches!(
+            name,
+            "table_info"
+                | "index_info"
+                | "index_list"
+                | "database_list"
+                | "compile_options"
+                | "function_list"
+                | "module_list"
+                | "collation_list"
+                | "integrity_check"
+                | "quick_check"
+                | "column_info"
+        )
+        || matches!(name, "optimize" | "incremental_vacuum" | "wal_checkpoint");
+    if !has_assignment && !side_effect_without_assignment {
+        return true;
+    }
+    !(matches!(
+        name,
+        "writable_schema"
+            | "journal_mode"
+            | "locking_mode"
+            | "optimize"
+            | "incremental_vacuum"
+            | "wal_checkpoint"
+    ) || (name == "foreign_keys"
+        && lower.split('=').nth(1).is_some_and(|value| {
+            matches!(
+                value.trim(),
+                "off" | "0" | "false" | "OFF" | "FALSE" | "Off" | "False"
+            )
+        })))
+}
+
+fn sqlite_export_not_rerunnable_error() -> DbOperationError {
+    DbOperationError::UnsupportedOperation(
+        "Cannot re-execute this query for CSV export because it contains write or DDL statements"
+            .to_string(),
+    )
+}
+
 fn should_wrap_transaction(query: &str) -> bool {
     let statements = split_sqlite_statements(query);
     statements.len() > 1
@@ -1692,6 +1764,9 @@ impl QueryExecutor for SqliteAdapter {
         path: &std::path::Path,
         read_only: bool,
     ) -> Result<usize, DbOperationError> {
+        if !is_rerunnable_sqlite_export_query(query) {
+            return Err(sqlite_export_not_rerunnable_error());
+        }
         self.cli
             .export_csv(Self::path_from_dsn(dsn)?, query, path, read_only)
             .await
@@ -3047,6 +3122,24 @@ mod tests {
 
             assert_eq!(row_count, 2);
             assert_eq!(csv, "id,name\n1,a\n2,b\n");
+        }
+
+        #[tokio::test]
+        async fn export_to_csv_rejects_write_sql() {
+            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let path = std::env::temp_dir().join("sabiql_write_export.csv");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .export_to_csv(&dsn, "INSERT INTO users(id) VALUES (1)", &path, false)
+                .await;
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::UnsupportedOperation(message))
+                if message.contains("write or DDL")
+            ));
+            assert!(!path.exists());
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Problem

SQLite CSV export re-ran the original query, so exporting results from write or mixed SQL could execute INSERT, UPDATE, DELETE, or DDL again.

## Background

[SAB-299](https://linear.app/sabiql/issue/SAB-299) — CSV export should behave like writing out what the user already saw, not as another execution of side-effect SQL.

## Approach

Classify SQLite export as either a safe read-only re-run or a cached export from the in-memory result. Block export with a clear message when the query has side effects and no tabular rows to write. Add a matching guard in the SQLite adapter so write SQL cannot be re-exported through the executor path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * CSVエクスポートを自動判定し、「再実行」または「キャッシュ結果から書き出し」を切り替えます（SQLite向け計画も追加）。
  * 確認ダイアログのCSV意図を分岐し、キャッシュ由来の書き出しも扱えるようになりました。  
* **不具合修正**
  * キャッシュ値のCSV表記（null/文字列/バイナリ）と表示内容の不整合を改善しました。  
* **テスト**
  * SQLiteの許可/非許可、キャッシュCSV生成の成功/失敗、変換ルールの検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->