### PR TITLE
fix: handle SQLite WITH write classification

### DIFF
--- a/src/app/policy/sql/statement_classifier.rs
+++ b/src/app/policy/sql/statement_classifier.rs
@@ -21,7 +21,7 @@ pub enum StatementKind {
 
 pub fn classify(sql: &str) -> StatementKind {
     let trimmed = sql.trim();
-    let statement = statement_after_leading_with(trimmed);
+    let statement = statement_after_leading_ctes(trimmed);
     let lower = statement.to_lowercase();
     if lower.is_empty() {
         return StatementKind::Other;
@@ -48,7 +48,7 @@ pub fn first_keyword(sql: &str) -> Option<String> {
         .map(|(_, token)| token.to_uppercase())
 }
 
-pub(crate) fn statement_after_leading_with(sql: &str) -> &str {
+pub(crate) fn statement_after_leading_ctes(sql: &str) -> &str {
     let trimmed = sql.trim();
     let chars: Vec<(usize, char)> = trimmed.char_indices().collect();
     let tokens = collect_top_level_tokens(trimmed, &chars);
@@ -89,7 +89,7 @@ pub(crate) fn statement_after_leading_with(sql: &str) -> &str {
 }
 
 pub fn extract_target_name(sql: &str, kind: &StatementKind) -> Option<String> {
-    let original_trimmed = statement_after_leading_with(sql);
+    let original_trimmed = statement_after_leading_ctes(sql);
     // Avoids byte-length mismatch when Unicode identifiers change size under case folding.
     let chars: Vec<(usize, char)> = original_trimmed.char_indices().collect();
 
@@ -793,6 +793,10 @@ mod tests {
         #[rstest]
         #[case::cte_insert(
             "WITH cte AS (SELECT 1) INSERT INTO users(id) SELECT * FROM cte",
+            StatementKind::Insert
+        )]
+        #[case::multiple_cte_insert(
+            "WITH a AS (SELECT 1), b AS (SELECT 2) INSERT INTO users(id) SELECT * FROM a",
             StatementKind::Insert
         )]
         #[case::cte_update(

--- a/src/app/policy/sql/statement_classifier.rs
+++ b/src/app/policy/sql/statement_classifier.rs
@@ -21,6 +21,9 @@ pub enum StatementKind {
 
 pub fn classify(sql: &str) -> StatementKind {
     let trimmed = sql.trim();
+    if let Some(kind) = leading_cte_write_kind(trimmed) {
+        return kind;
+    }
     let statement = statement_after_leading_ctes(trimmed);
     let lower = statement.to_lowercase();
     if lower.is_empty() {
@@ -86,6 +89,155 @@ pub(crate) fn statement_after_leading_ctes(sql: &str) -> &str {
             None => return trimmed,
         }
     }
+}
+
+fn leading_cte_write_kind(sql: &str) -> Option<StatementKind> {
+    let trimmed = sql.trim();
+    let chars: Vec<(usize, char)> = trimmed.char_indices().collect();
+    let tokens = collect_top_level_tokens(trimmed, &chars);
+    let lowers: Vec<String> = tokens
+        .iter()
+        .map(|(_, token)| token.to_lowercase())
+        .collect();
+    if lowers.first().map(String::as_str) != Some("with") {
+        return None;
+    }
+
+    let mut cursor = 1;
+    if lowers.get(cursor).map(String::as_str) == Some("recursive") {
+        cursor += 1;
+    }
+
+    loop {
+        cursor += 1;
+        if lowers.get(cursor).map(String::as_str) != Some("as") {
+            return None;
+        }
+
+        let mut body_search_start = token_end(&tokens[cursor]);
+        cursor += 1;
+        if lowers.get(cursor).map(String::as_str) == Some("not") {
+            body_search_start = token_end(&tokens[cursor]);
+            cursor += 1;
+            if lowers.get(cursor).map(String::as_str) == Some("materialized") {
+                body_search_start = token_end(&tokens[cursor]);
+                cursor += 1;
+            }
+        } else if lowers.get(cursor).map(String::as_str) == Some("materialized") {
+            body_search_start = token_end(&tokens[cursor]);
+            cursor += 1;
+        }
+
+        let body_end = tokens.get(cursor).map_or(trimmed.len(), |(pos, _)| *pos);
+        if let Some(body) = cte_body_sql(trimmed, &chars, body_search_start, body_end)
+            && let Some(kind) = cte_body_write_kind(body)
+        {
+            return Some(kind);
+        }
+
+        match lowers.get(cursor).map(String::as_str) {
+            Some(",") => cursor += 1,
+            Some(_) | None => return None,
+        }
+    }
+}
+
+fn token_end((pos, token): &(usize, String)) -> usize {
+    pos + token.len()
+}
+
+fn cte_body_write_kind(sql: &str) -> Option<StatementKind> {
+    let kind = classify(sql);
+    match kind {
+        StatementKind::Insert | StatementKind::Update { .. } | StatementKind::Delete { .. } => {
+            Some(kind)
+        }
+        StatementKind::Unsupported
+            if first_keyword(sql)
+                .as_deref()
+                .is_some_and(|keyword| keyword.eq_ignore_ascii_case("MERGE")) =>
+        {
+            Some(StatementKind::Unsupported)
+        }
+        _ => None,
+    }
+}
+
+fn cte_body_sql<'a>(
+    sql: &'a str,
+    chars: &[(usize, char)],
+    start_byte: usize,
+    end_byte: usize,
+) -> Option<&'a str> {
+    let mut cursor = chars
+        .iter()
+        .position(|(byte_pos, _)| *byte_pos >= start_byte)?;
+    while cursor < chars.len() && chars[cursor].0 < end_byte {
+        let (byte_pos, ch) = chars[cursor];
+        if ch.is_whitespace() {
+            cursor += 1;
+            continue;
+        }
+        if let Some(next) = skip_line_comment(chars, cursor, ch) {
+            cursor = next;
+            continue;
+        }
+        if let Some(next) = skip_block_comment(chars, cursor, ch) {
+            cursor = next;
+            continue;
+        }
+        if ch != '(' {
+            return None;
+        }
+        let close = matching_close_paren(sql, chars, cursor, end_byte)?;
+        return Some(&sql[byte_pos + ch.len_utf8()..chars[close].0]);
+    }
+    None
+}
+
+fn matching_close_paren(
+    sql: &str,
+    chars: &[(usize, char)],
+    open: usize,
+    end_byte: usize,
+) -> Option<usize> {
+    let mut cursor = open;
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    while cursor < chars.len() && chars[cursor].0 < end_byte {
+        let (byte_pos, ch) = chars[cursor];
+        if let Some(next) = skip_line_comment(chars, cursor, ch) {
+            cursor = next;
+            continue;
+        }
+        if let Some(next) = skip_block_comment(chars, cursor, ch) {
+            cursor = next;
+            continue;
+        }
+        if let Some(next) = advance_single_quote(chars, cursor, ch, &mut in_string) {
+            cursor = next;
+            continue;
+        }
+        if in_string {
+            cursor += 1;
+            continue;
+        }
+        if let Some(next) = skip_double_quoted_identifier(chars, cursor, ch) {
+            cursor = next;
+            continue;
+        }
+        if let Some(next) = skip_dollar_quoted_string(sql, chars, cursor, byte_pos, ch) {
+            cursor = next;
+            continue;
+        }
+
+        update_parentheses_depth(ch, &mut depth);
+        if depth == 0 {
+            return Some(cursor);
+        }
+        cursor += 1;
+    }
+    None
 }
 
 pub fn extract_target_name(sql: &str, kind: &StatementKind) -> Option<String> {
@@ -811,6 +963,30 @@ mod tests {
             "WITH cte AS (SELECT 1) DELETE FROM users WHERE id = 1",
             StatementKind::Delete { has_where: true }
         )]
+        #[case::cte_body_update(
+            "WITH x AS (UPDATE users SET name='a' RETURNING *) SELECT * FROM x",
+            StatementKind::Update { has_where: false }
+        )]
+        #[case::cte_body_update_where(
+            "WITH x AS (UPDATE users SET name='a' WHERE id = 1 RETURNING *) SELECT * FROM x",
+            StatementKind::Update { has_where: true }
+        )]
+        #[case::cte_body_delete(
+            "WITH x AS (DELETE FROM users RETURNING *) SELECT * FROM x",
+            StatementKind::Delete { has_where: false }
+        )]
+        #[case::cte_body_insert(
+            "WITH x AS (INSERT INTO users(id) VALUES (1) RETURNING *) SELECT * FROM x",
+            StatementKind::Insert
+        )]
+        #[case::second_cte_body_update(
+            "WITH a AS (SELECT 1), x AS (UPDATE users SET name='a' RETURNING *) SELECT * FROM x",
+            StatementKind::Update { has_where: false }
+        )]
+        #[case::cte_body_merge(
+            "WITH x AS (MERGE INTO users USING incoming ON users.id = incoming.id WHEN MATCHED THEN UPDATE SET name = incoming.name RETURNING *) SELECT * FROM x",
+            StatementKind::Unsupported
+        )]
         fn cte_dml(#[case] sql: &str, #[case] expected: StatementKind) {
             assert_eq!(classify(sql), expected);
         }
@@ -915,7 +1091,7 @@ mod tests {
         #[case::double_quoted_escaped("SELECT \"up\"\"date\" FROM t", StatementKind::Select)]
         #[case::cte_with_update_in_subquery(
             "WITH x AS (UPDATE users SET name='a' RETURNING *) SELECT * FROM x",
-            StatementKind::Select
+            StatementKind::Update { has_where: false }
         )]
         #[case::select_with_parenthesized_expr(
             "WITH cte AS (SELECT 1) SELECT (1+2)",

--- a/src/app/policy/sql/statement_classifier.rs
+++ b/src/app/policy/sql/statement_classifier.rs
@@ -20,7 +20,9 @@ pub enum StatementKind {
 }
 
 pub fn classify(sql: &str) -> StatementKind {
-    let lower = sql.trim().to_lowercase();
+    let trimmed = sql.trim();
+    let statement = statement_after_leading_with(trimmed);
+    let lower = statement.to_lowercase();
     if lower.is_empty() {
         return StatementKind::Other;
     }
@@ -46,8 +48,48 @@ pub fn first_keyword(sql: &str) -> Option<String> {
         .map(|(_, token)| token.to_uppercase())
 }
 
+pub(crate) fn statement_after_leading_with(sql: &str) -> &str {
+    let trimmed = sql.trim();
+    let chars: Vec<(usize, char)> = trimmed.char_indices().collect();
+    let tokens = collect_top_level_tokens(trimmed, &chars);
+    let lowers: Vec<String> = tokens
+        .iter()
+        .map(|(_, token)| token.to_lowercase())
+        .collect();
+    if lowers.first().map(String::as_str) != Some("with") {
+        return trimmed;
+    }
+
+    let mut cursor = 1;
+    if lowers.get(cursor).map(String::as_str) == Some("recursive") {
+        cursor += 1;
+    }
+
+    loop {
+        cursor += 1;
+        if lowers.get(cursor).map(String::as_str) != Some("as") {
+            return trimmed;
+        }
+        cursor += 1;
+        if lowers.get(cursor).map(String::as_str) == Some("not") {
+            cursor += 1;
+            if lowers.get(cursor).map(String::as_str) == Some("materialized") {
+                cursor += 1;
+            }
+        } else if lowers.get(cursor).map(String::as_str) == Some("materialized") {
+            cursor += 1;
+        }
+
+        match lowers.get(cursor).map(String::as_str) {
+            Some(",") => cursor += 1,
+            Some(_) => return &trimmed[tokens[cursor].0..],
+            None => return trimmed,
+        }
+    }
+}
+
 pub fn extract_target_name(sql: &str, kind: &StatementKind) -> Option<String> {
-    let original_trimmed = sql.trim();
+    let original_trimmed = statement_after_leading_with(sql);
     // Avoids byte-length mismatch when Unicode identifiers change size under case folding.
     let chars: Vec<(usize, char)> = original_trimmed.char_indices().collect();
 
@@ -196,7 +238,6 @@ fn classify_inner(lower: &str, chars: &[(usize, char)]) -> StatementKind {
     let mut i = 0;
     let mut depth: i32 = 0;
     let mut in_string = false;
-    let mut in_cte = false;
     let mut is_explain = false;
     let mut has_analyze = false;
     let mut kind: Option<StatementKind> = None;
@@ -283,15 +324,7 @@ fn classify_inner(lower: &str, chars: &[(usize, char)]) -> StatementKind {
                 return StatementKind::Other;
             }
 
-            if kind.is_none() && is_keyword(rest, "with") {
-                in_cte = true;
-                i += 1;
-                continue;
-            }
-
-            // CTE: keep overriding with each top-level keyword (last one wins).
-            // Non-CTE: first keyword determines the kind.
-            if in_cte || kind.is_none() {
+            if kind.is_none() {
                 if let Some(k) = match_keyword(rest) {
                     kind = Some(k);
                     if matches!(
@@ -305,7 +338,7 @@ fn classify_inner(lower: &str, chars: &[(usize, char)]) -> StatementKind {
                             other => other,
                         });
                     }
-                } else if !in_cte {
+                } else {
                     kind = Some(StatementKind::Unsupported);
                 }
             }
@@ -758,6 +791,10 @@ mod tests {
         }
 
         #[rstest]
+        #[case::cte_insert(
+            "WITH cte AS (SELECT 1) INSERT INTO users(id) SELECT * FROM cte",
+            StatementKind::Insert
+        )]
         #[case::cte_update(
             "WITH cte AS (SELECT 1) UPDATE users SET name = 'x'",
             StatementKind::Update { has_where: false }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -851,6 +851,22 @@ mod tests {
             ));
         }
 
+        #[test]
+        fn data_modifying_cte_blocks_read_only() {
+            let sql = "WITH x AS (UPDATE users SET name='a' RETURNING *) SELECT * FROM x";
+            let result = evaluate_sql_risk(&classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::High);
+            assert!(!result.read_only_allowed);
+            assert!(matches!(
+                result.confirmation,
+                ConfirmationType::Acknowledge {
+                    reason: AcknowledgeReason::TargetNameUnavailable,
+                    ref label,
+                } if label == "UPDATE (no WHERE)"
+            ));
+        }
+
         #[rstest]
         #[case::update_where(StatementKind::Update { has_where: true }, "UPDATE users SET x=1 WHERE id=1")]
         #[case::delete_where(StatementKind::Delete { has_where: true }, "DELETE FROM users WHERE id=1")]

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -3,7 +3,7 @@ use crate::domain::DatabaseType;
 use crate::policy::sql::statement_classifier::{
     StatementKind, advance_single_quote, classify, collect_top_level_tokens, drop_subtype,
     extract_target_name, first_keyword, skip_block_comment, skip_dollar_quoted_string,
-    skip_double_quoted_identifier, skip_line_comment, statement_after_leading_with,
+    skip_double_quoted_identifier, skip_line_comment, statement_after_leading_ctes,
 };
 
 // Why the statement cannot be confirmed via typed target name.
@@ -258,7 +258,8 @@ pub fn evaluate_sql_risk_for_database(
                 risk_level: RiskLevel::Low,
                 confirmation: ConfirmationType::Acknowledge {
                     reason: AcknowledgeReason::UnknownRisk,
-                    label: first_keyword(sql).unwrap_or_else(|| "SQL".to_string()),
+                    label: first_keyword(statement_after_leading_ctes(sql))
+                        .unwrap_or_else(|| "SQL".to_string()),
                 },
                 read_only_allowed: false,
             }
@@ -397,8 +398,8 @@ fn high_acknowledge_keyword(keyword: &str) -> SqlRiskDecision {
     high_acknowledge_label(&keyword.to_uppercase())
 }
 
-fn sqlite_replace_target(sql: &str) -> Option<String> {
-    let trimmed = statement_after_leading_with(sql);
+fn sqlite_replace_target_in_statement(sql: &str) -> Option<String> {
+    let trimmed = sql.trim();
     let tokens = top_level_token_pairs(trimmed);
     let lowers: Vec<String> = tokens
         .iter()
@@ -442,7 +443,7 @@ fn top_level_token_lowers(sql: &str) -> Vec<String> {
 }
 
 pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
-    let effective = statement_after_leading_with(sql);
+    let effective = statement_after_leading_ctes(sql);
     let tokens = top_level_token_lowers(effective);
     match tokens.first().map(String::as_str)? {
         "pragma" => Some("PRAGMA"),
@@ -452,7 +453,7 @@ pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
         "reindex" => Some("REINDEX"),
         "analyze" => Some("ANALYZE"),
         "replace" => Some("REPLACE"),
-        "insert" if sqlite_replace_target(effective).is_some() => Some("REPLACE"),
+        "insert" if sqlite_replace_target_in_statement(effective).is_some() => Some("REPLACE"),
         _ => None,
     }
 }
@@ -661,14 +662,14 @@ fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
 }
 
 fn evaluate_sqlite_specific_risk(sql: &str) -> Option<SqlRiskDecision> {
-    let effective = statement_after_leading_with(sql);
+    let effective = statement_after_leading_ctes(sql);
     let tokens = top_level_token_lowers(effective);
     match tokens.first().map(String::as_str)? {
         "pragma" => sqlite_pragma_risk(effective),
         "attach" | "detach" | "vacuum" | "reindex" | "analyze" => {
             Some(high_acknowledge_keyword(&tokens[0]))
         }
-        "replace" => sqlite_replace_target(effective).map_or_else(
+        "replace" => sqlite_replace_target_in_statement(effective).map_or_else(
             || Some(high_acknowledge_label("REPLACE")),
             |target| {
                 Some(SqlRiskDecision {
@@ -678,7 +679,7 @@ fn evaluate_sqlite_specific_risk(sql: &str) -> Option<SqlRiskDecision> {
                 })
             },
         ),
-        "insert" => sqlite_replace_target(effective).map(|target| SqlRiskDecision {
+        "insert" => sqlite_replace_target_in_statement(effective).map(|target| SqlRiskDecision {
             risk_level: RiskLevel::High,
             confirmation: ConfirmationType::TableNameInput { target },
             read_only_allowed: false,
@@ -794,6 +795,11 @@ mod tests {
             "DO"
         )]
         #[case::copy(StatementKind::Unsupported, "COPY users FROM '/tmp/data.csv'", "COPY")]
+        #[case::cte_unsupported(
+            StatementKind::Unsupported,
+            "WITH c AS (SELECT 1) CALL refresh()",
+            "CALL"
+        )]
         #[case::select_into(StatementKind::Other, "SELECT * INTO backup FROM users", "SELECT")]
         #[case::unparseable(StatementKind::Other, "??? invalid", "INVALID")]
         fn unassessable_requires_acknowledgment(
@@ -1000,6 +1006,14 @@ mod tests {
         )]
         #[case::with_materialized_insert_or_replace(
             "WITH payload(id) AS MATERIALIZED (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
+            "users"
+        )]
+        #[case::with_not_materialized_insert_or_replace(
+            "WITH payload(id) AS NOT MATERIALIZED (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
+            "users"
+        )]
+        #[case::with_multiple_ctes_insert_or_replace(
+            "WITH a(id) AS (VALUES (1)), b(id) AS (VALUES (2)) INSERT OR REPLACE INTO users(id) SELECT id FROM a",
             "users"
         )]
         #[case::replace("REPLACE INTO users(id) VALUES (1)", "users")]

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -3,7 +3,7 @@ use crate::domain::DatabaseType;
 use crate::policy::sql::statement_classifier::{
     StatementKind, advance_single_quote, classify, collect_top_level_tokens, drop_subtype,
     extract_target_name, first_keyword, skip_block_comment, skip_dollar_quoted_string,
-    skip_double_quoted_identifier, skip_line_comment,
+    skip_double_quoted_identifier, skip_line_comment, statement_after_leading_with,
 };
 
 // Why the statement cannot be confirmed via typed target name.
@@ -398,7 +398,7 @@ fn high_acknowledge_keyword(keyword: &str) -> SqlRiskDecision {
 }
 
 fn sqlite_replace_target(sql: &str) -> Option<String> {
-    let trimmed = sql.trim();
+    let trimmed = statement_after_leading_with(sql);
     let tokens = top_level_token_pairs(trimmed);
     let lowers: Vec<String> = tokens
         .iter()
@@ -442,7 +442,8 @@ fn top_level_token_lowers(sql: &str) -> Vec<String> {
 }
 
 pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
-    let tokens = top_level_token_lowers(sql);
+    let effective = statement_after_leading_with(sql);
+    let tokens = top_level_token_lowers(effective);
     match tokens.first().map(String::as_str)? {
         "pragma" => Some("PRAGMA"),
         "attach" => Some("ATTACH"),
@@ -451,7 +452,7 @@ pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
         "reindex" => Some("REINDEX"),
         "analyze" => Some("ANALYZE"),
         "replace" => Some("REPLACE"),
-        "insert" if sqlite_replace_target(sql).is_some() => Some("REPLACE"),
+        "insert" if sqlite_replace_target(effective).is_some() => Some("REPLACE"),
         _ => None,
     }
 }
@@ -660,13 +661,14 @@ fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
 }
 
 fn evaluate_sqlite_specific_risk(sql: &str) -> Option<SqlRiskDecision> {
-    let tokens = top_level_token_lowers(sql);
+    let effective = statement_after_leading_with(sql);
+    let tokens = top_level_token_lowers(effective);
     match tokens.first().map(String::as_str)? {
-        "pragma" => sqlite_pragma_risk(sql),
+        "pragma" => sqlite_pragma_risk(effective),
         "attach" | "detach" | "vacuum" | "reindex" | "analyze" => {
             Some(high_acknowledge_keyword(&tokens[0]))
         }
-        "replace" => sqlite_replace_target(sql).map_or_else(
+        "replace" => sqlite_replace_target(effective).map_or_else(
             || Some(high_acknowledge_label("REPLACE")),
             |target| {
                 Some(SqlRiskDecision {
@@ -676,7 +678,7 @@ fn evaluate_sqlite_specific_risk(sql: &str) -> Option<SqlRiskDecision> {
                 })
             },
         ),
-        "insert" => sqlite_replace_target(sql).map(|target| SqlRiskDecision {
+        "insert" => sqlite_replace_target(effective).map(|target| SqlRiskDecision {
             risk_level: RiskLevel::High,
             confirmation: ConfirmationType::TableNameInput { target },
             read_only_allowed: false,
@@ -988,7 +990,23 @@ mod tests {
 
         #[rstest]
         #[case::insert_or_replace("INSERT OR REPLACE INTO users(id) VALUES (1)", "users")]
+        #[case::with_insert_or_replace(
+            "WITH payload(id) AS (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
+            "users"
+        )]
+        #[case::with_recursive_insert_or_replace(
+            "WITH RECURSIVE payload(id) AS (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
+            "users"
+        )]
+        #[case::with_materialized_insert_or_replace(
+            "WITH payload(id) AS MATERIALIZED (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
+            "users"
+        )]
         #[case::replace("REPLACE INTO users(id) VALUES (1)", "users")]
+        #[case::with_replace(
+            "WITH payload(id) AS (VALUES (1)) REPLACE INTO users(id) SELECT id FROM payload",
+            "users"
+        )]
         #[case::bracket_quoted("REPLACE INTO [my table](id) VALUES (1)", "my table")]
         #[case::backtick_quoted("REPLACE INTO `my table`(id) VALUES (1)", "my table")]
         #[case::double_quoted(r#"REPLACE INTO "my table"(id) VALUES (1)"#, "my table")]
@@ -1019,6 +1037,13 @@ mod tests {
         #[test]
         fn sqlite_specific_label_detects_commented_insert_or_replace() {
             let sql = "-- upsert\nINSERT OR REPLACE INTO users(id) VALUES (1)";
+
+            assert_eq!(sqlite_specific_label(sql), Some("REPLACE"));
+        }
+
+        #[test]
+        fn sqlite_specific_label_detects_with_insert_or_replace() {
+            let sql = "WITH payload(id) AS (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload";
 
             assert_eq!(sqlite_specific_label(sql), Some("REPLACE"));
         }

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -725,9 +725,12 @@ fn is_transaction_control(statement: &str) -> bool {
 }
 
 fn is_write_statement(statement: &str) -> bool {
+    if is_dml_statement(statement) {
+        return true;
+    }
     matches!(
         first_keyword(statement).to_ascii_uppercase().as_str(),
-        "INSERT" | "REPLACE" | "UPDATE" | "DELETE" | "CREATE" | "ALTER" | "DROP" | "TRUNCATE"
+        "CREATE" | "ALTER" | "DROP" | "TRUNCATE"
     )
 }
 
@@ -1834,6 +1837,18 @@ mod tests {
     }
 
     #[test]
+    fn append_changes_wraps_multi_statement_with_write_without_explicit_transaction() {
+        let query = "WITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload; SELECT * FROM missing";
+
+        let wrapped = append_changes_query(query);
+
+        assert_eq!(
+            wrapped,
+            "BEGIN;\nWITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload; SELECT * FROM missing\n;\nCOMMIT\n;\nSELECT changes() AS affected_rows;"
+        );
+    }
+
+    #[test]
     fn append_changes_keeps_explicit_begin_commit_transaction_control() {
         let query = "BEGIN; INSERT INTO users(id) VALUES (1); COMMIT";
 
@@ -2819,6 +2834,29 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
+                    false,
+                )
+                .await;
+
+            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            let rows = adapter
+                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .await
+                .unwrap();
+            assert!(rows.rows().is_empty());
+        }
+
+        #[tokio::test]
+        async fn with_dml_rolls_back_when_later_statement_fails() {
+            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(
+                    &dsn,
+                    "WITH payload(id) AS (VALUES (1))
+                     INSERT INTO users(id) SELECT id FROM payload;
+                     INSERT INTO missing(id) VALUES (2)",
                     false,
                 )
                 .await;


### PR DESCRIPTION
## Problem

SQLite write statements can start with WITH, which made some writes look read-only and avoided transaction wrapping for multi-statement execution.

## Background

Linear: SAB-286

## Approach

Classify the actual statement after leading WITH clauses for SQLite write risk, including INSERT OR REPLACE and REPLACE. Treat WITH-backed SQLite DML as writes when deciding whether multi-statement execution needs an implicit transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `WITH` 句から始まるSQLでも、実際の文種別や対象名を正しく判定できるようになりました。
  * SQLite では、`WITH` 付きの書き込み操作も書き込みとして扱われるようになりました。

* **バグ修正**
  * `WITH ... INSERT/UPDATE/DELETE/REPLACE` の判定漏れを修正しました。
  * `INSERT OR REPLACE` や `REPLACE` の対象テーブル名抽出が、CTE付きSQLでも正しく動作するようになりました。
  * 失敗時のロールバックや複数文のトランザクション処理がより安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->