### PR TITLE
fix: parse SQLite quoted targets in risk checks

### DIFF
--- a/src/app/policy/sql/statement_classifier.rs
+++ b/src/app/policy/sql/statement_classifier.rs
@@ -320,6 +320,37 @@ pub(crate) fn skip_double_quoted_identifier(
     Some(cursor)
 }
 
+pub(crate) fn skip_sqlite_quoted_identifier(
+    chars: &[(usize, char)],
+    i: usize,
+    ch: char,
+) -> Option<usize> {
+    let close = match ch {
+        '`' => '`',
+        '[' => ']',
+        _ => return None,
+    };
+    let mut cursor = i + 1;
+    while cursor < chars.len() {
+        if chars[cursor].1 == close {
+            if close == '`' && next_char_is(chars, cursor, close) {
+                cursor += 2;
+            } else {
+                cursor += 1;
+                break;
+            }
+        } else {
+            cursor += 1;
+        }
+    }
+    Some(cursor)
+}
+
+fn skip_quoted_identifier(chars: &[(usize, char)], i: usize, ch: char) -> Option<usize> {
+    skip_double_quoted_identifier(chars, i, ch)
+        .or_else(|| skip_sqlite_quoted_identifier(chars, i, ch))
+}
+
 pub(crate) fn skip_dollar_quoted_string(
     lower: &str,
     chars: &[(usize, char)],
@@ -413,7 +444,7 @@ fn classify_inner(lower: &str, chars: &[(usize, char)]) -> StatementKind {
             i += 1;
             continue;
         }
-        if let Some(next_i) = skip_double_quoted_identifier(chars, i, ch) {
+        if let Some(next_i) = skip_quoted_identifier(chars, i, ch) {
             i = next_i;
             continue;
         }
@@ -565,7 +596,7 @@ fn scan_for_where(lower: &str, chars: &[(usize, char)], start: usize) -> bool {
             i += 1;
             continue;
         }
-        if let Some(next_i) = skip_double_quoted_identifier(chars, i, ch) {
+        if let Some(next_i) = skip_quoted_identifier(chars, i, ch) {
             i = next_i;
             continue;
         }
@@ -624,9 +655,9 @@ pub(crate) fn collect_top_level_tokens(
             continue;
         }
 
-        if ch == '"' {
+        if matches!(ch, '"' | '`' | '[') {
             let start_i = i;
-            if let Some(next_i) = skip_double_quoted_identifier(chars, i, ch) {
+            if let Some(next_i) = skip_quoted_identifier(chars, i, ch) {
                 if depth == 0 {
                     let start_byte = chars[start_i].0;
                     let end_byte = if next_i < chars.len() {
@@ -678,8 +709,8 @@ pub(crate) fn collect_top_level_tokens(
             i += 1;
             if i < chars.len() {
                 let (next_byte, next_ch) = chars[i];
-                if next_ch == '"' {
-                    if let Some(next_i) = skip_double_quoted_identifier(chars, i, next_ch) {
+                if matches!(next_ch, '"' | '`' | '[') {
+                    if let Some(next_i) = skip_quoted_identifier(chars, i, next_ch) {
                         let end_byte = if next_i < chars.len() {
                             chars[next_i].0
                         } else {
@@ -727,13 +758,18 @@ fn unquote_simple(name: &str) -> String {
 }
 
 fn find_unquoted_dot(name: &str) -> Option<usize> {
-    let mut in_quote = false;
-    for (i, ch) in name.char_indices() {
-        if ch == '"' {
-            in_quote = !in_quote;
-        } else if ch == '.' && !in_quote {
-            return Some(i);
+    let chars: Vec<(usize, char)> = name.char_indices().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let (byte_pos, ch) = chars[i];
+        if let Some(next_i) = skip_quoted_identifier(&chars, i, ch) {
+            i = next_i;
+            continue;
         }
+        if ch == '.' {
+            return Some(byte_pos);
+        }
+        i += 1;
     }
     None
 }
@@ -741,6 +777,10 @@ fn find_unquoted_dot(name: &str) -> Option<usize> {
 fn unquote_single_ident(s: &str) -> String {
     if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
         s[1..s.len() - 1].replace("\"\"", "\"")
+    } else if s.starts_with('`') && s.ends_with('`') && s.len() >= 2 {
+        s[1..s.len() - 1].replace("``", "`")
+    } else if s.starts_with('[') && s.ends_with(']') && s.len() >= 2 {
+        s[1..s.len() - 1].to_string()
     } else {
         s.to_string()
     }
@@ -1241,6 +1281,31 @@ mod tests {
             "UPDATE \"public\".\"MyTable\" SET x = 1",
             StatementKind::Update { has_where: false },
             Some("public.MyTable")
+        )]
+        #[case::delete_backtick_quoted(
+            "DELETE FROM `my table`",
+            StatementKind::Delete { has_where: false },
+            Some("my table")
+        )]
+        #[case::update_bracket_quoted(
+            "UPDATE [select] SET x = 1",
+            StatementKind::Update { has_where: false },
+            Some("select")
+        )]
+        #[case::drop_table_backtick_qualified(
+            "DROP TABLE main.`my.table`",
+            StatementKind::Drop,
+            Some("main.my.table")
+        )]
+        #[case::drop_table_bracket_quoted_dot(
+            "DROP TABLE [main.users]",
+            StatementKind::Drop,
+            Some("main.users")
+        )]
+        #[case::drop_table_bracket_multiple(
+            "DROP TABLE [main.users], other",
+            StatementKind::Drop,
+            None
         )]
         #[case::drop_index("DROP INDEX my_index", StatementKind::Drop, Some("my_index"))]
         #[case::drop_index_if_exists(

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -3,7 +3,8 @@ use crate::domain::DatabaseType;
 use crate::policy::sql::statement_classifier::{
     StatementKind, advance_single_quote, classify, collect_top_level_tokens, drop_subtype,
     extract_target_name, first_keyword, skip_block_comment, skip_dollar_quoted_string,
-    skip_double_quoted_identifier, skip_line_comment, statement_after_leading_ctes,
+    skip_double_quoted_identifier, skip_line_comment, skip_sqlite_quoted_identifier,
+    statement_after_leading_ctes,
 };
 
 // Why the statement cannot be confirmed via typed target name.
@@ -48,7 +49,7 @@ pub enum MultiStatementDecision {
     },
 }
 
-fn contains_cli_meta_command(sql: &str) -> bool {
+fn contains_cli_meta_command(database_type: DatabaseType, sql: &str) -> bool {
     let chars: Vec<(usize, char)> = sql.char_indices().collect();
     let mut i = 0;
     let mut in_string = false;
@@ -96,6 +97,13 @@ fn contains_cli_meta_command(sql: &str) -> bool {
             i = next_i;
             continue;
         }
+        if database_type == DatabaseType::SQLite
+            && let Some(next_i) = skip_sqlite_quoted_identifier(&chars, i, ch)
+        {
+            line_leading = false;
+            i = next_i;
+            continue;
+        }
         if let Some(next_i) = skip_dollar_quoted_string(sql, &chars, i, byte_pos, ch) {
             line_leading = false;
             i = next_i;
@@ -114,6 +122,10 @@ fn contains_cli_meta_command(sql: &str) -> bool {
 }
 
 pub fn split_statements(sql: &str) -> Vec<String> {
+    split_statements_for_database(DatabaseType::PostgreSQL, sql)
+}
+
+pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> Vec<String> {
     // Use sql's own char_indices so byte offsets remain valid for slicing sql.
     // to_lowercase() can change byte lengths (e.g. İ → i̇), which would corrupt offsets.
     let chars: Vec<(usize, char)> = sql.char_indices().collect();
@@ -143,6 +155,12 @@ pub fn split_statements(sql: &str) -> Vec<String> {
             continue;
         }
         if let Some(next_i) = skip_double_quoted_identifier(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if database_type == DatabaseType::SQLite
+            && let Some(next_i) = skip_sqlite_quoted_identifier(&chars, i, ch)
+        {
             i = next_i;
             continue;
         }
@@ -310,13 +328,13 @@ pub fn evaluate_multi_statement_for_database(
     database_type: DatabaseType,
     sql: &str,
 ) -> MultiStatementDecision {
-    if contains_cli_meta_command(sql) {
+    if contains_cli_meta_command(database_type, sql) {
         return MultiStatementDecision::Block {
             reason: "CLI meta-commands are not supported in SQL input".to_string(),
         };
     }
 
-    let statements = split_statements(sql);
+    let statements = split_statements_for_database(database_type, sql);
 
     if statements.is_empty() {
         return MultiStatementDecision::Block {
@@ -555,6 +573,10 @@ fn top_level_char_index(sql: &str, target: char) -> Option<usize> {
             i = next_i;
             continue;
         }
+        if let Some(next_i) = skip_sqlite_quoted_identifier(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
         if let Some(next_i) = skip_dollar_quoted_string(sql, &chars, i, byte_pos, ch) {
             i = next_i;
             continue;
@@ -713,6 +735,49 @@ mod tests {
         #[case::tagged_dollar_quote("SELECT $tag$a;b$tag$", vec!["SELECT $tag$a;b$tag$"])]
         fn semicolon_in_strings(#[case] sql: &str, #[case] expected: Vec<&str>) {
             assert_eq!(split_statements(sql), expected);
+        }
+
+        #[rstest]
+        #[case::bracket_quote(
+            "DROP TABLE [a;b]; SELECT 1",
+            vec!["DROP TABLE [a", "b]", "SELECT 1"]
+        )]
+        #[case::backtick_quote(
+            "DROP TABLE `a;b`; SELECT 1",
+            vec!["DROP TABLE `a", "b`", "SELECT 1"]
+        )]
+        #[case::bracket_contains_drop(
+            "SELECT [1; DROP TABLE users]",
+            vec!["SELECT [1", "DROP TABLE users]"]
+        )]
+        #[case::backtick_contains_drop(
+            "SELECT `1; DROP TABLE users`",
+            vec!["SELECT `1", "DROP TABLE users`"]
+        )]
+        fn postgres_brackets_and_backticks_do_not_hide_semicolons(
+            #[case] sql: &str,
+            #[case] expected: Vec<&str>,
+        ) {
+            assert_eq!(split_statements(sql), expected);
+        }
+
+        #[rstest]
+        #[case::backtick_quote(
+            "DROP TABLE `a;b`; SELECT 1",
+            vec!["DROP TABLE `a;b`", "SELECT 1"]
+        )]
+        #[case::bracket_quote(
+            "DROP TABLE [a;b]; SELECT 1",
+            vec!["DROP TABLE [a;b]", "SELECT 1"]
+        )]
+        fn sqlite_identifier_quotes_hide_semicolons(
+            #[case] sql: &str,
+            #[case] expected: Vec<&str>,
+        ) {
+            assert_eq!(
+                split_statements_for_database(DatabaseType::SQLite, sql),
+                expected
+            );
         }
 
         #[rstest]
@@ -1199,6 +1264,8 @@ mod tests {
         #[case::sqlite_open_after_select("SELECT 1;\n.open writable.db")]
         #[case::psql_shell("\\! echo injected")]
         #[case::indented_meta_command("  .output /tmp/out.csv")]
+        #[case::psql_backslash_inside_bracket_identifier("SELECT [\n\\! echo injected\n]")]
+        #[case::psql_backslash_inside_backtick_identifier("SELECT `\n\\! echo injected\n`")]
         fn cli_meta_commands_are_blocked(#[case] sql: &str) {
             let result = evaluate_multi_statement(sql);
 
@@ -1220,6 +1287,60 @@ mod tests {
             let result = evaluate_multi_statement(sql);
 
             assert!(matches!(result, MultiStatementDecision::Allow { .. }));
+        }
+
+        #[rstest]
+        #[case::dot_inside_bracket_identifier("SELECT [\n.shell ignored] FROM t")]
+        #[case::backslash_inside_backtick_identifier("SELECT `\n\\! ignored` FROM t")]
+        fn sqlite_cli_meta_command_like_identifier_text_is_allowed(#[case] sql: &str) {
+            let result = evaluate_multi_statement_for_database(DatabaseType::SQLite, sql);
+
+            assert!(matches!(result, MultiStatementDecision::Allow { .. }));
+        }
+
+        #[rstest]
+        #[case::bracket_contains_drop("SELECT [1; DROP TABLE users]", "users")]
+        #[case::backtick_contains_drop("SELECT `1; DROP TABLE users`", "users")]
+        fn postgres_brackets_and_backticks_do_not_hide_dangerous_statements(
+            #[case] sql: &str,
+            #[case] expected_target: &str,
+        ) {
+            let result = evaluate_multi_statement(sql);
+
+            match result {
+                MultiStatementDecision::Allow { statements, risk } => {
+                    assert_eq!(statements.len(), 2);
+                    assert_eq!(risk.risk_level, RiskLevel::High);
+                    assert!(matches!(
+                        risk.confirmation,
+                        ConfirmationType::TableNameInput { ref target } if target == expected_target
+                    ));
+                }
+                _ => panic!("expected Allow"),
+            }
+        }
+
+        #[rstest]
+        #[case::update_backtick_where_identifier("UPDATE `where` SET x = 1", "where")]
+        #[case::delete_bracket_quoted_dot("DELETE FROM [main.users]", "main.users")]
+        #[case::drop_table_backtick_qualified("DROP TABLE main.`my.table`", "main.my.table")]
+        #[case::drop_table_bracket_reserved_word("DROP TABLE [select]", "select")]
+        fn sqlite_quoted_targets_require_table_name_input(
+            #[case] sql: &str,
+            #[case] expected_target: &str,
+        ) {
+            let result = evaluate_multi_statement_for_database(DatabaseType::SQLite, sql);
+
+            match result {
+                MultiStatementDecision::Allow { risk, .. } => {
+                    assert_eq!(risk.risk_level, RiskLevel::High);
+                    assert!(matches!(
+                        risk.confirmation,
+                        ConfirmationType::TableNameInput { ref target } if target == expected_target
+                    ));
+                }
+                _ => panic!("expected Allow"),
+            }
         }
 
         #[test]

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -36,7 +36,8 @@ pub(super) fn reduce_analyze(
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {
                 return DispatchResult::handled();
             }
-            if is_multi_statement(&content) {
+            let database_type = state.session.active_database_type_or_default();
+            if is_multi_statement(database_type, &content) {
                 show_explain_error_on_plan(
                     state,
                     "EXPLAIN ANALYZE does not support multiple statements",
@@ -44,7 +45,6 @@ pub(super) fn reduce_analyze(
                 return DispatchResult::handled();
             }
             let kind = statement_classifier::classify(&content);
-            let database_type = state.session.active_database_type_or_default();
             let risk = evaluate_sql_risk_for_database(database_type, &kind, &content);
 
             if state.session.is_read_only() && !risk.read_only_allowed {

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -1,11 +1,12 @@
 use std::time::Instant;
 
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::sql_editor::modal::SqlModalTab;
-use crate::policy::write::sql_risk::split_statements;
+use crate::policy::write::sql_risk::split_statements_for_database;
 
-pub(super) fn is_multi_statement(content: &str) -> bool {
-    split_statements(content).len() > 1
+pub(super) fn is_multi_statement(database_type: DatabaseType, content: &str) -> bool {
+    split_statements_for_database(database_type, content).len() > 1
 }
 
 pub(super) fn mark_explain_unavailable(state: &mut AppState) {

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -34,12 +34,12 @@ pub(super) fn reduce_request(
             if matches!(state.sql_modal.status(), SqlModalStatus::Running) {
                 return DispatchResult::handled();
             }
-            if is_multi_statement(&content) {
+            let database_type = state.session.active_database_type_or_default();
+            if is_multi_statement(database_type, &content) {
                 show_explain_error_on_plan(state, "EXPLAIN does not support multiple statements");
                 return DispatchResult::handled();
             }
 
-            let database_type = state.session.active_database_type_or_default();
             let Some(query) = services
                 .sql_dialect
                 .build_explain_sql(database_type, &content)

--- a/src/app/update/sql_editor/submit.rs
+++ b/src/app/update/sql_editor/submit.rs
@@ -6,7 +6,7 @@ use crate::model::shared::text_input::TextInputLike;
 use crate::policy::sql::statement_classifier;
 use crate::policy::write::sql_risk::{
     ConfirmationType, MultiStatementDecision, evaluate_multi_statement_for_database,
-    sqlite_specific_label,
+    split_statements_for_database, sqlite_specific_label,
 };
 use crate::policy::write::write_guardrails::{AdhocRiskDecision, RiskLevel, evaluate_sql_risk};
 use crate::update::action::Action;
@@ -15,10 +15,9 @@ use crate::update::dispatch_result::DispatchResult;
 use super::helpers::start_adhoc_if_connected;
 
 fn multi_statement_label(database_type: DatabaseType, sql: &str) -> &'static str {
-    use crate::policy::write::sql_risk::split_statements;
     let mut worst_level = RiskLevel::Low;
     let mut worst_label = "SQL";
-    for stmt in split_statements(sql) {
+    for stmt in split_statements_for_database(database_type, sql) {
         let sqlite_label = (database_type == DatabaseType::SQLite)
             .then(|| sqlite_specific_label(&stmt))
             .flatten();


### PR DESCRIPTION
## Problem

SQLite quoted identifiers using backticks or brackets could be misread when extracting the target name for destructive SQL confirmation.

## Background

SQLite allows identifiers such as `[my table]` and `main.\`my.table\``, so treating only double-quoted identifiers as quoted can make confirmation prompts disagree with the actual SQL target.

## Approach

Extend SQL risk parsing to treat SQLite backtick and bracket identifiers as quoted during target extraction, statement splitting, and CLI meta-command detection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * データベース種別ごとに SQL の複数文判定や文分割を行うようになり、SQLite の引用識別子にも対応しました。
  * SQL エディタで、文ごとのリスク判定がより正確になりました。

* **Bug Fixes**
  * バッククォートや角括弧で囲まれた識別子内の区切り文字やセミコロンを誤認識しにくくなりました。
  * `WHERE` 句や対象名の抽出で、引用符付き識別子の解析精度が向上しました。

* **Tests**
  * SQLite / PostgreSQL を含む複数の SQL パターンの検証ケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->