### PR TITLE
fix(app): gate SQLite DROP INDEX/VIEW/TRIGGER behind high-risk confirmation

### DIFF
--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -460,6 +460,28 @@ fn top_level_token_lowers(sql: &str) -> Vec<String> {
         .collect()
 }
 
+fn sqlite_drop_label(sql: &str) -> Option<&'static str> {
+    match drop_subtype(sql).as_deref()? {
+        "index" => Some("DROP INDEX"),
+        "view" => Some("DROP VIEW"),
+        "trigger" => Some("DROP TRIGGER"),
+        _ => None,
+    }
+}
+
+fn sqlite_drop_risk(sql: &str) -> Option<SqlRiskDecision> {
+    sqlite_drop_label(sql)?;
+    let kind = StatementKind::Drop;
+    Some(match extract_target_name(sql, &kind) {
+        Some(target) => SqlRiskDecision {
+            risk_level: RiskLevel::High,
+            confirmation: ConfirmationType::TableNameInput { target },
+            read_only_allowed: false,
+        },
+        None => high_acknowledge_label(sqlite_drop_label(sql).unwrap_or("DROP")),
+    })
+}
+
 pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
     let effective = statement_after_leading_ctes(sql);
     let tokens = top_level_token_lowers(effective);
@@ -472,6 +494,7 @@ pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
         "analyze" => Some("ANALYZE"),
         "replace" => Some("REPLACE"),
         "insert" if sqlite_replace_target_in_statement(effective).is_some() => Some("REPLACE"),
+        "drop" => sqlite_drop_label(effective),
         _ => None,
     }
 }
@@ -706,6 +729,7 @@ fn evaluate_sqlite_specific_risk(sql: &str) -> Option<SqlRiskDecision> {
             confirmation: ConfirmationType::TableNameInput { target },
             read_only_allowed: false,
         }),
+        "drop" => sqlite_drop_risk(effective),
         _ => None,
     }
 }
@@ -1142,6 +1166,70 @@ mod tests {
 
             assert_eq!(sqlite_specific_label(sql), Some("REPLACE"));
         }
+
+        #[rstest]
+        #[case::drop_index("DROP INDEX my_index", "DROP INDEX")]
+        #[case::drop_index_if_exists("DROP INDEX IF EXISTS my_index", "DROP INDEX")]
+        #[case::drop_view("DROP VIEW my_view", "DROP VIEW")]
+        #[case::drop_view_if_exists("DROP VIEW IF EXISTS my_view", "DROP VIEW")]
+        #[case::drop_trigger("DROP TRIGGER my_trigger", "DROP TRIGGER")]
+        #[case::drop_trigger_if_exists("DROP TRIGGER IF EXISTS my_trigger", "DROP TRIGGER")]
+        fn sqlite_specific_label_detects_dangerous_drops(
+            #[case] sql: &str,
+            #[case] expected: &str,
+        ) {
+            assert_eq!(sqlite_specific_label(sql), Some(expected));
+        }
+
+        #[rstest]
+        #[case::drop_index("DROP INDEX my_index", "my_index")]
+        #[case::drop_index_if_exists("DROP INDEX IF EXISTS my_index", "my_index")]
+        #[case::drop_view("DROP VIEW my_view", "my_view")]
+        #[case::drop_view_if_exists("DROP VIEW IF EXISTS my_view", "my_view")]
+        #[case::drop_trigger("DROP TRIGGER my_trigger", "my_trigger")]
+        #[case::drop_trigger_if_exists("DROP TRIGGER IF EXISTS main.my_trigger", "main.my_trigger")]
+        #[case::drop_index_quoted("DROP INDEX `my index`", "my index")]
+        #[case::drop_view_quoted(r#"DROP VIEW "my view""#, "my view")]
+        #[case::drop_trigger_quoted("DROP TRIGGER [my trigger]", "my trigger")]
+        fn sqlite_dangerous_drop_requires_table_name_input(
+            #[case] sql: &str,
+            #[case] expected_target: &str,
+        ) {
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::High);
+            assert!(!result.read_only_allowed);
+            assert!(matches!(
+                result.confirmation,
+                ConfirmationType::TableNameInput { ref target } if target == expected_target
+            ));
+        }
+
+        #[rstest]
+        #[case::drop_policy("DROP POLICY p ON t")]
+        #[case::drop_schema("DROP SCHEMA s")]
+        fn sqlite_non_dangerous_drop_returns_low_immediate(#[case] sql: &str) {
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::Low);
+            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+        }
+
+        #[test]
+        fn sqlite_drop_multiple_index_requires_acknowledgment() {
+            let sql = "DROP INDEX a, b";
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::High);
+            assert!(!result.read_only_allowed);
+            assert!(matches!(
+                result.confirmation,
+                ConfirmationType::Acknowledge {
+                    reason: AcknowledgeReason::TargetNameUnavailable,
+                    ref label,
+                } if label == "DROP INDEX"
+            ));
+        }
     }
 
     mod evaluate_multi_statement_tests {
@@ -1475,12 +1563,31 @@ mod tests {
         }
 
         #[test]
-        fn drop_index_returns_low_immediate() {
+        fn drop_index_returns_low_immediate_for_postgres() {
             let result = evaluate_multi_statement("DROP INDEX my_index");
             match result {
                 MultiStatementDecision::Allow { risk, .. } => {
                     assert_eq!(risk.risk_level, RiskLevel::Low);
                     assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                }
+                _ => panic!("expected Allow"),
+            }
+        }
+
+        #[test]
+        fn sqlite_drop_index_requires_table_name_input() {
+            let result = evaluate_multi_statement_for_database(
+                DatabaseType::SQLite,
+                "DROP INDEX IF EXISTS my_index",
+            );
+            match result {
+                MultiStatementDecision::Allow { risk, .. } => {
+                    assert_eq!(risk.risk_level, RiskLevel::High);
+                    assert!(!risk.read_only_allowed);
+                    assert!(matches!(
+                        risk.confirmation,
+                        ConfirmationType::TableNameInput { ref target } if target == "my_index"
+                    ));
                 }
                 _ => panic!("expected Allow"),
             }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -499,6 +499,32 @@ pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
     }
 }
 
+pub fn adhoc_label_for_statement(database_type: DatabaseType, sql: &str) -> &'static str {
+    let sqlite_label = (database_type == DatabaseType::SQLite)
+        .then(|| sqlite_specific_label(sql))
+        .flatten();
+    let kind = classify(sql);
+    let decision = write_guardrails::evaluate_sql_risk(&kind);
+    sqlite_label.unwrap_or(decision.label)
+}
+
+pub fn adhoc_label_for_table_name_confirmation(
+    database_type: DatabaseType,
+    sql: &str,
+) -> Option<&'static str> {
+    for stmt in split_statements_for_database(database_type, sql) {
+        let kind = classify(&stmt);
+        let decision = evaluate_sql_risk_for_database(database_type, &kind, &stmt);
+        if matches!(
+            decision.confirmation,
+            ConfirmationType::TableNameInput { .. }
+        ) {
+            return Some(adhoc_label_for_statement(database_type, &stmt));
+        }
+    }
+    None
+}
+
 fn skip_whitespace(sql: &str, mut cursor: usize) -> usize {
     while cursor < sql.len() {
         let Some(ch) = sql[cursor..].chars().next() else {
@@ -1592,6 +1618,15 @@ mod tests {
                 }
                 _ => panic!("expected Allow"),
             }
+        }
+
+        #[test]
+        fn sqlite_table_name_confirmation_label_matches_first_target_statement() {
+            let sql = "DROP INDEX my_index; DROP VIEW my_view";
+            assert_eq!(
+                adhoc_label_for_table_name_confirmation(DatabaseType::SQLite, sql),
+                Some("DROP INDEX")
+            );
         }
 
         #[test]

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -470,7 +470,7 @@ fn sqlite_drop_label(sql: &str) -> Option<&'static str> {
 }
 
 fn sqlite_drop_risk(sql: &str) -> Option<SqlRiskDecision> {
-    sqlite_drop_label(sql)?;
+    let label = sqlite_drop_label(sql)?;
     let kind = StatementKind::Drop;
     Some(match extract_target_name(sql, &kind) {
         Some(target) => SqlRiskDecision {
@@ -478,7 +478,7 @@ fn sqlite_drop_risk(sql: &str) -> Option<SqlRiskDecision> {
             confirmation: ConfirmationType::TableNameInput { target },
             read_only_allowed: false,
         },
-        None => high_acknowledge_label(sqlite_drop_label(sql).unwrap_or("DROP")),
+        None => high_acknowledge_label(label),
     })
 }
 
@@ -1208,7 +1208,7 @@ mod tests {
         #[rstest]
         #[case::drop_policy("DROP POLICY p ON t")]
         #[case::drop_schema("DROP SCHEMA s")]
-        fn sqlite_non_dangerous_drop_returns_low_immediate(#[case] sql: &str) {
+        fn sqlite_unhandled_drop_subtypes_fall_back_to_generic_low_immediate(#[case] sql: &str) {
             let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
 
             assert_eq!(result.risk_level, RiskLevel::Low);
@@ -1569,6 +1569,26 @@ mod tests {
                 MultiStatementDecision::Allow { risk, .. } => {
                     assert_eq!(risk.risk_level, RiskLevel::Low);
                     assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                }
+                _ => panic!("expected Allow"),
+            }
+        }
+
+        #[test]
+        fn sqlite_multiple_high_drops_use_first_target() {
+            let result = evaluate_multi_statement_for_database(
+                DatabaseType::SQLite,
+                "DROP INDEX my_index; DROP VIEW my_view",
+            );
+            match result {
+                MultiStatementDecision::Allow { statements, risk } => {
+                    assert_eq!(statements, vec!["DROP INDEX my_index", "DROP VIEW my_view"]);
+                    assert_eq!(risk.risk_level, RiskLevel::High);
+                    assert!(!risk.read_only_allowed);
+                    assert!(matches!(
+                        risk.confirmation,
+                        ConfirmationType::TableNameInput { ref target } if target == "my_index"
+                    ));
                 }
                 _ => panic!("expected Allow"),
             }

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -602,6 +602,27 @@ mod tests {
         }
 
         #[test]
+        fn sqlite_submit_multi_drop_pairs_label_with_first_target() {
+            let mut state = sql_modal_state();
+            activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
+            state
+                .sql_modal
+                .editor
+                .set_content("DROP INDEX my_index; DROP VIEW my_view".to_string());
+
+            reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
+
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::ConfirmingHigh {
+                    decision,
+                    target_name,
+                    ..
+                } if decision.label == "DROP INDEX" && target_name == "my_index"
+            ));
+        }
+
+        #[test]
         fn high_risk_confirm_matches_full_name_not_truncated() {
             let full_name = "my_schema.very_long_table_name";
             let mut state = confirming_high_state(&format!("DROP TABLE {full_name}"), full_name);

--- a/src/app/update/sql_editor/submit.rs
+++ b/src/app/update/sql_editor/submit.rs
@@ -1,36 +1,17 @@
 use std::time::Instant;
 
-use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
-use crate::policy::sql::statement_classifier;
 use crate::policy::write::sql_risk::{
-    ConfirmationType, MultiStatementDecision, evaluate_multi_statement_for_database,
-    split_statements_for_database, sqlite_specific_label,
+    ConfirmationType, MultiStatementDecision, adhoc_label_for_table_name_confirmation,
+    evaluate_multi_statement_for_database,
 };
-use crate::policy::write::write_guardrails::{AdhocRiskDecision, RiskLevel, evaluate_sql_risk};
+use crate::policy::write::write_guardrails::AdhocRiskDecision;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::start_adhoc_if_connected;
 
-fn multi_statement_label(database_type: DatabaseType, sql: &str) -> &'static str {
-    let mut worst_level = RiskLevel::Low;
-    let mut worst_label = "SQL";
-    for stmt in split_statements_for_database(database_type, sql) {
-        let sqlite_label = (database_type == DatabaseType::SQLite)
-            .then(|| sqlite_specific_label(&stmt))
-            .flatten();
-        let kind = statement_classifier::classify(&stmt);
-        let d = evaluate_sql_risk(&kind);
-        let label = sqlite_label.unwrap_or(d.label);
-        if d.risk_level > worst_level || (d.risk_level == worst_level && label != "SQL") {
-            worst_level = d.risk_level;
-            worst_label = label;
-        }
-    }
-    worst_label
-}
 pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::SqlModalSubmit => {
@@ -48,11 +29,6 @@ pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant)
                     DispatchResult::handled()
                 }
                 MultiStatementDecision::Allow { risk, .. } => {
-                    let label = multi_statement_label(database_type, &query);
-                    let decision = AdhocRiskDecision {
-                        risk_level: risk.risk_level,
-                        label,
-                    };
                     if state.session.is_read_only() && !risk.read_only_allowed {
                         state.sql_modal.finish_adhoc_error(
                             "Read-only mode: write operations are disabled".to_string(),
@@ -66,6 +42,15 @@ pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant)
                             DispatchResult::handled()
                         }
                         ConfirmationType::TableNameInput { target } => {
+                            let label = adhoc_label_for_table_name_confirmation(
+                                database_type,
+                                &query,
+                            )
+                            .expect("TableNameInput confirmation must have a matching statement");
+                            let decision = AdhocRiskDecision {
+                                risk_level: risk.risk_level,
+                                label,
+                            };
                             state.sql_modal.begin_confirming_high(decision, target);
                             DispatchResult::handled()
                         }


### PR DESCRIPTION
## Problem

SQLite DROP INDEX, DROP VIEW, and DROP TRIGGER remove persistent database objects but were treated as low-risk statements, so users could execute them without typed-name confirmation.

## Background

Follow-up to the SQLite write-guardrail work under SAB-206. DROP TABLE already required high-risk confirmation; other destructive DROP variants did not.

## Approach

Extend SQLite-specific SQL risk evaluation so DROP INDEX, DROP VIEW, and DROP TRIGGER require high-risk confirmation with typed target names, including IF EXISTS forms. Surface the object kind in the confirmation label while PostgreSQL behavior stays unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * SQLiteで`DROP INDEX`、`DROP VIEW`、`DROP TRIGGER`の操作をより細かく判定し、適切な警告ラベルと確認ダイアログを表示するようになりました。
  * 複数のSQL文が含まれる場合でも、最初の危険な`DROP`対象に基づいて確認内容が選ばれます。

* **バグ修正**
  * `DROP INDEX IF EXISTS`や複数対象の`DROP`でも、対象名の入力確認が正しく求められるようになりました。
  * 未対応の`DROP`形式でも、安全側の判定にフォールバックするよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->