### PR TITLE
fix: compare SQLite JSON-like TEXT as raw strings, not JSONB

### DIFF
--- a/src/app/model/browse/cell_edit.rs
+++ b/src/app/model/browse/cell_edit.rs
@@ -1,11 +1,12 @@
+use crate::model::shared::cursor::CursorMove;
 use crate::model::shared::text_input::TextInputState;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CellEditState {
-    pub(crate) row: Option<usize>,
-    pub(crate) col: Option<usize>,
-    pub(crate) original_value: String,
-    pub(crate) input: TextInputState,
+    row: Option<usize>,
+    col: Option<usize>,
+    original_value: String,
+    input: TextInputState,
 }
 
 impl CellEditState {
@@ -36,8 +37,32 @@ impl CellEditState {
         &self.input
     }
 
-    pub fn input_mut(&mut self) -> &mut TextInputState {
-        &mut self.input
+    pub fn insert_char(&mut self, ch: char) {
+        self.input.insert_char(ch);
+    }
+
+    pub fn insert_str(&mut self, text: &str) {
+        self.input.insert_str(text);
+    }
+
+    pub fn backspace(&mut self) {
+        self.input.backspace();
+    }
+
+    pub fn delete(&mut self) {
+        self.input.delete();
+    }
+
+    pub fn move_cursor(&mut self, direction: CursorMove) {
+        self.input.move_cursor(direction);
+    }
+
+    pub fn set_content(&mut self, content: String) {
+        self.input.set_content(content);
+    }
+
+    pub fn set_cursor(&mut self, cursor: usize) {
+        self.input.set_cursor(cursor);
     }
 
     pub fn has_pending_draft(&self) -> bool {
@@ -54,6 +79,15 @@ impl CellEditState {
         self.original_value.clear();
         self.input.clear();
     }
+
+    #[cfg(test)]
+    pub(crate) fn with_selection_for_test(row: Option<usize>, col: Option<usize>) -> Self {
+        Self {
+            row,
+            col,
+            ..Default::default()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -67,9 +101,9 @@ mod tests {
 
         state.begin(3, 5, "Alice".to_string());
 
-        assert_eq!(state.row, Some(3));
-        assert_eq!(state.col, Some(5));
-        assert_eq!(state.original_value, "Alice");
+        assert_eq!(state.row(), Some(3));
+        assert_eq!(state.col(), Some(5));
+        assert_eq!(state.original_value(), "Alice");
         assert_eq!(state.draft_value(), "Alice");
         assert_eq!(state.input.cursor(), 5); // cursor at end
         assert!(state.is_active());
@@ -77,24 +111,14 @@ mod tests {
 
     #[test]
     fn only_row_selected_returns_inactive() {
-        let state = CellEditState {
-            row: Some(1),
-            col: None,
-            original_value: String::new(),
-            input: TextInputState::default(),
-        };
+        let state = CellEditState::with_selection_for_test(Some(1), None);
 
         assert!(!state.is_active());
     }
 
     #[test]
     fn only_col_selected_returns_inactive() {
-        let state = CellEditState {
-            row: None,
-            col: Some(1),
-            original_value: String::new(),
-            input: TextInputState::default(),
-        };
+        let state = CellEditState::with_selection_for_test(None, Some(1));
 
         assert!(!state.is_active());
     }
@@ -111,7 +135,7 @@ mod tests {
     fn has_pending_draft_returns_true_when_draft_differs() {
         let mut state = CellEditState::default();
         state.begin(0, 0, "Alice".to_string());
-        state.input.set_content("Bob".to_string());
+        state.set_content("Bob".to_string());
 
         assert!(state.has_pending_draft());
     }
@@ -127,13 +151,13 @@ mod tests {
     fn clear_after_begin_resets_all_fields() {
         let mut state = CellEditState::default();
         state.begin(1, 2, "Before".to_string());
-        state.input.set_content("After".to_string());
+        state.set_content("After".to_string());
 
         state.clear();
 
-        assert_eq!(state.row, None);
-        assert_eq!(state.col, None);
-        assert_eq!(state.original_value, "");
+        assert_eq!(state.row(), None);
+        assert_eq!(state.col(), None);
+        assert_eq!(state.original_value(), "");
         assert_eq!(state.draft_value(), "");
         assert!(!state.is_active());
     }
@@ -143,12 +167,12 @@ mod tests {
         let mut state = CellEditState::default();
         state.begin(0, 0, "hello".to_string());
 
-        state.input.move_cursor(CursorMove::Home);
-        assert_eq!(state.input.cursor(), 0);
+        state.move_cursor(CursorMove::Home);
+        assert_eq!(state.input().cursor(), 0);
 
-        state.input.insert_char('X');
+        state.insert_char('X');
         assert_eq!(state.draft_value(), "Xhello");
-        assert_eq!(state.input.cursor(), 1);
+        assert_eq!(state.input().cursor(), 1);
     }
 
     #[test]
@@ -156,12 +180,12 @@ mod tests {
         let mut state = CellEditState::default();
         state.begin(0, 0, "abcd".to_string());
 
-        state.input.move_cursor(CursorMove::Left);
-        state.input.move_cursor(CursorMove::Left);
-        state.input.backspace();
+        state.move_cursor(CursorMove::Left);
+        state.move_cursor(CursorMove::Left);
+        state.backspace();
 
         assert_eq!(state.draft_value(), "acd");
-        assert_eq!(state.input.cursor(), 1);
+        assert_eq!(state.input().cursor(), 1);
     }
 
     #[test]
@@ -169,10 +193,10 @@ mod tests {
         let mut state = CellEditState::default();
         state.begin(0, 0, "abcd".to_string());
 
-        state.input.move_cursor(CursorMove::Home);
-        state.input.delete();
+        state.move_cursor(CursorMove::Home);
+        state.delete();
 
         assert_eq!(state.draft_value(), "bcd");
-        assert_eq!(state.input.cursor(), 0);
+        assert_eq!(state.input().cursor(), 0);
     }
 }

--- a/src/app/model/browse/cell_edit.rs
+++ b/src/app/model/browse/cell_edit.rs
@@ -79,15 +79,6 @@ impl CellEditState {
         self.original_value.clear();
         self.input.clear();
     }
-
-    #[cfg(test)]
-    pub(crate) fn with_selection_for_test(row: Option<usize>, col: Option<usize>) -> Self {
-        Self {
-            row,
-            col,
-            ..Default::default()
-        }
-    }
 }
 
 #[cfg(test)]
@@ -110,17 +101,12 @@ mod tests {
     }
 
     #[test]
-    fn only_row_selected_returns_inactive() {
-        let state = CellEditState::with_selection_for_test(Some(1), None);
+    fn is_active_requires_both_row_and_col() {
+        assert!(!CellEditState::default().is_active());
 
-        assert!(!state.is_active());
-    }
-
-    #[test]
-    fn only_col_selected_returns_inactive() {
-        let state = CellEditState::with_selection_for_test(None, Some(1));
-
-        assert!(!state.is_active());
+        let mut state = CellEditState::default();
+        state.begin(1, 2, "Alice".to_string());
+        assert!(state.is_active());
     }
 
     #[test]

--- a/src/app/model/browse/cell_edit.rs
+++ b/src/app/model/browse/cell_edit.rs
@@ -57,7 +57,7 @@ impl CellEditState {
         self.input.move_cursor(direction);
     }
 
-    pub fn set_content(&mut self, content: String) {
+    pub fn replace_draft(&mut self, content: String) {
         self.input.set_content(content);
     }
 
@@ -135,7 +135,7 @@ mod tests {
     fn has_pending_draft_returns_true_when_draft_differs() {
         let mut state = CellEditState::default();
         state.begin(0, 0, "Alice".to_string());
-        state.set_content("Bob".to_string());
+        state.replace_draft("Bob".to_string());
 
         assert!(state.has_pending_draft());
     }
@@ -151,7 +151,7 @@ mod tests {
     fn clear_after_begin_resets_all_fields() {
         let mut state = CellEditState::default();
         state.begin(1, 2, "Before".to_string());
-        state.set_content("After".to_string());
+        state.replace_draft("After".to_string());
 
         state.clear();
 

--- a/src/app/model/browse/result_interaction.rs
+++ b/src/app/model/browse/result_interaction.rs
@@ -100,18 +100,22 @@ impl ResultInteraction {
 
     pub fn cell_edit_insert_char(&mut self, ch: char) {
         self.cell_edit.insert_char(ch);
+        self.clear_write_preview();
     }
 
     pub fn cell_edit_insert_str(&mut self, text: &str) {
         self.cell_edit.insert_str(text);
+        self.clear_write_preview();
     }
 
     pub fn cell_edit_backspace(&mut self) {
         self.cell_edit.backspace();
+        self.clear_write_preview();
     }
 
     pub fn cell_edit_delete(&mut self) {
         self.cell_edit.delete();
+        self.clear_write_preview();
     }
 
     pub fn cell_edit_move_cursor(&mut self, direction: CursorMove) {
@@ -120,6 +124,7 @@ impl ResultInteraction {
 
     pub fn replace_cell_edit_draft(&mut self, content: String) {
         self.cell_edit.replace_draft(content);
+        self.clear_write_preview();
     }
 
     pub fn cell_edit_set_cursor(&mut self, cursor: usize) {
@@ -264,13 +269,25 @@ mod tests {
         let mut ri = ResultInteraction::default();
         ri.activate_cell(2, 4);
         ri.begin_cell_edit(2, 4, "val".to_string());
-        ri.set_write_preview(test_preview());
         ri.replace_cell_edit_draft("changed".to_string());
+        ri.set_write_preview(test_preview());
 
         ri.leave_cell_edit();
 
         assert!(ri.cell_edit().is_active());
         assert_eq!(ri.cell_edit().draft_value(), "changed");
+        assert!(ri.pending_write_preview().is_none());
+    }
+
+    #[test]
+    fn cell_edit_mutation_clears_stale_write_preview() {
+        let mut ri = ResultInteraction::default();
+        ri.begin_cell_edit(0, 0, "val".to_string());
+        ri.set_write_preview(test_preview());
+
+        ri.cell_edit_insert_char('x');
+
+        assert_eq!(ri.cell_edit().draft_value(), "valx");
         assert!(ri.pending_write_preview().is_none());
     }
 

--- a/src/app/model/browse/result_interaction.rs
+++ b/src/app/model/browse/result_interaction.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::time::Instant;
 
 use super::cell_edit::CellEditState;
-use crate::model::shared::text_input::TextInputState;
+use crate::model::shared::cursor::CursorMove;
 use crate::model::shared::ui_state::{ResultSelection, YankFlash};
 use crate::policy::write::write_guardrails::WritePreview;
 
@@ -91,8 +91,47 @@ impl ResultInteraction {
         self.cell_edit.begin(row, col, value);
     }
 
-    pub fn cell_edit_input_mut(&mut self) -> &mut TextInputState {
-        self.cell_edit.input_mut()
+    pub fn ensure_cell_edit_at(&mut self, row: usize, col: usize, value: String) {
+        if self.cell_edit.row() != Some(row) || self.cell_edit.col() != Some(col) {
+            self.begin_cell_edit(row, col, value);
+            self.clear_write_preview();
+        }
+    }
+
+    pub fn cell_edit_insert_char(&mut self, ch: char) {
+        self.cell_edit.insert_char(ch);
+    }
+
+    pub fn cell_edit_insert_str(&mut self, text: &str) {
+        self.cell_edit.insert_str(text);
+    }
+
+    pub fn cell_edit_backspace(&mut self) {
+        self.cell_edit.backspace();
+    }
+
+    pub fn cell_edit_delete(&mut self) {
+        self.cell_edit.delete();
+    }
+
+    pub fn cell_edit_move_cursor(&mut self, direction: CursorMove) {
+        self.cell_edit.move_cursor(direction);
+    }
+
+    pub fn cell_edit_set_content(&mut self, content: String) {
+        self.cell_edit.set_content(content);
+    }
+
+    pub fn cell_edit_set_cursor(&mut self, cursor: usize) {
+        self.cell_edit.set_cursor(cursor);
+    }
+
+    pub fn cancel_cell_edit(&mut self) {
+        if self.cell_edit.has_pending_draft() {
+            self.clear_write_preview();
+        } else {
+            self.discard_cell_edit();
+        }
     }
 
     pub fn clear_cell_edit(&mut self) {
@@ -218,6 +257,32 @@ mod tests {
         assert_eq!(ri.horizontal_offset, 5);
         assert_eq!(ri.selection().mode(), ResultNavMode::Scroll);
         assert!(ri.staged_delete_rows().is_empty());
+    }
+
+    #[test]
+    fn cancel_cell_edit_preserves_draft_when_changed() {
+        let mut ri = ResultInteraction::default();
+        ri.activate_cell(2, 4);
+        ri.begin_cell_edit(2, 4, "val".to_string());
+        ri.set_write_preview(test_preview());
+        ri.cell_edit_set_content("changed".to_string());
+
+        ri.cancel_cell_edit();
+
+        assert!(ri.cell_edit().is_active());
+        assert_eq!(ri.cell_edit().draft_value(), "changed");
+        assert!(ri.pending_write_preview().is_none());
+    }
+
+    #[test]
+    fn cancel_cell_edit_clears_session_when_unchanged() {
+        let mut ri = ResultInteraction::default();
+        ri.activate_cell(2, 4);
+        ri.begin_cell_edit(2, 4, "val".to_string());
+
+        ri.cancel_cell_edit();
+
+        assert!(!ri.cell_edit().is_active());
     }
 
     #[test]

--- a/src/app/model/browse/result_interaction.rs
+++ b/src/app/model/browse/result_interaction.rs
@@ -118,15 +118,15 @@ impl ResultInteraction {
         self.cell_edit.move_cursor(direction);
     }
 
-    pub fn cell_edit_set_content(&mut self, content: String) {
-        self.cell_edit.set_content(content);
+    pub fn replace_cell_edit_draft(&mut self, content: String) {
+        self.cell_edit.replace_draft(content);
     }
 
     pub fn cell_edit_set_cursor(&mut self, cursor: usize) {
         self.cell_edit.set_cursor(cursor);
     }
 
-    pub fn cancel_cell_edit(&mut self) {
+    pub fn leave_cell_edit(&mut self) {
         if self.cell_edit.has_pending_draft() {
             self.clear_write_preview();
         } else {
@@ -260,14 +260,14 @@ mod tests {
     }
 
     #[test]
-    fn cancel_cell_edit_preserves_draft_when_changed() {
+    fn leave_cell_edit_preserves_draft_when_changed() {
         let mut ri = ResultInteraction::default();
         ri.activate_cell(2, 4);
         ri.begin_cell_edit(2, 4, "val".to_string());
         ri.set_write_preview(test_preview());
-        ri.cell_edit_set_content("changed".to_string());
+        ri.replace_cell_edit_draft("changed".to_string());
 
-        ri.cancel_cell_edit();
+        ri.leave_cell_edit();
 
         assert!(ri.cell_edit().is_active());
         assert_eq!(ri.cell_edit().draft_value(), "changed");
@@ -275,12 +275,12 @@ mod tests {
     }
 
     #[test]
-    fn cancel_cell_edit_clears_session_when_unchanged() {
+    fn leave_cell_edit_clears_session_when_unchanged() {
         let mut ri = ResultInteraction::default();
         ri.activate_cell(2, 4);
         ri.begin_cell_edit(2, 4, "val".to_string());
 
-        ri.cancel_cell_edit();
+        ri.leave_cell_edit();
 
         assert!(!ri.cell_edit().is_active());
     }

--- a/src/app/policy/mod.rs
+++ b/src/app/policy/mod.rs
@@ -1,4 +1,5 @@
 pub mod json;
 pub(crate) mod password_masking;
+pub(crate) mod preview_cell_text;
 pub mod sql;
 pub mod write;

--- a/src/app/policy/preview_cell_text/diff.rs
+++ b/src/app/policy/preview_cell_text/diff.rs
@@ -9,9 +9,9 @@ fn normalize_jsonb_for_diff(value: &str) -> String {
 pub fn normalize_for_write_diff(value: &str, handling: PreviewCellTextHandling) -> String {
     match handling {
         PreviewCellTextHandling::PostgreSqlJsonb => normalize_jsonb_for_diff(value),
-        PreviewCellTextHandling::RawText | PreviewCellTextHandling::PostgreSqlJson => {
-            value.to_string()
-        }
+        PreviewCellTextHandling::RawText
+        | PreviewCellTextHandling::PostgreSqlJsonLikeText
+        | PreviewCellTextHandling::PostgreSqlJson => value.to_string(),
     }
 }
 

--- a/src/app/policy/preview_cell_text/diff.rs
+++ b/src/app/policy/preview_cell_text/diff.rs
@@ -1,4 +1,4 @@
-use super::handling::PreviewCellTextHandling;
+use super::handling::PreviewCellTextDiffHandling;
 
 fn normalize_jsonb_for_diff(value: &str) -> String {
     serde_json::from_str::<serde_json::Value>(value)
@@ -6,17 +6,15 @@ fn normalize_jsonb_for_diff(value: &str) -> String {
         .unwrap_or_else(|_| value.to_string())
 }
 
-pub fn normalize_for_write_diff(value: &str, handling: PreviewCellTextHandling) -> String {
+pub fn normalize_for_write_diff(value: &str, handling: PreviewCellTextDiffHandling) -> String {
     match handling {
-        PreviewCellTextHandling::PostgreSqlJsonb => normalize_jsonb_for_diff(value),
-        PreviewCellTextHandling::RawText
-        | PreviewCellTextHandling::PostgreSqlJsonLikeText
-        | PreviewCellTextHandling::PostgreSqlJson => value.to_string(),
+        PreviewCellTextDiffHandling::PostgreSqlJsonb => normalize_jsonb_for_diff(value),
+        PreviewCellTextDiffHandling::RawText => value.to_string(),
     }
 }
 
-pub fn uses_structured_json_diff(handling: PreviewCellTextHandling) -> bool {
-    handling == PreviewCellTextHandling::PostgreSqlJsonb
+pub fn uses_structured_json_diff(handling: PreviewCellTextDiffHandling) -> bool {
+    handling == PreviewCellTextDiffHandling::PostgreSqlJsonb
 }
 
 #[cfg(test)]
@@ -24,11 +22,11 @@ mod tests {
     use super::*;
     use crate::domain::DatabaseType;
 
-    use super::super::handling::preview_cell_text_handling;
+    use super::super::handling::preview_cell_text_diff_handling;
 
     #[test]
     fn jsonb_column_normalizes_key_order() {
-        let handling = preview_cell_text_handling(DatabaseType::PostgreSQL, "jsonb");
+        let handling = preview_cell_text_diff_handling(DatabaseType::PostgreSQL, "jsonb");
         let pg_style = r#"{"industries": ["tech"], "company_size": "enterprise"}"#;
         let serde_style = r#"{"company_size":"enterprise","industries":["tech"]}"#;
         assert_eq!(
@@ -39,7 +37,7 @@ mod tests {
 
     #[test]
     fn text_column_preserves_json_like_string() {
-        let handling = preview_cell_text_handling(DatabaseType::PostgreSQL, "text");
+        let handling = preview_cell_text_diff_handling(DatabaseType::PostgreSQL, "text");
         let spaced = r#"{ "a": 1 }"#;
         let compact = r#"{"a":1}"#;
         assert_eq!(normalize_for_write_diff(spaced, handling), spaced);
@@ -51,14 +49,14 @@ mod tests {
 
     #[test]
     fn sqlite_text_column_preserves_json_like_string() {
-        let handling = preview_cell_text_handling(DatabaseType::SQLite, "TEXT");
+        let handling = preview_cell_text_diff_handling(DatabaseType::SQLite, "TEXT");
         let original = r#"{"items":["admin","writer"]}"#;
         assert_eq!(normalize_for_write_diff(original, handling), original);
     }
 
     #[test]
     fn sqlite_jsonb_declared_type_stays_raw() {
-        let handling = preview_cell_text_handling(DatabaseType::SQLite, "jsonb");
+        let handling = preview_cell_text_diff_handling(DatabaseType::SQLite, "jsonb");
         let pg_style = r#"{"industries": ["tech"], "company_size": "enterprise"}"#;
         let serde_style = r#"{"company_size":"enterprise","industries":["tech"]}"#;
         assert_eq!(

--- a/src/app/policy/preview_cell_text/diff.rs
+++ b/src/app/policy/preview_cell_text/diff.rs
@@ -1,0 +1,73 @@
+use super::handling::PreviewCellTextHandling;
+
+fn normalize_jsonb_for_diff(value: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(value)
+        .and_then(|v| serde_json::to_string(&v))
+        .unwrap_or_else(|_| value.to_string())
+}
+
+pub fn normalize_for_write_diff(value: &str, handling: PreviewCellTextHandling) -> String {
+    match handling {
+        PreviewCellTextHandling::PostgreSqlJsonb => normalize_jsonb_for_diff(value),
+        PreviewCellTextHandling::RawText | PreviewCellTextHandling::PostgreSqlJson => {
+            value.to_string()
+        }
+    }
+}
+
+pub fn uses_structured_json_diff(handling: PreviewCellTextHandling) -> bool {
+    handling == PreviewCellTextHandling::PostgreSqlJsonb
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::DatabaseType;
+
+    use super::super::handling::preview_cell_text_handling;
+
+    #[test]
+    fn jsonb_column_normalizes_key_order() {
+        let handling = preview_cell_text_handling(DatabaseType::PostgreSQL, "jsonb");
+        let pg_style = r#"{"industries": ["tech"], "company_size": "enterprise"}"#;
+        let serde_style = r#"{"company_size":"enterprise","industries":["tech"]}"#;
+        assert_eq!(
+            normalize_for_write_diff(pg_style, handling),
+            normalize_for_write_diff(serde_style, handling)
+        );
+    }
+
+    #[test]
+    fn text_column_preserves_json_like_string() {
+        let handling = preview_cell_text_handling(DatabaseType::PostgreSQL, "text");
+        let spaced = r#"{ "a": 1 }"#;
+        let compact = r#"{"a":1}"#;
+        assert_eq!(normalize_for_write_diff(spaced, handling), spaced);
+        assert_ne!(
+            normalize_for_write_diff(spaced, handling),
+            normalize_for_write_diff(compact, handling)
+        );
+    }
+
+    #[test]
+    fn sqlite_text_column_preserves_json_like_string() {
+        let handling = preview_cell_text_handling(DatabaseType::SQLite, "TEXT");
+        let original = r#"{"items":["admin","writer"]}"#;
+        assert_eq!(normalize_for_write_diff(original, handling), original);
+    }
+
+    #[test]
+    fn sqlite_jsonb_declared_type_stays_raw() {
+        let handling = preview_cell_text_handling(DatabaseType::SQLite, "jsonb");
+        let pg_style = r#"{"industries": ["tech"], "company_size": "enterprise"}"#;
+        let serde_style = r#"{"company_size":"enterprise","industries":["tech"]}"#;
+        assert_eq!(
+            normalize_for_write_diff(pg_style, handling),
+            pg_style.to_string()
+        );
+        assert_ne!(
+            normalize_for_write_diff(pg_style, handling),
+            normalize_for_write_diff(serde_style, handling)
+        );
+    }
+}

--- a/src/app/policy/preview_cell_text/display.rs
+++ b/src/app/policy/preview_cell_text/display.rs
@@ -1,0 +1,74 @@
+use crate::domain::DatabaseType;
+
+use super::handling::PreviewCellTextHandling;
+
+fn looks_like_json_container(value: &str) -> bool {
+    let trimmed = value.trim_start();
+    trimmed.starts_with('{') || trimmed.starts_with('[')
+}
+
+pub fn format_for_cell_detail(
+    value: &str,
+    database_type: DatabaseType,
+    handling: PreviewCellTextHandling,
+) -> String {
+    let should_pretty_print = match handling {
+        PreviewCellTextHandling::PostgreSqlJson => true,
+        PreviewCellTextHandling::PostgreSqlJsonb => false,
+        PreviewCellTextHandling::RawText => {
+            database_type != DatabaseType::SQLite && looks_like_json_container(value)
+        }
+    };
+    if !should_pretty_print {
+        return value.to_string();
+    }
+
+    serde_json::from_str::<serde_json::Value>(value)
+        .ok()
+        .and_then(|json| serde_json::to_string_pretty(&json).ok())
+        .unwrap_or_else(|| value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::handling::preview_cell_text_handling;
+    use super::*;
+
+    #[test]
+    fn postgresql_json_column_pretty_prints() {
+        let handling = preview_cell_text_handling(DatabaseType::PostgreSQL, "json");
+        let formatted =
+            format_for_cell_detail(r#"{"b":2,"a":1}"#, DatabaseType::PostgreSQL, handling);
+        assert_eq!(formatted, "{\n  \"a\": 1,\n  \"b\": 2\n}");
+    }
+
+    #[test]
+    fn sqlite_text_json_container_stays_raw() {
+        let handling = preview_cell_text_handling(DatabaseType::SQLite, "TEXT");
+        let value = r#"{"items":["admin","writer"]}"#;
+        assert_eq!(
+            format_for_cell_detail(value, DatabaseType::SQLite, handling),
+            value
+        );
+    }
+
+    #[test]
+    fn sqlite_json_declared_type_stays_raw() {
+        let handling = preview_cell_text_handling(DatabaseType::SQLite, "json");
+        let value = r#"{"b":2,"a":1}"#;
+        assert_eq!(
+            format_for_cell_detail(value, DatabaseType::SQLite, handling),
+            value
+        );
+    }
+
+    #[test]
+    fn postgresql_text_json_container_pretty_prints() {
+        let handling = preview_cell_text_handling(DatabaseType::PostgreSQL, "text");
+        let value = r#"{"items":["admin","writer"]}"#;
+        assert_eq!(
+            format_for_cell_detail(value, DatabaseType::PostgreSQL, handling),
+            "{\n  \"items\": [\n    \"admin\",\n    \"writer\"\n  ]\n}"
+        );
+    }
+}

--- a/src/app/policy/preview_cell_text/display.rs
+++ b/src/app/policy/preview_cell_text/display.rs
@@ -1,9 +1,10 @@
-use super::handling::PreviewCellTextHandling;
+use super::handling::PreviewCellTextDisplayHandling;
 
-pub fn format_for_cell_detail(value: &str, handling: PreviewCellTextHandling) -> String {
+pub fn format_for_cell_detail(value: &str, handling: PreviewCellTextDisplayHandling) -> String {
     let should_pretty_print = matches!(
         handling,
-        PreviewCellTextHandling::PostgreSqlJson | PreviewCellTextHandling::PostgreSqlJsonLikeText
+        PreviewCellTextDisplayHandling::PostgreSqlJson
+            | PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
     );
     if !should_pretty_print {
         return value.to_string();
@@ -18,14 +19,19 @@ pub fn format_for_cell_detail(value: &str, handling: PreviewCellTextHandling) ->
 #[cfg(test)]
 mod tests {
     use super::super::handling::{
-        PreviewCellTextHandling, preview_cell_text_display_handling, preview_cell_text_handling,
+        PreviewCellTextDisplayHandling, preview_cell_text_display_handling,
     };
     use super::*;
     use crate::domain::DatabaseType;
 
     #[test]
     fn postgresql_json_column_pretty_prints() {
-        let handling = preview_cell_text_handling(DatabaseType::PostgreSQL, "json");
+        let handling = preview_cell_text_display_handling(
+            DatabaseType::PostgreSQL,
+            "json",
+            r#"{"b":2,"a":1}"#,
+        );
+        assert_eq!(handling, PreviewCellTextDisplayHandling::PostgreSqlJson);
         let formatted = format_for_cell_detail(r#"{"b":2,"a":1}"#, handling);
         assert_eq!(formatted, "{\n  \"a\": 1,\n  \"b\": 2\n}");
     }
@@ -64,7 +70,10 @@ mod tests {
             "text",
             r#"{"items":["admin","writer"]}"#,
         );
-        assert_eq!(handling, PreviewCellTextHandling::PostgreSqlJsonLikeText);
+        assert_eq!(
+            handling,
+            PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
+        );
         assert_eq!(
             format_for_cell_detail(r#"{"items":["admin","writer"]}"#, handling),
             "{\n  \"items\": [\n    \"admin\",\n    \"writer\"\n  ]\n}"

--- a/src/app/policy/preview_cell_text/display.rs
+++ b/src/app/policy/preview_cell_text/display.rs
@@ -1,24 +1,10 @@
-use crate::domain::DatabaseType;
-
 use super::handling::PreviewCellTextHandling;
 
-fn looks_like_json_container(value: &str) -> bool {
-    let trimmed = value.trim_start();
-    trimmed.starts_with('{') || trimmed.starts_with('[')
-}
-
-pub fn format_for_cell_detail(
-    value: &str,
-    database_type: DatabaseType,
-    handling: PreviewCellTextHandling,
-) -> String {
-    let should_pretty_print = match handling {
-        PreviewCellTextHandling::PostgreSqlJson => true,
-        PreviewCellTextHandling::PostgreSqlJsonb => false,
-        PreviewCellTextHandling::RawText => {
-            database_type != DatabaseType::SQLite && looks_like_json_container(value)
-        }
-    };
+pub fn format_for_cell_detail(value: &str, handling: PreviewCellTextHandling) -> String {
+    let should_pretty_print = matches!(
+        handling,
+        PreviewCellTextHandling::PostgreSqlJson | PreviewCellTextHandling::PostgreSqlJsonLikeText
+    );
     if !should_pretty_print {
         return value.to_string();
     }
@@ -31,43 +17,56 @@ pub fn format_for_cell_detail(
 
 #[cfg(test)]
 mod tests {
-    use super::super::handling::preview_cell_text_handling;
+    use super::super::handling::{
+        PreviewCellTextHandling, preview_cell_text_display_handling, preview_cell_text_handling,
+    };
     use super::*;
+    use crate::domain::DatabaseType;
 
     #[test]
     fn postgresql_json_column_pretty_prints() {
         let handling = preview_cell_text_handling(DatabaseType::PostgreSQL, "json");
-        let formatted =
-            format_for_cell_detail(r#"{"b":2,"a":1}"#, DatabaseType::PostgreSQL, handling);
+        let formatted = format_for_cell_detail(r#"{"b":2,"a":1}"#, handling);
         assert_eq!(formatted, "{\n  \"a\": 1,\n  \"b\": 2\n}");
     }
 
     #[test]
     fn sqlite_text_json_container_stays_raw() {
-        let handling = preview_cell_text_handling(DatabaseType::SQLite, "TEXT");
-        let value = r#"{"items":["admin","writer"]}"#;
-        assert_eq!(
-            format_for_cell_detail(value, DatabaseType::SQLite, handling),
-            value
+        let handling = preview_cell_text_display_handling(
+            DatabaseType::SQLite,
+            "TEXT",
+            r#"{"items":["admin","writer"]}"#,
         );
+        let value = r#"{"items":["admin","writer"]}"#;
+        assert_eq!(format_for_cell_detail(value, handling), value);
     }
 
     #[test]
     fn sqlite_json_declared_type_stays_raw() {
-        let handling = preview_cell_text_handling(DatabaseType::SQLite, "json");
+        let handling =
+            preview_cell_text_display_handling(DatabaseType::SQLite, "json", r#"{"b":2,"a":1}"#);
         let value = r#"{"b":2,"a":1}"#;
-        assert_eq!(
-            format_for_cell_detail(value, DatabaseType::SQLite, handling),
-            value
-        );
+        assert_eq!(format_for_cell_detail(value, handling), value);
+    }
+
+    #[test]
+    fn sqlite_jsonb_declared_type_stays_raw() {
+        let handling =
+            preview_cell_text_display_handling(DatabaseType::SQLite, "jsonb", r#"{"b":2,"a":1}"#);
+        let value = r#"{"b":2,"a":1}"#;
+        assert_eq!(format_for_cell_detail(value, handling), value);
     }
 
     #[test]
     fn postgresql_text_json_container_pretty_prints() {
-        let handling = preview_cell_text_handling(DatabaseType::PostgreSQL, "text");
-        let value = r#"{"items":["admin","writer"]}"#;
+        let handling = preview_cell_text_display_handling(
+            DatabaseType::PostgreSQL,
+            "text",
+            r#"{"items":["admin","writer"]}"#,
+        );
+        assert_eq!(handling, PreviewCellTextHandling::PostgreSqlJsonLikeText);
         assert_eq!(
-            format_for_cell_detail(value, DatabaseType::PostgreSQL, handling),
+            format_for_cell_detail(r#"{"items":["admin","writer"]}"#, handling),
             "{\n  \"items\": [\n    \"admin\",\n    \"writer\"\n  ]\n}"
         );
     }

--- a/src/app/policy/preview_cell_text/handling.rs
+++ b/src/app/policy/preview_cell_text/handling.rs
@@ -1,0 +1,67 @@
+use crate::domain::DatabaseType;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreviewCellTextHandling {
+    RawText,
+    PostgreSqlJson,
+    PostgreSqlJsonb,
+}
+
+pub fn preview_cell_text_handling(
+    database_type: DatabaseType,
+    column_data_type: &str,
+) -> PreviewCellTextHandling {
+    if database_type == DatabaseType::SQLite {
+        return PreviewCellTextHandling::RawText;
+    }
+
+    match database_type {
+        DatabaseType::PostgreSQL => match column_data_type {
+            "jsonb" => PreviewCellTextHandling::PostgreSqlJsonb,
+            "json" => PreviewCellTextHandling::PostgreSqlJson,
+            _ => PreviewCellTextHandling::RawText,
+        },
+        DatabaseType::SQLite => PreviewCellTextHandling::RawText,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sqlite_columns_always_use_raw_text() {
+        assert_eq!(
+            preview_cell_text_handling(DatabaseType::SQLite, "TEXT"),
+            PreviewCellTextHandling::RawText
+        );
+        assert_eq!(
+            preview_cell_text_handling(DatabaseType::SQLite, "json"),
+            PreviewCellTextHandling::RawText
+        );
+    }
+
+    #[test]
+    fn postgresql_jsonb_uses_semantic_handling() {
+        assert_eq!(
+            preview_cell_text_handling(DatabaseType::PostgreSQL, "jsonb"),
+            PreviewCellTextHandling::PostgreSqlJsonb
+        );
+    }
+
+    #[test]
+    fn postgresql_json_uses_json_display_handling() {
+        assert_eq!(
+            preview_cell_text_handling(DatabaseType::PostgreSQL, "json"),
+            PreviewCellTextHandling::PostgreSqlJson
+        );
+    }
+
+    #[test]
+    fn postgresql_text_uses_raw_text() {
+        assert_eq!(
+            preview_cell_text_handling(DatabaseType::PostgreSQL, "text"),
+            PreviewCellTextHandling::RawText
+        );
+    }
+}

--- a/src/app/policy/preview_cell_text/handling.rs
+++ b/src/app/policy/preview_cell_text/handling.rs
@@ -1,28 +1,26 @@
 use crate::domain::DatabaseType;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PreviewCellTextHandling {
+pub enum PreviewCellTextDiffHandling {
+    RawText,
+    PostgreSqlJsonb,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreviewCellTextDisplayHandling {
     RawText,
     PostgreSqlJsonLikeText,
     PostgreSqlJson,
     PostgreSqlJsonb,
 }
 
-pub fn preview_cell_text_handling(
+pub fn preview_cell_text_diff_handling(
     database_type: DatabaseType,
     column_data_type: &str,
-) -> PreviewCellTextHandling {
-    if database_type == DatabaseType::SQLite {
-        return PreviewCellTextHandling::RawText;
-    }
-
-    match database_type {
-        DatabaseType::PostgreSQL => match column_data_type {
-            "jsonb" => PreviewCellTextHandling::PostgreSqlJsonb,
-            "json" => PreviewCellTextHandling::PostgreSqlJson,
-            _ => PreviewCellTextHandling::RawText,
-        },
-        DatabaseType::SQLite => PreviewCellTextHandling::RawText,
+) -> PreviewCellTextDiffHandling {
+    match (database_type, column_data_type) {
+        (DatabaseType::PostgreSQL, "jsonb") => PreviewCellTextDiffHandling::PostgreSqlJsonb,
+        _ => PreviewCellTextDiffHandling::RawText,
     }
 }
 
@@ -30,22 +28,22 @@ pub fn preview_cell_text_display_handling(
     database_type: DatabaseType,
     column_data_type: &str,
     value: &str,
-) -> PreviewCellTextHandling {
-    match preview_cell_text_handling(database_type, column_data_type) {
-        handling @ (PreviewCellTextHandling::PostgreSqlJson
-        | PreviewCellTextHandling::PostgreSqlJsonb
-        | PreviewCellTextHandling::PostgreSqlJsonLikeText) => handling,
-        PreviewCellTextHandling::RawText
-            if database_type != DatabaseType::SQLite && looks_like_json_container(value) =>
-        {
-            PreviewCellTextHandling::PostgreSqlJsonLikeText
-        }
-        PreviewCellTextHandling::RawText => PreviewCellTextHandling::RawText,
+) -> PreviewCellTextDisplayHandling {
+    match database_type {
+        DatabaseType::SQLite => PreviewCellTextDisplayHandling::RawText,
+        DatabaseType::PostgreSQL => match column_data_type {
+            "jsonb" => PreviewCellTextDisplayHandling::PostgreSqlJsonb,
+            "json" => PreviewCellTextDisplayHandling::PostgreSqlJson,
+            _ if looks_like_json_container(value) => {
+                PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
+            }
+            _ => PreviewCellTextDisplayHandling::RawText,
+        },
     }
 }
 
-pub fn uses_jsonb_detail_modal(handling: PreviewCellTextHandling) -> bool {
-    handling == PreviewCellTextHandling::PostgreSqlJsonb
+pub fn uses_jsonb_detail_modal(diff_handling: PreviewCellTextDiffHandling) -> bool {
+    diff_handling == PreviewCellTextDiffHandling::PostgreSqlJsonb
 }
 
 fn looks_like_json_container(value: &str) -> bool {
@@ -60,18 +58,18 @@ mod tests {
     #[test]
     fn sqlite_columns_always_use_raw_text() {
         assert_eq!(
-            preview_cell_text_handling(DatabaseType::SQLite, "TEXT"),
-            PreviewCellTextHandling::RawText
+            preview_cell_text_diff_handling(DatabaseType::SQLite, "TEXT"),
+            PreviewCellTextDiffHandling::RawText
         );
         assert_eq!(
-            preview_cell_text_handling(DatabaseType::SQLite, "json"),
-            PreviewCellTextHandling::RawText
+            preview_cell_text_diff_handling(DatabaseType::SQLite, "json"),
+            PreviewCellTextDiffHandling::RawText
         );
         assert_eq!(
-            preview_cell_text_handling(DatabaseType::SQLite, "jsonb"),
-            PreviewCellTextHandling::RawText
+            preview_cell_text_diff_handling(DatabaseType::SQLite, "jsonb"),
+            PreviewCellTextDiffHandling::RawText
         );
-        assert!(!uses_jsonb_detail_modal(preview_cell_text_handling(
+        assert!(!uses_jsonb_detail_modal(preview_cell_text_diff_handling(
             DatabaseType::SQLite,
             "jsonb"
         )));
@@ -80,28 +78,28 @@ mod tests {
     #[test]
     fn postgresql_jsonb_uses_semantic_handling() {
         assert_eq!(
-            preview_cell_text_handling(DatabaseType::PostgreSQL, "jsonb"),
-            PreviewCellTextHandling::PostgreSqlJsonb
+            preview_cell_text_diff_handling(DatabaseType::PostgreSQL, "jsonb"),
+            PreviewCellTextDiffHandling::PostgreSqlJsonb
         );
-        assert!(uses_jsonb_detail_modal(preview_cell_text_handling(
+        assert!(uses_jsonb_detail_modal(preview_cell_text_diff_handling(
             DatabaseType::PostgreSQL,
             "jsonb"
         )));
     }
 
     #[test]
-    fn postgresql_json_uses_json_display_handling() {
+    fn postgresql_json_uses_raw_text_for_diff() {
         assert_eq!(
-            preview_cell_text_handling(DatabaseType::PostgreSQL, "json"),
-            PreviewCellTextHandling::PostgreSqlJson
+            preview_cell_text_diff_handling(DatabaseType::PostgreSQL, "json"),
+            PreviewCellTextDiffHandling::RawText
         );
     }
 
     #[test]
     fn postgresql_text_uses_raw_text_for_diff() {
         assert_eq!(
-            preview_cell_text_handling(DatabaseType::PostgreSQL, "text"),
-            PreviewCellTextHandling::RawText
+            preview_cell_text_diff_handling(DatabaseType::PostgreSQL, "text"),
+            PreviewCellTextDiffHandling::RawText
         );
     }
 
@@ -113,7 +111,7 @@ mod tests {
                 "text",
                 r#"{"items":["admin"]}"#
             ),
-            PreviewCellTextHandling::PostgreSqlJsonLikeText
+            PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
         );
     }
 }

--- a/src/app/policy/preview_cell_text/handling.rs
+++ b/src/app/policy/preview_cell_text/handling.rs
@@ -3,6 +3,7 @@ use crate::domain::DatabaseType;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PreviewCellTextHandling {
     RawText,
+    PostgreSqlJsonLikeText,
     PostgreSqlJson,
     PostgreSqlJsonb,
 }
@@ -25,6 +26,33 @@ pub fn preview_cell_text_handling(
     }
 }
 
+pub fn preview_cell_text_display_handling(
+    database_type: DatabaseType,
+    column_data_type: &str,
+    value: &str,
+) -> PreviewCellTextHandling {
+    match preview_cell_text_handling(database_type, column_data_type) {
+        handling @ (PreviewCellTextHandling::PostgreSqlJson
+        | PreviewCellTextHandling::PostgreSqlJsonb
+        | PreviewCellTextHandling::PostgreSqlJsonLikeText) => handling,
+        PreviewCellTextHandling::RawText
+            if database_type != DatabaseType::SQLite && looks_like_json_container(value) =>
+        {
+            PreviewCellTextHandling::PostgreSqlJsonLikeText
+        }
+        PreviewCellTextHandling::RawText => PreviewCellTextHandling::RawText,
+    }
+}
+
+pub fn uses_jsonb_detail_modal(handling: PreviewCellTextHandling) -> bool {
+    handling == PreviewCellTextHandling::PostgreSqlJsonb
+}
+
+fn looks_like_json_container(value: &str) -> bool {
+    let trimmed = value.trim_start();
+    trimmed.starts_with('{') || trimmed.starts_with('[')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -39,6 +67,14 @@ mod tests {
             preview_cell_text_handling(DatabaseType::SQLite, "json"),
             PreviewCellTextHandling::RawText
         );
+        assert_eq!(
+            preview_cell_text_handling(DatabaseType::SQLite, "jsonb"),
+            PreviewCellTextHandling::RawText
+        );
+        assert!(!uses_jsonb_detail_modal(preview_cell_text_handling(
+            DatabaseType::SQLite,
+            "jsonb"
+        )));
     }
 
     #[test]
@@ -47,6 +83,10 @@ mod tests {
             preview_cell_text_handling(DatabaseType::PostgreSQL, "jsonb"),
             PreviewCellTextHandling::PostgreSqlJsonb
         );
+        assert!(uses_jsonb_detail_modal(preview_cell_text_handling(
+            DatabaseType::PostgreSQL,
+            "jsonb"
+        )));
     }
 
     #[test]
@@ -58,10 +98,22 @@ mod tests {
     }
 
     #[test]
-    fn postgresql_text_uses_raw_text() {
+    fn postgresql_text_uses_raw_text_for_diff() {
         assert_eq!(
             preview_cell_text_handling(DatabaseType::PostgreSQL, "text"),
             PreviewCellTextHandling::RawText
+        );
+    }
+
+    #[test]
+    fn postgresql_text_json_container_uses_json_like_display_handling() {
+        assert_eq!(
+            preview_cell_text_display_handling(
+                DatabaseType::PostgreSQL,
+                "text",
+                r#"{"items":["admin"]}"#
+            ),
+            PreviewCellTextHandling::PostgreSqlJsonLikeText
         );
     }
 }

--- a/src/app/policy/preview_cell_text/mod.rs
+++ b/src/app/policy/preview_cell_text/mod.rs
@@ -4,4 +4,6 @@ mod handling;
 
 pub use diff::{normalize_for_write_diff, uses_structured_json_diff};
 pub use display::format_for_cell_detail;
-pub use handling::preview_cell_text_handling;
+pub use handling::{
+    preview_cell_text_display_handling, preview_cell_text_handling, uses_jsonb_detail_modal,
+};

--- a/src/app/policy/preview_cell_text/mod.rs
+++ b/src/app/policy/preview_cell_text/mod.rs
@@ -1,0 +1,7 @@
+mod diff;
+mod display;
+mod handling;
+
+pub use diff::{normalize_for_write_diff, uses_structured_json_diff};
+pub use display::format_for_cell_detail;
+pub use handling::preview_cell_text_handling;

--- a/src/app/policy/preview_cell_text/mod.rs
+++ b/src/app/policy/preview_cell_text/mod.rs
@@ -5,5 +5,5 @@ mod handling;
 pub use diff::{normalize_for_write_diff, uses_structured_json_diff};
 pub use display::format_for_cell_detail;
 pub use handling::{
-    preview_cell_text_display_handling, preview_cell_text_handling, uses_jsonb_detail_modal,
+    preview_cell_text_diff_handling, preview_cell_text_display_handling, uses_jsonb_detail_modal,
 };

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -460,6 +460,28 @@ fn top_level_token_lowers(sql: &str) -> Vec<String> {
         .collect()
 }
 
+fn sqlite_drop_label(sql: &str) -> Option<&'static str> {
+    match drop_subtype(sql).as_deref()? {
+        "index" => Some("DROP INDEX"),
+        "view" => Some("DROP VIEW"),
+        "trigger" => Some("DROP TRIGGER"),
+        _ => None,
+    }
+}
+
+fn sqlite_drop_risk(sql: &str) -> Option<SqlRiskDecision> {
+    sqlite_drop_label(sql)?;
+    let kind = StatementKind::Drop;
+    Some(match extract_target_name(sql, &kind) {
+        Some(target) => SqlRiskDecision {
+            risk_level: RiskLevel::High,
+            confirmation: ConfirmationType::TableNameInput { target },
+            read_only_allowed: false,
+        },
+        None => high_acknowledge_label(sqlite_drop_label(sql).unwrap_or("DROP")),
+    })
+}
+
 pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
     let effective = statement_after_leading_ctes(sql);
     let tokens = top_level_token_lowers(effective);
@@ -472,6 +494,7 @@ pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
         "analyze" => Some("ANALYZE"),
         "replace" => Some("REPLACE"),
         "insert" if sqlite_replace_target_in_statement(effective).is_some() => Some("REPLACE"),
+        "drop" => sqlite_drop_label(effective),
         _ => None,
     }
 }
@@ -706,6 +729,7 @@ fn evaluate_sqlite_specific_risk(sql: &str) -> Option<SqlRiskDecision> {
             confirmation: ConfirmationType::TableNameInput { target },
             read_only_allowed: false,
         }),
+        "drop" => sqlite_drop_risk(effective),
         _ => None,
     }
 }
@@ -1142,6 +1166,70 @@ mod tests {
 
             assert_eq!(sqlite_specific_label(sql), Some("REPLACE"));
         }
+
+        #[rstest]
+        #[case::drop_index("DROP INDEX my_index", "DROP INDEX")]
+        #[case::drop_index_if_exists("DROP INDEX IF EXISTS my_index", "DROP INDEX")]
+        #[case::drop_view("DROP VIEW my_view", "DROP VIEW")]
+        #[case::drop_view_if_exists("DROP VIEW IF EXISTS my_view", "DROP VIEW")]
+        #[case::drop_trigger("DROP TRIGGER my_trigger", "DROP TRIGGER")]
+        #[case::drop_trigger_if_exists("DROP TRIGGER IF EXISTS my_trigger", "DROP TRIGGER")]
+        fn sqlite_specific_label_detects_dangerous_drops(
+            #[case] sql: &str,
+            #[case] expected: &str,
+        ) {
+            assert_eq!(sqlite_specific_label(sql), Some(expected));
+        }
+
+        #[rstest]
+        #[case::drop_index("DROP INDEX my_index", "my_index")]
+        #[case::drop_index_if_exists("DROP INDEX IF EXISTS my_index", "my_index")]
+        #[case::drop_view("DROP VIEW my_view", "my_view")]
+        #[case::drop_view_if_exists("DROP VIEW IF EXISTS my_view", "my_view")]
+        #[case::drop_trigger("DROP TRIGGER my_trigger", "my_trigger")]
+        #[case::drop_trigger_if_exists("DROP TRIGGER IF EXISTS main.my_trigger", "main.my_trigger")]
+        #[case::drop_index_quoted("DROP INDEX `my index`", "my index")]
+        #[case::drop_view_quoted(r#"DROP VIEW "my view""#, "my view")]
+        #[case::drop_trigger_quoted("DROP TRIGGER [my trigger]", "my trigger")]
+        fn sqlite_dangerous_drop_requires_table_name_input(
+            #[case] sql: &str,
+            #[case] expected_target: &str,
+        ) {
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::High);
+            assert!(!result.read_only_allowed);
+            assert!(matches!(
+                result.confirmation,
+                ConfirmationType::TableNameInput { ref target } if target == expected_target
+            ));
+        }
+
+        #[rstest]
+        #[case::drop_policy("DROP POLICY p ON t")]
+        #[case::drop_schema("DROP SCHEMA s")]
+        fn sqlite_non_dangerous_drop_returns_low_immediate(#[case] sql: &str) {
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::Low);
+            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+        }
+
+        #[test]
+        fn sqlite_drop_multiple_index_requires_acknowledgment() {
+            let sql = "DROP INDEX a, b";
+            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+            assert_eq!(result.risk_level, RiskLevel::High);
+            assert!(!result.read_only_allowed);
+            assert!(matches!(
+                result.confirmation,
+                ConfirmationType::Acknowledge {
+                    reason: AcknowledgeReason::TargetNameUnavailable,
+                    ref label,
+                } if label == "DROP INDEX"
+            ));
+        }
     }
 
     mod evaluate_multi_statement_tests {
@@ -1475,12 +1563,31 @@ mod tests {
         }
 
         #[test]
-        fn drop_index_returns_low_immediate() {
+        fn drop_index_returns_low_immediate_for_postgres() {
             let result = evaluate_multi_statement("DROP INDEX my_index");
             match result {
                 MultiStatementDecision::Allow { risk, .. } => {
                     assert_eq!(risk.risk_level, RiskLevel::Low);
                     assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                }
+                _ => panic!("expected Allow"),
+            }
+        }
+
+        #[test]
+        fn sqlite_drop_index_requires_table_name_input() {
+            let result = evaluate_multi_statement_for_database(
+                DatabaseType::SQLite,
+                "DROP INDEX IF EXISTS my_index",
+            );
+            match result {
+                MultiStatementDecision::Allow { risk, .. } => {
+                    assert_eq!(risk.risk_level, RiskLevel::High);
+                    assert!(!risk.read_only_allowed);
+                    assert!(matches!(
+                        risk.confirmation,
+                        ConfirmationType::TableNameInput { ref target } if target == "my_index"
+                    ));
                 }
                 _ => panic!("expected Allow"),
             }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -499,6 +499,32 @@ pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
     }
 }
 
+pub fn adhoc_label_for_statement(database_type: DatabaseType, sql: &str) -> &'static str {
+    let sqlite_label = (database_type == DatabaseType::SQLite)
+        .then(|| sqlite_specific_label(sql))
+        .flatten();
+    let kind = classify(sql);
+    let decision = write_guardrails::evaluate_sql_risk(&kind);
+    sqlite_label.unwrap_or(decision.label)
+}
+
+pub fn adhoc_label_for_table_name_confirmation(
+    database_type: DatabaseType,
+    sql: &str,
+) -> Option<&'static str> {
+    for stmt in split_statements_for_database(database_type, sql) {
+        let kind = classify(&stmt);
+        let decision = evaluate_sql_risk_for_database(database_type, &kind, &stmt);
+        if matches!(
+            decision.confirmation,
+            ConfirmationType::TableNameInput { .. }
+        ) {
+            return Some(adhoc_label_for_statement(database_type, &stmt));
+        }
+    }
+    None
+}
+
 fn skip_whitespace(sql: &str, mut cursor: usize) -> usize {
     while cursor < sql.len() {
         let Some(ch) = sql[cursor..].chars().next() else {
@@ -1592,6 +1618,15 @@ mod tests {
                 }
                 _ => panic!("expected Allow"),
             }
+        }
+
+        #[test]
+        fn sqlite_table_name_confirmation_label_matches_first_target_statement() {
+            let sql = "DROP INDEX my_index; DROP VIEW my_view";
+            assert_eq!(
+                adhoc_label_for_table_name_confirmation(DatabaseType::SQLite, sql),
+                Some("DROP INDEX")
+            );
         }
 
         #[test]

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -470,7 +470,7 @@ fn sqlite_drop_label(sql: &str) -> Option<&'static str> {
 }
 
 fn sqlite_drop_risk(sql: &str) -> Option<SqlRiskDecision> {
-    sqlite_drop_label(sql)?;
+    let label = sqlite_drop_label(sql)?;
     let kind = StatementKind::Drop;
     Some(match extract_target_name(sql, &kind) {
         Some(target) => SqlRiskDecision {
@@ -478,7 +478,7 @@ fn sqlite_drop_risk(sql: &str) -> Option<SqlRiskDecision> {
             confirmation: ConfirmationType::TableNameInput { target },
             read_only_allowed: false,
         },
-        None => high_acknowledge_label(sqlite_drop_label(sql).unwrap_or("DROP")),
+        None => high_acknowledge_label(label),
     })
 }
 
@@ -1208,7 +1208,7 @@ mod tests {
         #[rstest]
         #[case::drop_policy("DROP POLICY p ON t")]
         #[case::drop_schema("DROP SCHEMA s")]
-        fn sqlite_non_dangerous_drop_returns_low_immediate(#[case] sql: &str) {
+        fn sqlite_unhandled_drop_subtypes_fall_back_to_generic_low_immediate(#[case] sql: &str) {
             let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
 
             assert_eq!(result.risk_level, RiskLevel::Low);
@@ -1569,6 +1569,26 @@ mod tests {
                 MultiStatementDecision::Allow { risk, .. } => {
                     assert_eq!(risk.risk_level, RiskLevel::Low);
                     assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                }
+                _ => panic!("expected Allow"),
+            }
+        }
+
+        #[test]
+        fn sqlite_multiple_high_drops_use_first_target() {
+            let result = evaluate_multi_statement_for_database(
+                DatabaseType::SQLite,
+                "DROP INDEX my_index; DROP VIEW my_view",
+            );
+            match result {
+                MultiStatementDecision::Allow { statements, risk } => {
+                    assert_eq!(statements, vec!["DROP INDEX my_index", "DROP VIEW my_view"]);
+                    assert_eq!(risk.risk_level, RiskLevel::High);
+                    assert!(!risk.read_only_allowed);
+                    assert!(matches!(
+                        risk.confirmation,
+                        ConfirmationType::TableNameInput { ref target } if target == "my_index"
+                    ));
                 }
                 _ => panic!("expected Allow"),
             }

--- a/src/app/policy/write/write_update.rs
+++ b/src/app/policy/write/write_update.rs
@@ -1,12 +1,27 @@
 use crate::domain::QueryValue;
 
-/// Normalize a cell value for diff display.
-/// If the value is valid JSON, re-serialize it so both before/after
-/// share the same key ordering and formatting.
+/// Whether diff comparison should treat values as PostgreSQL JSONB semantics.
+pub fn uses_jsonb_semantic_diff(column_data_type: &str) -> bool {
+    column_data_type == "jsonb"
+}
+
+/// Normalize a JSONB cell value for diff display.
+/// Re-serialize valid JSON so before/after share key ordering and formatting.
 pub fn normalize_for_diff(value: &str) -> String {
     serde_json::from_str::<serde_json::Value>(value)
         .and_then(|v| serde_json::to_string(&v))
         .unwrap_or_else(|_| value.to_string())
+}
+
+/// Normalize a cell value for write-preview diff display.
+/// Only PostgreSQL JSONB columns use semantic JSON normalization; all other
+/// columns keep the stored string representation (including SQLite TEXT).
+pub fn normalize_cell_value_for_diff(column_data_type: &str, value: &str) -> String {
+    if uses_jsonb_semantic_diff(column_data_type) {
+        normalize_for_diff(value)
+    } else {
+        value.to_string()
+    }
 }
 
 pub fn escape_preview_value(value: &str) -> String {
@@ -56,6 +71,37 @@ mod tests {
         fn non_json_value_returns_unchanged() {
             assert_eq!(normalize_for_diff("plain text"), "plain text");
             assert_eq!(normalize_for_diff("42"), "42");
+        }
+    }
+
+    mod cell_diff_normalization {
+        use super::*;
+
+        #[test]
+        fn jsonb_column_normalizes_key_order() {
+            let pg_style = r#"{"industries": ["tech"], "company_size": "enterprise"}"#;
+            let serde_style = r#"{"company_size":"enterprise","industries":["tech"]}"#;
+            assert_eq!(
+                normalize_cell_value_for_diff("jsonb", pg_style),
+                normalize_cell_value_for_diff("jsonb", serde_style)
+            );
+        }
+
+        #[test]
+        fn text_column_preserves_json_like_string() {
+            let spaced = r#"{ "a": 1 }"#;
+            let compact = r#"{"a":1}"#;
+            assert_eq!(normalize_cell_value_for_diff("text", spaced), spaced);
+            assert_ne!(
+                normalize_cell_value_for_diff("text", spaced),
+                normalize_cell_value_for_diff("text", compact)
+            );
+        }
+
+        #[test]
+        fn sqlite_text_column_preserves_json_like_string() {
+            let original = r#"{"items":["admin","writer"]}"#;
+            assert_eq!(normalize_cell_value_for_diff("TEXT", original), original);
         }
     }
 

--- a/src/app/policy/write/write_update.rs
+++ b/src/app/policy/write/write_update.rs
@@ -1,29 +1,5 @@
 use crate::domain::QueryValue;
 
-/// Whether diff comparison should treat values as PostgreSQL JSONB semantics.
-pub fn uses_jsonb_semantic_diff(column_data_type: &str) -> bool {
-    column_data_type == "jsonb"
-}
-
-/// Normalize a JSONB cell value for diff display.
-/// Re-serialize valid JSON so before/after share key ordering and formatting.
-pub fn normalize_for_diff(value: &str) -> String {
-    serde_json::from_str::<serde_json::Value>(value)
-        .and_then(|v| serde_json::to_string(&v))
-        .unwrap_or_else(|_| value.to_string())
-}
-
-/// Normalize a cell value for write-preview diff display.
-/// Only PostgreSQL JSONB columns use semantic JSON normalization; all other
-/// columns keep the stored string representation (including SQLite TEXT).
-pub fn normalize_cell_value_for_diff(column_data_type: &str, value: &str) -> String {
-    if uses_jsonb_semantic_diff(column_data_type) {
-        normalize_for_diff(value)
-    } else {
-        value.to_string()
-    }
-}
-
 pub fn escape_preview_value(value: &str) -> String {
     value
         .replace('\\', "\\\\")
@@ -55,53 +31,6 @@ mod tests {
         #[test]
         fn value_with_control_chars_returns_escaped_preview_value() {
             assert_eq!(escape_preview_value("a\\b\"c\nd"), "a\\\\b\\\"c\\nd");
-        }
-
-        #[test]
-        fn json_with_different_key_order_returns_identical_output() {
-            let pg_style = r#"{"industries": ["tech"], "company_size": "enterprise"}"#;
-            let serde_style = r#"{"company_size":"enterprise","industries":["tech"]}"#;
-            assert_eq!(
-                normalize_for_diff(pg_style),
-                normalize_for_diff(serde_style)
-            );
-        }
-
-        #[test]
-        fn non_json_value_returns_unchanged() {
-            assert_eq!(normalize_for_diff("plain text"), "plain text");
-            assert_eq!(normalize_for_diff("42"), "42");
-        }
-    }
-
-    mod cell_diff_normalization {
-        use super::*;
-
-        #[test]
-        fn jsonb_column_normalizes_key_order() {
-            let pg_style = r#"{"industries": ["tech"], "company_size": "enterprise"}"#;
-            let serde_style = r#"{"company_size":"enterprise","industries":["tech"]}"#;
-            assert_eq!(
-                normalize_cell_value_for_diff("jsonb", pg_style),
-                normalize_cell_value_for_diff("jsonb", serde_style)
-            );
-        }
-
-        #[test]
-        fn text_column_preserves_json_like_string() {
-            let spaced = r#"{ "a": 1 }"#;
-            let compact = r#"{"a":1}"#;
-            assert_eq!(normalize_cell_value_for_diff("text", spaced), spaced);
-            assert_ne!(
-                normalize_cell_value_for_diff("text", spaced),
-                normalize_cell_value_for_diff("text", compact)
-            );
-        }
-
-        #[test]
-        fn sqlite_text_column_preserves_json_like_string() {
-            let original = r#"{"items":["admin","writer"]}"#;
-            assert_eq!(normalize_cell_value_for_diff("TEXT", original), original);
         }
     }
 

--- a/src/app/update/browse/navigation/input.rs
+++ b/src/app/update/browse/navigation/input.rs
@@ -25,10 +25,7 @@ pub fn reduce_input(state: &mut AppState, action: &Action) -> DispatchResult {
             }
             InputMode::CellEdit => {
                 let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-                state
-                    .result_interaction
-                    .cell_edit_input_mut()
-                    .insert_str(&clean);
+                state.result_interaction.cell_edit_insert_str(&clean);
                 DispatchResult::handled()
             }
             InputMode::QueryHistoryPicker => {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -764,8 +764,7 @@ mod tests {
                 .begin_cell_edit(0, 2, before.to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content(after.to_string());
+                .replace_cell_edit_draft(after.to_string());
 
             let effects = dispatch_query(
                 &mut state,
@@ -842,8 +841,7 @@ mod tests {
                 .begin_cell_edit(0, 1, before.to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content(after.to_string());
+                .replace_cell_edit_draft(after.to_string());
 
             let effects = dispatch_query(
                 &mut state,

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -6,12 +6,13 @@ use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSelection};
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::json::json_diff::compute_json_diff;
+use crate::policy::preview_cell_text::{
+    normalize_for_write_diff, preview_cell_text_handling, uses_structured_json_diff,
+};
 use crate::policy::write::write_guardrails::{
     ColumnDiff, RiskLevel, TargetSummary, WriteOperation, WritePreview, evaluate_guardrails,
 };
-use crate::policy::write::write_update::{
-    build_pk_pairs, escape_preview_value, normalize_cell_value_for_diff, uses_jsonb_semantic_diff,
-};
+use crate::policy::write::write_update::{build_pk_pairs, escape_preview_value};
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::browse::query::preview_effect_for_current_table;
@@ -95,20 +96,22 @@ fn build_update_preview(
         sql,
         target_summary: target,
         diff: {
+            let database_type = state.session.active_database_type_or_default();
             let column_data_type = state
                 .session
                 .table_detail()
                 .and_then(|td| td.columns.get(col_idx))
                 .map_or("", |c| c.data_type.as_str());
-            let before = normalize_cell_value_for_diff(
-                column_data_type,
+            let handling = preview_cell_text_handling(database_type, column_data_type);
+            let before = normalize_for_write_diff(
                 state.result_interaction.cell_edit().original_value(),
+                handling,
             );
-            let after = normalize_cell_value_for_diff(
-                column_data_type,
+            let after = normalize_for_write_diff(
                 state.result_interaction.cell_edit().draft_value(),
+                handling,
             );
-            let json_diff = uses_jsonb_semantic_diff(column_data_type)
+            let json_diff = uses_structured_json_diff(handling)
                 .then(|| compute_json_diff(&before, &after, 1))
                 .flatten();
             vec![ColumnDiff {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -442,7 +442,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "Alice".to_string());
             state
                 .result_interaction
-                .cell_edit_set_content("Bob".to_string());
+                .replace_cell_edit_draft("Bob".to_string());
             state
         }
 
@@ -676,7 +676,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "Alice".to_string());
             state
                 .result_interaction
-                .cell_edit_set_content("Bob".to_string());
+                .replace_cell_edit_draft("Bob".to_string());
 
             let effects = dispatch_query(
                 &mut state,
@@ -714,7 +714,7 @@ mod tests {
                 .begin_cell_edit(0, 2, r#"{"role":"admin"}"#.to_string());
             state
                 .result_interaction
-                .cell_edit_set_content(r#"{"role":"user"}"#.to_string());
+                .replace_cell_edit_draft(r#"{"role":"user"}"#.to_string());
             state
         }
 
@@ -796,7 +796,7 @@ mod tests {
                 .begin_cell_edit(0, 1, r#"{"key":"old"}"#.to_string());
             state
                 .result_interaction
-                .cell_edit_set_content(r#"{"key":"new"}"#.to_string());
+                .replace_cell_edit_draft(r#"{"key":"new"}"#.to_string());
 
             let effects = dispatch_query(
                 &mut state,

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -7,7 +7,7 @@ use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSe
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::json::json_diff::compute_json_diff;
 use crate::policy::preview_cell_text::{
-    normalize_for_write_diff, preview_cell_text_handling, uses_structured_json_diff,
+    normalize_for_write_diff, preview_cell_text_diff_handling, uses_structured_json_diff,
 };
 use crate::policy::write::write_guardrails::{
     ColumnDiff, RiskLevel, TargetSummary, WriteOperation, WritePreview, evaluate_guardrails,
@@ -102,7 +102,7 @@ fn build_update_preview(
                 .table_detail()
                 .and_then(|td| td.columns.get(col_idx))
                 .map_or("", |c| c.data_type.as_str());
-            let handling = preview_cell_text_handling(database_type, column_data_type);
+            let handling = preview_cell_text_diff_handling(database_type, column_data_type);
             let before = normalize_for_write_diff(
                 state.result_interaction.cell_edit().original_value(),
                 handling,
@@ -744,6 +744,50 @@ mod tests {
                 preview.diff[0].json_diff.is_some(),
                 "jsonb column should have structured diff"
             );
+        }
+
+        #[test]
+        fn sqlite_jsonb_declared_type_preserves_string_diff_in_write_preview() {
+            let mut state = editable_state_with_jsonb();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
+            let mut detail = jsonb_table_detail();
+            detail.schema = "main".to_string();
+            state.session.set_table_detail_raw(Some(detail));
+            state.query.pagination.reset_for_table("main", "users");
+
+            let before = r#"{"role":"admin"}"#;
+            let after = r#"{ "role": "admin" }"#;
+            state
+                .result_interaction
+                .begin_cell_edit(0, 2, before.to_string());
+            state
+                .result_interaction
+                .cell_edit_input_mut()
+                .set_content(after.to_string());
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            let preview = match &effects[0] {
+                Effect::DispatchActions(actions) => match actions.first().expect("action") {
+                    Action::OpenWritePreviewConfirm(preview) => preview.clone(),
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+            assert!(preview.diff[0].json_diff.is_none());
+            assert_eq!(preview.diff[0].before, before);
+            assert_eq!(preview.diff[0].after, after);
         }
 
         #[test]

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -35,12 +35,12 @@ fn build_update_preview(
     let row_idx = state
         .result_interaction
         .cell_edit()
-        .row
+        .row()
         .ok_or(EditGuardrailError::NoRowSelectedForEdit)?;
     let col_idx = state
         .result_interaction
         .cell_edit()
-        .col
+        .col()
         .ok_or(EditGuardrailError::NoColumnSelectedForEdit)?;
 
     let row_values = result
@@ -442,8 +442,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "Alice".to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content("Bob".to_string());
+                .cell_edit_set_content("Bob".to_string());
             state
         }
 
@@ -677,8 +676,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "Alice".to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content("Bob".to_string());
+                .cell_edit_set_content("Bob".to_string());
 
             let effects = dispatch_query(
                 &mut state,
@@ -716,8 +714,7 @@ mod tests {
                 .begin_cell_edit(0, 2, r#"{"role":"admin"}"#.to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content(r#"{"role":"user"}"#.to_string());
+                .cell_edit_set_content(r#"{"role":"user"}"#.to_string());
             state
         }
 
@@ -799,8 +796,7 @@ mod tests {
                 .begin_cell_edit(0, 1, r#"{"key":"old"}"#.to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content(r#"{"key":"new"}"#.to_string());
+                .cell_edit_set_content(r#"{"key":"new"}"#.to_string());
 
             let effects = dispatch_query(
                 &mut state,

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -10,7 +10,7 @@ use crate::policy::write::write_guardrails::{
     ColumnDiff, RiskLevel, TargetSummary, WriteOperation, WritePreview, evaluate_guardrails,
 };
 use crate::policy::write::write_update::{
-    build_pk_pairs, escape_preview_value, normalize_for_diff,
+    build_pk_pairs, escape_preview_value, normalize_cell_value_for_diff, uses_jsonb_semantic_diff,
 };
 use crate::services::AppServices;
 use crate::update::action::Action;
@@ -95,14 +95,20 @@ fn build_update_preview(
         sql,
         target_summary: target,
         diff: {
-            let before = normalize_for_diff(state.result_interaction.cell_edit().original_value());
-            let after = normalize_for_diff(state.result_interaction.cell_edit().draft_value());
-            let is_jsonb = state
+            let column_data_type = state
                 .session
                 .table_detail()
                 .and_then(|td| td.columns.get(col_idx))
-                .is_some_and(|c| c.data_type == "jsonb");
-            let json_diff = is_jsonb
+                .map_or("", |c| c.data_type.as_str());
+            let before = normalize_cell_value_for_diff(
+                column_data_type,
+                state.result_interaction.cell_edit().original_value(),
+            );
+            let after = normalize_cell_value_for_diff(
+                column_data_type,
+                state.result_interaction.cell_edit().draft_value(),
+            );
+            let json_diff = uses_jsonb_semantic_diff(column_data_type)
                 .then(|| compute_json_diff(&before, &after, 1))
                 .flatten();
             vec![ColumnDiff {
@@ -768,6 +774,52 @@ mod tests {
                 preview.diff[0].json_diff.is_none(),
                 "text column should not have structured diff even if value looks like JSON"
             );
+            assert_eq!(preview.diff[0].before, r#"{"key":"old"}"#);
+            assert_eq!(preview.diff[0].after, r#"{"key":"new"}"#);
+        }
+
+        #[test]
+        fn sqlite_text_json_column_preserves_string_diff() {
+            let mut state = editable_state();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
+            let mut detail = users_table_detail();
+            detail.schema = "main".to_string();
+            state.session.set_table_detail_raw(Some(detail));
+            state.query.pagination.reset_for_table("main", "users");
+
+            let before = r#"{"items":["admin","writer"]}"#;
+            let after = r#"{ "items": [ "admin", "writer" ] }"#;
+            state
+                .result_interaction
+                .begin_cell_edit(0, 1, before.to_string());
+            state
+                .result_interaction
+                .cell_edit_input_mut()
+                .set_content(after.to_string());
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            let preview = match &effects[0] {
+                Effect::DispatchActions(actions) => match actions.first().expect("action") {
+                    Action::OpenWritePreviewConfirm(preview) => preview.clone(),
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+            assert!(preview.diff[0].json_diff.is_none());
+            assert_eq!(preview.diff[0].before, before);
+            assert_eq!(preview.diff[0].after, after);
         }
 
         #[test]

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -6,7 +6,7 @@ use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::preview_cell_text::{
-    format_for_cell_detail, preview_cell_text_display_handling, preview_cell_text_handling,
+    format_for_cell_detail, preview_cell_text_diff_handling, preview_cell_text_display_handling,
     uses_jsonb_detail_modal,
 };
 use crate::ports::outbound::ClipboardError;
@@ -153,7 +153,7 @@ fn selected_cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
     let Some(column_data_type) = selected_column_data_type(state, col_idx) else {
         return false;
     };
-    let handling = preview_cell_text_handling(
+    let handling = preview_cell_text_diff_handling(
         state.session.active_database_type_or_default(),
         column_data_type,
     );

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -1,11 +1,11 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
+use crate::policy::preview_cell_text::{format_for_cell_detail, preview_cell_text_handling};
 use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, InputTarget, ModalKind, ScrollDirection, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
@@ -26,11 +26,10 @@ pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -
                 return DispatchResult::handled();
             };
 
-            let display_value = cell_detail_display_value(
-                &cell_value,
-                data_type.as_deref(),
-                state.session.active_database_type_or_default(),
-            );
+            let database_type = state.session.active_database_type_or_default();
+            let handling =
+                preview_cell_text_handling(database_type, data_type.as_deref().unwrap_or(""));
+            let display_value = format_for_cell_detail(&cell_value, database_type, handling);
             state.cell_detail =
                 CellDetailState::open(row_idx, col_idx, column_name, cell_value, display_value);
             state.modal.push_mode(InputMode::CellDetail);
@@ -160,28 +159,6 @@ fn selected_column_data_type(state: &AppState, col_idx: usize) -> Option<&str> {
         .map(|column| column.data_type.as_str())
 }
 
-fn cell_detail_display_value(
-    value: &str,
-    data_type: Option<&str>,
-    database_type: DatabaseType,
-) -> String {
-    let should_pretty_print_json = data_type == Some("json")
-        || (database_type != DatabaseType::SQLite && looks_like_json_container(value));
-    if !should_pretty_print_json {
-        return value.to_string();
-    }
-
-    serde_json::from_str::<serde_json::Value>(value)
-        .ok()
-        .and_then(|json| serde_json::to_string_pretty(&json).ok())
-        .unwrap_or_else(|| value.to_string())
-}
-
-fn looks_like_json_container(value: &str) -> bool {
-    let trimmed = value.trim_start();
-    trimmed.starts_with('{') || trimmed.starts_with('[')
-}
-
 fn update_search_matches(state: &mut AppState) {
     let query = state.cell_detail.search().input().content().to_string();
     let matches = find_text_matches(state.cell_detail.content(), &query);
@@ -273,6 +250,22 @@ mod tests {
         assert_eq!(state.input_mode(), InputMode::CellDetail);
         assert_eq!(state.cell_detail.content(), "{\n  \"a\": 1,\n  \"b\": 2\n}");
         assert_eq!(state.cell_detail.original_content(), r#"{"b":2,"a":1}"#);
+    }
+
+    #[test]
+    fn sqlite_json_declared_type_shows_raw_detail() {
+        let mut state = state_with_cell("json", r#"{"b":2,"a":1}"#);
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::from_string("sqlite-test"),
+            "sqlite",
+            DatabaseType::SQLite,
+            "sqlite:///tmp/app.db",
+        );
+
+        reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        assert_eq!(state.input_mode(), InputMode::CellDetail);
+        assert_eq!(state.cell_detail.content(), r#"{"b":2,"a":1}"#);
     }
 
     #[test]

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -5,7 +5,10 @@ use crate::model::app_state::AppState;
 use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
-use crate::policy::preview_cell_text::{format_for_cell_detail, preview_cell_text_handling};
+use crate::policy::preview_cell_text::{
+    format_for_cell_detail, preview_cell_text_display_handling, preview_cell_text_handling,
+    uses_jsonb_detail_modal,
+};
 use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, InputTarget, ModalKind, ScrollDirection, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
@@ -14,7 +17,7 @@ use crate::update::helpers::find_text_matches;
 pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::ResultOpenCellDetail => {
-            if selected_column_is_jsonb(state) {
+            if selected_cell_uses_jsonb_detail_modal(state) {
                 return DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
                     Action::OpenModal(ModalKind::JsonbDetail),
                 ])]);
@@ -27,9 +30,10 @@ pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -
             };
 
             let database_type = state.session.active_database_type_or_default();
-            let handling =
-                preview_cell_text_handling(database_type, data_type.as_deref().unwrap_or(""));
-            let display_value = format_for_cell_detail(&cell_value, database_type, handling);
+            let column_data_type = data_type.as_deref().unwrap_or("");
+            let display_handling =
+                preview_cell_text_display_handling(database_type, column_data_type, &cell_value);
+            let display_value = format_for_cell_detail(&cell_value, display_handling);
             state.cell_detail =
                 CellDetailState::open(row_idx, col_idx, column_name, cell_value, display_value);
             state.modal.push_mode(InputMode::CellDetail);
@@ -142,11 +146,18 @@ fn selected_cell_value(state: &AppState) -> Option<(usize, usize, String, String
     Some((row_idx, col_idx, column_name, cell_value, data_type))
 }
 
-fn selected_column_is_jsonb(state: &AppState) -> bool {
+fn selected_cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
     let Some(col_idx) = state.result_interaction.selection().cell() else {
         return false;
     };
-    selected_column_data_type(state, col_idx).is_some_and(|data_type| data_type == "jsonb")
+    let Some(column_data_type) = selected_column_data_type(state, col_idx) else {
+        return false;
+    };
+    let handling = preview_cell_text_handling(
+        state.session.active_database_type_or_default(),
+        column_data_type,
+    );
+    uses_jsonb_detail_modal(handling)
 }
 
 fn selected_column_data_type(state: &AppState, col_idx: usize) -> Option<&str> {
@@ -319,6 +330,24 @@ mod tests {
             result.expect("yank should copy").as_slice(),
             [Effect::CopyToClipboard { content, .. }] if content == r#"{"b":2,"a":1}"#
         ));
+    }
+
+    #[test]
+    fn sqlite_jsonb_cell_opens_raw_cell_detail() {
+        let mut state = state_with_cell("jsonb", r#"{"a":1}"#);
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::from_string("sqlite-test"),
+            "sqlite",
+            DatabaseType::SQLite,
+            "sqlite:///tmp/app.db",
+        );
+
+        reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        assert_eq!(state.input_mode(), InputMode::CellDetail);
+        assert!(state.cell_detail.is_active());
+        assert_eq!(state.cell_detail.content(), r#"{"a":1}"#);
+        assert!(!state.jsonb_detail.is_active());
     }
 
     #[test]

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -1,8 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-#[cfg(test)]
-use crate::domain::ColumnAttributes;
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::shared::flash_timer::FlashId;
@@ -27,7 +26,11 @@ pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -
                 return DispatchResult::handled();
             };
 
-            let display_value = cell_detail_display_value(&cell_value, data_type.as_deref());
+            let display_value = cell_detail_display_value(
+                &cell_value,
+                data_type.as_deref(),
+                state.session.active_database_type_or_default(),
+            );
             state.cell_detail =
                 CellDetailState::open(row_idx, col_idx, column_name, cell_value, display_value);
             state.modal.push_mode(InputMode::CellDetail);
@@ -157,8 +160,13 @@ fn selected_column_data_type(state: &AppState, col_idx: usize) -> Option<&str> {
         .map(|column| column.data_type.as_str())
 }
 
-fn cell_detail_display_value(value: &str, data_type: Option<&str>) -> String {
-    let should_pretty_print_json = data_type == Some("json") || looks_like_json_container(value);
+fn cell_detail_display_value(
+    value: &str,
+    data_type: Option<&str>,
+    database_type: DatabaseType,
+) -> String {
+    let should_pretty_print_json = data_type == Some("json")
+        || (database_type != DatabaseType::SQLite && looks_like_json_container(value));
     if !should_pretty_print_json {
         return value.to_string();
     }
@@ -184,7 +192,8 @@ fn update_search_matches(state: &mut AppState) {
 mod tests {
     use super::*;
     use crate::domain::column::Column;
-    use crate::domain::{QueryResult, QuerySource, Table};
+    use crate::domain::connection::ConnectionId;
+    use crate::domain::{ColumnAttributes, DatabaseType, QueryResult, QuerySource, Table};
     use std::sync::Arc;
 
     fn state_with_cell(data_type: &str, cell_value: &str) -> AppState {
@@ -264,6 +273,29 @@ mod tests {
         assert_eq!(state.input_mode(), InputMode::CellDetail);
         assert_eq!(state.cell_detail.content(), "{\n  \"a\": 1,\n  \"b\": 2\n}");
         assert_eq!(state.cell_detail.original_content(), r#"{"b":2,"a":1}"#);
+    }
+
+    #[test]
+    fn sqlite_text_json_container_shows_raw_detail() {
+        let mut state = state_with_cell("TEXT", r#"{"items":["admin","writer"]}"#);
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::from_string("sqlite-test"),
+            "sqlite",
+            DatabaseType::SQLite,
+            "sqlite:///tmp/app.db",
+        );
+
+        reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        assert_eq!(state.input_mode(), InputMode::CellDetail);
+        assert_eq!(
+            state.cell_detail.content(),
+            r#"{"items":["admin","writer"]}"#
+        );
+        assert_eq!(
+            state.cell_detail.original_content(),
+            r#"{"items":["admin","writer"]}"#
+        );
     }
 
     #[test]

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -10,7 +10,7 @@ use crate::policy::write::write_update::build_pk_pairs;
 use crate::update::action::{Action, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
 
-use crate::policy::preview_cell_text::{preview_cell_text_handling, uses_jsonb_detail_modal};
+use crate::policy::preview_cell_text::{preview_cell_text_diff_handling, uses_jsonb_detail_modal};
 use crate::update::helpers::{EditGuardrailError, editable_preview_base, ensure_column_writable};
 
 fn cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
@@ -26,7 +26,7 @@ fn cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
     let Some(column) = td.columns.get(col_idx) else {
         return false;
     };
-    let handling = preview_cell_text_handling(
+    let handling = preview_cell_text_diff_handling(
         state.session.active_database_type_or_default(),
         column.data_type.as_str(),
     );

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -93,14 +93,9 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
 
             match editable_cell_context(state) {
                 Ok((row_idx, col_idx, value)) => {
-                    if state.result_interaction.cell_edit().row() != Some(row_idx)
-                        || state.result_interaction.cell_edit().col() != Some(col_idx)
-                    {
-                        state
-                            .result_interaction
-                            .begin_cell_edit(row_idx, col_idx, value);
-                        state.result_interaction.clear_write_preview();
-                    }
+                    state
+                        .result_interaction
+                        .ensure_cell_edit_at(row_idx, col_idx, value);
                     state.modal.set_mode(InputMode::CellEdit);
                     DispatchResult::handled()
                 }
@@ -111,11 +106,7 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
             }
         }
         Action::ResultCancelCellEdit => {
-            if state.result_interaction.cell_edit().has_pending_draft() {
-                state.result_interaction.clear_write_preview();
-            } else {
-                state.result_interaction.discard_cell_edit();
-            }
+            state.result_interaction.cancel_cell_edit();
             state.modal.set_mode(InputMode::Normal);
             DispatchResult::handled()
         }
@@ -128,32 +119,26 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
             target: InputTarget::ResultCellEdit,
             ch: c,
         } => {
-            state
-                .result_interaction
-                .cell_edit_input_mut()
-                .insert_char(*c);
+            state.result_interaction.cell_edit_insert_char(*c);
             DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::ResultCellEdit,
         } => {
-            state.result_interaction.cell_edit_input_mut().backspace();
+            state.result_interaction.cell_edit_backspace();
             DispatchResult::handled()
         }
         Action::TextDelete {
             target: InputTarget::ResultCellEdit,
         } => {
-            state.result_interaction.cell_edit_input_mut().delete();
+            state.result_interaction.cell_edit_delete();
             DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: InputTarget::ResultCellEdit,
             direction: m,
         } => {
-            state
-                .result_interaction
-                .cell_edit_input_mut()
-                .move_cursor(*m);
+            state.result_interaction.cell_edit_move_cursor(*m);
             DispatchResult::handled()
         }
         _ => DispatchResult::pass(),
@@ -215,8 +200,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "alice".to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content("modified".to_string());
+                .cell_edit_set_content("modified".to_string());
             state.modal.set_mode(InputMode::Normal);
 
             reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
@@ -241,8 +225,7 @@ mod tests {
                 .begin_cell_edit(0, 99, "stale".to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content("stale-modified".to_string());
+                .cell_edit_set_content("stale-modified".to_string());
 
             reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
                 .into_effects()
@@ -382,8 +365,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "alice".to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content("bob".to_string());
+                .cell_edit_set_content("bob".to_string());
             state.modal.set_mode(InputMode::CellEdit);
 
             reduce_edit(&mut state, &Action::ResultCancelCellEdit, Instant::now())
@@ -492,10 +474,7 @@ mod tests {
             state
                 .result_interaction
                 .begin_cell_edit(0, 0, content.to_string());
-            state
-                .result_interaction
-                .cell_edit_input_mut()
-                .set_cursor(cursor);
+            state.result_interaction.cell_edit_set_cursor(cursor);
             state
         }
 

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -10,22 +10,27 @@ use crate::policy::write::write_update::build_pk_pairs;
 use crate::update::action::{Action, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
 
+use crate::policy::preview_cell_text::{preview_cell_text_handling, uses_jsonb_detail_modal};
 use crate::update::helpers::{EditGuardrailError, editable_preview_base, ensure_column_writable};
 
-fn is_jsonb_cell(state: &AppState) -> bool {
+fn cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
     let Some(col_idx) = state.result_interaction.selection().cell() else {
         return false;
     };
     let Some(td) = state.session.table_detail() else {
         return false;
     };
-    // Ensure table_detail matches current preview target
     if td.schema != state.query.pagination.schema() || td.name != state.query.pagination.table() {
         return false;
     }
-    td.columns
-        .get(col_idx)
-        .is_some_and(|c| c.data_type == "jsonb")
+    let Some(column) = td.columns.get(col_idx) else {
+        return false;
+    };
+    let handling = preview_cell_text_handling(
+        state.session.active_database_type_or_default(),
+        column.data_type.as_str(),
+    );
+    uses_jsonb_detail_modal(handling)
 }
 
 fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), EditGuardrailError> {
@@ -80,7 +85,7 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
             }
 
             // JSONB columns open the dedicated detail modal instead of inline edit
-            if is_jsonb_cell(state) {
+            if cell_uses_jsonb_detail_modal(state) {
                 return DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
                     Action::OpenModal(ModalKind::JsonbDetail),
                 ])]);
@@ -393,7 +398,9 @@ mod tests {
 
     mod jsonb_dispatch {
         use super::*;
+        use crate::domain::DatabaseType;
         use crate::domain::column::Column;
+        use crate::domain::connection::ConnectionId;
 
         fn state_with_jsonb_column() -> AppState {
             let mut state = cell_edit_entry_guardrails::preview_state_with_selection();
@@ -433,6 +440,25 @@ mod tests {
                 &effects[0],
                 Effect::DispatchActions(actions) if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonbDetail)])
             ));
+        }
+
+        #[test]
+        fn sqlite_jsonb_cell_opens_inline_edit() {
+            let mut state = state_with_jsonb_column();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
+
+            let effects = reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            assert!(effects.is_empty());
+            assert_eq!(state.input_mode(), InputMode::CellEdit);
+            assert!(state.result_interaction.cell_edit().is_active());
         }
     }
 

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -106,7 +106,7 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
             }
         }
         Action::ResultCancelCellEdit => {
-            state.result_interaction.cancel_cell_edit();
+            state.result_interaction.leave_cell_edit();
             state.modal.set_mode(InputMode::Normal);
             DispatchResult::handled()
         }
@@ -200,7 +200,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "alice".to_string());
             state
                 .result_interaction
-                .cell_edit_set_content("modified".to_string());
+                .replace_cell_edit_draft("modified".to_string());
             state.modal.set_mode(InputMode::Normal);
 
             reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
@@ -225,7 +225,7 @@ mod tests {
                 .begin_cell_edit(0, 99, "stale".to_string());
             state
                 .result_interaction
-                .cell_edit_set_content("stale-modified".to_string());
+                .replace_cell_edit_draft("stale-modified".to_string());
 
             reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
                 .into_effects()
@@ -365,7 +365,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "alice".to_string());
             state
                 .result_interaction
-                .cell_edit_set_content("bob".to_string());
+                .replace_cell_edit_draft("bob".to_string());
             state.modal.set_mode(InputMode::CellEdit);
 
             reduce_edit(&mut state, &Action::ResultCancelCellEdit, Instant::now())

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -343,7 +343,9 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
             .result_interaction
             .begin_cell_edit(row, col, original_cell);
         state.result_interaction.clear_write_preview();
-        state.result_interaction.cell_edit_set_content(compact_str);
+        state
+            .result_interaction
+            .replace_cell_edit_draft(compact_str);
     }
 }
 

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -9,7 +9,7 @@ use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::KeySequenceState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::shared::ui_state::DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS;
-use crate::policy::preview_cell_text::{preview_cell_text_handling, uses_jsonb_detail_modal};
+use crate::policy::preview_cell_text::{preview_cell_text_diff_handling, uses_jsonb_detail_modal};
 use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
@@ -45,7 +45,8 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
             let Some(column) = table_detail.columns.get(col_idx) else {
                 return DispatchResult::handled();
             };
-            let handling = preview_cell_text_handling(database_type, column.data_type.as_str());
+            let handling =
+                preview_cell_text_diff_handling(database_type, column.data_type.as_str());
             if !uses_jsonb_detail_modal(handling) {
                 return DispatchResult::handled();
             }

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -9,6 +9,7 @@ use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::KeySequenceState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::shared::ui_state::DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS;
+use crate::policy::preview_cell_text::{preview_cell_text_handling, uses_jsonb_detail_modal};
 use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
@@ -40,10 +41,14 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 return DispatchResult::handled();
             };
 
-            let column = match table_detail.columns.get(col_idx) {
-                Some(c) if c.data_type == "jsonb" => c,
-                _ => return DispatchResult::handled(),
+            let database_type = state.session.active_database_type_or_default();
+            let Some(column) = table_detail.columns.get(col_idx) else {
+                return DispatchResult::handled();
             };
+            let handling = preview_cell_text_handling(database_type, column.data_type.as_str());
+            if !uses_jsonb_detail_modal(handling) {
+                return DispatchResult::handled();
+            }
 
             let cell_value = match result.rows().get(row_idx).and_then(|r| r.get(col_idx)) {
                 Some(v) if !v.is_empty() => v,
@@ -455,6 +460,26 @@ mod tests {
         fn blocked_on_non_jsonb_column() {
             let mut state = state_with_jsonb_cell();
             state.result_interaction.move_cell(0);
+
+            reduce_jsonb(
+                &mut state,
+                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                Instant::now(),
+            );
+
+            assert!(!state.jsonb_detail.is_active());
+            assert_eq!(state.input_mode(), InputMode::Normal);
+        }
+
+        #[test]
+        fn blocked_on_sqlite_jsonb_column() {
+            let mut state = state_with_jsonb_cell();
+            state.session.activate_connection_with_dsn(
+                &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                crate::domain::DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
 
             reduce_jsonb(
                 &mut state,

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -441,6 +441,8 @@ mod tests {
 
     mod entry_guards {
         use super::*;
+        use crate::domain::DatabaseType;
+        use crate::domain::connection::ConnectionId;
 
         #[test]
         fn opens_on_valid_jsonb_cell() {
@@ -448,7 +450,7 @@ mod tests {
 
             reduce_jsonb(
                 &mut state,
-                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                &Action::OpenModal(ModalKind::JsonbDetail),
                 Instant::now(),
             );
 
@@ -463,7 +465,7 @@ mod tests {
 
             reduce_jsonb(
                 &mut state,
-                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                &Action::OpenModal(ModalKind::JsonbDetail),
                 Instant::now(),
             );
 
@@ -475,15 +477,15 @@ mod tests {
         fn blocked_on_sqlite_jsonb_column() {
             let mut state = state_with_jsonb_cell();
             state.session.activate_connection_with_dsn(
-                &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
+                &ConnectionId::from_string("sqlite-test"),
                 "sqlite",
-                crate::domain::DatabaseType::SQLite,
+                DatabaseType::SQLite,
                 "sqlite:///tmp/app.db",
             );
 
             reduce_jsonb(
                 &mut state,
-                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                &Action::OpenModal(ModalKind::JsonbDetail),
                 Instant::now(),
             );
 

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -343,10 +343,7 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
             .result_interaction
             .begin_cell_edit(row, col, original_cell);
         state.result_interaction.clear_write_preview();
-        state
-            .result_interaction
-            .cell_edit_input_mut()
-            .set_content(compact_str);
+        state.result_interaction.cell_edit_set_content(compact_str);
     }
 }
 

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -1139,8 +1139,7 @@ mod tests {
                     .begin_cell_edit(0, 1, "original".to_string());
                 state
                     .result_interaction
-                    .cell_edit_input_mut()
-                    .set_content("modified".to_string());
+                    .cell_edit_set_content("modified".to_string());
 
                 let result = handle_normal_mode(combo(Key::Esc), &state);
 

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -1139,7 +1139,7 @@ mod tests {
                     .begin_cell_edit(0, 1, "original".to_string());
                 state
                     .result_interaction
-                    .cell_edit_set_content("modified".to_string());
+                    .replace_cell_edit_draft("modified".to_string());
 
                 let result = handle_normal_mode(combo(Key::Esc), &state);
 

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -602,6 +602,27 @@ mod tests {
         }
 
         #[test]
+        fn sqlite_submit_multi_drop_pairs_label_with_first_target() {
+            let mut state = sql_modal_state();
+            activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
+            state
+                .sql_modal
+                .editor
+                .set_content("DROP INDEX my_index; DROP VIEW my_view".to_string());
+
+            reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
+
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::ConfirmingHigh {
+                    decision,
+                    target_name,
+                    ..
+                } if decision.label == "DROP INDEX" && target_name == "my_index"
+            ));
+        }
+
+        #[test]
         fn high_risk_confirm_matches_full_name_not_truncated() {
             let full_name = "my_schema.very_long_table_name";
             let mut state = confirming_high_state(&format!("DROP TABLE {full_name}"), full_name);

--- a/src/app/update/sql_editor/submit.rs
+++ b/src/app/update/sql_editor/submit.rs
@@ -1,36 +1,17 @@
 use std::time::Instant;
 
-use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
-use crate::policy::sql::statement_classifier;
 use crate::policy::write::sql_risk::{
-    ConfirmationType, MultiStatementDecision, evaluate_multi_statement_for_database,
-    split_statements_for_database, sqlite_specific_label,
+    ConfirmationType, MultiStatementDecision, adhoc_label_for_table_name_confirmation,
+    evaluate_multi_statement_for_database,
 };
-use crate::policy::write::write_guardrails::{AdhocRiskDecision, RiskLevel, evaluate_sql_risk};
+use crate::policy::write::write_guardrails::AdhocRiskDecision;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::start_adhoc_if_connected;
 
-fn multi_statement_label(database_type: DatabaseType, sql: &str) -> &'static str {
-    let mut worst_level = RiskLevel::Low;
-    let mut worst_label = "SQL";
-    for stmt in split_statements_for_database(database_type, sql) {
-        let sqlite_label = (database_type == DatabaseType::SQLite)
-            .then(|| sqlite_specific_label(&stmt))
-            .flatten();
-        let kind = statement_classifier::classify(&stmt);
-        let d = evaluate_sql_risk(&kind);
-        let label = sqlite_label.unwrap_or(d.label);
-        if d.risk_level > worst_level || (d.risk_level == worst_level && label != "SQL") {
-            worst_level = d.risk_level;
-            worst_label = label;
-        }
-    }
-    worst_label
-}
 pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::SqlModalSubmit => {
@@ -48,11 +29,6 @@ pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant)
                     DispatchResult::handled()
                 }
                 MultiStatementDecision::Allow { risk, .. } => {
-                    let label = multi_statement_label(database_type, &query);
-                    let decision = AdhocRiskDecision {
-                        risk_level: risk.risk_level,
-                        label,
-                    };
                     if state.session.is_read_only() && !risk.read_only_allowed {
                         state.sql_modal.finish_adhoc_error(
                             "Read-only mode: write operations are disabled".to_string(),
@@ -66,6 +42,15 @@ pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant)
                             DispatchResult::handled()
                         }
                         ConfirmationType::TableNameInput { target } => {
+                            let label = adhoc_label_for_table_name_confirmation(
+                                database_type,
+                                &query,
+                            )
+                            .expect("TableNameInput confirmation must have a matching statement");
+                            let decision = AdhocRiskDecision {
+                                risk_level: risk.risk_level,
+                                label,
+                            };
                             state.sql_modal.begin_confirming_high(decision, target);
                             DispatchResult::handled()
                         }

--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -18,6 +18,8 @@ impl IndexAttributes {
     pub const PARTIAL: Self = Self(0b0_0100);
     pub const EXPRESSION: Self = Self(0b0_1000);
     pub const HAS_AUXILIARY_COLUMNS: Self = Self(0b1_0000);
+    pub const DESCENDING: Self = Self(0b10_0000);
+    pub const NON_BINARY_COLLATION: Self = Self(0b100_0000);
 
     pub const fn empty() -> Self {
         Self(0)
@@ -68,6 +70,30 @@ impl Index {
     pub const fn has_auxiliary_columns(&self) -> bool {
         self.attributes
             .contains(IndexAttributes::HAS_AUXILIARY_COLUMNS)
+    }
+
+    pub const fn has_descending_key(&self) -> bool {
+        self.attributes.contains(IndexAttributes::DESCENDING)
+    }
+
+    pub const fn has_non_binary_collation(&self) -> bool {
+        self.attributes
+            .contains(IndexAttributes::NON_BINARY_COLLATION)
+    }
+
+    pub const fn has_index_detail(&self) -> bool {
+        self.is_partial()
+            || self.has_expression()
+            || self.has_auxiliary_columns()
+            || self.has_descending_key()
+            || self.has_non_binary_collation()
+    }
+
+    pub const fn needs_source_definition_detail(&self) -> bool {
+        self.is_partial()
+            || self.has_expression()
+            || self.has_descending_key()
+            || self.has_non_binary_collation()
     }
 }
 
@@ -160,6 +186,17 @@ mod tests {
 
             assert!(attributes.contains(IndexAttributes::UNIQUE));
             assert!(attributes.contains(IndexAttributes::PRIMARY));
+        }
+
+        #[test]
+        fn detail_visibility_splits_column_and_source_definition_needs() {
+            let auxiliary_only = make_index(IndexAttributes::HAS_AUXILIARY_COLUMNS);
+            assert!(auxiliary_only.has_index_detail());
+            assert!(!auxiliary_only.needs_source_definition_detail());
+
+            let partial = make_index(IndexAttributes::PARTIAL);
+            assert!(partial.has_index_detail());
+            assert!(partial.needs_source_definition_detail());
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
@@ -819,11 +819,67 @@ fn sqlite_export_not_rerunnable_error() -> DbOperationError {
     )
 }
 
-fn should_wrap_transaction(query: &str) -> bool {
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SqliteWrapMode {
+    None,
+    BeginCommit,
+    InternalSavepoint(String),
+}
+
+fn needs_write_batch_wrap(statements: &[&str]) -> bool {
+    statements.len() > 1 && statements.iter().any(|stmt| is_write_statement(stmt))
+}
+
+fn is_full_rollback(statement: &str) -> bool {
+    first_keyword(statement).eq_ignore_ascii_case("ROLLBACK")
+        && !second_keyword(statement).is_some_and(|kw| kw.eq_ignore_ascii_case("TO"))
+}
+
+fn user_savepoint_names(statements: &[&str]) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for statement in statements {
+        if first_keyword(statement).eq_ignore_ascii_case("SAVEPOINT")
+            && let Some(name) = second_keyword(statement)
+        {
+            names.insert(name.to_ascii_uppercase());
+        }
+        if first_keyword(statement).eq_ignore_ascii_case("RELEASE")
+            && let Some(name) = second_keyword(statement)
+        {
+            names.remove(&name.to_ascii_uppercase());
+        }
+    }
+    names
+}
+
+fn sqlite_wrap_mode(query: &str) -> SqliteWrapMode {
     let statements = split_sqlite_statements(query);
-    statements.len() > 1
-        && statements.iter().any(|stmt| is_write_statement(stmt))
-        && !statements.iter().any(|stmt| is_transaction_control(stmt))
+    if !needs_write_batch_wrap(&statements) {
+        return SqliteWrapMode::None;
+    }
+
+    if statements.iter().any(|stmt| {
+        matches!(
+            first_keyword(stmt).to_ascii_uppercase().as_str(),
+            "BEGIN" | "COMMIT" | "END" | "RELEASE"
+        ) || is_full_rollback(stmt)
+    }) {
+        return SqliteWrapMode::None;
+    }
+
+    if statements
+        .first()
+        .is_some_and(|stmt| first_keyword(stmt).eq_ignore_ascii_case("SAVEPOINT"))
+    {
+        let reserved = user_savepoint_names(&statements);
+        return SqliteWrapMode::InternalSavepoint(sqlite_wrap_marker(&reserved));
+    }
+
+    if statements.iter().any(|stmt| is_transaction_control(stmt)) {
+        return SqliteWrapMode::None;
+    }
+
+    SqliteWrapMode::BeginCommit
 }
 
 fn sqlite_transaction_block(query: &str) -> String {
@@ -831,11 +887,34 @@ fn sqlite_transaction_block(query: &str) -> String {
     format!("BEGIN;\n{trimmed}\n;\nCOMMIT")
 }
 
+fn sqlite_savepoint_block(query: &str, name: &str) -> String {
+    let trimmed = query.trim_end().trim_end_matches(';').trim_end();
+    format!("SAVEPOINT {name};\n{trimmed}\n;\nRELEASE {name}")
+}
+
 fn sqlite_execution_query(query: &str) -> Cow<'_, str> {
-    if should_wrap_transaction(query) {
-        Cow::Owned(sqlite_transaction_block(query))
-    } else {
-        Cow::Borrowed(query)
+    match sqlite_wrap_mode(query) {
+        SqliteWrapMode::BeginCommit => Cow::Owned(sqlite_transaction_block(query)),
+        SqliteWrapMode::InternalSavepoint(name) => Cow::Owned(sqlite_savepoint_block(query, &name)),
+        SqliteWrapMode::None => Cow::Borrowed(query),
+    }
+}
+
+fn sqlite_wrap_marker(reserved_names: &HashSet<String>) -> String {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    loop {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos());
+        let marker = format!(
+            "__sabiql_sqlite_wrap_{}_{}_{}",
+            std::process::id(),
+            nanos,
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        );
+        if !reserved_names.contains(&marker.to_ascii_uppercase()) {
+            return marker;
+        }
     }
 }
 
@@ -879,10 +958,14 @@ fn sqlite_adhoc_execution_query(query: &str, marker: &str) -> String {
         return query.to_string();
     }
 
-    let wrap = should_wrap_transaction(query);
-    let mut parts = Vec::with_capacity(statements.len() * 2 + usize::from(wrap) * 2);
-    if wrap {
-        parts.push("BEGIN".to_string());
+    let wrap_mode = sqlite_wrap_mode(query);
+    let mut parts = Vec::with_capacity(statements.len() * 2 + 2);
+    match &wrap_mode {
+        SqliteWrapMode::BeginCommit => parts.push("BEGIN".to_string()),
+        SqliteWrapMode::InternalSavepoint(name) => {
+            parts.push(format!("SAVEPOINT {name}"));
+        }
+        SqliteWrapMode::None => {}
     }
     for (index, statement) in statements.iter().enumerate() {
         parts.push((*statement).to_string());
@@ -893,8 +976,10 @@ fn sqlite_adhoc_execution_query(query: &str, marker: &str) -> String {
             parts.push(sqlite_result_probe(marker, index));
         }
     }
-    if wrap {
-        parts.push("COMMIT".to_string());
+    match wrap_mode {
+        SqliteWrapMode::BeginCommit => parts.push("COMMIT".to_string()),
+        SqliteWrapMode::InternalSavepoint(name) => parts.push(format!("RELEASE {name}")),
+        SqliteWrapMode::None => {}
     }
     parts.join("\n;\n")
 }
@@ -1498,15 +1583,15 @@ fn discard_rolled_back(tags: &[CommandTag]) -> Vec<CommandTag> {
                 frames.push((tag_name(raw, "SAVEPOINT"), Vec::new()));
             }
             CommandTag::Other(raw) if raw == "RELEASE" || raw.starts_with("RELEASE ") => {
-                if let Some(index) = savepoint_frame_index(&frames, tag_name(raw, "RELEASE"))
-                    && index > 0
-                {
+                if let Some(index) = savepoint_frame_index(&frames, tag_name(raw, "RELEASE")) {
                     let mut merged = Vec::new();
                     for (_, frame) in frames.drain(index..) {
                         merged.extend(frame);
                     }
                     if let Some((_, parent)) = frames.last_mut() {
                         parent.extend(merged);
+                    } else {
+                        effective.extend(merged);
                     }
                 }
             }
@@ -1559,9 +1644,10 @@ fn savepoint_frame_index(
         .enumerate()
         .rev()
         .find_map(|(index, (frame_name, _))| {
-            if index == 0 {
-                None
-            } else if name
+            if frame_name.is_none() && index == 0 {
+                return None;
+            }
+            if name
                 .as_ref()
                 .is_none_or(|name| frame_name.as_ref() == Some(name))
             {
@@ -1870,6 +1956,113 @@ mod tests {
             wrapped,
             "BEGIN; INSERT INTO users(id) VALUES (1); END\n;\nSELECT changes() AS affected_rows;"
         );
+    }
+
+    mod discard_rolled_back_policy {
+        use super::*;
+
+        fn sp(name: &str) -> CommandTag {
+            CommandTag::Other(format!("SAVEPOINT {name}"))
+        }
+
+        fn rollback_to(name: &str) -> CommandTag {
+            CommandTag::Other(format!("ROLLBACK TO {name}"))
+        }
+
+        fn release(name: &str) -> CommandTag {
+            CommandTag::Other(format!("RELEASE {name}"))
+        }
+
+        #[test]
+        fn top_level_savepoint_rollback_to_discards_inner_dml() {
+            let tags = vec![
+                sp("sp"),
+                CommandTag::Insert(1),
+                rollback_to("sp"),
+                CommandTag::Insert(2),
+                release("sp"),
+            ];
+
+            assert_eq!(discard_rolled_back(&tags), vec![CommandTag::Insert(2)]);
+        }
+
+        #[test]
+        fn top_level_savepoint_full_rollback_discards_all_dml() {
+            let tags = vec![sp("sp"), CommandTag::Insert(1), CommandTag::Rollback];
+
+            assert!(discard_rolled_back(&tags).is_empty());
+        }
+
+        #[test]
+        fn begin_savepoint_release_still_merges_nested_frame() {
+            let tags = vec![
+                CommandTag::Begin,
+                sp("inner"),
+                CommandTag::Insert(1),
+                release("inner"),
+                CommandTag::Commit,
+            ];
+
+            assert_eq!(discard_rolled_back(&tags), vec![CommandTag::Insert(1)]);
+        }
+    }
+
+    mod wrap_mode {
+        use super::*;
+
+        #[test]
+        fn autocommit_multi_write_uses_begin_commit() {
+            assert_eq!(
+                sqlite_wrap_mode(
+                    "INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)"
+                ),
+                SqliteWrapMode::BeginCommit
+            );
+        }
+
+        #[test]
+        fn explicit_begin_is_not_wrapped() {
+            assert_eq!(
+                sqlite_wrap_mode("BEGIN; INSERT INTO users(id) VALUES (1); COMMIT"),
+                SqliteWrapMode::None
+            );
+        }
+
+        #[test]
+        fn top_level_savepoint_multi_write_uses_internal_savepoint() {
+            let mode = sqlite_wrap_mode(
+                "SAVEPOINT user_sp; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)",
+            );
+
+            assert!(
+                matches!(mode, SqliteWrapMode::InternalSavepoint(name) if name.starts_with("__sabiql_sqlite_wrap_"))
+            );
+        }
+
+        #[test]
+        fn internal_savepoint_name_avoids_user_savepoint_collision() {
+            let user_name = "__sabiql_sqlite_wrap_collision";
+            let mode = sqlite_wrap_mode(&format!(
+                "SAVEPOINT {user_name}; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)"
+            ));
+
+            match mode {
+                SqliteWrapMode::InternalSavepoint(name) => {
+                    assert_ne!(name.to_ascii_uppercase(), user_name.to_ascii_uppercase());
+                }
+                other => panic!("expected internal savepoint wrap, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn mid_batch_savepoint_is_not_wrapped() {
+            assert_eq!(
+                sqlite_wrap_mode(
+                    "INSERT INTO users(id) VALUES (1); SAVEPOINT sp; INSERT INTO users(id) VALUES (2)"
+                ),
+                SqliteWrapMode::None
+            );
+        }
     }
 
     #[test]
@@ -2804,6 +2997,54 @@ mod tests {
 
             assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
             assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+        }
+
+        #[tokio::test]
+        async fn top_level_savepoint_rollback_to_discards_inner_dml_only() {
+            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(
+                    &dsn,
+                    "SAVEPOINT sp;
+                     INSERT INTO users(id) VALUES (1);
+                     INSERT INTO users(id) VALUES (2);
+                     ROLLBACK TO sp;
+                     INSERT INTO users(id) VALUES (3);
+                     RELEASE sp",
+                    false,
+                )
+                .await
+                .unwrap();
+            let rows = adapter
+                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .await
+                .unwrap();
+
+            assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+            assert_eq!(rows.rows(), vec![vec!["3".to_string()]]);
+        }
+
+        #[tokio::test]
+        async fn top_level_savepoint_multi_write_rolls_back_when_later_statement_fails() {
+            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(
+                    &dsn,
+                    "SAVEPOINT sp; INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
+                    false,
+                )
+                .await;
+
+            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            let rows = adapter
+                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .await
+                .unwrap();
+            assert!(rows.rows().is_empty());
         }
 
         #[tokio::test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
@@ -645,19 +645,6 @@ fn second_keyword(sql: &str) -> Option<&str> {
     next_keyword_from(sql, end).map(|(keyword, _)| keyword)
 }
 
-fn third_keyword(sql: &str) -> Option<&str> {
-    let (_, first_end) = next_keyword_from(sql, 0)?;
-    let (_, second_end) = next_keyword_from(sql, first_end)?;
-    next_keyword_from(sql, second_end).map(|(keyword, _)| keyword)
-}
-
-fn fourth_keyword(sql: &str) -> Option<&str> {
-    let (_, first_end) = next_keyword_from(sql, 0)?;
-    let (_, second_end) = next_keyword_from(sql, first_end)?;
-    let (_, third_end) = next_keyword_from(sql, second_end)?;
-    next_keyword_from(sql, third_end).map(|(keyword, _)| keyword)
-}
-
 fn contains_keyword(sql: &str, expected: &str) -> bool {
     let mut offset = 0;
     while let Some((keyword, end)) = next_keyword_from(sql, offset) {
@@ -823,56 +810,49 @@ fn sqlite_export_not_rerunnable_error() -> DbOperationError {
 enum SqliteWrapMode {
     None,
     BeginCommit,
-    InternalSavepoint(String),
 }
 
 fn needs_write_batch_wrap(statements: &[&str]) -> bool {
     statements.len() > 1 && statements.iter().any(|stmt| is_write_statement(stmt))
 }
 
-fn is_full_rollback(statement: &str) -> bool {
-    first_keyword(statement).eq_ignore_ascii_case("ROLLBACK")
-        && !second_keyword(statement).is_some_and(|kw| kw.eq_ignore_ascii_case("TO"))
+fn rollback_to_target(statement: &str) -> Option<&str> {
+    let (_, first_end) = next_keyword_from(statement, 0)?;
+    if !first_keyword(statement).eq_ignore_ascii_case("ROLLBACK") {
+        return None;
+    }
+    let (second, second_end) = next_keyword_from(statement, first_end)?;
+    if second.eq_ignore_ascii_case("TRANSACTION") {
+        let (third, third_end) = next_keyword_from(statement, second_end)?;
+        if !third.eq_ignore_ascii_case("TO") {
+            return None;
+        }
+        let (fourth, fourth_end) = next_keyword_from(statement, third_end)?;
+        if fourth.eq_ignore_ascii_case("SAVEPOINT") {
+            next_keyword_from(statement, fourth_end).map(|(name, _)| name)
+        } else {
+            Some(fourth)
+        }
+    } else if second.eq_ignore_ascii_case("TO") {
+        let (third, third_end) = next_keyword_from(statement, second_end)?;
+        if third.eq_ignore_ascii_case("SAVEPOINT") {
+            next_keyword_from(statement, third_end).map(|(name, _)| name)
+        } else {
+            Some(third)
+        }
+    } else {
+        None
+    }
 }
 
-fn user_savepoint_names(statements: &[&str]) -> HashSet<String> {
-    let mut names = HashSet::new();
-    for statement in statements {
-        if first_keyword(statement).eq_ignore_ascii_case("SAVEPOINT")
-            && let Some(name) = second_keyword(statement)
-        {
-            names.insert(name.to_ascii_uppercase());
-        }
-        if first_keyword(statement).eq_ignore_ascii_case("RELEASE")
-            && let Some(name) = second_keyword(statement)
-        {
-            names.remove(&name.to_ascii_uppercase());
-        }
-    }
-    names
+fn is_rollback_to(statement: &str) -> bool {
+    rollback_to_target(statement).is_some()
 }
 
 fn sqlite_wrap_mode(query: &str) -> SqliteWrapMode {
     let statements = split_sqlite_statements(query);
     if !needs_write_batch_wrap(&statements) {
         return SqliteWrapMode::None;
-    }
-
-    if statements.iter().any(|stmt| {
-        matches!(
-            first_keyword(stmt).to_ascii_uppercase().as_str(),
-            "BEGIN" | "COMMIT" | "END" | "RELEASE"
-        ) || is_full_rollback(stmt)
-    }) {
-        return SqliteWrapMode::None;
-    }
-
-    if statements
-        .first()
-        .is_some_and(|stmt| first_keyword(stmt).eq_ignore_ascii_case("SAVEPOINT"))
-    {
-        let reserved = user_savepoint_names(&statements);
-        return SqliteWrapMode::InternalSavepoint(sqlite_wrap_marker(&reserved));
     }
 
     if statements.iter().any(|stmt| is_transaction_control(stmt)) {
@@ -887,34 +867,10 @@ fn sqlite_transaction_block(query: &str) -> String {
     format!("BEGIN;\n{trimmed}\n;\nCOMMIT")
 }
 
-fn sqlite_savepoint_block(query: &str, name: &str) -> String {
-    let trimmed = query.trim_end().trim_end_matches(';').trim_end();
-    format!("SAVEPOINT {name};\n{trimmed}\n;\nRELEASE {name}")
-}
-
 fn sqlite_execution_query(query: &str) -> Cow<'_, str> {
     match sqlite_wrap_mode(query) {
         SqliteWrapMode::BeginCommit => Cow::Owned(sqlite_transaction_block(query)),
-        SqliteWrapMode::InternalSavepoint(name) => Cow::Owned(sqlite_savepoint_block(query, &name)),
         SqliteWrapMode::None => Cow::Borrowed(query),
-    }
-}
-
-fn sqlite_wrap_marker(reserved_names: &HashSet<String>) -> String {
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    loop {
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_or(0, |d| d.as_nanos());
-        let marker = format!(
-            "__sabiql_sqlite_wrap_{}_{}_{}",
-            std::process::id(),
-            nanos,
-            SEQ.fetch_add(1, Ordering::Relaxed)
-        );
-        if !reserved_names.contains(&marker.to_ascii_uppercase()) {
-            return marker;
-        }
     }
 }
 
@@ -960,12 +916,8 @@ fn sqlite_adhoc_execution_query(query: &str, marker: &str) -> String {
 
     let wrap_mode = sqlite_wrap_mode(query);
     let mut parts = Vec::with_capacity(statements.len() * 2 + 2);
-    match &wrap_mode {
-        SqliteWrapMode::BeginCommit => parts.push("BEGIN".to_string()),
-        SqliteWrapMode::InternalSavepoint(name) => {
-            parts.push(format!("SAVEPOINT {name}"));
-        }
-        SqliteWrapMode::None => {}
+    if matches!(wrap_mode, SqliteWrapMode::BeginCommit) {
+        parts.push("BEGIN".to_string());
     }
     for (index, statement) in statements.iter().enumerate() {
         parts.push((*statement).to_string());
@@ -976,10 +928,8 @@ fn sqlite_adhoc_execution_query(query: &str, marker: &str) -> String {
             parts.push(sqlite_result_probe(marker, index));
         }
     }
-    match wrap_mode {
-        SqliteWrapMode::BeginCommit => parts.push("COMMIT".to_string()),
-        SqliteWrapMode::InternalSavepoint(name) => parts.push(format!("RELEASE {name}")),
-        SqliteWrapMode::None => {}
+    if matches!(wrap_mode, SqliteWrapMode::BeginCommit) {
+        parts.push("COMMIT".to_string());
     }
     parts.join("\n;\n")
 }
@@ -1516,18 +1466,10 @@ fn transaction_control_tag(query: &str) -> Option<CommandTag> {
     match first_keyword(query).to_ascii_uppercase().as_str() {
         "BEGIN" => Some(CommandTag::Begin),
         "COMMIT" | "END" => Some(CommandTag::Commit),
-        "ROLLBACK" if second_keyword(query).is_some_and(|kw| kw.eq_ignore_ascii_case("TO")) => {
-            let name =
-                if third_keyword(query).is_some_and(|kw| kw.eq_ignore_ascii_case("SAVEPOINT")) {
-                    fourth_keyword(query)
-                } else {
-                    third_keyword(query)
-                };
-            Some(CommandTag::Other(format!(
-                "ROLLBACK TO {}",
-                name.unwrap_or("")
-            )))
-        }
+        "ROLLBACK" if is_rollback_to(query) => Some(CommandTag::Other(format!(
+            "ROLLBACK TO {}",
+            rollback_to_target(query).unwrap_or("")
+        ))),
         "ROLLBACK" => Some(CommandTag::Rollback),
         "SAVEPOINT" => Some(CommandTag::Other(format!(
             "SAVEPOINT {}",
@@ -2005,6 +1947,23 @@ mod tests {
 
             assert_eq!(discard_rolled_back(&tags), vec![CommandTag::Insert(1)]);
         }
+
+        #[test]
+        fn rollback_transaction_to_savepoint_discards_inner_dml() {
+            let tags = sqlite_statement_tags(
+                &[
+                    "SAVEPOINT sp",
+                    "INSERT INTO users(id) VALUES (1)",
+                    "INSERT INTO users(id) VALUES (2)",
+                    "ROLLBACK TRANSACTION TO SAVEPOINT sp",
+                    "INSERT INTO users(id) VALUES (3)",
+                    "RELEASE sp",
+                ],
+                &HashMap::from([(1, 1), (2, 1), (4, 1)]),
+            );
+
+            assert_eq!(discard_rolled_back(&tags), vec![CommandTag::Insert(1)]);
+        }
     }
 
     mod wrap_mode {
@@ -2029,29 +1988,13 @@ mod tests {
         }
 
         #[test]
-        fn top_level_savepoint_multi_write_uses_internal_savepoint() {
-            let mode = sqlite_wrap_mode(
-                "SAVEPOINT user_sp; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)",
+        fn top_level_savepoint_multi_write_is_not_wrapped() {
+            assert_eq!(
+                sqlite_wrap_mode(
+                    "SAVEPOINT user_sp; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)"
+                ),
+                SqliteWrapMode::None
             );
-
-            assert!(
-                matches!(mode, SqliteWrapMode::InternalSavepoint(name) if name.starts_with("__sabiql_sqlite_wrap_"))
-            );
-        }
-
-        #[test]
-        fn internal_savepoint_name_avoids_user_savepoint_collision() {
-            let user_name = "__sabiql_sqlite_wrap_collision";
-            let mode = sqlite_wrap_mode(&format!(
-                "SAVEPOINT {user_name}; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)"
-            ));
-
-            match mode {
-                SqliteWrapMode::InternalSavepoint(name) => {
-                    assert_ne!(name.to_ascii_uppercase(), user_name.to_ascii_uppercase());
-                }
-                other => panic!("expected internal savepoint wrap, got {other:?}"),
-            }
         }
 
         #[test]
@@ -3044,6 +2987,27 @@ mod tests {
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
                 .unwrap();
+            assert!(rows.rows().is_empty());
+        }
+
+        #[tokio::test]
+        async fn top_level_savepoint_without_release_does_not_persist_on_success() {
+            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let adapter = SqliteAdapter::new();
+
+            let _result = adapter
+                .execute_adhoc(
+                    &dsn,
+                    "SAVEPOINT sp; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)",
+                    false,
+                )
+                .await
+                .unwrap();
+            let rows = adapter
+                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .await
+                .unwrap();
+
             assert!(rows.rows().is_empty());
         }
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -58,6 +58,10 @@ struct RawIndexColumn {
     seqno: i64,
     cid: i64,
     name: Option<String>,
+    #[serde(default)]
+    desc: i64,
+    #[serde(default)]
+    coll: Option<String>,
     key: i64,
 }
 
@@ -275,6 +279,14 @@ impl SqliteAdapter {
             columns.sort_by_key(|col| col.seqno);
             let has_expression = columns.iter().any(|col| col.key != 0 && col.cid == -2);
             let has_auxiliary_columns = columns.iter().any(|col| col.key == 0);
+            let has_descending_key = columns.iter().any(|col| col.key != 0 && col.desc != 0);
+            let has_non_binary_collation = columns.iter().any(|col| {
+                col.key != 0
+                    && col
+                        .coll
+                        .as_deref()
+                        .is_some_and(|collation| !collation.eq_ignore_ascii_case("BINARY"))
+            });
             let columns = Self::index_key_column_names(&columns);
             let definition = self.index_definition(path, &raw.name).await;
 
@@ -287,6 +299,12 @@ impl SqliteAdapter {
             }
             if has_auxiliary_columns {
                 attributes = attributes | IndexAttributes::HAS_AUXILIARY_COLUMNS;
+            }
+            if has_descending_key {
+                attributes = attributes | IndexAttributes::DESCENDING;
+            }
+            if has_non_binary_collation {
+                attributes = attributes | IndexAttributes::NON_BINARY_COLLATION;
             }
 
             indexes.push(Index {
@@ -536,7 +554,7 @@ impl SqliteAdapter {
         }));
         parts.extend(detail.indexes.iter().map(|index| {
             format!(
-                "idx={}:{}:{}:{}:{}:{}:{}:{}",
+                "idx={}:{}:{}:{}:{}:{}:{}:{}:{}:{}",
                 index.name,
                 index.columns.join(","),
                 index.is_unique(),
@@ -544,6 +562,8 @@ impl SqliteAdapter {
                 index.is_partial(),
                 index.has_expression(),
                 index.has_auxiliary_columns(),
+                index.has_descending_key(),
+                index.has_non_binary_collation(),
                 index.definition.clone().unwrap_or_default()
             )
         }));
@@ -2099,24 +2119,32 @@ mod tests {
                 seqno: 0,
                 cid: 1,
                 name: Some("email".to_string()),
+                desc: 0,
+                coll: None,
                 key: 1,
             },
             RawIndexColumn {
                 seqno: 1,
                 cid: -2,
                 name: None,
+                desc: 0,
+                coll: None,
                 key: 1,
             },
             RawIndexColumn {
                 seqno: 2,
                 cid: 99,
                 name: None,
+                desc: 0,
+                coll: None,
                 key: 1,
             },
             RawIndexColumn {
                 seqno: 3,
                 cid: 2,
                 name: Some("rowid".to_string()),
+                desc: 0,
+                coll: None,
                 key: 0,
             },
         ];
@@ -3813,10 +3841,89 @@ mod tests {
             assert!(index.is_partial());
             assert!(index.has_expression());
             assert!(index.has_auxiliary_columns());
+            assert!(index.needs_source_definition_detail());
             assert!(index.definition.as_deref().is_some_and(|definition| {
                 definition.contains("lower(email)")
                     && definition.contains("WHERE email IS NOT NULL")
             }));
+        }
+
+        #[tokio::test]
+        async fn partial_index_preserves_where_clause_in_definition() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(email TEXT);
+            CREATE INDEX idx_users_email_active
+                ON users(email)
+                WHERE email IS NOT NULL;
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let detail = adapter
+                .fetch_table_detail(&dsn, "main", "users")
+                .await
+                .unwrap();
+            let index = detail
+                .indexes
+                .iter()
+                .find(|index| index.name == "idx_users_email_active")
+                .unwrap();
+
+            assert_eq!(index.columns, vec!["email".to_string()]);
+            assert!(index.is_partial());
+            assert!(index.needs_source_definition_detail());
+            assert!(
+                index
+                    .definition
+                    .as_deref()
+                    .is_some_and(|definition| { definition.contains("WHERE email IS NOT NULL") })
+            );
+        }
+
+        #[tokio::test]
+        async fn descending_and_collation_indexes_preserve_definition() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(name TEXT, created_at TEXT);
+            CREATE INDEX idx_users_name_desc ON users(name DESC);
+            CREATE INDEX idx_users_name_nocase ON users(name COLLATE NOCASE);
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let detail = adapter
+                .fetch_table_detail(&dsn, "main", "users")
+                .await
+                .unwrap();
+
+            let descending = detail
+                .indexes
+                .iter()
+                .find(|index| index.name == "idx_users_name_desc")
+                .unwrap();
+            assert!(descending.has_descending_key());
+            assert!(descending.needs_source_definition_detail());
+            assert!(
+                descending
+                    .definition
+                    .as_deref()
+                    .is_some_and(|definition| { definition.contains("DESC") })
+            );
+
+            let collation = detail
+                .indexes
+                .iter()
+                .find(|index| index.name == "idx_users_name_nocase")
+                .unwrap();
+            assert!(collation.has_non_binary_collation());
+            assert!(collation.needs_source_definition_detail());
+            assert!(
+                collation
+                    .definition
+                    .as_deref()
+                    .is_some_and(|definition| { definition.contains("COLLATE NOCASE") })
+            );
         }
     }
 
@@ -3999,6 +4106,81 @@ mod tests {
                 signature
                     .signature
                     .contains("fk=fk_users_0:org_id:orgs:id:CASCADE:SET NULL")
+            );
+        }
+
+        #[tokio::test]
+        async fn index_desc_and_collation_change_signature() {
+            let adapter = SqliteAdapter::new();
+            let (_asc_dir, asc_dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(name TEXT);
+            CREATE INDEX idx_users_name ON users(name);
+            ",
+            );
+            let (_desc_dir, desc_dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(name TEXT);
+            CREATE INDEX idx_users_name ON users(name DESC);
+            ",
+            );
+            let (_binary_dir, binary_dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(name TEXT);
+            CREATE INDEX idx_users_name ON users(name);
+            ",
+            );
+            let (_nocase_dir, nocase_dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(name TEXT);
+            CREATE INDEX idx_users_name ON users(name COLLATE NOCASE);
+            ",
+            );
+
+            let asc_signature = adapter
+                .fetch_table_signatures(&asc_dsn)
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|signature| signature.name == "users")
+                .unwrap()
+                .signature;
+            let desc_signature = adapter
+                .fetch_table_signatures(&desc_dsn)
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|signature| signature.name == "users")
+                .unwrap()
+                .signature;
+            let binary_signature = adapter
+                .fetch_table_signatures(&binary_dsn)
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|signature| signature.name == "users")
+                .unwrap()
+                .signature;
+            let nocase_signature = adapter
+                .fetch_table_signatures(&nocase_dsn)
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|signature| signature.name == "users")
+                .unwrap()
+                .signature;
+
+            assert_ne!(asc_signature, desc_signature);
+            assert!(
+                desc_signature.contains(
+                    "idx=idx_users_name:name:false:false:false:false:true:true:false:CREATE INDEX idx_users_name ON users(name DESC)"
+                )
+            );
+            assert_ne!(binary_signature, nocase_signature);
+            assert!(
+                nocase_signature.contains(
+                    "idx=idx_users_name:name:false:false:false:false:true:false:true:CREATE INDEX idx_users_name ON users(name COLLATE NOCASE)"
+                )
             );
         }
     }

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -816,6 +816,20 @@ fn needs_write_batch_wrap(statements: &[&str]) -> bool {
     statements.len() > 1 && statements.iter().any(|stmt| is_write_statement(stmt))
 }
 
+fn rollback_has_to_clause(statement: &str) -> bool {
+    if !first_keyword(statement).eq_ignore_ascii_case("ROLLBACK") {
+        return false;
+    }
+    let mut offset = 0;
+    while let Some((keyword, end)) = next_keyword_from(statement, offset) {
+        if keyword.eq_ignore_ascii_case("TO") {
+            return true;
+        }
+        offset = end;
+    }
+    false
+}
+
 fn rollback_to_target(statement: &str) -> Option<&str> {
     let (_, first_end) = next_keyword_from(statement, 0)?;
     if !first_keyword(statement).eq_ignore_ascii_case("ROLLBACK") {
@@ -846,7 +860,7 @@ fn rollback_to_target(statement: &str) -> Option<&str> {
 }
 
 fn is_rollback_to(statement: &str) -> bool {
-    rollback_to_target(statement).is_some()
+    rollback_to_target(statement).is_some() || rollback_has_to_clause(statement)
 }
 
 fn sqlite_wrap_mode(query: &str) -> SqliteWrapMode {
@@ -1563,10 +1577,6 @@ fn discard_rolled_back(tags: &[CommandTag]) -> Vec<CommandTag> {
         }
     }
 
-    for (_, frame) in frames.drain(..) {
-        effective.extend(frame);
-    }
-
     effective
 }
 
@@ -1932,6 +1942,52 @@ mod tests {
         fn top_level_savepoint_full_rollback_discards_all_dml() {
             let tags = vec![sp("sp"), CommandTag::Insert(1), CommandTag::Rollback];
 
+            assert!(discard_rolled_back(&tags).is_empty());
+        }
+
+        #[test]
+        fn unclosed_begin_discards_frame_from_effective() {
+            let tags = vec![CommandTag::Begin, CommandTag::Update(1)];
+
+            assert!(discard_rolled_back(&tags).is_empty());
+        }
+
+        #[test]
+        fn unclosed_top_level_savepoint_discards_frame_from_effective() {
+            let tags = vec![sp("sp"), CommandTag::Insert(1)];
+
+            assert!(discard_rolled_back(&tags).is_empty());
+        }
+
+        #[test]
+        fn unclosed_top_level_savepoint_aggregates_to_rollback() {
+            let tags = vec![sp("sp"), CommandTag::Insert(1)];
+
+            assert_eq!(
+                aggregate_sqlite_command_tag(&tags),
+                Some(CommandTag::Rollback)
+            );
+        }
+
+        #[test]
+        fn rollback_to_quoted_savepoint_is_not_full_rollback() {
+            let tags = sqlite_statement_tags(
+                &[
+                    "SAVEPOINT sp",
+                    "INSERT INTO users(id) VALUES (1)",
+                    "ROLLBACK TO \"sp\"",
+                ],
+                &HashMap::from([(1, 1)]),
+            );
+
+            assert_eq!(
+                tags,
+                vec![
+                    CommandTag::Other("SAVEPOINT sp".to_string()),
+                    CommandTag::Insert(1),
+                    CommandTag::Other("ROLLBACK TO ".to_string()),
+                ]
+            );
             assert!(discard_rolled_back(&tags).is_empty());
         }
 
@@ -2995,7 +3051,7 @@ mod tests {
             let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
             let adapter = SqliteAdapter::new();
 
-            let _result = adapter
+            let result = adapter
                 .execute_adhoc(
                     &dsn,
                     "SAVEPOINT sp; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)",
@@ -3008,6 +3064,7 @@ mod tests {
                 .await
                 .unwrap();
 
+            assert_eq!(result.command_tag, Some(CommandTag::Rollback));
             assert!(rows.rows().is_empty());
         }
 

--- a/src/tests/render_snapshots/confirm_dialogs.rs
+++ b/src/tests/render_snapshots/confirm_dialogs.rs
@@ -197,9 +197,8 @@ fn confirm_dialog_update_preview_jsonb_key_order_normalized() {
         .session
         .set_table_detail(fixtures::sample_table_detail(), 0);
 
-    // before: PostgreSQL key order (industries first, spaces)
-    // after: serde_json key order (alphabetical, compact)
-    // Only actual change is company_size value: "500+" → "600+"
+    // Snapshot uses pre-normalized jsonb strings; normalization behavior is covered in
+    // preview_cell_text policy tests.
     let serde_after =
         r#"{"company_size":["100-500","600+"],"industries":["technology","finance"]}"#;
 

--- a/src/tests/render_snapshots/confirm_dialogs.rs
+++ b/src/tests/render_snapshots/confirm_dialogs.rs
@@ -200,17 +200,16 @@ fn confirm_dialog_update_preview_jsonb_key_order_normalized() {
     // before: PostgreSQL key order (industries first, spaces)
     // after: serde_json key order (alphabetical, compact)
     // Only actual change is company_size value: "500+" → "600+"
-    let pg_before =
-        r#"{"industries": ["technology", "finance"], "company_size": ["100-500", "500+"]}"#;
     let serde_after =
         r#"{"company_size":["100-500","600+"],"industries":["technology","finance"]}"#;
 
     let sql = format!(
         "UPDATE \"public\".\"users\"\nSET \"target_audience\" = '{serde_after}'\nWHERE \"id\" = '1';"
     );
-    // Apply normalize_for_diff to mirror the real build_update_preview path
-    let before = normalize_for_diff(pg_before);
-    let after = normalize_for_diff(serde_after);
+    let before =
+        r#"{"company_size":["100-500","500+"],"industries":["technology","finance"]}"#.to_string();
+    let after =
+        r#"{"company_size":["100-500","600+"],"industries":["technology","finance"]}"#.to_string();
     let json_diff = compute_json_diff(&before, &after, 1);
     assert!(
         json_diff.is_some(),

--- a/src/tests/render_snapshots/inspector.rs
+++ b/src/tests/render_snapshots/inspector.rs
@@ -129,6 +129,95 @@ fn inspector_indexes_tab_for_sqlite_hides_unknown_type() {
 }
 
 #[test]
+fn inspector_indexes_tab_shows_sqlite_partial_index_definition() {
+    let mut state = harness::explorer_selected_state();
+    let mut terminal = create_test_terminal();
+
+    let mut table = fixtures::sample_table_detail();
+    table.indexes = vec![Index {
+        name: "idx_users_email_active".to_string(),
+        columns: vec!["email".to_string()],
+        attributes: IndexAttributes::PARTIAL,
+        index_type: IndexType::Unknown,
+        definition: Some(
+            "CREATE INDEX idx_users_email_active ON users(email) WHERE email IS NOT NULL"
+                .to_string(),
+        ),
+    }];
+    let _ = state.session.set_table_detail(table, 0);
+    state.session.activate_connection_with_dsn(
+        &ConnectionId::from_string("sqlite-test"),
+        "app.db",
+        DatabaseType::SQLite,
+        "sqlite:///tmp/app.db",
+    );
+    state.ui.set_inspector_tab(InspectorTab::Indexes);
+    state.ui.set_focused_pane(FocusedPane::Inspector);
+
+    let output = trim_line_endings(&render_to_string(&mut terminal, &mut state));
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn inspector_indexes_tab_shows_sqlite_descending_index_definition() {
+    let mut state = harness::explorer_selected_state();
+    let mut terminal = create_test_terminal();
+
+    let mut table = fixtures::sample_table_detail();
+    table.indexes = vec![Index {
+        name: "idx_users_name_desc".to_string(),
+        columns: vec!["name".to_string()],
+        attributes: IndexAttributes::DESCENDING,
+        index_type: IndexType::Unknown,
+        definition: Some("CREATE INDEX idx_users_name_desc ON users(name DESC)".to_string()),
+    }];
+    let _ = state.session.set_table_detail(table, 0);
+    state.session.activate_connection_with_dsn(
+        &ConnectionId::from_string("sqlite-test"),
+        "app.db",
+        DatabaseType::SQLite,
+        "sqlite:///tmp/app.db",
+    );
+    state.ui.set_inspector_tab(InspectorTab::Indexes);
+    state.ui.set_focused_pane(FocusedPane::Inspector);
+
+    let output = trim_line_endings(&render_to_string(&mut terminal, &mut state));
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn inspector_indexes_tab_shows_sqlite_collation_index_definition() {
+    let mut state = harness::explorer_selected_state();
+    let mut terminal = create_test_terminal();
+
+    let mut table = fixtures::sample_table_detail();
+    table.indexes = vec![Index {
+        name: "idx_users_name_nocase".to_string(),
+        columns: vec!["name".to_string()],
+        attributes: IndexAttributes::NON_BINARY_COLLATION,
+        index_type: IndexType::Unknown,
+        definition: Some(
+            "CREATE INDEX idx_users_name_nocase ON users(name COLLATE NOCASE)".to_string(),
+        ),
+    }];
+    let _ = state.session.set_table_detail(table, 0);
+    state.session.activate_connection_with_dsn(
+        &ConnectionId::from_string("sqlite-test"),
+        "app.db",
+        DatabaseType::SQLite,
+        "sqlite:///tmp/app.db",
+    );
+    state.ui.set_inspector_tab(InspectorTab::Indexes);
+    state.ui.set_focused_pane(FocusedPane::Inspector);
+
+    let output = trim_line_endings(&render_to_string(&mut terminal, &mut state));
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn inspector_indexes_tab_shows_sqlite_partial_expression_details() {
     let mut state = harness::explorer_selected_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/mod.rs
+++ b/src/tests/render_snapshots/mod.rs
@@ -20,7 +20,6 @@ use sabiql_app::policy::write::write_guardrails::{
     AdhocRiskDecision, ColumnDiff, GuardrailDecision, RiskLevel, TargetSummary, WriteOperation,
     WritePreview,
 };
-use sabiql_app::policy::write::write_update::normalize_for_diff;
 use sabiql_app::ports::outbound::DdlGenerator;
 use sabiql_app::services::AppServices;
 use sabiql_domain::{

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -238,8 +238,7 @@ fn result_pane_cell_edit_mode() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_input_mut()
-        .set_content("new@example.com".to_string());
+        .cell_edit_set_content("new@example.com".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -258,7 +257,7 @@ fn result_pane_cell_edit_cursor_at_head() {
     state
         .result_interaction
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
-    state.result_interaction.cell_edit_input_mut().set_cursor(0);
+    state.result_interaction.cell_edit_set_cursor(0);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -277,7 +276,7 @@ fn result_pane_cell_edit_cursor_at_middle() {
     state
         .result_interaction
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
-    state.result_interaction.cell_edit_input_mut().set_cursor(7);
+    state.result_interaction.cell_edit_set_cursor(7);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -298,8 +297,7 @@ fn result_pane_cell_active_pending_draft() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_input_mut()
-        .set_content("new@example.com".to_string());
+        .cell_edit_set_content("new@example.com".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -319,10 +317,7 @@ fn result_pane_cell_edit_cursor_at_tail() {
         .result_interaction
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     let len = state.result_interaction.cell_edit().input().content().len();
-    state
-        .result_interaction
-        .cell_edit_input_mut()
-        .set_cursor(len);
+    state.result_interaction.cell_edit_set_cursor(len);
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -238,7 +238,7 @@ fn result_pane_cell_edit_mode() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_set_content("new@example.com".to_string());
+        .replace_cell_edit_draft("new@example.com".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -297,7 +297,7 @@ fn result_pane_cell_active_pending_draft() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_set_content("new@example.com".to_string());
+        .replace_cell_edit_draft("new@example.com".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_collation_index_definition.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_collation_index_definition.snap
@@ -5,8 +5,8 @@ expression: output
 test_project | test_db | - | connected | app.db
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│  public.posts                         ││Name           Columns        Unique   Partial   Detail                                                                   │
-│  public.comments                      ││idx_users_emai <expression>            ✓         CREATE INDEX idx_users_email_lower ON users(lower(email)) WHERE email IS │
+│  public.posts                         ││Name                    Columns   Unique   Partial   Detail                                                               │
+│  public.comments                      ││idx_users_name_nocase   name                         CREATE INDEX idx_users_name_nocase ON users(name COLLATE NOCASE)     │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_descending_index_definition.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_descending_index_definition.snap
@@ -5,8 +5,8 @@ expression: output
 test_project | test_db | - | connected | app.db
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│  public.posts                         ││Name           Columns        Unique   Partial   Detail                                                                   │
-│  public.comments                      ││idx_users_emai <expression>            ✓         CREATE INDEX idx_users_email_lower ON users(lower(email)) WHERE email IS │
+│  public.posts                         ││Name                  Columns   Unique   Partial   Detail                                                                 │
+│  public.comments                      ││idx_users_name_desc   name                         CREATE INDEX idx_users_name_desc ON users(name DESC)                   │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_partial_index_definition.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_partial_index_definition.snap
@@ -5,8 +5,8 @@ expression: output
 test_project | test_db | - | connected | app.db
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│  public.posts                         ││Name           Columns        Unique   Partial   Detail                                                                   │
-│  public.comments                      ││idx_users_emai <expression>            ✓         CREATE INDEX idx_users_email_lower ON users(lower(email)) WHERE email IS │
+│  public.posts                         ││Name            Columns   Unique   Partial   Detail                                                                       │
+│  public.comments                      ││idx_users_email email              ✓         CREATE INDEX idx_users_email_active ON users(email) WHERE email IS NOT NULL  │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -110,8 +110,7 @@ fn pending_draft_cell_uses_orange_fg() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_input_mut()
-        .set_content("new@example.com".to_string());
+        .cell_edit_set_content("new@example.com".to_string());
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -138,8 +137,7 @@ fn active_cell_edit_uses_yellow_fg() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_input_mut()
-        .set_content("new@example.com".to_string());
+        .cell_edit_set_content("new@example.com".to_string());
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -986,8 +984,7 @@ fn test_contrast_theme_applies_result_pane_table_colors() {
         .begin_cell_edit(0, 0, "1".to_string());
     state
         .result_interaction
-        .cell_edit_input_mut()
-        .set_content("new@example.com".to_string());
+        .cell_edit_set_content("new@example.com".to_string());
 
     let draft_buffer =
         render_and_get_buffer_at_with_theme(&mut terminal, &mut state, now, &TEST_CONTRAST_THEME);

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -110,7 +110,7 @@ fn pending_draft_cell_uses_orange_fg() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_set_content("new@example.com".to_string());
+        .replace_cell_edit_draft("new@example.com".to_string());
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -137,7 +137,7 @@ fn active_cell_edit_uses_yellow_fg() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_set_content("new@example.com".to_string());
+        .replace_cell_edit_draft("new@example.com".to_string());
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -984,7 +984,7 @@ fn test_contrast_theme_applies_result_pane_table_colors() {
         .begin_cell_edit(0, 0, "1".to_string());
     state
         .result_interaction
-        .cell_edit_set_content("new@example.com".to_string());
+        .replace_cell_edit_draft("new@example.com".to_string());
 
     let draft_buffer =
         render_and_get_buffer_at_with_theme(&mut terminal, &mut state, now, &TEST_CONTRAST_THEME);

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -465,9 +465,7 @@ impl Inspector {
             .indexes
             .iter()
             .any(|index| index.index_type != IndexType::Unknown);
-        let has_details = table.indexes.iter().any(|index| {
-            index.is_partial() || index.has_expression() || index.has_auxiliary_columns()
-        });
+        let has_details = table.indexes.iter().any(Index::has_index_detail);
         let headers_with_type_and_details =
             ["Name", "Columns", "Type", "Unique", "Partial", "Detail"];
         let headers_with_type = ["Name", "Columns", "Type", "Unique"];
@@ -768,12 +766,24 @@ fn index_row(index: &Index, show_type: bool, show_details: bool) -> Vec<String> 
 }
 
 fn index_detail(index: &Index) -> String {
+    if index.needs_source_definition_detail()
+        && let Some(definition) = &index.definition
+    {
+        return definition.clone();
+    }
+
     let mut details = Vec::new();
     if index.has_expression() {
         details.push("expression".to_string());
     }
     if index.has_auxiliary_columns() {
         details.push("auxiliary-columns".to_string());
+    }
+    if index.has_descending_key() {
+        details.push("descending".to_string());
+    }
+    if index.has_non_binary_collation() {
+        details.push("collation".to_string());
     }
     details.join("; ")
 }


### PR DESCRIPTION
## Problem

SQLite stores JSON-shaped values as plain TEXT, but write preview diffs normalized any valid JSON string the same way as PostgreSQL JSONB. That could hide meaningful whitespace, key order, and formatting differences during cell edits.

## Background

SAB-298. SQLite TEXT and PostgreSQL JSONB have different storage semantics; diff comparison should follow the column type instead of inferring JSON from the string shape.

## Approach

Restrict semantic JSON normalization and structured JSON diffs to `jsonb` columns. Keep literal before/after strings for TEXT columns (including SQLite). For cell detail display, stop auto pretty-printing JSON-shaped SQLite TEXT while preserving pretty display for PostgreSQL text/json columns and JSONB modal flow.