### PR TITLE
refactor(app): consolidate CellEditState update paths for SQLite edit flow

### DIFF
--- a/src/app/model/browse/cell_edit.rs
+++ b/src/app/model/browse/cell_edit.rs
@@ -1,11 +1,12 @@
+use crate::model::shared::cursor::CursorMove;
 use crate::model::shared::text_input::TextInputState;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CellEditState {
-    pub(crate) row: Option<usize>,
-    pub(crate) col: Option<usize>,
-    pub(crate) original_value: String,
-    pub(crate) input: TextInputState,
+    row: Option<usize>,
+    col: Option<usize>,
+    original_value: String,
+    input: TextInputState,
 }
 
 impl CellEditState {
@@ -36,8 +37,32 @@ impl CellEditState {
         &self.input
     }
 
-    pub fn input_mut(&mut self) -> &mut TextInputState {
-        &mut self.input
+    pub fn insert_char(&mut self, ch: char) {
+        self.input.insert_char(ch);
+    }
+
+    pub fn insert_str(&mut self, text: &str) {
+        self.input.insert_str(text);
+    }
+
+    pub fn backspace(&mut self) {
+        self.input.backspace();
+    }
+
+    pub fn delete(&mut self) {
+        self.input.delete();
+    }
+
+    pub fn move_cursor(&mut self, direction: CursorMove) {
+        self.input.move_cursor(direction);
+    }
+
+    pub fn set_content(&mut self, content: String) {
+        self.input.set_content(content);
+    }
+
+    pub fn set_cursor(&mut self, cursor: usize) {
+        self.input.set_cursor(cursor);
     }
 
     pub fn has_pending_draft(&self) -> bool {
@@ -54,6 +79,15 @@ impl CellEditState {
         self.original_value.clear();
         self.input.clear();
     }
+
+    #[cfg(test)]
+    pub(crate) fn with_selection_for_test(row: Option<usize>, col: Option<usize>) -> Self {
+        Self {
+            row,
+            col,
+            ..Default::default()
+        }
+    }
 }
 
 #[cfg(test)]
@@ -67,9 +101,9 @@ mod tests {
 
         state.begin(3, 5, "Alice".to_string());
 
-        assert_eq!(state.row, Some(3));
-        assert_eq!(state.col, Some(5));
-        assert_eq!(state.original_value, "Alice");
+        assert_eq!(state.row(), Some(3));
+        assert_eq!(state.col(), Some(5));
+        assert_eq!(state.original_value(), "Alice");
         assert_eq!(state.draft_value(), "Alice");
         assert_eq!(state.input.cursor(), 5); // cursor at end
         assert!(state.is_active());
@@ -77,24 +111,14 @@ mod tests {
 
     #[test]
     fn only_row_selected_returns_inactive() {
-        let state = CellEditState {
-            row: Some(1),
-            col: None,
-            original_value: String::new(),
-            input: TextInputState::default(),
-        };
+        let state = CellEditState::with_selection_for_test(Some(1), None);
 
         assert!(!state.is_active());
     }
 
     #[test]
     fn only_col_selected_returns_inactive() {
-        let state = CellEditState {
-            row: None,
-            col: Some(1),
-            original_value: String::new(),
-            input: TextInputState::default(),
-        };
+        let state = CellEditState::with_selection_for_test(None, Some(1));
 
         assert!(!state.is_active());
     }
@@ -111,7 +135,7 @@ mod tests {
     fn has_pending_draft_returns_true_when_draft_differs() {
         let mut state = CellEditState::default();
         state.begin(0, 0, "Alice".to_string());
-        state.input.set_content("Bob".to_string());
+        state.set_content("Bob".to_string());
 
         assert!(state.has_pending_draft());
     }
@@ -127,13 +151,13 @@ mod tests {
     fn clear_after_begin_resets_all_fields() {
         let mut state = CellEditState::default();
         state.begin(1, 2, "Before".to_string());
-        state.input.set_content("After".to_string());
+        state.set_content("After".to_string());
 
         state.clear();
 
-        assert_eq!(state.row, None);
-        assert_eq!(state.col, None);
-        assert_eq!(state.original_value, "");
+        assert_eq!(state.row(), None);
+        assert_eq!(state.col(), None);
+        assert_eq!(state.original_value(), "");
         assert_eq!(state.draft_value(), "");
         assert!(!state.is_active());
     }
@@ -143,12 +167,12 @@ mod tests {
         let mut state = CellEditState::default();
         state.begin(0, 0, "hello".to_string());
 
-        state.input.move_cursor(CursorMove::Home);
-        assert_eq!(state.input.cursor(), 0);
+        state.move_cursor(CursorMove::Home);
+        assert_eq!(state.input().cursor(), 0);
 
-        state.input.insert_char('X');
+        state.insert_char('X');
         assert_eq!(state.draft_value(), "Xhello");
-        assert_eq!(state.input.cursor(), 1);
+        assert_eq!(state.input().cursor(), 1);
     }
 
     #[test]
@@ -156,12 +180,12 @@ mod tests {
         let mut state = CellEditState::default();
         state.begin(0, 0, "abcd".to_string());
 
-        state.input.move_cursor(CursorMove::Left);
-        state.input.move_cursor(CursorMove::Left);
-        state.input.backspace();
+        state.move_cursor(CursorMove::Left);
+        state.move_cursor(CursorMove::Left);
+        state.backspace();
 
         assert_eq!(state.draft_value(), "acd");
-        assert_eq!(state.input.cursor(), 1);
+        assert_eq!(state.input().cursor(), 1);
     }
 
     #[test]
@@ -169,10 +193,10 @@ mod tests {
         let mut state = CellEditState::default();
         state.begin(0, 0, "abcd".to_string());
 
-        state.input.move_cursor(CursorMove::Home);
-        state.input.delete();
+        state.move_cursor(CursorMove::Home);
+        state.delete();
 
         assert_eq!(state.draft_value(), "bcd");
-        assert_eq!(state.input.cursor(), 0);
+        assert_eq!(state.input().cursor(), 0);
     }
 }

--- a/src/app/model/browse/cell_edit.rs
+++ b/src/app/model/browse/cell_edit.rs
@@ -79,15 +79,6 @@ impl CellEditState {
         self.original_value.clear();
         self.input.clear();
     }
-
-    #[cfg(test)]
-    pub(crate) fn with_selection_for_test(row: Option<usize>, col: Option<usize>) -> Self {
-        Self {
-            row,
-            col,
-            ..Default::default()
-        }
-    }
 }
 
 #[cfg(test)]
@@ -110,17 +101,12 @@ mod tests {
     }
 
     #[test]
-    fn only_row_selected_returns_inactive() {
-        let state = CellEditState::with_selection_for_test(Some(1), None);
+    fn is_active_requires_both_row_and_col() {
+        assert!(!CellEditState::default().is_active());
 
-        assert!(!state.is_active());
-    }
-
-    #[test]
-    fn only_col_selected_returns_inactive() {
-        let state = CellEditState::with_selection_for_test(None, Some(1));
-
-        assert!(!state.is_active());
+        let mut state = CellEditState::default();
+        state.begin(1, 2, "Alice".to_string());
+        assert!(state.is_active());
     }
 
     #[test]

--- a/src/app/model/browse/cell_edit.rs
+++ b/src/app/model/browse/cell_edit.rs
@@ -57,7 +57,7 @@ impl CellEditState {
         self.input.move_cursor(direction);
     }
 
-    pub fn set_content(&mut self, content: String) {
+    pub fn replace_draft(&mut self, content: String) {
         self.input.set_content(content);
     }
 
@@ -135,7 +135,7 @@ mod tests {
     fn has_pending_draft_returns_true_when_draft_differs() {
         let mut state = CellEditState::default();
         state.begin(0, 0, "Alice".to_string());
-        state.set_content("Bob".to_string());
+        state.replace_draft("Bob".to_string());
 
         assert!(state.has_pending_draft());
     }
@@ -151,7 +151,7 @@ mod tests {
     fn clear_after_begin_resets_all_fields() {
         let mut state = CellEditState::default();
         state.begin(1, 2, "Before".to_string());
-        state.set_content("After".to_string());
+        state.replace_draft("After".to_string());
 
         state.clear();
 

--- a/src/app/model/browse/result_interaction.rs
+++ b/src/app/model/browse/result_interaction.rs
@@ -100,18 +100,22 @@ impl ResultInteraction {
 
     pub fn cell_edit_insert_char(&mut self, ch: char) {
         self.cell_edit.insert_char(ch);
+        self.clear_write_preview();
     }
 
     pub fn cell_edit_insert_str(&mut self, text: &str) {
         self.cell_edit.insert_str(text);
+        self.clear_write_preview();
     }
 
     pub fn cell_edit_backspace(&mut self) {
         self.cell_edit.backspace();
+        self.clear_write_preview();
     }
 
     pub fn cell_edit_delete(&mut self) {
         self.cell_edit.delete();
+        self.clear_write_preview();
     }
 
     pub fn cell_edit_move_cursor(&mut self, direction: CursorMove) {
@@ -120,6 +124,7 @@ impl ResultInteraction {
 
     pub fn replace_cell_edit_draft(&mut self, content: String) {
         self.cell_edit.replace_draft(content);
+        self.clear_write_preview();
     }
 
     pub fn cell_edit_set_cursor(&mut self, cursor: usize) {
@@ -264,13 +269,25 @@ mod tests {
         let mut ri = ResultInteraction::default();
         ri.activate_cell(2, 4);
         ri.begin_cell_edit(2, 4, "val".to_string());
-        ri.set_write_preview(test_preview());
         ri.replace_cell_edit_draft("changed".to_string());
+        ri.set_write_preview(test_preview());
 
         ri.leave_cell_edit();
 
         assert!(ri.cell_edit().is_active());
         assert_eq!(ri.cell_edit().draft_value(), "changed");
+        assert!(ri.pending_write_preview().is_none());
+    }
+
+    #[test]
+    fn cell_edit_mutation_clears_stale_write_preview() {
+        let mut ri = ResultInteraction::default();
+        ri.begin_cell_edit(0, 0, "val".to_string());
+        ri.set_write_preview(test_preview());
+
+        ri.cell_edit_insert_char('x');
+
+        assert_eq!(ri.cell_edit().draft_value(), "valx");
         assert!(ri.pending_write_preview().is_none());
     }
 

--- a/src/app/model/browse/result_interaction.rs
+++ b/src/app/model/browse/result_interaction.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::time::Instant;
 
 use super::cell_edit::CellEditState;
-use crate::model::shared::text_input::TextInputState;
+use crate::model::shared::cursor::CursorMove;
 use crate::model::shared::ui_state::{ResultSelection, YankFlash};
 use crate::policy::write::write_guardrails::WritePreview;
 
@@ -91,8 +91,47 @@ impl ResultInteraction {
         self.cell_edit.begin(row, col, value);
     }
 
-    pub fn cell_edit_input_mut(&mut self) -> &mut TextInputState {
-        self.cell_edit.input_mut()
+    pub fn ensure_cell_edit_at(&mut self, row: usize, col: usize, value: String) {
+        if self.cell_edit.row() != Some(row) || self.cell_edit.col() != Some(col) {
+            self.begin_cell_edit(row, col, value);
+            self.clear_write_preview();
+        }
+    }
+
+    pub fn cell_edit_insert_char(&mut self, ch: char) {
+        self.cell_edit.insert_char(ch);
+    }
+
+    pub fn cell_edit_insert_str(&mut self, text: &str) {
+        self.cell_edit.insert_str(text);
+    }
+
+    pub fn cell_edit_backspace(&mut self) {
+        self.cell_edit.backspace();
+    }
+
+    pub fn cell_edit_delete(&mut self) {
+        self.cell_edit.delete();
+    }
+
+    pub fn cell_edit_move_cursor(&mut self, direction: CursorMove) {
+        self.cell_edit.move_cursor(direction);
+    }
+
+    pub fn cell_edit_set_content(&mut self, content: String) {
+        self.cell_edit.set_content(content);
+    }
+
+    pub fn cell_edit_set_cursor(&mut self, cursor: usize) {
+        self.cell_edit.set_cursor(cursor);
+    }
+
+    pub fn cancel_cell_edit(&mut self) {
+        if self.cell_edit.has_pending_draft() {
+            self.clear_write_preview();
+        } else {
+            self.discard_cell_edit();
+        }
     }
 
     pub fn clear_cell_edit(&mut self) {
@@ -218,6 +257,32 @@ mod tests {
         assert_eq!(ri.horizontal_offset, 5);
         assert_eq!(ri.selection().mode(), ResultNavMode::Scroll);
         assert!(ri.staged_delete_rows().is_empty());
+    }
+
+    #[test]
+    fn cancel_cell_edit_preserves_draft_when_changed() {
+        let mut ri = ResultInteraction::default();
+        ri.activate_cell(2, 4);
+        ri.begin_cell_edit(2, 4, "val".to_string());
+        ri.set_write_preview(test_preview());
+        ri.cell_edit_set_content("changed".to_string());
+
+        ri.cancel_cell_edit();
+
+        assert!(ri.cell_edit().is_active());
+        assert_eq!(ri.cell_edit().draft_value(), "changed");
+        assert!(ri.pending_write_preview().is_none());
+    }
+
+    #[test]
+    fn cancel_cell_edit_clears_session_when_unchanged() {
+        let mut ri = ResultInteraction::default();
+        ri.activate_cell(2, 4);
+        ri.begin_cell_edit(2, 4, "val".to_string());
+
+        ri.cancel_cell_edit();
+
+        assert!(!ri.cell_edit().is_active());
     }
 
     #[test]

--- a/src/app/model/browse/result_interaction.rs
+++ b/src/app/model/browse/result_interaction.rs
@@ -118,15 +118,15 @@ impl ResultInteraction {
         self.cell_edit.move_cursor(direction);
     }
 
-    pub fn cell_edit_set_content(&mut self, content: String) {
-        self.cell_edit.set_content(content);
+    pub fn replace_cell_edit_draft(&mut self, content: String) {
+        self.cell_edit.replace_draft(content);
     }
 
     pub fn cell_edit_set_cursor(&mut self, cursor: usize) {
         self.cell_edit.set_cursor(cursor);
     }
 
-    pub fn cancel_cell_edit(&mut self) {
+    pub fn leave_cell_edit(&mut self) {
         if self.cell_edit.has_pending_draft() {
             self.clear_write_preview();
         } else {
@@ -260,14 +260,14 @@ mod tests {
     }
 
     #[test]
-    fn cancel_cell_edit_preserves_draft_when_changed() {
+    fn leave_cell_edit_preserves_draft_when_changed() {
         let mut ri = ResultInteraction::default();
         ri.activate_cell(2, 4);
         ri.begin_cell_edit(2, 4, "val".to_string());
         ri.set_write_preview(test_preview());
-        ri.cell_edit_set_content("changed".to_string());
+        ri.replace_cell_edit_draft("changed".to_string());
 
-        ri.cancel_cell_edit();
+        ri.leave_cell_edit();
 
         assert!(ri.cell_edit().is_active());
         assert_eq!(ri.cell_edit().draft_value(), "changed");
@@ -275,12 +275,12 @@ mod tests {
     }
 
     #[test]
-    fn cancel_cell_edit_clears_session_when_unchanged() {
+    fn leave_cell_edit_clears_session_when_unchanged() {
         let mut ri = ResultInteraction::default();
         ri.activate_cell(2, 4);
         ri.begin_cell_edit(2, 4, "val".to_string());
 
-        ri.cancel_cell_edit();
+        ri.leave_cell_edit();
 
         assert!(!ri.cell_edit().is_active());
     }

--- a/src/app/update/browse/navigation/input.rs
+++ b/src/app/update/browse/navigation/input.rs
@@ -25,10 +25,7 @@ pub fn reduce_input(state: &mut AppState, action: &Action) -> DispatchResult {
             }
             InputMode::CellEdit => {
                 let clean: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
-                state
-                    .result_interaction
-                    .cell_edit_input_mut()
-                    .insert_str(&clean);
+                state.result_interaction.cell_edit_insert_str(&clean);
                 DispatchResult::handled()
             }
             InputMode::QueryHistoryPicker => {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -34,12 +34,12 @@ fn build_update_preview(
     let row_idx = state
         .result_interaction
         .cell_edit()
-        .row
+        .row()
         .ok_or(EditGuardrailError::NoRowSelectedForEdit)?;
     let col_idx = state
         .result_interaction
         .cell_edit()
-        .col
+        .col()
         .ok_or(EditGuardrailError::NoColumnSelectedForEdit)?;
 
     let row_values = result
@@ -433,8 +433,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "Alice".to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content("Bob".to_string());
+                .cell_edit_set_content("Bob".to_string());
             state
         }
 
@@ -668,8 +667,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "Alice".to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content("Bob".to_string());
+                .cell_edit_set_content("Bob".to_string());
 
             let effects = dispatch_query(
                 &mut state,
@@ -707,8 +705,7 @@ mod tests {
                 .begin_cell_edit(0, 2, r#"{"role":"admin"}"#.to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content(r#"{"role":"user"}"#.to_string());
+                .cell_edit_set_content(r#"{"role":"user"}"#.to_string());
             state
         }
 
@@ -746,8 +743,7 @@ mod tests {
                 .begin_cell_edit(0, 1, r#"{"key":"old"}"#.to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content(r#"{"key":"new"}"#.to_string());
+                .cell_edit_set_content(r#"{"key":"new"}"#.to_string());
 
             let effects = dispatch_query(
                 &mut state,

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -433,7 +433,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "Alice".to_string());
             state
                 .result_interaction
-                .cell_edit_set_content("Bob".to_string());
+                .replace_cell_edit_draft("Bob".to_string());
             state
         }
 
@@ -667,7 +667,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "Alice".to_string());
             state
                 .result_interaction
-                .cell_edit_set_content("Bob".to_string());
+                .replace_cell_edit_draft("Bob".to_string());
 
             let effects = dispatch_query(
                 &mut state,
@@ -705,7 +705,7 @@ mod tests {
                 .begin_cell_edit(0, 2, r#"{"role":"admin"}"#.to_string());
             state
                 .result_interaction
-                .cell_edit_set_content(r#"{"role":"user"}"#.to_string());
+                .replace_cell_edit_draft(r#"{"role":"user"}"#.to_string());
             state
         }
 
@@ -743,7 +743,7 @@ mod tests {
                 .begin_cell_edit(0, 1, r#"{"key":"old"}"#.to_string());
             state
                 .result_interaction
-                .cell_edit_set_content(r#"{"key":"new"}"#.to_string());
+                .replace_cell_edit_draft(r#"{"key":"new"}"#.to_string());
 
             let effects = dispatch_query(
                 &mut state,

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -101,7 +101,7 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
             }
         }
         Action::ResultCancelCellEdit => {
-            state.result_interaction.cancel_cell_edit();
+            state.result_interaction.leave_cell_edit();
             state.modal.set_mode(InputMode::Normal);
             DispatchResult::handled()
         }
@@ -195,7 +195,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "alice".to_string());
             state
                 .result_interaction
-                .cell_edit_set_content("modified".to_string());
+                .replace_cell_edit_draft("modified".to_string());
             state.modal.set_mode(InputMode::Normal);
 
             reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
@@ -220,7 +220,7 @@ mod tests {
                 .begin_cell_edit(0, 99, "stale".to_string());
             state
                 .result_interaction
-                .cell_edit_set_content("stale-modified".to_string());
+                .replace_cell_edit_draft("stale-modified".to_string());
 
             reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
                 .into_effects()
@@ -360,7 +360,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "alice".to_string());
             state
                 .result_interaction
-                .cell_edit_set_content("bob".to_string());
+                .replace_cell_edit_draft("bob".to_string());
             state.modal.set_mode(InputMode::CellEdit);
 
             reduce_edit(&mut state, &Action::ResultCancelCellEdit, Instant::now())

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -88,14 +88,9 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
 
             match editable_cell_context(state) {
                 Ok((row_idx, col_idx, value)) => {
-                    if state.result_interaction.cell_edit().row() != Some(row_idx)
-                        || state.result_interaction.cell_edit().col() != Some(col_idx)
-                    {
-                        state
-                            .result_interaction
-                            .begin_cell_edit(row_idx, col_idx, value);
-                        state.result_interaction.clear_write_preview();
-                    }
+                    state
+                        .result_interaction
+                        .ensure_cell_edit_at(row_idx, col_idx, value);
                     state.modal.set_mode(InputMode::CellEdit);
                     DispatchResult::handled()
                 }
@@ -106,11 +101,7 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
             }
         }
         Action::ResultCancelCellEdit => {
-            if state.result_interaction.cell_edit().has_pending_draft() {
-                state.result_interaction.clear_write_preview();
-            } else {
-                state.result_interaction.discard_cell_edit();
-            }
+            state.result_interaction.cancel_cell_edit();
             state.modal.set_mode(InputMode::Normal);
             DispatchResult::handled()
         }
@@ -123,32 +114,26 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
             target: InputTarget::ResultCellEdit,
             ch: c,
         } => {
-            state
-                .result_interaction
-                .cell_edit_input_mut()
-                .insert_char(*c);
+            state.result_interaction.cell_edit_insert_char(*c);
             DispatchResult::handled()
         }
         Action::TextBackspace {
             target: InputTarget::ResultCellEdit,
         } => {
-            state.result_interaction.cell_edit_input_mut().backspace();
+            state.result_interaction.cell_edit_backspace();
             DispatchResult::handled()
         }
         Action::TextDelete {
             target: InputTarget::ResultCellEdit,
         } => {
-            state.result_interaction.cell_edit_input_mut().delete();
+            state.result_interaction.cell_edit_delete();
             DispatchResult::handled()
         }
         Action::TextMoveCursor {
             target: InputTarget::ResultCellEdit,
             direction: m,
         } => {
-            state
-                .result_interaction
-                .cell_edit_input_mut()
-                .move_cursor(*m);
+            state.result_interaction.cell_edit_move_cursor(*m);
             DispatchResult::handled()
         }
         _ => DispatchResult::pass(),
@@ -210,8 +195,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "alice".to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content("modified".to_string());
+                .cell_edit_set_content("modified".to_string());
             state.modal.set_mode(InputMode::Normal);
 
             reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
@@ -236,8 +220,7 @@ mod tests {
                 .begin_cell_edit(0, 99, "stale".to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content("stale-modified".to_string());
+                .cell_edit_set_content("stale-modified".to_string());
 
             reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
                 .into_effects()
@@ -377,8 +360,7 @@ mod tests {
                 .begin_cell_edit(0, 1, "alice".to_string());
             state
                 .result_interaction
-                .cell_edit_input_mut()
-                .set_content("bob".to_string());
+                .cell_edit_set_content("bob".to_string());
             state.modal.set_mode(InputMode::CellEdit);
 
             reduce_edit(&mut state, &Action::ResultCancelCellEdit, Instant::now())
@@ -466,10 +448,7 @@ mod tests {
             state
                 .result_interaction
                 .begin_cell_edit(0, 0, content.to_string());
-            state
-                .result_interaction
-                .cell_edit_input_mut()
-                .set_cursor(cursor);
+            state.result_interaction.cell_edit_set_cursor(cursor);
             state
         }
 

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -337,7 +337,9 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
             .result_interaction
             .begin_cell_edit(row, col, original_cell);
         state.result_interaction.clear_write_preview();
-        state.result_interaction.cell_edit_set_content(compact_str);
+        state
+            .result_interaction
+            .replace_cell_edit_draft(compact_str);
     }
 }
 

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -337,10 +337,7 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
             .result_interaction
             .begin_cell_edit(row, col, original_cell);
         state.result_interaction.clear_write_preview();
-        state
-            .result_interaction
-            .cell_edit_input_mut()
-            .set_content(compact_str);
+        state.result_interaction.cell_edit_set_content(compact_str);
     }
 }
 

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -1139,8 +1139,7 @@ mod tests {
                     .begin_cell_edit(0, 1, "original".to_string());
                 state
                     .result_interaction
-                    .cell_edit_input_mut()
-                    .set_content("modified".to_string());
+                    .cell_edit_set_content("modified".to_string());
 
                 let result = handle_normal_mode(combo(Key::Esc), &state);
 

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -1139,7 +1139,7 @@ mod tests {
                     .begin_cell_edit(0, 1, "original".to_string());
                 state
                     .result_interaction
-                    .cell_edit_set_content("modified".to_string());
+                    .replace_cell_edit_draft("modified".to_string());
 
                 let result = handle_normal_mode(combo(Key::Esc), &state);
 

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -238,8 +238,7 @@ fn result_pane_cell_edit_mode() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_input_mut()
-        .set_content("new@example.com".to_string());
+        .cell_edit_set_content("new@example.com".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -258,7 +257,7 @@ fn result_pane_cell_edit_cursor_at_head() {
     state
         .result_interaction
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
-    state.result_interaction.cell_edit_input_mut().set_cursor(0);
+    state.result_interaction.cell_edit_set_cursor(0);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -277,7 +276,7 @@ fn result_pane_cell_edit_cursor_at_middle() {
     state
         .result_interaction
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
-    state.result_interaction.cell_edit_input_mut().set_cursor(7);
+    state.result_interaction.cell_edit_set_cursor(7);
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -298,8 +297,7 @@ fn result_pane_cell_active_pending_draft() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_input_mut()
-        .set_content("new@example.com".to_string());
+        .cell_edit_set_content("new@example.com".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -319,10 +317,7 @@ fn result_pane_cell_edit_cursor_at_tail() {
         .result_interaction
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     let len = state.result_interaction.cell_edit().input().content().len();
-    state
-        .result_interaction
-        .cell_edit_input_mut()
-        .set_cursor(len);
+    state.result_interaction.cell_edit_set_cursor(len);
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -238,7 +238,7 @@ fn result_pane_cell_edit_mode() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_set_content("new@example.com".to_string());
+        .replace_cell_edit_draft("new@example.com".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 
@@ -297,7 +297,7 @@ fn result_pane_cell_active_pending_draft() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_set_content("new@example.com".to_string());
+        .replace_cell_edit_draft("new@example.com".to_string());
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -110,8 +110,7 @@ fn pending_draft_cell_uses_orange_fg() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_input_mut()
-        .set_content("new@example.com".to_string());
+        .cell_edit_set_content("new@example.com".to_string());
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -138,8 +137,7 @@ fn active_cell_edit_uses_yellow_fg() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_input_mut()
-        .set_content("new@example.com".to_string());
+        .cell_edit_set_content("new@example.com".to_string());
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -986,8 +984,7 @@ fn test_contrast_theme_applies_result_pane_table_colors() {
         .begin_cell_edit(0, 0, "1".to_string());
     state
         .result_interaction
-        .cell_edit_input_mut()
-        .set_content("new@example.com".to_string());
+        .cell_edit_set_content("new@example.com".to_string());
 
     let draft_buffer =
         render_and_get_buffer_at_with_theme(&mut terminal, &mut state, now, &TEST_CONTRAST_THEME);

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -110,7 +110,7 @@ fn pending_draft_cell_uses_orange_fg() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_set_content("new@example.com".to_string());
+        .replace_cell_edit_draft("new@example.com".to_string());
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -137,7 +137,7 @@ fn active_cell_edit_uses_yellow_fg() {
         .begin_cell_edit(1, 2, "bob@example.com".to_string());
     state
         .result_interaction
-        .cell_edit_set_content("new@example.com".to_string());
+        .replace_cell_edit_draft("new@example.com".to_string());
 
     let buffer = render_and_get_buffer(&mut terminal, &mut state);
 
@@ -984,7 +984,7 @@ fn test_contrast_theme_applies_result_pane_table_colors() {
         .begin_cell_edit(0, 0, "1".to_string());
     state
         .result_interaction
-        .cell_edit_set_content("new@example.com".to_string());
+        .replace_cell_edit_draft("new@example.com".to_string());
 
     let draft_buffer =
         render_and_get_buffer_at_with_theme(&mut terminal, &mut state, now, &TEST_CONTRAST_THEME);


### PR DESCRIPTION
## Problem

Cell edit state could still be mutated through direct field access and raw text-input handles, making it easy to miss paired updates when extending SQLite write guardrails or failure recovery.

## Background

[SAB-300](https://linear.app/sabiql/issue/SAB-300) follows the aggregate-state pattern established in SAB-236. SQLite update preview building already depended on cell-edit coordinates and draft values, but one code path still read private fields directly.

## Approach

Make `CellEditState` fields private and expose intent-level read/write helpers for editing, canceling, and applying drafts. Route reducers (cell edit input, paste, JSONB draft apply, write preview) through `ResultInteraction` instead of `cell_edit_input_mut` or field access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * セル編集の入力操作を、文字挿入・削除・カーソル移動・下書き置換などの明確な操作として扱えるようになりました。
  * セル編集の開始位置を指定して、内容を自動で反映できるようになりました。

* **バグ修正**
  * 貼り付け時の改行を除去して、セル編集へ安全に反映するようになりました。
  * 編集内容が残っている場合と残っていない場合で、キャンセル時の挙動を整理しました。

* **テスト**
  * セル編集の状態確認やスナップショット検証を、新しい操作方法に合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->