### PR TITLE
fix: discard stale browse state after SQLite connection save

### DIFF
--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -102,6 +102,15 @@ pub(super) fn reduce_loading(
             let was_connected = state.session.connection_state().is_connected();
             state.session.mark_connection_failed(error.masked_details());
             if !was_connected {
+                state.session.set_metadata(None);
+                state
+                    .session
+                    .clear_table_selection(&mut state.query.pagination);
+                state.query.clear_current_result();
+                state.ui.set_explorer_selection(None);
+                state.result_interaction.reset_view();
+            }
+            if !was_connected {
                 state.modal.replace_mode(InputMode::ConnectionError);
             }
             if state.er_preparation.status() == ErStatus::Waiting {

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -109,8 +109,6 @@ pub(super) fn reduce_loading(
                 state.query.clear_current_result();
                 state.ui.set_explorer_selection(None);
                 state.result_interaction.reset_view();
-            }
-            if !was_connected {
                 state.modal.replace_mode(InputMode::ConnectionError);
             }
             if state.er_preparation.status() == ErStatus::Waiting {

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -1,6 +1,22 @@
+use crate::domain::connection::{ConnectionId, DatabaseType};
 use crate::model::app_state::AppState;
 use crate::model::connection::cache::ConnectionCache;
 use crate::update::action::ConnectionTarget;
+
+pub(super) fn reset_for_new_connection(
+    state: &mut AppState,
+    id: &ConnectionId,
+    dsn: &str,
+    name: &str,
+    database_type: DatabaseType,
+) {
+    state.session.reset(&mut state.query);
+    state.result_interaction.reset_view();
+    state.ui.set_explorer_selection(None);
+    state
+        .session
+        .activate_connection_with_dsn(id, name, database_type, dsn);
+}
 
 pub(super) fn save_current_cache(state: &AppState) -> ConnectionCache {
     state.session.to_cache(

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -4,6 +4,12 @@ use crate::model::app_state::AppState;
 use crate::model::connection::cache::ConnectionCache;
 use crate::update::action::ConnectionTarget;
 
+fn reset_sql_and_er_state(state: &mut AppState) {
+    state.sql_modal.reset_prefetch();
+    state.er_preparation.reset();
+    state.ui.reset_er_picker_request();
+}
+
 pub(super) fn reset_for_new_connection(
     state: &mut AppState,
     id: &ConnectionId,
@@ -14,9 +20,7 @@ pub(super) fn reset_for_new_connection(
     state.session.reset(&mut state.query);
     state.result_interaction.reset_view();
     state.ui.set_explorer_selection(None);
-    state.sql_modal.reset_prefetch();
-    state.er_preparation.reset();
-    state.ui.reset_er_picker_request();
+    reset_sql_and_er_state(state);
     state
         .session
         .activate_connection_with_dsn(id, name, database_type, dsn);
@@ -76,4 +80,5 @@ pub(super) fn restore_cache(
         .ui
         .set_explorer_selection(Some(cache.explorer_selected));
     state.result_interaction.reset_view();
+    reset_sql_and_er_state(state);
 }

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -1,3 +1,4 @@
+use crate::cmd::effect::Effect;
 use crate::domain::connection::{ConnectionId, DatabaseType};
 use crate::model::app_state::AppState;
 use crate::model::connection::cache::ConnectionCache;
@@ -13,9 +14,34 @@ pub(super) fn reset_for_new_connection(
     state.session.reset(&mut state.query);
     state.result_interaction.reset_view();
     state.ui.set_explorer_selection(None);
+    state.sql_modal.reset_prefetch();
+    state.er_preparation.reset();
+    state.ui.reset_er_picker_request();
     state
         .session
         .activate_connection_with_dsn(id, name, database_type, dsn);
+}
+
+pub(super) fn connection_save_fetch_effects(
+    dsn: &str,
+    run_id: u64,
+    database_type: DatabaseType,
+) -> Vec<Effect> {
+    let fetch = Effect::FetchMetadata {
+        dsn: dsn.to_string(),
+        run_id,
+    };
+    if database_type == DatabaseType::SQLite {
+        vec![Effect::Sequence(vec![
+            Effect::CacheInvalidate {
+                dsn: dsn.to_string(),
+            },
+            Effect::ClearCompletionEngineCache,
+            fetch,
+        ])]
+    } else {
+        vec![Effect::ClearCompletionEngineCache, fetch]
+    }
 }
 
 pub(super) fn save_current_cache(state: &AppState) -> ConnectionCache {

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1,5 +1,4 @@
 use crate::cmd::effect::Effect;
-use crate::domain::connection::{ConnectionId, DatabaseType};
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
@@ -7,22 +6,7 @@ use crate::update::action::{Action, ConnectionTarget};
 
 use crate::update::dispatch_result::DispatchResult;
 
-use super::helpers::{restore_cache, save_current_cache};
-
-fn reset_for_new_connection(
-    state: &mut AppState,
-    id: &ConnectionId,
-    dsn: &str,
-    name: &str,
-    database_type: DatabaseType,
-) {
-    state.session.reset(&mut state.query);
-    state.result_interaction.reset_view();
-    state.ui.set_explorer_selection(None);
-    state
-        .session
-        .activate_connection_with_dsn(id, name, database_type, dsn);
-}
+use super::helpers::{reset_for_new_connection, restore_cache, save_current_cache};
 
 pub fn reduce_connection_lifecycle(
     state: &mut AppState,
@@ -83,6 +67,7 @@ pub fn reduce_connection_lifecycle(
 mod tests {
     use super::*;
     use crate::domain::ConnectionId;
+    use crate::domain::connection::DatabaseType;
     use crate::model::connection::cache::ConnectionCache;
     use crate::model::connection::state::ConnectionState;
     use crate::model::shared::inspector_tab::InspectorTab;

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -320,6 +320,20 @@ mod tests {
     }
 
     #[test]
+    fn switch_without_cache_resets_sql_prefetch() {
+        let mut state = AppState::new("test".to_string());
+        let new_id = ConnectionId::new();
+        let _ = state.sql_modal.begin_prefetch();
+        state.sql_modal.enqueue_prefetch("public.users".to_string());
+
+        let action = create_switch_action(&new_id, "fresh_db");
+        reduce(&mut state, &action);
+
+        assert!(!state.sql_modal.is_prefetch_started());
+        assert!(!state.sql_modal.has_pending_prefetch());
+    }
+
+    #[test]
     fn resets_result_selection_when_no_cache() {
         let mut state = AppState::new("test".to_string());
         let new_id = ConnectionId::new();

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -320,6 +320,23 @@ mod tests {
     }
 
     #[test]
+    fn switch_with_cache_resets_sql_prefetch() {
+        let mut state = AppState::new("test".to_string());
+        let target_id = ConnectionId::new();
+        state
+            .connection_caches
+            .save(&target_id, ConnectionCache::default());
+        let _ = state.sql_modal.begin_prefetch();
+        state.sql_modal.enqueue_prefetch("public.users".to_string());
+
+        let action = create_switch_action(&target_id, "cached_db");
+        reduce(&mut state, &action);
+
+        assert!(!state.sql_modal.is_prefetch_started());
+        assert!(!state.sql_modal.has_pending_prefetch());
+    }
+
+    #[test]
     fn switch_without_cache_resets_sql_prefetch() {
         let mut state = AppState::new("test".to_string());
         let new_id = ConnectionId::new();

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -151,29 +151,34 @@ pub fn reduce_connection_setup(
             DispatchResult::handled()
         }
         Action::ConnectionSetupSave => {
-            let setup = &mut state.connection_setup;
-            validate_all(setup);
-            if setup.has_validation_errors() {
-                DispatchResult::handled()
-            } else {
-                let config = match setup.to_connection_config() {
-                    Ok(config) => config,
-                    Err(error) => {
-                        setup.record_sqlite_config_error(error);
-                        return DispatchResult::handled();
-                    }
-                };
-                state.session.mark_connecting();
-                DispatchResult::handled_with(vec![Effect::SaveAndConnect {
-                    id: setup.editing_id().cloned(),
-                    name: setup
-                        .input(ConnectionField::Name)
-                        .expect("name is a text input")
-                        .content()
-                        .to_string(),
-                    config,
-                }])
+            validate_all(&mut state.connection_setup);
+            if state.connection_setup.has_validation_errors() {
+                return DispatchResult::handled();
             }
+            let config = match state.connection_setup.to_connection_config() {
+                Ok(config) => config,
+                Err(error) => {
+                    state.connection_setup.record_sqlite_config_error(error);
+                    return DispatchResult::handled();
+                }
+            };
+            if state.session.connection_state() == ConnectionState::Connected
+                && let Some(current_id) = state.session.active_connection_id().cloned()
+            {
+                let cache = save_current_cache(state);
+                state.connection_caches.save(&current_id, cache);
+            }
+            state.session.mark_connecting();
+            DispatchResult::handled_with(vec![Effect::SaveAndConnect {
+                id: state.connection_setup.editing_id().cloned(),
+                name: state
+                    .connection_setup
+                    .input(ConnectionField::Name)
+                    .expect("name is a text input")
+                    .content()
+                    .to_string(),
+                config,
+            }])
         }
         Action::ConnectionSetupCancel => {
             if state.connection_setup.is_first_run() {
@@ -199,25 +204,18 @@ pub fn reduce_connection_setup(
         }) => {
             state.connection_setup.set_first_run(false);
             state.modal.set_mode(InputMode::Normal);
-
-            if let Some(current_id) = state.session.active_connection_id().cloned()
-                && current_id != *id
-                && state.session.connection_state() == ConnectionState::Connected
-            {
-                let cache = save_current_cache(state);
-                state.connection_caches.save(&current_id, cache);
-            }
             state.connection_caches.remove(id);
 
             reset_for_new_connection(state, id, dsn, name, *database_type);
             let run_id = state.session.begin_connecting(dsn);
-            DispatchResult::handled_with(vec![
+            DispatchResult::handled_with(vec![Effect::Sequence(vec![
+                Effect::CacheInvalidate { dsn: dsn.clone() },
                 Effect::ClearCompletionEngineCache,
                 Effect::FetchMetadata {
                     dsn: dsn.clone(),
                     run_id,
                 },
-            ])
+            ])])
         }
         Action::ConnectionSaveFailed(e) => {
             if !state.session.connection_state().is_connected() {
@@ -572,16 +570,49 @@ mod tests {
             assert!(state.session.selected_table_key().is_none());
             assert!(state.session.connection_state().is_connecting());
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
-            assert!(
-                effects
-                    .iter()
-                    .any(|effect| matches!(effect, Effect::ClearCompletionEngineCache))
+            assert_eq!(effects.len(), 1);
+            if let Effect::Sequence(seq) = &effects[0] {
+                assert_eq!(seq.len(), 3);
+                assert!(matches!(seq[0], Effect::CacheInvalidate { .. }));
+                assert!(matches!(seq[1], Effect::ClearCompletionEngineCache));
+                assert!(matches!(seq[2], Effect::FetchMetadata { .. }));
+            } else {
+                panic!("expected Sequence effect, got {effects:?}");
+            }
+        }
+
+        #[test]
+        fn save_preserves_connected_cache_before_submit() {
+            use std::sync::Arc;
+
+            use crate::domain::{DatabaseMetadata, TableSummary};
+
+            let mut state = AppState::new("test".to_string());
+            let current_id = ConnectionId::new();
+            state.session.activate_connection_with_dsn(
+                &current_id,
+                "current",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/current",
             );
-            assert!(
-                effects
-                    .iter()
-                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
-            );
+            state.session.mark_connected(Arc::new(DatabaseMetadata {
+                database_name: "current".to_string(),
+                schemas: vec![],
+                table_summaries: vec![TableSummary::new(
+                    "public".to_string(),
+                    "users".to_string(),
+                    None,
+                    false,
+                )],
+            }));
+            state.ui.set_explorer_selected_raw(4);
+            fill_valid_form(&mut state);
+
+            reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
+
+            let saved = state.connection_caches.get(&current_id).unwrap();
+            assert_eq!(saved.explorer_selected, 4);
+            assert!(saved.metadata.is_some());
         }
 
         #[test]
@@ -633,11 +664,15 @@ mod tests {
             });
             let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
-            assert!(
-                effects
-                    .iter()
-                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
-            );
+            assert_eq!(effects.len(), 1);
+            if let Effect::Sequence(seq) = &effects[0] {
+                assert!(
+                    seq.iter()
+                        .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+                );
+            } else {
+                panic!("expected Sequence effect, got {effects:?}");
+            }
             assert_eq!(state.session.dsn(), Some("sqlite:///tmp/app.db"));
             assert_eq!(
                 state.session.active_database_type(),

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -8,7 +8,9 @@ use crate::model::connection::setup::{
 use crate::model::connection::state::ConnectionState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ConnectionTarget, InputTarget, ModalKind};
-use crate::update::connection::helpers::{reset_for_new_connection, save_current_cache};
+use crate::update::connection::helpers::{
+    connection_save_fetch_effects, reset_for_new_connection, save_current_cache,
+};
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{validate_all, validate_field};
 
@@ -208,14 +210,7 @@ pub fn reduce_connection_setup(
 
             reset_for_new_connection(state, id, dsn, name, *database_type);
             let run_id = state.session.begin_connecting(dsn);
-            DispatchResult::handled_with(vec![Effect::Sequence(vec![
-                Effect::CacheInvalidate { dsn: dsn.clone() },
-                Effect::ClearCompletionEngineCache,
-                Effect::FetchMetadata {
-                    dsn: dsn.clone(),
-                    run_id,
-                },
-            ])])
+            DispatchResult::handled_with(connection_save_fetch_effects(dsn, run_id, *database_type))
         }
         Action::ConnectionSaveFailed(e) => {
             if !state.session.connection_state().is_connected() {
@@ -234,7 +229,9 @@ mod tests {
     use super::*;
     use crate::domain::connection::{ConnectionProfile, SslMode};
     use crate::domain::{ConnectionId, DatabaseType};
-    use crate::update::test_support::activate_postgres_connection;
+    use crate::update::test_support::{
+        activate_postgres_connection, assert_connection_save_fetch_effects,
+    };
 
     fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
         reduce_connection_setup(state, action, now).into_effects()
@@ -570,15 +567,7 @@ mod tests {
             assert!(state.session.selected_table_key().is_none());
             assert!(state.session.connection_state().is_connecting());
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
-            assert_eq!(effects.len(), 1);
-            if let Effect::Sequence(seq) = &effects[0] {
-                assert_eq!(seq.len(), 3);
-                assert!(matches!(seq[0], Effect::CacheInvalidate { .. }));
-                assert!(matches!(seq[1], Effect::ClearCompletionEngineCache));
-                assert!(matches!(seq[2], Effect::FetchMetadata { .. }));
-            } else {
-                panic!("expected Sequence effect, got {effects:?}");
-            }
+            assert_connection_save_fetch_effects(&effects, DatabaseType::SQLite);
         }
 
         #[test]
@@ -665,14 +654,7 @@ mod tests {
             let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
             assert_eq!(effects.len(), 1);
-            if let Effect::Sequence(seq) = &effects[0] {
-                assert!(
-                    seq.iter()
-                        .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
-                );
-            } else {
-                panic!("expected Sequence effect, got {effects:?}");
-            }
+            assert_connection_save_fetch_effects(&effects, DatabaseType::SQLite);
             assert_eq!(state.session.dsn(), Some("sqlite:///tmp/app.db"));
             assert_eq!(
                 state.session.active_database_type(),

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -420,8 +420,13 @@ mod tests {
     }
 
     mod connection_save {
+        use std::sync::Arc;
+
         use super::*;
-        use crate::domain::MetadataState;
+        use crate::domain::{
+            DatabaseMetadata, MetadataState, QueryResult, QuerySource, TableSummary,
+        };
+        use crate::model::connection::cache::ConnectionCache;
         use crate::model::connection::state::ConnectionState;
         use crate::update::action::ConnectionTarget;
 
@@ -521,12 +526,6 @@ mod tests {
 
         #[test]
         fn save_completed_clears_previous_browse_state() {
-            use std::sync::Arc;
-
-            use crate::domain::{
-                DatabaseMetadata, MetadataState, QueryResult, QuerySource, TableSummary,
-            };
-
             let mut state = AppState::new("test".to_string());
             activate_postgres_connection(&mut state, "postgres://localhost/old");
             state.session.mark_connected(Arc::new(DatabaseMetadata {
@@ -572,10 +571,6 @@ mod tests {
 
         #[test]
         fn save_preserves_connected_cache_before_submit() {
-            use std::sync::Arc;
-
-            use crate::domain::{DatabaseMetadata, TableSummary};
-
             let mut state = AppState::new("test".to_string());
             let current_id = ConnectionId::new();
             state.session.activate_connection_with_dsn(
@@ -606,11 +601,6 @@ mod tests {
 
         #[test]
         fn save_completed_removes_stale_connection_cache_for_saved_profile() {
-            use std::sync::Arc;
-
-            use crate::domain::{DatabaseMetadata, TableSummary};
-            use crate::model::connection::cache::ConnectionCache;
-
             let mut state = AppState::new("test".to_string());
             let saved_id = ConnectionId::new();
             state.connection_caches.save(

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -5,8 +5,10 @@ use crate::model::app_state::AppState;
 use crate::model::connection::setup::{
     CONNECTION_INPUT_VISIBLE_WIDTH, ConnectionField, ConnectionSetupState,
 };
+use crate::model::connection::state::ConnectionState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ConnectionTarget, InputTarget, ModalKind};
+use crate::update::connection::helpers::{reset_for_new_connection, save_current_cache};
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{validate_all, validate_field};
 
@@ -197,14 +199,25 @@ pub fn reduce_connection_setup(
         }) => {
             state.connection_setup.set_first_run(false);
             state.modal.set_mode(InputMode::Normal);
-            state
-                .session
-                .activate_connection_with_dsn(id, name, *database_type, dsn);
+
+            if let Some(current_id) = state.session.active_connection_id().cloned()
+                && current_id != *id
+                && state.session.connection_state() == ConnectionState::Connected
+            {
+                let cache = save_current_cache(state);
+                state.connection_caches.save(&current_id, cache);
+            }
+            state.connection_caches.remove(id);
+
+            reset_for_new_connection(state, id, dsn, name, *database_type);
             let run_id = state.session.begin_connecting(dsn);
-            DispatchResult::handled_with(vec![Effect::FetchMetadata {
-                dsn: dsn.clone(),
-                run_id,
-            }])
+            DispatchResult::handled_with(vec![
+                Effect::ClearCompletionEngineCache,
+                Effect::FetchMetadata {
+                    dsn: dsn.clone(),
+                    run_id,
+                },
+            ])
         }
         Action::ConnectionSaveFailed(e) => {
             if !state.session.connection_state().is_connected() {
@@ -509,6 +522,103 @@ mod tests {
             reduce(&mut state, &action, Instant::now());
 
             assert!(!state.session.is_read_only());
+        }
+
+        #[test]
+        fn save_completed_clears_previous_browse_state() {
+            use std::sync::Arc;
+
+            use crate::domain::{
+                DatabaseMetadata, MetadataState, QueryResult, QuerySource, TableSummary,
+            };
+
+            let mut state = AppState::new("test".to_string());
+            activate_postgres_connection(&mut state, "postgres://localhost/old");
+            state.session.mark_connected(Arc::new(DatabaseMetadata {
+                database_name: "old_db".to_string(),
+                schemas: vec![],
+                table_summaries: vec![TableSummary::new(
+                    "public".to_string(),
+                    "users".to_string(),
+                    None,
+                    false,
+                )],
+            }));
+            state.ui.set_explorer_selected_raw(3);
+            let _ = state
+                .session
+                .select_table("public", "users", &mut state.query.pagination);
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success(
+                    "SELECT 1".to_string(),
+                    vec!["col".to_string()],
+                    vec![vec!["val".to_string()]],
+                    10,
+                    QuerySource::Preview,
+                )));
+
+            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "sqlite:///tmp/new.db".to_string(),
+                name: "new.db".to_string(),
+                database_type: DatabaseType::SQLite,
+            });
+            let effects = reduce(&mut state, &action, Instant::now()).unwrap();
+
+            assert!(state.session.metadata().is_none());
+            assert!(state.session.tables().is_empty());
+            assert!(state.query.current_result().is_none());
+            assert!(state.session.selected_table_key().is_none());
+            assert!(state.session.connection_state().is_connecting());
+            assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ClearCompletionEngineCache))
+            );
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
+        }
+
+        #[test]
+        fn save_completed_removes_stale_connection_cache_for_saved_profile() {
+            use std::sync::Arc;
+
+            use crate::domain::{DatabaseMetadata, TableSummary};
+            use crate::model::connection::cache::ConnectionCache;
+
+            let mut state = AppState::new("test".to_string());
+            let saved_id = ConnectionId::new();
+            state.connection_caches.save(
+                &saved_id,
+                ConnectionCache {
+                    metadata: Some(Arc::new(DatabaseMetadata {
+                        database_name: "stale".to_string(),
+                        schemas: vec![],
+                        table_summaries: vec![TableSummary::new(
+                            "main".to_string(),
+                            "old_table".to_string(),
+                            None,
+                            false,
+                        )],
+                    })),
+                    ..Default::default()
+                },
+            );
+
+            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
+                id: saved_id.clone(),
+                dsn: "sqlite:///tmp/new.db".to_string(),
+                name: "new.db".to_string(),
+                database_type: DatabaseType::SQLite,
+            });
+            reduce(&mut state, &action, Instant::now());
+
+            assert!(state.connection_caches.get(&saved_id).is_none());
         }
 
         #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -191,7 +191,9 @@ mod tests {
     use crate::update::action::ModalKind;
     use crate::update::action::{ConnectionSaveError, ConnectionTarget};
     use crate::update::action::{InputTarget, SelectMotion};
-    use crate::update::test_support::activate_postgres_connection;
+    use crate::update::test_support::{
+        activate_postgres_connection, assert_connection_save_fetch_effects,
+    };
 
     fn create_test_state() -> AppState {
         AppState::new("test_project".to_string())
@@ -1737,14 +1739,7 @@ mod tests {
                 Some("Test Connection")
             );
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(effects[0], Effect::Sequence(_)));
-            if let Effect::Sequence(seq) = &effects[0] {
-                assert_eq!(seq.len(), 3);
-                assert!(matches!(seq[0], Effect::CacheInvalidate { .. }));
-                assert!(matches!(seq[1], Effect::ClearCompletionEngineCache));
-                assert!(matches!(seq[2], Effect::FetchMetadata { .. }));
-            }
+            assert_connection_save_fetch_effects(&effects, DatabaseType::PostgreSQL);
         }
 
         #[test]
@@ -2264,14 +2259,7 @@ mod tests {
                 state.session.metadata_state(),
                 MetadataState::Loading
             ));
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(effects[0], Effect::Sequence(_)));
-            if let Effect::Sequence(seq) = &effects[0] {
-                assert!(
-                    seq.iter()
-                        .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
-                );
-            }
+            assert_connection_save_fetch_effects(&effects, DatabaseType::PostgreSQL);
         }
 
         #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -908,7 +908,9 @@ mod tests {
 
     mod response_handlers {
         use super::*;
-        use crate::domain::{DatabaseMetadata, MetadataState, TableSummary};
+        use crate::domain::{
+            DatabaseMetadata, MetadataState, QueryResult, QuerySource, TableSummary,
+        };
         use crate::model::connection::error::ConnectionErrorInfo;
         use crate::model::connection::state::ConnectionState;
 
@@ -975,8 +977,6 @@ mod tests {
 
         #[test]
         fn metadata_failed_clears_stale_browse_state_on_initial_connect() {
-            use crate::domain::{QueryResult, QuerySource};
-
             let mut state = create_test_state();
             activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.mark_connected(Arc::new(DatabaseMetadata {
@@ -1823,6 +1823,9 @@ mod tests {
     mod confirm_dialog_transitions {
         use super::*;
         use crate::model::shared::confirm_dialog::ConfirmIntent;
+        use crate::policy::write::write_guardrails::{
+            GuardrailDecision, RiskLevel, TargetSummary, WriteOperation, WritePreview,
+        };
 
         #[test]
         fn confirm_quit_no_connection_sets_should_quit() {
@@ -1867,10 +1870,6 @@ mod tests {
 
         #[test]
         fn confirm_delete_write_then_success_preserves_delete_context() {
-            use crate::policy::write::write_guardrails::{
-                GuardrailDecision, RiskLevel, TargetSummary, WriteOperation, WritePreview,
-            };
-
             let mut state = create_test_state();
             activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
@@ -1944,10 +1943,6 @@ mod tests {
 
         #[test]
         fn confirm_delete_write_then_failure_returns_to_normal() {
-            use crate::policy::write::write_guardrails::{
-                GuardrailDecision, RiskLevel, TargetSummary, WriteOperation, WritePreview,
-            };
-
             let mut state = create_test_state();
             activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
@@ -2006,6 +2001,7 @@ mod tests {
         use super::*;
         use crate::domain::{ConnectionId, DatabaseMetadata, MetadataState};
         use crate::model::connection::state::ConnectionState;
+        use crate::model::shared::inspector_tab::InspectorTab;
 
         #[test]
         fn try_connect_with_dsn_starts_connecting() {
@@ -2325,8 +2321,6 @@ mod tests {
 
         #[test]
         fn switch_connection_restores_from_cache() {
-            use crate::model::shared::inspector_tab::InspectorTab;
-
             let mut state = create_test_state();
             let conn_a = ConnectionId::new();
             let conn_b = ConnectionId::new();
@@ -2382,6 +2376,7 @@ mod tests {
     mod er_table_picker {
         use super::*;
         use crate::domain::{DatabaseMetadata, TableSummary};
+        use crate::model::er_state::ErStatus;
 
         fn state_with_metadata() -> AppState {
             let mut state = create_test_state();
@@ -2593,8 +2588,6 @@ mod tests {
 
         #[test]
         fn prefetch_complete_dispatches_er_generate() {
-            use crate::model::er_state::ErStatus;
-
             let mut state = state_with_metadata();
             activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
@@ -2627,8 +2620,6 @@ mod tests {
 
         #[test]
         fn prefetch_complete_with_failures_does_not_auto_open() {
-            use crate::model::er_state::ErStatus;
-
             let mut state = state_with_metadata();
             activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -975,6 +975,8 @@ mod tests {
 
         #[test]
         fn metadata_failed_clears_stale_browse_state_on_initial_connect() {
+            use crate::domain::{QueryResult, QuerySource};
+
             let mut state = create_test_state();
             activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.mark_connected(Arc::new(DatabaseMetadata {
@@ -987,6 +989,19 @@ mod tests {
                     false,
                 )],
             }));
+            state.ui.set_explorer_selected_raw(2);
+            let _ = state
+                .session
+                .select_table("public", "users", &mut state.query.pagination);
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success(
+                    "SELECT 1".to_string(),
+                    vec!["col".to_string()],
+                    vec![vec!["val".to_string()]],
+                    10,
+                    QuerySource::Preview,
+                )));
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
@@ -1007,7 +1022,9 @@ mod tests {
 
             assert!(state.session.metadata().is_none());
             assert!(state.session.tables().is_empty());
+            assert!(state.session.selected_table_key().is_none());
             assert!(state.query.current_result().is_none());
+            assert_eq!(state.ui.explorer_selected(), 0);
             assert!(state.session.connection_state().is_failed());
         }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1737,17 +1737,14 @@ mod tests {
                 Some("Test Connection")
             );
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert_eq!(effects.len(), 2);
-            assert!(
-                effects
-                    .iter()
-                    .any(|effect| matches!(effect, Effect::ClearCompletionEngineCache))
-            );
-            assert!(
-                effects
-                    .iter()
-                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
-            );
+            assert_eq!(effects.len(), 1);
+            assert!(matches!(effects[0], Effect::Sequence(_)));
+            if let Effect::Sequence(seq) = &effects[0] {
+                assert_eq!(seq.len(), 3);
+                assert!(matches!(seq[0], Effect::CacheInvalidate { .. }));
+                assert!(matches!(seq[1], Effect::ClearCompletionEngineCache));
+                assert!(matches!(seq[2], Effect::FetchMetadata { .. }));
+            }
         }
 
         #[test]
@@ -2267,12 +2264,14 @@ mod tests {
                 state.session.metadata_state(),
                 MetadataState::Loading
             ));
-            assert_eq!(effects.len(), 2);
-            assert!(
-                effects
-                    .iter()
-                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
-            );
+            assert_eq!(effects.len(), 1);
+            assert!(matches!(effects[0], Effect::Sequence(_)));
+            if let Effect::Sequence(seq) = &effects[0] {
+                assert!(
+                    seq.iter()
+                        .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+                );
+            }
         }
 
         #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -908,6 +908,7 @@ mod tests {
         use super::*;
         use crate::domain::{DatabaseMetadata, MetadataState, TableSummary};
         use crate::model::connection::error::ConnectionErrorInfo;
+        use crate::model::connection::state::ConnectionState;
 
         fn metadata_loaded_action(state: &mut AppState, metadata: DatabaseMetadata) -> Action {
             activate_postgres_connection(state, "postgres://localhost/test");
@@ -968,6 +969,44 @@ mod tests {
 
             assert!(state.session.metadata().is_some());
             assert_eq!(state.ui.explorer_selected(), 0);
+        }
+
+        #[test]
+        fn metadata_failed_clears_stale_browse_state_on_initial_connect() {
+            let mut state = create_test_state();
+            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            state.session.mark_connected(Arc::new(DatabaseMetadata {
+                database_name: "stale".to_string(),
+                schemas: vec![],
+                table_summaries: vec![TableSummary::new(
+                    "public".to_string(),
+                    "users".to_string(),
+                    None,
+                    false,
+                )],
+            }));
+            state
+                .session
+                .set_connection_state(ConnectionState::Connecting);
+            state.session.set_metadata_state(MetadataState::Loading);
+            let run_id = state.session.begin_metadata_refresh();
+            let now = Instant::now();
+
+            reduce(
+                &mut state,
+                Action::MetadataFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    error: DbOperationError::ConnectionFailed("connection refused".to_string()),
+                },
+                now,
+                &AppServices::stub(),
+            );
+
+            assert!(state.session.metadata().is_none());
+            assert!(state.session.tables().is_empty());
+            assert!(state.query.current_result().is_none());
+            assert!(state.session.connection_state().is_failed());
         }
 
         #[test]
@@ -1698,8 +1737,17 @@ mod tests {
                 Some("Test Connection")
             );
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(effects[0], Effect::FetchMetadata { .. }));
+            assert_eq!(effects.len(), 2);
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ClearCompletionEngineCache))
+            );
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
         }
 
         #[test]
@@ -2219,8 +2267,12 @@ mod tests {
                 state.session.metadata_state(),
                 MetadataState::Loading
             ));
-            assert_eq!(effects.len(), 1);
-            assert!(matches!(effects[0], Effect::FetchMetadata { .. }));
+            assert_eq!(effects.len(), 2);
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
         }
 
         #[test]

--- a/src/app/update/test_support.rs
+++ b/src/app/update/test_support.rs
@@ -18,3 +18,33 @@ pub(super) fn activate_sqlite_connection(state: &mut AppState, dsn: &str) {
         dsn,
     );
 }
+
+#[cfg(test)]
+pub(super) fn assert_connection_save_fetch_effects(
+    effects: &[crate::cmd::effect::Effect],
+    database_type: DatabaseType,
+) {
+    use crate::cmd::effect::Effect;
+
+    match database_type {
+        DatabaseType::SQLite => {
+            assert_eq!(effects.len(), 1, "sqlite save should emit Sequence");
+            let Effect::Sequence(seq) = &effects[0] else {
+                panic!("expected Sequence, got {effects:?}");
+            };
+            assert_eq!(seq.len(), 3);
+            assert!(matches!(seq[0], Effect::CacheInvalidate { .. }));
+            assert!(matches!(seq[1], Effect::ClearCompletionEngineCache));
+            assert!(matches!(seq[2], Effect::FetchMetadata { .. }));
+        }
+        DatabaseType::PostgreSQL => {
+            assert_eq!(
+                effects.len(),
+                2,
+                "postgres save should preserve prefetched metadata cache"
+            );
+            assert!(matches!(effects[0], Effect::ClearCompletionEngineCache));
+            assert!(matches!(effects[1], Effect::FetchMetadata { .. }));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

After saving a new SQLite connection, a failed metadata fetch could leave the previous connection's tables, query results, and per-connection cache visible, making it unclear which database was active.

## Background

SQLite profiles are saved before metadata is fetched, unlike PostgreSQL where metadata is prefetched during save. `ConnectionSaveCompleted` activated the new DSN but did not reset browse state the way `SwitchConnection` does.

## Approach

Reuse the shared new-connection reset path when save completes: clear browse/session display state, drop stale per-connection cache for the saved profile, then fetch metadata with a cleared completion cache. Also clear leftover browse data when an initial metadata fetch fails before the session is connected.