### PR TITLE
fix: hide PostgreSQL-only features for SQLite

### DIFF
--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -1,9 +1,11 @@
 use unicode_width::UnicodeWidthStr;
 
 use crate::model::app_state::AppState;
+use crate::model::shared::db_capabilities::DbCapabilities;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::help::{HelpOrigin, JsonbHelpMode, SqlHelpMode};
 use crate::model::shared::settings::KeymapPreset;
+use crate::update::action::{Action, ModalKind};
 #[allow(
     clippy::wildcard_imports,
     reason = "help catalog enumerates nearly every keybindings table; explicit list is churn"
@@ -29,6 +31,7 @@ impl HelpDocument {
             filter.content(),
             filter.cursor(),
             state.settings.saved_keymap_preset(),
+            state.session.active_db_capabilities(),
         )
     }
 
@@ -37,7 +40,13 @@ impl HelpDocument {
     }
 
     pub fn new_with_cursor(origin: HelpOrigin, filter: &str, filter_cursor: usize) -> Self {
-        Self::new_with_cursor_and_preset(origin, filter, filter_cursor, origin.keymap_preset())
+        Self::new_with_cursor_and_preset(
+            origin,
+            filter,
+            filter_cursor,
+            origin.keymap_preset(),
+            &DbCapabilities::postgres_like(),
+        )
     }
 
     fn new_with_cursor_and_preset(
@@ -45,10 +54,11 @@ impl HelpDocument {
         filter: &str,
         filter_cursor: usize,
         keymap_preset: KeymapPreset,
+        db_capabilities: &DbCapabilities,
     ) -> Self {
         let normalized = filter.trim().to_lowercase();
-        let mut sections = vec![current_section(origin)];
-        sections.extend(reference_sections(keymap_preset));
+        let mut sections = vec![current_section(origin, db_capabilities)];
+        sections.extend(reference_sections(keymap_preset, db_capabilities));
 
         if !normalized.is_empty() {
             sections = sections
@@ -198,7 +208,7 @@ impl HelpRow {
     }
 }
 
-fn current_section(origin: HelpOrigin) -> HelpSection {
+fn current_section(origin: HelpOrigin, db_capabilities: &DbCapabilities) -> HelpSection {
     let rows = match origin {
         HelpOrigin::Normal {
             focused_pane: FocusedPane::Result,
@@ -233,7 +243,7 @@ fn current_section(origin: HelpOrigin) -> HelpSection {
             &global::CONNECTIONS,
             &global::SQL,
         ]),
-        HelpOrigin::CommandLine => rows_from_bindings(COMMAND_LINE_KEYS),
+        HelpOrigin::CommandLine => command_line_rows(db_capabilities),
         HelpOrigin::CellEdit => rows_from_bindings(CELL_EDIT_KEYS),
         HelpOrigin::TablePicker => rows_from_mode_rows(TABLE_PICKER_ROWS),
         HelpOrigin::CommandPalette => rows_from_mode_rows(COMMAND_PALETTE_ROWS),
@@ -271,7 +281,81 @@ fn current_section(origin: HelpOrigin) -> HelpSection {
     }
 }
 
-fn reference_sections(keymap_preset: KeymapPreset) -> Vec<HelpSection> {
+fn command_line_rows(db_capabilities: &DbCapabilities) -> Vec<HelpRow> {
+    rows_from_binding_iter(COMMAND_LINE_KEYS.iter().filter(|binding| {
+        !matches!(
+            binding.action,
+            Action::OpenModal(ModalKind::ErTablePicker) if !db_capabilities.supports_er_diagram()
+        )
+    }))
+}
+
+fn reference_sections(
+    keymap_preset: KeymapPreset,
+    db_capabilities: &DbCapabilities,
+) -> Vec<HelpSection> {
+    let mut open_switch_rows = vec![
+        table_picker(keymap_preset),
+        &global::SQL,
+        &global::CONNECTIONS,
+        query_history(keymap_preset),
+        &global::PANE_SWITCH,
+        &global::INSPECTOR_TABS,
+    ];
+    if db_capabilities.supports_er_diagram() {
+        open_switch_rows.insert(2, &global::ER_DIAGRAM);
+    }
+
+    let mut data_action_rows = rows_from_binding_refs(&[
+        &global::RELOAD,
+        csv_export(keymap_preset),
+        &result_active::YANK,
+        &result_active::ROW_YANK,
+        &result_active::STAGE_DELETE,
+        &result_active::UNSTAGE_DELETE,
+        &inspector_ddl::YANK,
+    ]);
+    if db_capabilities.supports_jsonb_detail() {
+        data_action_rows.extend(rows_from_mode_row_refs(&[&jsonb_detail::YANK]));
+    }
+
+    let mut search_filter_rows = rows_from_mode_row_refs(&[
+        &table_picker::TYPE_FILTER,
+        &query_history_picker::TYPE_FILTER,
+    ]);
+    if db_capabilities.supports_er_diagram() {
+        search_filter_rows.insert(
+            1,
+            rows_from_mode_row_refs(&[&er_picker::TYPE_FILTER])[0].clone(),
+        );
+    }
+    if db_capabilities.supports_jsonb_detail() {
+        search_filter_rows.extend(rows_from_bindings(JSONB_SEARCH_KEYS));
+    }
+    search_filter_rows.extend(rows_from_mode_rows(HELP_ROWS));
+
+    let mut editing_rows = merge_rows(&[
+        sql_current_rows(SqlHelpMode::Normal, keymap_preset),
+        sql_current_rows(SqlHelpMode::Insert, keymap_preset),
+        rows_from_bindings(CELL_EDIT_KEYS),
+        rows_from_bindings(SQL_MODAL_CONFIRMING_KEYS),
+    ]);
+    if db_capabilities.supports_jsonb_detail() {
+        editing_rows.extend(rows_from_mode_rows(JSONB_EDIT_ROWS));
+    }
+
+    let mut advanced_rows = Vec::new();
+    if db_capabilities.supports_explain() {
+        advanced_rows.extend(sql_current_rows(SqlHelpMode::Plan, keymap_preset));
+        advanced_rows.extend(sql_current_rows(SqlHelpMode::Compare, keymap_preset));
+    }
+    if db_capabilities.supports_er_diagram() {
+        advanced_rows.extend(rows_from_mode_rows(er_picker_rows(keymap_preset)));
+    }
+    if db_capabilities.supports_jsonb_detail() {
+        advanced_rows.extend(rows_from_mode_rows(JSONB_DETAIL_ROWS));
+    }
+
     vec![
         section(
             "Common",
@@ -286,55 +370,10 @@ fn reference_sections(keymap_preset: KeymapPreset) -> Vec<HelpSection> {
             ]),
         ),
         section("Navigation", rows_from_bindings(NAVIGATION_KEYS)),
-        section(
-            "Open / Switch",
-            rows_from_binding_refs(&[
-                table_picker(keymap_preset),
-                &global::SQL,
-                &global::ER_DIAGRAM,
-                &global::CONNECTIONS,
-                query_history(keymap_preset),
-                &global::PANE_SWITCH,
-                &global::INSPECTOR_TABS,
-            ]),
-        ),
-        section(
-            "Data Actions",
-            merge_rows(&[
-                rows_from_binding_refs(&[
-                    &global::RELOAD,
-                    csv_export(keymap_preset),
-                    &result_active::YANK,
-                    &result_active::ROW_YANK,
-                    &result_active::STAGE_DELETE,
-                    &result_active::UNSTAGE_DELETE,
-                    &inspector_ddl::YANK,
-                ]),
-                rows_from_mode_row_refs(&[&jsonb_detail::YANK]),
-            ]),
-        ),
-        section(
-            "Editing",
-            merge_rows(&[
-                sql_current_rows(SqlHelpMode::Normal, keymap_preset),
-                sql_current_rows(SqlHelpMode::Insert, keymap_preset),
-                rows_from_bindings(CELL_EDIT_KEYS),
-                rows_from_mode_rows(JSONB_EDIT_ROWS),
-                rows_from_bindings(SQL_MODAL_CONFIRMING_KEYS),
-            ]),
-        ),
-        section(
-            "Search / Filter",
-            merge_rows(&[
-                rows_from_mode_row_refs(&[
-                    &table_picker::TYPE_FILTER,
-                    &er_picker::TYPE_FILTER,
-                    &query_history_picker::TYPE_FILTER,
-                ]),
-                rows_from_bindings(JSONB_SEARCH_KEYS),
-                rows_from_mode_rows(HELP_ROWS),
-            ]),
-        ),
+        section("Open / Switch", rows_from_binding_refs(&open_switch_rows)),
+        section("Data Actions", data_action_rows),
+        section("Editing", editing_rows),
+        section("Search / Filter", search_filter_rows),
         section(
             "Connections",
             merge_rows(&[
@@ -359,16 +398,11 @@ fn reference_sections(keymap_preset: KeymapPreset) -> Vec<HelpSection> {
                 rows_from_mode_rows(HELP_ROWS),
             ]),
         ),
-        section(
-            "Advanced",
-            merge_rows(&[
-                sql_current_rows(SqlHelpMode::Plan, keymap_preset),
-                sql_current_rows(SqlHelpMode::Compare, keymap_preset),
-                rows_from_mode_rows(er_picker_rows(keymap_preset)),
-                rows_from_mode_rows(JSONB_DETAIL_ROWS),
-            ]),
-        ),
+        section("Advanced", merge_rows(&[advanced_rows])),
     ]
+    .into_iter()
+    .filter(|section| !section.rows.is_empty())
+    .collect()
 }
 
 fn sql_current_rows(mode: SqlHelpMode, keymap_preset: KeymapPreset) -> Vec<HelpRow> {
@@ -513,8 +547,18 @@ fn merge_rows(groups: &[Vec<HelpRow>]) -> Vec<HelpRow> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::shared::input_mode::InputMode;
     use crate::model::sql_editor::modal::SqlModalTab;
+
+    fn row_descriptions(document: &HelpDocument) -> Vec<&str> {
+        document
+            .sections()
+            .iter()
+            .flat_map(HelpSection::rows)
+            .map(HelpRow::description)
+            .collect()
+    }
 
     #[test]
     fn document_starts_with_current_section() {
@@ -639,6 +683,12 @@ mod tests {
     #[test]
     fn origin_from_state_maps_sql_plan_and_jsonb_search() {
         let mut sql_state = AppState::new("test".to_string());
+        sql_state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            DatabaseType::PostgreSQL,
+            "postgres://localhost/test",
+        );
         sql_state.modal.set_mode(InputMode::SqlModal);
         sql_state.sql_modal.set_active_tab(SqlModalTab::Plan);
         let sql_document = HelpDocument::new(HelpOrigin::from_state(&sql_state), "");
@@ -656,6 +706,79 @@ mod tests {
         assert_eq!(
             jsonb_document.sections()[0].title(),
             "Current: JSONB Search"
+        );
+    }
+
+    #[test]
+    fn from_state_omits_postgresql_only_reference_rows_for_sqlite() {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            DatabaseType::SQLite,
+            "sqlite://test.db",
+        );
+        let origin = HelpOrigin::from_state(&state);
+        state.ui.help_mut().open(origin);
+
+        let document = HelpDocument::from_state(&state);
+        let descriptions = row_descriptions(&document);
+
+        assert!(
+            !descriptions
+                .iter()
+                .any(|description| description.contains("ER Diagram"))
+        );
+        assert!(
+            !descriptions
+                .iter()
+                .any(|description| description.contains("EXPLAIN"))
+        );
+        assert!(
+            !descriptions
+                .iter()
+                .any(|description| description.contains("JSONB"))
+        );
+    }
+
+    #[test]
+    fn sqlite_sql_help_origin_normalizes_unsupported_plan_tab() {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            DatabaseType::SQLite,
+            "sqlite://test.db",
+        );
+        state.modal.set_mode(InputMode::SqlModal);
+        state.sql_modal.set_active_tab(SqlModalTab::Plan);
+
+        let document = HelpDocument::new(HelpOrigin::from_state(&state), "");
+
+        assert_eq!(document.sections()[0].title(), "Current: SQL Editor");
+    }
+
+    #[test]
+    fn sqlite_command_line_help_omits_erd_command() {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            DatabaseType::SQLite,
+            "sqlite://test.db",
+        );
+        state.modal.set_mode(InputMode::CommandLine);
+        let origin = HelpOrigin::from_state(&state);
+        state.ui.help_mut().open(origin);
+
+        let document = HelpDocument::from_state(&state);
+
+        assert_eq!(document.sections()[0].title(), "Current: Command Line");
+        assert!(
+            !document.sections()[0]
+                .rows()
+                .iter()
+                .any(|row| row.key() == ":erd")
         );
     }
 }

--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -324,10 +324,7 @@ fn reference_sections(
         &query_history_picker::TYPE_FILTER,
     ]);
     if db_capabilities.supports_er_diagram() {
-        search_filter_rows.insert(
-            1,
-            rows_from_mode_row_refs(&[&er_picker::TYPE_FILTER])[0].clone(),
-        );
+        search_filter_rows.insert(1, row_from_mode_row(&er_picker::TYPE_FILTER));
     }
     if db_capabilities.supports_jsonb_detail() {
         search_filter_rows.extend(rows_from_bindings(JSONB_SEARCH_KEYS));
@@ -519,15 +516,15 @@ fn paired_binding_row(first: &KeyBinding, second: &KeyBinding) -> Option<HelpRow
 }
 
 fn rows_from_mode_rows(rows: &[ModeRow]) -> Vec<HelpRow> {
-    rows.iter()
-        .map(|row| HelpRow::new(row.key, row.description))
-        .collect()
+    rows.iter().map(row_from_mode_row).collect()
 }
 
 fn rows_from_mode_row_refs(rows: &[&ModeRow]) -> Vec<HelpRow> {
-    rows.iter()
-        .map(|row| HelpRow::new(row.key, row.description))
-        .collect()
+    rows.iter().map(|&row| row_from_mode_row(row)).collect()
+}
+
+fn row_from_mode_row(row: &ModeRow) -> HelpRow {
+    HelpRow::new(row.key, row.description)
 }
 
 fn merge_rows(groups: &[Vec<HelpRow>]) -> Vec<HelpRow> {

--- a/src/app/model/shared/db_capabilities.rs
+++ b/src/app/model/shared/db_capabilities.rs
@@ -21,7 +21,7 @@ pub struct DbCapabilities {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct CapabilityFlags {
+struct CapabilityFlags {
     supports_explain: bool,
     supports_er_diagram: bool,
     supports_jsonb_detail: bool,
@@ -42,7 +42,7 @@ impl CapabilityFlags {
 }
 
 impl DbCapabilities {
-    pub(crate) fn new(
+    fn new(
         flags: CapabilityFlags,
         supported_inspector_tabs: Vec<InspectorTab>,
         supported_inspector_info_fields: Vec<InspectorInfoField>,

--- a/src/app/model/shared/db_capabilities.rs
+++ b/src/app/model/shared/db_capabilities.rs
@@ -14,6 +14,8 @@ pub enum InspectorInfoField {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DbCapabilities {
     supports_explain: bool,
+    supports_er_diagram: bool,
+    supports_jsonb_detail: bool,
     supported_inspector_tabs: Vec<InspectorTab>,
     supported_inspector_info_fields: Vec<InspectorInfoField>,
 }
@@ -21,6 +23,8 @@ pub struct DbCapabilities {
 impl DbCapabilities {
     pub(crate) fn new(
         supports_explain: bool,
+        supports_er_diagram: bool,
+        supports_jsonb_detail: bool,
         supported_inspector_tabs: Vec<InspectorTab>,
         supported_inspector_info_fields: Vec<InspectorInfoField>,
     ) -> Self {
@@ -42,6 +46,8 @@ impl DbCapabilities {
         );
         Self {
             supports_explain,
+            supports_er_diagram,
+            supports_jsonb_detail,
             supported_inspector_tabs,
             supported_inspector_info_fields,
         }
@@ -50,6 +56,8 @@ impl DbCapabilities {
     pub fn disconnected() -> Self {
         Self::new(
             false,
+            false,
+            false,
             vec![InspectorTab::Info],
             vec![InspectorInfoField::Schema, InspectorInfoField::TableName],
         )
@@ -57,6 +65,8 @@ impl DbCapabilities {
 
     pub fn postgres_like() -> Self {
         Self::new(
+            true,
+            true,
             true,
             vec![
                 InspectorTab::Info,
@@ -79,6 +89,8 @@ impl DbCapabilities {
 
     pub fn sqlite_like() -> Self {
         Self::new(
+            false,
+            false,
             false,
             vec![
                 InspectorTab::Info,
@@ -104,6 +116,14 @@ impl DbCapabilities {
 
     pub fn supports_explain(&self) -> bool {
         self.supports_explain
+    }
+
+    pub fn supports_er_diagram(&self) -> bool {
+        self.supports_er_diagram
+    }
+
+    pub fn supports_jsonb_detail(&self) -> bool {
+        self.supports_jsonb_detail
     }
 
     pub fn supported_inspector_tabs(&self) -> &[InspectorTab] {
@@ -201,6 +221,8 @@ mod tests {
             let caps = DbCapabilities::postgres_like();
 
             assert!(caps.supports_explain());
+            assert!(caps.supports_er_diagram());
+            assert!(caps.supports_jsonb_detail());
             assert!(caps.supports_inspector_tab(InspectorTab::Ddl));
             assert_eq!(caps.supported_inspector_tabs().len(), 7);
             assert_eq!(
@@ -220,6 +242,8 @@ mod tests {
             let caps = DbCapabilities::sqlite_like();
 
             assert!(!caps.supports_explain());
+            assert!(!caps.supports_er_diagram());
+            assert!(!caps.supports_jsonb_detail());
             assert_eq!(
                 caps.supported_inspector_tabs(),
                 &[
@@ -258,6 +282,8 @@ mod tests {
             let caps = DbCapabilities::disconnected();
 
             assert!(!caps.supports_explain());
+            assert!(!caps.supports_er_diagram());
+            assert!(!caps.supports_jsonb_detail());
             assert_eq!(caps.supported_inspector_tabs(), &[InspectorTab::Info]);
             assert_eq!(
                 caps.supported_inspector_info_fields(),
@@ -274,6 +300,8 @@ mod tests {
         fn unsupported_inspector_tab_returns_first_supported_tab() {
             let caps = DbCapabilities::new(
                 false,
+                false,
+                false,
                 vec![InspectorTab::Info, InspectorTab::Columns],
                 vec![InspectorInfoField::Owner],
             );
@@ -288,6 +316,8 @@ mod tests {
         fn supported_sql_modal_tab_passes_through() {
             let caps = DbCapabilities::new(
                 true,
+                true,
+                true,
                 vec![InspectorTab::Info],
                 vec![InspectorInfoField::Owner],
             );
@@ -301,6 +331,8 @@ mod tests {
         #[test]
         fn unsupported_sql_modal_tab_returns_sql() {
             let no_explain_caps = DbCapabilities::new(
+                false,
+                false,
                 false,
                 vec![InspectorTab::Info],
                 vec![InspectorInfoField::Owner],
@@ -319,7 +351,8 @@ mod tests {
         #[test]
         #[should_panic(expected = "DbCapabilities requires at least one supported inspector tab")]
         fn rejects_empty_supported_inspector_tabs() {
-            let _ = DbCapabilities::new(false, vec![], vec![InspectorInfoField::Owner]);
+            let _ =
+                DbCapabilities::new(false, false, false, vec![], vec![InspectorInfoField::Owner]);
         }
 
         #[test]
@@ -327,13 +360,15 @@ mod tests {
             expected = "DbCapabilities requires at least one supported inspector info field"
         )]
         fn rejects_empty_supported_inspector_info_fields() {
-            let _ = DbCapabilities::new(false, vec![InspectorTab::Info], vec![]);
+            let _ = DbCapabilities::new(false, false, false, vec![InspectorTab::Info], vec![]);
         }
 
         #[test]
         #[should_panic(expected = "DbCapabilities supported inspector tabs must be unique")]
         fn rejects_duplicate_supported_inspector_tabs() {
             let _ = DbCapabilities::new(
+                false,
+                false,
                 false,
                 vec![InspectorTab::Info, InspectorTab::Info],
                 vec![InspectorInfoField::Schema],
@@ -344,6 +379,8 @@ mod tests {
         #[should_panic(expected = "DbCapabilities supported inspector info fields must be unique")]
         fn rejects_duplicate_supported_inspector_info_fields() {
             let _ = DbCapabilities::new(
+                false,
+                false,
                 false,
                 vec![InspectorTab::Info],
                 vec![InspectorInfoField::Schema, InspectorInfoField::Schema],

--- a/src/app/model/shared/db_capabilities.rs
+++ b/src/app/model/shared/db_capabilities.rs
@@ -20,11 +20,30 @@ pub struct DbCapabilities {
     supported_inspector_info_fields: Vec<InspectorInfoField>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CapabilityFlags {
+    supports_explain: bool,
+    supports_er_diagram: bool,
+    supports_jsonb_detail: bool,
+}
+
+impl CapabilityFlags {
+    const NONE: Self = Self {
+        supports_explain: false,
+        supports_er_diagram: false,
+        supports_jsonb_detail: false,
+    };
+
+    const POSTGRESQL: Self = Self {
+        supports_explain: true,
+        supports_er_diagram: true,
+        supports_jsonb_detail: true,
+    };
+}
+
 impl DbCapabilities {
     pub(crate) fn new(
-        supports_explain: bool,
-        supports_er_diagram: bool,
-        supports_jsonb_detail: bool,
+        flags: CapabilityFlags,
         supported_inspector_tabs: Vec<InspectorTab>,
         supported_inspector_info_fields: Vec<InspectorInfoField>,
     ) -> Self {
@@ -45,9 +64,9 @@ impl DbCapabilities {
             "DbCapabilities supported inspector info fields must be unique"
         );
         Self {
-            supports_explain,
-            supports_er_diagram,
-            supports_jsonb_detail,
+            supports_explain: flags.supports_explain,
+            supports_er_diagram: flags.supports_er_diagram,
+            supports_jsonb_detail: flags.supports_jsonb_detail,
             supported_inspector_tabs,
             supported_inspector_info_fields,
         }
@@ -55,9 +74,7 @@ impl DbCapabilities {
 
     pub fn disconnected() -> Self {
         Self::new(
-            false,
-            false,
-            false,
+            CapabilityFlags::NONE,
             vec![InspectorTab::Info],
             vec![InspectorInfoField::Schema, InspectorInfoField::TableName],
         )
@@ -65,9 +82,7 @@ impl DbCapabilities {
 
     pub fn postgres_like() -> Self {
         Self::new(
-            true,
-            true,
-            true,
+            CapabilityFlags::POSTGRESQL,
             vec![
                 InspectorTab::Info,
                 InspectorTab::Columns,
@@ -89,9 +104,7 @@ impl DbCapabilities {
 
     pub fn sqlite_like() -> Self {
         Self::new(
-            false,
-            false,
-            false,
+            CapabilityFlags::NONE,
             vec![
                 InspectorTab::Info,
                 InspectorTab::Columns,
@@ -299,9 +312,7 @@ mod tests {
         #[test]
         fn unsupported_inspector_tab_returns_first_supported_tab() {
             let caps = DbCapabilities::new(
-                false,
-                false,
-                false,
+                CapabilityFlags::NONE,
                 vec![InspectorTab::Info, InspectorTab::Columns],
                 vec![InspectorInfoField::Owner],
             );
@@ -315,9 +326,7 @@ mod tests {
         #[test]
         fn supported_sql_modal_tab_passes_through() {
             let caps = DbCapabilities::new(
-                true,
-                true,
-                true,
+                CapabilityFlags::POSTGRESQL,
                 vec![InspectorTab::Info],
                 vec![InspectorInfoField::Owner],
             );
@@ -331,9 +340,7 @@ mod tests {
         #[test]
         fn unsupported_sql_modal_tab_returns_sql() {
             let no_explain_caps = DbCapabilities::new(
-                false,
-                false,
-                false,
+                CapabilityFlags::NONE,
                 vec![InspectorTab::Info],
                 vec![InspectorInfoField::Owner],
             );
@@ -351,8 +358,11 @@ mod tests {
         #[test]
         #[should_panic(expected = "DbCapabilities requires at least one supported inspector tab")]
         fn rejects_empty_supported_inspector_tabs() {
-            let _ =
-                DbCapabilities::new(false, false, false, vec![], vec![InspectorInfoField::Owner]);
+            let _ = DbCapabilities::new(
+                CapabilityFlags::NONE,
+                vec![],
+                vec![InspectorInfoField::Owner],
+            );
         }
 
         #[test]
@@ -360,16 +370,14 @@ mod tests {
             expected = "DbCapabilities requires at least one supported inspector info field"
         )]
         fn rejects_empty_supported_inspector_info_fields() {
-            let _ = DbCapabilities::new(false, false, false, vec![InspectorTab::Info], vec![]);
+            let _ = DbCapabilities::new(CapabilityFlags::NONE, vec![InspectorTab::Info], vec![]);
         }
 
         #[test]
         #[should_panic(expected = "DbCapabilities supported inspector tabs must be unique")]
         fn rejects_duplicate_supported_inspector_tabs() {
             let _ = DbCapabilities::new(
-                false,
-                false,
-                false,
+                CapabilityFlags::NONE,
                 vec![InspectorTab::Info, InspectorTab::Info],
                 vec![InspectorInfoField::Schema],
             );
@@ -379,9 +387,7 @@ mod tests {
         #[should_panic(expected = "DbCapabilities supported inspector info fields must be unique")]
         fn rejects_duplicate_supported_inspector_info_fields() {
             let _ = DbCapabilities::new(
-                false,
-                false,
-                false,
+                CapabilityFlags::NONE,
                 vec![InspectorTab::Info],
                 vec![InspectorInfoField::Schema, InspectorInfoField::Schema],
             );

--- a/src/app/model/shared/help.rs
+++ b/src/app/model/shared/help.rs
@@ -236,13 +236,15 @@ impl SqlHelpMode {
             | SqlModalStatus::ConfirmingRisk { .. }
             | SqlModalStatus::ConfirmingAnalyzeRisk { .. } => Self::Confirm,
             SqlModalStatus::Running => Self::Running,
-            SqlModalStatus::Normal | SqlModalStatus::Success | SqlModalStatus::Error => {
-                match state.sql_modal.active_tab() {
-                    SqlModalTab::Sql => Self::Normal,
-                    SqlModalTab::Plan => Self::Plan,
-                    SqlModalTab::Compare => Self::Compare,
-                }
-            }
+            SqlModalStatus::Normal | SqlModalStatus::Success | SqlModalStatus::Error => match state
+                .session
+                .active_db_capabilities()
+                .normalize_sql_modal_tab(state.sql_modal.active_tab())
+            {
+                SqlModalTab::Sql => Self::Normal,
+                SqlModalTab::Plan => Self::Plan,
+                SqlModalTab::Compare => Self::Compare,
+            },
         }
     }
 

--- a/src/app/update/browse/navigation/input.rs
+++ b/src/app/update/browse/navigation/input.rs
@@ -149,7 +149,11 @@ pub fn reduce_input(state: &mut AppState, action: &Action) -> DispatchResult {
             target: ListTarget::CommandPalette,
             motion: ListMotion::Next,
         } => {
-            let max = palette_command_count(state.settings.saved_keymap_preset()).saturating_sub(1);
+            let max = palette_command_count(
+                state.settings.saved_keymap_preset(),
+                state.session.active_db_capabilities(),
+            )
+            .saturating_sub(1);
             let selected = state.ui.table_picker().selected();
             if selected < max {
                 state.ui.table_picker_mut().set_selection(selected + 1);

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -99,9 +99,13 @@ fn build_update_preview(
             let after = normalize_for_diff(state.result_interaction.cell_edit().draft_value());
             let is_jsonb = state
                 .session
-                .table_detail()
-                .and_then(|td| td.columns.get(col_idx))
-                .is_some_and(|c| c.data_type == "jsonb");
+                .active_db_capabilities()
+                .supports_jsonb_detail()
+                && state
+                    .session
+                    .table_detail()
+                    .and_then(|td| td.columns.get(col_idx))
+                    .is_some_and(|c| c.data_type == "jsonb");
             let json_diff = is_jsonb
                 .then(|| compute_json_diff(&before, &after, 1))
                 .flatten();
@@ -735,6 +739,34 @@ mod tests {
                 preview.diff[0].json_diff.is_some(),
                 "jsonb column should have structured diff"
             );
+        }
+
+        #[test]
+        fn sqlite_jsonb_type_name_does_not_produce_structured_diff() {
+            let mut state = editable_state_with_jsonb();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite://test.db",
+            );
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            let preview = match &effects[0] {
+                Effect::DispatchActions(actions) => match actions.first().expect("action") {
+                    Action::OpenWritePreviewConfirm(preview) => preview.clone(),
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+            assert!(preview.diff[0].json_diff.is_none());
         }
 
         #[test]

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -141,6 +141,13 @@ fn selected_cell_value(state: &AppState) -> Option<(usize, usize, String, String
 }
 
 fn selected_column_is_jsonb(state: &AppState) -> bool {
+    if !state
+        .session
+        .active_db_capabilities()
+        .supports_jsonb_detail()
+    {
+        return false;
+    }
     let Some(col_idx) = state.result_interaction.selection().cell() else {
         return false;
     };
@@ -184,11 +191,17 @@ fn update_search_matches(state: &mut AppState) {
 mod tests {
     use super::*;
     use crate::domain::column::Column;
-    use crate::domain::{QueryResult, QuerySource, Table};
+    use crate::domain::{ConnectionId, DatabaseType, QueryResult, QuerySource, Table};
     use std::sync::Arc;
 
     fn state_with_cell(data_type: &str, cell_value: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            DatabaseType::PostgreSQL,
+            "postgres://localhost/test",
+        );
         state
             .query
             .set_current_result(Arc::new(QueryResult::success(
@@ -308,6 +321,22 @@ mod tests {
                 if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonbDetail)])
         ));
         assert!(!state.cell_detail.is_active());
+    }
+
+    #[test]
+    fn sqlite_jsonb_type_name_opens_plain_cell_detail() {
+        let mut state = state_with_cell("jsonb", r#"{"a":1}"#);
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            DatabaseType::SQLite,
+            "sqlite://test.db",
+        );
+
+        reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
+
+        assert_eq!(state.input_mode(), InputMode::CellDetail);
+        assert_eq!(state.cell_detail.content(), "{\n  \"a\": 1\n}");
     }
 
     #[test]

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -371,22 +371,6 @@ mod tests {
     }
 
     #[test]
-    fn sqlite_jsonb_type_name_opens_plain_cell_detail() {
-        let mut state = state_with_cell("jsonb", r#"{"a":1}"#);
-        state.session.activate_connection_with_dsn(
-            &ConnectionId::new(),
-            "database",
-            DatabaseType::SQLite,
-            "sqlite://test.db",
-        );
-
-        reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());
-
-        assert_eq!(state.input_mode(), InputMode::CellDetail);
-        assert_eq!(state.cell_detail.content(), r#"{"a":1}"#);
-    }
-
-    #[test]
     fn search_input_tracks_matches_case_insensitively() {
         let mut state = state_with_cell("text", "Alpha\nalpha");
         reduce_cell_detail(&mut state, &Action::ResultOpenCellDetail, Instant::now());

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -13,6 +13,13 @@ use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{EditGuardrailError, editable_preview_base, ensure_column_writable};
 
 fn is_jsonb_cell(state: &AppState) -> bool {
+    if !state
+        .session
+        .active_db_capabilities()
+        .supports_jsonb_detail()
+    {
+        return false;
+    }
     let Some(col_idx) = state.result_interaction.selection().cell() else {
         return false;
     };
@@ -394,9 +401,16 @@ mod tests {
     mod jsonb_dispatch {
         use super::*;
         use crate::domain::column::Column;
+        use crate::domain::{ConnectionId, DatabaseType};
 
         fn state_with_jsonb_column() -> AppState {
             let mut state = cell_edit_entry_guardrails::preview_state_with_selection();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "database",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
             let mut table = cell_edit_entry_guardrails::minimal_users_table();
             table.columns = vec![
                 Column {
@@ -433,6 +447,22 @@ mod tests {
                 &effects[0],
                 Effect::DispatchActions(actions) if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonbDetail)])
             ));
+        }
+
+        #[test]
+        fn sqlite_jsonb_type_name_enters_plain_cell_edit() {
+            let mut state = state_with_jsonb_column();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "database",
+                DatabaseType::SQLite,
+                "sqlite://test.db",
+            );
+
+            reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now());
+
+            assert_eq!(state.input_mode(), InputMode::CellEdit);
+            assert!(state.result_interaction.cell_edit().is_active());
         }
     }
 

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -11,6 +11,18 @@ pub(super) fn save_current_cache(state: &AppState) -> ConnectionCache {
     )
 }
 
+pub(super) fn reset_connection_scoped_er_state(state: &mut AppState) {
+    state.ui.reset_er_picker_request();
+    state.er_preparation.reset();
+}
+
+pub(super) fn reset_active_connection_state(state: &mut AppState) {
+    state.session.reset(&mut state.query);
+    state.result_interaction.reset_view();
+    state.ui.set_explorer_selection(None);
+    reset_connection_scoped_er_state(state);
+}
+
 pub(super) fn restore_cache(
     state: &mut AppState,
     cache: &ConnectionCache,

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -17,10 +17,7 @@ pub(super) fn reset_for_new_connection(
     name: &str,
     database_type: DatabaseType,
 ) {
-    state.session.reset(&mut state.query);
-    state.result_interaction.reset_view();
-    state.ui.set_explorer_selection(None);
-    reset_sql_and_er_state(state);
+    reset_active_connection_state(state);
     state
         .session
         .activate_connection_with_dsn(id, name, database_type, dsn);

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -7,7 +7,10 @@ use crate::update::action::{Action, ConnectionTarget};
 
 use crate::update::dispatch_result::DispatchResult;
 
-use super::helpers::{restore_cache, save_current_cache};
+use super::helpers::{
+    reset_active_connection_state, reset_connection_scoped_er_state, restore_cache,
+    save_current_cache,
+};
 
 fn reset_for_new_connection(
     state: &mut AppState,
@@ -16,9 +19,7 @@ fn reset_for_new_connection(
     name: &str,
     database_type: DatabaseType,
 ) {
-    state.session.reset(&mut state.query);
-    state.result_interaction.reset_view();
-    state.ui.set_explorer_selection(None);
+    reset_active_connection_state(state);
     state
         .session
         .activate_connection_with_dsn(id, name, database_type, dsn);
@@ -53,12 +54,12 @@ pub fn reduce_connection_lifecycle(
                 name,
                 database_type,
             } = target;
-            state.ui.reset_er_picker_request();
 
             if let Some(current_id) = state.session.active_connection_id().cloned() {
                 let cache = save_current_cache(state);
                 state.connection_caches.save(&current_id, cache);
             }
+            reset_connection_scoped_er_state(state);
 
             if let Some(cached) = state.connection_caches.get(id).cloned() {
                 restore_cache(state, &cached, target);
@@ -87,6 +88,7 @@ mod tests {
     use crate::domain::ConnectionId;
     use crate::model::connection::cache::ConnectionCache;
     use crate::model::connection::state::ConnectionState;
+    use crate::model::er_state::ErStatus;
     use crate::model::shared::inspector_tab::InspectorTab;
 
     fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
@@ -264,11 +266,17 @@ mod tests {
         let mut state = AppState::new("test".to_string());
         let new_id = ConnectionId::new();
         state.ui.set_pending_er_picker(true);
+        let _ = state.er_preparation.start_waiting_run();
+        state
+            .er_preparation
+            .queue_pending_table("public.users".to_string());
 
         let action = create_switch_action(&new_id, "fresh_db");
         reduce(&mut state, &action);
 
         assert!(!state.ui.pending_er_picker());
+        assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+        assert!(state.er_preparation.pending_tables().is_empty());
     }
 
     #[test]
@@ -276,6 +284,10 @@ mod tests {
         let mut state = AppState::new("test".to_string());
         let target_id = ConnectionId::new();
         state.ui.set_pending_er_picker(true);
+        let _ = state.er_preparation.start_waiting_run();
+        state
+            .er_preparation
+            .queue_pending_table("public.users".to_string());
         state
             .connection_caches
             .save(&target_id, ConnectionCache::default());
@@ -284,6 +296,8 @@ mod tests {
         reduce(&mut state, &action);
 
         assert!(!state.ui.pending_er_picker());
+        assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+        assert!(state.er_preparation.pending_tables().is_empty());
     }
 
     #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -53,6 +53,8 @@ pub fn reduce_connection_lifecycle(
                 name,
                 database_type,
             } = target;
+            state.ui.reset_er_picker_request();
+
             if let Some(current_id) = state.session.active_connection_id().cloned() {
                 let cache = save_current_cache(state);
                 state.connection_caches.save(&current_id, cache);
@@ -255,6 +257,33 @@ mod tests {
             Some(DatabaseType::SQLite)
         );
         assert_eq!(state.session.connection_state(), ConnectionState::Connected);
+    }
+
+    #[test]
+    fn switch_without_cache_clears_pending_er_picker() {
+        let mut state = AppState::new("test".to_string());
+        let new_id = ConnectionId::new();
+        state.ui.set_pending_er_picker(true);
+
+        let action = create_switch_action(&new_id, "fresh_db");
+        reduce(&mut state, &action);
+
+        assert!(!state.ui.pending_er_picker());
+    }
+
+    #[test]
+    fn cached_switch_clears_pending_er_picker() {
+        let mut state = AppState::new("test".to_string());
+        let target_id = ConnectionId::new();
+        state.ui.set_pending_er_picker(true);
+        state
+            .connection_caches
+            .save(&target_id, ConnectionCache::default());
+
+        let action = create_switch_action(&target_id, "cached_db");
+        reduce(&mut state, &action);
+
+        assert!(!state.ui.pending_er_picker());
     }
 
     #[test]

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -4,6 +4,7 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ModalKind};
+use crate::update::connection::helpers::reset_active_connection_state;
 use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn reduce_connection_selector(
@@ -52,9 +53,7 @@ pub(super) fn reduce_connection_selector(
         }
         Action::ConnectionDeleted(id) => {
             if state.session.active_connection_id() == Some(id) {
-                state.session.reset(&mut state.query);
-                state.result_interaction.reset_view();
-                state.ui.set_explorer_selection(None);
+                reset_active_connection_state(state);
             }
 
             let id_clone = id.clone();
@@ -278,6 +277,7 @@ mod tests {
     mod connection_deleted {
         use super::*;
         use crate::model::connection::state::ConnectionState;
+        use crate::model::er_state::ErStatus;
 
         #[test]
         fn removes_connection_from_list() {
@@ -346,6 +346,11 @@ mod tests {
             state.result_interaction.set_scroll_offset(10);
             state.result_interaction.set_horizontal_offset(20);
             state.result_interaction.stage_row(0);
+            state.ui.set_pending_er_picker(true);
+            let _ = state.er_preparation.start_waiting_run();
+            state
+                .er_preparation
+                .queue_pending_table("public.users".to_string());
 
             reduce_connection_selector(
                 &mut state,
@@ -362,6 +367,9 @@ mod tests {
             assert_eq!(state.result_interaction.horizontal_offset(), 0);
             assert!(state.result_interaction.staged_delete_rows().is_empty());
             assert!(state.result_interaction.pending_write_preview().is_none());
+            assert!(!state.ui.pending_er_picker());
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+            assert!(state.er_preparation.pending_tables().is_empty());
         }
 
         #[test]

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -7,6 +7,7 @@ use crate::model::connection::setup::{
 };
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ConnectionTarget, InputTarget, ModalKind};
+use crate::update::connection::helpers::reset_connection_scoped_er_state;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{validate_all, validate_field};
 
@@ -197,6 +198,7 @@ pub fn reduce_connection_setup(
         }) => {
             state.connection_setup.set_first_run(false);
             state.modal.set_mode(InputMode::Normal);
+            reset_connection_scoped_er_state(state);
             state
                 .session
                 .activate_connection_with_dsn(id, name, *database_type, dsn);
@@ -223,6 +225,7 @@ mod tests {
     use super::*;
     use crate::domain::connection::{ConnectionProfile, SslMode};
     use crate::domain::{ConnectionId, DatabaseType};
+    use crate::model::er_state::ErStatus;
     use crate::update::test_support::activate_postgres_connection;
 
     fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
@@ -537,6 +540,28 @@ mod tests {
                 state.session.connection_state(),
                 ConnectionState::Connecting
             );
+        }
+
+        #[test]
+        fn save_completed_clears_er_state_from_previous_connection() {
+            let mut state = AppState::new("test".to_string());
+            state.ui.set_pending_er_picker(true);
+            let _ = state.er_preparation.start_waiting_run();
+            state
+                .er_preparation
+                .queue_pending_table("public.users".to_string());
+
+            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "sqlite:///tmp/app.db".to_string(),
+                name: "app.db".to_string(),
+                database_type: DatabaseType::SQLite,
+            });
+            reduce(&mut state, &action, Instant::now());
+
+            assert!(!state.ui.pending_er_picker());
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+            assert!(state.er_preparation.pending_tables().is_empty());
         }
     }
 

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -118,7 +118,9 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
             Action::ResultCellYank
         }
         Key::Char('s') => Action::OpenModal(ModalKind::SqlModal),
-        Key::Char('e') => Action::OpenModal(ModalKind::ErTablePicker),
+        Key::Char('e') if state.session.active_db_capabilities().supports_er_diagram() => {
+            Action::OpenModal(ModalKind::ErTablePicker)
+        }
         Key::Char('c') if state.ui.focused_pane() == FocusedPane::Explorer => {
             Action::OpenModal(ModalKind::ConnectionSelector)
         }
@@ -132,6 +134,7 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::connection::error::ConnectionErrorInfo;
     use crate::model::shared::key_sequence::KeySequenceState;
     use crate::model::shared::settings::KeymapPreset;
@@ -158,6 +161,17 @@ mod tests {
     fn browse_state_with_preset(preset: KeymapPreset) -> AppState {
         let mut state = browse_state();
         state.settings.load_keymap_preset(preset);
+        state
+    }
+
+    fn connected_state(database_type: DatabaseType) -> AppState {
+        let mut state = browse_state();
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            database_type,
+            "test://database",
+        );
         state
     }
 
@@ -272,6 +286,27 @@ mod tests {
                 let result = handle_normal_mode(input, &state);
 
                 assert!(same_payload_free_action(&result, &expected));
+            }
+
+            #[test]
+            fn er_key_opens_picker_for_postgresql() {
+                let state = connected_state(DatabaseType::PostgreSQL);
+
+                let result = handle_normal_mode(combo(Key::Char('e')), &state);
+
+                assert!(matches!(
+                    result,
+                    Action::OpenModal(ModalKind::ErTablePicker)
+                ));
+            }
+
+            #[test]
+            fn er_key_is_ignored_for_sqlite() {
+                let state = connected_state(DatabaseType::SQLite);
+
+                let result = handle_normal_mode(combo(Key::Char('e')), &state);
+
+                assert!(matches!(result, Action::None));
             }
 
             #[rstest]

--- a/src/app/update/input/palette.rs
+++ b/src/app/update/input/palette.rs
@@ -1,6 +1,7 @@
 use super::keybindings::{KeyBinding, global};
+use crate::model::shared::db_capabilities::DbCapabilities;
 use crate::model::shared::settings::KeymapPreset;
-use crate::update::action::Action;
+use crate::update::action::{Action, ModalKind};
 
 // Deliberate opt-in list in display order — not derived from GLOBAL_KEYS, so an
 // entry never appears in the palette by accident. A test forces every global
@@ -44,18 +45,34 @@ fn palette_commands_for(preset: KeymapPreset) -> &'static [KeyBinding] {
     }
 }
 
-pub fn palette_command_count(preset: KeymapPreset) -> usize {
-    palette_commands_for(preset).len()
+pub fn palette_command_count(preset: KeymapPreset, db_capabilities: &DbCapabilities) -> usize {
+    palette_commands(preset, db_capabilities).count()
 }
 
-pub fn palette_action_for_index(index: usize, preset: KeymapPreset) -> Action {
-    palette_commands_for(preset)
-        .get(index)
+pub fn palette_action_for_index(
+    index: usize,
+    preset: KeymapPreset,
+    db_capabilities: &DbCapabilities,
+) -> Action {
+    palette_commands(preset, db_capabilities)
+        .nth(index)
         .map_or(Action::None, |kb| kb.action.clone())
 }
 
-pub fn palette_commands(preset: KeymapPreset) -> impl Iterator<Item = &'static KeyBinding> {
-    palette_commands_for(preset).iter()
+pub fn palette_commands(
+    preset: KeymapPreset,
+    db_capabilities: &DbCapabilities,
+) -> impl Iterator<Item = &'static KeyBinding> {
+    palette_commands_for(preset)
+        .iter()
+        .filter(|kb| palette_command_supported(kb, db_capabilities))
+}
+
+fn palette_command_supported(kb: &KeyBinding, db_capabilities: &DbCapabilities) -> bool {
+    !matches!(
+        kb.action,
+        Action::OpenModal(ModalKind::ErTablePicker) if !db_capabilities.supports_er_diagram()
+    )
 }
 
 #[cfg(test)]
@@ -136,8 +153,9 @@ mod tests {
 
     #[test]
     fn palette_commands_contains_no_none_actions() {
+        let db_capabilities = DbCapabilities::postgres_like();
         for preset in [KeymapPreset::Default, KeymapPreset::Ide] {
-            let none_entries: Vec<_> = palette_commands(preset)
+            let none_entries: Vec<_> = palette_commands(preset, &db_capabilities)
                 .filter(|kb| matches!(kb.action, Action::None))
                 .collect();
 
@@ -147,5 +165,17 @@ mod tests {
                 none_entries.iter().map(|kb| kb.key).collect::<Vec<_>>()
             );
         }
+    }
+
+    #[test]
+    fn sqlite_palette_omits_er_diagram_command() {
+        let commands = palette_commands(KeymapPreset::Default, &DbCapabilities::sqlite_like())
+            .collect::<Vec<_>>();
+
+        assert!(
+            !commands
+                .iter()
+                .any(|kb| matches!(kb.action, Action::OpenModal(ModalKind::ErTablePicker)))
+        );
     }
 }

--- a/src/app/update/modal/er_picker.rs
+++ b/src/app/update/modal/er_picker.rs
@@ -13,6 +13,13 @@ pub(super) fn reduce_er_picker(
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::ErTablePicker) => {
+            if !state.session.active_db_capabilities().supports_er_diagram() {
+                state.messages.set_error_at(
+                    "ER diagrams are not available for this connection".to_string(),
+                    now,
+                );
+                return DispatchResult::handled();
+            }
             if state.session.metadata().is_none() {
                 state.ui.request_er_picker_after_metadata();
                 state

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -145,6 +145,35 @@ mod tests {
         }
     }
 
+    mod er_picker {
+        use super::*;
+
+        #[test]
+        fn sqlite_connection_rejects_er_picker() {
+            let mut state = create_test_state();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite://test.db",
+            );
+
+            let effects = super::dispatch_modal(
+                &mut state,
+                &Action::OpenModal(ModalKind::ErTablePicker),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert_eq!(
+                state.messages.last_error.as_deref(),
+                Some("ER diagrams are not available for this connection")
+            );
+            assert!(effects.is_empty());
+        }
+    }
+
     mod settings {
         use super::*;
         use crate::model::shared::theme_id::ThemeId;

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -123,6 +123,7 @@ fn reduce_inner(
                 let cmd_action = palette_action_for_index(
                     state.ui.table_picker().selected(),
                     state.settings.saved_keymap_preset(),
+                    state.session.active_db_capabilities(),
                 );
                 state.modal.set_mode(InputMode::Normal);
                 return reduce(state, cmd_action, now, services);
@@ -2329,6 +2330,7 @@ mod tests {
 
         fn state_with_metadata() -> AppState {
             let mut state = create_test_state();
+            activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new(DatabaseMetadata {
                 database_name: "test".to_string(),
                 schemas: vec![],
@@ -2365,6 +2367,7 @@ mod tests {
         #[test]
         fn open_without_metadata_sets_pending() {
             let mut state = create_test_state();
+            activate_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -2781,11 +2784,14 @@ mod tests {
         }
 
         fn palette_index_of(state: &AppState, target: impl Fn(&Action) -> bool) -> usize {
-            palette_commands(state.settings.saved_keymap_preset())
-                .enumerate()
-                .find(|(_, kb)| target(&kb.action))
-                .map(|(i, _)| i)
-                .expect("action must exist in palette")
+            palette_commands(
+                state.settings.saved_keymap_preset(),
+                state.session.active_db_capabilities(),
+            )
+            .enumerate()
+            .find(|(_, kb)| target(&kb.action))
+            .map(|(i, _)| i)
+            .expect("action must exist in palette")
         }
 
         fn same_palette_action(left: &Action, right: &Action) -> bool {

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_for_sqlite_hides_unknown_type.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_for_sqlite_hides_unknown_type.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/inspector.rs
-assertion_line: 111
 expression: output
 ---
 test_project | test_db | - | connected | app.db
@@ -52,4 +51,4 @@ test_project | test_db | - | connected | app.db
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit
+r:Reload  s:SQL  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_collation_index_definition.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_collation_index_definition.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | connected | app.db
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit
+r:Reload  s:SQL  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_descending_index_definition.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_descending_index_definition.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | connected | app.db
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit
+r:Reload  s:SQL  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_partial_expression_details.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_partial_expression_details.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | connected | app.db
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit
+r:Reload  s:SQL  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_partial_index_definition.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_partial_index_definition.snap
@@ -51,4 +51,4 @@ test_project | test_db | - | connected | app.db
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit
+r:Reload  s:SQL  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_for_sqlite_hides_postgres_only_fields.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_for_sqlite_hides_postgres_only_fields.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/inspector.rs
-assertion_line: 185
 expression: output
 ---
 test_project | test_db | - | connected | app.db
@@ -52,4 +51,4 @@ test_project | test_db | - | connected | app.db
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-r:Reload  s:SQL  e:ER Diagram  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit
+r:Reload  s:SQL  ^P:Tables  ^O:History  ^R:Read-Only  f:Focus  Tab/⇧Tab:InsTabs  ?:Help  F1:Palette  ,:Settings  q:Quit

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
@@ -18,7 +18,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                        │▸ Common                                                                                                        ┃│                        │
 │                        │  ?                                    Toggle help                                                              ┃│                        │
 │                        │  q                                    Quit application                                                         ┃│                        │
-│                        │  ,                                    Open Settings                                                            ┃│                        │
+│                        │  ,                                    Open Settings                                                            ││                        │
 │                        │  F1                                   Open Command Palette                                                     ││                        │
 │                        │  :                                    Enter command line                                                       ││                        │
 │                        │  f                                    Toggle Focus mode                                                        ││                        │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 429
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -19,21 +18,25 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                        │  Home/End                             Jump to start/end                                                        ││                        │
 │                        │  :                                    Open command line                                                        ││                        │
 │                        │  Esc                                  Exit to Cell Active (draft preserved)                                    ││                        │
-│                        │  Home / End                           Line start/end                                                           ││                        │
 │                        │  Enter                                Execute the confirmed statement                                          ││                        │
 │                        │  Esc                                  Cancel and return to editor                                              ││                        │
-│                        │                                                                                                                ││                        │
-│                        │▸ Search / Filter                                                                                               ││                        │
+│                        │  Esc                                  Return to Normal mode                                                    ││                        │
+│                        │  ↑↓←→                                 Move cursor                                                              ││                        │
+│                        │  Home / End                           Line start/end                                                           ││                        │
+│                        │                                                                                                                ┃│                        │
+│                        │▸ Search / Filter                                                                                               ┃│                        │
 │                        │  type                                 Type to filter                                                           ┃│                        │
+│                        │  type                                 Type to filter                                                           ┃│────────────────────────┘
+│                        │  type                                 Type to filter                                                           ┃│────────────────────────┐
 │                        │  type                                 Type to search                                                           ┃│                        │
 │                        │  Enter                                Confirm search                                                           ┃│                        │
-│                        │  Esc                                  Cancel search                                                            ┃│────────────────────────┘
-│                        │  Ctrl+N / Ctrl+P / ↑ / ↓              Scroll down / up                                                         ┃│────────────────────────┐
-│                        │  Home / End                           Jump to top / bottom                                                     ┃│                        │
-│                        │  Ctrl+D / Ctrl+U                      Scroll half page down / up                                               ┃│                        │
-│                        │  Ctrl+F / Ctrl+B / PageDown / PageUp  Scroll full page down / up                                               ┃│                        │
-│                        │  ← / →                                Scroll left / right                                                      ┃│                        │
-│                        │  type                                 Filter help                                                              ┃│                        │
+│                        │  Esc                                  Cancel search                                                            ┃│                        │
+│                        │  Ctrl+N / Ctrl+P / ↑ / ↓              Scroll down / up                                                         ┃│                        │
+│                        │  Home / End                           Jump to top / bottom                                                     ││                        │
+│                        │  Ctrl+D / Ctrl+U                      Scroll half page down / up                                               ││                        │
+│                        │  Ctrl+F / Ctrl+B / PageDown / PageUp  Scroll full page down / up                                               ││                        │
+│                        │  ← / →                                Scroll left / right                                                      ││                        │
+│                        │  type                                 Filter help                                                              ││                        │
 │                        │  Backspace                            Edit filter                                                              ││                        │
 │                        │  Esc                                  Close help                                                               ││                        │
 │                        │  ?                                    Close help                                                               ││                        │
@@ -43,11 +46,7 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                        │  Tab                                  Next field                                                               ││                        │
 │                        │  ⇧Tab                                 Previous field                                                           ││                        │
 │                        │  Ctrl+S                               Save and connect                                                         ││                        │
-│                        │  Esc                                  Cancel                                                                   ││                        │
-│                        │  Enter                                Toggle dropdown (SSL field)                                              ││                        │
-│                        │  Ctrl+N / Ctrl+P / ↑ / ↓              Dropdown navigation                                                      ││                        │
-│                        │  Enter                                Confirm selection                                                        ││                        │
-│                        │  Ctrl+N / Ctrl+P / ↑ / ↓ / j / k      Select connection                                                        ▼│                        │
+│                        │  Esc                                  Cancel                                                                   ▼│                        │
 │                        ╰ type: Filter │ Backspace: Edit │ Esc: Close │ ?: Close ─────────────────────────────────────────────────────────╯                        │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 445
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:54
@@ -16,13 +15,13 @@ test_project | test_db | - | no dsn | localhost:54
 │       │                     Jump to sta┃│      │
 │       │                     Open comman┃│──────┘
 │       │                     Exit to Cel││──────┐
-│       │                     Line start/││      │
 │       │                     Execute the││      │
 │       │                     Cancel and ││      │
+│       │                     Return to N││      │
+│       │                     Move cursor││      │
+│       │                     Line start/││      │
 │       │                                ││      │
-│       │                                ││      │
-│       │                     Type to fil││      │
-│       │                     Type to sea▼│      │
+│       │                                ▼│      │
 │       │ col  25% ◀︎────═════───────────▶︎ │      │
 └───────╰ type: Filter │ Backspace: Edit │╯──────┘
 ←→:H-Scroll  ?:Close

--- a/src/ui/features/pickers/command_palette.rs
+++ b/src/ui/features/pickers/command_palette.rs
@@ -22,18 +22,21 @@ impl CommandPalette {
             theme,
         );
 
-        let items: Vec<ListItem> = palette_commands(state.settings.saved_keymap_preset())
-            .enumerate()
-            .map(|(i, kb)| {
-                let style = if i == state.ui.table_picker().selected() {
-                    theme.picker_selected_style()
-                } else {
-                    Style::default().fg(theme.semantic.text.secondary)
-                };
-                let content = format!("  {:<18} {}", kb.key, kb.description);
-                ListItem::new(content).style(style)
-            })
-            .collect();
+        let items: Vec<ListItem> = palette_commands(
+            state.settings.saved_keymap_preset(),
+            state.session.active_db_capabilities(),
+        )
+        .enumerate()
+        .map(|(i, kb)| {
+            let style = if i == state.ui.table_picker().selected() {
+                theme.picker_selected_style()
+            } else {
+                Style::default().fg(theme.semantic.text.secondary)
+            };
+            let content = format!("  {:<18} {}", kb.key, kb.description);
+            ListItem::new(content).style(style)
+        })
+        .collect();
 
         let list = List::new(items);
         frame.render_widget(list, inner);

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -140,11 +140,10 @@ impl Footer {
                     let capabilities = state.session.active_db_capabilities();
                     let active_inspector_tab =
                         capabilities.normalize_inspector_tab(state.ui.inspector_tab());
-                    let mut list = vec![
-                        global::RELOAD.as_hint(),
-                        global::SQL.as_hint(),
-                        global::ER_DIAGRAM.as_hint(),
-                    ];
+                    let mut list = vec![global::RELOAD.as_hint(), global::SQL.as_hint()];
+                    if capabilities.supports_er_diagram() {
+                        list.push(global::ER_DIAGRAM.as_hint());
+                    }
                     if state.ui.focused_pane() == FocusedPane::Explorer {
                         list.push(global::CONNECTIONS.as_hint());
                     }
@@ -429,6 +428,29 @@ mod tests {
 
         assert_eq!(
             hints.contains(&global::INSPECTOR_TABS.as_hint()),
+            expected_visible
+        );
+    }
+
+    #[rstest]
+    #[case(DatabaseType::PostgreSQL, true)]
+    #[case(DatabaseType::SQLite, false)]
+    fn er_hint_visibility_tracks_capability(
+        #[case] database_type: DatabaseType,
+        #[case] expected_visible: bool,
+    ) {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            database_type,
+            "test://database",
+        );
+
+        let hints = Footer::get_context_hints(&state);
+
+        assert_eq!(
+            hints.contains(&global::ER_DIAGRAM.as_hint()),
             expected_visible
         );
     }


### PR DESCRIPTION
## Problem

SQLite connections still exposed PostgreSQL-only affordances such as ER diagram entry points and JSONB-specific detail/edit flows. That made unsupported actions appear usable even though SQLite cannot provide those semantics.

## Background

SAB-295 follows the SQLite branch capability split: PostgreSQL-only UI paths need to be gated by active connection capabilities, not by command location alone.

## Approach

Introduce explicit capability checks for ER diagram and JSONB detail support, then route footer hints, help/catalog entries, command palette actions, modal entry points, and result cell behavior through those capabilities. SQLite now falls back to normal cell detail/edit behavior for `jsonb` type names instead of invoking PostgreSQL JSONB tooling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 接続先の機能に応じて、表示されるヘルプ・コマンド・ヒントが自動で切り替わるようになりました。

* **不具合修正**
  * SQLite など対応外の接続では、ER ダイアグラム関連の操作や案内が表示されないようになりました。
  * SQL モーダルやコマンドパレットの表示内容が、現在の接続状態に合わせて正しく切り替わるようになりました。
  * 接続切り替え時に、ER 関連の保留状態や選択状態が確実にリセットされるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->