### PR TITLE
fix: keep CREATE TRIGGER body intact in SQLite statement splitting

### DIFF
--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -164,6 +164,32 @@ fn keyword_starting_at(sql: &str, chars: &[(usize, char)], i: usize) -> Option<(
     ))
 }
 
+fn is_dotted_identifier_suffix(sql: &str, keyword_start: usize) -> bool {
+    let mut index = keyword_start;
+    while index > 0 {
+        index -= 1;
+        match sql.as_bytes()[index] {
+            byte if byte.is_ascii_whitespace() => {}
+            b'.' => return true,
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn is_sqlite_trigger_body_end(
+    keyword: &str,
+    in_trigger_body: bool,
+    trigger_body_stmt_start: bool,
+    sql: &str,
+    keyword_start: usize,
+) -> bool {
+    in_trigger_body
+        && trigger_body_stmt_start
+        && keyword == "END"
+        && !is_dotted_identifier_suffix(sql, keyword_start)
+}
+
 pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> Vec<String> {
     // Use sql's own char_indices so byte offsets remain valid for slicing sql.
     // to_lowercase() can change byte lengths (e.g. İ → i̇), which would corrupt offsets.
@@ -174,6 +200,7 @@ pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> 
     let mut depth: i32 = 0;
     let mut in_string = false;
     let mut in_trigger_body = false;
+    let mut trigger_body_stmt_start = false;
 
     while i < chars.len() {
         let (byte_pos, ch) = chars[i];
@@ -214,9 +241,23 @@ pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> 
             && let Some((keyword, kw_end)) = keyword_starting_at(sql, &chars, i)
         {
             if keyword == "BEGIN" {
-                in_trigger_body = true;
-            } else if keyword == "END" && in_trigger_body {
+                if in_trigger_body {
+                    trigger_body_stmt_start = false;
+                } else {
+                    in_trigger_body = true;
+                    trigger_body_stmt_start = true;
+                }
+            } else if is_sqlite_trigger_body_end(
+                &keyword,
+                in_trigger_body,
+                trigger_body_stmt_start,
+                sql,
+                byte_pos,
+            ) {
                 in_trigger_body = false;
+                trigger_body_stmt_start = false;
+            } else if in_trigger_body {
+                trigger_body_stmt_start = false;
             }
             i = kw_end;
             continue;
@@ -228,13 +269,18 @@ pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> 
             depth -= 1;
         }
 
-        if depth == 0 && ch == ';' && !(database_type == DatabaseType::SQLite && in_trigger_body) {
-            let fragment = sql[start..byte_pos].trim();
-            if !fragment.is_empty() {
-                statements.push(fragment.to_string());
+        if depth == 0 && ch == ';' {
+            if database_type == DatabaseType::SQLite && in_trigger_body {
+                trigger_body_stmt_start = true;
+            } else {
+                let fragment = sql[start..byte_pos].trim();
+                if !fragment.is_empty() {
+                    statements.push(fragment.to_string());
+                }
+                start = byte_pos + 1;
+                in_trigger_body = false;
+                trigger_body_stmt_start = false;
             }
-            start = byte_pos + 1;
-            in_trigger_body = false;
         }
 
         i += 1;
@@ -900,7 +946,24 @@ END";
             assert_eq!(result[1], "SELECT 1");
         }
 
+        #[test]
+        fn sqlite_create_trigger_with_dotted_end_reference_is_not_split() {
+            let trigger = "\
+CREATE TRIGGER sync_end AFTER UPDATE ON events BEGIN
+    UPDATE counters SET end_value = new.end WHERE id = new.id;
+    INSERT INTO audit(event_id, end_value) VALUES (new.id, old.end);
+END";
+            let sql = format!("{trigger}; SELECT 1");
+
+            let result = split_statements_for_database(DatabaseType::SQLite, &sql);
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0], trigger);
+            assert_eq!(result[1], "SELECT 1");
+        }
+
         #[rstest]
+        #[case::line_comment("SELECT 1 -- ;comment\n; SELECT 2", vec!["SELECT 1 -- ;comment", "SELECT 2"])]
         #[case::block_comment("SELECT /* ; */ 1; SELECT 2", vec!["SELECT /* ; */ 1", "SELECT 2"])]
         fn semicolon_in_comments(#[case] sql: &str, #[case] expected: Vec<&str>) {
             assert_eq!(split_statements(sql), expected);

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -128,19 +128,62 @@ pub fn split_statements(sql: &str) -> Vec<String> {
 fn is_sqlite_create_trigger_prefix(sql: &str) -> bool {
     let trimmed = sql.trim_start();
     let chars: Vec<(usize, char)> = trimmed.char_indices().collect();
-    let tokens: Vec<String> = collect_top_level_tokens(trimmed, &chars)
-        .into_iter()
-        .map(|(_, token)| token.to_ascii_uppercase())
-        .collect();
 
-    if tokens.first().map(String::as_str) != Some("CREATE") {
+    let Some((first, second_start)) = next_keyword_from(trimmed, &chars, 0) else {
+        return false;
+    };
+    if first != "CREATE" {
         return false;
     }
-    match tokens.get(1).map(String::as_str) {
-        Some("TRIGGER") => true,
-        Some("TEMP" | "TEMPORARY") => tokens.get(2).map(String::as_str) == Some("TRIGGER"),
+    let Some((second, third_start)) = next_keyword_from(trimmed, &chars, second_start) else {
+        return false;
+    };
+    match second.as_str() {
+        "TRIGGER" => true,
+        "TEMP" | "TEMPORARY" => next_keyword_from(trimmed, &chars, third_start)
+            .is_some_and(|(third, _)| third == "TRIGGER"),
         _ => false,
     }
+}
+
+fn next_keyword_from(sql: &str, chars: &[(usize, char)], mut i: usize) -> Option<(String, usize)> {
+    let mut in_string = false;
+    while i < chars.len() {
+        let (byte_pos, ch) = chars[i];
+        if let Some(next_i) = skip_line_comment(chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_block_comment(chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = advance_single_quote(chars, i, ch, &mut in_string) {
+            i = next_i;
+            continue;
+        }
+        if in_string {
+            i += 1;
+            continue;
+        }
+        if let Some(next_i) = skip_double_quoted_identifier(chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_sqlite_quoted_identifier(chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_dollar_quoted_string(sql, chars, i, byte_pos, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(keyword) = keyword_starting_at(sql, chars, i) {
+            return Some(keyword);
+        }
+        i += 1;
+    }
+    None
 }
 
 fn keyword_starting_at(sql: &str, chars: &[(usize, char)], i: usize) -> Option<(String, usize)> {

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -125,6 +125,45 @@ pub fn split_statements(sql: &str) -> Vec<String> {
     split_statements_for_database(DatabaseType::PostgreSQL, sql)
 }
 
+fn is_sqlite_create_trigger_prefix(sql: &str) -> bool {
+    let trimmed = sql.trim_start();
+    let chars: Vec<(usize, char)> = trimmed.char_indices().collect();
+    let tokens: Vec<String> = collect_top_level_tokens(trimmed, &chars)
+        .into_iter()
+        .map(|(_, token)| token.to_ascii_uppercase())
+        .collect();
+
+    if tokens.first().map(String::as_str) != Some("CREATE") {
+        return false;
+    }
+    match tokens.get(1).map(String::as_str) {
+        Some("TRIGGER") => true,
+        Some("TEMP" | "TEMPORARY") => tokens.get(2).map(String::as_str) == Some("TRIGGER"),
+        _ => false,
+    }
+}
+
+fn keyword_starting_at(sql: &str, chars: &[(usize, char)], i: usize) -> Option<(String, usize)> {
+    let (byte_pos, ch) = chars[i];
+    if !ch.is_ascii_alphabetic() {
+        return None;
+    }
+    let start = byte_pos;
+    let mut j = i;
+    while j < chars.len() {
+        let (_, c) = chars[j];
+        if c.is_ascii_alphanumeric() || c == '_' {
+            j += 1;
+        } else {
+            break;
+        }
+    }
+    Some((
+        sql[start..chars.get(j).map_or(sql.len(), |(p, _)| *p)].to_ascii_uppercase(),
+        j,
+    ))
+}
+
 pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> Vec<String> {
     // Use sql's own char_indices so byte offsets remain valid for slicing sql.
     // to_lowercase() can change byte lengths (e.g. İ → i̇), which would corrupt offsets.
@@ -134,6 +173,7 @@ pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> 
     let mut i = 0;
     let mut depth: i32 = 0;
     let mut in_string = false;
+    let mut in_trigger_body = false;
 
     while i < chars.len() {
         let (byte_pos, ch) = chars[i];
@@ -169,18 +209,32 @@ pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> 
             continue;
         }
 
+        if database_type == DatabaseType::SQLite
+            && is_sqlite_create_trigger_prefix(&sql[start..])
+            && let Some((keyword, kw_end)) = keyword_starting_at(sql, &chars, i)
+        {
+            if keyword == "BEGIN" {
+                in_trigger_body = true;
+            } else if keyword == "END" && in_trigger_body {
+                in_trigger_body = false;
+            }
+            i = kw_end;
+            continue;
+        }
+
         if ch == '(' {
             depth += 1;
         } else if ch == ')' {
             depth -= 1;
         }
 
-        if depth == 0 && ch == ';' {
+        if depth == 0 && ch == ';' && !(database_type == DatabaseType::SQLite && in_trigger_body) {
             let fragment = sql[start..byte_pos].trim();
             if !fragment.is_empty() {
                 statements.push(fragment.to_string());
             }
             start = byte_pos + 1;
+            in_trigger_body = false;
         }
 
         i += 1;
@@ -830,8 +884,23 @@ mod tests {
             );
         }
 
+        #[test]
+        fn sqlite_create_trigger_body_is_not_split() {
+            let trigger = "\
+CREATE TRIGGER agent_messages_fts_ai AFTER INSERT ON agent_messages BEGIN
+    INSERT INTO agent_messages_fts(rowid, role, content)
+    VALUES (new.id, new.role, new.content);
+END";
+            let sql = format!("{trigger}; SELECT 1");
+
+            let result = split_statements_for_database(DatabaseType::SQLite, &sql);
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0], trigger);
+            assert_eq!(result[1], "SELECT 1");
+        }
+
         #[rstest]
-        #[case::line_comment("SELECT 1 -- ;comment\n; SELECT 2", vec!["SELECT 1 -- ;comment", "SELECT 2"])]
         #[case::block_comment("SELECT /* ; */ 1; SELECT 2", vec!["SELECT /* ; */ 1", "SELECT 2"])]
         fn semicolon_in_comments(#[case] sql: &str, #[case] expected: Vec<&str>) {
             assert_eq!(split_statements(sql), expected);

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -244,6 +244,8 @@ pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> 
     let mut in_string = false;
     let mut in_trigger_body = false;
     let mut trigger_body_stmt_start = false;
+    let mut is_trigger_stmt =
+        database_type == DatabaseType::SQLite && is_sqlite_create_trigger_prefix(&sql[start..]);
 
     while i < chars.len() {
         let (byte_pos, ch) = chars[i];
@@ -279,10 +281,7 @@ pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> 
             continue;
         }
 
-        if database_type == DatabaseType::SQLite
-            && is_sqlite_create_trigger_prefix(&sql[start..])
-            && let Some((keyword, kw_end)) = keyword_starting_at(sql, &chars, i)
-        {
+        if is_trigger_stmt && let Some((keyword, kw_end)) = keyword_starting_at(sql, &chars, i) {
             if keyword == "BEGIN" {
                 if in_trigger_body {
                     trigger_body_stmt_start = false;
@@ -323,6 +322,8 @@ pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> 
                 start = byte_pos + 1;
                 in_trigger_body = false;
                 trigger_body_stmt_start = false;
+                is_trigger_stmt = database_type == DatabaseType::SQLite
+                    && is_sqlite_create_trigger_prefix(&sql[start..]);
             }
         }
 
@@ -1003,6 +1004,36 @@ END";
             assert_eq!(result.len(), 2);
             assert_eq!(result[0], trigger);
             assert_eq!(result[1], "SELECT 1");
+        }
+
+        #[test]
+        fn sqlite_create_trigger_with_case_end_is_not_split() {
+            let trigger = "\
+CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
+    UPDATE counters
+    SET end_value = CASE WHEN new.end > 0 THEN new.end ELSE old.end END
+    WHERE id = new.id;
+    INSERT INTO audit(event_id) VALUES (new.id);
+END";
+            let sql = format!("{trigger}; SELECT 1");
+
+            let result = split_statements_for_database(DatabaseType::SQLite, &sql);
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0], trigger);
+            assert_eq!(result[1], "SELECT 1");
+        }
+
+        #[test]
+        fn sqlite_unclosed_create_trigger_body_is_not_split() {
+            let trigger = "\
+CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
+    UPDATE counters SET end_value = new.end WHERE id = new.id;
+    INSERT INTO audit(event_id) VALUES (new.id);";
+
+            let result = split_statements_for_database(DatabaseType::SQLite, trigger);
+
+            assert_eq!(result, vec![trigger]);
         }
 
         #[rstest]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -258,7 +258,7 @@ impl SqliteAdapter {
         let start = Instant::now();
         let stdout = self
             .cli
-            .execute_csv(path, &append_changes_query(query), read_only)
+            .execute_csv(path, &append_changes_query(query)?, read_only)
             .await?;
         let elapsed = start.elapsed().as_millis() as u64;
         Ok((parse_affected_rows(&stdout)?, elapsed))
@@ -676,11 +676,31 @@ fn contains_keyword(sql: &str, expected: &str) -> bool {
     false
 }
 
-fn split_sqlite_statements(sql: &str) -> Vec<&str> {
+fn is_create_trigger_prefix(sql: &str) -> bool {
+    let Some((first, pos)) = next_keyword_from(sql, 0) else {
+        return false;
+    };
+    if !first.eq_ignore_ascii_case("CREATE") {
+        return false;
+    }
+    let Some((second, pos)) = next_keyword_from(sql, pos) else {
+        return false;
+    };
+    if second.eq_ignore_ascii_case("TEMP") || second.eq_ignore_ascii_case("TEMPORARY") {
+        let Some((third, _)) = next_keyword_from(sql, pos) else {
+            return false;
+        };
+        return third.eq_ignore_ascii_case("TRIGGER");
+    }
+    second.eq_ignore_ascii_case("TRIGGER")
+}
+
+fn try_split_sqlite_statements(sql: &str) -> Result<Vec<&str>, DbOperationError> {
     let bytes = sql.as_bytes();
     let mut statements = Vec::new();
     let mut start = 0;
     let mut i = 0;
+    let mut in_trigger_body = false;
 
     while i < bytes.len() {
         match bytes[i] {
@@ -704,24 +724,49 @@ fn split_sqlite_statements(sql: &str) -> Vec<&str> {
             b'[' => {
                 i = skip_bracket_quoted(bytes, i);
             }
-            b';' => {
+            b';' if !in_trigger_body => {
                 let statement = sql[start..i].trim();
                 if !statement.is_empty() {
                     statements.push(statement);
                 }
                 i += 1;
                 start = i;
+                in_trigger_body = false;
             }
-            _ => i += 1,
+            _ => {
+                if bytes[i].is_ascii_alphabetic()
+                    && is_create_trigger_prefix(&sql[start..])
+                    && let Some((keyword, kw_end)) = next_keyword_from(sql, i)
+                {
+                    if keyword.eq_ignore_ascii_case("BEGIN") {
+                        in_trigger_body = true;
+                    } else if keyword.eq_ignore_ascii_case("END") && in_trigger_body {
+                        in_trigger_body = false;
+                    }
+                    i = kw_end;
+                    continue;
+                }
+                i += 1;
+            }
         }
     }
 
     let tail = sql[start..].trim();
     if !tail.is_empty() {
+        if in_trigger_body {
+            return Err(DbOperationError::QueryFailed(
+                "Unclosed CREATE TRIGGER body".to_string(),
+            ));
+        }
+        if is_create_trigger_prefix(tail) && !contains_keyword(tail, "BEGIN") {
+            return Err(DbOperationError::QueryFailed(
+                "Incomplete CREATE TRIGGER statement".to_string(),
+            ));
+        }
         statements.push(tail);
     }
 
-    statements
+    Ok(statements)
 }
 
 fn is_transaction_control(statement: &str) -> bool {
@@ -741,12 +786,12 @@ fn is_write_statement(statement: &str) -> bool {
     )
 }
 
-fn is_sqlite_rerunnable_export_query(query: &str) -> bool {
-    let statements = split_sqlite_statements(query);
-    statements.len() == 1
+fn is_sqlite_rerunnable_export_query(query: &str) -> Result<bool, DbOperationError> {
+    let statements = try_split_sqlite_statements(query)?;
+    Ok(statements.len() == 1
         && statements
             .iter()
-            .all(|statement| is_sqlite_rerunnable_export_statement(statement))
+            .all(|statement| is_sqlite_rerunnable_export_statement(statement)))
 }
 
 fn is_sqlite_rerunnable_export_statement(statement: &str) -> bool {
@@ -883,17 +928,17 @@ fn is_rollback_to(statement: &str) -> bool {
     rollback_to_target(statement).is_some() || rollback_has_to_clause(statement)
 }
 
-fn sqlite_wrap_mode(query: &str) -> SqliteWrapMode {
-    let statements = split_sqlite_statements(query);
+fn sqlite_wrap_mode(query: &str) -> Result<SqliteWrapMode, DbOperationError> {
+    let statements = try_split_sqlite_statements(query)?;
     if !needs_write_batch_wrap(&statements) {
-        return SqliteWrapMode::None;
+        return Ok(SqliteWrapMode::None);
     }
 
     if statements.iter().any(|stmt| is_transaction_control(stmt)) {
-        return SqliteWrapMode::None;
+        return Ok(SqliteWrapMode::None);
     }
 
-    SqliteWrapMode::BeginCommit
+    Ok(SqliteWrapMode::BeginCommit)
 }
 
 fn sqlite_transaction_block(query: &str) -> String {
@@ -901,11 +946,11 @@ fn sqlite_transaction_block(query: &str) -> String {
     format!("BEGIN;\n{trimmed}\n;\nCOMMIT")
 }
 
-fn sqlite_execution_query(query: &str) -> Cow<'_, str> {
-    match sqlite_wrap_mode(query) {
+fn sqlite_execution_query(query: &str) -> Result<Cow<'_, str>, DbOperationError> {
+    Ok(match sqlite_wrap_mode(query)? {
         SqliteWrapMode::BeginCommit => Cow::Owned(sqlite_transaction_block(query)),
         SqliteWrapMode::None => Cow::Borrowed(query),
-    }
+    })
 }
 
 fn sqlite_probe_marker() -> String {
@@ -942,13 +987,13 @@ fn sqlite_result_probe(marker: &str, index: usize) -> String {
     format!("SELECT {index} AS \"{stmt_col}\", '{marker}' AS \"{marker_col}\"")
 }
 
-fn sqlite_adhoc_execution_query(query: &str, marker: &str) -> String {
-    let statements = split_sqlite_statements(query);
+fn sqlite_adhoc_execution_query(query: &str, marker: &str) -> Result<String, DbOperationError> {
+    let statements = try_split_sqlite_statements(query)?;
     if statements.is_empty() {
-        return query.to_string();
+        return Ok(query.to_string());
     }
 
-    let wrap_mode = sqlite_wrap_mode(query);
+    let wrap_mode = sqlite_wrap_mode(query)?;
     let mut parts = Vec::with_capacity(statements.len() * 2 + 2);
     if matches!(wrap_mode, SqliteWrapMode::BeginCommit) {
         parts.push("BEGIN".to_string());
@@ -965,14 +1010,14 @@ fn sqlite_adhoc_execution_query(query: &str, marker: &str) -> String {
     if matches!(wrap_mode, SqliteWrapMode::BeginCommit) {
         parts.push("COMMIT".to_string());
     }
-    parts.join("\n;\n")
+    Ok(parts.join("\n;\n"))
 }
 
-fn append_changes_query(query: &str) -> String {
-    let body = sqlite_execution_query(query).trim_end().to_string();
+fn append_changes_query(query: &str) -> Result<String, DbOperationError> {
+    let body = sqlite_execution_query(query)?.trim_end().to_string();
     // The standalone separator also terminates a trailing line comment before
     // appending the changes() probe.
-    format!("{body}\n;\nSELECT changes() AS affected_rows;")
+    Ok(format!("{body}\n;\nSELECT changes() AS affected_rows;"))
 }
 
 fn dml_keyword(statement: &str) -> Option<&'static str> {
@@ -1753,8 +1798,8 @@ impl QueryExecutor for SqliteAdapter {
     ) -> Result<QueryResult, DbOperationError> {
         let path = Self::path_from_dsn(dsn)?;
         let marker = sqlite_probe_marker();
-        let execution_query = sqlite_adhoc_execution_query(query, &marker);
-        let statements = split_sqlite_statements(query);
+        let statements = try_split_sqlite_statements(query)?;
+        let execution_query = sqlite_adhoc_execution_query(query, &marker)?;
 
         #[expect(
             clippy::disallowed_methods,
@@ -1838,7 +1883,7 @@ impl QueryExecutor for SqliteAdapter {
         path: &std::path::Path,
         read_only: bool,
     ) -> Result<usize, DbOperationError> {
-        if !is_sqlite_rerunnable_export_query(query) {
+        if !is_sqlite_rerunnable_export_query(query)? {
             return Err(sqlite_export_not_rerunnable_error());
         }
         self.cli
@@ -1857,9 +1902,10 @@ mod tests {
 
     #[test]
     fn split_sqlite_statements_ignores_semicolons_in_literals_and_comments() {
-        let statements = split_sqlite_statements(
+        let statements = try_split_sqlite_statements(
             "INSERT INTO logs(message) VALUES ('a;b'); -- ; ignored\nSELECT ';' AS value;",
-        );
+        )
+        .unwrap();
 
         assert_eq!(
             statements,
@@ -1871,10 +1917,59 @@ mod tests {
     }
 
     #[test]
+    fn split_sqlite_statements_keeps_create_trigger_body_together() {
+        let trigger = "\
+CREATE TRIGGER agent_messages_fts_ai AFTER INSERT ON agent_messages BEGIN
+    INSERT INTO agent_messages_fts(rowid, role, content)
+    VALUES (new.id, new.role, new.content);
+END";
+        let sql = format!("{trigger}; SELECT 1 AS value;");
+
+        let statements = try_split_sqlite_statements(&sql).unwrap();
+
+        assert_eq!(statements.len(), 2);
+        assert_eq!(statements[0], trigger);
+        assert_eq!(statements[1], "SELECT 1 AS value");
+    }
+
+    #[test]
+    fn split_sqlite_statements_rejects_unclosed_create_trigger_body() {
+        let error = try_split_sqlite_statements(
+            "CREATE TRIGGER t AFTER INSERT ON users BEGIN INSERT INTO logs(id) VALUES (1);",
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, DbOperationError::QueryFailed(_)));
+    }
+
+    #[test]
+    fn split_sqlite_statements_rejects_incomplete_create_trigger_without_begin() {
+        let error =
+            try_split_sqlite_statements("CREATE TRIGGER t AFTER INSERT ON users").unwrap_err();
+
+        assert!(matches!(error, DbOperationError::QueryFailed(_)));
+    }
+
+    #[test]
+    fn adhoc_execution_query_does_not_insert_probes_inside_create_trigger() {
+        let trigger = "\
+CREATE TRIGGER agent_messages_fts_ai AFTER INSERT ON agent_messages BEGIN
+    INSERT INTO agent_messages_fts(rowid, role, content)
+    VALUES (new.id, new.role, new.content);
+END";
+        let marker = "probe_marker";
+
+        let execution_query = sqlite_adhoc_execution_query(trigger, marker).unwrap();
+
+        assert!(!execution_query.contains(marker));
+        assert_eq!(execution_query, trigger);
+    }
+
+    #[test]
     fn append_changes_wraps_multi_statement_write_without_explicit_transaction() {
         let query = "INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2);";
 
-        let wrapped = append_changes_query(query);
+        let wrapped = append_changes_query(query).unwrap();
 
         assert_eq!(
             wrapped,
@@ -1886,7 +1981,7 @@ mod tests {
     fn append_changes_wraps_multi_statement_replace_without_explicit_transaction() {
         let query = "REPLACE INTO users(id) VALUES (1); SELECT * FROM missing";
 
-        let wrapped = append_changes_query(query);
+        let wrapped = append_changes_query(query).unwrap();
 
         assert_eq!(
             wrapped,
@@ -1898,7 +1993,7 @@ mod tests {
     fn append_changes_wraps_multi_statement_with_write_without_explicit_transaction() {
         let query = "WITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload; SELECT * FROM missing";
 
-        let wrapped = append_changes_query(query);
+        let wrapped = append_changes_query(query).unwrap();
 
         assert_eq!(
             wrapped,
@@ -1910,7 +2005,7 @@ mod tests {
     fn append_changes_keeps_explicit_begin_commit_transaction_control() {
         let query = "BEGIN; INSERT INTO users(id) VALUES (1); COMMIT";
 
-        let wrapped = append_changes_query(query);
+        let wrapped = append_changes_query(query).unwrap();
 
         assert_eq!(
             wrapped,
@@ -1922,7 +2017,7 @@ mod tests {
     fn append_changes_keeps_explicit_begin_end_transaction_control() {
         let query = "BEGIN; INSERT INTO users(id) VALUES (1); END";
 
-        let wrapped = append_changes_query(query);
+        let wrapped = append_changes_query(query).unwrap();
 
         assert_eq!(
             wrapped,
@@ -2050,7 +2145,8 @@ mod tests {
             assert_eq!(
                 sqlite_wrap_mode(
                     "INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)"
-                ),
+                )
+                .unwrap(),
                 SqliteWrapMode::BeginCommit
             );
         }
@@ -2058,7 +2154,7 @@ mod tests {
         #[test]
         fn explicit_begin_is_not_wrapped() {
             assert_eq!(
-                sqlite_wrap_mode("BEGIN; INSERT INTO users(id) VALUES (1); COMMIT"),
+                sqlite_wrap_mode("BEGIN; INSERT INTO users(id) VALUES (1); COMMIT").unwrap(),
                 SqliteWrapMode::None
             );
         }
@@ -2068,7 +2164,8 @@ mod tests {
             assert_eq!(
                 sqlite_wrap_mode(
                     "SAVEPOINT user_sp; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)"
-                ),
+                )
+                .unwrap(),
                 SqliteWrapMode::None
             );
         }
@@ -2078,7 +2175,8 @@ mod tests {
             assert_eq!(
                 sqlite_wrap_mode(
                     "INSERT INTO users(id) VALUES (1); SAVEPOINT sp; INSERT INTO users(id) VALUES (2)"
-                ),
+                )
+                .unwrap(),
                 SqliteWrapMode::None
             );
         }
@@ -2610,6 +2708,62 @@ mod tests {
             assert_eq!(result.columns, vec!["value"]);
             assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
             assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
+        }
+
+        #[tokio::test]
+        async fn create_trigger_with_multi_statement_body_preserves_definition() {
+            let setup = r"
+            CREATE TABLE agent_messages(
+                id INTEGER PRIMARY KEY,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL
+            );
+            CREATE VIRTUAL TABLE agent_messages_fts USING fts5(role, content);
+            ";
+            let trigger = r"
+            CREATE TRIGGER agent_messages_fts_ai AFTER INSERT ON agent_messages BEGIN
+                INSERT INTO agent_messages_fts(rowid, role, content)
+                VALUES (new.id, new.role, new.content);
+            END
+            ";
+            let (_dir, dsn) = make_sqlite_db(setup);
+            let adapter = SqliteAdapter::new();
+
+            adapter.execute_adhoc(&dsn, trigger, false).await.unwrap();
+
+            let result = adapter
+                .execute_adhoc(
+                    &dsn,
+                    "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'agent_messages_fts_ai'",
+                    true,
+                )
+                .await
+                .unwrap();
+
+            let stored = result.rows()[0][0].replace('\n', " ");
+            let expected = trigger.trim().replace('\n', " ");
+            assert!(
+                !stored.contains("__sabiql_sqlite_probe_"),
+                "probe SQL must not appear in stored trigger definition: {stored}"
+            );
+            assert_eq!(stored, expected);
+        }
+
+        #[tokio::test]
+        async fn unclosed_create_trigger_fails_before_execution() {
+            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let adapter = SqliteAdapter::new();
+
+            let error = adapter
+                .execute_adhoc(
+                    &dsn,
+                    "CREATE TRIGGER t AFTER INSERT ON users BEGIN INSERT INTO logs(id) VALUES (1);",
+                    false,
+                )
+                .await
+                .unwrap_err();
+
+            assert!(matches!(error, DbOperationError::QueryFailed(_)));
         }
 
         #[tokio::test]
@@ -3452,14 +3606,14 @@ mod tests {
                 "PRAGMA foreign_keys=OFF",
                 "PRAGMA wal_checkpoint(TRUNCATE)",
             ] {
-                assert!(!is_sqlite_rerunnable_export_query(sql), "{sql}");
+                assert!(!is_sqlite_rerunnable_export_query(sql).unwrap(), "{sql}");
             }
         }
 
         #[test]
         fn export_guard_allows_read_only_sql() {
             for sql in ["SELECT 1", "PRAGMA table_info(users)"] {
-                assert!(is_sqlite_rerunnable_export_query(sql), "{sql}");
+                assert!(is_sqlite_rerunnable_export_query(sql).unwrap(), "{sql}");
             }
         }
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -695,12 +695,39 @@ fn is_create_trigger_prefix(sql: &str) -> bool {
     second.eq_ignore_ascii_case("TRIGGER")
 }
 
+fn is_dotted_identifier_suffix(sql: &str, keyword_start: usize) -> bool {
+    let mut index = keyword_start;
+    while index > 0 {
+        index -= 1;
+        match sql.as_bytes()[index] {
+            byte if byte.is_ascii_whitespace() => {}
+            b'.' => return true,
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn is_sqlite_trigger_body_end(
+    keyword: &str,
+    in_trigger_body: bool,
+    trigger_body_stmt_start: bool,
+    sql: &str,
+    keyword_start: usize,
+) -> bool {
+    in_trigger_body
+        && trigger_body_stmt_start
+        && keyword.eq_ignore_ascii_case("END")
+        && !is_dotted_identifier_suffix(sql, keyword_start)
+}
+
 fn try_split_sqlite_statements(sql: &str) -> Result<Vec<&str>, DbOperationError> {
     let bytes = sql.as_bytes();
     let mut statements = Vec::new();
     let mut start = 0;
     let mut i = 0;
     let mut in_trigger_body = false;
+    let mut trigger_body_stmt_start = false;
 
     while i < bytes.len() {
         match bytes[i] {
@@ -724,7 +751,11 @@ fn try_split_sqlite_statements(sql: &str) -> Result<Vec<&str>, DbOperationError>
             b'[' => {
                 i = skip_bracket_quoted(bytes, i);
             }
-            b';' if !in_trigger_body => {
+            b';' if in_trigger_body => {
+                trigger_body_stmt_start = true;
+                i += 1;
+            }
+            b';' => {
                 let statement = sql[start..i].trim();
                 if !statement.is_empty() {
                     statements.push(statement);
@@ -732,6 +763,7 @@ fn try_split_sqlite_statements(sql: &str) -> Result<Vec<&str>, DbOperationError>
                 i += 1;
                 start = i;
                 in_trigger_body = false;
+                trigger_body_stmt_start = false;
             }
             _ => {
                 if bytes[i].is_ascii_alphabetic()
@@ -739,9 +771,23 @@ fn try_split_sqlite_statements(sql: &str) -> Result<Vec<&str>, DbOperationError>
                     && let Some((keyword, kw_end)) = next_keyword_from(sql, i)
                 {
                     if keyword.eq_ignore_ascii_case("BEGIN") {
-                        in_trigger_body = true;
-                    } else if keyword.eq_ignore_ascii_case("END") && in_trigger_body {
+                        if in_trigger_body {
+                            trigger_body_stmt_start = false;
+                        } else {
+                            in_trigger_body = true;
+                            trigger_body_stmt_start = true;
+                        }
+                    } else if is_sqlite_trigger_body_end(
+                        keyword,
+                        in_trigger_body,
+                        trigger_body_stmt_start,
+                        sql,
+                        i,
+                    ) {
                         in_trigger_body = false;
+                        trigger_body_stmt_start = false;
+                    } else if in_trigger_body {
+                        trigger_body_stmt_start = false;
                     }
                     i = kw_end;
                     continue;
@@ -1933,6 +1979,37 @@ END";
     }
 
     #[test]
+    fn split_sqlite_statements_keeps_create_trigger_with_dotted_end_reference() {
+        let trigger = "\
+CREATE TRIGGER sync_end AFTER UPDATE ON events BEGIN
+    UPDATE counters SET end_value = new.end WHERE id = new.id;
+    INSERT INTO audit(event_id, end_value) VALUES (new.id, new.end);
+END";
+        let sql = format!("{trigger}; SELECT 1 AS value;");
+
+        let statements = try_split_sqlite_statements(&sql).unwrap();
+
+        assert_eq!(statements.len(), 2);
+        assert_eq!(statements[0], trigger);
+        assert_eq!(statements[1], "SELECT 1 AS value");
+    }
+
+    #[test]
+    fn adhoc_execution_query_does_not_insert_probes_when_trigger_references_new_end() {
+        let trigger = "\
+CREATE TRIGGER sync_end AFTER UPDATE ON events BEGIN
+    UPDATE counters SET end_value = new.end WHERE id = new.id;
+    INSERT INTO audit(event_id, end_value) VALUES (new.id, new.end);
+END";
+        let marker = "probe_marker";
+
+        let execution_query = sqlite_adhoc_execution_query(trigger, marker).unwrap();
+
+        assert!(!execution_query.contains(marker));
+        assert_eq!(execution_query, trigger);
+    }
+
+    #[test]
     fn split_sqlite_statements_rejects_unclosed_create_trigger_body() {
         let error = try_split_sqlite_statements(
             "CREATE TRIGGER t AFTER INSERT ON users BEGIN INSERT INTO logs(id) VALUES (1);",
@@ -2735,6 +2812,51 @@ END";
                 .execute_adhoc(
                     &dsn,
                     "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'agent_messages_fts_ai'",
+                    true,
+                )
+                .await
+                .unwrap();
+
+            let stored = result.rows()[0][0].replace('\n', " ");
+            let expected = trigger.trim().replace('\n', " ");
+            assert!(
+                !stored.contains("__sabiql_sqlite_probe_"),
+                "probe SQL must not appear in stored trigger definition: {stored}"
+            );
+            assert_eq!(stored, expected);
+        }
+
+        #[tokio::test]
+        async fn create_trigger_referencing_new_end_preserves_definition() {
+            let setup = r"
+            CREATE TABLE events(
+                id INTEGER PRIMARY KEY,
+                end INTEGER NOT NULL
+            );
+            CREATE TABLE counters(
+                id INTEGER PRIMARY KEY,
+                end_value INTEGER
+            );
+            CREATE TABLE audit(
+                event_id INTEGER,
+                end_value INTEGER
+            );
+            ";
+            let trigger = r"
+            CREATE TRIGGER sync_end AFTER UPDATE ON events BEGIN
+                UPDATE counters SET end_value = new.end WHERE id = new.id;
+                INSERT INTO audit(event_id, end_value) VALUES (new.id, new.end);
+            END
+            ";
+            let (_dir, dsn) = make_sqlite_db(setup);
+            let adapter = SqliteAdapter::new();
+
+            adapter.execute_adhoc(&dsn, trigger, false).await.unwrap();
+
+            let result = adapter
+                .execute_adhoc(
+                    &dsn,
+                    "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'sync_end'",
                     true,
                 )
                 .await

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1995,6 +1995,24 @@ END";
     }
 
     #[test]
+    fn split_sqlite_statements_keeps_create_trigger_with_case_end_expression() {
+        let trigger = "\
+CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
+    UPDATE counters
+    SET end_value = CASE WHEN new.end > 0 THEN new.end ELSE old.end END
+    WHERE id = new.id;
+    INSERT INTO audit(event_id) VALUES (new.id);
+END";
+        let sql = format!("{trigger}; SELECT 1 AS value;");
+
+        let statements = try_split_sqlite_statements(&sql).unwrap();
+
+        assert_eq!(statements.len(), 2);
+        assert_eq!(statements[0], trigger);
+        assert_eq!(statements[1], "SELECT 1 AS value");
+    }
+
+    #[test]
     fn adhoc_execution_query_does_not_insert_probes_when_trigger_references_new_end() {
         let trigger = "\
 CREATE TRIGGER sync_end AFTER UPDATE ON events BEGIN


### PR DESCRIPTION
## Problem

SQLite `CREATE TRIGGER` bodies can contain multiple semicolon-separated statements between `BEGIN` and `END`. Splitting on every semicolon could break trigger definitions and let execution probes leak into the stored trigger SQL.

## Background

Related to SAB-285. The SQLite adapter inserts measurement probes between split statements during ad-hoc execution, so an incorrect split can change the trigger that SQLite actually stores.

## Approach

Treat `CREATE TRIGGER ... BEGIN ... END` as a single statement when splitting SQLite SQL, skip probe insertion inside trigger bodies, and reject unclosed trigger definitions before execution. Apply the same split rule to SQLite risk and multi-statement detection so policy checks stay aligned with execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite で、トリガー内のセミコロンにより SQL が誤って分割される問題を修正しました。
  * `CREATE TRIGGER ... BEGIN ... END` を含むクエリの実行安定性が向上し、トリガー定義の途中で失敗しにくくなりました。
  * 不完全なトリガー定義や、ドット付き参照を含むケースでの誤判定を防ぎ、実行エラーをより適切に返すようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->