### PR TITLE
perf: defer SQLite table row counts until table detail fetch

### DIFF
--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1829,7 +1829,7 @@ impl MetadataProvider for SqliteAdapter {
             metadata.table_summaries.push(TableSummary::new(
                 MAIN_SCHEMA.to_string(),
                 table.name.clone(),
-                self.row_count(path, &table.name).await,
+                None,
                 false,
             ));
         }
@@ -3886,7 +3886,23 @@ END";
             assert_eq!(metadata.schemas, vec![Schema::new("main")]);
             assert_eq!(metadata.table_summaries.len(), 1);
             assert_eq!(metadata.table_summaries[0].qualified_name(), "main.users");
-            assert_eq!(metadata.table_summaries[0].row_count_estimate, Some(0));
+            assert!(metadata.table_summaries[0].row_count_estimate.is_none());
+        }
+
+        #[tokio::test]
+        async fn metadata_skips_row_count_even_when_table_has_rows() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY);
+            INSERT INTO users(id) VALUES (1), (2), (3);
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
+
+            assert_eq!(metadata.table_summaries.len(), 1);
+            assert!(metadata.table_summaries[0].row_count_estimate.is_none());
         }
 
         #[tokio::test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -86,6 +86,23 @@ struct RawRowCount {
     count: i64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TableDetailMode {
+    Full,
+    ColumnsAndFks,
+    Signature,
+}
+
+impl TableDetailMode {
+    const fn include_indexes(self) -> bool {
+        matches!(self, Self::Full | Self::Signature)
+    }
+
+    const fn include_row_count(self) -> bool {
+        matches!(self, Self::Full)
+    }
+}
+
 impl SqliteAdapter {
     pub fn new() -> Self {
         Self {
@@ -515,9 +532,10 @@ impl SqliteAdapter {
         &self,
         path: &str,
         table: &str,
-        include_indexes: bool,
-        include_row_count: bool,
+        mode: TableDetailMode,
     ) -> Result<Table, DbOperationError> {
+        let include_indexes = mode.include_indexes();
+        let include_row_count = mode.include_row_count();
         let (indexes, unique_single_columns) = if include_indexes {
             let indexes = self.indexes(path, table).await?;
             let unique_single_columns = indexes
@@ -603,7 +621,7 @@ impl SqliteAdapter {
         table: &RawTable,
     ) -> Result<TableSignature, DbOperationError> {
         let detail = self
-            .table_detail_with_mode(path, &table.name, true, false)
+            .table_detail_with_mode(path, &table.name, TableDetailMode::Signature)
             .await?;
         let mut parts = vec![format!("sql={}", table.sql.clone().unwrap_or_default())];
         parts.extend(detail.columns.iter().map(|column| {
@@ -1850,7 +1868,7 @@ impl MetadataProvider for SqliteAdapter {
         table: &str,
     ) -> Result<Table, DbOperationError> {
         Self::validate_main_schema(schema)?;
-        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, true, true)
+        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, TableDetailMode::Full)
             .await
     }
 
@@ -1861,8 +1879,12 @@ impl MetadataProvider for SqliteAdapter {
         table: &str,
     ) -> Result<Table, DbOperationError> {
         Self::validate_main_schema(schema)?;
-        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, false, false)
-            .await
+        self.table_detail_with_mode(
+            Self::path_from_dsn(dsn)?,
+            table,
+            TableDetailMode::ColumnsAndFks,
+        )
+        .await
     }
 
     async fn fetch_table_signatures(

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -516,6 +516,7 @@ impl SqliteAdapter {
         path: &str,
         table: &str,
         include_indexes: bool,
+        include_row_count: bool,
     ) -> Result<Table, DbOperationError> {
         let (indexes, unique_single_columns) = if include_indexes {
             let indexes = self.indexes(path, table).await?;
@@ -586,7 +587,11 @@ impl SqliteAdapter {
             indexes,
             rls: None,
             triggers: Vec::new(),
-            row_count_estimate: self.row_count(path, table).await,
+            row_count_estimate: if include_row_count {
+                self.row_count(path, table).await
+            } else {
+                None
+            },
             comment: None,
             source_ddl: self.table_definition(path, table).await,
         })
@@ -597,7 +602,9 @@ impl SqliteAdapter {
         path: &str,
         table: &RawTable,
     ) -> Result<TableSignature, DbOperationError> {
-        let detail = self.table_detail_with_mode(path, &table.name, true).await?;
+        let detail = self
+            .table_detail_with_mode(path, &table.name, true, false)
+            .await?;
         let mut parts = vec![format!("sql={}", table.sql.clone().unwrap_or_default())];
         parts.extend(detail.columns.iter().map(|column| {
             format!(
@@ -1843,7 +1850,7 @@ impl MetadataProvider for SqliteAdapter {
         table: &str,
     ) -> Result<Table, DbOperationError> {
         Self::validate_main_schema(schema)?;
-        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, true)
+        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, true, true)
             .await
     }
 
@@ -1854,7 +1861,7 @@ impl MetadataProvider for SqliteAdapter {
         table: &str,
     ) -> Result<Table, DbOperationError> {
         Self::validate_main_schema(schema)?;
-        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, false)
+        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, false, false)
             .await
     }
 
@@ -3890,7 +3897,7 @@ END";
         }
 
         #[tokio::test]
-        async fn metadata_skips_row_count_even_when_table_has_rows() {
+        async fn skips_row_count_even_when_table_has_rows() {
             let (_dir, dsn) = make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY);
@@ -4027,6 +4034,29 @@ END";
             assert_eq!(fk.on_delete, FkAction::Cascade);
             assert!(detail.rls.is_none());
             assert!(detail.triggers.is_empty());
+        }
+
+        #[tokio::test]
+        async fn columns_and_fks_skips_row_count() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY);
+            INSERT INTO users(id) VALUES (1), (2), (3);
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let light = adapter
+                .fetch_table_columns_and_fks(&dsn, "main", "users")
+                .await
+                .unwrap();
+            let full = adapter
+                .fetch_table_detail(&dsn, "main", "users")
+                .await
+                .unwrap();
+
+            assert!(light.row_count_estimate.is_none());
+            assert_eq!(full.row_count_estimate, Some(3));
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Problem

Opening a SQLite database blocked on `COUNT(*)` for every table during metadata load, which made large databases feel slow before the user could browse anything.

## Background

Parent issue SAB-206 (SQLite support). SAB-294 tracks the connection-time performance regression from eager row counts on all tables.

## Approach

Return table summaries without row count estimates from SQLite metadata fetch. Row counts are still loaded when table detail is fetched on selection, reload, or preview setup, and the UI already treats missing counts as unknown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * テーブル詳細の取得内容が、必要な場面でのみ行数見積りを含むようになりました。
  * 軽量なテーブル情報取得では行数見積りを返さず、表示や処理がより一貫するようになりました。
  * メタデータでは行数見積りが不要な場合に `None` として扱われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->