### PR TITLE
fix(sqlite): classify execution errors by cause for clearer TUI messages

### DIFF
--- a/src/infra/adapters/sqlite/cli.rs
+++ b/src/infra/adapters/sqlite/cli.rs
@@ -8,6 +8,8 @@ use tokio::time::timeout;
 
 use crate::app::ports::outbound::DbOperationError;
 
+use super::error::classify_query_error;
+
 pub(super) const BUSY_TIMEOUT_MS: u64 = 5_000;
 
 #[derive(Debug, Clone)]
@@ -33,7 +35,7 @@ impl SqliteCli {
     ) -> Result<T, DbOperationError> {
         let output = self.run(path, &["-json"], sql, true).await?;
         if !output.status.success() {
-            return Err(DbOperationError::QueryFailed(output.stderr));
+            return Err(classify_query_error(&output.stderr));
         }
         let stdout = match output.stdout.trim() {
             "" => "[]",
@@ -57,7 +59,7 @@ impl SqliteCli {
             )
             .await?;
         if !output.status.success() {
-            return Err(DbOperationError::QueryFailed(output.stderr));
+            return Err(classify_query_error(&output.stderr));
         }
         Ok(output.stdout)
     }
@@ -77,7 +79,7 @@ impl SqliteCli {
             )
             .await?;
         if !output.status.success() {
-            return Err(DbOperationError::QueryFailed(output.stderr));
+            return Err(classify_query_error(&output.stderr));
         }
         Ok(output.stdout)
     }
@@ -146,7 +148,7 @@ impl SqliteCli {
 
         if !status.success() {
             let _ = tokio::fs::remove_file(output_path).await;
-            return Err(DbOperationError::QueryFailed(stderr));
+            return Err(classify_query_error(&stderr));
         }
 
         Ok(newline_count.saturating_sub(1))

--- a/src/infra/adapters/sqlite/error.rs
+++ b/src/infra/adapters/sqlite/error.rs
@@ -124,7 +124,9 @@ mod tests {
             ClassifiedKind::QueryFailed
         )]
         fn classifies_sqlite_stderr(#[case] input: &str, #[case] expected: ClassifiedKind) {
-            assert_eq!(classified_kind(&classify_query_error(input)), expected);
+            let error = classify_query_error(input);
+
+            assert_eq!(classified_kind(&error), expected);
         }
 
         #[test]
@@ -143,16 +145,17 @@ mod tests {
 
         #[test]
         fn unknown_falls_back_safely() {
-            assert!(matches!(
-                classify_query_error("some random error"),
-                DbOperationError::QueryFailed(_)
-            ));
+            let error = classify_query_error("some random error");
+
+            assert!(matches!(error, DbOperationError::QueryFailed(_)));
         }
 
         #[test]
         fn empty_stderr_falls_back_to_query_failed() {
+            let error = classify_query_error("   ");
+
             assert!(matches!(
-                classify_query_error("   "),
+                error,
                 DbOperationError::QueryFailed(details) if details.is_empty()
             ));
         }

--- a/src/infra/adapters/sqlite/error.rs
+++ b/src/infra/adapters/sqlite/error.rs
@@ -1,0 +1,126 @@
+use crate::app::ports::outbound::DbOperationError;
+
+pub(in crate::adapters::sqlite) fn classify_query_error(stderr: &str) -> DbOperationError {
+    let trimmed = stderr.trim();
+    let Some(details) = (!trimmed.is_empty()).then_some(trimmed) else {
+        return DbOperationError::QueryFailed(String::new());
+    };
+
+    classify_by_stderr(details)
+}
+
+fn classify_by_stderr(details: &str) -> DbOperationError {
+    let lower = details.to_ascii_lowercase();
+
+    // Keep table-list fallback in SqliteAdapter::list_tables working.
+    if lower.contains("pragma_table_list") {
+        return DbOperationError::QueryFailed(details.to_string());
+    }
+
+    if is_locked(&lower) {
+        return DbOperationError::LockTimeout(details.to_string());
+    }
+
+    if is_readonly(&lower) {
+        return DbOperationError::PermissionDenied(details.to_string());
+    }
+
+    if lower.contains("foreign key constraint failed") {
+        return DbOperationError::ForeignKeyViolation(details.to_string());
+    }
+
+    if lower.contains("unique constraint failed") {
+        return DbOperationError::UniqueViolation(details.to_string());
+    }
+
+    if is_missing_object(&lower) {
+        return DbOperationError::ObjectMissing(details.to_string());
+    }
+
+    DbOperationError::QueryFailed(details.to_string())
+}
+
+fn is_locked(lower: &str) -> bool {
+    lower.contains("database is locked")
+        || lower.contains("database table is locked")
+        || lower.contains("sqlite_busy")
+}
+
+fn is_readonly(lower: &str) -> bool {
+    lower.contains("readonly database") || lower.contains("read-only database")
+}
+
+fn is_missing_object(lower: &str) -> bool {
+    lower.contains("no such table")
+        || lower.contains("no such column")
+        || lower.contains("no such view")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    mod classification {
+        use super::*;
+
+        #[rstest]
+        #[case("Error: database is locked", "LockTimeout")]
+        #[case("Runtime error: database is locked (SQLITE_BUSY)", "LockTimeout")]
+        #[case("Error: attempt to write a readonly database", "PermissionDenied")]
+        #[case("Error: FOREIGN KEY constraint failed", "ForeignKeyViolation")]
+        #[case("Error: UNIQUE constraint failed: users.email", "UniqueViolation")]
+        #[case("Parse error: near \"SELEKT\": syntax error", "QueryFailed")]
+        #[case("Error: near \"SELEKT\": syntax error", "QueryFailed")]
+        #[case("Error: no such table: users", "ObjectMissing")]
+        #[case("Error: no such column: missing", "ObjectMissing")]
+        #[case(
+            "Error: in prepare, no such table: main.pragma_table_list",
+            "QueryFailed"
+        )]
+        fn classifies_sqlite_stderr(#[case] input: &str, #[case] expected: &str) {
+            let error = classify_query_error(input);
+            let actual = match error {
+                DbOperationError::PermissionDenied(_) => "PermissionDenied",
+                DbOperationError::ForeignKeyViolation(_) => "ForeignKeyViolation",
+                DbOperationError::UniqueViolation(_) => "UniqueViolation",
+                DbOperationError::LockTimeout(_) => "LockTimeout",
+                DbOperationError::ObjectMissing(_) => "ObjectMissing",
+                DbOperationError::QueryFailed(_) => "QueryFailed",
+                _ => "Other",
+            };
+
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn lock_readonly_and_constraints_use_distinct_summaries() {
+            let lock = classify_query_error("Error: database is locked");
+            let readonly = classify_query_error("Error: attempt to write a readonly database");
+            let foreign_key = classify_query_error("Error: FOREIGN KEY constraint failed");
+            let unique = classify_query_error("Error: UNIQUE constraint failed: users.email");
+
+            assert_ne!(lock.summary(), readonly.summary());
+            assert_ne!(lock.summary(), foreign_key.summary());
+            assert_ne!(lock.summary(), unique.summary());
+            assert_ne!(readonly.summary(), foreign_key.summary());
+            assert_ne!(foreign_key.summary(), unique.summary());
+        }
+
+        #[test]
+        fn unknown_falls_back_safely() {
+            assert!(matches!(
+                classify_query_error("some random error"),
+                DbOperationError::QueryFailed(_)
+            ));
+        }
+
+        #[test]
+        fn empty_stderr_falls_back_to_query_failed() {
+            assert!(matches!(
+                classify_query_error("   "),
+                DbOperationError::QueryFailed(details) if details.is_empty()
+            ));
+        }
+    }
+}

--- a/src/infra/adapters/sqlite/error.rs
+++ b/src/infra/adapters/sqlite/error.rs
@@ -54,6 +54,8 @@ fn is_missing_object(lower: &str) -> bool {
     lower.contains("no such table")
         || lower.contains("no such column")
         || lower.contains("no such view")
+        || lower.contains("no such index")
+        || lower.contains("no such trigger")
 }
 
 #[cfg(test)]
@@ -61,36 +63,68 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ClassifiedKind {
+        PermissionDenied,
+        ForeignKeyViolation,
+        UniqueViolation,
+        LockTimeout,
+        ObjectMissing,
+        QueryFailed,
+        Other,
+    }
+
+    fn classified_kind(error: &DbOperationError) -> ClassifiedKind {
+        match error {
+            DbOperationError::PermissionDenied(_) => ClassifiedKind::PermissionDenied,
+            DbOperationError::ForeignKeyViolation(_) => ClassifiedKind::ForeignKeyViolation,
+            DbOperationError::UniqueViolation(_) => ClassifiedKind::UniqueViolation,
+            DbOperationError::LockTimeout(_) => ClassifiedKind::LockTimeout,
+            DbOperationError::ObjectMissing(_) => ClassifiedKind::ObjectMissing,
+            DbOperationError::QueryFailed(_) => ClassifiedKind::QueryFailed,
+            _ => ClassifiedKind::Other,
+        }
+    }
+
     mod classification {
         use super::*;
 
         #[rstest]
-        #[case("Error: database is locked", "LockTimeout")]
-        #[case("Runtime error: database is locked (SQLITE_BUSY)", "LockTimeout")]
-        #[case("Error: attempt to write a readonly database", "PermissionDenied")]
-        #[case("Error: FOREIGN KEY constraint failed", "ForeignKeyViolation")]
-        #[case("Error: UNIQUE constraint failed: users.email", "UniqueViolation")]
-        #[case("Parse error: near \"SELEKT\": syntax error", "QueryFailed")]
-        #[case("Error: near \"SELEKT\": syntax error", "QueryFailed")]
-        #[case("Error: no such table: users", "ObjectMissing")]
-        #[case("Error: no such column: missing", "ObjectMissing")]
+        #[case("Error: database is locked", ClassifiedKind::LockTimeout)]
+        #[case(
+            "Runtime error: database is locked (SQLITE_BUSY)",
+            ClassifiedKind::LockTimeout
+        )]
+        #[case(
+            "Error: attempt to write a readonly database",
+            ClassifiedKind::PermissionDenied
+        )]
+        #[case(
+            "Error: FOREIGN KEY constraint failed",
+            ClassifiedKind::ForeignKeyViolation
+        )]
+        #[case(
+            "Error: UNIQUE constraint failed: users.email",
+            ClassifiedKind::UniqueViolation
+        )]
+        #[case(
+            "Parse error: near \"SELEKT\": syntax error",
+            ClassifiedKind::QueryFailed
+        )]
+        #[case("Error: near \"SELEKT\": syntax error", ClassifiedKind::QueryFailed)]
+        #[case("Error: no such table: users", ClassifiedKind::ObjectMissing)]
+        #[case("Error: no such column: missing", ClassifiedKind::ObjectMissing)]
+        #[case("Error: no such index: missing_idx", ClassifiedKind::ObjectMissing)]
+        #[case(
+            "Error: no such trigger: missing_trigger",
+            ClassifiedKind::ObjectMissing
+        )]
         #[case(
             "Error: in prepare, no such table: main.pragma_table_list",
-            "QueryFailed"
+            ClassifiedKind::QueryFailed
         )]
-        fn classifies_sqlite_stderr(#[case] input: &str, #[case] expected: &str) {
-            let error = classify_query_error(input);
-            let actual = match error {
-                DbOperationError::PermissionDenied(_) => "PermissionDenied",
-                DbOperationError::ForeignKeyViolation(_) => "ForeignKeyViolation",
-                DbOperationError::UniqueViolation(_) => "UniqueViolation",
-                DbOperationError::LockTimeout(_) => "LockTimeout",
-                DbOperationError::ObjectMissing(_) => "ObjectMissing",
-                DbOperationError::QueryFailed(_) => "QueryFailed",
-                _ => "Other",
-            };
-
-            assert_eq!(actual, expected);
+        fn classifies_sqlite_stderr(#[case] input: &str, #[case] expected: ClassifiedKind) {
+            assert_eq!(classified_kind(&classify_query_error(input)), expected);
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -14,6 +14,7 @@ use crate::domain::{
 };
 
 mod cli;
+mod error;
 mod sql;
 
 use cli::SqliteCli;

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -3897,6 +3897,32 @@ END";
         }
 
         #[tokio::test]
+        async fn export_to_csv_missing_table_returns_object_missing_and_removes_file() {
+            let (dir, dsn) = make_sqlite_db("");
+            let path = dir.path().join("missing_export.csv");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .export_to_csv(&dsn, "SELECT id FROM missing", &path, true)
+                .await;
+
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+            assert!(!path.exists());
+        }
+
+        #[tokio::test]
+        async fn count_query_rows_missing_table_returns_object_missing() {
+            let (_dir, dsn) = make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .count_query_rows(&dsn, "SELECT COUNT(*) FROM missing", true)
+                .await;
+
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+        }
+
+        #[tokio::test]
         async fn read_only_write_fails() {
             let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
             let adapter = SqliteAdapter::new();

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -3421,7 +3421,7 @@ END";
                 )
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
@@ -3483,7 +3483,7 @@ END";
                 )
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
@@ -3506,7 +3506,7 @@ END";
                 )
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
@@ -3523,7 +3523,7 @@ END";
 
             let result = adapter.execute_adhoc(&dsn, query, false).await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
@@ -3544,7 +3544,7 @@ END";
                 )
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
@@ -3729,10 +3729,49 @@ END";
                 .await
                 .unwrap();
 
-            assert!(
-                matches!(result, Err(DbOperationError::QueryFailed(message)) if message.contains("FOREIGN KEY constraint failed"))
-            );
+            assert!(matches!(
+                result,
+                Err(DbOperationError::ForeignKeyViolation(_))
+            ));
             assert_eq!(children.rows(), vec![vec!["1".to_string()]]);
+        }
+
+        #[tokio::test]
+        async fn unique_constraint_violation_is_classified() {
+            let (_dir, dsn) = make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT UNIQUE NOT NULL);",
+            );
+            let adapter = SqliteAdapter::new();
+
+            adapter
+                .execute_write(
+                    &dsn,
+                    "INSERT INTO users(id, email) VALUES (1, 'a@example.com')",
+                    false,
+                )
+                .await
+                .unwrap();
+
+            let result = adapter
+                .execute_write(
+                    &dsn,
+                    "INSERT INTO users(id, email) VALUES (2, 'a@example.com')",
+                    false,
+                )
+                .await;
+
+            assert!(matches!(result, Err(DbOperationError::UniqueViolation(_))));
+        }
+
+        #[tokio::test]
+        async fn syntax_error_stays_query_failed_with_details() {
+            let (_dir, dsn) = make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter.execute_adhoc(&dsn, "SELEKT 1", true).await;
+
+            assert!(matches!(result, Err(DbOperationError::QueryFailed(message))
+                    if message.to_ascii_lowercase().contains("syntax error")));
         }
 
         #[tokio::test]
@@ -3866,7 +3905,7 @@ END";
                 .execute_write(&dsn, "INSERT INTO users(id) VALUES (1)", true)
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::PermissionDenied(_))));
         }
     }
 


### PR DESCRIPTION
## Problem

SQLite query failures were always surfaced as generic "Query failed" messages, making it hard to tell apart locks, read-only connections, constraint violations, and syntax errors.

## Background

PostgreSQL already maps `psql` stderr into typed `DbOperationError` variants with actionable summaries. SQLite still forwarded raw `sqlite3` stderr as `QueryFailed`, so the existing user-facing hint layer could not distinguish common failure modes.

## Approach

Add a SQLite stderr classifier modeled after the PostgreSQL adapter, map lock/read-only/constraint/missing-object cases to existing `DbOperationError` variants, and route `sqlite3` CLI failures through it so TUI messages reuse the shared summary and hint text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite 実行時の失敗が、内容に応じてより適切なエラーとして返るようになりました。
  * テーブルや列が存在しない場合、読み取り専用状態、外部キー違反、一意制約違反、ロック中などを区別して表示します。
  * CSV エクスポート時の失敗でも、原因に応じたエラー表示と、失敗時にファイルが残らない挙動が確認されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->