### PR TITLE
fix: include SQLite triggers in metadata and change detection

### DIFF
--- a/src/app/model/shared/db_capabilities.rs
+++ b/src/app/model/shared/db_capabilities.rs
@@ -110,6 +110,7 @@ impl DbCapabilities {
                 InspectorTab::Columns,
                 InspectorTab::Indexes,
                 InspectorTab::ForeignKeys,
+                InspectorTab::Triggers,
                 InspectorTab::Ddl,
             ],
             vec![
@@ -264,6 +265,7 @@ mod tests {
                     InspectorTab::Columns,
                     InspectorTab::Indexes,
                     InspectorTab::ForeignKeys,
+                    InspectorTab::Triggers,
                     InspectorTab::Ddl
                 ]
             );

--- a/src/infra/adapters/sqlite/cli.rs
+++ b/src/infra/adapters/sqlite/cli.rs
@@ -8,6 +8,8 @@ use tokio::time::timeout;
 
 use crate::app::ports::outbound::DbOperationError;
 
+use super::error::classify_query_error;
+
 pub(super) const BUSY_TIMEOUT_MS: u64 = 5_000;
 
 #[derive(Debug, Clone)]
@@ -33,7 +35,7 @@ impl SqliteCli {
     ) -> Result<T, DbOperationError> {
         let output = self.run(path, &["-json"], sql, true).await?;
         if !output.status.success() {
-            return Err(DbOperationError::QueryFailed(output.stderr));
+            return Err(classify_query_error(&output.stderr));
         }
         let stdout = match output.stdout.trim() {
             "" => "[]",
@@ -57,7 +59,7 @@ impl SqliteCli {
             )
             .await?;
         if !output.status.success() {
-            return Err(DbOperationError::QueryFailed(output.stderr));
+            return Err(classify_query_error(&output.stderr));
         }
         Ok(output.stdout)
     }
@@ -77,7 +79,7 @@ impl SqliteCli {
             )
             .await?;
         if !output.status.success() {
-            return Err(DbOperationError::QueryFailed(output.stderr));
+            return Err(classify_query_error(&output.stderr));
         }
         Ok(output.stdout)
     }
@@ -146,7 +148,7 @@ impl SqliteCli {
 
         if !status.success() {
             let _ = tokio::fs::remove_file(output_path).await;
-            return Err(DbOperationError::QueryFailed(stderr));
+            return Err(classify_query_error(&stderr));
         }
 
         Ok(newline_count.saturating_sub(1))

--- a/src/infra/adapters/sqlite/error.rs
+++ b/src/infra/adapters/sqlite/error.rs
@@ -124,7 +124,9 @@ mod tests {
             ClassifiedKind::QueryFailed
         )]
         fn classifies_sqlite_stderr(#[case] input: &str, #[case] expected: ClassifiedKind) {
-            assert_eq!(classified_kind(&classify_query_error(input)), expected);
+            let error = classify_query_error(input);
+
+            assert_eq!(classified_kind(&error), expected);
         }
 
         #[test]
@@ -143,16 +145,17 @@ mod tests {
 
         #[test]
         fn unknown_falls_back_safely() {
-            assert!(matches!(
-                classify_query_error("some random error"),
-                DbOperationError::QueryFailed(_)
-            ));
+            let error = classify_query_error("some random error");
+
+            assert!(matches!(error, DbOperationError::QueryFailed(_)));
         }
 
         #[test]
         fn empty_stderr_falls_back_to_query_failed() {
+            let error = classify_query_error("   ");
+
             assert!(matches!(
-                classify_query_error("   "),
+                error,
                 DbOperationError::QueryFailed(details) if details.is_empty()
             ));
         }

--- a/src/infra/adapters/sqlite/error.rs
+++ b/src/infra/adapters/sqlite/error.rs
@@ -1,0 +1,126 @@
+use crate::app::ports::outbound::DbOperationError;
+
+pub(in crate::adapters::sqlite) fn classify_query_error(stderr: &str) -> DbOperationError {
+    let trimmed = stderr.trim();
+    let Some(details) = (!trimmed.is_empty()).then_some(trimmed) else {
+        return DbOperationError::QueryFailed(String::new());
+    };
+
+    classify_by_stderr(details)
+}
+
+fn classify_by_stderr(details: &str) -> DbOperationError {
+    let lower = details.to_ascii_lowercase();
+
+    // Keep table-list fallback in SqliteAdapter::list_tables working.
+    if lower.contains("pragma_table_list") {
+        return DbOperationError::QueryFailed(details.to_string());
+    }
+
+    if is_locked(&lower) {
+        return DbOperationError::LockTimeout(details.to_string());
+    }
+
+    if is_readonly(&lower) {
+        return DbOperationError::PermissionDenied(details.to_string());
+    }
+
+    if lower.contains("foreign key constraint failed") {
+        return DbOperationError::ForeignKeyViolation(details.to_string());
+    }
+
+    if lower.contains("unique constraint failed") {
+        return DbOperationError::UniqueViolation(details.to_string());
+    }
+
+    if is_missing_object(&lower) {
+        return DbOperationError::ObjectMissing(details.to_string());
+    }
+
+    DbOperationError::QueryFailed(details.to_string())
+}
+
+fn is_locked(lower: &str) -> bool {
+    lower.contains("database is locked")
+        || lower.contains("database table is locked")
+        || lower.contains("sqlite_busy")
+}
+
+fn is_readonly(lower: &str) -> bool {
+    lower.contains("readonly database") || lower.contains("read-only database")
+}
+
+fn is_missing_object(lower: &str) -> bool {
+    lower.contains("no such table")
+        || lower.contains("no such column")
+        || lower.contains("no such view")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    mod classification {
+        use super::*;
+
+        #[rstest]
+        #[case("Error: database is locked", "LockTimeout")]
+        #[case("Runtime error: database is locked (SQLITE_BUSY)", "LockTimeout")]
+        #[case("Error: attempt to write a readonly database", "PermissionDenied")]
+        #[case("Error: FOREIGN KEY constraint failed", "ForeignKeyViolation")]
+        #[case("Error: UNIQUE constraint failed: users.email", "UniqueViolation")]
+        #[case("Parse error: near \"SELEKT\": syntax error", "QueryFailed")]
+        #[case("Error: near \"SELEKT\": syntax error", "QueryFailed")]
+        #[case("Error: no such table: users", "ObjectMissing")]
+        #[case("Error: no such column: missing", "ObjectMissing")]
+        #[case(
+            "Error: in prepare, no such table: main.pragma_table_list",
+            "QueryFailed"
+        )]
+        fn classifies_sqlite_stderr(#[case] input: &str, #[case] expected: &str) {
+            let error = classify_query_error(input);
+            let actual = match error {
+                DbOperationError::PermissionDenied(_) => "PermissionDenied",
+                DbOperationError::ForeignKeyViolation(_) => "ForeignKeyViolation",
+                DbOperationError::UniqueViolation(_) => "UniqueViolation",
+                DbOperationError::LockTimeout(_) => "LockTimeout",
+                DbOperationError::ObjectMissing(_) => "ObjectMissing",
+                DbOperationError::QueryFailed(_) => "QueryFailed",
+                _ => "Other",
+            };
+
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn lock_readonly_and_constraints_use_distinct_summaries() {
+            let lock = classify_query_error("Error: database is locked");
+            let readonly = classify_query_error("Error: attempt to write a readonly database");
+            let foreign_key = classify_query_error("Error: FOREIGN KEY constraint failed");
+            let unique = classify_query_error("Error: UNIQUE constraint failed: users.email");
+
+            assert_ne!(lock.summary(), readonly.summary());
+            assert_ne!(lock.summary(), foreign_key.summary());
+            assert_ne!(lock.summary(), unique.summary());
+            assert_ne!(readonly.summary(), foreign_key.summary());
+            assert_ne!(foreign_key.summary(), unique.summary());
+        }
+
+        #[test]
+        fn unknown_falls_back_safely() {
+            assert!(matches!(
+                classify_query_error("some random error"),
+                DbOperationError::QueryFailed(_)
+            ));
+        }
+
+        #[test]
+        fn empty_stderr_falls_back_to_query_failed() {
+            assert!(matches!(
+                classify_query_error("   "),
+                DbOperationError::QueryFailed(details) if details.is_empty()
+            ));
+        }
+    }
+}

--- a/src/infra/adapters/sqlite/error.rs
+++ b/src/infra/adapters/sqlite/error.rs
@@ -54,6 +54,8 @@ fn is_missing_object(lower: &str) -> bool {
     lower.contains("no such table")
         || lower.contains("no such column")
         || lower.contains("no such view")
+        || lower.contains("no such index")
+        || lower.contains("no such trigger")
 }
 
 #[cfg(test)]
@@ -61,36 +63,68 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ClassifiedKind {
+        PermissionDenied,
+        ForeignKeyViolation,
+        UniqueViolation,
+        LockTimeout,
+        ObjectMissing,
+        QueryFailed,
+        Other,
+    }
+
+    fn classified_kind(error: &DbOperationError) -> ClassifiedKind {
+        match error {
+            DbOperationError::PermissionDenied(_) => ClassifiedKind::PermissionDenied,
+            DbOperationError::ForeignKeyViolation(_) => ClassifiedKind::ForeignKeyViolation,
+            DbOperationError::UniqueViolation(_) => ClassifiedKind::UniqueViolation,
+            DbOperationError::LockTimeout(_) => ClassifiedKind::LockTimeout,
+            DbOperationError::ObjectMissing(_) => ClassifiedKind::ObjectMissing,
+            DbOperationError::QueryFailed(_) => ClassifiedKind::QueryFailed,
+            _ => ClassifiedKind::Other,
+        }
+    }
+
     mod classification {
         use super::*;
 
         #[rstest]
-        #[case("Error: database is locked", "LockTimeout")]
-        #[case("Runtime error: database is locked (SQLITE_BUSY)", "LockTimeout")]
-        #[case("Error: attempt to write a readonly database", "PermissionDenied")]
-        #[case("Error: FOREIGN KEY constraint failed", "ForeignKeyViolation")]
-        #[case("Error: UNIQUE constraint failed: users.email", "UniqueViolation")]
-        #[case("Parse error: near \"SELEKT\": syntax error", "QueryFailed")]
-        #[case("Error: near \"SELEKT\": syntax error", "QueryFailed")]
-        #[case("Error: no such table: users", "ObjectMissing")]
-        #[case("Error: no such column: missing", "ObjectMissing")]
+        #[case("Error: database is locked", ClassifiedKind::LockTimeout)]
+        #[case(
+            "Runtime error: database is locked (SQLITE_BUSY)",
+            ClassifiedKind::LockTimeout
+        )]
+        #[case(
+            "Error: attempt to write a readonly database",
+            ClassifiedKind::PermissionDenied
+        )]
+        #[case(
+            "Error: FOREIGN KEY constraint failed",
+            ClassifiedKind::ForeignKeyViolation
+        )]
+        #[case(
+            "Error: UNIQUE constraint failed: users.email",
+            ClassifiedKind::UniqueViolation
+        )]
+        #[case(
+            "Parse error: near \"SELEKT\": syntax error",
+            ClassifiedKind::QueryFailed
+        )]
+        #[case("Error: near \"SELEKT\": syntax error", ClassifiedKind::QueryFailed)]
+        #[case("Error: no such table: users", ClassifiedKind::ObjectMissing)]
+        #[case("Error: no such column: missing", ClassifiedKind::ObjectMissing)]
+        #[case("Error: no such index: missing_idx", ClassifiedKind::ObjectMissing)]
+        #[case(
+            "Error: no such trigger: missing_trigger",
+            ClassifiedKind::ObjectMissing
+        )]
         #[case(
             "Error: in prepare, no such table: main.pragma_table_list",
-            "QueryFailed"
+            ClassifiedKind::QueryFailed
         )]
-        fn classifies_sqlite_stderr(#[case] input: &str, #[case] expected: &str) {
-            let error = classify_query_error(input);
-            let actual = match error {
-                DbOperationError::PermissionDenied(_) => "PermissionDenied",
-                DbOperationError::ForeignKeyViolation(_) => "ForeignKeyViolation",
-                DbOperationError::UniqueViolation(_) => "UniqueViolation",
-                DbOperationError::LockTimeout(_) => "LockTimeout",
-                DbOperationError::ObjectMissing(_) => "ObjectMissing",
-                DbOperationError::QueryFailed(_) => "QueryFailed",
-                _ => "Other",
-            };
-
-            assert_eq!(actual, expected);
+        fn classifies_sqlite_stderr(#[case] input: &str, #[case] expected: ClassifiedKind) {
+            assert_eq!(classified_kind(&classify_query_error(input)), expected);
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -849,34 +849,10 @@ fn skip_update_of_clause(sql: &str, pos: usize) -> usize {
     }
 }
 
-fn parse_sqlite_trigger_header(
+fn parse_sqlite_trigger_events(
     sql: &str,
     pos: usize,
-) -> Result<(TriggerTiming, Vec<TriggerEvent>, usize), DbOperationError> {
-    let Some((keyword, next)) = next_keyword_from(sql, pos) else {
-        return Err(sqlite_trigger_parse_error(sql, "missing trigger timing"));
-    };
-
-    let (timing, pos) = match keyword.to_ascii_uppercase().as_str() {
-        "BEFORE" => (TriggerTiming::Before, next),
-        "AFTER" => (TriggerTiming::After, next),
-        "INSTEAD" => {
-            let Some((of, next)) = next_keyword_from(sql, next) else {
-                return Err(sqlite_trigger_parse_error(sql, "incomplete INSTEAD OF"));
-            };
-            if !of.eq_ignore_ascii_case("OF") {
-                return Err(sqlite_trigger_parse_error(sql, "expected OF after INSTEAD"));
-            }
-            (TriggerTiming::InsteadOf, next)
-        }
-        _ => {
-            return Err(sqlite_trigger_parse_error(
-                sql,
-                "unsupported trigger timing",
-            ));
-        }
-    };
-
+) -> Result<(Vec<TriggerEvent>, usize), DbOperationError> {
     let mut events = Vec::new();
     let mut pos = pos;
     loop {
@@ -904,7 +880,48 @@ fn parse_sqlite_trigger_header(
         return Err(sqlite_trigger_parse_error(sql, "no trigger events"));
     }
 
-    Ok((timing, events, pos))
+    Ok((events, pos))
+}
+
+fn parse_sqlite_trigger_header(
+    sql: &str,
+    pos: usize,
+) -> Result<(TriggerTiming, Vec<TriggerEvent>, usize), DbOperationError> {
+    let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+        return Err(sqlite_trigger_parse_error(
+            sql,
+            "missing trigger timing or event",
+        ));
+    };
+
+    match keyword.to_ascii_uppercase().as_str() {
+        "BEFORE" => {
+            let (events, pos) = parse_sqlite_trigger_events(sql, next)?;
+            Ok((TriggerTiming::Before, events, pos))
+        }
+        "AFTER" => {
+            let (events, pos) = parse_sqlite_trigger_events(sql, next)?;
+            Ok((TriggerTiming::After, events, pos))
+        }
+        "INSTEAD" => {
+            let Some((of, next)) = next_keyword_from(sql, next) else {
+                return Err(sqlite_trigger_parse_error(sql, "incomplete INSTEAD OF"));
+            };
+            if !of.eq_ignore_ascii_case("OF") {
+                return Err(sqlite_trigger_parse_error(sql, "expected OF after INSTEAD"));
+            }
+            let (events, pos) = parse_sqlite_trigger_events(sql, next)?;
+            Ok((TriggerTiming::InsteadOf, events, pos))
+        }
+        "INSERT" | "UPDATE" | "DELETE" => {
+            let (events, pos) = parse_sqlite_trigger_events(sql, pos)?;
+            Ok((TriggerTiming::Before, events, pos))
+        }
+        _ => Err(sqlite_trigger_parse_error(
+            sql,
+            "unsupported trigger timing or event",
+        )),
+    }
 }
 
 fn parse_sqlite_trigger(trigger_name: &str, sql: &str) -> Result<Trigger, DbOperationError> {
@@ -4961,6 +4978,40 @@ END";
 
             assert_eq!(trigger.timing, TriggerTiming::InsteadOf);
             assert_eq!(trigger.events, vec![TriggerEvent::Delete]);
+        }
+
+        #[test]
+        fn omitted_timing_defaults_to_before() {
+            let sql = "CREATE TRIGGER users_log INSERT ON users BEGIN SELECT 1; END";
+            let trigger = parse_sqlite_trigger("users_log", sql).unwrap();
+
+            assert_eq!(trigger.timing, TriggerTiming::Before);
+            assert_eq!(trigger.events, vec![TriggerEvent::Insert]);
+        }
+    }
+
+    mod trigger_metadata {
+        use super::*;
+
+        #[tokio::test]
+        async fn table_detail_loads_trigger_without_explicit_timing() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY);
+            CREATE TRIGGER users_log INSERT ON users BEGIN SELECT 1; END;
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let detail = adapter
+                .fetch_table_detail(&dsn, "main", "users")
+                .await
+                .unwrap();
+
+            assert_eq!(detail.triggers.len(), 1);
+            assert_eq!(detail.triggers[0].name, "users_log");
+            assert_eq!(detail.triggers[0].timing, TriggerTiming::Before);
+            assert_eq!(detail.triggers[0].events, vec![TriggerEvent::Insert]);
         }
     }
 }

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -875,34 +875,10 @@ fn skip_update_of_clause(sql: &str, pos: usize) -> usize {
     }
 }
 
-fn parse_sqlite_trigger_header(
+fn parse_sqlite_trigger_events(
     sql: &str,
     pos: usize,
-) -> Result<(TriggerTiming, Vec<TriggerEvent>, usize), DbOperationError> {
-    let Some((keyword, next)) = next_keyword_from(sql, pos) else {
-        return Err(sqlite_trigger_parse_error(sql, "missing trigger timing"));
-    };
-
-    let (timing, pos) = match keyword.to_ascii_uppercase().as_str() {
-        "BEFORE" => (TriggerTiming::Before, next),
-        "AFTER" => (TriggerTiming::After, next),
-        "INSTEAD" => {
-            let Some((of, next)) = next_keyword_from(sql, next) else {
-                return Err(sqlite_trigger_parse_error(sql, "incomplete INSTEAD OF"));
-            };
-            if !of.eq_ignore_ascii_case("OF") {
-                return Err(sqlite_trigger_parse_error(sql, "expected OF after INSTEAD"));
-            }
-            (TriggerTiming::InsteadOf, next)
-        }
-        _ => {
-            return Err(sqlite_trigger_parse_error(
-                sql,
-                "unsupported trigger timing",
-            ));
-        }
-    };
-
+) -> Result<(Vec<TriggerEvent>, usize), DbOperationError> {
     let mut events = Vec::new();
     let mut pos = pos;
     loop {
@@ -930,7 +906,48 @@ fn parse_sqlite_trigger_header(
         return Err(sqlite_trigger_parse_error(sql, "no trigger events"));
     }
 
-    Ok((timing, events, pos))
+    Ok((events, pos))
+}
+
+fn parse_sqlite_trigger_header(
+    sql: &str,
+    pos: usize,
+) -> Result<(TriggerTiming, Vec<TriggerEvent>, usize), DbOperationError> {
+    let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+        return Err(sqlite_trigger_parse_error(
+            sql,
+            "missing trigger timing or event",
+        ));
+    };
+
+    match keyword.to_ascii_uppercase().as_str() {
+        "BEFORE" => {
+            let (events, pos) = parse_sqlite_trigger_events(sql, next)?;
+            Ok((TriggerTiming::Before, events, pos))
+        }
+        "AFTER" => {
+            let (events, pos) = parse_sqlite_trigger_events(sql, next)?;
+            Ok((TriggerTiming::After, events, pos))
+        }
+        "INSTEAD" => {
+            let Some((of, next)) = next_keyword_from(sql, next) else {
+                return Err(sqlite_trigger_parse_error(sql, "incomplete INSTEAD OF"));
+            };
+            if !of.eq_ignore_ascii_case("OF") {
+                return Err(sqlite_trigger_parse_error(sql, "expected OF after INSTEAD"));
+            }
+            let (events, pos) = parse_sqlite_trigger_events(sql, next)?;
+            Ok((TriggerTiming::InsteadOf, events, pos))
+        }
+        "INSERT" | "UPDATE" | "DELETE" => {
+            let (events, pos) = parse_sqlite_trigger_events(sql, pos)?;
+            Ok((TriggerTiming::Before, events, pos))
+        }
+        _ => Err(sqlite_trigger_parse_error(
+            sql,
+            "unsupported trigger timing or event",
+        )),
+    }
 }
 
 fn parse_sqlite_trigger(trigger_name: &str, sql: &str) -> Result<Trigger, DbOperationError> {
@@ -5095,6 +5112,40 @@ END";
 
             assert_eq!(trigger.timing, TriggerTiming::InsteadOf);
             assert_eq!(trigger.events, vec![TriggerEvent::Delete]);
+        }
+
+        #[test]
+        fn omitted_timing_defaults_to_before() {
+            let sql = "CREATE TRIGGER users_log INSERT ON users BEGIN SELECT 1; END";
+            let trigger = parse_sqlite_trigger("users_log", sql).unwrap();
+
+            assert_eq!(trigger.timing, TriggerTiming::Before);
+            assert_eq!(trigger.events, vec![TriggerEvent::Insert]);
+        }
+    }
+
+    mod trigger_metadata {
+        use super::*;
+
+        #[tokio::test]
+        async fn table_detail_loads_trigger_without_explicit_timing() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY);
+            CREATE TRIGGER users_log INSERT ON users BEGIN SELECT 1; END;
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let detail = adapter
+                .fetch_table_detail(&dsn, "main", "users")
+                .await
+                .unwrap();
+
+            assert_eq!(detail.triggers.len(), 1);
+            assert_eq!(detail.triggers[0].name, "users_log");
+            assert_eq!(detail.triggers[0].timing, TriggerTiming::Before);
+            assert_eq!(detail.triggers[0].events, vec![TriggerEvent::Insert]);
         }
     }
 }

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -1829,7 +1829,7 @@ impl MetadataProvider for SqliteAdapter {
             metadata.table_summaries.push(TableSummary::new(
                 MAIN_SCHEMA.to_string(),
                 table.name.clone(),
-                self.row_count(path, &table.name).await,
+                None,
                 false,
             ));
         }
@@ -3886,7 +3886,23 @@ END";
             assert_eq!(metadata.schemas, vec![Schema::new("main")]);
             assert_eq!(metadata.table_summaries.len(), 1);
             assert_eq!(metadata.table_summaries[0].qualified_name(), "main.users");
-            assert_eq!(metadata.table_summaries[0].row_count_estimate, Some(0));
+            assert!(metadata.table_summaries[0].row_count_estimate.is_none());
+        }
+
+        #[tokio::test]
+        async fn metadata_skips_row_count_even_when_table_has_rows() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY);
+            INSERT INTO users(id) VALUES (1), (2), (3);
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
+
+            assert_eq!(metadata.table_summaries.len(), 1);
+            assert!(metadata.table_summaries[0].row_count_estimate.is_none());
         }
 
         #[tokio::test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -86,6 +86,23 @@ struct RawRowCount {
     count: i64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TableDetailMode {
+    Full,
+    ColumnsAndFks,
+    Signature,
+}
+
+impl TableDetailMode {
+    const fn include_indexes(self) -> bool {
+        matches!(self, Self::Full | Self::Signature)
+    }
+
+    const fn include_row_count(self) -> bool {
+        matches!(self, Self::Full)
+    }
+}
+
 impl SqliteAdapter {
     pub fn new() -> Self {
         Self {
@@ -515,9 +532,10 @@ impl SqliteAdapter {
         &self,
         path: &str,
         table: &str,
-        include_indexes: bool,
-        include_row_count: bool,
+        mode: TableDetailMode,
     ) -> Result<Table, DbOperationError> {
+        let include_indexes = mode.include_indexes();
+        let include_row_count = mode.include_row_count();
         let (indexes, unique_single_columns) = if include_indexes {
             let indexes = self.indexes(path, table).await?;
             let unique_single_columns = indexes
@@ -603,7 +621,7 @@ impl SqliteAdapter {
         table: &RawTable,
     ) -> Result<TableSignature, DbOperationError> {
         let detail = self
-            .table_detail_with_mode(path, &table.name, true, false)
+            .table_detail_with_mode(path, &table.name, TableDetailMode::Signature)
             .await?;
         let mut parts = vec![format!("sql={}", table.sql.clone().unwrap_or_default())];
         parts.extend(detail.columns.iter().map(|column| {
@@ -1850,7 +1868,7 @@ impl MetadataProvider for SqliteAdapter {
         table: &str,
     ) -> Result<Table, DbOperationError> {
         Self::validate_main_schema(schema)?;
-        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, true, true)
+        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, TableDetailMode::Full)
             .await
     }
 
@@ -1861,8 +1879,12 @@ impl MetadataProvider for SqliteAdapter {
         table: &str,
     ) -> Result<Table, DbOperationError> {
         Self::validate_main_schema(schema)?;
-        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, false, false)
-            .await
+        self.table_detail_with_mode(
+            Self::path_from_dsn(dsn)?,
+            table,
+            TableDetailMode::ColumnsAndFks,
+        )
+        .await
     }
 
     async fn fetch_table_signatures(

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -14,6 +14,7 @@ use crate::domain::{
 };
 
 mod cli;
+mod error;
 mod sql;
 
 use cli::SqliteCli;

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -10,7 +10,8 @@ use crate::app::ports::outbound::{DbOperationError, MetadataProvider, QueryExecu
 use crate::domain::{
     Column, ColumnAttributes, CommandTag, DatabaseMetadata, FkAction, ForeignKey, Index,
     IndexAttributes, IndexType, QueryResult, QuerySource, QueryValue, Schema, Table,
-    TableSignature, TableSummary, UNRESOLVED_FK_COLUMN, WriteExecutionResult,
+    TableSignature, TableSummary, Trigger, TriggerEvent, TriggerTiming, UNRESOLVED_FK_COLUMN,
+    WriteExecutionResult,
 };
 
 mod cli;
@@ -80,6 +81,12 @@ struct RawForeignKey {
     to: Option<String>,
     on_update: String,
     on_delete: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawTrigger {
+    name: String,
+    sql: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -399,6 +406,23 @@ impl SqliteAdapter {
             .and_then(|row| row.sql)
     }
 
+    async fn triggers(&self, path: &str, table: &str) -> Result<Vec<Trigger>, DbOperationError> {
+        let raw: Vec<RawTrigger> = self
+            .cli
+            .execute_json(path, &sql::trigger_list_query(table))
+            .await?;
+        let mut triggers = Vec::new();
+
+        for raw in raw {
+            if let Some(sql) = raw.sql {
+                triggers.push(parse_sqlite_trigger(&raw.name, &sql)?);
+            }
+        }
+
+        triggers.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(triggers)
+    }
+
     async fn foreign_keys(
         &self,
         path: &str,
@@ -605,7 +629,7 @@ impl SqliteAdapter {
             foreign_keys: self.foreign_keys(path, table).await?,
             indexes,
             rls: None,
-            triggers: Vec::new(),
+            triggers: self.triggers(path, table).await?,
             row_count_estimate: if include_row_count {
                 self.row_count(path, table).await
             } else {
@@ -662,6 +686,20 @@ impl SqliteAdapter {
                 fk.on_delete,
                 fk.on_update,
                 fk.reference_resolved
+            )
+        }));
+        parts.extend(detail.triggers.iter().map(|trigger| {
+            format!(
+                "trg={}:{}:{}:{}",
+                trigger.name,
+                trigger.timing,
+                trigger
+                    .events
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(","),
+                trigger.function_name
             )
         }));
 
@@ -760,6 +798,173 @@ fn contains_keyword(sql: &str, expected: &str) -> bool {
         offset = end;
     }
     false
+}
+
+fn sqlite_trigger_parse_error(sql: &str, detail: &str) -> DbOperationError {
+    DbOperationError::MetadataParseFailed(format!(
+        "sqlite trigger parse failed ({detail}): {}",
+        sql.chars().take(120).collect::<String>()
+    ))
+}
+
+fn skip_optional_if_not_exists(sql: &str, pos: usize) -> usize {
+    let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+        return pos;
+    };
+    if !keyword.eq_ignore_ascii_case("IF") {
+        return pos;
+    }
+    let Some((not, next)) = next_keyword_from(sql, next) else {
+        return pos;
+    };
+    if !not.eq_ignore_ascii_case("NOT") {
+        return pos;
+    }
+    let Some((exists, next)) = next_keyword_from(sql, next) else {
+        return pos;
+    };
+    if exists.eq_ignore_ascii_case("EXISTS") {
+        next
+    } else {
+        pos
+    }
+}
+
+fn skip_object_reference(sql: &str, pos: usize) -> usize {
+    let bytes = sql.as_bytes();
+    let mut i = pos;
+    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    let start = match bytes.get(i) {
+        Some(b'"' | b'\'' | b'`') => skip_quoted(bytes, i, bytes[i]),
+        Some(b'[') => skip_bracket_quoted(bytes, i),
+        Some(b) if b.is_ascii_alphanumeric() || *b == b'_' => {
+            let Some((_, end)) = next_keyword_from(sql, i) else {
+                return i;
+            };
+            end
+        }
+        _ => return i,
+    };
+    if bytes.get(start) == Some(&b'.')
+        && let Some((_, end)) = next_keyword_from(sql, start + 1)
+    {
+        return end;
+    }
+    start
+}
+
+fn skip_update_of_clause(sql: &str, pos: usize) -> usize {
+    let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+        return pos;
+    };
+    if !keyword.eq_ignore_ascii_case("OF") {
+        return pos;
+    }
+
+    let mut pos = next;
+    loop {
+        let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+            return pos;
+        };
+        match keyword.to_ascii_uppercase().as_str() {
+            "INSERT" | "UPDATE" | "DELETE" | "ON" | "FOR" | "WHEN" | "BEGIN" => return pos,
+            _ => pos = next,
+        }
+    }
+}
+
+fn parse_sqlite_trigger_header(
+    sql: &str,
+    pos: usize,
+) -> Result<(TriggerTiming, Vec<TriggerEvent>, usize), DbOperationError> {
+    let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+        return Err(sqlite_trigger_parse_error(sql, "missing trigger timing"));
+    };
+
+    let (timing, pos) = match keyword.to_ascii_uppercase().as_str() {
+        "BEFORE" => (TriggerTiming::Before, next),
+        "AFTER" => (TriggerTiming::After, next),
+        "INSTEAD" => {
+            let Some((of, next)) = next_keyword_from(sql, next) else {
+                return Err(sqlite_trigger_parse_error(sql, "incomplete INSTEAD OF"));
+            };
+            if !of.eq_ignore_ascii_case("OF") {
+                return Err(sqlite_trigger_parse_error(sql, "expected OF after INSTEAD"));
+            }
+            (TriggerTiming::InsteadOf, next)
+        }
+        _ => {
+            return Err(sqlite_trigger_parse_error(
+                sql,
+                "unsupported trigger timing",
+            ));
+        }
+    };
+
+    let mut events = Vec::new();
+    let mut pos = pos;
+    loop {
+        let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+            return Err(sqlite_trigger_parse_error(sql, "missing trigger event"));
+        };
+        if keyword.eq_ignore_ascii_case("ON") {
+            break;
+        }
+
+        match keyword.to_ascii_uppercase().as_str() {
+            "INSERT" => events.push(TriggerEvent::Insert),
+            "UPDATE" => {
+                events.push(TriggerEvent::Update);
+                pos = skip_update_of_clause(sql, next);
+                continue;
+            }
+            "DELETE" => events.push(TriggerEvent::Delete),
+            _ => return Err(sqlite_trigger_parse_error(sql, "unsupported trigger event")),
+        }
+        pos = next;
+    }
+
+    if events.is_empty() {
+        return Err(sqlite_trigger_parse_error(sql, "no trigger events"));
+    }
+
+    Ok((timing, events, pos))
+}
+
+fn parse_sqlite_trigger(trigger_name: &str, sql: &str) -> Result<Trigger, DbOperationError> {
+    let Some((first, pos)) = next_keyword_from(sql, 0) else {
+        return Err(sqlite_trigger_parse_error(sql, "missing CREATE"));
+    };
+    if !first.eq_ignore_ascii_case("CREATE") {
+        return Err(sqlite_trigger_parse_error(sql, "expected CREATE"));
+    }
+    let Some((second, pos)) = next_keyword_from(sql, pos) else {
+        return Err(sqlite_trigger_parse_error(sql, "missing TRIGGER"));
+    };
+    if !second.eq_ignore_ascii_case("TRIGGER") {
+        return Err(sqlite_trigger_parse_error(sql, "expected TRIGGER"));
+    }
+
+    let mut pos = pos;
+    if let Some((keyword, next)) = next_keyword_from(sql, pos)
+        && keyword.eq_ignore_ascii_case("TEMP")
+    {
+        pos = next;
+    }
+    pos = skip_optional_if_not_exists(sql, pos);
+    pos = skip_object_reference(sql, pos);
+
+    let (timing, events, _) = parse_sqlite_trigger_header(sql, pos)?;
+
+    Ok(Trigger {
+        name: trigger_name.to_string(),
+        timing,
+        events,
+        function_name: sql.to_string(),
+        security_definer: false,
+    })
 }
 
 fn is_create_trigger_prefix(sql: &str) -> bool {
@@ -4148,6 +4353,33 @@ END";
         }
 
         #[tokio::test]
+        async fn loads_table_bound_triggers() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            CREATE TABLE audit(user_id INTEGER);
+            CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN
+                INSERT INTO audit(user_id) VALUES (new.id);
+            END;
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let detail = adapter
+                .fetch_table_detail(&dsn, "main", "users")
+                .await
+                .unwrap();
+
+            assert_eq!(detail.triggers.len(), 1);
+            let trigger = &detail.triggers[0];
+            assert_eq!(trigger.name, "users_audit");
+            assert_eq!(trigger.timing, TriggerTiming::After);
+            assert_eq!(trigger.events, vec![TriggerEvent::Insert]);
+            assert!(trigger.function_name.contains("CREATE TRIGGER users_audit"));
+            assert!(!trigger.security_definer);
+        }
+
+        #[tokio::test]
         async fn without_primary_key_sets_primary_key_none() {
             let (_dir, dsn) = make_sqlite_db("CREATE TABLE logs(message TEXT);");
             let adapter = SqliteAdapter::new();
@@ -4790,6 +5022,79 @@ END";
                     "idx=idx_users_name:name:false:false:false:false:true:false:true:CREATE INDEX idx_users_name ON users(name COLLATE NOCASE)"
                 )
             );
+        }
+
+        #[tokio::test]
+        async fn trigger_change_updates_signature() {
+            let setup = r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY);
+            CREATE TABLE audit(user_id INTEGER);
+            ";
+            let trigger = r"
+            CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN
+                INSERT INTO audit(user_id) VALUES (new.id);
+            END;
+            ";
+            let (_dir, dsn) = make_sqlite_db(setup);
+            let adapter = SqliteAdapter::new();
+
+            let before = adapter.fetch_table_signatures(&dsn).await.unwrap();
+            let before_signature = before
+                .iter()
+                .find(|signature| signature.name == "users")
+                .unwrap()
+                .signature
+                .clone();
+
+            adapter.execute_adhoc(&dsn, trigger, false).await.unwrap();
+
+            let after = adapter.fetch_table_signatures(&dsn).await.unwrap();
+            let after_signature = &after
+                .iter()
+                .find(|signature| signature.name == "users")
+                .unwrap()
+                .signature;
+
+            assert_ne!(before_signature, after_signature.as_str());
+            assert!(
+                after_signature.contains("trg=users_audit:AFTER:INSERT:CREATE TRIGGER users_audit")
+            );
+        }
+    }
+
+    mod trigger_parsing {
+        use super::*;
+
+        #[test]
+        fn parses_after_insert_trigger() {
+            let sql = "CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END";
+            let trigger = parse_sqlite_trigger("users_audit", sql).unwrap();
+
+            assert_eq!(trigger.name, "users_audit");
+            assert_eq!(trigger.timing, TriggerTiming::After);
+            assert_eq!(trigger.events, vec![TriggerEvent::Insert]);
+            assert_eq!(trigger.function_name, sql);
+            assert!(!trigger.security_definer);
+        }
+
+        #[test]
+        fn parses_before_update_of_columns() {
+            let sql =
+                "CREATE TRIGGER users_guard BEFORE UPDATE OF name ON users BEGIN SELECT 1; END";
+            let trigger = parse_sqlite_trigger("users_guard", sql).unwrap();
+
+            assert_eq!(trigger.timing, TriggerTiming::Before);
+            assert_eq!(trigger.events, vec![TriggerEvent::Update]);
+        }
+
+        #[test]
+        fn parses_instead_of_delete_trigger() {
+            let sql =
+                "CREATE TRIGGER users_view_io INSTEAD OF DELETE ON users_view BEGIN SELECT 1; END";
+            let trigger = parse_sqlite_trigger("users_view_io", sql).unwrap();
+
+            assert_eq!(trigger.timing, TriggerTiming::InsteadOf);
+            assert_eq!(trigger.events, vec![TriggerEvent::Delete]);
         }
     }
 }

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -3897,6 +3897,32 @@ END";
         }
 
         #[tokio::test]
+        async fn export_to_csv_missing_table_returns_object_missing_and_removes_file() {
+            let (dir, dsn) = make_sqlite_db("");
+            let path = dir.path().join("missing_export.csv");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .export_to_csv(&dsn, "SELECT id FROM missing", &path, true)
+                .await;
+
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+            assert!(!path.exists());
+        }
+
+        #[tokio::test]
+        async fn count_query_rows_missing_table_returns_object_missing() {
+            let (_dir, dsn) = make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .count_query_rows(&dsn, "SELECT COUNT(*) FROM missing", true)
+                .await;
+
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+        }
+
+        #[tokio::test]
         async fn read_only_write_fails() {
             let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
             let adapter = SqliteAdapter::new();

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -516,6 +516,7 @@ impl SqliteAdapter {
         path: &str,
         table: &str,
         include_indexes: bool,
+        include_row_count: bool,
     ) -> Result<Table, DbOperationError> {
         let (indexes, unique_single_columns) = if include_indexes {
             let indexes = self.indexes(path, table).await?;
@@ -586,7 +587,11 @@ impl SqliteAdapter {
             indexes,
             rls: None,
             triggers: Vec::new(),
-            row_count_estimate: self.row_count(path, table).await,
+            row_count_estimate: if include_row_count {
+                self.row_count(path, table).await
+            } else {
+                None
+            },
             comment: None,
             source_ddl: self.table_definition(path, table).await,
         })
@@ -597,7 +602,9 @@ impl SqliteAdapter {
         path: &str,
         table: &RawTable,
     ) -> Result<TableSignature, DbOperationError> {
-        let detail = self.table_detail_with_mode(path, &table.name, true).await?;
+        let detail = self
+            .table_detail_with_mode(path, &table.name, true, false)
+            .await?;
         let mut parts = vec![format!("sql={}", table.sql.clone().unwrap_or_default())];
         parts.extend(detail.columns.iter().map(|column| {
             format!(
@@ -1843,7 +1850,7 @@ impl MetadataProvider for SqliteAdapter {
         table: &str,
     ) -> Result<Table, DbOperationError> {
         Self::validate_main_schema(schema)?;
-        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, true)
+        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, true, true)
             .await
     }
 
@@ -1854,7 +1861,7 @@ impl MetadataProvider for SqliteAdapter {
         table: &str,
     ) -> Result<Table, DbOperationError> {
         Self::validate_main_schema(schema)?;
-        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, false)
+        self.table_detail_with_mode(Self::path_from_dsn(dsn)?, table, false, false)
             .await
     }
 
@@ -3890,7 +3897,7 @@ END";
         }
 
         #[tokio::test]
-        async fn metadata_skips_row_count_even_when_table_has_rows() {
+        async fn skips_row_count_even_when_table_has_rows() {
             let (_dir, dsn) = make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY);
@@ -4027,6 +4034,29 @@ END";
             assert_eq!(fk.on_delete, FkAction::Cascade);
             assert!(detail.rls.is_none());
             assert!(detail.triggers.is_empty());
+        }
+
+        #[tokio::test]
+        async fn columns_and_fks_skips_row_count() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY);
+            INSERT INTO users(id) VALUES (1), (2), (3);
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let light = adapter
+                .fetch_table_columns_and_fks(&dsn, "main", "users")
+                .await
+                .unwrap();
+            let full = adapter
+                .fetch_table_detail(&dsn, "main", "users")
+                .await
+                .unwrap();
+
+            assert!(light.row_count_estimate.is_none());
+            assert_eq!(full.row_count_estimate, Some(3));
         }
 
         #[tokio::test]

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -3421,7 +3421,7 @@ END";
                 )
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
@@ -3483,7 +3483,7 @@ END";
                 )
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
@@ -3506,7 +3506,7 @@ END";
                 )
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
@@ -3523,7 +3523,7 @@ END";
 
             let result = adapter.execute_adhoc(&dsn, query, false).await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
@@ -3544,7 +3544,7 @@ END";
                 )
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
                 .execute_adhoc(&dsn, "SELECT id FROM users", true)
                 .await
@@ -3729,10 +3729,49 @@ END";
                 .await
                 .unwrap();
 
-            assert!(
-                matches!(result, Err(DbOperationError::QueryFailed(message)) if message.contains("FOREIGN KEY constraint failed"))
-            );
+            assert!(matches!(
+                result,
+                Err(DbOperationError::ForeignKeyViolation(_))
+            ));
             assert_eq!(children.rows(), vec![vec!["1".to_string()]]);
+        }
+
+        #[tokio::test]
+        async fn unique_constraint_violation_is_classified() {
+            let (_dir, dsn) = make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT UNIQUE NOT NULL);",
+            );
+            let adapter = SqliteAdapter::new();
+
+            adapter
+                .execute_write(
+                    &dsn,
+                    "INSERT INTO users(id, email) VALUES (1, 'a@example.com')",
+                    false,
+                )
+                .await
+                .unwrap();
+
+            let result = adapter
+                .execute_write(
+                    &dsn,
+                    "INSERT INTO users(id, email) VALUES (2, 'a@example.com')",
+                    false,
+                )
+                .await;
+
+            assert!(matches!(result, Err(DbOperationError::UniqueViolation(_))));
+        }
+
+        #[tokio::test]
+        async fn syntax_error_stays_query_failed_with_details() {
+            let (_dir, dsn) = make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter.execute_adhoc(&dsn, "SELEKT 1", true).await;
+
+            assert!(matches!(result, Err(DbOperationError::QueryFailed(message))
+                    if message.to_ascii_lowercase().contains("syntax error")));
         }
 
         #[tokio::test]
@@ -3866,7 +3905,7 @@ END";
                 .execute_write(&dsn, "INSERT INTO users(id) VALUES (1)", true)
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(result, Err(DbOperationError::PermissionDenied(_))));
         }
     }
 

--- a/src/infra/adapters/sqlite/mod.rs
+++ b/src/infra/adapters/sqlite/mod.rs
@@ -10,7 +10,8 @@ use crate::app::ports::outbound::{DbOperationError, MetadataProvider, QueryExecu
 use crate::domain::{
     Column, ColumnAttributes, CommandTag, DatabaseMetadata, FkAction, ForeignKey, Index,
     IndexAttributes, IndexType, QueryResult, QuerySource, QueryValue, Schema, Table,
-    TableSignature, TableSummary, UNRESOLVED_FK_COLUMN, WriteExecutionResult,
+    TableSignature, TableSummary, Trigger, TriggerEvent, TriggerTiming, UNRESOLVED_FK_COLUMN,
+    WriteExecutionResult,
 };
 
 mod cli;
@@ -79,6 +80,12 @@ struct RawForeignKey {
     to: Option<String>,
     on_update: String,
     on_delete: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawTrigger {
+    name: String,
+    sql: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -381,6 +388,23 @@ impl SqliteAdapter {
             .and_then(|row| row.sql)
     }
 
+    async fn triggers(&self, path: &str, table: &str) -> Result<Vec<Trigger>, DbOperationError> {
+        let raw: Vec<RawTrigger> = self
+            .cli
+            .execute_json(path, &sql::trigger_list_query(table))
+            .await?;
+        let mut triggers = Vec::new();
+
+        for raw in raw {
+            if let Some(sql) = raw.sql {
+                triggers.push(parse_sqlite_trigger(&raw.name, &sql)?);
+            }
+        }
+
+        triggers.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(triggers)
+    }
+
     async fn foreign_keys(
         &self,
         path: &str,
@@ -585,7 +609,7 @@ impl SqliteAdapter {
             foreign_keys: self.foreign_keys(path, table).await?,
             indexes,
             rls: None,
-            triggers: Vec::new(),
+            triggers: self.triggers(path, table).await?,
             row_count_estimate: self.row_count(path, table).await,
             comment: None,
             source_ddl: self.table_definition(path, table).await,
@@ -636,6 +660,20 @@ impl SqliteAdapter {
                 fk.on_delete,
                 fk.on_update,
                 fk.reference_resolved
+            )
+        }));
+        parts.extend(detail.triggers.iter().map(|trigger| {
+            format!(
+                "trg={}:{}:{}:{}",
+                trigger.name,
+                trigger.timing,
+                trigger
+                    .events
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(","),
+                trigger.function_name
             )
         }));
 
@@ -734,6 +772,173 @@ fn contains_keyword(sql: &str, expected: &str) -> bool {
         offset = end;
     }
     false
+}
+
+fn sqlite_trigger_parse_error(sql: &str, detail: &str) -> DbOperationError {
+    DbOperationError::MetadataParseFailed(format!(
+        "sqlite trigger parse failed ({detail}): {}",
+        sql.chars().take(120).collect::<String>()
+    ))
+}
+
+fn skip_optional_if_not_exists(sql: &str, pos: usize) -> usize {
+    let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+        return pos;
+    };
+    if !keyword.eq_ignore_ascii_case("IF") {
+        return pos;
+    }
+    let Some((not, next)) = next_keyword_from(sql, next) else {
+        return pos;
+    };
+    if !not.eq_ignore_ascii_case("NOT") {
+        return pos;
+    }
+    let Some((exists, next)) = next_keyword_from(sql, next) else {
+        return pos;
+    };
+    if exists.eq_ignore_ascii_case("EXISTS") {
+        next
+    } else {
+        pos
+    }
+}
+
+fn skip_object_reference(sql: &str, pos: usize) -> usize {
+    let bytes = sql.as_bytes();
+    let mut i = pos;
+    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    let start = match bytes.get(i) {
+        Some(b'"' | b'\'' | b'`') => skip_quoted(bytes, i, bytes[i]),
+        Some(b'[') => skip_bracket_quoted(bytes, i),
+        Some(b) if b.is_ascii_alphanumeric() || *b == b'_' => {
+            let Some((_, end)) = next_keyword_from(sql, i) else {
+                return i;
+            };
+            end
+        }
+        _ => return i,
+    };
+    if bytes.get(start) == Some(&b'.')
+        && let Some((_, end)) = next_keyword_from(sql, start + 1)
+    {
+        return end;
+    }
+    start
+}
+
+fn skip_update_of_clause(sql: &str, pos: usize) -> usize {
+    let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+        return pos;
+    };
+    if !keyword.eq_ignore_ascii_case("OF") {
+        return pos;
+    }
+
+    let mut pos = next;
+    loop {
+        let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+            return pos;
+        };
+        match keyword.to_ascii_uppercase().as_str() {
+            "INSERT" | "UPDATE" | "DELETE" | "ON" | "FOR" | "WHEN" | "BEGIN" => return pos,
+            _ => pos = next,
+        }
+    }
+}
+
+fn parse_sqlite_trigger_header(
+    sql: &str,
+    pos: usize,
+) -> Result<(TriggerTiming, Vec<TriggerEvent>, usize), DbOperationError> {
+    let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+        return Err(sqlite_trigger_parse_error(sql, "missing trigger timing"));
+    };
+
+    let (timing, pos) = match keyword.to_ascii_uppercase().as_str() {
+        "BEFORE" => (TriggerTiming::Before, next),
+        "AFTER" => (TriggerTiming::After, next),
+        "INSTEAD" => {
+            let Some((of, next)) = next_keyword_from(sql, next) else {
+                return Err(sqlite_trigger_parse_error(sql, "incomplete INSTEAD OF"));
+            };
+            if !of.eq_ignore_ascii_case("OF") {
+                return Err(sqlite_trigger_parse_error(sql, "expected OF after INSTEAD"));
+            }
+            (TriggerTiming::InsteadOf, next)
+        }
+        _ => {
+            return Err(sqlite_trigger_parse_error(
+                sql,
+                "unsupported trigger timing",
+            ));
+        }
+    };
+
+    let mut events = Vec::new();
+    let mut pos = pos;
+    loop {
+        let Some((keyword, next)) = next_keyword_from(sql, pos) else {
+            return Err(sqlite_trigger_parse_error(sql, "missing trigger event"));
+        };
+        if keyword.eq_ignore_ascii_case("ON") {
+            break;
+        }
+
+        match keyword.to_ascii_uppercase().as_str() {
+            "INSERT" => events.push(TriggerEvent::Insert),
+            "UPDATE" => {
+                events.push(TriggerEvent::Update);
+                pos = skip_update_of_clause(sql, next);
+                continue;
+            }
+            "DELETE" => events.push(TriggerEvent::Delete),
+            _ => return Err(sqlite_trigger_parse_error(sql, "unsupported trigger event")),
+        }
+        pos = next;
+    }
+
+    if events.is_empty() {
+        return Err(sqlite_trigger_parse_error(sql, "no trigger events"));
+    }
+
+    Ok((timing, events, pos))
+}
+
+fn parse_sqlite_trigger(trigger_name: &str, sql: &str) -> Result<Trigger, DbOperationError> {
+    let Some((first, pos)) = next_keyword_from(sql, 0) else {
+        return Err(sqlite_trigger_parse_error(sql, "missing CREATE"));
+    };
+    if !first.eq_ignore_ascii_case("CREATE") {
+        return Err(sqlite_trigger_parse_error(sql, "expected CREATE"));
+    }
+    let Some((second, pos)) = next_keyword_from(sql, pos) else {
+        return Err(sqlite_trigger_parse_error(sql, "missing TRIGGER"));
+    };
+    if !second.eq_ignore_ascii_case("TRIGGER") {
+        return Err(sqlite_trigger_parse_error(sql, "expected TRIGGER"));
+    }
+
+    let mut pos = pos;
+    if let Some((keyword, next)) = next_keyword_from(sql, pos)
+        && keyword.eq_ignore_ascii_case("TEMP")
+    {
+        pos = next;
+    }
+    pos = skip_optional_if_not_exists(sql, pos);
+    pos = skip_object_reference(sql, pos);
+
+    let (timing, events, _) = parse_sqlite_trigger_header(sql, pos)?;
+
+    Ok(Trigger {
+        name: trigger_name.to_string(),
+        timing,
+        events,
+        function_name: sql.to_string(),
+        security_definer: false,
+    })
 }
 
 fn is_create_trigger_prefix(sql: &str) -> bool {
@@ -4014,6 +4219,33 @@ END";
         }
 
         #[tokio::test]
+        async fn loads_table_bound_triggers() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            CREATE TABLE audit(user_id INTEGER);
+            CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN
+                INSERT INTO audit(user_id) VALUES (new.id);
+            END;
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let detail = adapter
+                .fetch_table_detail(&dsn, "main", "users")
+                .await
+                .unwrap();
+
+            assert_eq!(detail.triggers.len(), 1);
+            let trigger = &detail.triggers[0];
+            assert_eq!(trigger.name, "users_audit");
+            assert_eq!(trigger.timing, TriggerTiming::After);
+            assert_eq!(trigger.events, vec![TriggerEvent::Insert]);
+            assert!(trigger.function_name.contains("CREATE TRIGGER users_audit"));
+            assert!(!trigger.security_definer);
+        }
+
+        #[tokio::test]
         async fn without_primary_key_sets_primary_key_none() {
             let (_dir, dsn) = make_sqlite_db("CREATE TABLE logs(message TEXT);");
             let adapter = SqliteAdapter::new();
@@ -4656,6 +4888,79 @@ END";
                     "idx=idx_users_name:name:false:false:false:false:true:false:true:CREATE INDEX idx_users_name ON users(name COLLATE NOCASE)"
                 )
             );
+        }
+
+        #[tokio::test]
+        async fn trigger_change_updates_signature() {
+            let setup = r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY);
+            CREATE TABLE audit(user_id INTEGER);
+            ";
+            let trigger = r"
+            CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN
+                INSERT INTO audit(user_id) VALUES (new.id);
+            END;
+            ";
+            let (_dir, dsn) = make_sqlite_db(setup);
+            let adapter = SqliteAdapter::new();
+
+            let before = adapter.fetch_table_signatures(&dsn).await.unwrap();
+            let before_signature = before
+                .iter()
+                .find(|signature| signature.name == "users")
+                .unwrap()
+                .signature
+                .clone();
+
+            adapter.execute_adhoc(&dsn, trigger, false).await.unwrap();
+
+            let after = adapter.fetch_table_signatures(&dsn).await.unwrap();
+            let after_signature = &after
+                .iter()
+                .find(|signature| signature.name == "users")
+                .unwrap()
+                .signature;
+
+            assert_ne!(before_signature, after_signature.as_str());
+            assert!(
+                after_signature.contains("trg=users_audit:AFTER:INSERT:CREATE TRIGGER users_audit")
+            );
+        }
+    }
+
+    mod trigger_parsing {
+        use super::*;
+
+        #[test]
+        fn parses_after_insert_trigger() {
+            let sql = "CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END";
+            let trigger = parse_sqlite_trigger("users_audit", sql).unwrap();
+
+            assert_eq!(trigger.name, "users_audit");
+            assert_eq!(trigger.timing, TriggerTiming::After);
+            assert_eq!(trigger.events, vec![TriggerEvent::Insert]);
+            assert_eq!(trigger.function_name, sql);
+            assert!(!trigger.security_definer);
+        }
+
+        #[test]
+        fn parses_before_update_of_columns() {
+            let sql =
+                "CREATE TRIGGER users_guard BEFORE UPDATE OF name ON users BEGIN SELECT 1; END";
+            let trigger = parse_sqlite_trigger("users_guard", sql).unwrap();
+
+            assert_eq!(trigger.timing, TriggerTiming::Before);
+            assert_eq!(trigger.events, vec![TriggerEvent::Update]);
+        }
+
+        #[test]
+        fn parses_instead_of_delete_trigger() {
+            let sql =
+                "CREATE TRIGGER users_view_io INSTEAD OF DELETE ON users_view BEGIN SELECT 1; END";
+            let trigger = parse_sqlite_trigger("users_view_io", sql).unwrap();
+
+            assert_eq!(trigger.timing, TriggerTiming::InsteadOf);
+            assert_eq!(trigger.events, vec![TriggerEvent::Delete]);
         }
     }
 }

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -232,13 +232,27 @@ pub(super) fn trigger_list_query(table: &str) -> String {
     )
 }
 
+fn terminate_ddl_statement(ddl: &mut String) {
+    let trimmed_len = ddl.trim_end().len();
+    if trimmed_len == 0 {
+        ddl.clear();
+        return;
+    }
+    ddl.truncate(trimmed_len);
+    if !ddl.ends_with(';') {
+        ddl.push(';');
+    }
+}
+
 fn append_trigger_ddls(ddl: &mut String, triggers: &[Trigger]) {
+    if triggers.is_empty() {
+        return;
+    }
+    terminate_ddl_statement(ddl);
     for trigger in triggers {
-        if !ddl.is_empty() {
-            ddl.push('\n');
-        }
         ddl.push('\n');
-        ddl.push_str(&trigger.function_name);
+        ddl.push('\n');
+        ddl.push_str(trigger.function_name.trim());
         if !trigger.function_name.trim_end().ends_with(';') {
             ddl.push(';');
         }
@@ -775,7 +789,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
             let mut table = make_table(vec![make_column("id", "INTEGER", false)], None);
             table.source_ddl =
-                Some("CREATE TABLE \"users\" (\n  \"id\" INTEGER NOT NULL\n);".to_string());
+                Some("CREATE TABLE \"users\" (\n  \"id\" INTEGER NOT NULL\n)".to_string());
             table.triggers.push(Trigger {
                 name: "users_audit".to_string(),
                 timing: TriggerTiming::After,
@@ -788,11 +802,9 @@ mod tests {
 
             let ddl = adapter.generate_ddl(DatabaseType::SQLite, &table);
 
-            assert!(ddl.starts_with("CREATE TABLE \"users\""));
-            assert!(
-                ddl.contains(
-                    "CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END"
-                )
+            assert_eq!(
+                ddl,
+                "CREATE TABLE \"users\" (\n  \"id\" INTEGER NOT NULL\n);\n\nCREATE TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END;"
             );
         }
     }

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write as _;
 
 use crate::app::ports::outbound::{DbOperationError, DdlGenerator, SqlDialect};
-use crate::domain::{DatabaseType, QueryValue, Table};
+use crate::domain::{DatabaseType, QueryValue, Table, Trigger};
 
 use super::SqliteAdapter;
 
@@ -225,10 +225,32 @@ pub(super) fn foreign_key_list_query(table: &str) -> String {
     format!("PRAGMA foreign_key_list({})", quote_ident(table))
 }
 
+pub(super) fn trigger_list_query(table: &str) -> String {
+    format!(
+        "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = {} ORDER BY name",
+        quote_literal(table)
+    )
+}
+
+fn append_trigger_ddls(ddl: &mut String, triggers: &[Trigger]) {
+    for trigger in triggers {
+        if !ddl.is_empty() {
+            ddl.push('\n');
+        }
+        ddl.push('\n');
+        ddl.push_str(&trigger.function_name);
+        if !trigger.function_name.trim_end().ends_with(';') {
+            ddl.push(';');
+        }
+    }
+}
+
 impl DdlGenerator for SqliteAdapter {
     fn generate_ddl(&self, _database_type: DatabaseType, table: &Table) -> String {
         if let Some(source_ddl) = table.source_ddl() {
-            return source_ddl.to_string();
+            let mut ddl = source_ddl.to_string();
+            append_trigger_ddls(&mut ddl, &table.triggers);
+            return ddl;
         }
 
         let mut ddl = format!("CREATE TABLE {} (\n", quote_ident(&table.name));
@@ -265,6 +287,7 @@ impl DdlGenerator for SqliteAdapter {
         }
 
         ddl.push_str(");");
+        append_trigger_ddls(&mut ddl, &table.triggers);
         ddl
     }
 }
@@ -331,7 +354,7 @@ impl SqlDialect for SqliteAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{Column, ColumnAttributes};
+    use crate::domain::{Column, ColumnAttributes, Trigger, TriggerEvent, TriggerTiming};
 
     fn make_column(name: &str, data_type: &str, nullable: bool) -> Column {
         Column {
@@ -495,6 +518,10 @@ mod tests {
         assert_eq!(
             foreign_key_list_query(r#"my"table"#),
             r#"PRAGMA foreign_key_list("my""table")"#
+        );
+        assert_eq!(
+            trigger_list_query("users"),
+            "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'users' ORDER BY name"
         );
         assert_eq!(
             index_xinfo_query(r#"my"index"#),
@@ -741,6 +768,32 @@ mod tests {
 
             assert!(ddl.contains("\"created_at\" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP"));
             assert!(!ddl.contains("COMMENT ON"));
+        }
+
+        #[test]
+        fn source_ddl_appends_trigger_definitions() {
+            let adapter = SqliteAdapter::new();
+            let mut table = make_table(vec![make_column("id", "INTEGER", false)], None);
+            table.source_ddl =
+                Some("CREATE TABLE \"users\" (\n  \"id\" INTEGER NOT NULL\n);".to_string());
+            table.triggers.push(Trigger {
+                name: "users_audit".to_string(),
+                timing: TriggerTiming::After,
+                events: vec![TriggerEvent::Insert],
+                function_name:
+                    "CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END"
+                        .to_string(),
+                security_definer: false,
+            });
+
+            let ddl = adapter.generate_ddl(DatabaseType::SQLite, &table);
+
+            assert!(ddl.starts_with("CREATE TABLE \"users\""));
+            assert!(
+                ddl.contains(
+                    "CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END"
+                )
+            );
         }
     }
 }

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_for_sqlite_hides_unknown_type.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_for_sqlite_hides_unknown_type.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
 test_project | test_db | - | connected | app.db
-┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [DDL]
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [Trig] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name              Columns   Unique                                                                                        │
 │  public.comments                      ││users_pkey        id        ✓                                                                                             │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_collation_index_definition.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_collation_index_definition.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
 test_project | test_db | - | connected | app.db
-┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [DDL]
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [Trig] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name                    Columns   Unique   Partial   Detail                                                               │
 │  public.comments                      ││idx_users_name_nocase   name                         CREATE INDEX idx_users_name_nocase ON users(name COLLATE NOCASE)     │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_descending_index_definition.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_descending_index_definition.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
 test_project | test_db | - | connected | app.db
-┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [DDL]
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [Trig] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name                  Columns   Unique   Partial   Detail                                                                 │
 │  public.comments                      ││idx_users_name_desc   name                         CREATE INDEX idx_users_name_desc ON users(name DESC)                   │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_partial_expression_details.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_partial_expression_details.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
 test_project | test_db | - | connected | app.db
-┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [DDL]
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [Trig] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name           Columns        Unique   Partial   Detail                                                                   │
 │  public.comments                      ││idx_users_emai <expression>            ✓         CREATE INDEX idx_users_email_lower ON users(lower(email)) WHERE email IS │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_partial_index_definition.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_shows_sqlite_partial_index_definition.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
 test_project | test_db | - | connected | app.db
-┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [DDL]
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [Trig] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name            Columns   Unique   Partial   Detail                                                                       │
 │  public.comments                      ││idx_users_email email              ✓         CREATE INDEX idx_users_email_active ON users(email) WHERE email IS NOT NULL  │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_for_sqlite_hides_postgres_only_fields.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_for_sqlite_hides_postgres_only_fields.snap
@@ -3,7 +3,7 @@ source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
 test_project | test_db | - | connected | app.db
-┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [DDL]
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [Trig] [DDL]
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Rows:    ~100                                                                                                             │
 │  public.comments                      ││Schema:  public                                                                                                           │


### PR DESCRIPTION
## Problem

SQLite triggers change how INSERT, UPDATE, and DELETE behave, but sabiql did not load them into table metadata, inspector views, or schema change signatures.

## Background

SAB-290. PostgreSQL already surfaces triggers in the inspector; SQLite table detail always returned an empty trigger list.

## Approach

Load trigger definitions from `sqlite_master`, parse timing and events from the stored CREATE TRIGGER SQL, attach them to table detail, append them in generated DDL, add the Triggers inspector tab for SQLite, and include trigger definitions in table signature hashing for change detection.