### PR TITLE
fix: reject unsupported SQLite in-memory and URI filename paths

### DIFF
--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -357,6 +357,9 @@ impl ConnectionSetupState {
         let message = match error {
             SqliteConnectionConfigError::EmptyPath => "Required",
             SqliteConnectionConfigError::UnsupportedPath => "Unsupported characters",
+            SqliteConnectionConfigError::UnsupportedConnectionFormat => {
+                "Use a regular file path (in-memory and URI filenames unsupported)"
+            }
         };
         self.validation_errors
             .insert(ConnectionField::SqlitePath, message.to_string());

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -550,6 +550,40 @@ mod tests {
         }
 
         #[test]
+        fn in_memory_database_sets_unsupported_format_error() {
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::SQLite);
+            state
+                .input_mut(ConnectionField::SqlitePath)
+                .unwrap()
+                .set_content(":memory:".to_string());
+
+            validate_field(&mut state, ConnectionField::SqlitePath);
+
+            assert_eq!(
+                state.validation_error(ConnectionField::SqlitePath),
+                Some("Use a regular file path (in-memory and URI filenames unsupported)")
+            );
+        }
+
+        #[test]
+        fn uri_filename_sets_unsupported_format_error() {
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::SQLite);
+            state
+                .input_mut(ConnectionField::SqlitePath)
+                .unwrap()
+                .set_content("file:/tmp/app.db?mode=ro".to_string());
+
+            validate_field(&mut state, ConnectionField::SqlitePath);
+
+            assert_eq!(
+                state.validation_error(ConnectionField::SqlitePath),
+                Some("Use a regular file path (in-memory and URI filenames unsupported)")
+            );
+        }
+
+        #[test]
         fn validate_all_removes_errors_for_hidden_fields() {
             let mut state = ConnectionSetupState::default();
             state.set_database_type(DatabaseType::SQLite);

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -43,6 +43,10 @@ pub enum SqliteConnectionConfigError {
     EmptyPath,
     #[error("SQLite database path contains unsupported characters")]
     UnsupportedPath,
+    #[error(
+        "SQLite in-memory databases and URI filenames are not supported; use a regular file path"
+    )]
+    UnsupportedConnectionFormat,
 }
 
 impl SqliteConnectionConfig {
@@ -79,7 +83,20 @@ fn validate_sqlite_path(path: &str) -> Result<(), SqliteConnectionConfigError> {
     if path.chars().any(|c| c == '\0' || c.is_control()) {
         return Err(SqliteConnectionConfigError::UnsupportedPath);
     }
+    if is_unsupported_sqlite_connection_format(path) {
+        return Err(SqliteConnectionConfigError::UnsupportedConnectionFormat);
+    }
     Ok(())
+}
+
+fn is_unsupported_sqlite_connection_format(path: &str) -> bool {
+    if path.trim() == ":memory:" {
+        return true;
+    }
+
+    path.as_bytes()
+        .get(..5)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"file:"))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -139,6 +156,63 @@ mod tests {
                 serde_json::from_str::<SqliteConnectionConfig>(r#"{ "path": "/tmp/app\n.db" }"#);
 
             assert!(result.is_err());
+        }
+
+        #[test]
+        fn rejects_in_memory_database() {
+            let result =
+                serde_json::from_str::<SqliteConnectionConfig>(r#"{ "path": ":memory:" }"#);
+
+            assert!(matches!(
+                result,
+                Err(error) if error.to_string().contains("in-memory")
+            ));
+        }
+
+        #[test]
+        fn rejects_uri_filename() {
+            let result = serde_json::from_str::<SqliteConnectionConfig>(
+                r#"{ "path": "file:/tmp/app.db?mode=ro" }"#,
+            );
+
+            assert!(matches!(
+                result,
+                Err(error) if error.to_string().contains("URI filename")
+            ));
+        }
+
+        #[test]
+        fn rejects_uri_filename_case_insensitively() {
+            let result =
+                serde_json::from_str::<SqliteConnectionConfig>(r#"{ "path": "FILE:/tmp/app.db" }"#);
+
+            assert!(result.is_err());
+        }
+    }
+
+    mod validate_sqlite_path {
+        use super::*;
+
+        #[test]
+        fn accepts_regular_file_path() {
+            assert!(validate_sqlite_path("/tmp/app.db").is_ok());
+            assert!(validate_sqlite_path("./relative/app.db").is_ok());
+        }
+
+        #[test]
+        fn rejects_memory_database() {
+            assert!(matches!(
+                validate_sqlite_path(":memory:"),
+                Err(SqliteConnectionConfigError::UnsupportedConnectionFormat)
+            ));
+        }
+
+        #[test]
+        fn rejects_file_uri() {
+            assert!(matches!(
+                validate_sqlite_path("file:memdb?mode=memory"),
+                Err(SqliteConnectionConfigError::UnsupportedConnectionFormat)
+            ));
         }
     }
 }

--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -16,6 +16,10 @@ pub enum ConnectionProfileError {
     EmptySqlitePath,
     #[error("SQLite database path contains unsupported characters")]
     InvalidSqlitePath,
+    #[error(
+        "SQLite in-memory databases and URI filenames are not supported; use a regular file path"
+    )]
+    UnsupportedSqliteConnectionFormat,
     #[error("PostgreSQL connection field `{0}` is required")]
     MissingPostgresField(&'static str),
 }
@@ -25,6 +29,9 @@ impl From<SqliteConnectionConfigError> for ConnectionProfileError {
         match error {
             SqliteConnectionConfigError::EmptyPath => Self::EmptySqlitePath,
             SqliteConnectionConfigError::UnsupportedPath => Self::InvalidSqlitePath,
+            SqliteConnectionConfigError::UnsupportedConnectionFormat => {
+                Self::UnsupportedSqliteConnectionFormat
+            }
         }
     }
 }
@@ -212,6 +219,26 @@ mod tests {
             assert!(matches!(
                 result,
                 Err(ConnectionProfileError::InvalidSqlitePath)
+            ));
+        }
+
+        #[test]
+        fn sqlite_profile_rejects_in_memory_database() {
+            let result = ConnectionProfile::new_sqlite("Local", ":memory:");
+
+            assert!(matches!(
+                result,
+                Err(ConnectionProfileError::UnsupportedSqliteConnectionFormat)
+            ));
+        }
+
+        #[test]
+        fn sqlite_profile_rejects_uri_filename() {
+            let result = ConnectionProfile::new_sqlite("Local", "file:/tmp/app.db?mode=ro");
+
+            assert!(matches!(
+                result,
+                Err(ConnectionProfileError::UnsupportedSqliteConnectionFormat)
             ));
         }
     }

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -237,4 +237,50 @@ mod tests {
             Err(ConnectionProfileError::InvalidSqlitePath)
         ));
     }
+
+    #[test]
+    fn sqlite_entry_rejects_in_memory_database() {
+        let entry = ConnectionConfigEntry {
+            id: "sqlite-id".to_string(),
+            name: "Local".to_string(),
+            db_type: DatabaseType::SQLite,
+            host: None,
+            port: None,
+            database: None,
+            username: None,
+            password: None,
+            ssl_mode: None,
+            path: Some(":memory:".to_string()),
+        };
+
+        let result = ConnectionProfile::try_from(&entry);
+
+        assert!(matches!(
+            result,
+            Err(ConnectionProfileError::UnsupportedSqliteConnectionFormat)
+        ));
+    }
+
+    #[test]
+    fn sqlite_entry_rejects_uri_filename() {
+        let entry = ConnectionConfigEntry {
+            id: "sqlite-id".to_string(),
+            name: "Local".to_string(),
+            db_type: DatabaseType::SQLite,
+            host: None,
+            port: None,
+            database: None,
+            username: None,
+            password: None,
+            ssl_mode: None,
+            path: Some("file:/tmp/app.db?mode=ro".to_string()),
+        };
+
+        let result = ConnectionProfile::try_from(&entry);
+
+        assert!(matches!(
+            result,
+            Err(ConnectionProfileError::UnsupportedSqliteConnectionFormat)
+        ));
+    }
 }


### PR DESCRIPTION
## Problem

SQLite `:memory:` and `file:...` URI filenames can be accepted as ordinary paths, but sabiql launches a new `sqlite3` process per operation, so in-memory data disappears between actions and URI open modes are unpredictable for users.

## Background

SAB-280 scopes the first SQLite release to regular on-disk file paths only. Unsupported formats should fail as input validation, not as a generic connection error after save.

## Approach

Extend shared SQLite path validation in the connection config domain so profile creation, config deserialization, and the connection setup form all reject `:memory:` and case-insensitive `file:` URIs with a clear message, while keeping existing empty-path and control-character checks.