### PR TITLE
docs: update README and crate metadata for SQLite support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,12 +52,12 @@ name = "sabiql"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-description = "A fast, driver-less TUI for browsing and editing PostgreSQL databases"
+description = "A fast, driver-less TUI for browsing and editing PostgreSQL and SQLite databases"
 license.workspace = true
 repository.workspace = true
 homepage = "https://github.com/riii111/sabiql"
 readme = "README.md"
-keywords = ["postgresql", "tui", "database", "cli", "sql"]
+keywords = ["postgresql", "sqlite", "tui", "database", "cli", "sql"]
 categories = ["command-line-utilities", "database"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ nix develop
 - [x] EXPLAIN workflow (plan tree view & comparison)
 - [x] JSON/JSONB support (tree view, editing, validation)
 - [x] Theme switching (Sabiql Dark / Light)
+- [x] SQLite support
 - [ ] Neovim integration (`sabiql.nvim`)
-- [ ] SQLite support
 - [ ] Zero-config connection (env vars, `.pgpass`, URI auto-detect)
 - [ ] Google Cloud SQL / AlloyDB support
 - [ ] MySQL support

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ On first run, enter your connection details. They are saved to your platform con
 - macOS: `~/Library/Application Support/sabiql/connections.toml`
 - Linux: `~/.config/sabiql/connections.toml`
 
+For PostgreSQL, fill in host, port, database, and credentials. For SQLite, set **Type** to `SQLite` and enter the path to a database file (for example `/path/to/app.db`).
+
 Press `?` for help.
 
 Open Settings with `,` to switch themes, keymap presets, and the ER diagram browser command.
@@ -96,12 +98,28 @@ Open Settings with `,` to switch themes, keymap presets, and the ER diagram brow
 
 ## Requirements
 
-- `psql` CLI (PostgreSQL client)
-- Graphviz (optional, for ER diagrams): `brew install graphviz`
+Install the CLI for the database you want to open:
+
+- **PostgreSQL:** `psql` (PostgreSQL client)
+- **SQLite:** `sqlite3` (SQLite shell)
+
+Optional:
+
+- Graphviz (for ER diagrams on PostgreSQL): `brew install graphviz`
 
 ### Android / Termux
 
-Android/Termux support is build-only, not full platform support. `cargo install sabiql` should compile on Android, but clipboard yank is unavailable because the desktop clipboard backend is not supported there. `psql` is still required.
+Android/Termux support is build-only, not full platform support. `cargo install sabiql` should compile on Android, but clipboard yank is unavailable because the desktop clipboard backend is not supported there. Install `psql` for PostgreSQL and `sqlite3` for SQLite.
+
+## SQLite Limitations
+
+SQLite support covers browsing, editing, and ad-hoc SQL on regular database files. A few things are intentionally out of scope today:
+
+- **File paths only** — In-memory databases (`:memory:`) and URI filenames (`file:...`) are not supported.
+- **No EXPLAIN workflow** — Plan and compare tabs in the SQL modal are PostgreSQL-only.
+- **No ER diagrams** — Graphviz export requires PostgreSQL metadata.
+- **No JSON tree view** — Structured JSON editing is PostgreSQL-only.
+- **Virtual tables** — Databases with FTS, RTree, or other virtual tables require `sqlite3` 3.37.0 or later.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ PostgreSQL multi-statement SQL runs in one transaction. SQLite multi-statement w
 
 ### Query Analysis
 
-- **EXPLAIN / EXPLAIN ANALYZE** — Run your query, then switch tabs to instantly view its execution plan. Compare two plans side-by-side to pinpoint performance bottlenecks — no copy-paste, no external tools, all within the same modal. (PostgreSQL only)
+- **EXPLAIN / EXPLAIN ANALYZE** — PostgreSQL: run your query, then switch tabs to view its execution plan or compare two plans side-by-side.
+- **EXPLAIN QUERY PLAN** — SQLite: view query plans for single SELECT statements in the Plan tab.
 
 ### Navigation
 
@@ -83,7 +84,14 @@ curl -fsSL https://raw.githubusercontent.com/riii111/sabiql/main/install.sh | sh
 sabiql
 ```
 
-On first run, enter your connection details. They are saved to your platform config directory:
+For SQLite, you can also pass a database file path or `sqlite://` DSN directly:
+
+```bash
+sabiql /path/to/app.db
+sabiql sqlite:///path/to/app.db
+```
+
+On first run without a startup argument, enter your connection details. They are saved to your platform config directory:
 
 - macOS: `~/Library/Application Support/sabiql/connections.toml`
 - Linux: `~/.config/sabiql/connections.toml`
@@ -101,7 +109,7 @@ Open Settings with `,` to switch themes, keymap presets, and the ER diagram brow
 Install the CLI for the database you want to open:
 
 - **PostgreSQL:** `psql` (PostgreSQL client)
-- **SQLite:** `sqlite3` (SQLite shell)
+- **SQLite:** `sqlite3` (SQLite shell). Use 3.37.0 or later for databases with FTS, RTree, or other virtual tables.
 
 Optional:
 
@@ -113,13 +121,14 @@ Android/Termux support is build-only, not full platform support. `cargo install 
 
 ## SQLite Limitations
 
-SQLite support covers browsing, editing, and ad-hoc SQL on regular database files. A few things are intentionally out of scope today:
+SQLite support covers browsing, editing, and ad-hoc SQL on regular database files. Compared with PostgreSQL:
 
-- **File paths only** — In-memory databases (`:memory:`) and URI filenames (`file:...`) are not supported.
-- **No EXPLAIN workflow** — Plan and compare tabs in the SQL modal are PostgreSQL-only.
+- **File paths only** — Use a regular database file path or a `sqlite://` DSN to that file. In-memory databases (`:memory:`) and SQLite URI filenames (`file:...`) are not supported.
+- **No new database files** — Opening a path that does not exist does not create a database.
+- **Main database only** — Attached and temporary databases are not browsed as separate namespaces.
+- **Query plans** — SQLite shows `EXPLAIN QUERY PLAN` in the Plan tab. Plan comparison and `EXPLAIN ANALYZE` are PostgreSQL-only.
 - **No ER diagrams** — Graphviz export requires PostgreSQL metadata.
 - **No JSON tree view** — Structured JSON editing is PostgreSQL-only.
-- **Virtual tables** — Databases with FTS, RTree, or other virtual tables require `sqlite3` 3.37.0 or later.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sabiql
 ![hero](https://github.com/user-attachments/assets/745ab18f-915c-4017-81a6-465c5c5ee11c)
 
-A fast, driver-less TUI to browse, query, and edit PostgreSQL databases — no drivers, no setup, just `psql`.
+A fast, driver-less TUI to browse, query, and edit PostgreSQL and SQLite databases — no drivers, no setup, just your database CLI (`psql` or `sqlite3`).
 
 [![CI](https://github.com/riii111/sabiql/actions/workflows/ci.yml/badge.svg)](https://github.com/riii111/sabiql/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -10,11 +10,11 @@ A fast, driver-less TUI to browse, query, and edit PostgreSQL databases — no d
 
 > Vim-first · Safe by design · Oil-and-vinegar UI · Fast and lightweight
 
-sabiql wraps your existing `psql` CLI. No Rust database drivers, no connection pools, no extra dependencies. Point it at your database and get a full-featured TUI. Your `psql` config, `.pgpass`, SSL setup all just work.
+sabiql wraps your existing database CLI. For PostgreSQL it uses `psql`; for SQLite it uses `sqlite3`. No Rust database drivers, no connection pools, no extra dependencies. Point it at your database and get a full-featured TUI. Your `psql` config, `.pgpass`, and SSL setup all just work for PostgreSQL connections.
 
 Inspired by [oil.nvim](https://github.com/stevearc/oil.nvim)'s "oil and vinegar" philosophy: UI elements appear only when needed, never occupying your screen permanently. Vim-native keybindings (`j/k`, `dd`, `/`) let you navigate and edit without leaving your muscle memory.
 
-Destructive operations are guarded. Inline edits and row deletions always show a preview modal before touching your data. Read-only mode (`Ctrl+R`) goes further — block all writes at the PostgreSQL session level with a single keystroke.
+Destructive operations are guarded. Inline edits and row deletions always show a preview modal before touching your data. Read-only mode (`Ctrl+R`) goes further — block all writes at the database client level with a single keystroke.
 
 Built in Rust for minimal memory footprint and near-zero idle CPU. A full-featured alternative to GUI tools like DBeaver or DataGrip, without ever leaving the terminal.
 
@@ -33,7 +33,7 @@ PostgreSQL multi-statement SQL runs in one transaction. SQLite multi-statement w
 
 - **Read-Only Mode** (`Ctrl+R`) — Toggle safe-browse mode; writes are blocked at both app and DB session level
 - **SQL Modal** (`s`) — Ad-hoc queries with auto-completion for tables, columns, and keywords; browse past results with `Ctrl+H`; recall previous queries with `Ctrl+O`
-- **ER Diagram** (`e`) — Generate relationship diagrams via Graphviz, opened instantly in your browser
+- **ER Diagram** (`e`) — Generate relationship diagrams via Graphviz, opened instantly in your browser (PostgreSQL only)
 - **Inspector Pane** (`2`) — Column details, types, constraints, and indexes for any table
 
 ### Editing
@@ -45,7 +45,7 @@ PostgreSQL multi-statement SQL runs in one transaction. SQLite multi-statement w
 
 ### Query Analysis
 
-- **EXPLAIN / EXPLAIN ANALYZE** — Run your query, then switch tabs to instantly view its execution plan. Compare two plans side-by-side to pinpoint performance bottlenecks — no copy-paste, no external tools, all within the same modal.
+- **EXPLAIN / EXPLAIN ANALYZE** — Run your query, then switch tabs to instantly view its execution plan. Compare two plans side-by-side to pinpoint performance bottlenecks — no copy-paste, no external tools, all within the same modal. (PostgreSQL only)
 
 ### Navigation
 


### PR DESCRIPTION
## Problem

README and crate metadata still described sabiql as PostgreSQL-only, so new users could miss that SQLite is supported and which CLI tools they need before trying it.

## Background

SQLite support has landed on the `sqlite` branch, but onboarding docs and distribution metadata had not caught up.

## Approach

Refresh the README overview, quick start, requirements, roadmap, and a short SQLite limitations section, and align `Cargo.toml` description and keywords with the current database support.