### PR TITLE
feat: enable EXPLAIN QUERY PLAN for SQLite SQL editor

### DIFF
--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -727,7 +727,7 @@ mod tests {
                 .any(|description| description.contains("ER Diagram"))
         );
         assert!(
-            !descriptions
+            descriptions
                 .iter()
                 .any(|description| description.contains("EXPLAIN"))
         );
@@ -739,7 +739,7 @@ mod tests {
     }
 
     #[test]
-    fn sqlite_sql_help_origin_normalizes_unsupported_plan_tab() {
+    fn sqlite_sql_help_origin_includes_plan_tab() {
         let mut state = AppState::new("test".to_string());
         state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
@@ -752,7 +752,7 @@ mod tests {
 
         let document = HelpDocument::new(HelpOrigin::from_state(&state), "");
 
-        assert_eq!(document.sections()[0].title(), "Current: SQL Editor");
+        assert_eq!(document.sections()[0].title(), "Current: SQL Editor Plan");
     }
 
     #[test]

--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -252,7 +252,7 @@ fn current_section(origin: HelpOrigin, db_capabilities: &DbCapabilities) -> Help
         HelpOrigin::SqlModal {
             mode,
             keymap_preset,
-        } => sql_current_rows(mode, keymap_preset),
+        } => sql_current_rows(mode, keymap_preset, db_capabilities),
         HelpOrigin::ConnectionSetup { keymap_preset } => rows_from_binding_refs(&[
             &connection_setup::TAB_NAV,
             &connection_setup::TAB_NEXT,
@@ -332,8 +332,8 @@ fn reference_sections(
     search_filter_rows.extend(rows_from_mode_rows(HELP_ROWS));
 
     let mut editing_rows = merge_rows(&[
-        sql_current_rows(SqlHelpMode::Normal, keymap_preset),
-        sql_current_rows(SqlHelpMode::Insert, keymap_preset),
+        sql_current_rows(SqlHelpMode::Normal, keymap_preset, db_capabilities),
+        sql_current_rows(SqlHelpMode::Insert, keymap_preset, db_capabilities),
         rows_from_bindings(CELL_EDIT_KEYS),
         rows_from_bindings(SQL_MODAL_CONFIRMING_KEYS),
     ]);
@@ -343,8 +343,16 @@ fn reference_sections(
 
     let mut advanced_rows = Vec::new();
     if db_capabilities.supports_explain() {
-        advanced_rows.extend(sql_current_rows(SqlHelpMode::Plan, keymap_preset));
-        advanced_rows.extend(sql_current_rows(SqlHelpMode::Compare, keymap_preset));
+        advanced_rows.extend(sql_current_rows(
+            SqlHelpMode::Plan,
+            keymap_preset,
+            db_capabilities,
+        ));
+        advanced_rows.extend(sql_current_rows(
+            SqlHelpMode::Compare,
+            keymap_preset,
+            db_capabilities,
+        ));
     }
     if db_capabilities.supports_er_diagram() {
         advanced_rows.extend(rows_from_mode_rows(er_picker_rows(keymap_preset)));
@@ -402,7 +410,11 @@ fn reference_sections(
     .collect()
 }
 
-fn sql_current_rows(mode: SqlHelpMode, keymap_preset: KeymapPreset) -> Vec<HelpRow> {
+fn sql_current_rows(
+    mode: SqlHelpMode,
+    keymap_preset: KeymapPreset,
+    db_capabilities: &DbCapabilities,
+) -> Vec<HelpRow> {
     match mode {
         SqlHelpMode::Normal => rows_from_binding_refs(&[
             &sql_modal_normal::RUN,
@@ -427,25 +439,35 @@ fn sql_current_rows(mode: SqlHelpMode, keymap_preset: KeymapPreset) -> Vec<HelpR
                 &sql_modal::CLEAR,
             ]),
         },
-        SqlHelpMode::Plan => rows_from_binding_refs(&[
-            sql_modal_plan_explain(keymap_preset),
-            &sql_modal_plan::ANALYZE,
-            &sql_modal_plan::YANK,
-            &sql_modal_plan::SCROLL,
-            &sql_modal_plan::TAB,
-            &sql_modal_plan::BACKTAB,
-            &sql_modal_plan::CLOSE,
-        ]),
-        SqlHelpMode::Compare => rows_from_binding_refs(&[
-            sql_modal_compare_explain(keymap_preset),
-            &sql_modal_compare::ANALYZE,
-            &sql_modal_compare::EDIT_QUERY,
-            &sql_modal_compare::YANK,
-            &sql_modal_compare::SCROLL,
-            &sql_modal_compare::TAB,
-            &sql_modal_compare::BACKTAB,
-            &sql_modal_compare::CLOSE,
-        ]),
+        SqlHelpMode::Plan => {
+            let mut bindings: Vec<&KeyBinding> = vec![sql_modal_plan_explain(keymap_preset)];
+            if db_capabilities.supports_explain_analyze() {
+                bindings.push(&sql_modal_plan::ANALYZE);
+            }
+            bindings.extend([
+                &sql_modal_plan::YANK,
+                &sql_modal_plan::SCROLL,
+                &sql_modal_plan::TAB,
+                &sql_modal_plan::BACKTAB,
+                &sql_modal_plan::CLOSE,
+            ]);
+            rows_from_binding_refs(&bindings)
+        }
+        SqlHelpMode::Compare => {
+            let mut bindings: Vec<&KeyBinding> = vec![sql_modal_compare_explain(keymap_preset)];
+            if db_capabilities.supports_explain_analyze() {
+                bindings.push(&sql_modal_compare::ANALYZE);
+            }
+            bindings.extend([
+                &sql_modal_compare::EDIT_QUERY,
+                &sql_modal_compare::YANK,
+                &sql_modal_compare::SCROLL,
+                &sql_modal_compare::TAB,
+                &sql_modal_compare::BACKTAB,
+                &sql_modal_compare::CLOSE,
+            ]);
+            rows_from_binding_refs(&bindings)
+        }
         SqlHelpMode::Confirm => rows_from_bindings(SQL_MODAL_CONFIRMING_KEYS),
     }
 }
@@ -730,6 +752,11 @@ mod tests {
             descriptions
                 .iter()
                 .any(|description| description.contains("EXPLAIN"))
+        );
+        assert!(
+            !descriptions
+                .iter()
+                .any(|description| description.contains("ANALYZE"))
         );
         assert!(
             !descriptions

--- a/src/app/model/shared/db_capabilities.rs
+++ b/src/app/model/shared/db_capabilities.rs
@@ -39,6 +39,12 @@ impl CapabilityFlags {
         supports_er_diagram: true,
         supports_jsonb_detail: true,
     };
+
+    const SQLITE: Self = Self {
+        supports_explain: true,
+        supports_er_diagram: false,
+        supports_jsonb_detail: false,
+    };
 }
 
 impl DbCapabilities {
@@ -104,7 +110,7 @@ impl DbCapabilities {
 
     pub fn sqlite_like() -> Self {
         Self::new(
-            CapabilityFlags::NONE,
+            CapabilityFlags::SQLITE,
             vec![
                 InspectorTab::Info,
                 InspectorTab::Columns,
@@ -255,7 +261,7 @@ mod tests {
         fn sqlite_omits_postgresql_only_info_fields() {
             let caps = DbCapabilities::sqlite_like();
 
-            assert!(!caps.supports_explain());
+            assert!(caps.supports_explain());
             assert!(!caps.supports_er_diagram());
             assert!(!caps.supports_jsonb_detail());
             assert_eq!(
@@ -277,7 +283,10 @@ mod tests {
                     InspectorInfoField::TableName,
                 ]
             );
-            assert_eq!(caps.supported_sql_modal_tabs(), &[SqlModalTab::Sql]);
+            assert_eq!(
+                caps.supported_sql_modal_tabs(),
+                &[SqlModalTab::Sql, SqlModalTab::Plan, SqlModalTab::Compare]
+            );
         }
 
         #[test]

--- a/src/app/model/shared/db_capabilities.rs
+++ b/src/app/model/shared/db_capabilities.rs
@@ -11,9 +11,16 @@ pub enum InspectorInfoField {
     TableName,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExplainCapability {
+    None,
+    QueryPlanOnly,
+    QueryPlanAndAnalyze,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DbCapabilities {
-    supports_explain: bool,
+    explain: ExplainCapability,
     supports_er_diagram: bool,
     supports_jsonb_detail: bool,
     supported_inspector_tabs: Vec<InspectorTab>,
@@ -22,26 +29,26 @@ pub struct DbCapabilities {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CapabilityFlags {
-    supports_explain: bool,
+    explain: ExplainCapability,
     supports_er_diagram: bool,
     supports_jsonb_detail: bool,
 }
 
 impl CapabilityFlags {
     const NONE: Self = Self {
-        supports_explain: false,
+        explain: ExplainCapability::None,
         supports_er_diagram: false,
         supports_jsonb_detail: false,
     };
 
     const POSTGRESQL: Self = Self {
-        supports_explain: true,
+        explain: ExplainCapability::QueryPlanAndAnalyze,
         supports_er_diagram: true,
         supports_jsonb_detail: true,
     };
 
     const SQLITE: Self = Self {
-        supports_explain: true,
+        explain: ExplainCapability::QueryPlanOnly,
         supports_er_diagram: false,
         supports_jsonb_detail: false,
     };
@@ -70,7 +77,7 @@ impl DbCapabilities {
             "DbCapabilities supported inspector info fields must be unique"
         );
         Self {
-            supports_explain: flags.supports_explain,
+            explain: flags.explain,
             supports_er_diagram: flags.supports_er_diagram,
             supports_jsonb_detail: flags.supports_jsonb_detail,
             supported_inspector_tabs,
@@ -135,7 +142,11 @@ impl DbCapabilities {
     }
 
     pub fn supports_explain(&self) -> bool {
-        self.supports_explain
+        !matches!(self.explain, ExplainCapability::None)
+    }
+
+    pub fn supports_explain_analyze(&self) -> bool {
+        matches!(self.explain, ExplainCapability::QueryPlanAndAnalyze)
     }
 
     pub fn supports_er_diagram(&self) -> bool {
@@ -241,6 +252,7 @@ mod tests {
             let caps = DbCapabilities::postgres_like();
 
             assert!(caps.supports_explain());
+            assert!(caps.supports_explain_analyze());
             assert!(caps.supports_er_diagram());
             assert!(caps.supports_jsonb_detail());
             assert!(caps.supports_inspector_tab(InspectorTab::Ddl));
@@ -262,6 +274,7 @@ mod tests {
             let caps = DbCapabilities::sqlite_like();
 
             assert!(caps.supports_explain());
+            assert!(!caps.supports_explain_analyze());
             assert!(!caps.supports_er_diagram());
             assert!(!caps.supports_jsonb_detail());
             assert_eq!(
@@ -306,6 +319,7 @@ mod tests {
             let caps = DbCapabilities::disconnected();
 
             assert!(!caps.supports_explain());
+            assert!(!caps.supports_explain_analyze());
             assert!(!caps.supports_er_diagram());
             assert!(!caps.supports_jsonb_detail());
             assert_eq!(caps.supported_inspector_tabs(), &[InspectorTab::Info]);

--- a/src/app/policy/sql/mod.rs
+++ b/src/app/policy/sql/mod.rs
@@ -1,3 +1,4 @@
 pub mod lexer;
+pub mod sqlite_explain;
 pub mod sqlite_export;
 pub mod statement_classifier;

--- a/src/app/policy/sql/sqlite_explain.rs
+++ b/src/app/policy/sql/sqlite_explain.rs
@@ -1,0 +1,92 @@
+use crate::policy::sql::statement_classifier::{self, StatementKind};
+
+pub const SQLITE_EXPLAIN_QUERY_PLAN_PREFIX: &str = "EXPLAIN QUERY PLAN";
+
+fn strip_sqlite_explain_query_plan_prefix(trimmed: &str) -> Option<&str> {
+    let prefix = SQLITE_EXPLAIN_QUERY_PLAN_PREFIX;
+    trimmed
+        .get(..prefix.len())
+        .filter(|head| head.eq_ignore_ascii_case(prefix))
+        .and_then(|_| trimmed.get(prefix.len()..))
+        .map(str::trim_start)
+}
+
+pub fn build_sqlite_explain_query_plan_sql(query: &str) -> Option<String> {
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(inner) = strip_sqlite_explain_query_plan_prefix(trimmed) {
+        if matches!(statement_classifier::classify(inner), StatementKind::Select) {
+            return Some(trimmed.to_string());
+        }
+        return None;
+    }
+    if statement_classifier::first_keyword(trimmed)
+        .is_some_and(|keyword| keyword.eq_ignore_ascii_case("EXPLAIN"))
+    {
+        return None;
+    }
+    if !matches!(
+        statement_classifier::classify(trimmed),
+        StatementKind::Select
+    ) {
+        return None;
+    }
+    Some(format!("{SQLITE_EXPLAIN_QUERY_PLAN_PREFIX} {trimmed}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wraps_select_with_query_plan() {
+        assert_eq!(
+            build_sqlite_explain_query_plan_sql("SELECT 1"),
+            Some("EXPLAIN QUERY PLAN SELECT 1".to_string())
+        );
+    }
+
+    #[test]
+    fn passes_through_existing_query_plan_prefix() {
+        assert_eq!(
+            build_sqlite_explain_query_plan_sql("EXPLAIN QUERY PLAN SELECT * FROM users"),
+            Some("EXPLAIN QUERY PLAN SELECT * FROM users".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_non_select_and_prefixed_explain() {
+        assert_eq!(
+            build_sqlite_explain_query_plan_sql("DELETE FROM users"),
+            None
+        );
+        assert_eq!(
+            build_sqlite_explain_query_plan_sql("EXPLAIN SELECT 1"),
+            None
+        );
+    }
+
+    #[test]
+    fn prefix_check_does_not_panic_at_non_char_boundary() {
+        let input = format!("EXPLAIN QUERY PLA{} SELECT 1", '\u{1F600}');
+        let _ = build_sqlite_explain_query_plan_sql(&input);
+    }
+
+    #[test]
+    fn leading_text_before_query_plan_prefix_is_not_treated_as_prefix() {
+        assert_eq!(
+            build_sqlite_explain_query_plan_sql("😀 EXPLAIN QUERY PLAN SELECT 1"),
+            None
+        );
+    }
+
+    #[test]
+    fn multiline_select_with_leading_emoji_line_is_wrapped() {
+        assert_eq!(
+            build_sqlite_explain_query_plan_sql("😀\nSELECT 1"),
+            Some("EXPLAIN QUERY PLAN 😀\nSELECT 1".to_string())
+        );
+    }
+}

--- a/src/app/policy/sql/sqlite_explain.rs
+++ b/src/app/policy/sql/sqlite_explain.rs
@@ -2,12 +2,21 @@ use crate::policy::sql::statement_classifier::{self, StatementKind};
 
 pub const SQLITE_EXPLAIN_QUERY_PLAN_PREFIX: &str = "EXPLAIN QUERY PLAN";
 
+fn is_valid_explain_query_plan_boundary(rest: &str) -> bool {
+    if rest.is_empty() {
+        return false;
+    }
+    let first = rest.as_bytes()[0];
+    first.is_ascii_whitespace() || rest.starts_with("--") || rest.starts_with("/*")
+}
+
 fn strip_sqlite_explain_query_plan_prefix(trimmed: &str) -> Option<&str> {
     let prefix = SQLITE_EXPLAIN_QUERY_PLAN_PREFIX;
     trimmed
         .get(..prefix.len())
         .filter(|head| head.eq_ignore_ascii_case(prefix))
         .and_then(|_| trimmed.get(prefix.len()..))
+        .filter(|rest| is_valid_explain_query_plan_boundary(rest))
         .map(str::trim_start)
 }
 
@@ -69,6 +78,22 @@ mod tests {
     }
 
     #[test]
+    fn rejects_query_plan_prefix_without_boundary() {
+        assert_eq!(
+            build_sqlite_explain_query_plan_sql("EXPLAIN QUERY PLANSELECT 1"),
+            None
+        );
+    }
+
+    #[test]
+    fn passes_through_query_plan_with_sql_comment_after_prefix() {
+        assert_eq!(
+            build_sqlite_explain_query_plan_sql("EXPLAIN QUERY PLAN -- note\nSELECT 1"),
+            Some("EXPLAIN QUERY PLAN -- note\nSELECT 1".to_string())
+        );
+    }
+
+    #[test]
     fn prefix_check_does_not_panic_at_non_char_boundary() {
         let input = format!("EXPLAIN QUERY PLA{} SELECT 1", '\u{1F600}');
         let _ = build_sqlite_explain_query_plan_sql(&input);
@@ -83,10 +108,10 @@ mod tests {
     }
 
     #[test]
-    fn multiline_select_with_leading_emoji_line_is_wrapped() {
+    fn multiline_select_with_leading_sql_comment_is_wrapped() {
         assert_eq!(
-            build_sqlite_explain_query_plan_sql("😀\nSELECT 1"),
-            Some("EXPLAIN QUERY PLAN 😀\nSELECT 1".to_string())
+            build_sqlite_explain_query_plan_sql("-- filter\nSELECT 1"),
+            Some("EXPLAIN QUERY PLAN -- filter\nSELECT 1".to_string())
         );
     }
 }

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -67,7 +67,23 @@ impl AppServices {
             ) -> Option<String> {
                 match database_type {
                     DatabaseType::PostgreSQL => Some(format!("EXPLAIN {query}")),
-                    DatabaseType::SQLite => None,
+                    DatabaseType::SQLite => {
+                        use crate::policy::sql::statement_classifier::{self, StatementKind};
+                        let trimmed = query.trim();
+                        if statement_classifier::first_keyword(trimmed)
+                            .is_some_and(|keyword| keyword.eq_ignore_ascii_case("EXPLAIN"))
+                        {
+                            return None;
+                        }
+                        if matches!(
+                            statement_classifier::classify(trimmed),
+                            StatementKind::Select
+                        ) {
+                            Some(format!("EXPLAIN QUERY PLAN {trimmed}"))
+                        } else {
+                            None
+                        }
+                    }
                 }
             }
 

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -70,6 +70,18 @@ impl AppServices {
                     DatabaseType::SQLite => {
                         use crate::policy::sql::statement_classifier::{self, StatementKind};
                         let trimmed = query.trim();
+                        if trimmed.len() >= 19
+                            && trimmed[..19].eq_ignore_ascii_case("EXPLAIN QUERY PLAN")
+                        {
+                            let inner = trimmed[19..].trim_start();
+                            if matches!(
+                                statement_classifier::classify(inner),
+                                StatementKind::Select
+                            ) {
+                                return Some(trimmed.to_string());
+                            }
+                            return None;
+                        }
                         if statement_classifier::first_keyword(trimmed)
                             .is_some_and(|keyword| keyword.eq_ignore_ascii_case("EXPLAIN"))
                         {

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -15,6 +15,8 @@ impl AppServices {
     #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn stub() -> Self {
+        use crate::policy::sql::sqlite_explain::build_sqlite_explain_query_plan_sql;
+
         fn quote_literal(value: &str) -> String {
             format!("'{}'", value.replace('\'', "''"))
         }
@@ -67,35 +69,7 @@ impl AppServices {
             ) -> Option<String> {
                 match database_type {
                     DatabaseType::PostgreSQL => Some(format!("EXPLAIN {query}")),
-                    DatabaseType::SQLite => {
-                        use crate::policy::sql::statement_classifier::{self, StatementKind};
-                        let trimmed = query.trim();
-                        if trimmed.len() >= 19
-                            && trimmed[..19].eq_ignore_ascii_case("EXPLAIN QUERY PLAN")
-                        {
-                            let inner = trimmed[19..].trim_start();
-                            if matches!(
-                                statement_classifier::classify(inner),
-                                StatementKind::Select
-                            ) {
-                                return Some(trimmed.to_string());
-                            }
-                            return None;
-                        }
-                        if statement_classifier::first_keyword(trimmed)
-                            .is_some_and(|keyword| keyword.eq_ignore_ascii_case("EXPLAIN"))
-                        {
-                            return None;
-                        }
-                        if matches!(
-                            statement_classifier::classify(trimmed),
-                            StatementKind::Select
-                        ) {
-                            Some(format!("EXPLAIN QUERY PLAN {trimmed}"))
-                        } else {
-                            None
-                        }
-                    }
+                    DatabaseType::SQLite => build_sqlite_explain_query_plan_sql(query),
                 }
             }
 
@@ -174,7 +148,19 @@ impl AppServices {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::QueryValue;
+    use crate::domain::{DatabaseType, QueryValue};
+
+    #[test]
+    fn stub_sqlite_explain_passes_through_existing_query_plan_prefix() {
+        let services = AppServices::stub();
+
+        assert_eq!(
+            services
+                .sql_dialect
+                .build_explain_sql(DatabaseType::SQLite, "EXPLAIN QUERY PLAN SELECT 1"),
+            Some("EXPLAIN QUERY PLAN SELECT 1".to_string())
+        );
+    }
 
     #[test]
     fn stub_sql_dialect_formats_typed_values() {

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -12,7 +12,7 @@ use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::{
     begin_explain_running, finish_explain_unsupported_analyze, is_multi_statement,
-    reject_unsupported_explain, show_explain_error_on_plan,
+    reject_unsupported_explain_analyze, show_explain_error_on_plan,
 };
 
 pub(super) fn reduce_analyze(
@@ -23,7 +23,7 @@ pub(super) fn reduce_analyze(
 ) -> DispatchResult {
     match action {
         Action::ExplainAnalyzeRequest => {
-            if reject_unsupported_explain(state) {
+            if reject_unsupported_explain_analyze(state) {
                 return DispatchResult::handled();
             }
             let content = state.sql_modal.editor.content().trim().to_string();
@@ -92,7 +92,7 @@ pub(super) fn reduce_analyze(
         }
 
         Action::ExplainAnalyzeConfirm => {
-            if reject_unsupported_explain(state) {
+            if reject_unsupported_explain_analyze(state) {
                 return DispatchResult::handled();
             }
             let query = match state.sql_modal.status() {

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -11,7 +11,7 @@ use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::{
-    begin_explain_running, is_multi_statement, mark_explain_unavailable,
+    begin_explain_running, finish_explain_unsupported_analyze, is_multi_statement,
     reject_unsupported_explain, show_explain_error_on_plan,
 };
 
@@ -73,7 +73,7 @@ pub(super) fn reduce_analyze(
                         .sql_dialect
                         .build_explain_analyze_sql(database_type, &content)
                     else {
-                        mark_explain_unavailable(state);
+                        finish_explain_unsupported_analyze(state);
                         return DispatchResult::handled();
                     };
                     let run_id = begin_explain_running(state, now);
@@ -112,7 +112,7 @@ pub(super) fn reduce_analyze(
                     .sql_dialect
                     .build_explain_analyze_sql(database_type, &query)
                 else {
-                    mark_explain_unavailable(state);
+                    finish_explain_unsupported_analyze(state);
                     return DispatchResult::handled();
                 };
                 let run_id = begin_explain_running(state, now);

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -2,13 +2,24 @@ use std::time::Instant;
 
 use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
-use crate::model::sql_editor::modal::SqlModalTab;
+use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
+use crate::policy::sql::statement_classifier;
 use crate::policy::write::sql_risk::split_statements_for_database;
 
 pub(super) fn explain_unsupported_query_message(database_type: DatabaseType) -> &'static str {
     match database_type {
         DatabaseType::SQLite => "EXPLAIN QUERY PLAN supports SELECT statements only",
         DatabaseType::PostgreSQL => "EXPLAIN is unavailable for this statement",
+    }
+}
+
+pub(super) fn explain_unsupported_sqlite_query_message(content: &str) -> &'static str {
+    if statement_classifier::first_keyword(content.trim())
+        .is_some_and(|keyword| keyword.eq_ignore_ascii_case("EXPLAIN"))
+    {
+        "EXPLAIN QUERY PLAN is added automatically; enter a SELECT query only"
+    } else {
+        explain_unsupported_query_message(DatabaseType::SQLite)
     }
 }
 
@@ -19,9 +30,13 @@ pub(super) fn explain_unsupported_analyze_message(database_type: DatabaseType) -
     }
 }
 
-pub(super) fn mark_explain_unsupported_query(state: &mut AppState) {
+pub(super) fn mark_explain_unsupported_query(state: &mut AppState, content: &str) {
     let database_type = state.session.active_database_type_or_default();
-    show_explain_error_on_plan(state, explain_unsupported_query_message(database_type));
+    let message = match database_type {
+        DatabaseType::SQLite => explain_unsupported_sqlite_query_message(content),
+        DatabaseType::PostgreSQL => explain_unsupported_query_message(database_type),
+    };
+    show_explain_error_on_plan(state, message);
 }
 
 pub(super) fn mark_explain_unsupported_analyze(state: &mut AppState) {
@@ -34,6 +49,12 @@ pub(super) fn finish_explain_unsupported_analyze(state: &mut AppState) {
         mark_explain_unsupported_analyze(state);
     } else {
         mark_explain_unavailable(state);
+    }
+    if matches!(
+        state.sql_modal.status(),
+        SqlModalStatus::ConfirmingAnalyzeHigh { .. } | SqlModalStatus::ConfirmingAnalyzeRisk { .. }
+    ) {
+        state.sql_modal.cancel_confirmation();
     }
 }
 
@@ -84,6 +105,23 @@ pub(super) fn finish_explain_error(state: &mut AppState, error: impl Into<String
     state.sql_modal.enter_normal();
     state.sql_modal.set_active_tab(SqlModalTab::Plan);
     state.query.mark_idle();
+}
+
+pub(super) fn reject_unsupported_explain_analyze(state: &mut AppState) -> bool {
+    if state
+        .session
+        .active_db_capabilities()
+        .supports_explain_analyze()
+    {
+        return false;
+    }
+
+    if state.session.active_db_capabilities().supports_explain() {
+        mark_explain_unsupported_analyze(state);
+    } else {
+        mark_explain_unavailable(state);
+    }
+    true
 }
 
 pub(super) fn reject_unsupported_explain(state: &mut AppState) -> bool {

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -5,6 +5,38 @@ use crate::model::app_state::AppState;
 use crate::model::sql_editor::modal::SqlModalTab;
 use crate::policy::write::sql_risk::split_statements_for_database;
 
+pub(super) fn explain_unsupported_query_message(database_type: DatabaseType) -> &'static str {
+    match database_type {
+        DatabaseType::SQLite => "EXPLAIN QUERY PLAN supports SELECT statements only",
+        DatabaseType::PostgreSQL => "EXPLAIN is unavailable for this statement",
+    }
+}
+
+pub(super) fn explain_unsupported_analyze_message(database_type: DatabaseType) -> &'static str {
+    match database_type {
+        DatabaseType::SQLite => "EXPLAIN ANALYZE is not supported for SQLite",
+        DatabaseType::PostgreSQL => "EXPLAIN ANALYZE is unavailable for this statement",
+    }
+}
+
+pub(super) fn mark_explain_unsupported_query(state: &mut AppState) {
+    let database_type = state.session.active_database_type_or_default();
+    show_explain_error_on_plan(state, explain_unsupported_query_message(database_type));
+}
+
+pub(super) fn mark_explain_unsupported_analyze(state: &mut AppState) {
+    let database_type = state.session.active_database_type_or_default();
+    show_explain_error_on_plan(state, explain_unsupported_analyze_message(database_type));
+}
+
+pub(super) fn finish_explain_unsupported_analyze(state: &mut AppState) {
+    if state.session.active_db_capabilities().supports_explain() {
+        mark_explain_unsupported_analyze(state);
+    } else {
+        mark_explain_unavailable(state);
+    }
+}
+
 pub(super) fn is_multi_statement(database_type: DatabaseType, content: &str) -> bool {
     split_statements_for_database(database_type, content).len() > 1
 }

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -44,12 +44,16 @@ pub(super) fn mark_explain_unsupported_analyze(state: &mut AppState) {
     show_explain_error_on_plan(state, explain_unsupported_analyze_message(database_type));
 }
 
-pub(super) fn finish_explain_unsupported_analyze(state: &mut AppState) {
+fn apply_explain_unsupported_analyze_state(state: &mut AppState) {
     if state.session.active_db_capabilities().supports_explain() {
         mark_explain_unsupported_analyze(state);
     } else {
         mark_explain_unavailable(state);
     }
+}
+
+pub(super) fn finish_explain_unsupported_analyze(state: &mut AppState) {
+    apply_explain_unsupported_analyze_state(state);
     if matches!(
         state.sql_modal.status(),
         SqlModalStatus::ConfirmingAnalyzeHigh { .. } | SqlModalStatus::ConfirmingAnalyzeRisk { .. }
@@ -116,11 +120,7 @@ pub(super) fn reject_unsupported_explain_analyze(state: &mut AppState) -> bool {
         return false;
     }
 
-    if state.session.active_db_capabilities().supports_explain() {
-        mark_explain_unsupported_analyze(state);
-    } else {
-        mark_explain_unavailable(state);
-    }
+    apply_explain_unsupported_analyze_state(state);
     true
 }
 

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -122,9 +122,39 @@ mod tests {
         }
 
         #[test]
-        fn sqlite_connection_sets_explain_unavailable_error_without_effects() {
+        fn sqlite_connection_emits_execute_explain_query_plan_effect() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
+            activate_sqlite_connection(&mut state);
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert_eq!(effects.len(), 1);
+            assert!(matches!(
+                &effects[0],
+                Effect::ExecuteExplain {
+                    query,
+                    is_analyze: false,
+                    read_only: true,
+                    ..
+                } if query == "EXPLAIN QUERY PLAN SELECT 1"
+            ));
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
+        }
+
+        #[test]
+        fn sqlite_non_select_sets_query_plan_error_on_plan_tab() {
+            let mut state = sql_modal_state();
+            state
+                .sql_modal
+                .editor
+                .set_content("DELETE FROM users".to_string());
             activate_sqlite_connection(&mut state);
 
             let effects = dispatch_explain(
@@ -138,9 +168,9 @@ mod tests {
             assert!(effects.is_empty());
             assert_eq!(
                 state.explain.error.as_deref(),
-                Some("EXPLAIN is unavailable for this database")
+                Some("EXPLAIN QUERY PLAN supports SELECT statements only")
             );
-            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
         }
 
         #[test]
@@ -1037,7 +1067,7 @@ mod tests {
         }
 
         #[test]
-        fn next_tab_stays_on_sql_for_sqlite_connection() {
+        fn next_tab_cycles_to_plan_for_sqlite_connection() {
             let mut state = sql_modal_state();
             activate_sqlite_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
@@ -1049,7 +1079,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
         }
 
         #[test]
@@ -1116,7 +1146,7 @@ mod tests {
         }
 
         #[test]
-        fn prev_tab_stays_on_sql_for_sqlite_connection() {
+        fn prev_tab_cycles_to_compare_for_sqlite_connection() {
             let mut state = sql_modal_state();
             activate_sqlite_connection(&mut state);
             state.sql_modal.set_active_tab(SqlModalTab::Sql);
@@ -1128,7 +1158,7 @@ mod tests {
                 &AppServices::stub(),
             );
 
-            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Compare);
         }
 
         #[test]

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -174,6 +174,60 @@ mod tests {
         }
 
         #[test]
+        fn sqlite_explain_prefixed_query_sets_prefix_specific_error() {
+            let mut state = sql_modal_state();
+            state
+                .sql_modal
+                .editor
+                .set_content("EXPLAIN SELECT 1".to_string());
+            activate_sqlite_connection(&mut state);
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.explain.error.as_deref(),
+                Some("EXPLAIN QUERY PLAN is added automatically; enter a SELECT query only")
+            );
+        }
+
+        #[test]
+        fn sqlite_explain_analyze_request_stops_before_confirmation() {
+            let mut state = sql_modal_state();
+            state
+                .sql_modal
+                .editor
+                .set_content("DELETE FROM users".to_string());
+            activate_sqlite_connection(&mut state);
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainAnalyzeRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.explain.error.as_deref(),
+                Some("EXPLAIN ANALYZE is not supported for SQLite")
+            );
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
+            assert!(!matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::ConfirmingAnalyzeHigh { .. }
+                    | SqlModalStatus::ConfirmingAnalyzeRisk { .. }
+            ));
+        }
+
+        #[test]
         fn multi_statement_sets_error_and_switches_to_plan_tab() {
             let mut state = sql_modal_state();
             state

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -10,7 +10,7 @@ use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::{
     begin_explain_running, is_multi_statement, mark_explain_unavailable,
-    reject_unsupported_explain, show_explain_error_on_plan,
+    mark_explain_unsupported_query, reject_unsupported_explain, show_explain_error_on_plan,
 };
 
 pub(super) fn reduce_request(
@@ -40,12 +40,19 @@ pub(super) fn reduce_request(
                 return DispatchResult::handled();
             }
 
-            let Some(query) = services
+            let query = match services
                 .sql_dialect
                 .build_explain_sql(database_type, &content)
-            else {
-                mark_explain_unavailable(state);
-                return DispatchResult::handled();
+            {
+                Some(query) => query,
+                None if state.session.active_db_capabilities().supports_explain() => {
+                    mark_explain_unsupported_query(state);
+                    return DispatchResult::handled();
+                }
+                None => {
+                    mark_explain_unavailable(state);
+                    return DispatchResult::handled();
+                }
             };
             let run_id = begin_explain_running(state, now);
 

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -46,7 +46,7 @@ pub(super) fn reduce_request(
             {
                 Some(query) => query,
                 None if state.session.active_db_capabilities().supports_explain() => {
-                    mark_explain_unsupported_query(state);
+                    mark_explain_unsupported_query(state, &content);
                     return DispatchResult::handled();
                 }
                 None => {

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -59,6 +59,10 @@ fn handle_key_event(combo: KeyCombo, state: &AppState) -> Action {
                     .normalize_sql_modal_tab(state.sql_modal.active_tab()),
                 state.ui.key_sequence().pending_prefix(),
                 state.settings.saved_keymap_preset(),
+                state
+                    .session
+                    .active_db_capabilities()
+                    .supports_explain_analyze(),
             )
         }
         InputMode::ConnectionSetup => connections::handle_connection_setup_keys(combo, state),

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -129,13 +129,6 @@ mod tests {
                 .sql_modal
                 .set_active_tab(crate::model::sql_editor::modal::SqlModalTab::Plan);
 
-            state.session.activate_connection_with_dsn(
-                &crate::domain::connection::ConnectionId::from_string("sqlite-test"),
-                "sqlite",
-                crate::domain::DatabaseType::SQLite,
-                "sqlite:///tmp/app.db",
-            );
-
             let result = handle_key_event(combo(Key::Char('i')), &state);
 
             assert!(matches!(result, Action::SqlModalEnterInsert));

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -26,6 +26,7 @@ pub fn handle_sql_modal_keys(
         active_tab,
         None,
         KeymapPreset::Default,
+        true,
     )
 }
 
@@ -36,6 +37,7 @@ pub fn handle_sql_modal_keys_with_prefix(
     active_tab: SqlModalTab,
     pending_prefix: Option<Prefix>,
     keymap_preset: KeymapPreset,
+    supports_explain_analyze: bool,
 ) -> Action {
     use crate::update::action::CursorMove;
 
@@ -99,7 +101,7 @@ pub fn handle_sql_modal_keys_with_prefix(
             }
 
             return match combo.key {
-                Key::Char('e') if alt => Action::ExplainAnalyzeRequest,
+                Key::Char('e') if alt && supports_explain_analyze => Action::ExplainAnalyzeRequest,
                 _ => Action::None,
             };
         }
@@ -114,13 +116,13 @@ pub fn handle_sql_modal_keys_with_prefix(
             }
 
             return match combo.key {
-                Key::Char('e') if alt => Action::ExplainAnalyzeRequest,
+                Key::Char('e') if alt && supports_explain_analyze => Action::ExplainAnalyzeRequest,
                 Key::Char('e') if plain => Action::CompareEditQuery,
                 _ => Action::None,
             };
         }
 
-        if alt && combo.key == Key::Char('e') {
+        if alt && combo.key == Key::Char('e') && supports_explain_analyze {
             return Action::ExplainAnalyzeRequest;
         }
         if sql_modal_normal_query_history(keymap_preset)
@@ -824,6 +826,7 @@ mod tests {
                 SqlModalTab::Sql,
                 Some(Prefix::G),
                 KeymapPreset::Default,
+                true,
             );
 
             assert_action(result, Expected::SqlModalMoveCursor(CursorMove::FirstLine));
@@ -838,6 +841,7 @@ mod tests {
                 SqlModalTab::Sql,
                 Some(Prefix::G),
                 KeymapPreset::Default,
+                true,
             );
 
             assert!(matches!(result, Action::CancelKeySequence));
@@ -852,6 +856,7 @@ mod tests {
                 SqlModalTab::Sql,
                 Some(Prefix::G),
                 KeymapPreset::Default,
+                true,
             );
 
             assert!(matches!(result, Action::CancelKeySequence));
@@ -866,6 +871,7 @@ mod tests {
                 SqlModalTab::Sql,
                 None,
                 KeymapPreset::Ide,
+                true,
             );
 
             assert!(matches!(
@@ -883,6 +889,7 @@ mod tests {
                 SqlModalTab::Sql,
                 None,
                 KeymapPreset::Ide,
+                true,
             );
 
             assert!(matches!(result, Action::None));
@@ -897,6 +904,7 @@ mod tests {
                 SqlModalTab::Plan,
                 None,
                 KeymapPreset::Ide,
+                true,
             );
 
             assert!(matches!(result, Action::ExplainRequest));
@@ -911,6 +919,7 @@ mod tests {
                 SqlModalTab::Plan,
                 None,
                 KeymapPreset::Ide,
+                true,
             );
 
             assert!(matches!(result, Action::None));
@@ -925,6 +934,7 @@ mod tests {
                 SqlModalTab::Sql,
                 None,
                 KeymapPreset::Ide,
+                true,
             );
 
             assert!(matches!(result, Action::None));
@@ -939,6 +949,7 @@ mod tests {
                 SqlModalTab::Sql,
                 None,
                 KeymapPreset::Ide,
+                true,
             );
 
             assert!(matches!(result, Action::None));

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -311,7 +311,11 @@ pub fn handle_sql_modal_keys_with_prefix(
     }
 
     if alt && combo.key == Key::Char('e') {
-        return Action::ExplainAnalyzeRequest;
+        return if supports_explain_analyze {
+            Action::ExplainAnalyzeRequest
+        } else {
+            Action::None
+        };
     }
 
     if completion_visible {
@@ -1376,6 +1380,21 @@ mod tests {
             );
 
             assert_action(result, Expected::ExplainAnalyzeRequest);
+        }
+
+        #[test]
+        fn editing_alt_e_is_noop_when_analyze_is_unsupported() {
+            let result = handle_sql_modal_keys_with_prefix(
+                combo_alt(Key::Char('e')),
+                false,
+                &SqlModalStatus::Editing,
+                SqlModalTab::Sql,
+                None,
+                KeymapPreset::Default,
+                false,
+            );
+
+            assert!(matches!(result, Action::None));
         }
 
         #[rstest]

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -1398,6 +1398,23 @@ mod tests {
         }
 
         #[rstest]
+        #[case(SqlModalTab::Plan)]
+        #[case(SqlModalTab::Compare)]
+        fn alt_e_is_noop_when_analyze_is_unsupported(#[case] tab: SqlModalTab) {
+            let result = handle_sql_modal_keys_with_prefix(
+                combo_alt(Key::Char('e')),
+                false,
+                &SqlModalStatus::Normal,
+                tab,
+                None,
+                KeymapPreset::Default,
+                false,
+            );
+
+            assert!(matches!(result, Action::None));
+        }
+
+        #[rstest]
         #[case(Key::Char('a'))]
         #[case(Key::Enter)]
         #[case(Key::Esc)]

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -393,15 +393,19 @@ mod tests {
     }
 
     #[test]
-    fn sqlite_explain_generation_is_unsupported() {
+    fn sqlite_explain_generation_uses_query_plan() {
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
 
         assert_eq!(
             registry.build_explain_sql(DatabaseType::SQLite, "SELECT 1"),
-            None
+            Some("EXPLAIN QUERY PLAN SELECT 1".to_string())
         );
         assert_eq!(
             registry.build_explain_analyze_sql(DatabaseType::SQLite, "SELECT 1"),
+            None
+        );
+        assert_eq!(
+            registry.build_explain_sql(DatabaseType::SQLite, "DELETE FROM users"),
             None
         );
     }

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -307,9 +307,21 @@ impl DdlGenerator for SqliteAdapter {
     }
 }
 
+const SQLITE_EXPLAIN_QUERY_PLAN_PREFIX: &str = "EXPLAIN QUERY PLAN";
+
 fn explain_query_plan_sql(query: &str) -> Option<String> {
     let trimmed = query.trim();
     if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.len() >= SQLITE_EXPLAIN_QUERY_PLAN_PREFIX.len()
+        && trimmed[..SQLITE_EXPLAIN_QUERY_PLAN_PREFIX.len()]
+            .eq_ignore_ascii_case(SQLITE_EXPLAIN_QUERY_PLAN_PREFIX)
+    {
+        let inner = trimmed[SQLITE_EXPLAIN_QUERY_PLAN_PREFIX.len()..].trim_start();
+        if matches!(statement_classifier::classify(inner), StatementKind::Select) {
+            return Some(trimmed.to_string());
+        }
         return None;
     }
     if statement_classifier::first_keyword(trimmed)
@@ -509,6 +521,19 @@ mod tests {
         assert_eq!(
             adapter.build_explain_analyze_sql(DatabaseType::SQLite, "SELECT 1"),
             None
+        );
+    }
+
+    #[test]
+    fn explain_generation_passes_through_existing_query_plan_prefix() {
+        let adapter = SqliteAdapter::new();
+
+        assert_eq!(
+            adapter.build_explain_sql(
+                DatabaseType::SQLite,
+                "EXPLAIN QUERY PLAN SELECT * FROM users"
+            ),
+            Some("EXPLAIN QUERY PLAN SELECT * FROM users".to_string())
         );
     }
 

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write as _;
 
+use crate::app::policy::sql::statement_classifier::{self, StatementKind};
 use crate::app::ports::outbound::{DbOperationError, DdlGenerator, SqlDialect};
 use crate::domain::{DatabaseType, QueryValue, Table, Trigger};
 
@@ -306,9 +307,28 @@ impl DdlGenerator for SqliteAdapter {
     }
 }
 
+fn explain_query_plan_sql(query: &str) -> Option<String> {
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if statement_classifier::first_keyword(trimmed)
+        .is_some_and(|keyword| keyword.eq_ignore_ascii_case("EXPLAIN"))
+    {
+        return None;
+    }
+    if !matches!(
+        statement_classifier::classify(trimmed),
+        StatementKind::Select
+    ) {
+        return None;
+    }
+    Some(format!("EXPLAIN QUERY PLAN {trimmed}"))
+}
+
 impl SqlDialect for SqliteAdapter {
-    fn build_explain_sql(&self, _database_type: DatabaseType, _query: &str) -> Option<String> {
-        None
+    fn build_explain_sql(&self, _database_type: DatabaseType, query: &str) -> Option<String> {
+        explain_query_plan_sql(query)
     }
 
     fn build_explain_analyze_sql(
@@ -458,11 +478,32 @@ mod tests {
     }
 
     #[test]
-    fn explain_generation_is_unsupported() {
+    fn explain_generation_wraps_select_with_query_plan() {
         let adapter = SqliteAdapter::new();
 
         assert_eq!(
             adapter.build_explain_sql(DatabaseType::SQLite, "SELECT 1"),
+            Some("EXPLAIN QUERY PLAN SELECT 1".to_string())
+        );
+        assert_eq!(
+            adapter.build_explain_sql(
+                DatabaseType::SQLite,
+                "WITH cte AS (SELECT 1 AS n) SELECT * FROM cte"
+            ),
+            Some("EXPLAIN QUERY PLAN WITH cte AS (SELECT 1 AS n) SELECT * FROM cte".to_string())
+        );
+    }
+
+    #[test]
+    fn explain_generation_rejects_non_select_and_prefixed_explain() {
+        let adapter = SqliteAdapter::new();
+
+        assert_eq!(
+            adapter.build_explain_sql(DatabaseType::SQLite, "DELETE FROM users"),
+            None
+        );
+        assert_eq!(
+            adapter.build_explain_sql(DatabaseType::SQLite, "EXPLAIN SELECT 1"),
             None
         );
         assert_eq!(

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as _;
 
-use crate::app::policy::sql::statement_classifier::{self, StatementKind};
+use crate::app::policy::sql::sqlite_explain::build_sqlite_explain_query_plan_sql;
 use crate::app::ports::outbound::{DbOperationError, DdlGenerator, SqlDialect};
 use crate::domain::{DatabaseType, QueryValue, Table, Trigger};
 
@@ -307,40 +307,9 @@ impl DdlGenerator for SqliteAdapter {
     }
 }
 
-const SQLITE_EXPLAIN_QUERY_PLAN_PREFIX: &str = "EXPLAIN QUERY PLAN";
-
-fn explain_query_plan_sql(query: &str) -> Option<String> {
-    let trimmed = query.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-    if trimmed.len() >= SQLITE_EXPLAIN_QUERY_PLAN_PREFIX.len()
-        && trimmed[..SQLITE_EXPLAIN_QUERY_PLAN_PREFIX.len()]
-            .eq_ignore_ascii_case(SQLITE_EXPLAIN_QUERY_PLAN_PREFIX)
-    {
-        let inner = trimmed[SQLITE_EXPLAIN_QUERY_PLAN_PREFIX.len()..].trim_start();
-        if matches!(statement_classifier::classify(inner), StatementKind::Select) {
-            return Some(trimmed.to_string());
-        }
-        return None;
-    }
-    if statement_classifier::first_keyword(trimmed)
-        .is_some_and(|keyword| keyword.eq_ignore_ascii_case("EXPLAIN"))
-    {
-        return None;
-    }
-    if !matches!(
-        statement_classifier::classify(trimmed),
-        StatementKind::Select
-    ) {
-        return None;
-    }
-    Some(format!("EXPLAIN QUERY PLAN {trimmed}"))
-}
-
 impl SqlDialect for SqliteAdapter {
     fn build_explain_sql(&self, _database_type: DatabaseType, query: &str) -> Option<String> {
-        explain_query_plan_sql(query)
+        build_sqlite_explain_query_plan_sql(query)
     }
 
     fn build_explain_analyze_sql(

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -659,21 +659,16 @@ mod tests {
                 .await
                 .unwrap();
 
-            let plan_text = result
-                .rows()
-                .iter()
-                .filter_map(|row| row.first())
-                .cloned()
-                .collect::<Vec<_>>()
-                .join("\n");
+            let plan_text = explain_plan_text_from_result(&result);
 
+            assert!(!plan_text.trim().is_empty(), "plan text must not be empty");
             assert!(
-                plan_text.contains("SEARCH users"),
-                "expected index search detail, got: {plan_text}"
+                plan_text.to_ascii_lowercase().contains("users"),
+                "expected users table in plan, got: {plan_text}"
             );
             assert!(
-                plan_text.contains("idx_users_name"),
-                "expected index name in plan, got: {plan_text}"
+                !explain_plan_operation_lines(&plan_text).is_empty(),
+                "expected at least one SCAN/SEARCH operation, got: {plan_text}"
             );
         }
 
@@ -694,22 +689,49 @@ mod tests {
                 .await
                 .unwrap();
 
-            let plan_text = result
+            let plan_text = explain_plan_text_from_result(&result);
+            let operation_lines = explain_plan_operation_lines(&plan_text);
+
+            assert!(
+                operation_lines.len() >= 2,
+                "expected multiple plan operations, got: {plan_text}"
+            );
+            assert!(
+                plan_mentions_table_or_alias(&plan_text, "users", 'u'),
+                "expected users side in plan, got: {plan_text}"
+            );
+            assert!(
+                plan_mentions_table_or_alias(&plan_text, "orders", 'o'),
+                "expected orders side in plan, got: {plan_text}"
+            );
+        }
+
+        fn explain_plan_text_from_result(result: &QueryResult) -> String {
+            result
                 .rows()
                 .iter()
                 .filter_map(|row| row.first())
                 .cloned()
                 .collect::<Vec<_>>()
-                .join("\n");
+                .join("\n")
+        }
 
-            assert!(
-                plan_text.contains("SCAN o"),
-                "expected orders scan: {plan_text}"
-            );
-            assert!(
-                plan_text.contains("SEARCH u"),
-                "expected users search: {plan_text}"
-            );
+        fn explain_plan_operation_lines(plan_text: &str) -> Vec<&str> {
+            plan_text
+                .lines()
+                .filter(|line| {
+                    let upper = line.to_ascii_uppercase();
+                    upper.contains("SCAN") || upper.contains("SEARCH")
+                })
+                .collect()
+        }
+
+        fn plan_mentions_table_or_alias(plan_text: &str, table: &str, alias: char) -> bool {
+            let lower = plan_text.to_ascii_lowercase();
+            lower.contains(table)
+                || lower
+                    .split_whitespace()
+                    .any(|token| token == alias.to_string())
         }
 
         #[tokio::test]

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -643,6 +643,76 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn explain_query_plan_returns_readable_detail_lines() {
+            let (_dir, dsn) = make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+                 CREATE INDEX idx_users_name ON users(name);",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(
+                    &dsn,
+                    "EXPLAIN QUERY PLAN SELECT * FROM users WHERE name = 'alice'",
+                    true,
+                )
+                .await
+                .unwrap();
+
+            let plan_text = result
+                .rows()
+                .iter()
+                .filter_map(|row| row.first())
+                .cloned()
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            assert!(
+                plan_text.contains("SEARCH users"),
+                "expected index search detail, got: {plan_text}"
+            );
+            assert!(
+                plan_text.contains("idx_users_name"),
+                "expected index name in plan, got: {plan_text}"
+            );
+        }
+
+        #[tokio::test]
+        async fn explain_query_plan_for_join_includes_both_scan_targets() {
+            let (_dir, dsn) = make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);
+                 CREATE TABLE orders(id INTEGER, user_id INTEGER);",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_adhoc(
+                    &dsn,
+                    "EXPLAIN QUERY PLAN SELECT * FROM users u JOIN orders o ON u.id = o.user_id",
+                    true,
+                )
+                .await
+                .unwrap();
+
+            let plan_text = result
+                .rows()
+                .iter()
+                .filter_map(|row| row.first())
+                .cloned()
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            assert!(
+                plan_text.contains("SCAN o"),
+                "expected orders scan: {plan_text}"
+            );
+            assert!(
+                plan_text.contains("SEARCH u"),
+                "expected users search: {plan_text}"
+            );
+        }
+
+        #[tokio::test]
         async fn create_trigger_with_multi_statement_body_preserves_definition() {
             let setup = r"
             CREATE TABLE agent_messages(


### PR DESCRIPTION
## Problem

SQLite connections could not inspect query plans from the SQL editor, so users had to leave sabiql and use external tools to understand scan paths and index usage.

## Background

PostgreSQL already exposes execution plans through the SQL modal Plan tab. SAB-304 extends the same workflow to SQLite using `EXPLAIN QUERY PLAN` instead of PostgreSQL-style `EXPLAIN`.

## Approach

Enable explain capability for SQLite connections, generate `EXPLAIN QUERY PLAN` for single SELECT statements, reject empty input, multi-statement batches, and non-SELECT SQL with explicit Plan-tab errors, and display sqlite3 plan detail lines in the existing Plan UI without changing PostgreSQL behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SQLite で `EXPLAIN QUERY PLAN` を使ったクエリプラン表示に対応しました。
  * SQL モーダルのヘルプやキー操作が、データベースの対応状況に応じて表示・動作するようになりました。

* **Bug Fixes**
  * SQLite で `EXPLAIN ANALYZE` 非対応時の扱いが改善され、無効な操作で誤った案内が出にくくなりました。
  * SQL モーダルのタブ遷移とエラー表示が、SQLite 環境でより正確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->