### PR TITLE
fix(sqlite): accept TEMP/TEMPORARY in trigger SQL parser

### DIFF
--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -1672,5 +1672,32 @@ mod tests {
             assert_eq!(detail.triggers[0].timing, TriggerTiming::Before);
             assert_eq!(detail.triggers[0].events, vec![TriggerEvent::Insert]);
         }
+
+        #[tokio::test]
+        async fn table_detail_loads_trigger_metadata_from_sqlite_master_sql() {
+            let (_dir, dsn) = make_sqlite_db(
+                r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY);
+            CREATE TRIGGER IF NOT EXISTS users_audit AFTER INSERT ON users BEGIN SELECT 1; END;
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let detail = adapter
+                .fetch_table_detail(&dsn, "main", "users")
+                .await
+                .unwrap();
+
+            assert_eq!(detail.triggers.len(), 1);
+            assert_eq!(detail.triggers[0].name, "users_audit");
+            assert_eq!(detail.triggers[0].timing, TriggerTiming::After);
+            assert_eq!(detail.triggers[0].events, vec![TriggerEvent::Insert]);
+            assert!(
+                !detail.triggers[0]
+                    .function_name
+                    .to_ascii_uppercase()
+                    .contains("TEMP")
+            );
+        }
     }
 }

--- a/src/infra/adapters/sqlite/sqlite3/metadata/trigger.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata/trigger.rs
@@ -219,6 +219,8 @@ fn parse_sqlite_trigger_header(
     }
 }
 
+// SQLite stores trigger DDL in sqlite_master without TEMP/TEMPORARY or IF NOT EXISTS.
+// TEMP prefix support is for direct SQL input only; metadata collection uses sqlite_master.
 pub(super) fn parse_sqlite_trigger(
     trigger_name: &str,
     sql: &str,
@@ -303,6 +305,7 @@ mod tests {
 
     #[test]
     fn parses_temp_trigger() {
+        // Direct SQL input hardening; sqlite_master stores CREATE TRIGGER without TEMP.
         let sql = "CREATE TEMP TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END";
         let trigger = parse_sqlite_trigger("users_audit", sql).unwrap();
 

--- a/src/infra/adapters/sqlite/sqlite3/metadata/trigger.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata/trigger.rs
@@ -229,18 +229,19 @@ pub(super) fn parse_sqlite_trigger(
     if !first.eq_ignore_ascii_case("CREATE") {
         return Err(sqlite_trigger_parse_error(sql, "expected CREATE"));
     }
-    let Some((second, pos)) = next_keyword_from(sql, pos) else {
+    let Some((second, mut pos)) = next_keyword_from(sql, pos) else {
         return Err(sqlite_trigger_parse_error(sql, "missing TRIGGER"));
     };
-    if !second.eq_ignore_ascii_case("TRIGGER") {
-        return Err(sqlite_trigger_parse_error(sql, "expected TRIGGER"));
-    }
-
-    let mut pos = pos;
-    if let Some((keyword, next)) = next_keyword_from(sql, pos)
-        && keyword.eq_ignore_ascii_case("TEMP")
-    {
+    if second.eq_ignore_ascii_case("TEMP") || second.eq_ignore_ascii_case("TEMPORARY") {
+        let Some((third, next)) = next_keyword_from(sql, pos) else {
+            return Err(sqlite_trigger_parse_error(sql, "missing TRIGGER"));
+        };
+        if !third.eq_ignore_ascii_case("TRIGGER") {
+            return Err(sqlite_trigger_parse_error(sql, "expected TRIGGER"));
+        }
         pos = next;
+    } else if !second.eq_ignore_ascii_case("TRIGGER") {
+        return Err(sqlite_trigger_parse_error(sql, "expected TRIGGER"));
     }
     pos = skip_optional_if_not_exists(sql, pos);
     pos = skip_object_reference(sql, pos);
@@ -298,5 +299,35 @@ mod tests {
 
         assert_eq!(trigger.timing, TriggerTiming::Before);
         assert_eq!(trigger.events, vec![TriggerEvent::Insert]);
+    }
+
+    #[test]
+    fn parses_temp_trigger() {
+        let sql = "CREATE TEMP TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END";
+        let trigger = parse_sqlite_trigger("users_audit", sql).unwrap();
+
+        assert_eq!(trigger.name, "users_audit");
+        assert_eq!(trigger.timing, TriggerTiming::After);
+        assert_eq!(trigger.events, vec![TriggerEvent::Insert]);
+    }
+
+    #[test]
+    fn parses_temporary_trigger() {
+        let sql = "CREATE TEMPORARY TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END";
+        let trigger = parse_sqlite_trigger("users_audit", sql).unwrap();
+
+        assert_eq!(trigger.name, "users_audit");
+        assert_eq!(trigger.timing, TriggerTiming::After);
+        assert_eq!(trigger.events, vec![TriggerEvent::Insert]);
+    }
+
+    #[test]
+    fn parses_temp_trigger_if_not_exists_with_quoted_name() {
+        let sql = r#"CREATE TEMP TRIGGER IF NOT EXISTS "user audit" AFTER UPDATE ON users BEGIN SELECT 1; END"#;
+        let trigger = parse_sqlite_trigger("user audit", sql).unwrap();
+
+        assert_eq!(trigger.name, "user audit");
+        assert_eq!(trigger.timing, TriggerTiming::After);
+        assert_eq!(trigger.events, vec![TriggerEvent::Update]);
     }
 }


### PR DESCRIPTION
## Problem

The SQLite trigger SQL parser rejected `CREATE TEMP TRIGGER` and `CREATE TEMPORARY TRIGGER` strings, diverging from grammar handling elsewhere in the adapter.

## Background

Closes SAB-309. Current trigger metadata collection reads `sqlite_master`, where SQLite stores normalized `CREATE TRIGGER ...` DDL without `TEMP`/`TEMPORARY` or `IF NOT EXISTS`. TEMP triggers also live in the connection-scoped temp schema and are outside today's collection query. This change is parser hardening for direct SQL input, not a fix for metadata collection failing on stored TEMP trigger DDL.

## Approach

Accept optional `TEMP`/`TEMPORARY` before `TRIGGER` in the metadata trigger parser, matching the statement splitter. Add an integration test that loads trigger metadata through the actual `sqlite_master` path, and keep unit tests for TEMP-prefixed direct SQL input.