### PR TITLE
chore(deps): bump quinn-proto to fix audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Problem

Dependabot PRs are blocked because the security audit now reports RUSTSEC-2026-0185 for quinn-proto.

## Background

The advisory database added a high-severity issue for the locked quinn-proto version used by main.

## Approach

Update the locked quinn-proto patch version to the fixed release.