### PR TITLE
chore: enable absolute path lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,6 +2597,7 @@ dependencies = [
  "sabiql-app",
  "sabiql-domain",
  "sabiql-infra",
+ "sabiql-test-support",
  "sabiql-ui",
  "self_update",
  "tempfile",
@@ -2616,6 +2617,7 @@ dependencies = [
  "nucleo-matcher",
  "rstest",
  "sabiql-domain",
+ "sabiql-test-support",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
@@ -2648,6 +2650,7 @@ dependencies = [
  "rstest",
  "sabiql-app",
  "sabiql-domain",
+ "sabiql-test-support",
  "serde",
  "serde_json",
  "tempfile",
@@ -2655,6 +2658,14 @@ dependencies = [
  "tokio",
  "toml",
  "urlencoding",
+]
+
+[[package]]
+name = "sabiql-test-support"
+version = "1.13.0"
+dependencies = [
+ "sabiql-domain",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ used_underscore_binding = "allow"  # rstest #[case] doc params use _prefix conve
 naive_bytecount = "allow"  # bytecount crate would be an unnecessary dependency
 
 # Restriction lints (opt-in)
+absolute_paths = "warn"
 dbg_macro = "deny"
 todo = "deny"
 print_stdout = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "src/app",
     "src/domain",
     "src/infra",
+    "src/test-support",
     "src/ui",
 ]
 resolver = "3"
@@ -15,9 +16,11 @@ license = "MIT"
 repository = "https://github.com/riii111/sabiql"
 
 [workspace.dependencies]
+# When adding third-party dependencies, update `absolute-paths-allowed-crates` in clippy.toml.
 sabiql-domain = { path = "src/domain", version = "1.13.0" }
 sabiql-app = { path = "src/app", version = "1.13.0" }
 sabiql-infra = { path = "src/infra", version = "1.13.0" }
+sabiql-test-support = { path = "src/test-support", version = "1.13.0" }
 sabiql-ui = { path = "src/ui", version = "1.13.0" }
 arboard = "3"
 async-trait = "0.1"
@@ -79,6 +82,7 @@ self-update = ["dep:self_update"]
 [dev-dependencies]
 sabiql-domain.workspace = true
 sabiql-app = { workspace = true, features = ["test-support"] }
+sabiql-test-support.workspace = true
 sabiql-ui = { workspace = true, features = ["test-support"] }
 ratatui.workspace = true
 insta.workspace = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,8 +1,7 @@
 msrv = "1.96"
 allow-dbg-in-tests = true
 too-many-arguments-threshold = 8
-absolute-paths-max-segments = 5
-# Allow std and third-party crate roots; keep workspace-internal paths linted.
+# Allow std and third-party crate roots; update this list when adding dependencies.
 absolute-paths-allowed-crates = [
     "alloc",
     "arboard",
@@ -21,6 +20,7 @@ absolute-paths-allowed-crates = [
     "nucleo_matcher",
     "ratatui",
     "rstest",
+    "sabiql_test_support",
     "self_update",
     "serde",
     "serde_json",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,6 +1,39 @@
 msrv = "1.96"
 allow-dbg-in-tests = true
 too-many-arguments-threshold = 8
+absolute-paths-max-segments = 5
+absolute-paths-allowed-crates = [
+    "alloc",
+    "arboard",
+    "async_trait",
+    "clap",
+    "color_eyre",
+    "core",
+    "crossterm",
+    "csv",
+    "dirs",
+    "dotenvy",
+    "futures",
+    "insta",
+    "lru",
+    "mockall",
+    "nucleo_matcher",
+    "ratatui",
+    "rstest",
+    "self_update",
+    "serde",
+    "serde_json",
+    "std",
+    "tempfile",
+    "thiserror",
+    "tokio",
+    "tokio_util",
+    "toml",
+    "unicode_casefold",
+    "unicode_width",
+    "urlencoding",
+    "uuid",
+]
 
 disallowed-methods = [
     { path = "std::time::Instant::now", reason = "reducers must receive `now` as a parameter; read the clock only at the runtime boundary (main loop / effect layer)" },

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,6 +2,7 @@ msrv = "1.96"
 allow-dbg-in-tests = true
 too-many-arguments-threshold = 8
 absolute-paths-max-segments = 5
+# Allow std and third-party crate roots; keep workspace-internal paths linted.
 absolute-paths-allowed-crates = [
     "alloc",
     "arboard",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,7 +1,7 @@
 msrv = "1.96"
 allow-dbg-in-tests = true
 too-many-arguments-threshold = 8
-# Allow std and third-party crate roots; update this list when adding dependencies.
+# Allow std, third-party crate roots, and the test helper crate; update this list when adding dependencies.
 absolute-paths-allowed-crates = [
     "alloc",
     "arboard",

--- a/src/app/Cargo.toml
+++ b/src/app/Cargo.toml
@@ -32,6 +32,7 @@ uuid.workspace = true
 [dev-dependencies]
 mockall.workspace = true
 rstest.workspace = true
+sabiql-test-support.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -284,7 +284,7 @@ mod tests {
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
-    use crate::cmd::test_support::*;
+    use crate::cmd::test_fixtures;
     use std::time::Instant;
 
     use crate::domain::DatabaseMetadata;
@@ -318,11 +318,14 @@ mod tests {
 
             let cache: TtlCache<String, Arc<DatabaseMetadata>> = TtlCache::new(300);
             cache
-                .set("dsn://test".to_string(), Arc::new(sample_metadata()))
+                .set(
+                    "dsn://test".to_string(),
+                    Arc::new(test_fixtures::sample_metadata()),
+                )
                 .await;
 
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(mock_provider),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -379,7 +382,7 @@ mod tests {
 
             let cache: TtlCache<String, Arc<DatabaseMetadata>> = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(mock_provider),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -438,11 +441,11 @@ mod tests {
             mock_provider
                 .expect_fetch_metadata()
                 .once()
-                .returning(|_| Ok(sample_metadata()));
+                .returning(|_| Ok(test_fixtures::sample_metadata()));
 
             let cache: TtlCache<String, Arc<DatabaseMetadata>> = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(mock_provider),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -491,11 +494,11 @@ mod tests {
             mock_provider
                 .expect_fetch_metadata()
                 .once()
-                .returning(|_| Ok(sample_metadata()));
+                .returning(|_| Ok(test_fixtures::sample_metadata()));
 
             let cache: TtlCache<String, Arc<DatabaseMetadata>> = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(mock_provider),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -548,7 +551,7 @@ mod tests {
 
             let cache: TtlCache<String, Arc<DatabaseMetadata>> = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(mock_provider),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -600,7 +603,7 @@ mod tests {
             Table {
                 schema: "public".to_string(),
                 name: "users".to_string(),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             }
         }
 
@@ -615,7 +618,7 @@ mod tests {
 
             let cache: TtlCache<String, Arc<DatabaseMetadata>> = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(mock_provider),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -673,7 +676,7 @@ mod tests {
 
             let cache: TtlCache<String, Arc<DatabaseMetadata>> = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(mock_provider),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -719,13 +722,16 @@ mod tests {
         async fn invalidate_removes_cache_entry() {
             let cache: TtlCache<String, Arc<DatabaseMetadata>> = TtlCache::new(300);
             cache
-                .set("dsn://target".to_string(), Arc::new(sample_metadata()))
+                .set(
+                    "dsn://target".to_string(),
+                    Arc::new(test_fixtures::sample_metadata()),
+                )
                 .await;
 
             assert!(cache.get(&"dsn://target".to_string()).await.is_some());
 
             let (tx, _rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -9,6 +9,7 @@ use crate::cmd::effect::Effect;
 use crate::domain::ConnectionId;
 use crate::domain::QuerySource;
 use crate::domain::QueryValue;
+use crate::domain::command_tag::CommandTag;
 use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{DbOperationError, QueryExecutor, QueryHistoryStore};
@@ -253,7 +254,7 @@ pub async fn run(
                             let rows = result
                                 .command_tag
                                 .as_ref()
-                                .and_then(crate::domain::command_tag::CommandTag::affected_rows);
+                                .and_then(CommandTag::affected_rows);
                             save_query_history(
                                 &history_store,
                                 &history_tx,
@@ -564,7 +565,7 @@ mod tests {
         use crate::cmd::cache::TtlCache;
         use crate::cmd::completion_engine::CompletionEngine;
         use crate::cmd::effect::Effect;
-        use crate::cmd::test_support::*;
+        use crate::cmd::test_fixtures;
         use crate::domain::QueryValue;
         use crate::model::app_state::AppState;
         use crate::ports::outbound::connection_store::MockConnectionStore;
@@ -594,7 +595,7 @@ mod tests {
         async fn writes_file_and_dispatches_success() {
             let cache = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -647,7 +648,7 @@ mod tests {
         async fn dispatches_failure_when_file_cannot_be_created() {
             let cache = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -693,7 +694,7 @@ mod tests {
         use crate::cmd::cache::TtlCache;
         use crate::cmd::completion_engine::CompletionEngine;
         use crate::cmd::effect::Effect;
-        use crate::cmd::test_support::*;
+        use crate::cmd::test_fixtures;
         use std::time::Instant;
 
         use crate::domain::QuerySource;
@@ -723,11 +724,11 @@ mod tests {
             mock_executor
                 .expect_execute_preview()
                 .once()
-                .returning(|_, _, _, _, _, _| Ok(sample_query_result()));
+                .returning(|_, _, _, _, _, _| Ok(test_fixtures::sample_query_result()));
 
             let cache = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(mock_executor),
                 Arc::new(MockConnectionStore::new()),
@@ -782,7 +783,7 @@ mod tests {
 
             let cache = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(mock_executor),
                 Arc::new(MockConnectionStore::new()),

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use crate::cmd::cache::BoundedLruCache;
 #[cfg(test)]
 use crate::domain::ColumnAttributes;
-use crate::domain::{DatabaseMetadata, Table};
+use crate::domain::{DatabaseMetadata, Table, TableSummary};
 use crate::model::sql_editor::completion::{CompletionCandidate, CompletionKind};
 use crate::policy::sql::lexer::{SqlContext, SqlLexer, TableReference, Token, TokenKind};
 use crate::update::helpers::char_to_byte_index;
@@ -319,8 +319,7 @@ impl CompletionEngine {
                     .map(|t| self.qualified_name_from_ref(t, metadata))
                     .collect();
 
-                let selected_qualified =
-                    table_detail.map(crate::domain::table::Table::qualified_name);
+                let selected_qualified = table_detail.map(Table::qualified_name);
                 let use_all_cache = referenced_tables.is_empty();
                 for (qualified_name, cached_table) in self.table_detail_cache.iter() {
                     if selected_qualified.as_ref() == Some(qualified_name) {
@@ -903,10 +902,7 @@ impl CompletionEngine {
                 .table_summaries
                 .iter()
                 .find(|t| t.name.to_lowercase() == table_ref.table.to_lowercase())
-                .map_or_else(
-                    || table_ref.table.clone(),
-                    crate::domain::table::TableSummary::qualified_name,
-                )
+                .map_or_else(|| table_ref.table.clone(), TableSummary::qualified_name)
         } else {
             table_ref.table.clone()
         }
@@ -927,7 +923,6 @@ mod tests {
     use super::*;
     pub use crate::domain::Column;
     use crate::domain::Table;
-    use crate::test_support::column::test_nullable_column;
 
     fn engine() -> CompletionEngine {
         CompletionEngine::new()
@@ -940,9 +935,11 @@ mod tests {
             columns: columns
                 .iter()
                 .enumerate()
-                .map(|(i, col)| test_nullable_column(*col, "text", (i + 1) as i32))
+                .map(|(i, col)| {
+                    sabiql_test_support::column::test_nullable_column(*col, "text", (i + 1) as i32)
+                })
                 .collect(),
-            ..crate::test_support::table::minimal("", "")
+            ..sabiql_test_support::table::minimal("", "")
         }
     }
 
@@ -951,7 +948,7 @@ mod tests {
             schema: "public".to_string(),
             name: "test".to_string(),
             columns: vec![col1, col2],
-            ..crate::test_support::table::minimal("", "")
+            ..sabiql_test_support::table::minimal("", "")
         }
     }
 
@@ -1213,14 +1210,14 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    test_nullable_column("user_name", "text", 1),
+                    sabiql_test_support::column::test_nullable_column("user_name", "text", 1),
                     Column {
                         attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("user_id", "int", 2)
+                        ..sabiql_test_support::column::test_nullable_column("user_id", "int", 2)
                     },
                 ],
                 primary_key: Some(vec!["user_id".to_string()]),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             };
 
             let candidates = e.column_candidates(Some(&table), "user");
@@ -1340,10 +1337,10 @@ mod tests {
         fn pk_column_returns_higher_score() {
             let e = engine();
             let table = table_with_two_columns(
-                test_nullable_column("name", "text", 1),
+                sabiql_test_support::column::test_nullable_column("name", "text", 1),
                 Column {
                     attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "int", 2)
+                    ..sabiql_test_support::column::test_nullable_column("id", "int", 2)
                 },
             );
 
@@ -1357,10 +1354,10 @@ mod tests {
         fn not_null_column_returns_higher_score() {
             let e = engine();
             let table = table_with_two_columns(
-                test_nullable_column("optional_field", "text", 1),
+                sabiql_test_support::column::test_nullable_column("optional_field", "text", 1),
                 Column {
                     attributes: ColumnAttributes::empty(),
-                    ..test_nullable_column("required_field", "text", 2)
+                    ..sabiql_test_support::column::test_nullable_column("required_field", "text", 2)
                 },
             );
 
@@ -1506,7 +1503,7 @@ mod tests {
             };
 
             let mut metadata = DatabaseMetadata::new("test".to_string());
-            metadata.table_summaries = vec![crate::domain::TableSummary::new(
+            metadata.table_summaries = vec![TableSummary::new(
                 "public".to_string(),
                 "users".to_string(),
                 None,
@@ -1561,12 +1558,12 @@ mod tests {
                 columns: vec![
                     Column {
                         attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("id", "int", 1)
+                        ..sabiql_test_support::column::test_nullable_column("id", "int", 1)
                     },
-                    test_nullable_column("name", "text", 2),
+                    sabiql_test_support::column::test_nullable_column("name", "text", 2),
                 ],
                 primary_key: Some(vec!["id".to_string()]),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             };
 
             e.cache_table_detail("public.users".to_string(), table);
@@ -1627,13 +1624,13 @@ mod tests {
                 columns: vec![
                     Column {
                         attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("user_id", "int", 1)
+                        ..sabiql_test_support::column::test_nullable_column("user_id", "int", 1)
                     },
-                    test_nullable_column("username", "text", 2),
-                    test_nullable_column("email", "text", 3),
+                    sabiql_test_support::column::test_nullable_column("username", "text", 2),
+                    sabiql_test_support::column::test_nullable_column("email", "text", 3),
                 ],
                 primary_key: Some(vec!["user_id".to_string()]),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             };
 
             e.cache_table_detail("public.users".to_string(), table);
@@ -1676,13 +1673,13 @@ mod tests {
                 columns: vec![
                     Column {
                         attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("id", "int", 1)
+                        ..sabiql_test_support::column::test_nullable_column("id", "int", 1)
                     },
                     Column {
                         attributes: ColumnAttributes::empty(),
-                        ..test_nullable_column("user_id", "int", 2)
+                        ..sabiql_test_support::column::test_nullable_column("user_id", "int", 2)
                     },
-                    test_nullable_column("status", "text", 3),
+                    sabiql_test_support::column::test_nullable_column("status", "text", 3),
                 ],
                 primary_key: Some(vec!["id".to_string()]),
                 foreign_keys: vec![ForeignKey {
@@ -1697,7 +1694,7 @@ mod tests {
                     on_update: FkAction::NoAction,
                     reference_resolved: true,
                 }],
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             }
         }
 
@@ -1752,10 +1749,10 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    test_nullable_column("user_id", "int", 1),
-                    test_nullable_column("created_at", "timestamp", 2),
+                    sabiql_test_support::column::test_nullable_column("user_id", "int", 1),
+                    sabiql_test_support::column::test_nullable_column("created_at", "timestamp", 2),
                 ],
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             };
 
             // "id" is contained in "user_id"
@@ -1772,10 +1769,10 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    test_nullable_column("id", "int", 1),
-                    test_nullable_column("user_id", "int", 2),
+                    sabiql_test_support::column::test_nullable_column("id", "int", 1),
+                    sabiql_test_support::column::test_nullable_column("user_id", "int", 2),
                 ],
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             };
 
             let candidates = e.column_candidates_with_fk(Some(&table), "id", &[]);
@@ -1799,10 +1796,10 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    test_nullable_column("name", "text", 1),
-                    test_nullable_column("email", "text", 2),
+                    sabiql_test_support::column::test_nullable_column("name", "text", 1),
+                    sabiql_test_support::column::test_nullable_column("email", "text", 2),
                 ],
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             };
 
             let recent = vec!["email".to_string()];
@@ -1923,9 +1920,9 @@ mod tests {
                 name: "users".to_string(),
                 columns: vec![Column {
                     attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "int", 1)
+                    ..sabiql_test_support::column::test_nullable_column("id", "int", 1)
                 }],
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             };
             e.cache_table_detail("public.users".to_string(), table);
 
@@ -2010,7 +2007,7 @@ mod tests {
             let table = Table {
                 schema: "public".to_string(),
                 name: "users".to_string(),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             };
             e.cache_table_detail("public.users".to_string(), table);
 
@@ -2022,7 +2019,7 @@ mod tests {
             Table {
                 schema: schema.to_string(),
                 name: name.to_string(),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             }
         }
 
@@ -2062,16 +2059,16 @@ mod tests {
                 columns: vec![
                     Column {
                         attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("id", "int", 1)
+                        ..sabiql_test_support::column::test_nullable_column("id", "int", 1)
                     },
-                    test_nullable_column("name", "text", 2),
+                    sabiql_test_support::column::test_nullable_column("name", "text", 2),
                     Column {
                         attributes: ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("email", "text", 3)
+                        ..sabiql_test_support::column::test_nullable_column("email", "text", 3)
                     },
                 ],
                 primary_key: Some(vec!["id".to_string()]),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             }
         }
 
@@ -2266,8 +2263,10 @@ mod tests {
             let table = Table {
                 schema: "public".to_string(),
                 name: "test".to_string(),
-                columns: vec![test_nullable_column("and", "text", 1)],
-                ..crate::test_support::table::minimal("", "")
+                columns: vec![sabiql_test_support::column::test_nullable_column(
+                    "and", "text", 1,
+                )],
+                ..sabiql_test_support::table::minimal("", "")
             };
 
             let candidates = e.get_candidates("SELECT ", 7, None, Some(&table), &[]);

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -229,7 +229,7 @@ mod tests {
     use crate::cmd::cache::TtlCache;
     use crate::cmd::completion_engine::CompletionEngine;
     use crate::cmd::effect::Effect;
-    use crate::cmd::test_support::*;
+    use crate::cmd::test_fixtures;
     use crate::domain::connection::{
         ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
         SqliteConnectionConfig, SqlitePathError, SslMode,
@@ -286,7 +286,7 @@ mod tests {
 
             let cache = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner_with_dsn(
+            let runner = test_fixtures::make_runner_with_dsn(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(mock_store),
@@ -337,7 +337,7 @@ mod tests {
 
             let cache = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner_with_dsn(
+            let runner = test_fixtures::make_runner_with_dsn(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(mock_store),
@@ -393,7 +393,7 @@ mod tests {
 
             let cache = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(mock_store),
@@ -437,7 +437,7 @@ mod tests {
 
             let cache = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(mock_store),
@@ -490,7 +490,7 @@ mod tests {
 
             let cache = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(mock_store),
@@ -533,27 +533,27 @@ mod tests {
             let runner = EffectRunner::new(
                 Arc::new(MockMetadataProvider::new()),
                 ConnectionDeps {
-                    dsn_builder: Arc::new(NoopDsnBuilder),
+                    dsn_builder: Arc::new(test_fixtures::NoopDsnBuilder),
                     connection_store: Arc::new(mock_store),
                     pg_service_entry_reader: None,
-                    sqlite_path_validator: Arc::new(TestFsSqlitePathValidator),
+                    sqlite_path_validator: Arc::new(test_fixtures::TestFsSqlitePathValidator),
                 },
                 QueryDeps {
                     query_executor: Arc::new(MockQueryExecutor::new()),
-                    query_history_store: Arc::new(NoopQueryHistoryStore),
-                    sqlite_diagnostics: Arc::new(NoopSqliteDiagnosticsProvider),
+                    query_history_store: Arc::new(test_fixtures::NoopQueryHistoryStore),
+                    sqlite_diagnostics: Arc::new(test_fixtures::NoopSqliteDiagnosticsProvider),
                 },
                 ErDeps {
-                    er_exporter: Arc::new(NoopErExporter),
-                    config_writer: Arc::new(NoopConfigWriter),
-                    er_log_writer: Arc::new(NoopErLogWriter),
+                    er_exporter: Arc::new(test_fixtures::NoopErExporter),
+                    config_writer: Arc::new(test_fixtures::NoopConfigWriter),
+                    er_log_writer: Arc::new(test_fixtures::NoopErLogWriter),
                 },
                 UtilityDeps {
-                    clipboard: Arc::new(NoopClipboardWriter),
-                    folder_opener: Arc::new(NoopFolderOpener),
+                    clipboard: Arc::new(test_fixtures::NoopClipboardWriter),
+                    folder_opener: Arc::new(test_fixtures::NoopFolderOpener),
                 },
                 SettingsDeps {
-                    settings_store: Arc::new(NoopSettingsStore),
+                    settings_store: Arc::new(test_fixtures::NoopSettingsStore),
                 },
                 cache,
                 tx,
@@ -606,7 +606,7 @@ mod tests {
         }
 
         fn make_runner_with_dsn_builder(action_tx: mpsc::Sender<Action>) -> EffectRunner {
-            make_runner_with_dsn(
+            test_fixtures::make_runner_with_dsn(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -146,7 +146,7 @@ pub enum Effect {
 
     LoadQueryHistory {
         project_name: String,
-        connection_id: crate::domain::ConnectionId,
+        connection_id: ConnectionId,
     },
 
     SaveSettings {

--- a/src/app/cmd/er/task.rs
+++ b/src/app/cmd/er/task.rs
@@ -5,7 +5,7 @@ use tokio::sync::mpsc;
 
 use crate::domain::ErTableInfo;
 use crate::ports::outbound::ErDiagramExporter;
-use crate::update::action::{Action, ErDiagramInfo};
+use crate::update::action::{Action, ErDiagramError, ErDiagramInfo};
 
 pub fn spawn_er_diagram_task(
     exporter: Arc<dyn ErDiagramExporter>,
@@ -35,16 +35,16 @@ pub fn spawn_er_diagram_task(
             }
             Ok(Err(e)) => {
                 let _ = tx
-                    .send(Action::ErDiagramFailed(
-                        crate::update::action::ErDiagramError::ExportFailed(e.to_string()),
-                    ))
+                    .send(Action::ErDiagramFailed(ErDiagramError::ExportFailed(
+                        e.to_string(),
+                    )))
                     .await;
             }
             Err(e) => {
                 let _ = tx
-                    .send(Action::ErDiagramFailed(
-                        crate::update::action::ErDiagramError::TaskPanicked(e.to_string()),
-                    ))
+                    .send(Action::ErDiagramFailed(ErDiagramError::TaskPanicked(
+                        e.to_string(),
+                    )))
                     .await;
             }
         }

--- a/src/app/cmd/mod.rs
+++ b/src/app/cmd/mod.rs
@@ -11,7 +11,6 @@ pub mod settings;
 pub mod sql_editor;
 pub mod sqlite_diagnostics;
 pub mod sqlite_path_validate;
-pub mod utility;
-
 #[cfg(test)]
-pub(crate) mod test_support;
+pub(crate) mod test_fixtures;
+pub mod utility;

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -17,6 +17,7 @@ use crate::cmd::er::handler as cmd_er;
 use crate::cmd::settings as cmd_settings;
 use crate::cmd::sql_editor::completion as cmd_completion;
 use crate::cmd::sql_editor::query_history as cmd_query_history;
+use crate::cmd::sqlite_diagnostics;
 use crate::cmd::utility as cmd_utility;
 use crate::domain::DatabaseMetadata;
 use crate::model::app_state::AppState;
@@ -246,11 +247,7 @@ impl EffectRunner {
 
             e @ (Effect::FetchSqliteDiagnosticsCore { .. }
             | Effect::FetchSqliteDiagnosticsQuickCheck { .. }) => {
-                crate::cmd::sqlite_diagnostics::run(
-                    e,
-                    &self.action_tx,
-                    &self.query.sqlite_diagnostics,
-                );
+                sqlite_diagnostics::run(e, &self.action_tx, &self.query.sqlite_diagnostics);
                 Ok(vec![])
             }
 
@@ -269,7 +266,7 @@ impl EffectRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cmd::test_support::*;
+    use crate::cmd::test_fixtures;
     use crate::domain::{DatabaseMetadata, TableSummary};
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
@@ -333,7 +330,7 @@ mod tests {
         #[tokio::test]
         async fn calls_draw() {
             let (tx, _rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -360,7 +357,7 @@ mod tests {
         #[tokio::test]
         async fn clamps_stale_explorer_horizontal_offset_to_new_maximum() {
             let (tx, _rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -403,7 +400,7 @@ mod tests {
         #[tokio::test]
         async fn recomputes_jsonb_editor_scroll_when_visible_rows_change() {
             let (tx, _rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),
@@ -450,7 +447,7 @@ mod tests {
         #[tokio::test]
         async fn dispatches_all_actions() {
             let (tx, _rx) = mpsc::channel(8);
-            let runner = make_runner(
+            let runner = test_fixtures::make_runner(
                 Arc::new(MockMetadataProvider::new()),
                 Arc::new(MockQueryExecutor::new()),
                 Arc::new(MockConnectionStore::new()),

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -16,8 +16,8 @@ use crate::domain::{
 };
 use crate::ports::outbound::DbOperationError;
 use crate::ports::outbound::{
-    ClipboardError, ClipboardWriter, ConfigWriter, ConfigWriterError, ConnectionStore, DsnBuilder,
-    ErDiagramExporter, ErExportResult, ErLogWriter, FolderOpenError, FolderOpener,
+    AppSettings, ClipboardError, ClipboardWriter, ConfigWriter, ConfigWriterError, ConnectionStore,
+    DsnBuilder, ErDiagramExporter, ErExportResult, ErLogWriter, FolderOpenError, FolderOpener,
     MetadataProvider, PgServiceEntryReader, QueryExecutor, QueryHistoryError, QueryHistoryStore,
     ServiceFileError, SettingsStore, SettingsStoreError, SqliteDiagnosticsProvider,
     SqlitePathValidator,
@@ -143,14 +143,11 @@ impl QueryHistoryStore for NoopQueryHistoryStore {
 
 pub struct NoopSettingsStore;
 impl SettingsStore for NoopSettingsStore {
-    fn load(&self) -> Result<crate::ports::outbound::AppSettings, SettingsStoreError> {
-        Ok(crate::ports::outbound::AppSettings::default())
+    fn load(&self) -> Result<AppSettings, SettingsStoreError> {
+        Ok(AppSettings::default())
     }
 
-    fn save(
-        &self,
-        _settings: crate::ports::outbound::AppSettings,
-    ) -> Result<(), SettingsStoreError> {
+    fn save(&self, _settings: AppSettings) -> Result<(), SettingsStoreError> {
         Ok(())
     }
 }

--- a/src/app/lib.rs
+++ b/src/app/lib.rs
@@ -15,7 +15,4 @@ pub mod update;
 pub mod ports;
 pub mod services;
 
-#[cfg(test)]
-pub(crate) mod test_support;
-
 pub use sabiql_domain as domain;

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -11,7 +11,7 @@ use crate::model::browse::result_interaction::ResultInteraction;
 use crate::model::browse::session::BrowseSession;
 use crate::model::connection::cache::ConnectionCacheStore;
 use crate::model::connection::error_state::ConnectionErrorState;
-use crate::model::connection::list::ConnectionListItem;
+use crate::model::connection::list::{self, ConnectionListItem};
 use crate::model::connection::setup::ConnectionSetupState;
 use crate::model::shared::confirm_dialog::ConfirmDialogState;
 use crate::model::shared::flash_timer::FlashTimerStore;
@@ -20,14 +20,16 @@ use crate::model::shared::message::MessageState;
 use crate::model::shared::modal::ModalState;
 use crate::model::shared::render_output::RenderOutput;
 use crate::model::shared::settings::SettingsState;
+use crate::model::shared::text_input::TextInputState;
 use crate::model::shared::ui_state::{UiState, scroll_max_offset};
 use crate::model::sql_editor::modal::SqlModalContext;
 use crate::model::sql_editor::query_history::QueryHistoryPickerState;
+use crate::model::sqlite::diagnostics::SqliteDiagnosticsState;
 use crate::policy::table_kind::max_explorer_table_label_width;
 
 pub struct AppState {
     pub should_quit: bool,
-    pub command_line_input: crate::model::shared::text_input::TextInputState,
+    pub command_line_input: TextInputState,
     pub command_line_visible_width: usize,
 
     pub render_dirty: bool,
@@ -47,7 +49,7 @@ pub struct AppState {
     pub jsonb_detail: JsonbDetailState,
     pub query_history_picker: QueryHistoryPickerState,
     pub settings: SettingsState,
-    pub sqlite_diagnostics: crate::model::sqlite::diagnostics::SqliteDiagnosticsState,
+    pub sqlite_diagnostics: SqliteDiagnosticsState,
     pub explain: ExplainContext,
     pub modal: ModalState,
     pub flash_timers: FlashTimerStore,
@@ -61,7 +63,7 @@ impl AppState {
     pub fn new(project_name: String) -> Self {
         Self {
             should_quit: false,
-            command_line_input: crate::model::shared::text_input::TextInputState::default(),
+            command_line_input: TextInputState::default(),
             command_line_visible_width: 70,
             render_dirty: true,
             session: BrowseSession::default(),
@@ -79,8 +81,7 @@ impl AppState {
             jsonb_detail: JsonbDetailState::default(),
             query_history_picker: QueryHistoryPickerState::default(),
             settings: SettingsState::default(),
-            sqlite_diagnostics: crate::model::sqlite::diagnostics::SqliteDiagnosticsState::default(
-            ),
+            sqlite_diagnostics: SqliteDiagnosticsState::default(),
             explain: ExplainContext::default(),
             modal: ModalState::default(),
             flash_timers: FlashTimerStore::default(),
@@ -275,10 +276,8 @@ impl AppState {
     }
 
     fn rebuild_connection_list(&mut self) {
-        self.connection_list_items = crate::model::connection::list::build_connection_list(
-            self.connections.len(),
-            self.service_entries.len(),
-        );
+        self.connection_list_items =
+            list::build_connection_list(self.connections.len(), self.service_entries.len());
     }
 
     pub fn toggle_focus(&mut self) -> bool {
@@ -302,9 +301,12 @@ mod tests {
     use std::time::Instant;
 
     use super::*;
-    use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, QuerySource, Table};
+    use crate::domain::{
+        ConnectionId, DatabaseMetadata, DatabaseType, QueryResult, QuerySource, Table,
+    };
     use crate::model::er_state::ErStatus;
     use crate::model::shared::focused_pane::FocusedPane;
+    use crate::model::sql_editor::modal::FailedPrefetchEntry;
     use crate::update::action::Action;
     use crate::update::dispatch_metadata;
     use rstest::rstest;
@@ -321,8 +323,8 @@ mod tests {
         );
     }
 
-    fn make_query_result(source: QuerySource) -> Arc<crate::domain::QueryResult> {
-        Arc::new(crate::domain::QueryResult::success(
+    fn make_query_result(source: QuerySource) -> Arc<QueryResult> {
+        Arc::new(QueryResult::success(
             "SELECT 1".to_string(),
             vec!["col".to_string()],
             vec![vec!["val".to_string()]],
@@ -341,7 +343,7 @@ mod tests {
         Table {
             schema: "public".to_string(),
             name: "users".to_string(),
-            ..crate::test_support::table::minimal("", "")
+            ..sabiql_test_support::table::minimal("", "")
         }
     }
 
@@ -578,7 +580,7 @@ mod tests {
 
             state.sql_modal.record_prefetch_failure(
                 "public.users".to_string(),
-                crate::model::sql_editor::modal::FailedPrefetchEntry {
+                FailedPrefetchEntry {
                     failed_at: now,
                     error: "connection timeout".to_string(),
                     retry_count: 0,
@@ -614,7 +616,7 @@ mod tests {
                 .mark_prefetching("public.orders".to_string());
             state.sql_modal.record_prefetch_failure(
                 "public.failed".to_string(),
-                crate::model::sql_editor::modal::FailedPrefetchEntry {
+                FailedPrefetchEntry {
                     failed_at: Instant::now(),
                     error: "timeout".to_string(),
                     retry_count: 0,
@@ -792,8 +794,8 @@ mod tests {
             .unwrap()
         }
 
-        fn make_service(name: &str) -> crate::domain::connection::ServiceEntry {
-            crate::domain::connection::ServiceEntry {
+        fn make_service(name: &str) -> ServiceEntry {
+            ServiceEntry {
                 service_name: name.to_string(),
                 host: None,
                 dbname: None,

--- a/src/app/model/browse/cell_detail.rs
+++ b/src/app/model/browse/cell_detail.rs
@@ -1,1 +1,3 @@
-pub type CellDetailState = crate::model::shared::detail_view::ReadOnlyDetailState;
+use crate::model::shared::detail_view::ReadOnlyDetailState;
+
+pub type CellDetailState = ReadOnlyDetailState;

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -464,7 +464,7 @@ mod tests {
             schema: "public".to_string(),
             name: "users".to_string(),
             row_count_estimate: Some(100),
-            ..crate::test_support::table::minimal("", "")
+            ..sabiql_test_support::table::minimal("", "")
         }
     }
 

--- a/src/app/model/shared/confirm_dialog.rs
+++ b/src/app/model/shared/confirm_dialog.rs
@@ -1,4 +1,5 @@
 use crate::domain::{ConnectionId, QueryValue};
+use crate::update::action::ScrollDirection;
 
 #[derive(Debug, Clone)]
 pub struct CsvExportCacheSnapshot {
@@ -86,7 +87,7 @@ impl ConfirmDialogState {
         self.preview_scroll = scroll.min(self.max_scroll());
     }
 
-    pub fn scroll_preview(&mut self, direction: crate::update::action::ScrollDirection) {
+    pub fn scroll_preview(&mut self, direction: ScrollDirection) {
         let max_scroll = self.max_scroll() as usize;
         self.preview_scroll =
             direction.clamp_vertical_offset(self.preview_scroll as usize, max_scroll, 1) as u16;

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::domain::connection::{
     ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
 };
+use crate::domain::query_history::QueryHistoryEntry;
 use crate::model::connection::error::ConnectionErrorInfo;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::key_sequence::Prefix;
@@ -541,11 +542,8 @@ pub enum Action {
     ToggleReadOnly,
 
     // Query history
-    QueryHistoryLoaded(
-        crate::domain::ConnectionId,
-        Vec<crate::domain::query_history::QueryHistoryEntry>,
-    ),
-    QueryHistoryLoadFailed(crate::domain::ConnectionId, QueryHistoryError),
+    QueryHistoryLoaded(ConnectionId, Vec<QueryHistoryEntry>),
+    QueryHistoryLoadFailed(ConnectionId, QueryHistoryError),
     QueryHistoryAppendFailed(QueryHistoryError),
     QueryHistoryConfirmSelection,
 

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -52,7 +52,7 @@ pub fn dispatch_metadata(state: &mut AppState, action: &Action, now: Instant) ->
 mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
-    use crate::domain::{ConnectionId, DatabaseType};
+    use crate::domain::{ConnectionId, DatabaseType, Table};
     use crate::model::app_state::AppState;
     use crate::model::sql_editor::modal::FailedPrefetchEntry;
     use crate::update::action::Action;
@@ -70,8 +70,8 @@ mod tests {
         state
     }
 
-    fn empty_table(schema: &str, name: &str) -> Box<crate::domain::Table> {
-        Box::new(crate::test_support::table::minimal(schema, name))
+    fn empty_table(schema: &str, name: &str) -> Box<Table> {
+        Box::new(sabiql_test_support::table::minimal(schema, name))
     }
 
     mod freshness_guards {

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::TableSummary;
 use crate::model::app_state::AppState;
 use crate::model::sql_editor::modal::FailedPrefetchEntry;
 use crate::update::action::Action;
@@ -30,7 +31,7 @@ pub(super) fn reduce_prefetch(
                 let qualified_names: Vec<String> = metadata
                     .table_summaries
                     .iter()
-                    .map(crate::domain::TableSummary::qualified_name)
+                    .map(TableSummary::qualified_name)
                     .collect();
                 state
                     .er_preparation

--- a/src/app/update/browse/navigation/connection_list.rs
+++ b/src/app/update/browse/navigation/connection_list.rs
@@ -304,6 +304,7 @@ mod tests {
 
     mod confirm_connection_selection {
         use super::*;
+        use crate::domain::DatabaseType;
 
         fn create_test_profile_with_id(name: &str, id: ConnectionId) -> ConnectionProfile {
             ConnectionProfile::with_id_postgres(
@@ -332,7 +333,7 @@ mod tests {
             state.session.activate_connection_with_dsn(
                 &active_id,
                 "active",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
             );
             state.ui.set_connection_list_selection(Some(1));
@@ -366,7 +367,7 @@ mod tests {
             state.session.activate_connection_with_dsn(
                 &active_id,
                 "active",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
             );
             state.ui.set_connection_list_selection(Some(0));
@@ -410,7 +411,7 @@ mod tests {
             state.session.activate_connection_with_dsn(
                 &active_id,
                 "active",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
             );
             state.modal.set_mode(InputMode::ConnectionSelector);
@@ -442,7 +443,7 @@ mod tests {
             state.session.activate_connection_with_dsn(
                 &active_id,
                 "active",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
             );
             state.modal.set_mode(InputMode::ConnectionSelector);

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -111,7 +111,6 @@ mod tests {
     use super::*;
     use crate::domain::{Column, ColumnAttributes, ConnectionId, DatabaseType, Table};
     use crate::model::shared::db_capabilities::DbCapabilities;
-    use crate::test_support::column::test_nullable_column;
     use crate::update::browse::navigation::dispatch_navigation;
     use std::time::Instant;
 
@@ -131,7 +130,11 @@ mod tests {
             let cols: Vec<Column> = (0..columns)
                 .map(|i| Column {
                     attributes: ColumnAttributes::empty(),
-                    ..test_nullable_column(format!("col_{i}"), "text", i as i32)
+                    ..sabiql_test_support::column::test_nullable_column(
+                        format!("col_{i}"),
+                        "text",
+                        i as i32,
+                    )
                 })
                 .collect();
             state.session.set_table_detail_raw(Some(Table {
@@ -139,7 +142,7 @@ mod tests {
                 name: "test_table".to_string(),
                 columns: cols,
                 row_count_estimate: Some(0),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             }));
             state
         }

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -849,7 +849,7 @@ mod tests {
         #[test]
         fn no_command_tag_emits_no_effects() {
             let mut state = state_with_table("public", "users");
-            let result = Arc::new(crate::domain::QueryResult::success(
+            let result = Arc::new(QueryResult::success(
                 "SELECT 1".to_string(),
                 vec!["?column?".to_string()],
                 vec![vec!["1".to_string()]],
@@ -868,6 +868,7 @@ mod tests {
     mod adhoc_refresh_integration {
         use super::*;
         use crate::domain::{CommandTag, DatabaseMetadata, TableSummary};
+        use crate::model::sql_editor::modal::SqlModalStatus;
         use crate::update::browse::metadata::dispatch_metadata;
 
         fn make_metadata(tables: Vec<(&str, &str)>) -> Arc<DatabaseMetadata> {
@@ -999,10 +1000,7 @@ mod tests {
                     .iter()
                     .any(|e| matches!(e, Effect::ExecutePreview { .. }))
             );
-            assert_eq!(
-                *state.sql_modal.status(),
-                crate::model::sql_editor::modal::SqlModalStatus::Success
-            );
+            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Success);
         }
 
         #[test]

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -54,7 +54,6 @@ pub(super) fn preview_effect_for_current_table(
 #[cfg(test)]
 pub(super) mod tests {
     use crate::domain::Column;
-    use crate::test_support::column::test_nullable_column;
     use std::sync::Arc;
     use std::time::Instant;
 
@@ -64,11 +63,11 @@ pub(super) mod tests {
     };
     use crate::model::app_state::AppState;
     use crate::update::action::Action;
-    use crate::update::test_support::activate_postgres_connection;
+    use crate::update::test_fixtures;
 
     pub fn create_test_state() -> AppState {
         let mut state = AppState::new("test_project".to_string());
-        activate_postgres_connection(&mut state, "postgres://localhost/test");
+        test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
         state
     }
 
@@ -130,9 +129,9 @@ pub(super) mod tests {
             columns: vec![
                 Column {
                     attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "int", 1)
+                    ..sabiql_test_support::column::test_nullable_column("id", "int", 1)
                 },
-                test_nullable_column("name", "text", 2),
+                sabiql_test_support::column::test_nullable_column("name", "text", 2),
             ],
             primary_key: Some(vec!["id".to_string()]),
             indexes: vec![Index {
@@ -149,7 +148,7 @@ pub(super) mod tests {
                 function_name: "f".to_string(),
                 security_definer: false,
             }],
-            ..crate::test_support::table::minimal("", "")
+            ..sabiql_test_support::table::minimal("", "")
         }
     }
 
@@ -157,7 +156,9 @@ pub(super) mod tests {
         let mut detail = users_table_detail();
         detail
             .columns
-            .push(test_nullable_column("metadata", "jsonb", 3));
+            .push(sabiql_test_support::column::test_nullable_column(
+                "metadata", "jsonb", 3,
+            ));
         detail
     }
 

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -300,7 +300,7 @@ mod tests {
     use super::*;
     use crate::domain::{QueryResult, QuerySource};
     use crate::ports::outbound::DbOperationError;
-    use crate::update::test_support::activate_postgres_connection;
+    use crate::update::test_fixtures;
     use std::sync::Arc;
 
     use crate::model::browse::query_execution::PREVIEW_PAGE_SIZE;
@@ -583,7 +583,7 @@ mod tests {
 
         fn export_test_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
         }
 
@@ -791,11 +791,10 @@ mod tests {
 
         mod sqlite {
             use super::*;
-            use crate::update::test_support::activate_sqlite_connection;
 
             fn sqlite_state() -> AppState {
                 let mut state = AppState::new("test_project".to_string());
-                activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
+                test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
                 state
             }
 

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -4,6 +4,7 @@ use crate::cmd::effect::Effect;
 use crate::domain::QueryValue;
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSelection};
+use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::json::json_diff::compute_json_diff;
 use crate::policy::preview_cell_text::{
@@ -236,7 +237,7 @@ pub fn reduce_write(
             state.confirm_dialog.open(
                 title,
                 build_write_preview_fallback_message(preview),
-                crate::model::shared::confirm_dialog::ConfirmIntent::ExecuteWrite {
+                ConfirmIntent::ExecuteWrite {
                     sql: preview.sql.clone(),
                     blocked: preview.guardrail.blocked,
                 },
@@ -391,6 +392,7 @@ pub fn reduce_write(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::update::test_fixtures;
 
     use crate::domain::connection::ConnectionId;
     use crate::domain::{ColumnAttributes, DatabaseType, QueryResult, QuerySource};
@@ -403,7 +405,6 @@ mod tests {
     use crate::ports::outbound::DbOperationError;
     use crate::update::browse::query::dispatch_query;
     use crate::update::browse::query::tests::*;
-    use crate::update::test_support::activate_postgres_connection;
     use rstest::rstest;
     use std::sync::Arc;
 
@@ -430,7 +431,7 @@ mod tests {
 
         fn editable_state() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.query.set_current_result(editable_preview_result());
             state
                 .session
@@ -699,7 +700,7 @@ mod tests {
 
         fn editable_state_with_jsonb() -> AppState {
             let mut state = AppState::new("test_project".to_string());
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .query
                 .set_current_result(editable_preview_result_with_jsonb());
@@ -898,10 +899,7 @@ mod tests {
                 Some(expected_sql.as_str())
             );
             match state.confirm_dialog.intent() {
-                Some(crate::model::shared::confirm_dialog::ConfirmIntent::ExecuteWrite {
-                    sql,
-                    blocked,
-                }) => {
+                Some(ConfirmIntent::ExecuteWrite { sql, blocked }) => {
                     assert_eq!(sql, &expected_sql);
                     assert!(!blocked);
                 }

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -182,7 +182,6 @@ mod tests {
     use crate::domain::Column;
     use crate::domain::connection::ConnectionId;
     use crate::domain::{ColumnAttributes, DatabaseType, QueryResult, QuerySource, Table};
-    use crate::test_support::column::test_nullable_column;
     use std::sync::Arc;
 
     fn state_with_cell(data_type: &str, cell_value: &str) -> AppState {
@@ -209,12 +208,12 @@ mod tests {
             columns: vec![
                 Column {
                     attributes: ColumnAttributes::PRIMARY_KEY,
-                    ..test_nullable_column("id", "integer", 1)
+                    ..sabiql_test_support::column::test_nullable_column("id", "integer", 1)
                 },
-                test_nullable_column("body", data_type.to_string(), 2),
+                sabiql_test_support::column::test_nullable_column("body", data_type.to_string(), 2),
             ],
             primary_key: Some(vec!["id".to_string()]),
-            ..crate::test_support::table::minimal("", "")
+            ..sabiql_test_support::table::minimal("", "")
         }));
         state.result_interaction.activate_cell(0, 1);
         state

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -150,7 +150,6 @@ mod tests {
     use super::*;
     pub use crate::domain::Column;
     use crate::domain::{QueryResult, QuerySource, QueryValue, Table};
-    use crate::test_support::column::test_nullable_column;
     use crate::update::action::CursorMove;
     use rstest::rstest;
     use std::sync::Arc;
@@ -163,7 +162,7 @@ mod tests {
                 schema: "public".to_string(),
                 name: "users".to_string(),
                 primary_key: Some(vec!["id".to_string()]),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             }
         }
 
@@ -270,7 +269,7 @@ mod tests {
                 schema: "public".to_string(),
                 name: "posts".to_string(),
                 primary_key: Some(vec!["id".to_string()]),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             }));
 
             let effects = reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
@@ -292,11 +291,11 @@ mod tests {
             table.columns = vec![
                 Column {
                     attributes: ColumnAttributes::PRIMARY_KEY,
-                    ..test_nullable_column("id", "integer", 1)
+                    ..sabiql_test_support::column::test_nullable_column("id", "integer", 1)
                 },
                 Column {
                     attributes: ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED,
-                    ..test_nullable_column("name", "text", 2)
+                    ..sabiql_test_support::column::test_nullable_column("name", "text", 2)
                 },
             ];
             state.session.set_table_detail_raw(Some(table));
@@ -373,9 +372,9 @@ mod tests {
             table.columns = vec![
                 Column {
                     attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "integer", 1)
+                    ..sabiql_test_support::column::test_nullable_column("id", "integer", 1)
                 },
-                test_nullable_column("name", "jsonb", 2),
+                sabiql_test_support::column::test_nullable_column("name", "jsonb", 2),
             ];
             state.session.set_table_detail_raw(Some(table));
             state

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -13,7 +13,9 @@ use crate::policy::preview_cell_text::{preview_cell_text_diff_handling, uses_jso
 use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
-use crate::update::helpers::{editable_preview_base, ensure_column_writable, find_text_matches};
+use crate::update::helpers::{
+    EditGuardrailError, editable_preview_base, ensure_column_writable, find_text_matches,
+};
 use std::time::Instant;
 
 pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
@@ -290,9 +292,7 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
     }
 }
 
-fn ensure_jsonb_column_writable(
-    state: &AppState,
-) -> Result<(), crate::update::helpers::EditGuardrailError> {
+fn ensure_jsonb_column_writable(state: &AppState) -> Result<(), EditGuardrailError> {
     let (_, pk_cols) = editable_preview_base(state)?;
     ensure_column_writable(state, state.jsonb_detail.column_name(), pk_cols)
 }
@@ -355,7 +355,6 @@ mod tests {
     pub use crate::domain::Column;
     use crate::domain::{QueryResult, QuerySource, Table};
     use crate::services::AppServices;
-    use crate::test_support::column::test_nullable_column;
     use std::sync::Arc;
 
     fn jsonb_table() -> Table {
@@ -365,12 +364,12 @@ mod tests {
             columns: vec![
                 Column {
                     attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "integer", 1)
+                    ..sabiql_test_support::column::test_nullable_column("id", "integer", 1)
                 },
-                test_nullable_column("settings", "jsonb", 2),
+                sabiql_test_support::column::test_nullable_column("settings", "jsonb", 2),
             ],
             primary_key: Some(vec!["id".to_string()]),
-            ..crate::test_support::table::minimal("", "")
+            ..sabiql_test_support::table::minimal("", "")
         }
     }
 
@@ -398,7 +397,7 @@ mod tests {
     fn open_detail(state: &mut AppState) {
         reduce_jsonb(
             state,
-            &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+            &Action::OpenModal(ModalKind::JsonbDetail),
             Instant::now(),
         );
     }
@@ -491,7 +490,7 @@ mod tests {
 
             reduce_jsonb(
                 &mut state,
-                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                &Action::OpenModal(ModalKind::JsonbDetail),
                 Instant::now(),
             );
 
@@ -513,7 +512,7 @@ mod tests {
 
             reduce_jsonb(
                 &mut state,
-                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                &Action::OpenModal(ModalKind::JsonbDetail),
                 Instant::now(),
             );
 
@@ -527,7 +526,7 @@ mod tests {
 
             reduce_jsonb(
                 &mut state,
-                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                &Action::OpenModal(ModalKind::JsonbDetail),
                 Instant::now(),
             );
 
@@ -543,14 +542,14 @@ mod tests {
             let mut state = state_with_jsonb_cell();
             reduce_jsonb(
                 &mut state,
-                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                &Action::OpenModal(ModalKind::JsonbDetail),
                 Instant::now(),
             );
             assert!(state.jsonb_detail.is_active());
 
             reduce_jsonb(
                 &mut state,
-                &Action::CloseModal(crate::update::action::ModalKind::JsonbDetail),
+                &Action::CloseModal(ModalKind::JsonbDetail),
                 Instant::now(),
             );
 
@@ -627,11 +626,11 @@ mod tests {
                 columns: vec![
                     Column {
                         attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("id", "integer", 1)
+                        ..sabiql_test_support::column::test_nullable_column("id", "integer", 1)
                     },
                     Column {
                         attributes: ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED,
-                        ..test_nullable_column("settings", "jsonb", 2)
+                        ..sabiql_test_support::column::test_nullable_column("settings", "jsonb", 2)
                     },
                 ],
                 ..jsonb_table()
@@ -655,11 +654,11 @@ mod tests {
                 columns: vec![
                     Column {
                         attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("id", "integer", 1)
+                        ..sabiql_test_support::column::test_nullable_column("id", "integer", 1)
                     },
                     Column {
                         attributes: ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED,
-                        ..test_nullable_column("settings", "jsonb", 2)
+                        ..sabiql_test_support::column::test_nullable_column("settings", "jsonb", 2)
                     },
                 ],
                 ..jsonb_table()
@@ -826,7 +825,7 @@ mod tests {
 
             reduce_jsonb(
                 &mut state,
-                &Action::CloseModal(crate::update::action::ModalKind::JsonbDetail),
+                &Action::CloseModal(ModalKind::JsonbDetail),
                 Instant::now(),
             );
 
@@ -844,7 +843,7 @@ mod tests {
 
             reduce_jsonb(
                 &mut state,
-                &Action::CloseModal(crate::update::action::ModalKind::JsonbDetail),
+                &Action::CloseModal(ModalKind::JsonbDetail),
                 Instant::now(),
             );
 
@@ -862,7 +861,7 @@ mod tests {
             let mut state = state_with_jsonb_cell();
             reduce_jsonb(
                 &mut state,
-                &Action::OpenModal(crate::update::action::ModalKind::JsonbDetail),
+                &Action::OpenModal(ModalKind::JsonbDetail),
                 Instant::now(),
             );
 

--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -275,6 +275,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::domain::{QueryResult, QuerySource};
     use crate::model::shared::key_sequence::Prefix;
 
     fn state_with_result_rows(rows: usize, pane_height: u16) -> AppState {
@@ -283,12 +284,12 @@ mod tests {
         let result_rows: Vec<Vec<String>> = (0..rows).map(|i| vec![format!("{}", i)]).collect();
         state
             .query
-            .set_current_result(Arc::new(crate::domain::QueryResult::success(
+            .set_current_result(Arc::new(QueryResult::success(
                 String::new(),
                 vec!["id".to_string()],
                 result_rows,
                 1,
-                crate::domain::QuerySource::Preview,
+                QuerySource::Preview,
             )));
         state
     }

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -97,7 +97,6 @@ mod tests {
     use super::*;
     use crate::domain::Column;
     use crate::domain::{QueryResult, QuerySource, Table};
-    use crate::test_support::column::test_nullable_column;
     use std::sync::Arc;
     use std::time::Instant;
 
@@ -133,10 +132,10 @@ mod tests {
                 name: "users".to_string(),
                 columns: vec![Column {
                     attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "integer", 1)
+                    ..sabiql_test_support::column::test_nullable_column("id", "integer", 1)
                 }],
                 primary_key: pk.map(|cols| cols.into_iter().map(ToString::to_string).collect()),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             }));
             state
         }

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -135,10 +135,8 @@ fn clipboard_unavailable() -> Action {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::Column;
-    use crate::domain::Table;
+    use crate::domain::{Column, DatabaseType, QueryResult, QuerySource, Table};
     use crate::ports::outbound::ddl_generator::DdlGenerator;
-    use crate::test_support::column::test_nullable_column;
     use std::sync::Arc;
 
     mod cell_yank {
@@ -155,12 +153,12 @@ mod tests {
                 .collect();
             state
                 .query
-                .set_current_result(Arc::new(crate::domain::QueryResult::success(
+                .set_current_result(Arc::new(QueryResult::success(
                     String::new(),
                     columns,
                     result_rows,
                     1,
-                    crate::domain::QuerySource::Preview,
+                    QuerySource::Preview,
                 )));
             state
         }
@@ -290,12 +288,12 @@ mod tests {
             let rows = vec![values.iter().map(ToString::to_string).collect()];
             state
                 .query
-                .set_current_result(Arc::new(crate::domain::QueryResult::success(
+                .set_current_result(Arc::new(QueryResult::success(
                     String::new(),
                     columns,
                     rows,
                     1,
-                    crate::domain::QuerySource::Preview,
+                    QuerySource::Preview,
                 )));
             state
         }
@@ -430,11 +428,7 @@ mod tests {
 
         struct FakeDdlGenerator;
         impl DdlGenerator for FakeDdlGenerator {
-            fn generate_ddl(
-                &self,
-                _database_type: crate::domain::DatabaseType,
-                table: &Table,
-            ) -> String {
+            fn generate_ddl(&self, _database_type: DatabaseType, table: &Table) -> String {
                 format!("CREATE TABLE {}.{} ();", table.schema, table.name)
             }
         }
@@ -453,11 +447,11 @@ mod tests {
                 name: "users".to_string(),
                 columns: vec![Column {
                     attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "integer", 1)
+                    ..sabiql_test_support::column::test_nullable_column("id", "integer", 1)
                 }],
                 primary_key: Some(vec!["id".to_string()]),
                 row_count_estimate: Some(0),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             }));
             state
         }

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -92,7 +92,7 @@ pub(super) fn reduce_connection_error(
 mod tests {
     use super::*;
     use crate::domain::{ConnectionId, DatabaseType};
-    use crate::update::test_support::activate_postgres_connection;
+    use crate::update::test_fixtures;
 
     mod scroll_down {
         use super::*;
@@ -167,7 +167,7 @@ mod tests {
         #[test]
         fn allowed_for_profile_connection() {
             let mut state = AppState::new("test".to_string());
-            activate_postgres_connection(&mut state, "postgres://localhost/db");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/db");
             state.modal.set_mode(InputMode::ConnectionError);
 
             reduce_connection_error(&mut state, &Action::ReenterConnectionSetup, Instant::now());

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -73,6 +73,7 @@ mod tests {
     use crate::model::connection::state::ConnectionState;
     use crate::model::er_state::ErStatus;
     use crate::model::shared::inspector_tab::InspectorTab;
+    use crate::model::shared::ui_state::ResultNavMode;
 
     fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
         reduce_connection_lifecycle(
@@ -356,7 +357,7 @@ mod tests {
 
         assert_eq!(
             state.result_interaction.selection().mode(),
-            crate::model::shared::ui_state::ResultNavMode::Scroll
+            ResultNavMode::Scroll
         );
     }
 
@@ -403,7 +404,7 @@ mod tests {
 
         assert_eq!(
             state.result_interaction.selection().mode(),
-            crate::model::shared::ui_state::ResultNavMode::Scroll
+            ResultNavMode::Scroll
         );
     }
 

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -2,6 +2,7 @@ use std::time::Instant;
 
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
+use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, ModalKind};
 use crate::update::connection::helpers::reset_active_connection_state;
@@ -42,7 +43,7 @@ pub(super) fn reduce_connection_selector(
                 state.confirm_dialog.open(
                     "Delete Connection",
                     message,
-                    crate::model::shared::confirm_dialog::ConfirmIntent::DeleteConnection(id),
+                    ConfirmIntent::DeleteConnection(id),
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
             }
@@ -104,8 +105,9 @@ pub(super) fn reduce_connection_selector(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::connection::{ConnectionProfile, SslMode};
+    use crate::domain::connection::{ConnectionProfile, DatabaseType, SslMode};
     use crate::model::connection::list::build_connection_list;
+    use crate::model::shared::ui_state::ResultNavMode;
 
     fn create_profile(name: &str) -> ConnectionProfile {
         ConnectionProfile::new_postgres(
@@ -192,7 +194,7 @@ mod tests {
             state.session.activate_connection_with_dsn(
                 &profile_id,
                 "Production",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/db",
             );
 
@@ -306,7 +308,7 @@ mod tests {
             state.session.activate_connection_with_dsn(
                 &profile_id,
                 "Production",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/db",
             );
             state
@@ -333,7 +335,7 @@ mod tests {
             state.session.activate_connection_with_dsn(
                 &profile_id,
                 "Production",
-                crate::domain::DatabaseType::PostgreSQL,
+                DatabaseType::PostgreSQL,
                 "postgres://localhost/db",
             );
             state
@@ -361,7 +363,7 @@ mod tests {
             assert_eq!(state.query.pagination.current_page(), 0);
             assert_eq!(
                 state.result_interaction.selection().mode(),
-                crate::model::shared::ui_state::ResultNavMode::Scroll
+                ResultNavMode::Scroll
             );
             assert_eq!(state.result_interaction.scroll_offset(), 0);
             assert_eq!(state.result_interaction.horizontal_offset(), 0);

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -7,6 +7,7 @@ use crate::model::connection::setup::{
     CONNECTION_INPUT_VISIBLE_WIDTH, ConnectionField, ConnectionSetupState,
 };
 use crate::model::connection::state::ConnectionState;
+use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{
     Action, ConnectionSaveError, ConnectionTarget, InputTarget, ModalKind,
@@ -190,7 +191,7 @@ pub fn reduce_connection_setup(
                 state.confirm_dialog.open(
                     "Confirm",
                     "No connection configured.\nAre you sure you want to quit?",
-                    crate::model::shared::confirm_dialog::ConfirmIntent::QuitNoConnection,
+                    ConfirmIntent::QuitNoConnection,
                 );
                 state.modal.push_mode(InputMode::ConfirmDialog);
                 DispatchResult::handled()
@@ -238,10 +239,7 @@ mod tests {
     use crate::domain::connection::{ConnectionProfile, SslMode};
     use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::er_state::ErStatus;
-    use crate::update::test_support::{
-        activate_postgres_connection, assert_connection_save_fetch_effects,
-    };
-
+    use crate::update::test_fixtures;
     fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
         reduce_connection_setup(state, action, now).into_effects()
     }
@@ -536,7 +534,7 @@ mod tests {
         #[test]
         fn save_completed_clears_previous_browse_state() {
             let mut state = AppState::new("test".to_string());
-            activate_postgres_connection(&mut state, "postgres://localhost/old");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/old");
             state.session.mark_connected(Arc::new({
                 let mut metadata = DatabaseMetadata::new("old_db".to_string());
                 metadata.table_summaries = vec![TableSummary::new(
@@ -575,7 +573,7 @@ mod tests {
             assert!(state.session.selected_table_key().is_none());
             assert!(state.session.connection_state().is_connecting());
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
-            assert_connection_save_fetch_effects(&effects, DatabaseType::SQLite);
+            test_fixtures::assert_connection_save_fetch_effects(&effects, DatabaseType::SQLite);
         }
 
         #[test]
@@ -653,7 +651,7 @@ mod tests {
             let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
             assert_eq!(effects.len(), 1);
-            assert_connection_save_fetch_effects(&effects, DatabaseType::SQLite);
+            test_fixtures::assert_connection_save_fetch_effects(&effects, DatabaseType::SQLite);
             assert_eq!(state.session.dsn(), Some("sqlite:///tmp/app.db"));
             assert_eq!(
                 state.session.active_database_type(),
@@ -722,7 +720,7 @@ mod tests {
         #[test]
         fn is_first_run_false_when_already_connected() {
             let mut state = AppState::new("test".to_string());
-            activate_postgres_connection(&mut state, "postgres://localhost/db");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/db");
 
             reduce(
                 &mut state,

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -27,7 +27,7 @@ pub fn dispatch_explain(
 
 #[cfg(test)]
 fn reduce_explain(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
-    dispatch_explain(state, action, now, &crate::services::AppServices::stub())
+    dispatch_explain(state, action, now, &AppServices::stub())
 }
 
 #[cfg(test)]
@@ -38,10 +38,7 @@ mod tests {
     use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
     use crate::services::AppServices;
     use crate::update::action::{ScrollAmount, ScrollDirection, ScrollTarget};
-    use crate::update::test_support::{
-        activate_postgres_connection as activate_postgres_connection_with_dsn,
-        activate_sqlite_connection as activate_sqlite_connection_with_dsn,
-    };
+    use crate::update::test_fixtures;
     use std::time::Instant;
 
     fn sql_modal_state() -> AppState {
@@ -51,11 +48,11 @@ mod tests {
     }
 
     fn activate_postgres_connection(state: &mut AppState) {
-        activate_postgres_connection_with_dsn(state, "dsn://test");
+        test_fixtures::activate_postgres_connection(state, "dsn://test");
     }
 
     fn activate_sqlite_connection(state: &mut AppState) {
-        activate_sqlite_connection_with_dsn(state, "sqlite:///tmp/app.db");
+        test_fixtures::activate_sqlite_connection(state, "sqlite:///tmp/app.db");
     }
 
     mod explain_request {
@@ -599,7 +596,7 @@ mod tests {
         fn confirm_from_high_with_matching_table_emits_effect() {
             let mut state = sql_modal_state();
             activate_postgres_connection(&mut state);
-            let mut input = crate::model::shared::text_input::TextInputState::default();
+            let mut input = TextInputState::default();
             for c in "users".chars() {
                 input.insert_char(c);
             }
@@ -624,7 +621,7 @@ mod tests {
         fn confirm_from_high_with_mismatch_is_noop() {
             let mut state = sql_modal_state();
             activate_postgres_connection(&mut state);
-            let mut input = crate::model::shared::text_input::TextInputState::default();
+            let mut input = TextInputState::default();
             input.insert_char('x');
             state
                 .sql_modal
@@ -733,7 +730,7 @@ mod tests {
         #[test]
         fn mismatched_dsn_does_not_replace_plan() {
             let mut state = sql_modal_state();
-            activate_postgres_connection_with_dsn(&mut state, "dsn://current");
+            test_fixtures::activate_postgres_connection(&mut state, "dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
             state
@@ -795,7 +792,7 @@ mod tests {
         #[test]
         fn mismatched_dsn_does_not_replace_plan_with_error() {
             let mut state = sql_modal_state();
-            activate_postgres_connection_with_dsn(&mut state, "dsn://current");
+            test_fixtures::activate_postgres_connection(&mut state, "dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
             state
@@ -876,6 +873,7 @@ mod tests {
 
     mod scroll {
         use super::*;
+        use crate::model::explain_context::ExplainContext;
 
         #[test]
         fn plan_scroll_up_saturates_at_zero() {
@@ -927,9 +925,7 @@ mod tests {
                 .collect::<Vec<_>>()
                 .join("\n");
             state.explain.set_plan(long_plan, false, 0, "Q1");
-            let modal_inner = crate::model::explain_context::ExplainContext::modal_inner_height(
-                state.ui.terminal_height(),
-            );
+            let modal_inner = ExplainContext::modal_inner_height(state.ui.terminal_height());
             let max = state.explain.line_count().saturating_sub(modal_inner);
             state.explain.scroll_offset = max;
 

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -4,6 +4,7 @@ use crate::domain::DatabaseType;
 use crate::domain::connection::SqliteConnectionConfig;
 use crate::domain::{QueryResult, QueryValue};
 use crate::model::app_state::AppState;
+use crate::model::browse::query_execution::QueryStatus;
 use crate::model::connection::setup::{ConnectionField, ConnectionSetupState};
 use crate::policy::write::write_guardrails::{
     TargetSummary, WriteOperation, WritePreview, evaluate_guardrails,
@@ -159,7 +160,7 @@ pub fn build_bulk_delete_preview(
     if state.session.dsn().is_none() {
         return Err(EditGuardrailError::NoActiveConnection);
     }
-    if state.query.status() != crate::model::browse::query_execution::QueryStatus::Idle {
+    if state.query.status() != QueryStatus::Idle {
         return Err(EditGuardrailError::WriteUnavailableWhileQueryRunning);
     }
 
@@ -437,7 +438,6 @@ pub fn validate_all(state: &mut ConnectionSetupState) {
 mod tests {
     use super::*;
     use crate::domain::Column;
-    use crate::test_support::column::test_nullable_column;
     use std::sync::Arc;
 
     use crate::domain::connection::ConnectionId;
@@ -670,12 +670,12 @@ mod tests {
                 columns: vec![
                     Column {
                         attributes: ColumnAttributes::PRIMARY_KEY,
-                        ..test_nullable_column("id", "INTEGER", 1)
+                        ..sabiql_test_support::column::test_nullable_column("id", "INTEGER", 1)
                     },
-                    test_nullable_column("name", "TEXT", 2),
+                    sabiql_test_support::column::test_nullable_column("name", "TEXT", 2),
                 ],
                 primary_key: Some(vec!["id".to_string()]),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             }));
             state.query.pagination.reset_for_table("main", "users");
             state.result_interaction.stage_row(0);

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -100,6 +100,7 @@ mod tests {
 
     mod mode_dispatch {
         use super::*;
+        use crate::model::sql_editor::modal::SqlModalTab;
 
         fn make_state(mode: InputMode) -> AppState {
             let mut state = AppState::new("test".to_string());
@@ -130,9 +131,7 @@ mod tests {
         #[test]
         fn sql_modal_normalizes_unsupported_tab_before_handling_keys() {
             let mut state = make_state(InputMode::SqlModal);
-            state
-                .sql_modal
-                .set_active_tab(crate::model::sql_editor::modal::SqlModalTab::Plan);
+            state.sql_modal.set_active_tab(SqlModalTab::Plan);
 
             let result = handle_key_event(combo(Key::Char('i')), &state);
 

--- a/src/app/update/input/handlers/overlays.rs
+++ b/src/app/update/input/handlers/overlays.rs
@@ -1,4 +1,4 @@
-use crate::update::action::Action;
+use crate::update::action::{Action, InputTarget};
 use crate::update::input::keybindings::{self, KeyCombo, Modifiers};
 use crate::update::input::keymap;
 
@@ -9,7 +9,7 @@ pub fn handle_help_keys(combo: KeyCombo) -> Action {
 
     match (combo.key, combo.modifiers) {
         (keybindings::Key::Char(ch), Modifiers::NONE | Modifiers::SHIFT) => Action::TextInput {
-            target: crate::update::action::InputTarget::HelpFilter,
+            target: InputTarget::HelpFilter,
             ch,
         },
         _ => Action::None,

--- a/src/app/update/input/vim/actions/browse.rs
+++ b/src/app/update/input/vim/actions/browse.rs
@@ -293,7 +293,9 @@ fn result_navigation(navigation: VimNavigation, ctx: ResultVimContext) -> Action
 mod tests {
     use super::*;
     use crate::model::shared::ui_state::ResultNavMode;
-    use crate::update::input::vim::{VimCommand, VimSurfaceContext, action_for_command};
+    use crate::update::input::vim::{
+        SearchContinuation, VimCommand, VimSurfaceContext, action_for_command,
+    };
     use rstest::rstest;
 
     fn result_ctx(mode: ResultNavMode) -> ResultVimContext {
@@ -466,7 +468,7 @@ mod tests {
     #[test]
     fn result_search_continuation_stays_unsupported() {
         let action = action_for_command(
-            VimCommand::SearchContinuation(crate::update::input::vim::SearchContinuation::Next),
+            VimCommand::SearchContinuation(SearchContinuation::Next),
             browse_result(result_ctx(ResultNavMode::Scroll)),
         );
 

--- a/src/app/update/input/vim/actions/jsonb.rs
+++ b/src/app/update/input/vim/actions/jsonb.rs
@@ -66,7 +66,7 @@ mod tests {
     use super::*;
     use crate::model::shared::key_sequence::Prefix;
     use crate::update::input::keybindings::{Key, KeyCombo};
-    use crate::update::input::vim::{VimSurfaceContext, action_for_key};
+    use crate::update::input::vim::{VimSurfaceContext, action_for_input, action_for_key};
     use rstest::rstest;
 
     fn combo(key: Key) -> KeyCombo {
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn gg_moves_to_first_line() {
-        let action = crate::update::input::vim::action_for_input(
+        let action = action_for_input(
             &combo(Key::Char('g')),
             Some(Prefix::G),
             VimSurfaceContext::JsonbDetail(JsonbDetailVimContext::Viewing),

--- a/src/app/update/input/vim/actions/sql.rs
+++ b/src/app/update/input/vim/actions/sql.rs
@@ -82,7 +82,7 @@ mod tests {
     use super::*;
     use crate::model::shared::key_sequence::Prefix;
     use crate::update::input::keybindings::{Key, KeyCombo};
-    use crate::update::input::vim::{VimSurfaceContext, action_for_key};
+    use crate::update::input::vim::{VimSurfaceContext, action_for_input, action_for_key};
     use rstest::rstest;
 
     fn combo(key: Key) -> KeyCombo {
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn gg_moves_to_first_line() {
-        let action = crate::update::input::vim::action_for_input(
+        let action = action_for_input(
             &combo(Key::Char('g')),
             Some(Prefix::G),
             VimSurfaceContext::SqlModal(SqlModalVimContext::QueryNormal),

--- a/src/app/update/mod.rs
+++ b/src/app/update/mod.rs
@@ -10,8 +10,7 @@ pub mod modal;
 pub mod reducer;
 pub mod sql_editor;
 #[cfg(test)]
-pub(crate) mod test_support;
-
+pub(crate) mod test_fixtures;
 // Facade: re-export sub-reducer entry points for update/reducer.rs dispatch
 pub use browse::metadata::dispatch_metadata;
 pub use browse::navigation::dispatch_navigation;

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -36,8 +36,7 @@ mod tests {
     use crate::update::action::{
         InputTarget, ListMotion, ListTarget, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget,
     };
-
-    use crate::update::test_support::activate_postgres_connection;
+    use crate::update::test_fixtures;
     use std::time::Instant;
 
     fn create_test_state() -> AppState {
@@ -179,6 +178,7 @@ mod tests {
     mod settings {
         use super::*;
         use crate::model::shared::theme_id::ThemeId;
+        use crate::ports::outbound::SettingsStoreError;
 
         mod theme_selection {
             use super::*;
@@ -370,9 +370,9 @@ mod tests {
 
             let effects = super::dispatch_modal(
                 &mut state,
-                &Action::SettingsSaveFailed(crate::ports::outbound::SettingsStoreError::Io(
-                    std::sync::Arc::new(std::io::Error::other("disk full")),
-                )),
+                &Action::SettingsSaveFailed(SettingsStoreError::Io(std::sync::Arc::new(
+                    std::io::Error::other("disk full"),
+                ))),
                 Instant::now(),
             )
             .unwrap();
@@ -398,7 +398,7 @@ mod tests {
         fn csv_state_with_current_run() -> (AppState, u64) {
             let mut state = create_test_state();
             enter_confirm_dialog(&mut state, InputMode::Normal);
-            activate_postgres_connection(&mut state, CSV_TEST_DSN);
+            test_fixtures::activate_postgres_connection(&mut state, CSV_TEST_DSN);
             let run_id = state.query.begin_running(Instant::now());
             (state, run_id)
         }
@@ -471,6 +471,9 @@ mod tests {
 
         mod confirm {
             use super::*;
+            use crate::policy::write::write_guardrails::{
+                GuardrailDecision, RiskLevel, TargetSummary, WriteOperation, WritePreview,
+            };
 
             #[test]
             fn quit_no_connection_sets_should_quit() {
@@ -517,7 +520,10 @@ mod tests {
             fn execute_write_sets_running_state_and_returns_effect() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::CellEdit);
-                activate_postgres_connection(&mut state, "postgres://localhost/test");
+                test_fixtures::activate_postgres_connection(
+                    &mut state,
+                    "postgres://localhost/test",
+                );
                 state.confirm_dialog.open(
                     "",
                     "",
@@ -595,24 +601,22 @@ mod tests {
             fn execute_write_blocked_confirm_clears_preview_state() {
                 let mut state = create_test_state();
                 enter_confirm_dialog(&mut state, InputMode::Normal);
-                state.result_interaction.set_write_preview(
-                    crate::policy::write::write_guardrails::WritePreview {
-                        operation: crate::policy::write::write_guardrails::WriteOperation::Update,
-                        sql: "UPDATE t SET x=1".to_string(),
-                        target_summary: crate::policy::write::write_guardrails::TargetSummary {
-                            schema: "public".to_string(),
-                            table: "t".to_string(),
-                            key_values: vec![],
-                        },
-                        diff: vec![],
-                        guardrail: crate::policy::write::write_guardrails::GuardrailDecision {
-                            risk_level: crate::policy::write::write_guardrails::RiskLevel::High,
-                            blocked: true,
-                            reason: Some("too risky".to_string()),
-                            target_summary: None,
-                        },
+                state.result_interaction.set_write_preview(WritePreview {
+                    operation: WriteOperation::Update,
+                    sql: "UPDATE t SET x=1".to_string(),
+                    target_summary: TargetSummary {
+                        schema: "public".to_string(),
+                        table: "t".to_string(),
+                        key_values: vec![],
                     },
-                );
+                    diff: vec![],
+                    guardrail: GuardrailDecision {
+                        risk_level: RiskLevel::High,
+                        blocked: true,
+                        reason: Some("too risky".to_string()),
+                        target_summary: None,
+                    },
+                });
                 state.query.set_delete_refresh_target(0, None, 1);
                 state.confirm_dialog.open(
                     "",
@@ -1290,6 +1294,8 @@ mod tests {
 
         mod confirm_selection {
             use super::*;
+            use crate::model::sql_editor::completion::{CompletionCandidate, CompletionKind};
+            use crate::model::sql_editor::modal::SqlModalStatus;
 
             #[test]
             fn confirm_sets_cursor_to_char_count_not_byte_len() {
@@ -1332,10 +1338,7 @@ mod tests {
 
                 assert_eq!(state.input_mode(), InputMode::SqlModal);
                 assert_eq!(state.sql_modal.editor.content(), "SELECT * FROM users");
-                assert!(matches!(
-                    state.sql_modal.status(),
-                    crate::model::sql_editor::modal::SqlModalStatus::Normal
-                ));
+                assert!(matches!(state.sql_modal.status(), SqlModalStatus::Normal));
                 assert!(effects.is_empty());
             }
 
@@ -1344,16 +1347,13 @@ mod tests {
                 let mut state = connected_state();
                 enter_query_history(&mut state, InputMode::SqlModal);
                 state.sql_modal.editor.set_content("old query".to_string());
-                state
-                    .sql_modal
-                    .set_status_for_test(crate::model::sql_editor::modal::SqlModalStatus::Editing);
+                state.sql_modal.set_status_for_test(SqlModalStatus::Editing);
                 state.sql_modal.completion_mut_for_test().visible = true;
-                state.sql_modal.completion_mut_for_test().candidates =
-                    vec![crate::model::sql_editor::completion::CompletionCandidate {
-                        text: "stale".to_string(),
-                        kind: crate::model::sql_editor::completion::CompletionKind::Keyword,
-                        score: 1,
-                    }];
+                state.sql_modal.completion_mut_for_test().candidates = vec![CompletionCandidate {
+                    text: "stale".to_string(),
+                    kind: CompletionKind::Keyword,
+                    score: 1,
+                }];
                 state.sql_modal.completion_mut_for_test().selected_index = 3;
                 let test_conn = ConnectionId::from_string("test-conn");
                 state
@@ -1369,10 +1369,7 @@ mod tests {
 
                 assert_eq!(state.input_mode(), InputMode::SqlModal);
                 assert_eq!(state.sql_modal.editor.content(), "new query");
-                assert!(matches!(
-                    state.sql_modal.status(),
-                    crate::model::sql_editor::modal::SqlModalStatus::Normal
-                ));
+                assert!(matches!(state.sql_modal.status(), SqlModalStatus::Normal));
                 assert!(!state.sql_modal.completion().visible);
                 assert!(state.sql_modal.completion().candidates.is_empty());
                 assert_eq!(state.sql_modal.completion().selected_index, 0);

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -97,12 +97,12 @@ mod tests {
     use super::*;
     use crate::domain::connection::DatabaseType;
     use crate::domain::{ConnectionId, DiagnosticField, SqliteDiagnosticsSnapshot};
-    use crate::update::test_support::activate_sqlite_connection;
+    use crate::update::test_fixtures;
 
     #[test]
     fn open_starts_split_fetch_for_sqlite_connection() {
         let mut state = AppState::new("test".to_string());
-        activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
+        test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
 
         let effects = reduce_sqlite_diagnostics(
             &mut state,
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn quick_check_loaded_ignores_stale_run_id() {
         let mut state = AppState::new("test".to_string());
-        activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
+        test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
         let run_id = state.sqlite_diagnostics.begin_fetch();
         state
             .sqlite_diagnostics
@@ -170,7 +170,7 @@ mod tests {
     #[test]
     fn quick_check_loaded_before_core_clears_pending_when_core_arrives() {
         let mut state = AppState::new("test".to_string());
-        activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
+        test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
         let run_id = state.sqlite_diagnostics.begin_fetch();
 
         reduce_sqlite_diagnostics(
@@ -215,7 +215,7 @@ mod tests {
     #[test]
     fn scroll_down_is_clamped_when_content_fits_viewport() {
         let mut state = AppState::new("test".to_string());
-        activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
+        test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
         state.sqlite_diagnostics.apply_viewport_metrics(5, 10);
 
         reduce_sqlite_diagnostics(

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -192,10 +192,7 @@ mod tests {
     use crate::update::action::ModalKind;
     use crate::update::action::{ConnectionSaveError, ConnectionTarget};
     use crate::update::action::{InputTarget, SelectMotion};
-    use crate::update::test_support::{
-        activate_postgres_connection, assert_connection_save_fetch_effects,
-    };
-
+    use crate::update::test_fixtures;
     fn create_test_state() -> AppState {
         AppState::new("test_project".to_string())
     }
@@ -916,7 +913,7 @@ mod tests {
         use crate::model::connection::state::ConnectionState;
 
         fn metadata_loaded_action(state: &mut AppState, metadata: DatabaseMetadata) -> Action {
-            activate_postgres_connection(state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
@@ -926,7 +923,7 @@ mod tests {
         }
 
         fn metadata_failed_action(state: &mut AppState, error: DbOperationError) -> Action {
-            activate_postgres_connection(state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
@@ -975,7 +972,7 @@ mod tests {
         #[test]
         fn metadata_failed_clears_stale_browse_state_on_initial_connect() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.mark_connected(Arc::new({
                 let mut metadata = DatabaseMetadata::new("stale".to_string());
                 metadata.table_summaries = vec![TableSummary::new(
@@ -1213,7 +1210,7 @@ mod tests {
             Table {
                 schema: "public".to_string(),
                 name: "old_table".to_string(),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             }
         }
 
@@ -1281,7 +1278,7 @@ mod tests {
         #[test]
         fn load_metadata_with_dsn_returns_fetch_effect() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::LoadMetadata, now, &AppServices::stub());
@@ -1308,7 +1305,7 @@ mod tests {
         #[test]
         fn reload_metadata_returns_sequence_effect() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -1332,7 +1329,7 @@ mod tests {
         #[test]
         fn reload_metadata_sets_is_reloading_flag() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             reduce(
@@ -1349,7 +1346,7 @@ mod tests {
         fn reload_then_metadata_loaded_shows_reloaded_message() {
             let mut state = create_test_state();
             state.session.activate_connection_with_dsn(
-                &crate::domain::connection::ConnectionId::from_string("test-connection"),
+                &ConnectionId::from_string("test-connection"),
                 "test",
                 DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
@@ -1382,7 +1379,7 @@ mod tests {
         #[test]
         fn execute_adhoc_with_dsn_returns_effect() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -1416,7 +1413,7 @@ mod tests {
         #[test]
         fn always_emits_smart_refresh_even_with_pending_tables() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .session
                 .set_metadata(Some(Arc::new(DatabaseMetadata::new("test".to_string()))));
@@ -1437,7 +1434,7 @@ mod tests {
         #[test]
         fn prefetch_started_true_emits_smart_refresh() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .session
                 .set_metadata(Some(Arc::new(DatabaseMetadata::new("test".to_string()))));
@@ -1454,7 +1451,7 @@ mod tests {
         #[test]
         fn no_prefetch_emits_smart_refresh() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .session
                 .set_metadata(Some(Arc::new(DatabaseMetadata::new("test".to_string()))));
@@ -1484,7 +1481,7 @@ mod tests {
             let mut state = create_test_state();
             state.er_preparation.mark_waiting_for_test();
             let now = Instant::now();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let action = Action::MetadataFailed {
                 dsn: "postgres://localhost/test".to_string(),
@@ -1506,14 +1503,14 @@ mod tests {
             Box::new(Table {
                 schema: "public".to_string(),
                 name: "users".to_string(),
-                ..crate::test_support::table::minimal("", "")
+                ..sabiql_test_support::table::minimal("", "")
             })
         }
 
         #[test]
         fn emits_cache_effect() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state.sql_modal.mark_prefetching("public.users".to_string());
             let now = Instant::now();
@@ -1542,7 +1539,7 @@ mod tests {
         #[test]
         fn with_queue_returns_process_effect() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state
                 .sql_modal
@@ -1689,6 +1686,7 @@ mod tests {
 
     mod connection_setup_transitions {
         use super::*;
+        use crate::model::shared::confirm_dialog::ConfirmIntent;
 
         #[test]
         fn save_completed_sets_dsn_and_returns_fetch_effect() {
@@ -1725,7 +1723,7 @@ mod tests {
                 Some("Test Connection")
             );
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert_connection_save_fetch_effects(&effects, DatabaseType::PostgreSQL);
+            test_fixtures::assert_connection_save_fetch_effects(&effects, DatabaseType::PostgreSQL);
         }
 
         #[test]
@@ -1764,7 +1762,7 @@ mod tests {
             assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
             assert!(matches!(
                 state.confirm_dialog.intent(),
-                Some(&crate::model::shared::confirm_dialog::ConfirmIntent::QuitNoConnection)
+                Some(&ConfirmIntent::QuitNoConnection)
             ));
             assert!(effects.is_empty());
         }
@@ -1791,6 +1789,7 @@ mod tests {
 
     mod confirm_dialog_transitions {
         use super::*;
+        use crate::domain::QueryValue;
         use crate::model::shared::confirm_dialog::ConfirmIntent;
         use crate::policy::write::write_guardrails::{
             GuardrailDecision, RiskLevel, TargetSummary, WriteOperation, WritePreview,
@@ -1840,7 +1839,7 @@ mod tests {
         #[test]
         fn confirm_delete_write_then_success_preserves_delete_context() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             let delete_sql = "DELETE FROM \"public\".\"users\"\nWHERE \"id\" = '2';".to_string();
@@ -1850,7 +1849,7 @@ mod tests {
                 target_summary: TargetSummary {
                     schema: "public".to_string(),
                     table: "users".to_string(),
-                    key_values: vec![("id".to_string(), crate::domain::QueryValue::text("2"))],
+                    key_values: vec![("id".to_string(), QueryValue::text("2"))],
                 },
                 diff: vec![],
                 guardrail: GuardrailDecision {
@@ -1913,7 +1912,7 @@ mod tests {
         #[test]
         fn confirm_delete_write_then_failure_returns_to_normal() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.modal.set_mode(InputMode::ConfirmDialog);
 
             state.result_interaction.set_write_preview(WritePreview {
@@ -1969,13 +1968,14 @@ mod tests {
     mod connection_state_tests {
         use super::*;
         use crate::domain::{ConnectionId, DatabaseMetadata, MetadataState};
+        use crate::model::connection::cache::ConnectionCache;
         use crate::model::connection::state::ConnectionState;
         use crate::model::shared::inspector_tab::InspectorTab;
 
         #[test]
         fn try_connect_with_dsn_starts_connecting() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -2012,7 +2012,7 @@ mod tests {
         #[test]
         fn try_connect_when_already_connecting_is_noop() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
@@ -2028,7 +2028,7 @@ mod tests {
         #[test]
         fn try_connect_when_already_connected_is_noop() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::Connected);
@@ -2044,7 +2044,7 @@ mod tests {
         #[test]
         fn try_connect_when_not_in_normal_mode_is_noop() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
@@ -2063,7 +2063,7 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let metadata = DatabaseMetadata::new("test".to_string());
             let now = Instant::now();
@@ -2092,7 +2092,7 @@ mod tests {
             state
                 .session
                 .set_connection_state(ConnectionState::Connecting);
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             let now = Instant::now();
 
@@ -2120,7 +2120,7 @@ mod tests {
             // (metadata-only failure, e.g., permission denied on schema)
             let mut state = create_test_state();
             state.session.activate_connection_with_dsn(
-                &crate::domain::connection::ConnectionId::from_string("test-connection"),
+                &ConnectionId::from_string("test-connection"),
                 "test",
                 DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
@@ -2237,7 +2237,7 @@ mod tests {
                 state.session.metadata_state(),
                 MetadataState::Loading
             ));
-            assert_connection_save_fetch_effects(&effects, DatabaseType::PostgreSQL);
+            test_fixtures::assert_connection_save_fetch_effects(&effects, DatabaseType::PostgreSQL);
         }
 
         #[test]
@@ -2301,7 +2301,7 @@ mod tests {
                 .set_connection_state(ConnectionState::Connected);
             state.ui.set_explorer_selected_raw(3);
 
-            let cached = crate::model::connection::cache::ConnectionCache {
+            let cached = ConnectionCache {
                 explorer_selected: 10,
                 inspector_tab: InspectorTab::Indexes,
                 metadata: Some(Arc::new(DatabaseMetadata::new("cached_db".to_string()))),
@@ -2341,7 +2341,7 @@ mod tests {
 
         fn state_with_metadata() -> AppState {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.set_metadata(Some(Arc::new({
                 let mut metadata = DatabaseMetadata::new("test".to_string());
                 metadata.table_summaries = vec![
@@ -2378,7 +2378,7 @@ mod tests {
         #[test]
         fn open_without_metadata_sets_pending() {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             let effects = reduce(
@@ -2408,7 +2408,7 @@ mod tests {
         }
 
         fn metadata_loaded_action(state: &mut AppState) -> Action {
-            activate_postgres_connection(state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(state, "postgres://localhost/test");
             let run_id = state.session.begin_metadata_refresh();
             Action::MetadataLoaded {
                 dsn: "postgres://localhost/test".to_string(),
@@ -2532,7 +2532,7 @@ mod tests {
         #[test]
         fn target_tables_survive_er_open() {
             let mut state = state_with_metadata();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
             state
                 .er_preparation
@@ -2552,7 +2552,7 @@ mod tests {
         #[test]
         fn prefetch_complete_dispatches_er_generate() {
             let mut state = state_with_metadata();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.begin_full_prefetch(1);
@@ -2584,7 +2584,7 @@ mod tests {
         #[test]
         fn prefetch_complete_with_failures_does_not_auto_open() {
             let mut state = state_with_metadata();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.begin_full_prefetch(2);
@@ -2626,7 +2626,7 @@ mod tests {
 
         fn state_after_confirm_and_complete() -> (AppState, Instant) {
             let mut state = create_test_state();
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let now = Instant::now();
 
             // Load metadata with a table
@@ -2865,7 +2865,7 @@ mod tests {
         fn confirm_selection_with_reload_emits_sequence_effect() {
             let mut state = state_in_palette_mode(KeymapPreset::Ide);
             let entry_index = palette_index_of(&state, |a| matches!(a, Action::ReloadMetadata));
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.ui.table_picker_mut().set_selection(entry_index);
             let now = Instant::now();
 

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -28,9 +28,11 @@ mod tests {
     use crate::model::shared::flash_timer::FlashId;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::text_input::{TextInputLike, TextInputState};
-    use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
-    use crate::policy::write::write_guardrails::RiskLevel;
+    use crate::model::sql_editor::modal::{AdhocSuccessSnapshot, SqlModalStatus, SqlModalTab};
+    use crate::policy::write::sql_risk::AcknowledgeReason;
+    use crate::policy::write::write_guardrails::{AdhocRiskDecision, RiskLevel};
     use crate::update::action::{CursorMove, InputTarget, ModalKind};
+    use crate::update::test_fixtures;
     use std::time::Instant;
 
     fn reduce_sql_modal(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
@@ -42,8 +44,6 @@ mod tests {
         state.modal.set_mode(InputMode::SqlModal);
         state
     }
-    use crate::update::test_support::{activate_postgres_connection, activate_sqlite_connection};
-
     mod paste {
         use super::*;
 
@@ -147,7 +147,7 @@ mod tests {
             state
                 .sql_modal
                 .set_status_for_test(SqlModalStatus::ConfirmingHigh {
-                    decision: crate::policy::write::write_guardrails::AdhocRiskDecision {
+                    decision: AdhocRiskDecision {
                         risk_level: RiskLevel::High,
                         label: "DROP",
                     },
@@ -271,14 +271,14 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("SELECT * INTO backup FROM users".to_string());
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
             assert!(matches!(
                 state.sql_modal.status(),
                 SqlModalStatus::ConfirmingRisk {
-                    reason: crate::policy::write::sql_risk::AcknowledgeReason::UnknownRisk,
+                    reason: AcknowledgeReason::UnknownRisk,
                     ..
                 }
             ));
@@ -291,14 +291,14 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("COPY users FROM '/tmp/data.csv'".to_string());
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
             assert!(matches!(
                 state.sql_modal.status(),
                 SqlModalStatus::ConfirmingRisk {
-                    reason: crate::policy::write::sql_risk::AcknowledgeReason::UnknownRisk,
+                    reason: AcknowledgeReason::UnknownRisk,
                     ..
                 }
             ));
@@ -311,15 +311,14 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DROP TABLE a, b".to_string());
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
             assert!(matches!(
                 state.sql_modal.status(),
                 SqlModalStatus::ConfirmingRisk {
-                    reason:
-                        crate::policy::write::sql_risk::AcknowledgeReason::TargetNameUnavailable,
+                    reason: AcknowledgeReason::TargetNameUnavailable,
                     ..
                 }
             ));
@@ -332,7 +331,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("UPDATE users SET x=1 WHERE id=1".to_string());
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 
@@ -415,7 +414,7 @@ mod tests {
         #[test]
         fn high_risk_confirm_executes_on_match() {
             let mut state = confirming_high_state("DROP TABLE users", "users");
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             for c in "users".chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -604,7 +603,7 @@ mod tests {
         #[test]
         fn sqlite_submit_multi_drop_pairs_label_with_first_target() {
             let mut state = sql_modal_state();
-            activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
+            test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
             state
                 .sql_modal
                 .editor
@@ -626,7 +625,7 @@ mod tests {
         fn high_risk_confirm_matches_full_name_not_truncated() {
             let full_name = "my_schema.very_long_table_name";
             let mut state = confirming_high_state(&format!("DROP TABLE {full_name}"), full_name);
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             for c in full_name.chars() {
                 reduce_sql_modal(
                     &mut state,
@@ -661,7 +660,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DELETE FROM users WHERE id = 1".to_string());
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
@@ -680,17 +679,15 @@ mod tests {
         fn read_only_reject_clears_prior_success() {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.enable_read_only();
 
             // Simulate a prior adhoc success
-            state.sql_modal.finish_adhoc_success(
-                crate::model::sql_editor::modal::AdhocSuccessSnapshot {
-                    command_tag: None,
-                    row_count: 5,
-                    execution_time_ms: 10,
-                },
-            );
+            state.sql_modal.finish_adhoc_success(AdhocSuccessSnapshot {
+                command_tag: None,
+                row_count: 5,
+                execution_time_ms: 10,
+            });
             assert!(state.sql_modal.last_adhoc_success().is_some());
 
             // Now submit a write query in read-only mode
@@ -712,7 +709,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content("SELECT 1".to_string());
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
@@ -731,7 +728,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("PRAGMA table_info(users)".to_string());
-            activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
+            test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
@@ -750,7 +747,7 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("PRAGMA foreign_keys = OFF".to_string());
-            activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
+            test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/test.db");
             state.session.enable_read_only();
 
             let effects = reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now())
@@ -773,7 +770,7 @@ mod tests {
         fn confirming_risk_state(content: &str) -> AppState {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content(content.to_string());
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
                 .sql_modal
                 .set_status_for_test(SqlModalStatus::ConfirmingRisk {
@@ -818,7 +815,7 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.editor.set_content(query.to_string());
-            activate_postgres_connection(&mut state, "postgres://localhost/test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             state
         }
 
@@ -1079,7 +1076,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_copies_plan_text() {
             let mut state = sql_modal_state();
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = Some("Seq Scan on users".to_string());
 
@@ -1096,7 +1093,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_no_plan_is_noop() {
             let mut state = sql_modal_state();
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = None;
 
@@ -1110,7 +1107,7 @@ mod tests {
         #[test]
         fn plan_tab_yank_error_state_is_noop() {
             let mut state = sql_modal_state();
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
             state.explain.plan_text = None;
             state.explain.error = Some("syntax error".to_string());
@@ -1125,7 +1122,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_both_slots() {
             let mut state = sql_modal_state();
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 420, SlotSource::AutoPrevious));
             state.explain.right = Some(make_slot("Index Scan", true, 50, SlotSource::AutoLatest));
@@ -1151,7 +1148,7 @@ mod tests {
         #[test]
         fn both_auto_slots_yank_returns_distinguishable_headers() {
             let mut state = sql_modal_state();
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 300, SlotSource::AutoPrevious));
             state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
@@ -1172,7 +1169,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_right_only_is_noop() {
             let mut state = sql_modal_state();
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = None;
             state.explain.right = Some(make_slot("Index Scan", false, 100, SlotSource::AutoLatest));
@@ -1187,7 +1184,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_left_only_is_noop() {
             let mut state = sql_modal_state();
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = Some(make_slot("Seq Scan", false, 200, SlotSource::AutoPrevious));
             state.explain.right = None;
@@ -1202,7 +1199,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_empty_is_noop() {
             let mut state = sql_modal_state();
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.left = None;
             state.explain.right = None;
@@ -1217,7 +1214,7 @@ mod tests {
         #[test]
         fn compare_tab_yank_includes_verdict_with_reasons() {
             let mut state = sql_modal_state();
-            activate_postgres_connection(&mut state, "postgres://test");
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://test");
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             // Use parseable EXPLAIN output so compare_plans produces a real verdict
             state.explain.left = Some(CompareSlot {

--- a/src/app/update/test_fixtures.rs
+++ b/src/app/update/test_fixtures.rs
@@ -1,7 +1,8 @@
+use crate::cmd::effect::Effect;
 use crate::domain::{ConnectionId, DatabaseType};
 use crate::model::app_state::AppState;
 
-pub(super) fn activate_postgres_connection(state: &mut AppState, dsn: &str) {
+pub fn activate_postgres_connection(state: &mut AppState, dsn: &str) {
     state.session.activate_connection_with_dsn(
         &ConnectionId::new(),
         "postgres",
@@ -10,7 +11,7 @@ pub(super) fn activate_postgres_connection(state: &mut AppState, dsn: &str) {
     );
 }
 
-pub(super) fn activate_sqlite_connection(state: &mut AppState, dsn: &str) {
+pub fn activate_sqlite_connection(state: &mut AppState, dsn: &str) {
     state.session.activate_connection_with_dsn(
         &ConnectionId::new(),
         "sqlite",
@@ -19,13 +20,7 @@ pub(super) fn activate_sqlite_connection(state: &mut AppState, dsn: &str) {
     );
 }
 
-#[cfg(test)]
-pub(super) fn assert_connection_save_fetch_effects(
-    effects: &[crate::cmd::effect::Effect],
-    database_type: DatabaseType,
-) {
-    use crate::cmd::effect::Effect;
-
+pub fn assert_connection_save_fetch_effects(effects: &[Effect], database_type: DatabaseType) {
     match database_type {
         DatabaseType::SQLite => {
             assert_eq!(effects.len(), 1, "sqlite save should emit Sequence");

--- a/src/infra/Cargo.toml
+++ b/src/infra/Cargo.toml
@@ -28,6 +28,7 @@ arboard.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
+sabiql-test-support.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/src/infra/adapters/connection_store.rs
+++ b/src/infra/adapters/connection_store.rs
@@ -13,6 +13,8 @@ use crate::domain::connection::{ConnectionId, ConnectionProfile};
 #[cfg(test)]
 use super::app_config_file::CONFIG_FILE_NAME;
 #[cfg(test)]
+use crate::domain::connection::{ConnectionConfig, DatabaseType, PostgresConnectionConfig};
+#[cfg(test)]
 use std::path::Path;
 
 pub struct TomlConnectionStore {
@@ -237,10 +239,7 @@ ssl_mode = "prefer"
             let profiles = store.load_all().unwrap();
 
             assert_eq!(profiles.len(), 1);
-            assert_eq!(
-                profiles[0].database_type(),
-                crate::domain::DatabaseType::PostgreSQL
-            );
+            assert_eq!(profiles[0].database_type(), DatabaseType::PostgreSQL);
             assert_eq!(profiles[0].postgres_config().unwrap().database, "testdb");
             assert!(
                 fs::read_to_string(&config_path)
@@ -291,16 +290,14 @@ ssl_mode = "prefer"
             let mut profile = make_test_profile("Production");
             store.save(&profile).unwrap();
 
-            profile.config = crate::domain::ConnectionConfig::PostgreSQL(
-                crate::domain::PostgresConnectionConfig::new(
-                    "newhost",
-                    5432,
-                    "testdb",
-                    "testuser",
-                    "testpass",
-                    SslMode::Prefer,
-                ),
-            );
+            profile.config = ConnectionConfig::PostgreSQL(PostgresConnectionConfig::new(
+                "newhost",
+                5432,
+                "testdb",
+                "testuser",
+                "testpass",
+                SslMode::Prefer,
+            ));
             let result = store.save(&profile);
 
             assert!(result.is_ok());
@@ -427,7 +424,7 @@ ssl_mode = "prefer"
             store.save(&profile).unwrap();
             let loaded = store.load().unwrap().unwrap();
 
-            assert_eq!(loaded.database_type(), crate::domain::DatabaseType::SQLite);
+            assert_eq!(loaded.database_type(), DatabaseType::SQLite);
             assert_eq!(loaded.sqlite_config().unwrap().path(), "/tmp/app.db");
         }
 
@@ -545,16 +542,14 @@ ssl_mode = "prefer"
             store.save(&profile1).unwrap();
             store.save(&profile2).unwrap();
 
-            profile2.config = crate::domain::ConnectionConfig::PostgreSQL(
-                crate::domain::PostgresConnectionConfig::new(
-                    "updated-host",
-                    5432,
-                    "testdb",
-                    "testuser",
-                    "testpass",
-                    SslMode::Prefer,
-                ),
-            );
+            profile2.config = ConnectionConfig::PostgreSQL(PostgresConnectionConfig::new(
+                "updated-host",
+                5432,
+                "testdb",
+                "testuser",
+                "testpass",
+                SslMode::Prefer,
+            ));
             store.save(&profile2).unwrap();
 
             let all = store.load_all().unwrap();

--- a/src/infra/adapters/mod.rs
+++ b/src/infra/adapters/mod.rs
@@ -12,9 +12,6 @@ pub mod query_history;
 pub mod registry;
 pub mod settings_store;
 pub mod sqlite;
-#[cfg(test)]
-pub(crate) mod test_support;
-
 pub use clipboard::ArboardClipboard;
 pub use config_writer::FileConfigWriter;
 pub use connection_store::TomlConnectionStore;

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -821,7 +821,7 @@ mod tests {
             assert_eq!(tag.as_ref(), Some(&expected_tag));
             let rows = tag
                 .as_ref()
-                .and_then(crate::domain::command_tag::CommandTag::affected_rows)
+                .and_then(CommandTag::affected_rows)
                 .unwrap_or(0) as usize;
             assert_eq!(rows, expected_rows);
         }
@@ -854,9 +854,7 @@ mod tests {
             let csv = "id,name\n1,Alice\n2,Bob\n";
             let tag = PostgresAdapter::extract_command_tag(csv);
             // Should be Other or None, never a DML/DDL variant
-            let is_dml = tag
-                .as_ref()
-                .is_some_and(crate::domain::command_tag::CommandTag::is_data_modifying);
+            let is_dml = tag.as_ref().is_some_and(CommandTag::is_data_modifying);
             assert!(!is_dml, "CSV output should not be parsed as DML tag");
         }
 

--- a/src/infra/adapters/postgres/sql/ddl.rs
+++ b/src/infra/adapters/postgres/sql/ddl.rs
@@ -98,7 +98,7 @@ mod tests {
             name: "test_table".to_string(),
             columns,
             primary_key,
-            ..crate::adapters::test_support::minimal_table("", "")
+            ..sabiql_test_support::infra::minimal_table("", "")
         }
     }
 

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -125,10 +125,10 @@ impl QueryHistoryStore for FileQueryHistoryStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::query_history::QueryResultStatus;
     use tempfile::TempDir;
 
     fn make_entry(query: &str) -> QueryHistoryEntry {
-        use crate::domain::query_history::QueryResultStatus;
         QueryHistoryEntry::new(
             query.to_string(),
             "2026-03-13T12:00:00Z".to_string(),
@@ -389,16 +389,10 @@ mod tests {
 
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].query, "SELECT 1");
-        assert_eq!(
-            entries[0].result_status,
-            crate::domain::query_history::QueryResultStatus::Success
-        );
+        assert_eq!(entries[0].result_status, QueryResultStatus::Success);
         assert_eq!(entries[0].affected_rows, None);
         assert_eq!(entries[1].query, "UPDATE t SET x=1");
-        assert_eq!(
-            entries[1].result_status,
-            crate::domain::query_history::QueryResultStatus::Success
-        );
+        assert_eq!(entries[1].result_status, QueryResultStatus::Success);
         assert_eq!(entries[1].affected_rows, Some(5));
     }
 }

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -269,7 +269,6 @@ impl SqlDialect for DbAdapterRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::adapters::test_support::make_sqlite_db;
     use crate::domain::connection::SslMode;
     use crate::domain::{Column, ColumnAttributes, QueryValue};
 
@@ -286,7 +285,7 @@ mod tests {
                 ordinal_position: 1,
             }],
             primary_key: Some(vec!["id".to_string()]),
-            ..crate::adapters::test_support::minimal_table("", "")
+            ..sabiql_test_support::infra::minimal_table("", "")
         }
     }
 
@@ -416,7 +415,9 @@ mod tests {
 
     #[tokio::test]
     async fn sqlite_metadata_is_dispatched_to_sqlite_adapter() {
-        let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+            "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+        );
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
 
         let metadata = registry.fetch_metadata(&dsn).await.unwrap();
@@ -426,7 +427,9 @@ mod tests {
 
     #[tokio::test]
     async fn sqlite_table_signatures_are_dispatched_to_sqlite_adapter() {
-        let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+            "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+        );
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
 
         let signatures = registry.fetch_table_signatures(&dsn).await.unwrap();
@@ -436,7 +439,9 @@ mod tests {
 
     #[tokio::test]
     async fn sqlite_table_detail_is_dispatched_to_sqlite_adapter() {
-        let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+            "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+        );
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
 
         let detail = registry
@@ -450,7 +455,9 @@ mod tests {
 
     #[tokio::test]
     async fn sqlite_query_execution_is_dispatched_to_sqlite_adapter() {
-        let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+            "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+        );
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
 
         let result = registry
@@ -464,7 +471,9 @@ mod tests {
 
     #[tokio::test]
     async fn sqlite_columns_request_is_dispatched_to_sqlite_adapter() {
-        let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+            "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+        );
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
 
         let detail = registry

--- a/src/infra/adapters/sqlite/diagnostics.rs
+++ b/src/infra/adapters/sqlite/diagnostics.rs
@@ -157,7 +157,6 @@ fn format_database_list_row(row: &[String]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::adapters::test_support::make_sqlite_db;
     use crate::domain::{QueryResult, QuerySource};
 
     fn empty_query_result() -> QueryResult {
@@ -166,7 +165,9 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_diagnostics_core_reports_pragmas_without_quick_check() {
-        let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+            "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+        );
         let adapter = SqliteAdapter::new();
 
         let snapshot = adapter.fetch_diagnostics_core(&dsn, true).await.unwrap();
@@ -183,7 +184,9 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_quick_check_reports_integrity_summary() {
-        let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+            "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+        );
         let adapter = SqliteAdapter::new();
 
         let quick_check = adapter.fetch_quick_check(&dsn, true).await;

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -408,7 +408,7 @@ mod tests {
             name: "test_table".to_string(),
             columns,
             primary_key,
-            ..crate::adapters::test_support::minimal_table("", "")
+            ..sabiql_test_support::infra::minimal_table("", "")
         }
     }
 

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -436,7 +436,6 @@ impl QueryExecutor for SqliteAdapter {
 
 #[cfg(test)]
 mod tests {
-    use crate::adapters::test_support::make_sqlite_db;
     use crate::app::ports::outbound::{QueryExecutor, SqlDialect};
     use crate::domain::{CommandTag, DatabaseType, QuerySource, QueryValue};
 
@@ -447,7 +446,7 @@ mod tests {
 
         #[tokio::test]
         async fn returns_columns_rows_and_respects_pagination() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (2, 'b'), (1, 'a'), (3, 'c');
@@ -467,7 +466,9 @@ mod tests {
 
         #[tokio::test]
         async fn rejects_non_main_schema() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -479,7 +480,7 @@ mod tests {
 
         #[tokio::test]
         async fn preserves_nul_text_primary_key_for_preview_and_delete() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id TEXT PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES ('a' || char(0) || 'bc', 'target'), ('only', 'other');
@@ -526,7 +527,7 @@ mod tests {
 
         #[tokio::test]
         async fn excludes_hidden_columns_from_preview_select_list() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE VIRTUAL TABLE notes_fts USING fts5(body);
             INSERT INTO notes_fts(body) VALUES ('hello');
@@ -548,7 +549,7 @@ mod tests {
 
         #[tokio::test]
         async fn preserves_distinct_c0_text_values_in_preview() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, value TEXT);
             INSERT INTO users(value) VALUES (char(1) || char(1));
@@ -574,7 +575,7 @@ mod tests {
 
         #[tokio::test]
         async fn preserves_sentinel_like_text_without_nul_in_preview() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, token TEXT);
             INSERT INTO users(token) VALUES (char(1) || 'SABIQL_HEX:4142');
@@ -598,7 +599,7 @@ mod tests {
 
         #[tokio::test]
         async fn keeps_generated_columns_in_preview_select_list() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(
                 id INTEGER PRIMARY KEY,
@@ -628,8 +629,9 @@ mod tests {
 
         #[tokio::test]
         async fn select_returns_query_result() {
-            let (_dir, dsn) =
-                make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -644,7 +646,7 @@ mod tests {
 
         #[tokio::test]
         async fn explain_query_plan_returns_readable_detail_lines() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
                  CREATE INDEX idx_users_name ON users(name);",
             );
@@ -674,7 +676,7 @@ mod tests {
 
         #[tokio::test]
         async fn explain_query_plan_for_join_includes_both_scan_targets() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 "CREATE TABLE users(id INTEGER PRIMARY KEY);
                  CREATE TABLE orders(id INTEGER, user_id INTEGER);",
             );
@@ -750,7 +752,7 @@ mod tests {
                 VALUES (new.id, new.role, new.content);
             END
             ";
-            let (_dir, dsn) = make_sqlite_db(setup);
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(setup);
             let adapter = SqliteAdapter::new();
 
             adapter.execute_adhoc(&dsn, trigger, false).await.unwrap();
@@ -795,7 +797,7 @@ mod tests {
                 INSERT INTO audit(event_id, end_value) VALUES (new.id, new.end);
             END
             ";
-            let (_dir, dsn) = make_sqlite_db(setup);
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(setup);
             let adapter = SqliteAdapter::new();
 
             adapter.execute_adhoc(&dsn, trigger, false).await.unwrap();
@@ -820,7 +822,9 @@ mod tests {
 
         #[tokio::test]
         async fn unclosed_create_trigger_fails_before_execution() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let error = adapter
@@ -837,8 +841,9 @@ mod tests {
 
         #[tokio::test]
         async fn select_preserves_quoted_newline_in_multicolumn_result() {
-            let (_dir, dsn) =
-                make_sqlite_db("CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -860,7 +865,7 @@ mod tests {
 
         #[tokio::test]
         async fn multi_select_preserves_quoted_newline_in_last_result() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -882,7 +887,7 @@ mod tests {
 
         #[tokio::test]
         async fn multi_select_does_not_treat_data_row_as_next_header() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -901,7 +906,7 @@ mod tests {
 
         #[tokio::test]
         async fn multi_select_empty_trailing_result_returns_empty_result() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -916,7 +921,9 @@ mod tests {
 
         #[tokio::test]
         async fn pragma_result_does_not_get_select_command_tag() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -933,7 +940,7 @@ mod tests {
 
         #[tokio::test]
         async fn enables_foreign_keys_before_user_sql() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -946,7 +953,7 @@ mod tests {
 
         #[tokio::test]
         async fn read_only_session_enables_query_only_before_user_sql() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -959,7 +966,7 @@ mod tests {
 
         #[tokio::test]
         async fn applies_busy_timeout_before_user_sql() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -972,7 +979,7 @@ mod tests {
 
         #[tokio::test]
         async fn values_result_does_not_get_select_command_tag() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -986,7 +993,7 @@ mod tests {
 
         #[tokio::test]
         async fn dml_returns_affected_rows_command_tag() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
@@ -1005,7 +1012,7 @@ mod tests {
 
         #[tokio::test]
         async fn replace_into_returns_insert_refresh_tag() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a');
@@ -1024,7 +1031,7 @@ mod tests {
 
         #[tokio::test]
         async fn dml_with_following_select_uses_trailing_changes_result() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a');
@@ -1047,7 +1054,7 @@ mod tests {
 
         #[tokio::test]
         async fn dml_with_following_select_preserves_result_set_and_refresh_tag() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a');
@@ -1071,7 +1078,7 @@ mod tests {
 
         #[tokio::test]
         async fn multi_dml_uses_last_effective_refresh_tag() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a');
@@ -1096,7 +1103,7 @@ mod tests {
 
         #[tokio::test]
         async fn ddl_wins_over_later_dml_for_refresh_tag() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1118,7 +1125,9 @@ mod tests {
 
         #[tokio::test]
         async fn rolled_back_dml_returns_rollback_tag() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1140,7 +1149,9 @@ mod tests {
 
         #[tokio::test]
         async fn full_rollback_inside_savepoint_discards_outer_dml() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1166,7 +1177,9 @@ mod tests {
 
         #[tokio::test]
         async fn savepoint_rollback_discards_inner_dml_only() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1193,7 +1206,9 @@ mod tests {
 
         #[tokio::test]
         async fn rollback_to_keeps_savepoint_for_later_rollback() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1222,7 +1237,9 @@ mod tests {
 
         #[tokio::test]
         async fn rollback_to_named_outer_savepoint_discards_nested_frames() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1251,7 +1268,9 @@ mod tests {
 
         #[tokio::test]
         async fn top_level_savepoint_rollback_to_discards_inner_dml_only() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1278,7 +1297,9 @@ mod tests {
 
         #[tokio::test]
         async fn top_level_savepoint_multi_write_rolls_back_when_later_statement_fails() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1299,7 +1320,9 @@ mod tests {
 
         #[tokio::test]
         async fn top_level_savepoint_without_release_does_not_persist_on_success() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1321,7 +1344,9 @@ mod tests {
 
         #[tokio::test]
         async fn with_insert_reports_affected_rows_command_tag() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1340,7 +1365,9 @@ mod tests {
 
         #[tokio::test]
         async fn multi_statement_dml_rolls_back_when_later_statement_fails() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1361,7 +1388,9 @@ mod tests {
 
         #[tokio::test]
         async fn with_dml_rolls_back_when_later_statement_fails() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1384,7 +1413,9 @@ mod tests {
 
         #[tokio::test]
         async fn returning_dml_rolls_back_when_later_statement_fails() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
             let query =
                 "INSERT INTO users(id) VALUES (1) RETURNING id; INSERT INTO missing(id) VALUES (2)";
@@ -1401,7 +1432,9 @@ mod tests {
 
         #[tokio::test]
         async fn select_then_dml_rolls_back_when_later_statement_fails() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1422,7 +1455,7 @@ mod tests {
 
         #[tokio::test]
         async fn dml_with_trailing_line_comment_returns_affected_rows() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a');
@@ -1445,8 +1478,9 @@ mod tests {
 
         #[tokio::test]
         async fn dml_returning_preserves_returned_rows() {
-            let (_dir, dsn) =
-                make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1465,7 +1499,7 @@ mod tests {
 
         #[tokio::test]
         async fn update_returning_preserves_returned_rows() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
@@ -1488,7 +1522,7 @@ mod tests {
 
         #[tokio::test]
         async fn delete_returning_preserves_returned_rows() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
@@ -1511,8 +1545,9 @@ mod tests {
 
         #[tokio::test]
         async fn dml_table_name_containing_returning_reports_affected_rows() {
-            let (_dir, dsn) =
-                make_sqlite_db("CREATE TABLE returning_log(id INTEGER PRIMARY KEY, name TEXT);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE returning_log(id INTEGER PRIMARY KEY, name TEXT);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1526,8 +1561,9 @@ mod tests {
 
         #[tokio::test]
         async fn dml_backtick_quoted_identifier_containing_returning_reports_affected_rows() {
-            let (_dir, dsn) =
-                make_sqlite_db("CREATE TABLE `my returning`(id INTEGER PRIMARY KEY, name TEXT);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE `my returning`(id INTEGER PRIMARY KEY, name TEXT);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1541,8 +1577,9 @@ mod tests {
 
         #[tokio::test]
         async fn dml_bracket_quoted_identifier_containing_returning_reports_affected_rows() {
-            let (_dir, dsn) =
-                make_sqlite_db("CREATE TABLE [my returning](id INTEGER PRIMARY KEY, name TEXT);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE [my returning](id INTEGER PRIMARY KEY, name TEXT);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1556,7 +1593,7 @@ mod tests {
 
         #[tokio::test]
         async fn ddl_returns_schema_refresh_command_tag() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1576,7 +1613,7 @@ mod tests {
 
         #[tokio::test]
         async fn foreign_key_restrict_rejects_parent_delete_with_child_row() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE orgs(id INTEGER PRIMARY KEY);
             CREATE TABLE users(
@@ -1606,7 +1643,7 @@ mod tests {
 
         #[tokio::test]
         async fn unique_constraint_violation_is_classified() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 "CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT UNIQUE NOT NULL);",
             );
             let adapter = SqliteAdapter::new();
@@ -1633,7 +1670,7 @@ mod tests {
 
         #[tokio::test]
         async fn syntax_error_stays_query_failed_with_details() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let result = adapter.execute_adhoc(&dsn, "SELEKT 1", true).await;
@@ -1644,7 +1681,7 @@ mod tests {
 
         #[tokio::test]
         async fn foreign_key_cascade_applies_to_parent_delete() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE orgs(id INTEGER PRIMARY KEY);
             CREATE TABLE users(
@@ -1672,7 +1709,7 @@ mod tests {
 
         #[tokio::test]
         async fn returns_affected_rows() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
@@ -1690,7 +1727,7 @@ mod tests {
 
         #[tokio::test]
         async fn count_query_rows_parses_count_result() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY);
             INSERT INTO users(id) VALUES (1), (2), (3);
@@ -1708,7 +1745,7 @@ mod tests {
 
         #[tokio::test]
         async fn export_to_csv_writes_rows_and_returns_row_count() {
-            let (dir, dsn) = make_sqlite_db(
+            let (dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
@@ -1729,7 +1766,7 @@ mod tests {
 
         #[tokio::test]
         async fn export_to_csv_counts_records_with_embedded_newlines() {
-            let (dir, dsn) = make_sqlite_db(
+            let (dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE logs(id INTEGER PRIMARY KEY, message TEXT);
             INSERT INTO logs(id, message) VALUES (1, 'hello
@@ -1754,7 +1791,9 @@ world'), (2, 'done');
 
         #[tokio::test]
         async fn export_to_csv_rejects_write_sql() {
-            let (dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let path = dir.path().join("write_export.csv");
             let adapter = SqliteAdapter::new();
 
@@ -1772,7 +1811,7 @@ world'), (2, 'done');
 
         #[tokio::test]
         async fn export_to_csv_missing_table_returns_object_missing_and_removes_file() {
-            let (dir, dsn) = make_sqlite_db("");
+            let (dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let path = dir.path().join("missing_export.csv");
             let adapter = SqliteAdapter::new();
 
@@ -1786,7 +1825,7 @@ world'), (2, 'done');
 
         #[tokio::test]
         async fn count_query_rows_missing_table_returns_object_missing() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let result = adapter
@@ -1798,7 +1837,9 @@ world'), (2, 'done');
 
         #[tokio::test]
         async fn read_only_write_fails() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use serde::Deserialize;
 
 use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
+#[cfg(test)]
+use crate::domain::TableKind;
 use crate::domain::{
     Column, ColumnAttributes, DatabaseMetadata, FkAction, ForeignKey, Index, IndexAttributes,
     IndexType, Schema, Table, TableKindInfo, TableSignature, TableSummary, Trigger,
@@ -789,7 +791,6 @@ impl MetadataProvider for SqliteAdapter {
 
 #[cfg(test)]
 mod tests {
-    use crate::adapters::test_support::make_sqlite_db;
     use crate::app::ports::outbound::{DdlGenerator, MetadataProvider, QueryExecutor};
     use crate::domain::{
         DatabaseType, FkAction, IndexType, Schema, TriggerEvent, TriggerTiming,
@@ -895,7 +896,7 @@ mod tests {
 
         #[tokio::test]
         async fn lists_user_tables_in_main_schema() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY AUTOINCREMENT);
             ",
@@ -912,7 +913,7 @@ mod tests {
 
         #[tokio::test]
         async fn skips_row_count_even_when_table_has_rows() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY);
             INSERT INTO users(id) VALUES (1), (2), (3);
@@ -928,7 +929,7 @@ mod tests {
 
         #[tokio::test]
         async fn empty_database_returns_no_tables() {
-            let (_dir, dsn) = make_sqlite_db("");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
             let metadata = adapter.fetch_metadata(&dsn).await.unwrap();
@@ -939,7 +940,7 @@ mod tests {
 
         #[tokio::test]
         async fn hides_fts5_shadow_tables_from_normal_table_list() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);
             CREATE VIRTUAL TABLE notes_fts USING fts5(body);
@@ -959,12 +960,12 @@ mod tests {
 
         struct TableKindInfoMetadataFixture {
             _dir: tempfile::TempDir,
-            kind_info_by_name: std::collections::HashMap<String, crate::domain::TableKindInfo>,
+            kind_info_by_name: std::collections::HashMap<String, TableKindInfo>,
         }
 
         impl TableKindInfoMetadataFixture {
             async fn new() -> Self {
-                let (dir, dsn) = make_sqlite_db(
+                let (dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                     r"
             CREATE TABLE users(id INTEGER PRIMARY KEY);
             CREATE TABLE strict_users(id INTEGER PRIMARY KEY, name TEXT);
@@ -990,7 +991,7 @@ mod tests {
                 }
             }
 
-            fn kind_info(&self, name: &str) -> &crate::domain::TableKindInfo {
+            fn kind_info(&self, name: &str) -> &TableKindInfo {
                 &self.kind_info_by_name[name]
             }
         }
@@ -999,10 +1000,7 @@ mod tests {
         async fn classifies_regular_table_kind() {
             let fixture = TableKindInfoMetadataFixture::new().await;
 
-            assert_eq!(
-                fixture.kind_info("users").kind,
-                crate::domain::TableKind::Table
-            );
+            assert_eq!(fixture.kind_info("users").kind, TableKind::Table);
             assert!(!fixture.kind_info("users").is_strict);
             assert!(!fixture.kind_info("users").without_rowid);
         }
@@ -1035,10 +1033,7 @@ mod tests {
         async fn classifies_virtual_table_kind() {
             let fixture = TableKindInfoMetadataFixture::new().await;
 
-            assert_eq!(
-                fixture.kind_info("notes_fts").kind,
-                crate::domain::TableKind::Virtual
-            );
+            assert_eq!(fixture.kind_info("notes_fts").kind, TableKind::Virtual);
             assert_eq!(
                 fixture.kind_info("notes_fts").virtual_module.as_deref(),
                 Some("fts5")
@@ -1047,7 +1042,7 @@ mod tests {
 
         #[tokio::test]
         async fn hides_rtree_shadow_tables_from_normal_table_list() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE places(id INTEGER PRIMARY KEY, name TEXT);
             CREATE VIRTUAL TABLE places_geo USING rtree(
@@ -1071,7 +1066,9 @@ mod tests {
 
         #[tokio::test]
         async fn detects_virtual_tables_in_schema() {
-            let (_dir, dsn) = make_sqlite_db("CREATE VIRTUAL TABLE notes_fts USING fts5(body);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE VIRTUAL TABLE notes_fts USING fts5(body);",
+            );
             let adapter = SqliteAdapter::new();
             let path = SqliteAdapter::path_from_dsn(&dsn).unwrap();
 
@@ -1080,7 +1077,9 @@ mod tests {
 
         #[tokio::test]
         async fn simple_schema_has_no_virtual_tables() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
             let path = SqliteAdapter::path_from_dsn(&dsn).unwrap();
 
@@ -1093,7 +1092,9 @@ mod tests {
 
         #[tokio::test]
         async fn non_main_schema_returns_object_missing() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter.fetch_table_detail(&dsn, "other", "users").await;
@@ -1103,7 +1104,9 @@ mod tests {
 
         #[tokio::test]
         async fn missing_table_returns_object_missing() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let result = adapter.fetch_table_detail(&dsn, "main", "missing").await;
@@ -1113,7 +1116,7 @@ mod tests {
 
         #[tokio::test]
         async fn loads_columns_indexes_and_foreign_keys() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE orgs(id INTEGER PRIMARY KEY);
             CREATE TABLE users(
@@ -1160,7 +1163,7 @@ mod tests {
 
         #[tokio::test]
         async fn columns_and_fks_skips_row_count() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY);
             INSERT INTO users(id) VALUES (1), (2), (3);
@@ -1183,7 +1186,7 @@ mod tests {
 
         #[tokio::test]
         async fn columns_and_fks_skips_triggers_and_source_ddl() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY);
             CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN
@@ -1210,7 +1213,8 @@ mod tests {
 
         #[tokio::test]
         async fn without_primary_key_sets_primary_key_none() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE logs(message TEXT);");
+            let (_dir, dsn) =
+                sabiql_test_support::infra::make_sqlite_db("CREATE TABLE logs(message TEXT);");
             let adapter = SqliteAdapter::new();
 
             let detail = adapter
@@ -1224,7 +1228,9 @@ mod tests {
 
         #[tokio::test]
         async fn columns_and_fks_preserves_unique_column_attributes_without_returning_indexes() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(email TEXT UNIQUE NOT NULL);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(email TEXT UNIQUE NOT NULL);",
+            );
             let adapter = SqliteAdapter::new();
 
             let detail = adapter
@@ -1243,7 +1249,7 @@ mod tests {
 
         #[tokio::test]
         async fn partial_unique_index_does_not_mark_column_unique() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(email TEXT);
             CREATE UNIQUE INDEX idx_users_email_active
@@ -1287,7 +1293,7 @@ mod tests {
 
         #[tokio::test]
         async fn generated_and_hidden_columns_are_read_only() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(
                 id INTEGER PRIMARY KEY,
@@ -1328,7 +1334,7 @@ mod tests {
 
         #[tokio::test]
         async fn source_ddl_preserves_without_rowid_and_virtual_table_syntax() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE settings(
                 key TEXT PRIMARY KEY,
@@ -1363,10 +1369,7 @@ mod tests {
                     .source_ddl()
                     .is_some_and(|ddl| ddl.starts_with("CREATE VIRTUAL TABLE"))
             );
-            assert_eq!(
-                virtual_table.kind_info.kind,
-                crate::domain::TableKind::Virtual
-            );
+            assert_eq!(virtual_table.kind_info.kind, TableKind::Virtual);
             assert_eq!(
                 virtual_table.kind_info.virtual_module.as_deref(),
                 Some("fts5")
@@ -1375,7 +1378,7 @@ mod tests {
 
         #[tokio::test]
         async fn partial_expression_index_preserves_metadata_and_definition() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT);
             CREATE INDEX idx_users_email_lower
@@ -1408,7 +1411,7 @@ mod tests {
 
         #[tokio::test]
         async fn partial_index_preserves_where_clause_in_definition() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(email TEXT);
             CREATE INDEX idx_users_email_active
@@ -1441,7 +1444,7 @@ mod tests {
 
         #[tokio::test]
         async fn descending_and_collation_indexes_preserve_definition() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(name TEXT, created_at TEXT);
             CREATE INDEX idx_users_name_desc ON users(name DESC);
@@ -1490,7 +1493,7 @@ mod tests {
 
         #[tokio::test]
         async fn composite_foreign_key_groups_columns_in_sequence_order() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE parent(a INTEGER, b INTEGER, PRIMARY KEY(a, b));
             CREATE TABLE child(
@@ -1520,7 +1523,7 @@ mod tests {
 
         #[tokio::test]
         async fn foreign_key_without_target_columns_resolves_parent_primary_key() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE parent(a INTEGER, b INTEGER, PRIMARY KEY(a, b));
             CREATE TABLE child(
@@ -1546,7 +1549,7 @@ mod tests {
 
         #[tokio::test]
         async fn foreign_key_to_missing_table_is_kept_as_unresolved() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             PRAGMA foreign_keys=OFF;
             CREATE TABLE child(
@@ -1570,7 +1573,7 @@ mod tests {
 
         #[tokio::test]
         async fn foreign_key_to_missing_column_is_kept_as_unresolved() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             PRAGMA foreign_keys=OFF;
             CREATE TABLE parent(a INTEGER PRIMARY KEY);
@@ -1596,7 +1599,7 @@ mod tests {
 
         #[tokio::test]
         async fn foreign_key_without_target_columns_and_missing_parent_pk_is_unresolved() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             PRAGMA foreign_keys=OFF;
             CREATE TABLE parent(a INTEGER);
@@ -1620,7 +1623,7 @@ mod tests {
 
         #[tokio::test]
         async fn foreign_key_target_column_matches_case_insensitively() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE parent(id INTEGER PRIMARY KEY);
             CREATE TABLE child(x INTEGER REFERENCES parent(ID));
@@ -1644,7 +1647,9 @@ mod tests {
 
         #[tokio::test]
         async fn change_with_table_shape() {
-            let (_dir, dsn) = make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
+                "CREATE TABLE users(id INTEGER PRIMARY KEY);",
+            );
             let adapter = SqliteAdapter::new();
 
             let signatures = adapter.fetch_table_signatures(&dsn).await.unwrap();
@@ -1657,7 +1662,7 @@ mod tests {
 
         #[tokio::test]
         async fn include_foreign_key_update_action() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE orgs(id INTEGER PRIMARY KEY);
             CREATE TABLE users(
@@ -1684,7 +1689,7 @@ mod tests {
 
         #[tokio::test]
         async fn unresolved_foreign_key_is_included_in_signature() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             PRAGMA foreign_keys=OFF;
             CREATE TABLE child(
@@ -1710,25 +1715,25 @@ mod tests {
         #[tokio::test]
         async fn index_desc_and_collation_change_signature() {
             let adapter = SqliteAdapter::new();
-            let (_asc_dir, asc_dsn) = make_sqlite_db(
+            let (_asc_dir, asc_dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(name TEXT);
             CREATE INDEX idx_users_name ON users(name);
             ",
             );
-            let (_desc_dir, desc_dsn) = make_sqlite_db(
+            let (_desc_dir, desc_dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(name TEXT);
             CREATE INDEX idx_users_name ON users(name DESC);
             ",
             );
-            let (_binary_dir, binary_dsn) = make_sqlite_db(
+            let (_binary_dir, binary_dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(name TEXT);
             CREATE INDEX idx_users_name ON users(name);
             ",
             );
-            let (_nocase_dir, nocase_dsn) = make_sqlite_db(
+            let (_nocase_dir, nocase_dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(name TEXT);
             CREATE INDEX idx_users_name ON users(name COLLATE NOCASE);
@@ -1793,7 +1798,7 @@ mod tests {
                 INSERT INTO audit(user_id) VALUES (new.id);
             END;
             ";
-            let (_dir, dsn) = make_sqlite_db(setup);
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(setup);
             let adapter = SqliteAdapter::new();
 
             let before = adapter.fetch_table_signatures(&dsn).await.unwrap();
@@ -1825,7 +1830,7 @@ mod tests {
 
         #[tokio::test]
         async fn table_detail_loads_trigger_without_explicit_timing() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY);
             CREATE TRIGGER users_log INSERT ON users BEGIN SELECT 1; END;
@@ -1846,7 +1851,7 @@ mod tests {
 
         #[tokio::test]
         async fn table_detail_loads_trigger_metadata_from_sqlite_master_sql() {
-            let (_dir, dsn) = make_sqlite_db(
+            let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY);
             CREATE TRIGGER IF NOT EXISTS users_audit AFTER INSERT ON users BEGIN SELECT 1; END;

--- a/src/test-support/Cargo.toml
+++ b/src/test-support/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sabiql-test-support"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Test support utilities for sabiql"
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+sabiql-domain.workspace = true
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/src/test-support/column.rs
+++ b/src/test-support/column.rs
@@ -1,4 +1,4 @@
-use crate::domain::{Column, ColumnAttributes};
+use sabiql_domain::{Column, ColumnAttributes};
 
 #[must_use]
 pub fn test_nullable_column(

--- a/src/test-support/infra/mod.rs
+++ b/src/test-support/infra/mod.rs
@@ -1,24 +1,12 @@
 use std::process::Command;
 
-use sabiql_domain::{Table, TableKindInfo};
+use sabiql_domain::Table;
+
+use crate::table;
 
 #[must_use]
 pub fn minimal_table(schema: impl Into<String>, name: impl Into<String>) -> Table {
-    Table {
-        schema: schema.into(),
-        name: name.into(),
-        owner: None,
-        columns: Vec::new(),
-        primary_key: None,
-        foreign_keys: Vec::new(),
-        indexes: Vec::new(),
-        rls: None,
-        triggers: Vec::new(),
-        row_count_estimate: None,
-        comment: None,
-        source_ddl: None,
-        kind_info: TableKindInfo::default(),
-    }
+    table::minimal(schema, name)
 }
 
 #[must_use]

--- a/src/test-support/infra/mod.rs
+++ b/src/test-support/infra/mod.rs
@@ -1,6 +1,9 @@
+use std::process::Command;
+
 use sabiql_domain::{Table, TableKindInfo};
 
-pub(super) fn minimal_table(schema: impl Into<String>, name: impl Into<String>) -> Table {
+#[must_use]
+pub fn minimal_table(schema: impl Into<String>, name: impl Into<String>) -> Table {
     Table {
         schema: schema.into(),
         name: name.into(),
@@ -18,9 +21,8 @@ pub(super) fn minimal_table(schema: impl Into<String>, name: impl Into<String>) 
     }
 }
 
-use std::process::Command;
-
-pub(super) fn make_sqlite_db(sql: &str) -> (tempfile::TempDir, String) {
+#[must_use]
+pub fn make_sqlite_db(sql: &str) -> (tempfile::TempDir, String) {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("app.db");
     let output = Command::new("sqlite3")

--- a/src/test-support/lib.rs
+++ b/src/test-support/lib.rs
@@ -1,2 +1,3 @@
 pub mod column;
+pub mod infra;
 pub mod table;

--- a/src/test-support/table.rs
+++ b/src/test-support/table.rs
@@ -1,5 +1,6 @@
-use crate::domain::{Table, TableKindInfo};
+use sabiql_domain::{Table, TableKindInfo};
 
+#[must_use]
 pub fn minimal(schema: impl Into<String>, name: impl Into<String>) -> Table {
     Table {
         schema: schema.into(),

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -2,6 +2,7 @@ use super::*;
 use harness::connected_state;
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
+use sabiql_app::model::app_state::AppState;
 use sabiql_app::model::shared::help::HelpOrigin;
 use sabiql_app::model::sql_editor::modal::SqlModalStatus;
 use sabiql_app::policy::write::sql_risk::AcknowledgeReason;
@@ -816,7 +817,7 @@ fn sql_modal_normal_initial() {
     insta::assert_snapshot!(output);
 }
 
-fn sqlite_connected_state() -> sabiql_app::model::app_state::AppState {
+fn sqlite_connected_state() -> AppState {
     let mut state = create_test_state();
     state.session.activate_connection_with_dsn(
         &ConnectionId::new(),

--- a/src/ui/adapters/tui_adapter.rs
+++ b/src/ui/adapters/tui_adapter.rs
@@ -5,6 +5,7 @@ use crossterm::execute;
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::input_mode::InputMode;
+use crate::app::model::sql_editor::modal::SqlModalStatus;
 use crate::app::ports::outbound::renderer::{RenderOutput, RenderResult, Renderer};
 use crate::app::services::AppServices;
 use crate::shell::layout::MainLayout;
@@ -56,10 +57,7 @@ fn uses_insert_cursor(state: &AppState) -> bool {
         InputMode::JsonbEdit => true,
         InputMode::JsonbDetail => state.jsonb_detail.search().is_active(),
         InputMode::CellDetail => state.cell_detail.search().is_active(),
-        InputMode::SqlModal => matches!(
-            state.sql_modal.status(),
-            crate::app::model::sql_editor::modal::SqlModalStatus::Editing
-        ),
+        InputMode::SqlModal => matches!(state.sql_modal.status(), SqlModalStatus::Editing),
         _ => false,
     }
 }

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -9,7 +9,7 @@ use ratatui::widgets::{Cell, Paragraph, Row, Table as RatatuiTable, Wrap};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::db_capabilities::{DbCapabilities, InspectorInfoField};
-use crate::app::model::shared::flash_timer::FlashId;
+use crate::app::model::shared::flash_timer::{FlashId, FlashTimerStore};
 use crate::app::model::shared::focused_pane::FocusedPane;
 use crate::app::model::shared::inspector_tab::InspectorTab;
 use crate::app::model::shared::viewport::{
@@ -722,7 +722,7 @@ impl Inspector {
         area: Rect,
         ddl: String,
         scroll_offset: usize,
-        flash_timers: &crate::app::model::shared::flash_timer::FlashTimerStore,
+        flash_timers: &FlashTimerStore,
         now: Instant,
         theme: &ThemePalette,
     ) {

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -19,7 +19,7 @@ use crate::app::model::shared::viewport::{
 use crate::app::policy::table_kind::{inspector_flags_label, inspector_kind_label};
 use crate::app::services::AppServices;
 use crate::domain::{ForeignKey, Index, IndexType, Table};
-use crate::primitives::atoms::panel_block;
+use crate::primitives::atoms::{apply_yank_flash, panel_block};
 use crate::primitives::utils::text_utils::{
     MIN_COL_WIDTH, PADDING, calculate_header_min_widths, truncate_to_width,
 };
@@ -743,7 +743,7 @@ impl Inspector {
             })
             .collect();
 
-        crate::primitives::atoms::apply_yank_flash(&mut lines, flash_active, theme);
+        apply_yank_flash(&mut lines, flash_active, theme);
 
         let paragraph = Paragraph::new(lines)
             .wrap(Wrap { trim: false })

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -10,7 +10,8 @@ use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::shared::text_input::TextInputLike;
 use crate::features::browse::detail_view::render_detail_search;
 use crate::primitives::atoms::{
-    CursorKind, ModalTextSurface, build_modal_text_surface_lines, render_modal_text_surface,
+    CursorKind, ModalTextSurface, apply_yank_flash, build_modal_text_surface_lines,
+    render_modal_text_surface,
 };
 use crate::primitives::molecules::{FooterHintBar, render_modal};
 use crate::theme::ThemePalette;
@@ -126,7 +127,7 @@ impl JsonbDetail {
         let mut lines = build_modal_text_surface_lines(surface, line_spans, theme);
 
         let flash_active = state.flash_timers.is_active(FlashId::JsonbDetail, now);
-        crate::primitives::atoms::apply_yank_flash(&mut lines, flash_active, theme);
+        apply_yank_flash(&mut lines, flash_active, theme);
 
         render_modal_text_surface(frame, area, surface, lines);
     }

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -11,6 +11,7 @@ use crate::primitives::atoms::{panel_block_highlight, text_cursor_spans};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::focused_pane::FocusedPane;
+use crate::app::model::shared::input_mode::InputMode;
 use crate::app::model::shared::ui_state::{RESULT_INNER_OVERHEAD, ResultSelection, YankFlash};
 use crate::app::model::shared::viewport::{
     ColumnWidthConfig, ColumnWidthsCache, MAX_COL_WIDTH, SelectionContext, ViewportPlan,
@@ -79,8 +80,7 @@ impl ResultPane {
                     row: cell_edit.row().unwrap_or_default(),
                     col: cell_edit.col().unwrap_or_default(),
                     draft: cell_edit.draft_value(),
-                    actively_editing: state.input_mode()
-                        == crate::app::model::shared::input_mode::InputMode::CellEdit,
+                    actively_editing: state.input_mode() == InputMode::CellEdit,
                     cursor: cell_edit.input().cursor(),
                 });
                 Self::render_table(

--- a/src/ui/features/connections/error.rs
+++ b/src/ui/features/connections/error.rs
@@ -8,6 +8,7 @@ use ratatui::widgets::{Paragraph, Wrap};
 use crate::theme::ThemePalette;
 
 use crate::app::model::app_state::AppState;
+use crate::app::model::connection::error_state::ConnectionErrorState;
 use crate::primitives::atoms::key_chip;
 use crate::primitives::molecules::{FooterHintBar, render_modal};
 use crate::primitives::utils::text_utils::wrapped_line_count;
@@ -114,7 +115,7 @@ impl ConnectionError {
     fn render_details_section(
         frame: &mut Frame,
         area: Rect,
-        error_state: &crate::app::model::connection::error_state::ConnectionErrorState,
+        error_state: &ConnectionErrorState,
         expanded: bool,
         theme: &ThemePalette,
     ) {

--- a/src/ui/features/connections/selector.rs
+++ b/src/ui/features/connections/selector.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem, ListState};
 
 use crate::app::model::app_state::AppState;
-use crate::app::model::connection::list::ConnectionListItem;
+use crate::app::model::connection::list::{ConnectionListItem, is_service_selected};
 use crate::app::update::input::keybindings::connection_selector;
 use crate::domain::connection::ConnectionId;
 use crate::primitives::atoms::scroll_indicator::{
@@ -22,7 +22,7 @@ pub struct ConnectionSelector;
 
 impl ConnectionSelector {
     pub fn render(frame: &mut Frame, state: &AppState, theme: &ThemePalette) -> u16 {
-        let is_service_selected = crate::app::model::connection::list::is_service_selected(
+        let is_service_selected = is_service_selected(
             state.connection_list_items(),
             state.ui.connection_list_selected(),
         );

--- a/src/ui/features/connections/selector.rs
+++ b/src/ui/features/connections/selector.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem, ListState};
 
 use crate::app::model::app_state::AppState;
-use crate::app::model::connection::list::{ConnectionListItem, is_service_selected};
+use crate::app::model::connection::list::{self, ConnectionListItem};
 use crate::app::update::input::keybindings::connection_selector;
 use crate::domain::connection::ConnectionId;
 use crate::primitives::atoms::scroll_indicator::{
@@ -22,7 +22,7 @@ pub struct ConnectionSelector;
 
 impl ConnectionSelector {
     pub fn render(frame: &mut Frame, state: &AppState, theme: &ThemePalette) -> u16 {
-        let is_service_selected = is_service_selected(
+        let is_service_selected = list::is_service_selected(
             state.connection_list_items(),
             state.ui.connection_list_selected(),
         );

--- a/src/ui/features/sql_modal/compare.rs
+++ b/src/ui/features/sql_modal/compare.rs
@@ -11,6 +11,7 @@ use crate::app::model::explain_context::CompareSlot;
 use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::update::input::keybindings::sql_modal_compare_explain;
 use crate::domain::explain_plan::{self, ComparisonVerdict};
+use crate::primitives::atoms::apply_yank_flash_masked;
 use crate::primitives::utils::text_utils::truncate_to_width_with;
 use crate::theme::ThemePalette;
 
@@ -53,12 +54,7 @@ pub fn render(
     let visible_mask: Vec<bool> = flash_mask.into_iter().skip(clamped).collect();
 
     let flash_active = can_yank && state.flash_timers.is_active(FlashId::SqlModal, now);
-    crate::primitives::atoms::apply_yank_flash_masked(
-        &mut visible,
-        flash_active,
-        &visible_mask,
-        theme,
-    );
+    apply_yank_flash_masked(&mut visible, flash_active, &visible_mask, theme);
 
     frame.render_widget(
         Paragraph::new(visible)

--- a/src/ui/features/sql_modal/editor.rs
+++ b/src/ui/features/sql_modal/editor.rs
@@ -11,8 +11,8 @@ use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::shared::text_input::TextInputLike;
 use crate::app::model::sql_editor::modal::SqlModalStatus;
 use crate::primitives::atoms::{
-    CursorKind, ModalTextSurface, build_modal_text_surface_lines, highlight_sql_spans,
-    render_modal_text_surface,
+    CursorKind, ModalTextSurface, apply_yank_flash, build_modal_text_surface_lines,
+    highlight_sql_spans, render_modal_text_surface,
 };
 use crate::theme::ThemePalette;
 
@@ -78,7 +78,7 @@ pub(super) fn render_editor(
     let mut lines = build_modal_text_surface_lines(surface, line_spans, theme);
 
     let flash_active = state.flash_timers.is_active(FlashId::SqlModal, now);
-    crate::primitives::atoms::apply_yank_flash(&mut lines, flash_active, theme);
+    apply_yank_flash(&mut lines, flash_active, theme);
 
     render_modal_text_surface(frame, area, surface, lines);
 }

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -12,7 +12,7 @@ use crate::app::model::shared::text_input::TextInputState;
 use crate::app::model::sql_editor::modal::{HIGH_RISK_INPUT_VISIBLE_WIDTH, SqlModalStatus};
 use crate::app::policy::write::sql_risk::AcknowledgeReason;
 use crate::app::update::input::keybindings::sql_modal_plan_explain;
-use crate::primitives::atoms::text_cursor_spans;
+use crate::primitives::atoms::{apply_yank_flash, text_cursor_spans};
 use crate::theme::ThemePalette;
 
 pub fn render(
@@ -106,11 +106,7 @@ pub fn render(
 
         let flash_active = state.flash_timers.is_active(FlashId::SqlModal, now);
         let content_start = 3; // skip header, query snippet, empty line
-        crate::primitives::atoms::apply_yank_flash(
-            &mut lines[content_start..],
-            flash_active,
-            theme,
-        );
+        apply_yank_flash(&mut lines[content_start..], flash_active, theme);
 
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
         area.height

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -8,6 +8,7 @@ use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::flash_timer::FlashId;
+use crate::app::model::shared::text_input::TextInputState;
 use crate::app::model::sql_editor::modal::{HIGH_RISK_INPUT_VISIBLE_WIDTH, SqlModalStatus};
 use crate::app::policy::write::sql_risk::AcknowledgeReason;
 use crate::app::update::input::keybindings::sql_modal_plan_explain;
@@ -134,7 +135,7 @@ fn render_scrolled(frame: &mut Frame, area: Rect, lines: Vec<Line>, scroll_offse
 fn build_analyze_confirm_lines<'a>(
     area: Rect,
     query: &'a str,
-    input: &'a crate::app::model::shared::text_input::TextInputState,
+    input: &'a TextInputState,
     name: &'a str,
     theme: &ThemePalette,
 ) -> Vec<Line<'a>> {

--- a/src/ui/features/sql_modal/status.rs
+++ b/src/ui/features/sql_modal/status.rs
@@ -5,8 +5,10 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
 use crate::app::model::app_state::AppState;
+use crate::app::model::shared::text_input::TextInputState;
 use crate::app::model::sql_editor::modal::{HIGH_RISK_INPUT_VISIBLE_WIDTH, SqlModalStatus};
 use crate::app::policy::write::sql_risk::AcknowledgeReason;
+use crate::app::policy::write::write_guardrails::AdhocRiskDecision;
 use crate::primitives::atoms::{spinner_char, text_cursor_spans};
 use crate::primitives::utils::text_utils::truncate_to_width_with;
 use crate::theme::ThemePalette;
@@ -135,8 +137,8 @@ pub(super) fn render_status(frame: &mut Frame, area: Rect, state: &AppState, the
 fn render_confirming_high_status(
     frame: &mut Frame,
     area: Rect,
-    decision: &crate::app::policy::write::write_guardrails::AdhocRiskDecision,
-    input: &crate::app::model::shared::text_input::TextInputState,
+    decision: &AdhocRiskDecision,
+    input: &TextInputState,
     name: &str,
     theme: &ThemePalette,
 ) {

--- a/src/ui/primitives/atoms/sql_highlight.rs
+++ b/src/ui/primitives/atoms/sql_highlight.rs
@@ -75,7 +75,9 @@ fn token_style(kind: &TokenKind, theme: &ThemePalette) -> Style {
 mod tests {
     use super::*;
     use crate::primitives::atoms::{CursorKind, insert_cursor_span_with_kind};
-    use crate::theme::{DEFAULT_THEME, ThemePalette};
+    use crate::theme::{
+        ComponentTokens, CursorTokens, DEFAULT_THEME, SemanticTokens, SyntaxTokens, ThemePalette,
+    };
 
     fn line_text(line: &Line<'_>) -> String {
         line.spans
@@ -258,8 +260,8 @@ mod tests {
     #[test]
     fn highlight_sql_honors_injected_theme_colors() {
         let custom_theme = ThemePalette {
-            component: crate::theme::ComponentTokens {
-                syntax: crate::theme::SyntaxTokens {
+            component: ComponentTokens {
+                syntax: SyntaxTokens {
                     sql_keyword: ratatui::style::Color::Rgb(0x12, 0x34, 0x56),
                     ..DEFAULT_THEME.component.syntax
                 },
@@ -279,8 +281,8 @@ mod tests {
     #[test]
     fn highlight_sql_with_insert_cursor_preserves_injected_token_style() {
         let custom_theme = ThemePalette {
-            semantic: crate::theme::SemanticTokens {
-                cursor: crate::theme::CursorTokens {
+            semantic: SemanticTokens {
+                cursor: CursorTokens {
                     fg: ratatui::style::Color::Rgb(0xfe, 0xdc, 0xba),
                     ..DEFAULT_THEME.semantic.cursor
                 },

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
 use crate::app::model::app_state::AppState;
-use crate::app::model::connection::list;
+use crate::app::model::connection::list as connection_list;
 use crate::app::model::connection::setup::ConnectionField;
 use crate::app::model::er_state::ErStatus;
 use crate::app::model::shared::input_mode::InputMode;
@@ -349,7 +349,7 @@ impl Footer {
             }
             InputMode::ConnectionSelector => {
                 use connection_selector as cs;
-                let is_service_selected = list::is_service_selected(
+                let is_service_selected = connection_list::is_service_selected(
                     state.connection_list_items(),
                     state.ui.connection_list_selected(),
                 );

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
 use crate::app::model::app_state::AppState;
-use crate::app::model::connection::list::is_service_selected;
+use crate::app::model::connection::list;
 use crate::app::model::connection::setup::ConnectionField;
 use crate::app::model::er_state::ErStatus;
 use crate::app::model::shared::input_mode::InputMode;
@@ -349,7 +349,7 @@ impl Footer {
             }
             InputMode::ConnectionSelector => {
                 use connection_selector as cs;
-                let is_service_selected = is_service_selected(
+                let is_service_selected = list::is_service_selected(
                     state.connection_list_items(),
                     state.ui.connection_list_selected(),
                 );

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -5,6 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
 use crate::app::model::app_state::AppState;
+use crate::app::model::connection::list::is_service_selected;
 use crate::app::model::connection::setup::ConnectionField;
 use crate::app::model::er_state::ErStatus;
 use crate::app::model::shared::input_mode::InputMode;
@@ -348,7 +349,7 @@ impl Footer {
             }
             InputMode::ConnectionSelector => {
                 use connection_selector as cs;
-                let is_service_selected = crate::app::model::connection::list::is_service_selected(
+                let is_service_selected = is_service_selected(
                     state.connection_list_items(),
                     state.ui.connection_list_selected(),
                 );


### PR DESCRIPTION
## Problem

Long workspace-internal absolute paths can hide the subject of UI and app code, leaving review comments to catch them manually.

## Background

SAB-311 asks for a mechanical Clippy signal while keeping standard library and third-party crate paths allowed during the initial rollout.

## Approach

Enable the specific `clippy::absolute_paths` lint at workspace scope, configure the initial threshold and allowed external roots, and shorten the existing long internal paths reported by that policy.

Refs SAB-311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 絶対パス指定に関する lint を警告レベルで検出するよう更新しました。
  * lint の許可方針を明確化し、標準ライブラリおよび許可対象のクレートは利用しやすくしました。
* **Style**
  * UI/処理まわりの参照表記を整理し、可読性を向上しました。
* **Tests**
  * テスト用サポートの集約・再配置を行い、テストデータ生成やテストヘルパの参照を統一しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->