### PR TITLE
test(app): introduce closure fixture builders for readable test data

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -927,37 +927,32 @@ mod tests {
     use super::*;
     pub use crate::domain::Column;
     use crate::domain::Table;
-    use crate::test_support::column::column_fixture;
-    use crate::test_support::table::table_fixture;
+    use crate::test_support::column::{column_fixture, test_nullable_column};
 
     fn engine() -> CompletionEngine {
         CompletionEngine::new()
     }
 
     fn create_table(schema: &str, name: &str, columns: &[&str]) -> Table {
-        table_fixture(|t| {
-            t.schema = schema.to_string();
-            t.name = name.to_string();
-            t.columns = columns
+        Table {
+            schema: schema.to_string(),
+            name: name.to_string(),
+            columns: columns
                 .iter()
                 .enumerate()
-                .map(|(i, col)| {
-                    column_fixture(|c| {
-                        c.name = (*col).into();
-                        c.data_type = "text".into();
-                        c.ordinal_position = (i + 1) as i32;
-                    })
-                })
-                .collect();
-        })
+                .map(|(i, col)| test_nullable_column(*col, "text", (i + 1) as i32))
+                .collect(),
+            ..crate::test_support::table::minimal("", "")
+        }
     }
 
     fn table_with_two_columns(col1: Column, col2: Column) -> Table {
-        table_fixture(|t| {
-            t.schema = "public".to_string();
-            t.name = "test".to_string();
-            t.columns = vec![col1, col2];
-        })
+        Table {
+            schema: "public".to_string(),
+            name: "test".to_string(),
+            columns: vec![col1, col2],
+            ..crate::test_support::table::minimal("", "")
+        }
     }
 
     mod context_detection {
@@ -1218,11 +1213,7 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    column_fixture(|c| {
-                        c.name = "user_name".into();
-                        c.data_type = "text".into();
-                        c.ordinal_position = 1;
-                    }),
+                    test_nullable_column("user_name", "text", 1),
                     column_fixture(|c| {
                         c.name = "user_id".into();
                         c.data_type = "int".into();
@@ -1351,11 +1342,7 @@ mod tests {
         fn pk_column_returns_higher_score() {
             let e = engine();
             let table = table_with_two_columns(
-                column_fixture(|c| {
-                    c.name = "name".into();
-                    c.data_type = "text".into();
-                    c.ordinal_position = 1;
-                }),
+                test_nullable_column("name", "text", 1),
                 column_fixture(|c| {
                     c.name = "id".into();
                     c.data_type = "int".into();
@@ -1374,11 +1361,7 @@ mod tests {
         fn not_null_column_returns_higher_score() {
             let e = engine();
             let table = table_with_two_columns(
-                column_fixture(|c| {
-                    c.name = "optional_field".into();
-                    c.data_type = "text".into();
-                    c.ordinal_position = 1;
-                }),
+                test_nullable_column("optional_field", "text", 1),
                 column_fixture(|c| {
                     c.name = "required_field".into();
                     c.data_type = "text".into();
@@ -1588,11 +1571,7 @@ mod tests {
                         c.ordinal_position = 1;
                         c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
                     }),
-                    column_fixture(|c| {
-                        c.name = "name".into();
-                        c.data_type = "text".into();
-                        c.ordinal_position = 2;
-                    }),
+                    test_nullable_column("name", "text", 2),
                 ],
                 primary_key: Some(vec!["id".to_string()]),
                 ..crate::test_support::table::minimal("", "")
@@ -1660,16 +1639,8 @@ mod tests {
                         c.ordinal_position = 1;
                         c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
                     }),
-                    column_fixture(|c| {
-                        c.name = "username".into();
-                        c.data_type = "text".into();
-                        c.ordinal_position = 2;
-                    }),
-                    column_fixture(|c| {
-                        c.name = "email".into();
-                        c.data_type = "text".into();
-                        c.ordinal_position = 3;
-                    }),
+                    test_nullable_column("username", "text", 2),
+                    test_nullable_column("email", "text", 3),
                 ],
                 primary_key: Some(vec!["user_id".to_string()]),
                 ..crate::test_support::table::minimal("", "")
@@ -1725,11 +1696,7 @@ mod tests {
                         c.ordinal_position = 2;
                         c.attributes = ColumnAttributes::empty();
                     }),
-                    column_fixture(|c| {
-                        c.name = "status".into();
-                        c.data_type = "text".into();
-                        c.ordinal_position = 3;
-                    }),
+                    test_nullable_column("status", "text", 3),
                 ],
                 primary_key: Some(vec!["id".to_string()]),
                 foreign_keys: vec![ForeignKey {
@@ -1799,16 +1766,8 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    column_fixture(|c| {
-                        c.name = "user_id".into();
-                        c.data_type = "int".into();
-                        c.ordinal_position = 1;
-                    }),
-                    column_fixture(|c| {
-                        c.name = "created_at".into();
-                        c.data_type = "timestamp".into();
-                        c.ordinal_position = 2;
-                    }),
+                    test_nullable_column("user_id", "int", 1),
+                    test_nullable_column("created_at", "timestamp", 2),
                 ],
                 ..crate::test_support::table::minimal("", "")
             };
@@ -1827,16 +1786,8 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    column_fixture(|c| {
-                        c.name = "id".into();
-                        c.data_type = "int".into();
-                        c.ordinal_position = 1;
-                    }),
-                    column_fixture(|c| {
-                        c.name = "user_id".into();
-                        c.data_type = "int".into();
-                        c.ordinal_position = 2;
-                    }),
+                    test_nullable_column("id", "int", 1),
+                    test_nullable_column("user_id", "int", 2),
                 ],
                 ..crate::test_support::table::minimal("", "")
             };
@@ -1862,16 +1813,8 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    column_fixture(|c| {
-                        c.name = "name".into();
-                        c.data_type = "text".into();
-                        c.ordinal_position = 1;
-                    }),
-                    column_fixture(|c| {
-                        c.name = "email".into();
-                        c.data_type = "text".into();
-                        c.ordinal_position = 2;
-                    }),
+                    test_nullable_column("name", "text", 1),
+                    test_nullable_column("email", "text", 2),
                 ],
                 ..crate::test_support::table::minimal("", "")
             };
@@ -2139,11 +2082,7 @@ mod tests {
                         c.ordinal_position = 1;
                         c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
                     }),
-                    column_fixture(|c| {
-                        c.name = "name".into();
-                        c.data_type = "text".into();
-                        c.ordinal_position = 2;
-                    }),
+                    test_nullable_column("name", "text", 2),
                     column_fixture(|c| {
                         c.name = "email".into();
                         c.data_type = "text".into();
@@ -2347,11 +2286,7 @@ mod tests {
             let table = Table {
                 schema: "public".to_string(),
                 name: "test".to_string(),
-                columns: vec![column_fixture(|c| {
-                    c.name = "and".into();
-                    c.data_type = "text".into();
-                    c.ordinal_position = 1;
-                })],
+                columns: vec![test_nullable_column("and", "text", 1)],
                 ..crate::test_support::table::minimal("", "")
             };
 

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -927,32 +927,37 @@ mod tests {
     use super::*;
     pub use crate::domain::Column;
     use crate::domain::Table;
-    use crate::test_support::column::test_nullable_column;
+    use crate::test_support::column::column_fixture;
+    use crate::test_support::table::table_fixture;
 
     fn engine() -> CompletionEngine {
         CompletionEngine::new()
     }
 
     fn create_table(schema: &str, name: &str, columns: &[&str]) -> Table {
-        Table {
-            schema: schema.to_string(),
-            name: name.to_string(),
-            columns: columns
+        table_fixture(|t| {
+            t.schema = schema.to_string();
+            t.name = name.to_string();
+            t.columns = columns
                 .iter()
                 .enumerate()
-                .map(|(i, col)| test_nullable_column(*col, "text", (i + 1) as i32))
-                .collect(),
-            ..crate::test_support::table::minimal("", "")
-        }
+                .map(|(i, col)| {
+                    column_fixture(|c| {
+                        c.name = (*col).into();
+                        c.data_type = "text".into();
+                        c.ordinal_position = (i + 1) as i32;
+                    })
+                })
+                .collect();
+        })
     }
 
     fn table_with_two_columns(col1: Column, col2: Column) -> Table {
-        Table {
-            schema: "public".to_string(),
-            name: "test".to_string(),
-            columns: vec![col1, col2],
-            ..crate::test_support::table::minimal("", "")
-        }
+        table_fixture(|t| {
+            t.schema = "public".to_string();
+            t.name = "test".to_string();
+            t.columns = vec![col1, col2];
+        })
     }
 
     mod context_detection {
@@ -1213,11 +1218,17 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    test_nullable_column("user_name", "text", 1),
-                    Column {
-                        attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("user_id", "int", 2)
-                    },
+                    column_fixture(|c| {
+                        c.name = "user_name".into();
+                        c.data_type = "text".into();
+                        c.ordinal_position = 1;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "user_id".into();
+                        c.data_type = "int".into();
+                        c.ordinal_position = 2;
+                        c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                    }),
                 ],
                 primary_key: Some(vec!["user_id".to_string()]),
                 ..crate::test_support::table::minimal("", "")
@@ -1340,11 +1351,17 @@ mod tests {
         fn pk_column_returns_higher_score() {
             let e = engine();
             let table = table_with_two_columns(
-                test_nullable_column("name", "text", 1),
-                Column {
-                    attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "int", 2)
-                },
+                column_fixture(|c| {
+                    c.name = "name".into();
+                    c.data_type = "text".into();
+                    c.ordinal_position = 1;
+                }),
+                column_fixture(|c| {
+                    c.name = "id".into();
+                    c.data_type = "int".into();
+                    c.ordinal_position = 2;
+                    c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                }),
             );
 
             let candidates = e.column_candidates(Some(&table), "");
@@ -1357,11 +1374,17 @@ mod tests {
         fn not_null_column_returns_higher_score() {
             let e = engine();
             let table = table_with_two_columns(
-                test_nullable_column("optional_field", "text", 1),
-                Column {
-                    attributes: ColumnAttributes::empty(),
-                    ..test_nullable_column("required_field", "text", 2)
-                },
+                column_fixture(|c| {
+                    c.name = "optional_field".into();
+                    c.data_type = "text".into();
+                    c.ordinal_position = 1;
+                }),
+                column_fixture(|c| {
+                    c.name = "required_field".into();
+                    c.data_type = "text".into();
+                    c.ordinal_position = 2;
+                    c.attributes = ColumnAttributes::empty();
+                }),
             );
 
             let candidates = e.column_candidates(Some(&table), "");
@@ -1559,11 +1582,17 @@ mod tests {
                 schema: "public".to_string(),
                 name: "users".to_string(),
                 columns: vec![
-                    Column {
-                        attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("id", "int", 1)
-                    },
-                    test_nullable_column("name", "text", 2),
+                    column_fixture(|c| {
+                        c.name = "id".into();
+                        c.data_type = "int".into();
+                        c.ordinal_position = 1;
+                        c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "name".into();
+                        c.data_type = "text".into();
+                        c.ordinal_position = 2;
+                    }),
                 ],
                 primary_key: Some(vec!["id".to_string()]),
                 ..crate::test_support::table::minimal("", "")
@@ -1625,12 +1654,22 @@ mod tests {
                 schema: "public".to_string(),
                 name: "users".to_string(),
                 columns: vec![
-                    Column {
-                        attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("user_id", "int", 1)
-                    },
-                    test_nullable_column("username", "text", 2),
-                    test_nullable_column("email", "text", 3),
+                    column_fixture(|c| {
+                        c.name = "user_id".into();
+                        c.data_type = "int".into();
+                        c.ordinal_position = 1;
+                        c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "username".into();
+                        c.data_type = "text".into();
+                        c.ordinal_position = 2;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "email".into();
+                        c.data_type = "text".into();
+                        c.ordinal_position = 3;
+                    }),
                 ],
                 primary_key: Some(vec!["user_id".to_string()]),
                 ..crate::test_support::table::minimal("", "")
@@ -1674,15 +1713,23 @@ mod tests {
                 schema: "public".to_string(),
                 name: "orders".to_string(),
                 columns: vec![
-                    Column {
-                        attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("id", "int", 1)
-                    },
-                    Column {
-                        attributes: ColumnAttributes::empty(),
-                        ..test_nullable_column("user_id", "int", 2)
-                    },
-                    test_nullable_column("status", "text", 3),
+                    column_fixture(|c| {
+                        c.name = "id".into();
+                        c.data_type = "int".into();
+                        c.ordinal_position = 1;
+                        c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "user_id".into();
+                        c.data_type = "int".into();
+                        c.ordinal_position = 2;
+                        c.attributes = ColumnAttributes::empty();
+                    }),
+                    column_fixture(|c| {
+                        c.name = "status".into();
+                        c.data_type = "text".into();
+                        c.ordinal_position = 3;
+                    }),
                 ],
                 primary_key: Some(vec!["id".to_string()]),
                 foreign_keys: vec![ForeignKey {
@@ -1752,8 +1799,16 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    test_nullable_column("user_id", "int", 1),
-                    test_nullable_column("created_at", "timestamp", 2),
+                    column_fixture(|c| {
+                        c.name = "user_id".into();
+                        c.data_type = "int".into();
+                        c.ordinal_position = 1;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "created_at".into();
+                        c.data_type = "timestamp".into();
+                        c.ordinal_position = 2;
+                    }),
                 ],
                 ..crate::test_support::table::minimal("", "")
             };
@@ -1772,8 +1827,16 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    test_nullable_column("id", "int", 1),
-                    test_nullable_column("user_id", "int", 2),
+                    column_fixture(|c| {
+                        c.name = "id".into();
+                        c.data_type = "int".into();
+                        c.ordinal_position = 1;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "user_id".into();
+                        c.data_type = "int".into();
+                        c.ordinal_position = 2;
+                    }),
                 ],
                 ..crate::test_support::table::minimal("", "")
             };
@@ -1799,8 +1862,16 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test".to_string(),
                 columns: vec![
-                    test_nullable_column("name", "text", 1),
-                    test_nullable_column("email", "text", 2),
+                    column_fixture(|c| {
+                        c.name = "name".into();
+                        c.data_type = "text".into();
+                        c.ordinal_position = 1;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "email".into();
+                        c.data_type = "text".into();
+                        c.ordinal_position = 2;
+                    }),
                 ],
                 ..crate::test_support::table::minimal("", "")
             };
@@ -1921,10 +1992,12 @@ mod tests {
             let table = Table {
                 schema: "public".to_string(),
                 name: "users".to_string(),
-                columns: vec![Column {
-                    attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "int", 1)
-                }],
+                columns: vec![column_fixture(|c| {
+                    c.name = "id".into();
+                    c.data_type = "int".into();
+                    c.ordinal_position = 1;
+                    c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                })],
                 ..crate::test_support::table::minimal("", "")
             };
             e.cache_table_detail("public.users".to_string(), table);
@@ -2060,15 +2133,23 @@ mod tests {
                 schema: "public".to_string(),
                 name: "users".to_string(),
                 columns: vec![
-                    Column {
-                        attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("id", "int", 1)
-                    },
-                    test_nullable_column("name", "text", 2),
-                    Column {
-                        attributes: ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("email", "text", 3)
-                    },
+                    column_fixture(|c| {
+                        c.name = "id".into();
+                        c.data_type = "int".into();
+                        c.ordinal_position = 1;
+                        c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "name".into();
+                        c.data_type = "text".into();
+                        c.ordinal_position = 2;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "email".into();
+                        c.data_type = "text".into();
+                        c.ordinal_position = 3;
+                        c.attributes = ColumnAttributes::UNIQUE;
+                    }),
                 ],
                 primary_key: Some(vec!["id".to_string()]),
                 ..crate::test_support::table::minimal("", "")
@@ -2266,7 +2347,11 @@ mod tests {
             let table = Table {
                 schema: "public".to_string(),
                 name: "test".to_string(),
-                columns: vec![test_nullable_column("and", "text", 1)],
+                columns: vec![column_fixture(|c| {
+                    c.name = "and".into();
+                    c.data_type = "text".into();
+                    c.ordinal_position = 1;
+                })],
                 ..crate::test_support::table::minimal("", "")
             };
 

--- a/src/app/test_support/column.rs
+++ b/src/app/test_support/column.rs
@@ -1,17 +1,19 @@
 use crate::domain::{Column, ColumnAttributes};
 
-#[must_use]
-pub fn test_nullable_column(
-    name: impl Into<String>,
-    data_type: impl Into<String>,
-    ordinal_position: i32,
-) -> Column {
+fn default_column() -> Column {
     Column {
-        name: name.into(),
-        data_type: data_type.into(),
+        name: String::new(),
+        data_type: String::new(),
         attributes: ColumnAttributes::NULLABLE,
-        ordinal_position,
+        ordinal_position: 0,
         default: None,
         comment: None,
     }
+}
+
+#[must_use]
+pub fn column_fixture(configure: impl FnOnce(&mut Column)) -> Column {
+    let mut column = default_column();
+    configure(&mut column);
+    column
 }

--- a/src/app/test_support/column.rs
+++ b/src/app/test_support/column.rs
@@ -12,6 +12,22 @@ fn default_column() -> Column {
 }
 
 #[must_use]
+pub fn test_nullable_column(
+    name: impl Into<String>,
+    data_type: impl Into<String>,
+    ordinal_position: i32,
+) -> Column {
+    Column {
+        name: name.into(),
+        data_type: data_type.into(),
+        attributes: ColumnAttributes::NULLABLE,
+        ordinal_position,
+        default: None,
+        comment: None,
+    }
+}
+
+#[must_use]
 pub fn column_fixture(configure: impl FnOnce(&mut Column)) -> Column {
     let mut column = default_column();
     configure(&mut column);

--- a/src/app/test_support/column.rs
+++ b/src/app/test_support/column.rs
@@ -17,14 +17,11 @@ pub fn test_nullable_column(
     data_type: impl Into<String>,
     ordinal_position: i32,
 ) -> Column {
-    Column {
-        name: name.into(),
-        data_type: data_type.into(),
-        attributes: ColumnAttributes::NULLABLE,
-        ordinal_position,
-        default: None,
-        comment: None,
-    }
+    let mut column = default_column();
+    column.name = name.into();
+    column.data_type = data_type.into();
+    column.ordinal_position = ordinal_position;
+    column
 }
 
 #[must_use]

--- a/src/app/test_support/mod.rs
+++ b/src/app/test_support/mod.rs
@@ -1,10 +1,10 @@
-//! Test-only fixture builders for app unit tests.
+//! Test-only fixture helpers for app unit tests.
 //!
 //! # Closure fixture builders
 //!
-//! Prefer [`column::column_fixture`] and [`table::table_fixture`] when a fixture is
-//! complex, reused across tests, or has many field override patterns. The closure
-//! makes the overridden fields visible at the call site:
+//! Prefer [`column::column_fixture`] when a column fixture is complex, reused across
+//! tests, or has field override patterns. The closure makes the overridden fields
+//! visible at the call site:
 //!
 //! ```ignore
 //! column_fixture(|c| {
@@ -15,9 +15,10 @@
 //! });
 //! ```
 //!
-//! Keep small one-off literals or struct updates when every field is part of the
-//! test subject. Avoid positional helpers such as `helper(name, type, ordinal)` —
-//! test defaults belong here, not on production types.
+//! For tables, use a struct literal with [`table::minimal`] for unrelated fields.
+//! For small one-off columns where every field is part of the test subject, keep a
+//! struct literal or a small helper such as [`column::test_nullable_column`]. Test
+//! defaults belong here, not on production types.
 
 pub mod column;
 pub mod table;

--- a/src/app/test_support/mod.rs
+++ b/src/app/test_support/mod.rs
@@ -1,2 +1,23 @@
+//! Test-only fixture builders for app unit tests.
+//!
+//! # Closure fixture builders
+//!
+//! Prefer [`column::column_fixture`] and [`table::table_fixture`] when a fixture is
+//! complex, reused across tests, or has many field override patterns. The closure
+//! makes the overridden fields visible at the call site:
+//!
+//! ```ignore
+//! column_fixture(|c| {
+//!     c.name = "id".into();
+//!     c.data_type = "integer".into();
+//!     c.ordinal_position = 1;
+//!     c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+//! });
+//! ```
+//!
+//! Keep small one-off literals or struct updates when every field is part of the
+//! test subject. Avoid positional helpers such as `helper(name, type, ordinal)` —
+//! test defaults belong here, not on production types.
+
 pub mod column;
 pub mod table;

--- a/src/app/test_support/table.rs
+++ b/src/app/test_support/table.rs
@@ -17,3 +17,10 @@ pub fn minimal(schema: impl Into<String>, name: impl Into<String>) -> Table {
         kind_info: TableKindInfo::default(),
     }
 }
+
+#[must_use]
+pub fn table_fixture(configure: impl FnOnce(&mut Table)) -> Table {
+    let mut table = minimal("", "");
+    configure(&mut table);
+    table
+}

--- a/src/app/test_support/table.rs
+++ b/src/app/test_support/table.rs
@@ -17,10 +17,3 @@ pub fn minimal(schema: impl Into<String>, name: impl Into<String>) -> Table {
         kind_info: TableKindInfo::default(),
     }
 }
-
-#[must_use]
-pub fn table_fixture(configure: impl FnOnce(&mut Table)) -> Table {
-    let mut table = minimal("", "");
-    configure(&mut table);
-    table
-}

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -109,9 +109,10 @@ pub fn reduce_inspector(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{Column, ColumnAttributes, ConnectionId, DatabaseType, Table};
+    use crate::domain::{Column, ColumnAttributes, ConnectionId, DatabaseType};
     use crate::model::shared::db_capabilities::DbCapabilities;
-    use crate::test_support::column::test_nullable_column;
+    use crate::test_support::column::column_fixture;
+    use crate::test_support::table::table_fixture;
     use crate::update::browse::navigation::dispatch_navigation;
     use std::time::Instant;
 
@@ -129,18 +130,21 @@ mod tests {
                 "postgres://test",
             );
             let cols: Vec<Column> = (0..columns)
-                .map(|i| Column {
-                    attributes: ColumnAttributes::empty(),
-                    ..test_nullable_column(format!("col_{i}"), "text", i as i32)
+                .map(|i| {
+                    column_fixture(|c| {
+                        c.name = format!("col_{i}");
+                        c.data_type = "text".into();
+                        c.ordinal_position = i as i32;
+                        c.attributes = ColumnAttributes::empty();
+                    })
                 })
                 .collect();
-            state.session.set_table_detail_raw(Some(Table {
-                schema: "public".to_string(),
-                name: "test_table".to_string(),
-                columns: cols,
-                row_count_estimate: Some(0),
-                ..crate::test_support::table::minimal("", "")
-            }));
+            state.session.set_table_detail_raw(Some(table_fixture(|t| {
+                t.schema = "public".to_string();
+                t.name = "test_table".to_string();
+                t.columns = cols;
+                t.row_count_estimate = Some(0);
+            })));
             state
         }
 

--- a/src/app/update/browse/navigation/inspector.rs
+++ b/src/app/update/browse/navigation/inspector.rs
@@ -109,10 +109,9 @@ pub fn reduce_inspector(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{Column, ColumnAttributes, ConnectionId, DatabaseType};
+    use crate::domain::{Column, ColumnAttributes, ConnectionId, DatabaseType, Table};
     use crate::model::shared::db_capabilities::DbCapabilities;
     use crate::test_support::column::column_fixture;
-    use crate::test_support::table::table_fixture;
     use crate::update::browse::navigation::dispatch_navigation;
     use std::time::Instant;
 
@@ -139,12 +138,13 @@ mod tests {
                     })
                 })
                 .collect();
-            state.session.set_table_detail_raw(Some(table_fixture(|t| {
-                t.schema = "public".to_string();
-                t.name = "test_table".to_string();
-                t.columns = cols;
-                t.row_count_estimate = Some(0);
-            })));
+            state.session.set_table_detail_raw(Some(Table {
+                schema: "public".to_string(),
+                name: "test_table".to_string(),
+                columns: cols,
+                row_count_estimate: Some(0),
+                ..crate::test_support::table::minimal("", "")
+            }));
             state
         }
 

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -53,8 +53,7 @@ pub(super) fn preview_effect_for_current_table(
 
 #[cfg(test)]
 pub(super) mod tests {
-    use crate::test_support::column::column_fixture;
-    use crate::test_support::table::table_fixture;
+    use crate::test_support::column::{column_fixture, test_nullable_column};
     use std::sync::Arc;
     use std::time::Instant;
 
@@ -124,47 +123,42 @@ pub(super) mod tests {
     }
 
     pub fn users_table_detail() -> Table {
-        table_fixture(|t| {
-            t.schema = "public".to_string();
-            t.name = "users".to_string();
-            t.columns = vec![
+        Table {
+            schema: "public".to_string(),
+            name: "users".to_string(),
+            columns: vec![
                 column_fixture(|c| {
                     c.name = "id".into();
                     c.data_type = "int".into();
                     c.ordinal_position = 1;
                     c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
                 }),
-                column_fixture(|c| {
-                    c.name = "name".into();
-                    c.data_type = "text".into();
-                    c.ordinal_position = 2;
-                }),
-            ];
-            t.primary_key = Some(vec!["id".to_string()]);
-            t.indexes = vec![Index {
+                test_nullable_column("name", "text", 2),
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            indexes: vec![Index {
                 name: "users_pkey".to_string(),
                 columns: vec!["id".to_string()],
                 attributes: IndexAttributes::UNIQUE | IndexAttributes::PRIMARY,
                 index_type: IndexType::BTree,
                 definition: None,
-            }];
-            t.triggers = vec![Trigger {
+            }],
+            triggers: vec![Trigger {
                 name: "trg".to_string(),
                 timing: TriggerTiming::After,
                 events: vec![TriggerEvent::Update],
                 function_name: "f".to_string(),
                 security_definer: false,
-            }];
-        })
+            }],
+            ..crate::test_support::table::minimal("", "")
+        }
     }
 
     pub fn jsonb_table_detail() -> Table {
         let mut detail = users_table_detail();
-        detail.columns.push(column_fixture(|c| {
-            c.name = "metadata".into();
-            c.data_type = "jsonb".into();
-            c.ordinal_position = 3;
-        }));
+        detail
+            .columns
+            .push(test_nullable_column("metadata", "jsonb", 3));
         detail
     }
 

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -53,8 +53,8 @@ pub(super) fn preview_effect_for_current_table(
 
 #[cfg(test)]
 pub(super) mod tests {
-    use crate::domain::Column;
-    use crate::test_support::column::test_nullable_column;
+    use crate::test_support::column::column_fixture;
+    use crate::test_support::table::table_fixture;
     use std::sync::Arc;
     use std::time::Instant;
 
@@ -124,40 +124,47 @@ pub(super) mod tests {
     }
 
     pub fn users_table_detail() -> Table {
-        Table {
-            schema: "public".to_string(),
-            name: "users".to_string(),
-            columns: vec![
-                Column {
-                    attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "int", 1)
-                },
-                test_nullable_column("name", "text", 2),
-            ],
-            primary_key: Some(vec!["id".to_string()]),
-            indexes: vec![Index {
+        table_fixture(|t| {
+            t.schema = "public".to_string();
+            t.name = "users".to_string();
+            t.columns = vec![
+                column_fixture(|c| {
+                    c.name = "id".into();
+                    c.data_type = "int".into();
+                    c.ordinal_position = 1;
+                    c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                }),
+                column_fixture(|c| {
+                    c.name = "name".into();
+                    c.data_type = "text".into();
+                    c.ordinal_position = 2;
+                }),
+            ];
+            t.primary_key = Some(vec!["id".to_string()]);
+            t.indexes = vec![Index {
                 name: "users_pkey".to_string(),
                 columns: vec!["id".to_string()],
                 attributes: IndexAttributes::UNIQUE | IndexAttributes::PRIMARY,
                 index_type: IndexType::BTree,
                 definition: None,
-            }],
-            triggers: vec![Trigger {
+            }];
+            t.triggers = vec![Trigger {
                 name: "trg".to_string(),
                 timing: TriggerTiming::After,
                 events: vec![TriggerEvent::Update],
                 function_name: "f".to_string(),
                 security_definer: false,
-            }],
-            ..crate::test_support::table::minimal("", "")
-        }
+            }];
+        })
     }
 
     pub fn jsonb_table_detail() -> Table {
         let mut detail = users_table_detail();
-        detail
-            .columns
-            .push(test_nullable_column("metadata", "jsonb", 3));
+        detail.columns.push(column_fixture(|c| {
+            c.name = "metadata".into();
+            c.data_type = "jsonb".into();
+            c.ordinal_position = 3;
+        }));
         detail
     }
 

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -180,9 +180,8 @@ fn update_search_matches(state: &mut AppState) {
 mod tests {
     use super::*;
     use crate::domain::connection::ConnectionId;
-    use crate::domain::{ColumnAttributes, DatabaseType, QueryResult, QuerySource};
-    use crate::test_support::column::column_fixture;
-    use crate::test_support::table::table_fixture;
+    use crate::domain::{ColumnAttributes, DatabaseType, QueryResult, QuerySource, Table};
+    use crate::test_support::column::{column_fixture, test_nullable_column};
     use std::sync::Arc;
 
     fn state_with_cell(data_type: &str, cell_value: &str) -> AppState {
@@ -203,24 +202,21 @@ mod tests {
                 QuerySource::Preview,
             )));
         state.query.pagination.reset_for_table("public", "notes");
-        state.session.set_table_detail_raw(Some(table_fixture(|t| {
-            t.schema = "public".to_string();
-            t.name = "notes".to_string();
-            t.columns = vec![
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "public".to_string(),
+            name: "notes".to_string(),
+            columns: vec![
                 column_fixture(|c| {
                     c.name = "id".into();
                     c.data_type = "integer".into();
                     c.ordinal_position = 1;
                     c.attributes = ColumnAttributes::PRIMARY_KEY;
                 }),
-                column_fixture(|c| {
-                    c.name = "body".into();
-                    c.data_type = data_type.to_string();
-                    c.ordinal_position = 2;
-                }),
-            ];
-            t.primary_key = Some(vec!["id".to_string()]);
-        })));
+                test_nullable_column("body", data_type, 2),
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..crate::test_support::table::minimal("", "")
+        }));
         state.result_interaction.activate_cell(0, 1);
         state
     }

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -179,10 +179,10 @@ fn update_search_matches(state: &mut AppState) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::Column;
     use crate::domain::connection::ConnectionId;
-    use crate::domain::{ColumnAttributes, DatabaseType, QueryResult, QuerySource, Table};
-    use crate::test_support::column::test_nullable_column;
+    use crate::domain::{ColumnAttributes, DatabaseType, QueryResult, QuerySource};
+    use crate::test_support::column::column_fixture;
+    use crate::test_support::table::table_fixture;
     use std::sync::Arc;
 
     fn state_with_cell(data_type: &str, cell_value: &str) -> AppState {
@@ -203,19 +203,24 @@ mod tests {
                 QuerySource::Preview,
             )));
         state.query.pagination.reset_for_table("public", "notes");
-        state.session.set_table_detail_raw(Some(Table {
-            schema: "public".to_string(),
-            name: "notes".to_string(),
-            columns: vec![
-                Column {
-                    attributes: ColumnAttributes::PRIMARY_KEY,
-                    ..test_nullable_column("id", "integer", 1)
-                },
-                test_nullable_column("body", data_type.to_string(), 2),
-            ],
-            primary_key: Some(vec!["id".to_string()]),
-            ..crate::test_support::table::minimal("", "")
-        }));
+        state.session.set_table_detail_raw(Some(table_fixture(|t| {
+            t.schema = "public".to_string();
+            t.name = "notes".to_string();
+            t.columns = vec![
+                column_fixture(|c| {
+                    c.name = "id".into();
+                    c.data_type = "integer".into();
+                    c.ordinal_position = 1;
+                    c.attributes = ColumnAttributes::PRIMARY_KEY;
+                }),
+                column_fixture(|c| {
+                    c.name = "body".into();
+                    c.data_type = data_type.to_string();
+                    c.ordinal_position = 2;
+                }),
+            ];
+            t.primary_key = Some(vec!["id".to_string()]);
+        })));
         state.result_interaction.activate_cell(0, 1);
         state
     }

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -148,9 +148,8 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
 #[cfg(test)]
 mod tests {
     use super::*;
-    pub use crate::domain::Column;
     use crate::domain::{QueryResult, QuerySource, QueryValue, Table};
-    use crate::test_support::column::test_nullable_column;
+    use crate::test_support::column::column_fixture;
     use crate::update::action::CursorMove;
     use rstest::rstest;
     use std::sync::Arc;
@@ -290,14 +289,18 @@ mod tests {
             let mut state = preview_state_with_selection();
             let mut table = minimal_users_table();
             table.columns = vec![
-                Column {
-                    attributes: ColumnAttributes::PRIMARY_KEY,
-                    ..test_nullable_column("id", "integer", 1)
-                },
-                Column {
-                    attributes: ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED,
-                    ..test_nullable_column("name", "text", 2)
-                },
+                column_fixture(|c| {
+                    c.name = "id".into();
+                    c.data_type = "integer".into();
+                    c.ordinal_position = 1;
+                    c.attributes = ColumnAttributes::PRIMARY_KEY;
+                }),
+                column_fixture(|c| {
+                    c.name = "name".into();
+                    c.data_type = "text".into();
+                    c.ordinal_position = 2;
+                    c.attributes = ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED;
+                }),
             ];
             state.session.set_table_detail_raw(Some(table));
 
@@ -371,11 +374,17 @@ mod tests {
             );
             let mut table = cell_edit_entry_guardrails::minimal_users_table();
             table.columns = vec![
-                Column {
-                    attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "integer", 1)
-                },
-                test_nullable_column("name", "jsonb", 2),
+                column_fixture(|c| {
+                    c.name = "id".into();
+                    c.data_type = "integer".into();
+                    c.ordinal_position = 1;
+                    c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                }),
+                column_fixture(|c| {
+                    c.name = "name".into();
+                    c.data_type = "jsonb".into();
+                    c.ordinal_position = 2;
+                }),
             ];
             state.session.set_table_detail_raw(Some(table));
             state

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -149,7 +149,7 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
 mod tests {
     use super::*;
     use crate::domain::{QueryResult, QuerySource, QueryValue, Table};
-    use crate::test_support::column::column_fixture;
+    use crate::test_support::column::{column_fixture, test_nullable_column};
     use crate::update::action::CursorMove;
     use rstest::rstest;
     use std::sync::Arc;
@@ -380,11 +380,7 @@ mod tests {
                     c.ordinal_position = 1;
                     c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
                 }),
-                column_fixture(|c| {
-                    c.name = "name".into();
-                    c.data_type = "jsonb".into();
-                    c.ordinal_position = 2;
-                }),
+                test_nullable_column("name", "jsonb", 2),
             ];
             state.session.set_table_detail_raw(Some(table));
             state

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -375,6 +375,17 @@ mod tests {
         }
     }
 
+    fn read_only_jsonb_table() -> Table {
+        let mut table = jsonb_table();
+        table.columns[1] = column_fixture(|c| {
+            c.name = "settings".into();
+            c.data_type = "jsonb".into();
+            c.ordinal_position = 2;
+            c.attributes = ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED;
+        });
+        table
+    }
+
     fn state_with_jsonb_cell() -> AppState {
         state_with_jsonb_value(r#"{"theme":"dark","count":5}"#)
     }
@@ -624,24 +635,9 @@ mod tests {
         #[test]
         fn enter_edit_blocks_read_only_column() {
             let mut state = state_with_jsonb_cell();
-            state.session.set_table_detail_raw(Some({
-                let mut table = jsonb_table();
-                table.columns = vec![
-                    column_fixture(|c| {
-                        c.name = "id".into();
-                        c.data_type = "integer".into();
-                        c.ordinal_position = 1;
-                        c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
-                    }),
-                    column_fixture(|c| {
-                        c.name = "settings".into();
-                        c.data_type = "jsonb".into();
-                        c.ordinal_position = 2;
-                        c.attributes = ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED;
-                    }),
-                ];
-                table
-            }));
+            state
+                .session
+                .set_table_detail_raw(Some(read_only_jsonb_table()));
             open_detail(&mut state);
 
             reduce_jsonb(&mut state, &Action::JsonbEnterEdit, Instant::now());
@@ -657,24 +653,9 @@ mod tests {
         #[test]
         fn append_insert_blocks_read_only_column() {
             let mut state = state_with_jsonb_cell();
-            state.session.set_table_detail_raw(Some({
-                let mut table = jsonb_table();
-                table.columns = vec![
-                    column_fixture(|c| {
-                        c.name = "id".into();
-                        c.data_type = "integer".into();
-                        c.ordinal_position = 1;
-                        c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
-                    }),
-                    column_fixture(|c| {
-                        c.name = "settings".into();
-                        c.data_type = "jsonb".into();
-                        c.ordinal_position = 2;
-                        c.attributes = ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED;
-                    }),
-                ];
-                table
-            }));
+            state
+                .session
+                .set_table_detail_raw(Some(read_only_jsonb_table()));
             open_detail(&mut state);
 
             reduce_jsonb(&mut state, &Action::JsonbAppendInsert, Instant::now());

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -352,38 +352,48 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{QueryResult, QuerySource, Table};
+    use crate::domain::{Column, QueryResult, QuerySource, Table};
     use crate::services::AppServices;
     use crate::test_support::column::{column_fixture, test_nullable_column};
     use std::sync::Arc;
 
-    fn jsonb_table() -> Table {
+    fn jsonb_id_column() -> Column {
+        column_fixture(|c| {
+            c.name = "id".into();
+            c.data_type = "integer".into();
+            c.ordinal_position = 1;
+            c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+        })
+    }
+
+    fn read_only_jsonb_settings_column() -> Column {
+        column_fixture(|c| {
+            c.name = "settings".into();
+            c.data_type = "jsonb".into();
+            c.ordinal_position = 2;
+            c.attributes = ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED;
+        })
+    }
+
+    fn users_jsonb_table(columns: Vec<Column>) -> Table {
         Table {
             schema: "public".to_string(),
             name: "users".to_string(),
-            columns: vec![
-                column_fixture(|c| {
-                    c.name = "id".into();
-                    c.data_type = "integer".into();
-                    c.ordinal_position = 1;
-                    c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
-                }),
-                test_nullable_column("settings", "jsonb", 2),
-            ],
+            columns,
             primary_key: Some(vec!["id".to_string()]),
             ..crate::test_support::table::minimal("", "")
         }
     }
 
+    fn jsonb_table() -> Table {
+        users_jsonb_table(vec![
+            jsonb_id_column(),
+            test_nullable_column("settings", "jsonb", 2),
+        ])
+    }
+
     fn read_only_jsonb_table() -> Table {
-        let mut table = jsonb_table();
-        table.columns[1] = column_fixture(|c| {
-            c.name = "settings".into();
-            c.data_type = "jsonb".into();
-            c.ordinal_position = 2;
-            c.attributes = ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED;
-        });
-        table
+        users_jsonb_table(vec![jsonb_id_column(), read_only_jsonb_settings_column()])
     }
 
     fn state_with_jsonb_cell() -> AppState {

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -352,26 +352,31 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    pub use crate::domain::Column;
     use crate::domain::{QueryResult, QuerySource, Table};
     use crate::services::AppServices;
-    use crate::test_support::column::test_nullable_column;
+    use crate::test_support::column::column_fixture;
+    use crate::test_support::table::table_fixture;
     use std::sync::Arc;
 
     fn jsonb_table() -> Table {
-        Table {
-            schema: "public".to_string(),
-            name: "users".to_string(),
-            columns: vec![
-                Column {
-                    attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "integer", 1)
-                },
-                test_nullable_column("settings", "jsonb", 2),
-            ],
-            primary_key: Some(vec!["id".to_string()]),
-            ..crate::test_support::table::minimal("", "")
-        }
+        table_fixture(|t| {
+            t.schema = "public".to_string();
+            t.name = "users".to_string();
+            t.columns = vec![
+                column_fixture(|c| {
+                    c.name = "id".into();
+                    c.data_type = "integer".into();
+                    c.ordinal_position = 1;
+                    c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                }),
+                column_fixture(|c| {
+                    c.name = "settings".into();
+                    c.data_type = "jsonb".into();
+                    c.ordinal_position = 2;
+                }),
+            ];
+            t.primary_key = Some(vec!["id".to_string()]);
+        })
     }
 
     fn state_with_jsonb_cell() -> AppState {
@@ -623,18 +628,23 @@ mod tests {
         #[test]
         fn enter_edit_blocks_read_only_column() {
             let mut state = state_with_jsonb_cell();
-            state.session.set_table_detail_raw(Some(Table {
-                columns: vec![
-                    Column {
-                        attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("id", "integer", 1)
-                    },
-                    Column {
-                        attributes: ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED,
-                        ..test_nullable_column("settings", "jsonb", 2)
-                    },
-                ],
-                ..jsonb_table()
+            state.session.set_table_detail_raw(Some({
+                let mut table = jsonb_table();
+                table.columns = vec![
+                    column_fixture(|c| {
+                        c.name = "id".into();
+                        c.data_type = "integer".into();
+                        c.ordinal_position = 1;
+                        c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "settings".into();
+                        c.data_type = "jsonb".into();
+                        c.ordinal_position = 2;
+                        c.attributes = ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED;
+                    }),
+                ];
+                table
             }));
             open_detail(&mut state);
 
@@ -651,18 +661,23 @@ mod tests {
         #[test]
         fn append_insert_blocks_read_only_column() {
             let mut state = state_with_jsonb_cell();
-            state.session.set_table_detail_raw(Some(Table {
-                columns: vec![
-                    Column {
-                        attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                        ..test_nullable_column("id", "integer", 1)
-                    },
-                    Column {
-                        attributes: ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED,
-                        ..test_nullable_column("settings", "jsonb", 2)
-                    },
-                ],
-                ..jsonb_table()
+            state.session.set_table_detail_raw(Some({
+                let mut table = jsonb_table();
+                table.columns = vec![
+                    column_fixture(|c| {
+                        c.name = "id".into();
+                        c.data_type = "integer".into();
+                        c.ordinal_position = 1;
+                        c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "settings".into();
+                        c.data_type = "jsonb".into();
+                        c.ordinal_position = 2;
+                        c.attributes = ColumnAttributes::READ_ONLY | ColumnAttributes::GENERATED;
+                    }),
+                ];
+                table
             }));
             open_detail(&mut state);
 

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -354,29 +354,25 @@ mod tests {
     use super::*;
     use crate::domain::{QueryResult, QuerySource, Table};
     use crate::services::AppServices;
-    use crate::test_support::column::column_fixture;
-    use crate::test_support::table::table_fixture;
+    use crate::test_support::column::{column_fixture, test_nullable_column};
     use std::sync::Arc;
 
     fn jsonb_table() -> Table {
-        table_fixture(|t| {
-            t.schema = "public".to_string();
-            t.name = "users".to_string();
-            t.columns = vec![
+        Table {
+            schema: "public".to_string(),
+            name: "users".to_string(),
+            columns: vec![
                 column_fixture(|c| {
                     c.name = "id".into();
                     c.data_type = "integer".into();
                     c.ordinal_position = 1;
                     c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
                 }),
-                column_fixture(|c| {
-                    c.name = "settings".into();
-                    c.data_type = "jsonb".into();
-                    c.ordinal_position = 2;
-                }),
-            ];
-            t.primary_key = Some(vec!["id".to_string()]);
-        })
+                test_nullable_column("settings", "jsonb", 2),
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..crate::test_support::table::minimal("", "")
+        }
     }
 
     fn state_with_jsonb_cell() -> AppState {

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -95,9 +95,9 @@ pub fn reduce_selection(state: &mut AppState, action: &Action, now: Instant) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::Column;
-    use crate::domain::{QueryResult, QuerySource, Table};
-    use crate::test_support::column::test_nullable_column;
+    use crate::domain::{QueryResult, QuerySource};
+    use crate::test_support::column::column_fixture;
+    use crate::test_support::table::table_fixture;
     use std::sync::Arc;
     use std::time::Instant;
 
@@ -128,16 +128,17 @@ mod tests {
                     1,
                     QuerySource::Preview,
                 )));
-            state.session.set_table_detail_raw(Some(Table {
-                schema: "public".to_string(),
-                name: "users".to_string(),
-                columns: vec![Column {
-                    attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "integer", 1)
-                }],
-                primary_key: pk.map(|cols| cols.into_iter().map(ToString::to_string).collect()),
-                ..crate::test_support::table::minimal("", "")
-            }));
+            state.session.set_table_detail_raw(Some(table_fixture(|t| {
+                t.schema = "public".to_string();
+                t.name = "users".to_string();
+                t.columns = vec![column_fixture(|c| {
+                    c.name = "id".into();
+                    c.data_type = "integer".into();
+                    c.ordinal_position = 1;
+                    c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                })];
+                t.primary_key = pk.map(|cols| cols.into_iter().map(ToString::to_string).collect());
+            })));
             state
         }
 

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -95,9 +95,9 @@ pub fn reduce_selection(state: &mut AppState, action: &Action, now: Instant) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::Table;
     use crate::domain::{QueryResult, QuerySource};
     use crate::test_support::column::column_fixture;
-    use crate::test_support::table::table_fixture;
     use std::sync::Arc;
     use std::time::Instant;
 
@@ -128,17 +128,18 @@ mod tests {
                     1,
                     QuerySource::Preview,
                 )));
-            state.session.set_table_detail_raw(Some(table_fixture(|t| {
-                t.schema = "public".to_string();
-                t.name = "users".to_string();
-                t.columns = vec![column_fixture(|c| {
+            state.session.set_table_detail_raw(Some(Table {
+                schema: "public".to_string(),
+                name: "users".to_string(),
+                columns: vec![column_fixture(|c| {
                     c.name = "id".into();
                     c.data_type = "integer".into();
                     c.ordinal_position = 1;
                     c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
-                })];
-                t.primary_key = pk.map(|cols| cols.into_iter().map(ToString::to_string).collect());
-            })));
+                })],
+                primary_key: pk.map(|cols| cols.into_iter().map(ToString::to_string).collect()),
+                ..crate::test_support::table::minimal("", "")
+            }));
             state
         }
 

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -135,10 +135,10 @@ fn clipboard_unavailable() -> Action {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::Column;
     use crate::domain::Table;
     use crate::ports::outbound::ddl_generator::DdlGenerator;
-    use crate::test_support::column::test_nullable_column;
+    use crate::test_support::column::column_fixture;
+    use crate::test_support::table::table_fixture;
     use std::sync::Arc;
 
     mod cell_yank {
@@ -448,17 +448,18 @@ mod tests {
         fn state_with_ddl_tab() -> AppState {
             let mut state = AppState::new("test".to_string());
             state.ui.set_inspector_tab(InspectorTab::Ddl);
-            state.session.set_table_detail_raw(Some(Table {
-                schema: "public".to_string(),
-                name: "users".to_string(),
-                columns: vec![Column {
-                    attributes: ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE,
-                    ..test_nullable_column("id", "integer", 1)
-                }],
-                primary_key: Some(vec!["id".to_string()]),
-                row_count_estimate: Some(0),
-                ..crate::test_support::table::minimal("", "")
-            }));
+            state.session.set_table_detail_raw(Some(table_fixture(|t| {
+                t.schema = "public".to_string();
+                t.name = "users".to_string();
+                t.columns = vec![column_fixture(|c| {
+                    c.name = "id".into();
+                    c.data_type = "integer".into();
+                    c.ordinal_position = 1;
+                    c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
+                })];
+                t.primary_key = Some(vec!["id".to_string()]);
+                t.row_count_estimate = Some(0);
+            })));
             state
         }
 

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -138,7 +138,6 @@ mod tests {
     use crate::domain::Table;
     use crate::ports::outbound::ddl_generator::DdlGenerator;
     use crate::test_support::column::column_fixture;
-    use crate::test_support::table::table_fixture;
     use std::sync::Arc;
 
     mod cell_yank {
@@ -448,18 +447,19 @@ mod tests {
         fn state_with_ddl_tab() -> AppState {
             let mut state = AppState::new("test".to_string());
             state.ui.set_inspector_tab(InspectorTab::Ddl);
-            state.session.set_table_detail_raw(Some(table_fixture(|t| {
-                t.schema = "public".to_string();
-                t.name = "users".to_string();
-                t.columns = vec![column_fixture(|c| {
+            state.session.set_table_detail_raw(Some(Table {
+                schema: "public".to_string(),
+                name: "users".to_string(),
+                columns: vec![column_fixture(|c| {
                     c.name = "id".into();
                     c.data_type = "integer".into();
                     c.ordinal_position = 1;
                     c.attributes = ColumnAttributes::PRIMARY_KEY | ColumnAttributes::UNIQUE;
-                })];
-                t.primary_key = Some(vec!["id".to_string()]);
-                t.row_count_estimate = Some(0);
-            })));
+                })],
+                primary_key: Some(vec!["id".to_string()]),
+                row_count_estimate: Some(0),
+                ..crate::test_support::table::minimal("", "")
+            }));
             state
         }
 

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -436,12 +436,11 @@ pub fn validate_all(state: &mut ConnectionSetupState) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::column::column_fixture;
-    use crate::test_support::table::table_fixture;
+    use crate::test_support::column::{column_fixture, test_nullable_column};
     use std::sync::Arc;
 
     use crate::domain::connection::ConnectionId;
-    use crate::domain::{ColumnAttributes, DatabaseType, QuerySource};
+    use crate::domain::{ColumnAttributes, DatabaseType, QuerySource, Table};
     use rstest::rstest;
 
     mod validate_field_name {
@@ -664,24 +663,21 @@ mod tests {
                     10,
                     QuerySource::Preview,
                 )));
-            state.session.set_table_detail_raw(Some(table_fixture(|t| {
-                t.schema = "main".to_string();
-                t.name = "users".to_string();
-                t.columns = vec![
+            state.session.set_table_detail_raw(Some(Table {
+                schema: "main".to_string(),
+                name: "users".to_string(),
+                columns: vec![
                     column_fixture(|c| {
                         c.name = "id".into();
                         c.data_type = "INTEGER".into();
                         c.ordinal_position = 1;
                         c.attributes = ColumnAttributes::PRIMARY_KEY;
                     }),
-                    column_fixture(|c| {
-                        c.name = "name".into();
-                        c.data_type = "TEXT".into();
-                        c.ordinal_position = 2;
-                    }),
-                ];
-                t.primary_key = Some(vec!["id".to_string()]);
-            })));
+                    test_nullable_column("name", "TEXT", 2),
+                ],
+                primary_key: Some(vec!["id".to_string()]),
+                ..crate::test_support::table::minimal("", "")
+            }));
             state.query.pagination.reset_for_table("main", "users");
             state.result_interaction.stage_row(0);
             state

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -436,12 +436,12 @@ pub fn validate_all(state: &mut ConnectionSetupState) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::Column;
-    use crate::test_support::column::test_nullable_column;
+    use crate::test_support::column::column_fixture;
+    use crate::test_support::table::table_fixture;
     use std::sync::Arc;
 
     use crate::domain::connection::ConnectionId;
-    use crate::domain::{ColumnAttributes, DatabaseType, QuerySource, Table};
+    use crate::domain::{ColumnAttributes, DatabaseType, QuerySource};
     use rstest::rstest;
 
     mod validate_field_name {
@@ -664,19 +664,24 @@ mod tests {
                     10,
                     QuerySource::Preview,
                 )));
-            state.session.set_table_detail_raw(Some(Table {
-                schema: "main".to_string(),
-                name: "users".to_string(),
-                columns: vec![
-                    Column {
-                        attributes: ColumnAttributes::PRIMARY_KEY,
-                        ..test_nullable_column("id", "INTEGER", 1)
-                    },
-                    test_nullable_column("name", "TEXT", 2),
-                ],
-                primary_key: Some(vec!["id".to_string()]),
-                ..crate::test_support::table::minimal("", "")
-            }));
+            state.session.set_table_detail_raw(Some(table_fixture(|t| {
+                t.schema = "main".to_string();
+                t.name = "users".to_string();
+                t.columns = vec![
+                    column_fixture(|c| {
+                        c.name = "id".into();
+                        c.data_type = "INTEGER".into();
+                        c.ordinal_position = 1;
+                        c.attributes = ColumnAttributes::PRIMARY_KEY;
+                    }),
+                    column_fixture(|c| {
+                        c.name = "name".into();
+                        c.data_type = "TEXT".into();
+                        c.ordinal_position = 2;
+                    }),
+                ];
+                t.primary_key = Some(vec!["id".to_string()]);
+            })));
             state.query.pagination.reset_for_table("main", "users");
             state.result_interaction.stage_row(0);
             state


### PR DESCRIPTION
## Problem

Test fixtures that override only a few fields were hard to read when values were passed through positional helpers or struct updates spread from defaults.

## Background

Related to SAB-312 and the Default/struct-init conventions from SAB-310. Test-only defaults should stay in `test_support`, not on production types.

## Approach

Add `column_fixture` in app `test_support` for column fixtures with field override patterns, document when to prefer it in module docs, and migrate representative complex/reused fixtures (browse result reducers, query helpers, completion engine). Simple one-off columns keep `test_nullable_column` or struct literals; tables use struct literals with `table::minimal` for unrelated fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * カラム定義のテストデータ生成方法を整理し、関連機能の検証をより一貫した形にしました。
  * 読み取り専用カラム、JSONBカラム、主キー列などを含むケースのテスト網を更新し、編集・閲覧まわりの安定性を高めました。
  * 既存の動作や画面上の挙動は変更していません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->