### PR TITLE
feat: add PostgreSQL DSN preview to connection setup

### DIFF
--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -58,6 +58,15 @@ impl ConnectionField {
         matches!(self, Self::Name | Self::Port | Self::Database)
     }
 
+    pub fn max_chars(self) -> Option<usize> {
+        match self {
+            Self::Name => Some(50),
+            Self::Host | Self::Database | Self::User | Self::Password => Some(255),
+            Self::Port => Some(5),
+            Self::SslMode => None,
+        }
+    }
+
     pub fn placeholder(self) -> &'static str {
         match self {
             Self::Host | Self::User => "empty = psql default",
@@ -261,6 +270,17 @@ mod tests {
             assert_eq!(all.len(), 7);
             assert_eq!(all[0], ConnectionField::Name);
             assert_eq!(all[6], ConnectionField::SslMode);
+        }
+
+        #[test]
+        fn max_chars_returns_expected_limits() {
+            assert_eq!(ConnectionField::Name.max_chars(), Some(50));
+            assert_eq!(ConnectionField::Host.max_chars(), Some(255));
+            assert_eq!(ConnectionField::Port.max_chars(), Some(5));
+            assert_eq!(ConnectionField::Database.max_chars(), Some(255));
+            assert_eq!(ConnectionField::User.max_chars(), Some(255));
+            assert_eq!(ConnectionField::Password.max_chars(), Some(255));
+            assert_eq!(ConnectionField::SslMode.max_chars(), None);
         }
     }
 

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -273,7 +273,7 @@ mod tests {
         }
 
         #[test]
-        fn max_chars_returns_expected_limits() {
+        fn max_chars_limits_match_field_policy() {
             assert_eq!(ConnectionField::Name.max_chars(), Some(50));
             assert_eq!(ConnectionField::Host.max_chars(), Some(255));
             assert_eq!(ConnectionField::Port.max_chars(), Some(5));

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -123,14 +123,6 @@ impl Default for ConnectionSetupState {
 }
 
 impl ConnectionSetupState {
-    pub fn default_name(&self) -> String {
-        match (self.database.content(), self.host.content()) {
-            ("", host) => host.to_string(),
-            (database, "") => database.to_string(),
-            (database, host) => format!("{database}@{host}"),
-        }
-    }
-
     pub fn field_value(&self, field: ConnectionField) -> &str {
         match field {
             ConnectionField::Name => self.name.content(),
@@ -288,27 +280,6 @@ mod tests {
             assert_eq!(state.focused_field, ConnectionField::Name);
             assert!(state.is_first_run);
             assert!(state.editing_id.is_none());
-        }
-
-        #[test]
-        fn default_name_without_database() {
-            let state = ConnectionSetupState::default();
-            assert_eq!(state.default_name(), "localhost");
-        }
-
-        #[test]
-        fn default_name_with_database() {
-            let mut state = ConnectionSetupState::default();
-            state.database.set_content("mydb".to_string());
-            assert_eq!(state.default_name(), "mydb@localhost");
-        }
-
-        #[test]
-        fn default_name_with_database_and_empty_host() {
-            let mut state = ConnectionSetupState::default();
-            state.host.clear();
-            state.database.set_content("mydb".to_string());
-            assert_eq!(state.default_name(), "mydb");
         }
 
         #[test]

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -60,8 +60,7 @@ impl ConnectionField {
 
     pub fn placeholder(self) -> &'static str {
         match self {
-            Self::Host => "default host/socket",
-            Self::User => "psql default user",
+            Self::Host | Self::User => "empty = psql default",
             _ => "",
         }
     }
@@ -125,10 +124,10 @@ impl Default for ConnectionSetupState {
 
 impl ConnectionSetupState {
     pub fn default_name(&self) -> String {
-        if self.database.content().is_empty() {
-            self.host.content().to_string()
-        } else {
-            format!("{}@{}", self.database.content(), self.host.content())
+        match (self.database.content(), self.host.content()) {
+            ("", host) => host.to_string(),
+            (database, "") => database.to_string(),
+            (database, host) => format!("{database}@{host}"),
         }
     }
 
@@ -302,6 +301,14 @@ mod tests {
             let mut state = ConnectionSetupState::default();
             state.database.set_content("mydb".to_string());
             assert_eq!(state.default_name(), "mydb@localhost");
+        }
+
+        #[test]
+        fn default_name_with_database_and_empty_host() {
+            let mut state = ConnectionSetupState::default();
+            state.host.clear();
+            state.database.set_content("mydb".to_string());
+            assert_eq!(state.default_name(), "mydb");
         }
 
         #[test]

--- a/src/app/policy/mod.rs
+++ b/src/app/policy/mod.rs
@@ -2,3 +2,5 @@ pub mod json;
 pub(crate) mod password_masking;
 pub mod sql;
 pub mod write;
+
+pub use password_masking::mask_password;

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -74,21 +74,8 @@ impl AppServices {
 
         struct StubDsnBuilder;
         impl DsnBuilder for StubDsnBuilder {
-            fn build_dsn(&self, profile: &ConnectionProfile) -> String {
-                fn push_part(parts: &mut Vec<String>, key: &str, value: &str) {
-                    if !value.is_empty() {
-                        parts.push(format!("{key}='{value}'"));
-                    }
-                }
-
-                let mut parts = Vec::new();
-                push_part(&mut parts, "host", profile.host.trim());
-                push_part(&mut parts, "port", &profile.port.to_string());
-                push_part(&mut parts, "dbname", profile.database.trim());
-                push_part(&mut parts, "user", profile.username.trim());
-                push_part(&mut parts, "password", profile.password.as_str());
-                push_part(&mut parts, "sslmode", &profile.ssl_mode.to_string());
-                parts.join(" ")
+            fn build_dsn(&self, _profile: &ConnectionProfile) -> String {
+                "stub-dsn".to_string()
             }
         }
 

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -1,11 +1,13 @@
 use std::sync::Arc;
 
-use super::ports::outbound::{DdlGenerator, SqlDialect};
+use super::ports::outbound::{DdlGenerator, DsnBuilder, SqlDialect};
+use crate::domain::connection::ConnectionProfile;
 use crate::model::shared::db_capabilities::DbCapabilities;
 
 pub struct AppServices {
     pub ddl_generator: Arc<dyn DdlGenerator>,
     pub sql_dialect: Arc<dyn SqlDialect>,
+    pub dsn_builder: Arc<dyn DsnBuilder>,
     pub db_capabilities: DbCapabilities,
 }
 
@@ -70,9 +72,30 @@ impl AppServices {
             }
         }
 
+        struct StubDsnBuilder;
+        impl DsnBuilder for StubDsnBuilder {
+            fn build_dsn(&self, profile: &ConnectionProfile) -> String {
+                fn push_part(parts: &mut Vec<String>, key: &str, value: &str) {
+                    if !value.is_empty() {
+                        parts.push(format!("{key}='{value}'"));
+                    }
+                }
+
+                let mut parts = Vec::new();
+                push_part(&mut parts, "host", profile.host.trim());
+                push_part(&mut parts, "port", &profile.port.to_string());
+                push_part(&mut parts, "dbname", profile.database.trim());
+                push_part(&mut parts, "user", profile.username.trim());
+                push_part(&mut parts, "password", profile.password.as_str());
+                push_part(&mut parts, "sslmode", &profile.ssl_mode.to_string());
+                parts.join(" ")
+            }
+        }
+
         Self {
             ddl_generator: Arc::new(StubDdlGenerator),
             sql_dialect: Arc::new(StubSqlDialect),
+            dsn_builder: Arc::new(StubDsnBuilder),
             db_capabilities: DbCapabilities::postgres_like(),
         }
     }

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -183,7 +183,7 @@ pub(super) fn reduce_connection_setup(
                     name: setup.name.content().to_string(),
                     host: setup.host.content().trim().to_string(),
                     port,
-                    database: setup.database.content().to_string(),
+                    database: setup.database.content().trim().to_string(),
                     user: setup.user.content().trim().to_string(),
                     password: setup.password.content().to_string(),
                     ssl_mode: setup.ssl_mode,
@@ -434,13 +434,17 @@ mod tests {
         }
 
         #[test]
-        fn save_trims_host_and_user_but_preserves_password() {
+        fn save_trims_connection_identifiers_but_preserves_password() {
             let mut state = AppState::new("test".to_string());
             fill_valid_form(&mut state);
             state
                 .connection_setup
                 .host
                 .set_content("  localhost  ".to_string());
+            state
+                .connection_setup
+                .database
+                .set_content("  mydb  ".to_string());
             state
                 .connection_setup
                 .user
@@ -458,10 +462,14 @@ mod tests {
                 effects.as_slice(),
                 [Effect::SaveAndConnect {
                     host,
+                    database,
                     user,
                     password,
                     ..
-                }] if host == "localhost" && user == "postgres" && password == "  pass  "
+                }] if host == "localhost"
+                    && database == "mydb"
+                    && user == "postgres"
+                    && password == "  pass  "
             ));
         }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -49,7 +49,7 @@ pub(super) fn reduce_connection_setup(
             match setup.focused_field {
                 ConnectionField::Port => {
                     let current_len = setup.port.char_count();
-                    let remaining = 5usize.saturating_sub(current_len);
+                    let remaining = remaining_input_capacity(ConnectionField::Port, current_len);
                     let digits: String = clean
                         .chars()
                         .filter(char::is_ascii_digit)
@@ -84,7 +84,10 @@ pub(super) fn reduce_connection_setup(
             let setup = &mut state.connection_setup;
             match setup.focused_field {
                 ConnectionField::Port => {
-                    if c.is_ascii_digit() && setup.port.char_count() < 5 {
+                    if c.is_ascii_digit()
+                        && remaining_input_capacity(ConnectionField::Port, setup.port.char_count())
+                            > 0
+                    {
                         setup.port.insert_char(*c);
                         setup.port.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
                     }
@@ -188,7 +191,7 @@ pub(super) fn reduce_connection_setup(
                 state.session.mark_connecting();
                 DispatchResult::handled_with(vec![Effect::SaveAndConnect {
                     id: setup.editing_id.clone(),
-                    name: setup.name.content().to_string(),
+                    name: setup.name.content().trim().to_string(),
                     host: setup.host.content().trim().to_string(),
                     port,
                     database: setup.database.content().trim().to_string(),
@@ -461,9 +464,13 @@ mod tests {
         }
 
         #[test]
-        fn save_trims_connection_identifiers_but_preserves_password() {
+        fn save_trims_connection_identifiers_and_name_but_preserves_password() {
             let mut state = AppState::new("test".to_string());
             fill_valid_form(&mut state);
+            state
+                .connection_setup
+                .name
+                .set_content("  test-db  ".to_string());
             state
                 .connection_setup
                 .host
@@ -488,12 +495,14 @@ mod tests {
             assert!(matches!(
                 effects.as_slice(),
                 [Effect::SaveAndConnect {
+                    name,
                     host,
                     database,
                     user,
                     password,
                     ..
-                }] if host == "localhost"
+                }] if name == "test-db"
+                    && host == "localhost"
                     && database == "mydb"
                     && user == "postgres"
                     && password == "  pass  "

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -181,10 +181,10 @@ pub(super) fn reduce_connection_setup(
                 DispatchResult::handled_with(vec![Effect::SaveAndConnect {
                     id: setup.editing_id.clone(),
                     name: setup.name.content().to_string(),
-                    host: setup.host.content().to_string(),
+                    host: setup.host.content().trim().to_string(),
                     port,
                     database: setup.database.content().to_string(),
-                    user: setup.user.content().to_string(),
+                    user: setup.user.content().trim().to_string(),
                     password: setup.password.content().to_string(),
                     ssl_mode: setup.ssl_mode,
                 }])
@@ -430,6 +430,38 @@ mod tests {
                     ssl_mode: SslMode::Require,
                     ..
                 }]
+            ));
+        }
+
+        #[test]
+        fn save_trims_host_and_user_but_preserves_password() {
+            let mut state = AppState::new("test".to_string());
+            fill_valid_form(&mut state);
+            state
+                .connection_setup
+                .host
+                .set_content("  localhost  ".to_string());
+            state
+                .connection_setup
+                .user
+                .set_content("  postgres  ".to_string());
+            state
+                .connection_setup
+                .password
+                .set_content("  pass  ".to_string());
+
+            let effects =
+                reduce_connection_setup(&mut state, &Action::ConnectionSetupSave, Instant::now())
+                    .unwrap();
+
+            assert!(matches!(
+                effects.as_slice(),
+                [Effect::SaveAndConnect {
+                    host,
+                    user,
+                    password,
+                    ..
+                }] if host == "localhost" && user == "postgres" && password == "  pass  "
             ));
         }
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -62,9 +62,14 @@ pub(super) fn reduce_connection_setup(
                 }
                 ConnectionField::SslMode => {}
                 _ => {
+                    let field = setup.focused_field;
                     if let Some(input) = setup.focused_input_mut() {
-                        input.insert_str(&clean);
-                        input.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
+                        let remaining = remaining_input_capacity(field, input.char_count());
+                        let allowed = take_chars(&clean, remaining);
+                        if !allowed.is_empty() {
+                            input.insert_str(&allowed);
+                            input.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
+                        }
                     }
                 }
             }
@@ -86,7 +91,10 @@ pub(super) fn reduce_connection_setup(
                 }
                 ConnectionField::SslMode => {}
                 _ => {
-                    if let Some(input) = setup.focused_input_mut() {
+                    let field = setup.focused_field;
+                    if let Some(input) = setup.focused_input_mut()
+                        && remaining_input_capacity(field, input.char_count()) > 0
+                    {
                         input.insert_char(*c);
                         input.update_viewport(CONNECTION_INPUT_VISIBLE_WIDTH);
                     }
@@ -232,6 +240,16 @@ pub(super) fn reduce_connection_setup(
     }
 }
 
+fn remaining_input_capacity(field: ConnectionField, current_len: usize) -> usize {
+    field
+        .max_chars()
+        .map_or(usize::MAX, |max| max.saturating_sub(current_len))
+}
+
+fn take_chars(text: &str, max_chars: usize) -> String {
+    text.chars().take(max_chars).collect()
+}
+
 fn confirm_ssl_dropdown_selection(setup: &mut ConnectionSetupState) {
     if setup.ssl_dropdown.is_open {
         if let Some(mode) = SslMode::all_variants().get(setup.ssl_dropdown.selected_index) {
@@ -367,6 +385,15 @@ mod tests {
 
             assert_eq!(state.connection_setup.host.cursor(), 14);
         }
+
+        #[test]
+        fn host_paste_respects_limit() {
+            let mut state = setup_state_with_field(ConnectionField::Host);
+
+            reduce_connection_setup(&mut state, &Action::Paste("a".repeat(300)), Instant::now());
+
+            assert_eq!(state.connection_setup.host.char_count(), 255);
+        }
     }
 
     mod connection_save {
@@ -486,6 +513,25 @@ mod tests {
             reduce_connection_setup(&mut state, &action, Instant::now());
 
             assert!(!state.session.read_only);
+        }
+
+        #[test]
+        fn save_rejects_host_over_limit() {
+            let mut state = AppState::new("test".to_string());
+            fill_valid_form(&mut state);
+            state.connection_setup.host.set_content("a".repeat(256));
+
+            let result =
+                reduce_connection_setup(&mut state, &Action::ConnectionSetupSave, Instant::now());
+
+            assert!(result.is_handled());
+            assert_eq!(
+                state
+                    .connection_setup
+                    .validation_errors
+                    .get(&ConnectionField::Host),
+                Some(&"Must be 255 characters or less".to_string())
+            );
         }
     }
 

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -200,6 +200,16 @@ pub fn char_to_byte_index(s: &str, char_idx: usize) -> usize {
 pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) {
     state.validation_errors.remove(&field);
 
+    if let Some(max_chars) = field.max_chars() {
+        let length = state.field_value(field).chars().count();
+        if length > max_chars {
+            state
+                .validation_errors
+                .insert(field, format!("Must be {max_chars} characters or less"));
+            return;
+        }
+    }
+
     match field {
         ConnectionField::Port => {
             if state.port.content().trim().is_empty() {
@@ -235,10 +245,6 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
                 state
                     .validation_errors
                     .insert(field, "Name is required".to_string());
-            } else if name.chars().count() > 50 {
-                state
-                    .validation_errors
-                    .insert(field, "Name must be 50 characters or less".to_string());
             }
         }
         ConnectionField::Host
@@ -305,7 +311,7 @@ mod tests {
             if expect_error {
                 assert_eq!(
                     state.validation_errors.get(&ConnectionField::Name),
-                    Some(&"Name must be 50 characters or less".to_string())
+                    Some(&"Must be 50 characters or less".to_string())
                 );
             } else {
                 assert!(!state.validation_errors.contains_key(&ConnectionField::Name));
@@ -322,6 +328,49 @@ mod tests {
             validate_field(&mut state, ConnectionField::Name);
 
             assert!(!state.validation_errors.contains_key(&ConnectionField::Name));
+        }
+    }
+
+    mod validate_field_max_length {
+        use super::*;
+        use crate::model::shared::text_input::TextInputState;
+
+        #[rstest]
+        #[case(ConnectionField::Host, "a".repeat(255), false)]
+        #[case(ConnectionField::Host, "a".repeat(256), true)]
+        #[case(ConnectionField::Database, "a".repeat(255), false)]
+        #[case(ConnectionField::Database, "a".repeat(256), true)]
+        #[case(ConnectionField::User, "a".repeat(255), false)]
+        #[case(ConnectionField::User, "a".repeat(256), true)]
+        #[case(ConnectionField::Password, "a".repeat(255), false)]
+        #[case(ConnectionField::Password, "a".repeat(256), true)]
+        fn max_length_validation(
+            #[case] field: ConnectionField,
+            #[case] value: String,
+            #[case] expect_error: bool,
+        ) {
+            let mut state = ConnectionSetupState::default();
+            let len = value.chars().count();
+            let input = TextInputState::new(value, len);
+
+            match field {
+                ConnectionField::Host => state.host = input,
+                ConnectionField::Database => state.database = input,
+                ConnectionField::User => state.user = input,
+                ConnectionField::Password => state.password = input,
+                _ => unreachable!(),
+            }
+
+            validate_field(&mut state, field);
+
+            if expect_error {
+                assert_eq!(
+                    state.validation_errors.get(&field),
+                    Some(&"Must be 255 characters or less".to_string())
+                );
+            } else {
+                assert!(!state.validation_errors.contains_key(&field));
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,7 @@ async fn main() -> Result<()> {
     let services = AppServices {
         ddl_generator,
         sql_dialect,
+        dsn_builder: adapter.clone(),
         db_capabilities,
     };
 

--- a/src/tests/harness/mod.rs
+++ b/src/tests/harness/mod.rs
@@ -11,6 +11,7 @@ use ratatui::layout::Position;
 
 use sabiql_app::model::app_state::AppState;
 use sabiql_app::services::AppServices;
+use sabiql_infra::adapters::PostgresAdapter;
 use sabiql_ui::shell::layout::MainLayout;
 use sabiql_ui::theme::{ThemePalette, palette_for};
 
@@ -57,13 +58,14 @@ pub fn render_and_get_buffer_at_with_theme(
     now: Instant,
     theme: &ThemePalette,
 ) -> Buffer {
+    let services = render_services();
     terminal
         .draw(|frame| {
             let output = MainLayout::render_with_theme(
                 frame,
                 state,
                 Some(FIXED_TIME_MS),
-                &AppServices::stub(),
+                &services,
                 now,
                 theme,
             );
@@ -93,6 +95,13 @@ pub fn render_and_get_buffer_at_with_theme(
         .unwrap();
 
     terminal.backend().buffer().clone()
+}
+
+fn render_services() -> AppServices {
+    AppServices {
+        dsn_builder: Arc::new(PostgresAdapter::new()),
+        ..AppServices::stub()
+    }
 }
 
 pub fn render_to_string(terminal: &mut Terminal<TestBackend>, state: &mut AppState) -> String {

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -1,6 +1,10 @@
 use super::*;
 use sabiql_app::model::shared::settings::KeymapPreset;
 
+fn repeated(ch: char, len: usize) -> String {
+    std::iter::repeat_n(ch, len).collect()
+}
+
 #[test]
 fn connection_setup_form() {
     let mut state = create_test_state();
@@ -101,6 +105,30 @@ fn connection_setup_preview_wraps_across_multiple_rows_for_long_conninfo() {
     state.connection_setup.user.set_content(
         "customer_success_preview_validation_operator_with_extended_scope".to_string(),
     );
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn connection_setup_preview_with_max_length_fields() {
+    let mut state = create_test_state();
+    let mut terminal = create_test_terminal();
+
+    state.modal.set_mode(InputMode::ConnectionSetup);
+    state.connection_setup.name.set_content(repeated('n', 50));
+    state.connection_setup.host.set_content(repeated('h', 255));
+    state.connection_setup.port.set_content("65535".to_string());
+    state
+        .connection_setup
+        .database
+        .set_content(repeated('d', 255));
+    state.connection_setup.user.set_content(repeated('u', 255));
+    state
+        .connection_setup
+        .password
+        .set_content(repeated('p', 255));
 
     let output = render_to_string(&mut terminal, &mut state);
 

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -22,6 +22,46 @@ fn connection_setup_form() {
 }
 
 #[test]
+fn connection_setup_empty_host_focused() {
+    let mut state = create_test_state();
+    let mut terminal = create_test_terminal();
+
+    state.modal.set_mode(InputMode::ConnectionSetup);
+    state.connection_setup.focused_field = ConnectionField::Host;
+    state.connection_setup.host = TextInputState::default();
+    state
+        .connection_setup
+        .database
+        .set_content("mydb".to_string());
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
+fn connection_setup_preview_omits_empty_optional_fields() {
+    let mut state = create_test_state();
+    let mut terminal = create_test_terminal();
+
+    state.modal.set_mode(InputMode::ConnectionSetup);
+    state.connection_setup.host = TextInputState::default();
+    state
+        .connection_setup
+        .database
+        .set_content("mydb".to_string());
+    state.connection_setup.user = TextInputState::default();
+    state
+        .connection_setup
+        .password
+        .set_content("secret".to_string());
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn connection_setup_cursor_at_head() {
     let mut state = create_test_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -86,6 +86,28 @@ fn connection_setup_preview_uses_postgres_conninfo_escaping() {
 }
 
 #[test]
+fn connection_setup_preview_wraps_across_multiple_rows_for_long_conninfo() {
+    let mut state = create_test_state();
+    let mut terminal = create_test_terminal();
+
+    state.modal.set_mode(InputMode::ConnectionSetup);
+    state.connection_setup.host.set_content(
+        "analytics-primary-read-replica.cluster.internal.example.company.service".to_string(),
+    );
+    state
+        .connection_setup
+        .database
+        .set_content("warehouse_reporting_environment_for_customer_success_dashboards".to_string());
+    state.connection_setup.user.set_content(
+        "customer_success_preview_validation_operator_with_extended_scope".to_string(),
+    );
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn connection_setup_cursor_at_head() {
     let mut state = create_test_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -62,6 +62,30 @@ fn connection_setup_preview_omits_empty_optional_fields() {
 }
 
 #[test]
+fn connection_setup_preview_uses_postgres_conninfo_escaping() {
+    let mut state = create_test_state();
+    let mut terminal = create_test_terminal();
+
+    state.modal.set_mode(InputMode::ConnectionSetup);
+    state
+        .connection_setup
+        .host
+        .set_content("/var/run/postgresql".to_string());
+    state
+        .connection_setup
+        .database
+        .set_content("my'db".to_string());
+    state
+        .connection_setup
+        .user
+        .set_content("user'org".to_string());
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn connection_setup_cursor_at_head() {
     let mut state = create_test_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
@@ -20,21 +20,21 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [ db.example.com             ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       │└──────────│  Database:   [                            ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  User:       [ psql default user          ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  Password:   [                            ]                │                                                  │
-│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │  Database:   [                            ]                │                                                  │
+│                                       │└──────────│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  → host='db.example.com' port='5432' sslmode='prefer'      │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
@@ -20,18 +20,18 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [ db.example.com             ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       ││          │  Database:   [                            ]                │                                                  │
-│                                       │└──────────│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       │└──────────│  Database:   [                            ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  Password:   [                            ]                │                                                  │
+│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  → host='db.example.com' port='5432' sslmode='prefer'      │                                                  │
-│                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
@@ -20,21 +20,21 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [ db.example.com             ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       │└──────────│  Database:   [                            ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  User:       [ psql default user          ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  Password:   [                            ]                │                                                  │
-│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │  Database:   [                            ]                │                                                  │
+│                                       │└──────────│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  → host='db.example.com' port='5432' sslmode='prefer'      │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
@@ -20,18 +20,18 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [ db.example.com             ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       ││          │  Database:   [                            ]                │                                                  │
-│                                       │└──────────│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       │└──────────│  Database:   [                            ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  Password:   [                            ]                │                                                  │
+│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  → host='db.example.com' port='5432' sslmode='prefer'      │                                                  │
-│                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
@@ -20,21 +20,21 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [ db.example.com             ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       │└──────────│  Database:   [                            ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  User:       [ psql default user          ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  Password:   [                            ]                │                                                  │
-│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │  Database:   [                            ]                │                                                  │
+│                                       │└──────────│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  → host='db.example.com' port='5432' sslmode='prefer'      │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
@@ -20,18 +20,18 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [ db.example.com             ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       ││          │  Database:   [                            ]                │                                                  │
-│                                       │└──────────│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       │└──────────│  Database:   [                            ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  Password:   [                            ]                │                                                  │
+│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  → host='db.example.com' port='5432' sslmode='prefer'      │                                                  │
-│                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_host_focused.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_host_focused.snap
@@ -23,14 +23,14 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
-│                                       ││          │  Host:       [ empty = psql default       ]                │                                                  │
+│                                       ││          │  Host:       [  empty = psql default      ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       ││          │  Database:   [                            ] Required       │                                                  │
+│                                       ││          │  Database:   [ mydb                       ]                │                                                  │
 │                                       │└──────────│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┘
 │                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
 │                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          │  → port='5432' sslmode='prefer'                            │                                                  │
+│                                       ││          │  → port='5432' dbname='mydb' sslmode='prefer'              │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_host_focused.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_host_focused.snap
@@ -20,18 +20,18 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [  empty = psql default      ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       ││          │  Database:   [ mydb                       ]                │                                                  │
-│                                       │└──────────│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       │└──────────│  Database:   [ mydb                       ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  Password:   [                            ]                │                                                  │
+│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  → port='5432' dbname='mydb' sslmode='prefer'              │                                                  │
-│                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
@@ -1,6 +1,5 @@
 ---
 source: src/tests/render_snapshots/connection_flow.rs
-assertion_line: 21
 expression: output
 ---
 test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
@@ -21,21 +20,21 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [ localhost                  ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       │└──────────│  Database:   [ mydb                       ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  User:       [ postgres                   ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  Password:   [                            ]                │                                                  │
-│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │  Database:   [ mydb                       ]                │                                                  │
+│                                       │└──────────│  User:       [ postgres                   ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
+│                                       ││          │  → host='localhost' port='5432' dbname='mydb' user='postg  │                                                  │
+│                                       ││          │    res' sslmode='prefer'                                   │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_omits_empty_optional_fields.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_omits_empty_optional_fields.snap
@@ -25,13 +25,13 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [ empty = psql default       ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       ││          │  Database:   [                            ] Required       │                                                  │
+│                                       ││          │  Database:   [ mydb                       ]                │                                                  │
 │                                       │└──────────│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
+│                                       │┌ [3] Resul│  Password:   [ ******                     ]                │──────────────────────────────────────────────────┐
 │                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
-│                                       ││          │  → port='5432' sslmode='prefer'                            │                                                  │
-│                                       ││          │                                                            │                                                  │
+│                                       ││          │  → port='5432' dbname='mydb' password='****' sslmode='pre  │                                                  │
+│                                       ││          │    fer'                                                    │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_uses_postgres_conninfo_escaping.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_uses_postgres_conninfo_escaping.snap
@@ -1,0 +1,54 @@
+---
+source: src/tests/render_snapshots/connection_flow.rs
+expression: output
+---
+test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
+│ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                       ││(select a table)                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  Name:       [                            ]                │                                                  │
+│                                       ││          │  Host:       [ /var/run/postgresql        ]                │                                                  │
+│                                       ││          │  Port:       [ 5432                       ]                │                                                  │
+│                                       ││          │  Database:   [ my'db                      ]                │                                                  │
+│                                       │└──────────│  User:       [ user'org                   ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  → host='/var/run/postgresql' port='5432' dbname='my\'db'  │                                                  │
+│                                       ││          │     user='user\'org' sslmode='prefer'                      │                                                  │
+│                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+└───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+^S:Connect  Tab/⇧Tab:Field  Esc:Cancel

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_with_max_length_fields.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_with_max_length_fields.snap
@@ -1,0 +1,54 @@
+---
+source: src/tests/render_snapshots/connection_flow.rs
+expression: output
+---
+test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
+│ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                       ││(select a table)                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  Name:       [ nnnnnnnnnnnnnnnnnnnnnnnnn  ]                │                                                  │
+│                                       ││          │  Host:       [ hhhhhhhhhhhhhhhhhhhhhhhhhh ]                │                                                  │
+│                                       ││          │  Port:       [ 65535                      ]                │                                                  │
+│                                       ││          │  Database:   [ dddddddddddddddddddddddddd ]                │                                                  │
+│                                       ││          │  User:       [ uuuuuuuuuuuuuuuuuuuuuuuuuu ]                │                                                  │
+│                                       ││          │  Password:   [ ************************** ]                │                                                  │
+│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  → host='hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh  │                                                  │
+│                                       ││          │    hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh  │                                                  │
+│                                       ││          │    hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh  │                                                  │
+│                                       │└──────────│    hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh  │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│    hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh' port='6  │──────────────────────────────────────────────────┐
+│                                       ││(select a │    5535' dbname='dddddddddddddddddddddddddddddddddddddddd  │                                                  │
+│                                       ││          │    dddddddddddddddddddddddddddddddddddddddddddddddddddddd  │                                                  │
+│                                       ││          │    dddddddddddddddddddddddddddddddddddddddddddddddddddddd  │                                                  │
+│                                       ││          │    dddddddddddddddddddddddddddddddddddddddddddddddddddddd  │                                                  │
+│                                       ││          │    ddddddddddddddddddddddddddddddddddddddddddddddddddddd'  │                                                  │
+│                                       ││          │     user='uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu  │                                                  │
+│                                       ││          │    uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu  │                                                  │
+│                                       ││          │    uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu  │                                                  │
+│                                       ││          │    uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu  │                                                  │
+│                                       ││          │    uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu' passwo  │                                                  │
+│                                       ││          │    rd='****' sslmode='prefer'                              │                                                  │
+│                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+└───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+^S:Connect  Tab/⇧Tab:Field  Esc:Cancel

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_wraps_across_multiple_rows_for_long_conninfo.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_wraps_across_multiple_rows_for_long_conninfo.snap
@@ -19,24 +19,24 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
-│                                       ││          │  Host:       [ empty = psql default       ]                │                                                  │
+│                                       ││          │  Host:       [ analytics-primary-read-rep ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       │└──────────│  Database:   [                            ] Required       │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  Password:   [                            ]                │                                                  │
-│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
-│                                       ││          │                                                            │                                                  │
-│                                       ││          │  → port='5432' sslmode='prefer'                            │                                                  │
+│                                       ││          │  Database:   [ warehouse_reporting_enviro ]                │                                                  │
+│                                       ││          │  User:       [ customer_success_preview_v ]                │                                                  │
+│                                       │└──────────│  Password:   [                            ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  SSL Mode:   [ prefer                   ▼ ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │                                                            │                                                  │
+│                                       ││          │  → host='analytics-primary-read-replica.cluster.internal.  │                                                  │
+│                                       ││          │    example.company.service' port='5432' dbname='warehouse  │                                                  │
+│                                       ││          │    _reporting_environment_for_customer_success_dashboards  │                                                  │
+│                                       ││          │    ' user='customer_success_preview_validation_operator_w  │                                                  │
+│                                       ││          │    ith_extended_scope' sslmode='prefer'                    │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ ^S: Connect │ Esc: Cancel ───────────────╯                                                  │
-│                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
@@ -20,21 +20,21 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [ localhost                  ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       │└──────────│  Database:   [                            ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  User:       [ psql default user          ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  Password:   [                            ]                │                                                  │
-│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │  Database:   [                            ]                │                                                  │
+│                                       │└──────────│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       ││          │                                                            │                                                  │
+│                                       ││          │  → host='localhost' port='5432' sslmode='prefer'           │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ Enter: Toggle │ ^S: Connect │ Esc: Cancel╯                                                  │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
@@ -20,18 +20,18 @@ test_project | - | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [ localhost                  ]                │                                                  │
 │                                       ││          │  Port:       [ 5432                       ]                │                                                  │
-│                                       ││          │  Database:   [                            ]                │                                                  │
-│                                       │└──────────│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  Password:   [                            ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
+│                                       │└──────────│  Database:   [                            ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  User:       [ empty = psql default       ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  Password:   [                            ]                │                                                  │
+│                                       ││          │  SSL Mode:   [ prefer                   ▼ ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  → host='localhost' port='5432' sslmode='prefer'           │                                                  │
-│                                       ││          │                                                            │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ Enter: Toggle │ ^S: Connect │ Esc: Cancel╯                                                  │

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -1,7 +1,7 @@
 use ratatui::prelude::*;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_width::UnicodeWidthStr;
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::connection::setup::{
@@ -13,6 +13,7 @@ use crate::app::update::input::keybindings::{connection_setup, connection_setup_
 use crate::domain::connection::{ConnectionId, ConnectionProfile, SslMode};
 use crate::primitives::atoms::text_cursor_spans;
 use crate::primitives::molecules::{FooterHintBar, render_modal};
+use crate::primitives::utils::text_utils::{take_within_width, truncate_to_width_with};
 use crate::theme::ThemePalette;
 
 const LABEL_WIDTH: u16 = 12;
@@ -397,11 +398,7 @@ fn focused_placeholder_spans(
         return vec![];
     }
 
-    let placeholder_width = effective_width.saturating_sub(1);
-    let placeholder_text = placeholder
-        .chars()
-        .take(placeholder_width)
-        .collect::<String>();
+    let placeholder_text = take_within_width(placeholder, effective_width.saturating_sub(1));
     vec![
         Span::styled(" ", theme.block_cursor_style()),
         Span::styled(
@@ -434,73 +431,27 @@ fn preview_lines(dsn: &str, width: usize) -> Vec<String> {
         return vec![String::new(), String::new()];
     }
 
-    let mut chars = dsn.chars().peekable();
-    let mut lines = [FIRST_PREFIX, CONTINUATION_PREFIX]
-        .into_iter()
-        .map(|prefix| {
-            let prefix = if UnicodeWidthStr::width(prefix) >= width {
-                ""
-            } else {
-                prefix
-            };
-            let available = width.saturating_sub(UnicodeWidthStr::width(prefix));
-            let content = take_preview_segment(&mut chars, available);
-            format!("{prefix}{content}")
-        })
-        .collect::<Vec<_>>();
+    let first_prefix = preview_prefix(FIRST_PREFIX, width);
+    let first_available = width.saturating_sub(UnicodeWidthStr::width(first_prefix));
+    let first_segment = take_within_width(dsn, first_available);
+    let rest = &dsn[first_segment.len()..];
 
-    if chars.peek().is_some()
-        && let Some(last) = lines.last_mut()
-    {
-        *last = with_preview_ellipsis(last, width);
-    }
+    let continuation_prefix = preview_prefix(CONTINUATION_PREFIX, width);
+    let continuation_available = width.saturating_sub(UnicodeWidthStr::width(continuation_prefix));
+    let continuation_segment = truncate_to_width_with(rest, continuation_available, "…");
 
-    lines
+    vec![
+        format!("{first_prefix}{first_segment}"),
+        format!("{continuation_prefix}{continuation_segment}"),
+    ]
 }
 
-fn take_preview_segment<I>(chars: &mut std::iter::Peekable<I>, width: usize) -> String
-where
-    I: Iterator<Item = char>,
-{
-    let mut segment = String::new();
-    let mut used = 0;
-    while let Some(ch) = chars.peek().copied() {
-        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if used + ch_width > width {
-            break;
-        }
-        segment.push(ch);
-        used += ch_width;
-        chars.next();
+fn preview_prefix(prefix: &'static str, width: usize) -> &'static str {
+    if UnicodeWidthStr::width(prefix) >= width {
+        ""
+    } else {
+        prefix
     }
-    segment
-}
-
-fn with_preview_ellipsis(line: &str, width: usize) -> String {
-    const ELLIPSIS: &str = "…";
-
-    let ellipsis_width = UnicodeWidthStr::width(ELLIPSIS);
-    if width < ellipsis_width {
-        return take_within_width(ELLIPSIS, width);
-    }
-
-    let mut truncated = take_within_width(line, width - ellipsis_width);
-    truncated.push_str(ELLIPSIS);
-    truncated
-}
-
-fn take_within_width(text: &str, width: usize) -> String {
-    let mut segment = String::new();
-    let mut used = 0;
-    for ch in text.chars() {
-        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
-        if used + ch_width > width {
-            break;
-        }
-        segment.push(ch);
-        used += ch_width;
-    }
-    segment
 }
 
 #[cfg(test)]

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -1,13 +1,16 @@
 use ratatui::prelude::*;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::connection::setup::{
     CONNECTION_INPUT_VISIBLE_WIDTH, CONNECTION_INPUT_WIDTH, ConnectionField, ConnectionSetupState,
 };
+use crate::app::policy::mask_password;
+use crate::app::services::AppServices;
 use crate::app::update::input::keybindings::{connection_setup, connection_setup_save};
-use crate::domain::connection::SslMode;
+use crate::domain::connection::{ConnectionId, ConnectionProfile, SslMode};
 use crate::primitives::atoms::text_cursor_spans;
 use crate::primitives::molecules::{FooterHintBar, render_modal};
 use crate::theme::ThemePalette;
@@ -32,7 +35,12 @@ fn bracketed_input(content: &str, border_style: Style, theme: &ThemePalette) -> 
 pub struct ConnectionSetup;
 
 impl ConnectionSetup {
-    pub fn render(frame: &mut Frame, state: &AppState, theme: &ThemePalette) {
+    pub fn render(
+        frame: &mut Frame,
+        state: &AppState,
+        services: &AppServices,
+        theme: &ThemePalette,
+    ) {
         let form_state = &state.connection_setup;
 
         let (title, submit_desc) = if form_state.is_edit_mode() {
@@ -47,7 +55,7 @@ impl ConnectionSetup {
         let footer = FooterHintBar::new(footer_hints);
 
         let modal_width = LABEL_WIDTH + INPUT_WIDTH + ERROR_WIDTH + 8;
-        let modal_height = 13;
+        let modal_height = 15;
         let (_, modal_inner) = render_modal(
             frame,
             Constraint::Length(modal_width),
@@ -67,6 +75,7 @@ impl ConnectionSetup {
             Constraint::Length(FIELD_HEIGHT), // Password
             Constraint::Length(FIELD_HEIGHT), // SslMode
             Constraint::Length(1),            // spacer
+            Constraint::Length(2),            // DSN preview
             Constraint::Length(1),            // notice
         ])
         .split(inner);
@@ -126,11 +135,12 @@ impl ConnectionSetup {
             form_state.focused_field == ConnectionField::SslMode,
             theme,
         );
+        Self::render_dsn_preview(frame, chunks[8], form_state, services, theme);
 
         let notice = "Note: Connection info is stored locally in plain text";
         let notice_para =
             Paragraph::new(notice).style(Style::default().fg(theme.component.feedback.note_text));
-        frame.render_widget(notice_para, chunks[8]);
+        frame.render_widget(notice_para, chunks[9]);
 
         if form_state.ssl_dropdown.is_open {
             Self::render_dropdown(
@@ -198,7 +208,7 @@ impl ConnectionSetup {
         let border_style = theme.modal_input_border_style(is_focused, error.is_some());
 
         let placeholder = field.placeholder();
-        let show_placeholder = !is_focused && value.is_empty() && !placeholder.is_empty();
+        let show_placeholder = value.is_empty() && !placeholder.is_empty();
 
         let input_line = if is_focused {
             let input = state.focused_input().unwrap();
@@ -206,17 +216,18 @@ impl ConnectionSetup {
             let cursor = input.cursor();
             let char_count = display_value.chars().count();
 
-            // same reservation logic as TextInputState::update_viewport
             let effective_width = if cursor >= char_count {
                 content_width.saturating_sub(1)
             } else {
                 content_width
             };
 
-            let cursor_spans =
-                text_cursor_spans(&display_value, cursor, viewport, effective_width, theme);
+            let cursor_spans = if show_placeholder && !mask {
+                focused_placeholder_spans(placeholder, effective_width, theme)
+            } else {
+                text_cursor_spans(&display_value, cursor, viewport, effective_width, theme)
+            };
 
-            // Calculate total display width of cursor spans (including block cursor)
             let used_width: usize = cursor_spans.iter().map(|s| s.content.chars().count()).sum();
             let padding = content_width.saturating_sub(used_width);
 
@@ -301,6 +312,27 @@ impl ConnectionSetup {
         frame.render_widget(input_para, chunks[1]);
     }
 
+    fn render_dsn_preview(
+        frame: &mut Frame,
+        area: Rect,
+        form_state: &ConnectionSetupState,
+        services: &AppServices,
+        theme: &ThemePalette,
+    ) {
+        let profile = preview_profile(form_state);
+        let preview = mask_password(&services.dsn_builder.build_dsn(&profile));
+        let lines = preview_lines(&preview, area.width as usize)
+            .into_iter()
+            .map(|line| {
+                Line::from(Span::styled(
+                    line,
+                    Style::default().fg(theme.semantic.text.secondary),
+                ))
+            })
+            .collect::<Vec<_>>();
+        frame.render_widget(Paragraph::new(lines), area);
+    }
+
     fn render_dropdown(
         frame: &mut Frame,
         ssl_field_area: Rect,
@@ -356,6 +388,121 @@ impl ConnectionSetup {
     }
 }
 
+fn focused_placeholder_spans(
+    placeholder: &str,
+    effective_width: usize,
+    theme: &ThemePalette,
+) -> Vec<Span<'static>> {
+    if effective_width == 0 {
+        return vec![];
+    }
+
+    let placeholder_width = effective_width.saturating_sub(1);
+    let placeholder_text = placeholder
+        .chars()
+        .take(placeholder_width)
+        .collect::<String>();
+    vec![
+        Span::styled(" ", theme.block_cursor_style()),
+        Span::styled(
+            placeholder_text,
+            Style::default().fg(theme.semantic.text.placeholder),
+        ),
+    ]
+}
+
+fn preview_profile(state: &ConnectionSetupState) -> ConnectionProfile {
+    let port = state.port.content().trim().parse().unwrap_or(5432);
+    ConnectionProfile::with_id(
+        ConnectionId::from_string("preview"),
+        "preview",
+        state.host.content().trim(),
+        port,
+        state.database.content(),
+        state.user.content().trim(),
+        state.password.content(),
+        state.ssl_mode,
+    )
+    .expect("static preview connection name is valid")
+}
+
+fn preview_lines(dsn: &str, width: usize) -> Vec<String> {
+    const FIRST_PREFIX: &str = "→ ";
+    const CONTINUATION_PREFIX: &str = "  ";
+
+    if width == 0 {
+        return vec![String::new(), String::new()];
+    }
+
+    let mut chars = dsn.chars().peekable();
+    let mut lines = [FIRST_PREFIX, CONTINUATION_PREFIX]
+        .into_iter()
+        .map(|prefix| {
+            let prefix = if UnicodeWidthStr::width(prefix) >= width {
+                ""
+            } else {
+                prefix
+            };
+            let available = width.saturating_sub(UnicodeWidthStr::width(prefix));
+            let content = take_preview_segment(&mut chars, available);
+            format!("{prefix}{content}")
+        })
+        .collect::<Vec<_>>();
+
+    if chars.peek().is_some()
+        && let Some(last) = lines.last_mut()
+    {
+        *last = with_preview_ellipsis(last, width);
+    }
+
+    lines
+}
+
+fn take_preview_segment<I>(chars: &mut std::iter::Peekable<I>, width: usize) -> String
+where
+    I: Iterator<Item = char>,
+{
+    let mut segment = String::new();
+    let mut used = 0;
+    while let Some(ch) = chars.peek().copied() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + ch_width > width {
+            break;
+        }
+        segment.push(ch);
+        used += ch_width;
+        chars.next();
+    }
+    segment
+}
+
+fn with_preview_ellipsis(line: &str, width: usize) -> String {
+    const ELLIPSIS: &str = "…";
+
+    let ellipsis_width = UnicodeWidthStr::width(ELLIPSIS);
+    if width < ellipsis_width {
+        return take_within_width(ELLIPSIS, width);
+    }
+
+    let mut truncated = take_within_width(line, width - ellipsis_width);
+    truncated.push_str(ELLIPSIS);
+    truncated
+}
+
+fn take_within_width(text: &str, width: usize) -> String {
+    let mut segment = String::new();
+    let mut used = 0;
+    for ch in text.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + ch_width > width {
+            break;
+        }
+        segment.push(ch);
+        used += ch_width;
+    }
+    segment
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -395,6 +542,43 @@ mod tests {
         assert_eq!(
             ConnectionSetup::submit_hints(&state, &form_state, "Connect"),
             vec![("^S", "Connect")]
+        );
+    }
+
+    #[test]
+    fn preview_profile_trims_host_and_user() {
+        let mut form_state = ConnectionSetupState::default();
+        form_state.host.set_content("  localhost  ".to_string());
+        form_state.user.set_content("  postgres  ".to_string());
+        form_state.password.set_content("  pass  ".to_string());
+
+        let profile = preview_profile(&form_state);
+
+        assert_eq!(profile.host, "localhost");
+        assert_eq!(profile.username, "postgres");
+        assert_eq!(profile.password, "  pass  ");
+    }
+
+    #[test]
+    fn preview_lines_use_two_rows_with_ellipsis() {
+        assert_eq!(
+            preview_lines("host='localhost' port='5432'", 12),
+            vec!["→ host='loca".to_string(), "  lhost' po…".to_string()]
+        );
+    }
+
+    #[test]
+    fn preview_lines_respect_display_width() {
+        let lines = preview_lines("dbname='日本語db' sslmode='prefer'", 12);
+
+        assert_eq!(
+            lines,
+            vec!["→ dbname='日".to_string(), "  本語db' s…".to_string()]
+        );
+        assert!(
+            lines
+                .iter()
+                .all(|line| UnicodeWidthStr::width(line.as_str()) <= 12)
         );
     }
 }

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -21,6 +21,10 @@ const INPUT_WIDTH: u16 = CONNECTION_INPUT_WIDTH;
 const ERROR_WIDTH: u16 = 12;
 const FIELD_HEIGHT: u16 = 1;
 const DROPDOWN_ITEM_COUNT: usize = 6;
+const MODAL_HORIZONTAL_CHROME: u16 = 6;
+const MODAL_VERTICAL_CHROME: u16 = 4;
+const NON_PREVIEW_CONTENT_HEIGHT: u16 = 9;
+const MIN_PREVIEW_LINES: usize = 2;
 
 fn bracketed_input(content: &str, border_style: Style, theme: &ThemePalette) -> Line<'static> {
     Line::from(vec![
@@ -56,7 +60,16 @@ impl ConnectionSetup {
         let footer = FooterHintBar::new(footer_hints);
 
         let modal_width = LABEL_WIDTH + INPUT_WIDTH + ERROR_WIDTH + 8;
-        let modal_height = 15;
+        let preview = preview_text(form_state, services);
+        let preview_width = modal_width.saturating_sub(MODAL_HORIZONTAL_CHROME) as usize;
+        let max_preview_lines = frame
+            .area()
+            .height
+            .saturating_sub(MODAL_VERTICAL_CHROME + NON_PREVIEW_CONTENT_HEIGHT)
+            .max(MIN_PREVIEW_LINES as u16) as usize;
+        let preview_lines = preview_lines(&preview, preview_width, max_preview_lines);
+        let modal_height =
+            MODAL_VERTICAL_CHROME + NON_PREVIEW_CONTENT_HEIGHT + preview_lines.len() as u16;
         let (_, modal_inner) = render_modal(
             frame,
             Constraint::Length(modal_width),
@@ -68,16 +81,16 @@ impl ConnectionSetup {
 
         let inner = modal_inner.inner(Margin::new(2, 1));
         let chunks = Layout::vertical([
-            Constraint::Length(FIELD_HEIGHT), // Name
-            Constraint::Length(FIELD_HEIGHT), // Host
-            Constraint::Length(FIELD_HEIGHT), // Port
-            Constraint::Length(FIELD_HEIGHT), // Database
-            Constraint::Length(FIELD_HEIGHT), // User
-            Constraint::Length(FIELD_HEIGHT), // Password
-            Constraint::Length(FIELD_HEIGHT), // SslMode
-            Constraint::Length(1),            // spacer
-            Constraint::Length(2),            // DSN preview
-            Constraint::Length(1),            // notice
+            Constraint::Length(FIELD_HEIGHT),               // Name
+            Constraint::Length(FIELD_HEIGHT),               // Host
+            Constraint::Length(FIELD_HEIGHT),               // Port
+            Constraint::Length(FIELD_HEIGHT),               // Database
+            Constraint::Length(FIELD_HEIGHT),               // User
+            Constraint::Length(FIELD_HEIGHT),               // Password
+            Constraint::Length(FIELD_HEIGHT),               // SslMode
+            Constraint::Length(1),                          // spacer
+            Constraint::Length(preview_lines.len() as u16), // DSN preview
+            Constraint::Length(1),                          // notice
         ])
         .split(inner);
 
@@ -136,7 +149,7 @@ impl ConnectionSetup {
             form_state.focused_field == ConnectionField::SslMode,
             theme,
         );
-        Self::render_dsn_preview(frame, chunks[8], form_state, services, theme);
+        Self::render_dsn_preview(frame, chunks[8], &preview_lines, theme);
 
         let notice = "Note: Connection info is stored locally in plain text";
         let notice_para =
@@ -316,17 +329,14 @@ impl ConnectionSetup {
     fn render_dsn_preview(
         frame: &mut Frame,
         area: Rect,
-        form_state: &ConnectionSetupState,
-        services: &AppServices,
+        preview_lines: &[String],
         theme: &ThemePalette,
     ) {
-        let profile = preview_profile(form_state);
-        let preview = mask_password(&services.dsn_builder.build_dsn(&profile));
-        let lines = preview_lines(&preview, area.width as usize)
-            .into_iter()
+        let lines = preview_lines
+            .iter()
             .map(|line| {
                 Line::from(Span::styled(
-                    line,
+                    line.as_str(),
                     Style::default().fg(theme.semantic.text.secondary),
                 ))
             })
@@ -423,27 +433,46 @@ fn preview_profile(state: &ConnectionSetupState) -> ConnectionProfile {
     .expect("static preview connection name is valid")
 }
 
-fn preview_lines(dsn: &str, width: usize) -> Vec<String> {
+fn preview_text(form_state: &ConnectionSetupState, services: &AppServices) -> String {
+    let profile = preview_profile(form_state);
+    mask_password(&services.dsn_builder.build_dsn(&profile))
+}
+
+fn preview_lines(dsn: &str, width: usize, max_lines: usize) -> Vec<String> {
     const FIRST_PREFIX: &str = "→ ";
     const CONTINUATION_PREFIX: &str = "  ";
 
-    if width == 0 {
-        return vec![String::new(), String::new()];
+    if width == 0 || max_lines == 0 {
+        return vec![];
     }
 
-    let first_prefix = preview_prefix(FIRST_PREFIX, width);
-    let first_available = width.saturating_sub(UnicodeWidthStr::width(first_prefix));
-    let first_segment = take_within_width(dsn, first_available);
-    let rest = &dsn[first_segment.len()..];
+    let mut remaining = dsn;
+    let mut lines = Vec::new();
 
-    let continuation_prefix = preview_prefix(CONTINUATION_PREFIX, width);
-    let continuation_available = width.saturating_sub(UnicodeWidthStr::width(continuation_prefix));
-    let continuation_segment = truncate_to_width_with(rest, continuation_available, "…");
+    for index in 0..max_lines {
+        let prefix = if index == 0 {
+            preview_prefix(FIRST_PREFIX, width)
+        } else {
+            preview_prefix(CONTINUATION_PREFIX, width)
+        };
+        let available = width.saturating_sub(UnicodeWidthStr::width(prefix));
 
-    vec![
-        format!("{first_prefix}{first_segment}"),
-        format!("{continuation_prefix}{continuation_segment}"),
-    ]
+        if index + 1 == max_lines {
+            let last_segment = truncate_to_width_with(remaining, available, "…");
+            lines.push(format!("{prefix}{last_segment}"));
+            break;
+        }
+
+        let segment = take_within_width(remaining, available);
+        remaining = &remaining[segment.len()..];
+        lines.push(format!("{prefix}{segment}"));
+
+        if remaining.is_empty() {
+            break;
+        }
+    }
+
+    lines
 }
 
 fn preview_prefix(prefix: &'static str, width: usize) -> &'static str {
@@ -513,14 +542,14 @@ mod tests {
     #[test]
     fn preview_lines_use_two_rows_with_ellipsis() {
         assert_eq!(
-            preview_lines("host='localhost' port='5432'", 12),
+            preview_lines("host='localhost' port='5432'", 12, 2),
             vec!["→ host='loca".to_string(), "  lhost' po…".to_string()]
         );
     }
 
     #[test]
     fn preview_lines_respect_display_width() {
-        let lines = preview_lines("dbname='日本語db' sslmode='prefer'", 12);
+        let lines = preview_lines("dbname='日本語db' sslmode='prefer'", 12, 2);
 
         assert_eq!(
             lines,
@@ -530,6 +559,32 @@ mod tests {
             lines
                 .iter()
                 .all(|line| UnicodeWidthStr::width(line.as_str()) <= 12)
+        );
+    }
+
+    #[test]
+    fn preview_lines_expand_beyond_two_rows_before_truncating() {
+        assert_eq!(
+            preview_lines("abcdefghijklmnopqrstuvwx", 8, 4),
+            vec![
+                "→ abcdef".to_string(),
+                "  ghijkl".to_string(),
+                "  mnopqr".to_string(),
+                "  stuvwx".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn preview_lines_truncate_on_last_available_row() {
+        assert_eq!(
+            preview_lines("abcdefghijklmnopqrstuvwxyz", 8, 4),
+            vec![
+                "→ abcdef".to_string(),
+                "  ghijkl".to_string(),
+                "  mnopqr".to_string(),
+                "  stuvw…".to_string(),
+            ]
         );
     }
 }

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -425,7 +425,7 @@ fn preview_profile(state: &ConnectionSetupState) -> ConnectionProfile {
         "preview",
         state.host.content().trim(),
         port,
-        state.database.content(),
+        state.database.content().trim(),
         state.user.content().trim(),
         state.password.content(),
         state.ssl_mode,
@@ -526,15 +526,17 @@ mod tests {
     }
 
     #[test]
-    fn preview_profile_trims_host_and_user() {
+    fn preview_profile_trims_host_user_and_database() {
         let mut form_state = ConnectionSetupState::default();
         form_state.host.set_content("  localhost  ".to_string());
+        form_state.database.set_content("  app_db  ".to_string());
         form_state.user.set_content("  postgres  ".to_string());
         form_state.password.set_content("  pass  ".to_string());
 
         let profile = preview_profile(&form_state);
 
         assert_eq!(profile.host, "localhost");
+        assert_eq!(profile.database, "app_db");
         assert_eq!(profile.username, "postgres");
         assert_eq!(profile.password, "  pass  ");
     }

--- a/src/ui/primitives/utils/text_utils.rs
+++ b/src/ui/primitives/utils/text_utils.rs
@@ -34,7 +34,7 @@ pub fn truncate_to_width(s: &str, max_width: usize) -> String {
     truncate_to_width_with(s, max_width, "...")
 }
 
-fn take_within_width(s: &str, budget: usize) -> String {
+pub fn take_within_width(s: &str, budget: usize) -> String {
     use unicode_width::UnicodeWidthChar;
 
     let mut taken = String::new();

--- a/src/ui/shell/layout.rs
+++ b/src/ui/shell/layout.rs
@@ -168,7 +168,7 @@ impl MainLayout {
             InputMode::CommandPalette => CommandPalette::render(frame, state, theme),
             InputMode::Settings => SettingsOverlay::render(frame, state, theme),
             InputMode::Help => HelpOverlay::render(frame, state, theme),
-            InputMode::ConnectionSetup => ConnectionSetup::render(frame, state, theme),
+            InputMode::ConnectionSetup => ConnectionSetup::render(frame, state, services, theme),
             InputMode::ConnectionError => ConnectionError::render(frame, state, now, theme),
             _ => {}
         }


### PR DESCRIPTION
## Problem

Creating a PostgreSQL connection in the setup modal did not show the actual conninfo that would be used, which made it hard to verify defaults and optional fields before saving.

## Background

SAB-320 adds a preview requirement, and follow-up review found that snapshot coverage was validating a duplicated stub builder instead of the real PostgreSQL conninfo formatting.

## Approach

Render a masked PostgreSQL DSN preview from the same builder used by the adapter, trim saved connection identifiers so persisted values stay aligned with the preview, and reuse shared display-width helpers for preview truncation. Remove the unused default connection name helper instead of extending dead code.

<img width="533" height="317" alt="image" src="https://github.com/user-attachments/assets/11ceaf24-0ef0-45c5-834c-4cf5af44a679" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 接続設定画面で各入力欄の最大文字数が反映され、DSNプレビュー（折り返し・省略）を表示するようになりました。
  * フォーカス中のプレースホルダー表示や通知枠のレイアウトを改善しました。
* **Bug Fixes**
  * 貼り付け/入力時に各項目の上限に合わせて自動で切り詰められます。
  * 保存時は Name/Host/Database/User をトリムし、Password はそのまま扱います。
  * 上限超過時のエラーメッセージを統一しました。
* **Tests**
  * 接続フローのスナップショットと境界値の検証を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->