### PR TITLE
refactor: move sqlite app file io behind ports

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::SystemTime;
 
@@ -8,12 +8,11 @@ use tokio::sync::mpsc;
 use crate::cmd::effect::Effect;
 use crate::domain::ConnectionId;
 use crate::domain::QuerySource;
-use crate::domain::QueryValue;
 use crate::domain::command_tag::CommandTag;
 use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
 use crate::domain::sqlite_explain_query_plan_text_from_result;
 use crate::model::app_state::AppState;
-use crate::ports::outbound::{DbOperationError, QueryExecutor, QueryHistoryStore};
+use crate::ports::outbound::{CachedResultExporter, QueryExecutor, QueryHistoryStore};
 use crate::update::action::Action;
 
 fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
@@ -92,44 +91,6 @@ fn resolve_export_path(file_name: &str) -> PathBuf {
     dir.join(file_stem)
 }
 
-fn cached_csv_cell(value: &QueryValue) -> String {
-    match value {
-        QueryValue::Null => String::new(),
-        QueryValue::Text(text) | QueryValue::SqlLiteral(text) => text.clone(),
-        QueryValue::Blob(bytes) => {
-            let mut hex = String::with_capacity(bytes.len() * 2);
-            for byte in bytes {
-                use std::fmt::Write as _;
-                let _ = write!(hex, "{byte:02X}");
-            }
-            hex
-        }
-    }
-}
-
-fn write_cached_result_csv(
-    path: &Path,
-    columns: &[String],
-    values: &[Vec<QueryValue>],
-) -> Result<usize, DbOperationError> {
-    let file = std::fs::File::create(path)
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    let mut writer = csv::WriterBuilder::new().from_writer(file);
-    writer
-        .write_record(columns)
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    for row in values {
-        let record: Vec<String> = row.iter().map(cached_csv_cell).collect();
-        writer
-            .write_record(&record)
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    }
-    writer
-        .flush()
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    Ok(values.len())
-}
-
 #[allow(
     clippy::unused_async,
     reason = "consistent async interface for effect runner dispatch"
@@ -139,6 +100,7 @@ pub async fn run(
     action_tx: &mpsc::Sender<Action>,
     query_executor: &Arc<dyn QueryExecutor>,
     query_history_store: &Arc<dyn QueryHistoryStore>,
+    cached_result_exporter: &Arc<dyn CachedResultExporter>,
     state: &AppState,
 ) -> Result<()> {
     match effect {
@@ -434,16 +396,13 @@ pub async fn run(
             row_count,
         } => {
             let tx = action_tx.clone();
+            let exporter = Arc::clone(cached_result_exporter);
             let path = resolve_export_path(&file_name);
 
             tokio::spawn(async move {
-                let export_path = path.clone();
-                let result = tokio::task::spawn_blocking(move || {
-                    write_cached_result_csv(&export_path, &columns, &values)
-                })
-                .await
-                .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
-                .and_then(|inner| inner);
+                let result = exporter
+                    .export_cached_result_to_csv(&path, &columns, &values)
+                    .await;
 
                 match result {
                     Ok(_) => {
@@ -522,34 +481,6 @@ mod tests {
         }
     }
 
-    mod cached_csv_cell_tests {
-        use super::super::cached_csv_cell;
-        use crate::domain::QueryValue;
-
-        #[test]
-        fn null_is_empty_field() {
-            assert_eq!(cached_csv_cell(&QueryValue::Null), "");
-        }
-
-        #[test]
-        fn blob_is_uppercase_hex() {
-            assert_eq!(cached_csv_cell(&QueryValue::Blob(vec![0xAB, 0xCD])), "ABCD");
-        }
-
-        #[test]
-        fn text_preserves_embedded_nul_byte() {
-            assert_eq!(cached_csv_cell(&QueryValue::text("a\0bc")), "a\0bc");
-        }
-
-        #[test]
-        fn text_is_not_display_form() {
-            assert_ne!(
-                cached_csv_cell(&QueryValue::Null),
-                QueryValue::Null.display_value()
-            );
-        }
-    }
-
     mod explain_plan_text {
         use crate::domain::{QueryResult, QuerySource, sqlite_explain_query_plan_text_from_result};
 
@@ -603,7 +534,6 @@ mod tests {
             );
         }
     }
-
     mod cached_csv_export_effect {
         use std::cell::RefCell;
         use std::sync::Arc;

--- a/src/app/cmd/cli_sqlite.rs
+++ b/src/app/cmd/cli_sqlite.rs
@@ -37,7 +37,7 @@ pub enum CliSqliteResolveError {
 #[derive(Debug, thiserror::Error)]
 pub enum CliSqliteActivateError {
     #[error("Cannot resolve SQLite database path: {0}")]
-    Canonicalize(#[from] std::io::Error),
+    Path(#[from] SqlitePathError),
 }
 
 impl CliSqliteTarget {
@@ -89,8 +89,9 @@ pub fn resolve_cli_sqlite_target(
 pub fn activate_cli_sqlite_connection(
     state: &mut AppState,
     target: &CliSqliteTarget,
+    validator: &impl SqlitePathValidator,
 ) -> Result<(), CliSqliteActivateError> {
-    let canonical_path = std::fs::canonicalize(target.path())?;
+    let canonical_path = validator.canonicalize_database_path(target.path())?;
     let connection_id = connection_id_for_path(&canonical_path.to_string_lossy());
     state.session.activate_cli_ephemeral_connection(
         &connection_id,

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -542,6 +542,7 @@ mod tests {
                     query_executor: Arc::new(MockQueryExecutor::new()),
                     query_history_store: Arc::new(test_fixtures::NoopQueryHistoryStore),
                     sqlite_diagnostics: Arc::new(test_fixtures::NoopSqliteDiagnosticsProvider),
+                    cached_result_exporter: Arc::new(test_fixtures::TestCachedResultExporter),
                 },
                 ErDeps {
                     er_exporter: Arc::new(test_fixtures::NoopErExporter),

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -22,9 +22,10 @@ use crate::cmd::utility as cmd_utility;
 use crate::domain::DatabaseMetadata;
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{
-    ClipboardWriter, ConfigWriter, ConnectionStore, DsnBuilder, ErDiagramExporter, ErLogWriter,
-    FolderOpener, MetadataProvider, PgServiceEntryReader, QueryExecutor, QueryHistoryStore,
-    Renderer, SettingsStore, SqliteDiagnosticsProvider, SqlitePathValidator,
+    CachedResultExporter, ClipboardWriter, ConfigWriter, ConnectionStore, DsnBuilder,
+    ErDiagramExporter, ErLogWriter, FolderOpener, MetadataProvider, PgServiceEntryReader,
+    QueryExecutor, QueryHistoryStore, Renderer, SettingsStore, SqliteDiagnosticsProvider,
+    SqlitePathValidator,
 };
 use crate::services::AppServices;
 use crate::update::action::Action;
@@ -40,6 +41,7 @@ pub struct QueryDeps {
     pub query_executor: Arc<dyn QueryExecutor>,
     pub query_history_store: Arc<dyn QueryHistoryStore>,
     pub sqlite_diagnostics: Arc<dyn SqliteDiagnosticsProvider>,
+    pub cached_result_exporter: Arc<dyn CachedResultExporter>,
 }
 
 pub struct ErDeps {
@@ -211,6 +213,7 @@ impl EffectRunner {
                     &self.action_tx,
                     &self.query.query_executor,
                     &self.query.query_history_store,
+                    &self.query.cached_result_exporter,
                     state,
                 )
                 .await?;

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -12,15 +12,15 @@ use crate::domain::connection::{ConnectionProfile, ServiceEntry};
 use crate::domain::query_history::QueryHistoryEntry;
 use crate::domain::{
     ConnectionId, DatabaseMetadata, DiagnosticField, ErTableInfo, QueryResult, QuerySource,
-    SqlitePathError, classify_sqlite_metadata_error, classify_sqlite_read_error,
+    QueryValue, SqlitePathError, classify_sqlite_metadata_error, classify_sqlite_read_error,
 };
 use crate::ports::outbound::DbOperationError;
 use crate::ports::outbound::{
-    AppSettings, ClipboardError, ClipboardWriter, ConfigWriter, ConfigWriterError, ConnectionStore,
-    DsnBuilder, ErDiagramExporter, ErExportResult, ErLogWriter, FolderOpenError, FolderOpener,
-    MetadataProvider, PgServiceEntryReader, QueryExecutor, QueryHistoryError, QueryHistoryStore,
-    ServiceFileError, SettingsStore, SettingsStoreError, SqliteDiagnosticsProvider,
-    SqlitePathValidator,
+    AppSettings, CachedResultExporter, ClipboardError, ClipboardWriter, ConfigWriter,
+    ConfigWriterError, ConnectionStore, DsnBuilder, ErDiagramExporter, ErExportResult, ErLogWriter,
+    FolderOpenError, FolderOpener, MetadataProvider, PgServiceEntryReader, QueryExecutor,
+    QueryHistoryError, QueryHistoryStore, ServiceFileError, SettingsStore, SettingsStoreError,
+    SqliteDiagnosticsProvider, SqlitePathValidator,
 };
 use crate::update::action::Action;
 
@@ -58,6 +58,52 @@ impl SqlitePathValidator for TestFsSqlitePathValidator {
                 &error.to_string(),
             )),
         }
+    }
+
+    fn canonicalize_database_path(&self, path: &str) -> Result<PathBuf, SqlitePathError> {
+        let path = Path::new(path);
+        let display = path.display().to_string();
+        std::fs::canonicalize(path).map_err(|error| {
+            classify_sqlite_metadata_error(&display, error.kind(), &error.to_string())
+        })
+    }
+}
+
+pub struct TestCachedResultExporter;
+#[async_trait::async_trait]
+impl CachedResultExporter for TestCachedResultExporter {
+    async fn export_cached_result_to_csv(
+        &self,
+        path: &Path,
+        columns: &[String],
+        values: &[Vec<QueryValue>],
+    ) -> Result<usize, DbOperationError> {
+        let file = std::fs::File::create(path)
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        let mut writer = csv::WriterBuilder::new().from_writer(file);
+        writer.write_record(columns)?;
+        for row in values {
+            let record = row
+                .iter()
+                .map(|value| match value {
+                    QueryValue::Null => String::new(),
+                    QueryValue::Text(text) | QueryValue::SqlLiteral(text) => text.clone(),
+                    QueryValue::Blob(bytes) => {
+                        let mut hex = String::with_capacity(bytes.len() * 2);
+                        for byte in bytes {
+                            let _ =
+                                std::fmt::Write::write_fmt(&mut hex, format_args!("{byte:02X}"));
+                        }
+                        hex
+                    }
+                })
+                .collect::<Vec<_>>();
+            writer.write_record(&record)?;
+        }
+        writer
+            .flush()
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        Ok(values.len())
     }
 }
 
@@ -205,6 +251,7 @@ pub fn make_runner_with_dsn(
             query_executor,
             query_history_store: Arc::new(NoopQueryHistoryStore),
             sqlite_diagnostics: Arc::new(NoopSqliteDiagnosticsProvider),
+            cached_result_exporter: Arc::new(TestCachedResultExporter),
         },
         ErDeps {
             er_exporter: Arc::new(NoopErExporter),

--- a/src/app/ports/outbound/cached_result_exporter.rs
+++ b/src/app/ports/outbound/cached_result_exporter.rs
@@ -1,0 +1,17 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+
+use crate::domain::QueryValue;
+
+use super::DbOperationError;
+
+#[async_trait]
+pub trait CachedResultExporter: Send + Sync {
+    async fn export_cached_result_to_csv(
+        &self,
+        path: &Path,
+        columns: &[String],
+        values: &[Vec<QueryValue>],
+    ) -> Result<usize, DbOperationError>;
+}

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -3,6 +3,7 @@
 //! Error variants may preserve `Error::source()` chains, but method signatures
 //! stay free of adapter-specific types.
 
+pub mod cached_result_exporter;
 pub mod clipboard;
 pub mod config_writer;
 pub mod connection_store;
@@ -22,6 +23,7 @@ pub mod sql_dialect;
 pub mod sqlite_diagnostics;
 pub mod sqlite_path_validator;
 
+pub use cached_result_exporter::CachedResultExporter;
 pub use clipboard::{ClipboardError, ClipboardWriter};
 pub use config_writer::{ConfigWriter, ConfigWriterError};
 pub use connection_store::{ConnectionStore, ConnectionStoreError};

--- a/src/app/ports/outbound/sqlite_path_validator.rs
+++ b/src/app/ports/outbound/sqlite_path_validator.rs
@@ -1,5 +1,8 @@
+use std::path::PathBuf;
+
 use crate::domain::SqlitePathError;
 
 pub trait SqlitePathValidator: Send + Sync {
     fn validate_database_path(&self, path: &str) -> Result<(), SqlitePathError>;
+    fn canonicalize_database_path(&self, path: &str) -> Result<PathBuf, SqlitePathError>;
 }

--- a/src/infra/adapters/cached_result_exporter.rs
+++ b/src/infra/adapters/cached_result_exporter.rs
@@ -1,0 +1,133 @@
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use sabiql_app::domain::QueryValue;
+use sabiql_app::ports::outbound::{CachedResultExporter, DbOperationError};
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CsvCachedResultExporter;
+
+#[async_trait]
+impl CachedResultExporter for CsvCachedResultExporter {
+    async fn export_cached_result_to_csv(
+        &self,
+        path: &Path,
+        columns: &[String],
+        values: &[Vec<QueryValue>],
+    ) -> Result<usize, DbOperationError> {
+        let path = path.to_path_buf();
+        let columns = columns.to_vec();
+        let values = values.to_vec();
+        tokio::task::spawn_blocking(move || write_cached_result_csv(path, columns, values))
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?
+    }
+}
+
+fn cached_csv_cell(value: &QueryValue) -> String {
+    match value {
+        QueryValue::Null => String::new(),
+        QueryValue::Text(text) | QueryValue::SqlLiteral(text) => text.clone(),
+        QueryValue::Blob(bytes) => {
+            let mut hex = String::with_capacity(bytes.len() * 2);
+            for byte in bytes {
+                use std::fmt::Write as _;
+                let _ = write!(hex, "{byte:02X}");
+            }
+            hex
+        }
+    }
+}
+
+fn write_cached_result_csv(
+    path: PathBuf,
+    columns: Vec<String>,
+    values: Vec<Vec<QueryValue>>,
+) -> Result<usize, DbOperationError> {
+    let file = std::fs::File::create(path)
+        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    let mut writer = csv::WriterBuilder::new().from_writer(file);
+    writer.write_record(columns)?;
+    for row in &values {
+        let record: Vec<String> = row.iter().map(cached_csv_cell).collect();
+        writer.write_record(&record)?;
+    }
+    writer
+        .flush()
+        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    Ok(values.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    mod cached_csv_cell_tests {
+        use super::*;
+
+        #[test]
+        fn null_is_empty_field() {
+            assert_eq!(cached_csv_cell(&QueryValue::Null), "");
+        }
+
+        #[test]
+        fn blob_is_uppercase_hex() {
+            assert_eq!(cached_csv_cell(&QueryValue::Blob(vec![0xAB, 0xCD])), "ABCD");
+        }
+
+        #[test]
+        fn text_preserves_embedded_nul_byte() {
+            assert_eq!(cached_csv_cell(&QueryValue::text("a\0bc")), "a\0bc");
+        }
+
+        #[test]
+        fn text_is_not_display_form() {
+            assert_ne!(
+                cached_csv_cell(&QueryValue::Null),
+                QueryValue::Null.display_value()
+            );
+        }
+    }
+
+    mod export_cached_result_to_csv {
+        use super::*;
+
+        #[tokio::test]
+        async fn writes_columns_rows_and_returns_row_count() {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("export.csv");
+
+            let row_count = CsvCachedResultExporter
+                .export_cached_result_to_csv(
+                    &path,
+                    &["id".to_string(), "payload".to_string()],
+                    &[vec![
+                        QueryValue::SqlLiteral("1".to_string()),
+                        QueryValue::Blob(vec![0xAB, 0xCD]),
+                    ]],
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(row_count, 1);
+            assert_eq!(
+                std::fs::read_to_string(path).unwrap(),
+                "id,payload\n1,ABCD\n"
+            );
+        }
+
+        #[tokio::test]
+        async fn returns_error_when_file_cannot_be_created() {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("missing").join("export.csv");
+
+            let error = CsvCachedResultExporter
+                .export_cached_result_to_csv(&path, &["id".to_string()], &[])
+                .await
+                .unwrap_err();
+
+            assert!(matches!(error, DbOperationError::QueryFailed(_)));
+        }
+    }
+}

--- a/src/infra/adapters/mod.rs
+++ b/src/infra/adapters/mod.rs
@@ -1,5 +1,6 @@
 mod app_config_file;
 
+pub mod cached_result_exporter;
 pub mod clipboard;
 pub mod config_writer;
 pub mod connection_store;
@@ -12,6 +13,7 @@ pub mod query_history;
 pub mod registry;
 pub mod settings_store;
 pub mod sqlite;
+pub use cached_result_exporter::CsvCachedResultExporter;
 pub use clipboard::ArboardClipboard;
 pub use config_writer::FileConfigWriter;
 pub use connection_store::TomlConnectionStore;

--- a/src/infra/adapters/sqlite/path_validation.rs
+++ b/src/infra/adapters/sqlite/path_validation.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::app::ports::outbound::SqlitePathValidator;
 use crate::domain::{SqlitePathError, classify_sqlite_metadata_error, classify_sqlite_read_error};
@@ -9,6 +9,14 @@ pub struct FsSqlitePathValidator;
 impl SqlitePathValidator for FsSqlitePathValidator {
     fn validate_database_path(&self, path: &str) -> Result<(), SqlitePathError> {
         validate_sqlite_database_path(Path::new(path))
+    }
+
+    fn canonicalize_database_path(&self, path: &str) -> Result<PathBuf, SqlitePathError> {
+        let path = Path::new(path);
+        let display = path.display().to_string();
+        std::fs::canonicalize(path).map_err(|error| {
+            classify_sqlite_metadata_error(&display, error.kind(), &error.to_string())
+        })
     }
 }
 
@@ -60,6 +68,30 @@ mod tests {
                 .validate_database_path(path.to_str().unwrap())
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn canonicalizes_existing_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("app.db");
+        fs::write(&path, b"").unwrap();
+
+        let canonical_path = FsSqlitePathValidator
+            .canonicalize_database_path(path.to_str().unwrap())
+            .unwrap();
+
+        assert_eq!(canonical_path, fs::canonicalize(path).unwrap());
+    }
+
+    #[test]
+    fn canonicalize_reports_missing_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("missing.db");
+
+        assert!(matches!(
+            FsSqlitePathValidator.canonicalize_database_path(path.to_str().unwrap()),
+            Err(SqlitePathError::FileNotFound(_))
+        ));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,9 +40,9 @@ use sabiql_app::update::action::Action;
 use sabiql_app::update::input::handle_event;
 use sabiql_app::update::reducer::reduce;
 use sabiql_infra::adapters::{
-    ArboardClipboard, DbAdapterRegistry, FileConfigWriter, FileQueryHistoryStore, FsErLogWriter,
-    FsSqlitePathValidator, NativeFolderOpener, PgServiceFileReader, PostgresAdapter,
-    TomlConnectionStore, TomlSettingsStore,
+    ArboardClipboard, CsvCachedResultExporter, DbAdapterRegistry, FileConfigWriter,
+    FileQueryHistoryStore, FsErLogWriter, FsSqlitePathValidator, NativeFolderOpener,
+    PgServiceFileReader, PostgresAdapter, TomlConnectionStore, TomlSettingsStore,
 };
 use sabiql_infra::config::project_root::{find_project_root, get_project_name};
 use sabiql_infra::export::DotExporter;
@@ -131,6 +131,7 @@ async fn main() -> Result<()> {
             query_executor: Arc::clone(&adapter_registry) as _,
             query_history_store: Arc::new(FileQueryHistoryStore::new()),
             sqlite_diagnostics: Arc::clone(&adapter_registry) as _,
+            cached_result_exporter: Arc::new(CsvCachedResultExporter),
         },
         ErDeps {
             er_exporter: Arc::new(DotExporter::new()),
@@ -205,7 +206,7 @@ async fn main() -> Result<()> {
     }
 
     if let Some(target) = cli_sqlite.as_ref() {
-        activate_cli_sqlite_connection(&mut state, target)
+        activate_cli_sqlite_connection(&mut state, target, &FsSqlitePathValidator)
             .map_err(|error| color_eyre::eyre::eyre!(error.to_string()))?;
     }
 


### PR DESCRIPTION
## Problem

SQLite support left file-system writes and path canonicalization inside the app layer, which violates the port/adapter boundary and makes the pattern easy to copy.

## Background

SAB-325 tracks the app-layer I/O cleanup for cached SQLite CSV export and direct CLI SQLite startup. This replaces the closed PR whose base branch was removed.

## Approach

Move cached result CSV writing behind a dedicated outbound port implemented by infra, and route SQLite path canonicalization through the existing path validator port. Keep the app layer limited to effect dispatch and result handling.