### PR TITLE
fix: validate sqlite files by header

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ For SQLite, you can also pass a database file path or `sqlite://` DSN directly:
 
 ```bash
 sabiql /path/to/app.db
+sabiql /path/to/History
 sabiql sqlite:///path/to/app.db
 ```
 
@@ -123,7 +124,7 @@ Android/Termux support is build-only, not full platform support. `cargo install 
 
 SQLite support covers browsing, editing, and ad-hoc SQL on regular database files. Compared with PostgreSQL:
 
-- **File paths only** — Use a regular database file path or a `sqlite://` DSN to that file. In-memory databases (`:memory:`) and SQLite URI filenames (`file:...`) are not supported.
+- **File paths only** — Use a regular SQLite database file path or a `sqlite://` DSN to that file. The `sqlite://` form treats everything after the prefix as a raw path; it does not percent-decode URI escapes. In-memory databases (`:memory:`) and SQLite URI filenames (`file:...`) are not supported because sabiql starts `sqlite3` per operation; use a temporary database file instead.
 - **No new database files** — Opening a path that does not exist does not create a database.
 - **Main database only** — Attached and temporary databases are not browsed as separate namespaces.
 - **Query plans** — SQLite shows `EXPLAIN QUERY PLAN` in the Plan tab. Plan comparison and `EXPLAIN ANALYZE` are PostgreSQL-only.

--- a/src/app/cmd/cli_sqlite.rs
+++ b/src/app/cmd/cli_sqlite.rs
@@ -20,7 +20,7 @@ pub struct CliSqliteTarget {
 pub enum CliSqliteTargetError {
     #[error("{0}")]
     Config(#[from] SqliteConnectionConfigError),
-    #[error("Unsupported SQLite target; use a .db/.sqlite/.sqlite3 file path or sqlite:// DSN")]
+    #[error("Unsupported SQLite target; use a SQLite database file path or sqlite:// DSN")]
     UnsupportedFormat,
 }
 
@@ -116,11 +116,11 @@ fn parse_cli_path(input: &str) -> Result<String, CliSqliteTargetError> {
 }
 
 fn validate_cli_path(path: &str) -> Result<String, CliSqliteTargetError> {
-    if looks_like_non_sqlite_target(path) {
+    if path.is_empty() {
         return Err(CliSqliteTargetError::UnsupportedFormat);
     }
 
-    if !has_sqlite_file_extension(path) {
+    if looks_like_non_sqlite_target(path) {
         return Err(CliSqliteTargetError::UnsupportedFormat);
     }
 
@@ -129,17 +129,6 @@ fn validate_cli_path(path: &str) -> Result<String, CliSqliteTargetError> {
 
 fn looks_like_non_sqlite_target(input: &str) -> bool {
     input.starts_with("service=") || input.contains("://")
-}
-
-fn has_sqlite_file_extension(path: &str) -> bool {
-    Path::new(path)
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| {
-            ext.eq_ignore_ascii_case("db")
-                || ext.eq_ignore_ascii_case("sqlite")
-                || ext.eq_ignore_ascii_case("sqlite3")
-        })
 }
 
 #[cfg(test)]
@@ -160,10 +149,11 @@ mod tests {
 
         #[rstest]
         #[case("app.db")]
+        #[case("History")]
         #[case("data.sqlite")]
         #[case("archive.SQLITE3")]
         #[case("./relative/app.db")]
-        fn accepts_file_paths_with_supported_extensions(#[case] input: &str) {
+        fn accepts_file_paths_without_extension_filtering(#[case] input: &str) {
             let target = CliSqliteTarget::parse_cli_argument(input).unwrap();
 
             assert_eq!(target.path(), input);
@@ -181,11 +171,9 @@ mod tests {
         #[case("sqlite://", ExpectedRejection::UnsupportedFormat)]
         #[case("postgres://localhost/db", ExpectedRejection::UnsupportedFormat)]
         #[case("service=mydb", ExpectedRejection::UnsupportedFormat)]
-        #[case("/tmp/app", ExpectedRejection::UnsupportedFormat)]
-        #[case(":memory:", ExpectedRejection::UnsupportedFormat)]
+        #[case(":memory:", ExpectedRejection::Config)]
         #[case("file:/tmp/app.db", ExpectedRejection::Config)]
-        #[case("sqlite:///tmp/app", ExpectedRejection::UnsupportedFormat)]
-        #[case("sqlite://:memory:", ExpectedRejection::UnsupportedFormat)]
+        #[case("sqlite://:memory:", ExpectedRejection::Config)]
         fn rejects_unsupported_targets(#[case] input: &str, #[case] expected: ExpectedRejection) {
             let result = CliSqliteTarget::parse_cli_argument(input);
 

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -13,6 +13,7 @@ pub enum ConnectionErrorKind {
     SqliteFileNotFound,
     SqlitePathIsDirectory,
     SqlitePathNotRegularFile,
+    SqliteNotDatabaseFile,
     SqliteReadAccessDenied,
     SqlitePathAccessDenied,
     SqlitePathIo,
@@ -79,6 +80,7 @@ impl ConnectionErrorKind {
             Self::SqliteFileNotFound => "SQLite database file not found",
             Self::SqlitePathIsDirectory => "SQLite path is a directory",
             Self::SqlitePathNotRegularFile => "SQLite path is not a regular file",
+            Self::SqliteNotDatabaseFile => "File is not a SQLite database",
             Self::SqliteReadAccessDenied => "Cannot read SQLite database file",
             Self::SqlitePathAccessDenied => "Cannot access SQLite database file",
             Self::SqlitePathIo => "Cannot open SQLite database file",
@@ -103,6 +105,9 @@ impl ConnectionErrorKind {
             Self::SqlitePathIsDirectory => "Enter a path to a database file, not a folder",
             Self::SqlitePathNotRegularFile => {
                 "Enter a path to a regular database file, not a pipe or special file"
+            }
+            Self::SqliteNotDatabaseFile => {
+                "Choose a readable SQLite database file, or create one with sqlite3"
             }
             Self::SqliteReadAccessDenied => "Check read permissions for the database file",
             Self::SqlitePathAccessDenied => "Check file permissions for the database file",
@@ -282,6 +287,7 @@ mod tests {
         #[case(ConnectionErrorKind::SqliteFileNotFound)]
         #[case(ConnectionErrorKind::SqlitePathIsDirectory)]
         #[case(ConnectionErrorKind::SqlitePathNotRegularFile)]
+        #[case(ConnectionErrorKind::SqliteNotDatabaseFile)]
         #[case(ConnectionErrorKind::SqliteReadAccessDenied)]
         #[case(ConnectionErrorKind::SqlitePathAccessDenied)]
         #[case(ConnectionErrorKind::SqlitePathIo)]
@@ -349,6 +355,10 @@ mod tests {
         #[case(
             "SQLite path is not a regular file: /tmp/pipe.db",
             ConnectionErrorKind::SqlitePathNotRegularFile
+        )]
+        #[case(
+            "File is readable but not a SQLite database: /tmp/not-db",
+            ConnectionErrorKind::SqliteNotDatabaseFile
         )]
         #[case(
             "Cannot read SQLite database file: /tmp/app.db: permission denied",

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -378,8 +378,11 @@ impl ConnectionSetupState {
         let message = match error {
             SqliteConnectionConfigError::EmptyPath => "Required",
             SqliteConnectionConfigError::UnsupportedPath => "Unsupported characters",
-            SqliteConnectionConfigError::UnsupportedConnectionFormat => {
-                "Use a regular file path (in-memory and URI filenames unsupported)"
+            SqliteConnectionConfigError::UnsupportedInMemoryDatabase => {
+                "In-memory SQLite databases cannot retain contents because sabiql starts sqlite3 per operation; use a temporary file"
+            }
+            SqliteConnectionConfigError::UnsupportedUriFilename => {
+                "SQLite URI filenames are not supported; use a regular file path"
             }
         };
         self.validation_errors
@@ -391,6 +394,7 @@ impl ConnectionSetupState {
             SqlitePathError::FileNotFound(_) => "File not found",
             SqlitePathError::IsDirectory(_) => "Path is a directory",
             SqlitePathError::NotRegularFile(_) => "Not a regular file",
+            SqlitePathError::NotDatabaseFile(_) => "Not a SQLite database",
             SqlitePathError::ReadAccessDenied(_) => "Read permission denied",
             SqlitePathError::PathAccessDenied(_) => "Access denied",
             SqlitePathError::Io(_) => "Cannot access file",

--- a/src/app/policy/sqlite_path.rs
+++ b/src/app/policy/sqlite_path.rs
@@ -7,6 +7,7 @@ pub fn connection_error_kind(error: &SqlitePathError) -> ConnectionErrorKind {
         SqlitePathError::FileNotFound(_) => ConnectionErrorKind::SqliteFileNotFound,
         SqlitePathError::IsDirectory(_) => ConnectionErrorKind::SqlitePathIsDirectory,
         SqlitePathError::NotRegularFile(_) => ConnectionErrorKind::SqlitePathNotRegularFile,
+        SqlitePathError::NotDatabaseFile(_) => ConnectionErrorKind::SqliteNotDatabaseFile,
         SqlitePathError::ReadAccessDenied(_) => ConnectionErrorKind::SqliteReadAccessDenied,
         SqlitePathError::PathAccessDenied(_) => ConnectionErrorKind::SqlitePathAccessDenied,
         SqlitePathError::Io(_) => ConnectionErrorKind::SqlitePathIo,

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -676,7 +676,9 @@ mod tests {
 
             assert_eq!(
                 state.validation_error(ConnectionField::SqlitePath),
-                Some("Use a regular file path (in-memory and URI filenames unsupported)")
+                Some(
+                    "In-memory SQLite databases cannot retain contents because sabiql starts sqlite3 per operation; use a temporary file"
+                )
             );
         }
 
@@ -693,7 +695,7 @@ mod tests {
 
             assert_eq!(
                 state.validation_error(ConnectionField::SqlitePath),
-                Some("Use a regular file path (in-memory and URI filenames unsupported)")
+                Some("SQLite URI filenames are not supported; use a regular file path")
             );
         }
 

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -44,9 +44,11 @@ pub enum SqliteConnectionConfigError {
     #[error("SQLite database path contains unsupported characters")]
     UnsupportedPath,
     #[error(
-        "SQLite in-memory databases and URI filenames are not supported; use a regular file path"
+        "SQLite in-memory databases are not supported because sabiql starts sqlite3 per operation and cannot retain their contents; use a temporary database file"
     )]
-    UnsupportedConnectionFormat,
+    UnsupportedInMemoryDatabase,
+    #[error("SQLite URI filenames are not supported; use a regular file path")]
+    UnsupportedUriFilename,
 }
 
 impl SqliteConnectionConfig {
@@ -83,17 +85,16 @@ fn validate_sqlite_path(path: &str) -> Result<(), SqliteConnectionConfigError> {
     if path.chars().any(|c| c == '\0' || c.is_control()) {
         return Err(SqliteConnectionConfigError::UnsupportedPath);
     }
-    if is_unsupported_sqlite_connection_format(path) {
-        return Err(SqliteConnectionConfigError::UnsupportedConnectionFormat);
+    if path.trim() == ":memory:" {
+        return Err(SqliteConnectionConfigError::UnsupportedInMemoryDatabase);
+    }
+    if is_sqlite_uri_filename(path) {
+        return Err(SqliteConnectionConfigError::UnsupportedUriFilename);
     }
     Ok(())
 }
 
-fn is_unsupported_sqlite_connection_format(path: &str) -> bool {
-    if path.trim() == ":memory:" {
-        return true;
-    }
-
+fn is_sqlite_uri_filename(path: &str) -> bool {
     path.as_bytes()
         .get(..5)
         .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"file:"))
@@ -203,7 +204,7 @@ mod tests {
         fn rejects_memory_database() {
             assert!(matches!(
                 validate_sqlite_path(":memory:"),
-                Err(SqliteConnectionConfigError::UnsupportedConnectionFormat)
+                Err(SqliteConnectionConfigError::UnsupportedInMemoryDatabase)
             ));
         }
 
@@ -211,7 +212,7 @@ mod tests {
         fn rejects_file_uri() {
             assert!(matches!(
                 validate_sqlite_path("file:memdb?mode=memory"),
-                Err(SqliteConnectionConfigError::UnsupportedConnectionFormat)
+                Err(SqliteConnectionConfigError::UnsupportedUriFilename)
             ));
         }
     }

--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -18,9 +18,11 @@ pub enum ConnectionProfileError {
     #[error("SQLite database path contains unsupported characters")]
     InvalidSqlitePath,
     #[error(
-        "SQLite in-memory databases and URI filenames are not supported; use a regular file path"
+        "SQLite in-memory databases are not supported because sabiql starts sqlite3 per operation and cannot retain their contents; use a temporary database file"
     )]
-    UnsupportedSqliteConnectionFormat,
+    UnsupportedSqliteInMemoryDatabase,
+    #[error("SQLite URI filenames are not supported; use a regular file path")]
+    UnsupportedSqliteUriFilename,
     #[error("PostgreSQL connection field `{0}` is required")]
     MissingPostgresField(&'static str),
     #[error("{0}")]
@@ -32,8 +34,11 @@ impl From<SqliteConnectionConfigError> for ConnectionProfileError {
         match error {
             SqliteConnectionConfigError::EmptyPath => Self::EmptySqlitePath,
             SqliteConnectionConfigError::UnsupportedPath => Self::InvalidSqlitePath,
-            SqliteConnectionConfigError::UnsupportedConnectionFormat => {
-                Self::UnsupportedSqliteConnectionFormat
+            SqliteConnectionConfigError::UnsupportedInMemoryDatabase => {
+                Self::UnsupportedSqliteInMemoryDatabase
+            }
+            SqliteConnectionConfigError::UnsupportedUriFilename => {
+                Self::UnsupportedSqliteUriFilename
             }
         }
     }
@@ -231,7 +236,7 @@ mod tests {
 
             assert!(matches!(
                 result,
-                Err(ConnectionProfileError::UnsupportedSqliteConnectionFormat)
+                Err(ConnectionProfileError::UnsupportedSqliteInMemoryDatabase)
             ));
         }
 
@@ -241,7 +246,7 @@ mod tests {
 
             assert!(matches!(
                 result,
-                Err(ConnectionProfileError::UnsupportedSqliteConnectionFormat)
+                Err(ConnectionProfileError::UnsupportedSqliteUriFilename)
             ));
         }
     }

--- a/src/domain/connection/sqlite_path.rs
+++ b/src/domain/connection/sqlite_path.rs
@@ -6,6 +6,8 @@ pub enum SqlitePathError {
     IsDirectory(String),
     #[error("SQLite path is not a regular file: {0}")]
     NotRegularFile(String),
+    #[error("File is readable but not a SQLite database: {0}")]
+    NotDatabaseFile(String),
     #[error("Cannot read SQLite database file: {0}")]
     ReadAccessDenied(String),
     #[error("Cannot access SQLite database file: {0}")]
@@ -19,6 +21,7 @@ impl SqlitePathError {
         const NOT_FOUND: &str = "SQLite database file not found: ";
         const IS_DIRECTORY: &str = "SQLite path is a directory, not a file: ";
         const NOT_REGULAR_FILE: &str = "SQLite path is not a regular file: ";
+        const NOT_DATABASE_FILE: &str = "File is readable but not a SQLite database: ";
         const READ_ACCESS_DENIED: &str = "Cannot read SQLite database file: ";
         const PATH_ACCESS_DENIED: &str = "Cannot access SQLite database file: ";
         const IO: &str = "Cannot read SQLite database file metadata: ";
@@ -29,6 +32,8 @@ impl SqlitePathError {
             Some(Self::IsDirectory(path.to_string()))
         } else if let Some(path) = message.strip_prefix(NOT_REGULAR_FILE) {
             Some(Self::NotRegularFile(path.to_string()))
+        } else if let Some(path) = message.strip_prefix(NOT_DATABASE_FILE) {
+            Some(Self::NotDatabaseFile(path.to_string()))
         } else if let Some(details) = message.strip_prefix(READ_ACCESS_DENIED) {
             Some(Self::ReadAccessDenied(details.to_string()))
         } else if let Some(details) = message.strip_prefix(PATH_ACCESS_DENIED) {

--- a/src/infra/adapters/sqlite/path_validation.rs
+++ b/src/infra/adapters/sqlite/path_validation.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use crate::app::ports::outbound::SqlitePathValidator;
 use crate::domain::{SqlitePathError, classify_sqlite_metadata_error, classify_sqlite_read_error};
 
+const SQLITE_HEADER_MAGIC: &[u8; 16] = b"SQLite format 3\0";
+
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FsSqlitePathValidator;
 
@@ -34,7 +36,33 @@ fn validate_sqlite_database_path(path: &Path) -> Result<(), SqlitePathError> {
     }
 
     match std::fs::File::open(path) {
-        Ok(_) => Ok(()),
+        Ok(mut file) => validate_sqlite_header(&mut file, metadata.len(), display),
+        Err(error) => Err(classify_sqlite_read_error(
+            &display,
+            error.kind(),
+            &error.to_string(),
+        )),
+    }
+}
+
+fn validate_sqlite_header(
+    file: &mut std::fs::File,
+    file_len: u64,
+    display: String,
+) -> Result<(), SqlitePathError> {
+    use std::io::Read;
+
+    if file_len == 0 {
+        return Ok(());
+    }
+
+    let mut header = [0; 16];
+    match file.read_exact(&mut header) {
+        Ok(()) if &header == SQLITE_HEADER_MAGIC => Ok(()),
+        Ok(()) => Err(SqlitePathError::NotDatabaseFile(display)),
+        Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => {
+            Err(SqlitePathError::NotDatabaseFile(display))
+        }
         Err(error) => Err(classify_sqlite_read_error(
             &display,
             error.kind(),
@@ -50,7 +78,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn accepts_existing_file() {
+    fn accepts_empty_existing_file() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("app.db");
         fs::write(&path, b"").unwrap();
@@ -60,6 +88,43 @@ mod tests {
                 .validate_database_path(path.to_str().unwrap())
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn accepts_sqlite_file_by_header() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("History");
+        fs::write(&path, b"SQLite format 3\0rest").unwrap();
+
+        assert!(
+            FsSqlitePathValidator
+                .validate_database_path(path.to_str().unwrap())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_readable_non_sqlite_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("notes.txt");
+        fs::write(&path, b"not a sqlite db at all").unwrap();
+
+        assert!(matches!(
+            FsSqlitePathValidator.validate_database_path(path.to_str().unwrap()),
+            Err(SqlitePathError::NotDatabaseFile(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_short_non_empty_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("partial.db");
+        fs::write(&path, b"SQLite").unwrap();
+
+        assert!(matches!(
+            FsSqlitePathValidator.validate_database_path(path.to_str().unwrap()),
+            Err(SqlitePathError::NotDatabaseFile(_))
+        ));
     }
 
     #[test]

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -287,7 +287,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(ConnectionProfileError::UnsupportedSqliteConnectionFormat)
+            Err(ConnectionProfileError::UnsupportedSqliteInMemoryDatabase)
         ));
     }
 
@@ -299,7 +299,7 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(ConnectionProfileError::UnsupportedSqliteConnectionFormat)
+            Err(ConnectionProfileError::UnsupportedSqliteUriFilename)
         ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ use sabiql_ui::tui::TuiRunner;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// SQLite database file (.db, .sqlite, .sqlite3) or sqlite:// DSN
+    /// SQLite database file path or sqlite:// DSN
     database: Option<String>,
 
     #[command(subcommand)]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -39,13 +39,37 @@ mod cli_sqlite_startup {
     fn resolves_existing_sqlite_file() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("app.db");
-        fs::write(&path, b"").unwrap();
+        fs::write(&path, b"SQLite format 3\0rest").unwrap();
 
         let target =
             resolve_cli_sqlite_target(path.to_str().unwrap(), &FsSqlitePathValidator).unwrap();
 
         assert_eq!(target.path(), path.to_str().unwrap());
         assert_eq!(target.dsn(), format!("sqlite://{}", path.display()));
+    }
+
+    #[test]
+    fn resolves_extensionless_sqlite_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("History");
+        fs::write(&path, b"SQLite format 3\0rest").unwrap();
+
+        let target =
+            resolve_cli_sqlite_target(path.to_str().unwrap(), &FsSqlitePathValidator).unwrap();
+
+        assert_eq!(target.path(), path.to_str().unwrap());
+    }
+
+    #[test]
+    fn rejects_non_sqlite_file_before_startup() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("notes.txt");
+        fs::write(&path, b"not a sqlite database").unwrap();
+
+        let error =
+            resolve_cli_sqlite_target(path.to_str().unwrap(), &FsSqlitePathValidator).unwrap_err();
+
+        assert!(error.to_string().contains("not a SQLite database"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

SQLite file acceptance depended on extensions in CLI startup and only basic filesystem checks in connection setup, so extensionless SQLite files were blocked while non-SQLite readable files failed later.

## Background

Linear: SAB-322

SQLite files often use extensionless or custom names, and `:memory:` cannot retain contents because sabiql starts `sqlite3` per operation.

## Approach

Validate readable SQLite files by their header magic at the shared path validator boundary, keep empty existing files valid, and surface specific non-SQLite and in-memory database errors before metadata loading.

Update CLI startup, connection setup, connection error classification, tests, and README guidance to match the new file-content based behavior.
