### PR TITLE
fix: export SQLite previews from typed results

### DIFF
--- a/src/app/policy/sql/sqlite_export.rs
+++ b/src/app/policy/sql/sqlite_export.rs
@@ -1,4 +1,4 @@
-use crate::domain::DatabaseType;
+use crate::domain::{DatabaseType, QuerySource};
 use crate::policy::sql::statement_classifier::{classify, first_keyword};
 use crate::policy::write::sql_risk::{
     MultiStatementDecision, evaluate_multi_statement_for_database, evaluate_sql_risk_for_database,
@@ -11,7 +11,15 @@ pub enum SqliteExportPlan {
     NotExportable { reason: String },
 }
 
-pub fn sqlite_export_plan(query: &str, columns: &[String], row_count: usize) -> SqliteExportPlan {
+pub fn sqlite_export_plan(
+    source: QuerySource,
+    query: &str,
+    columns: &[String],
+    row_count: usize,
+) -> SqliteExportPlan {
+    if source == QuerySource::Preview {
+        return SqliteExportPlan::CachedResult { row_count };
+    }
     if is_sqlite_rerunnable_export_query(query) {
         return SqliteExportPlan::RerunnableQuery {
             query: query.to_string(),
@@ -209,7 +217,12 @@ mod tests {
 
         #[test]
         fn write_only_without_rows_is_not_exportable() {
-            let plan = sqlite_export_plan("INSERT INTO users(id) VALUES (1)", &[], 0);
+            let plan = sqlite_export_plan(
+                QuerySource::Adhoc,
+                "INSERT INTO users(id) VALUES (1)",
+                &[],
+                0,
+            );
             assert_eq!(
                 plan,
                 SqliteExportPlan::NotExportable {
@@ -221,6 +234,7 @@ mod tests {
         #[test]
         fn mixed_query_with_rows_uses_cached_result() {
             let plan = sqlite_export_plan(
+                QuerySource::Adhoc,
                 "INSERT INTO users(id) VALUES (1); SELECT id FROM users",
                 &["id".to_string()],
                 1,
@@ -230,8 +244,25 @@ mod tests {
 
         #[test]
         fn select_uses_rerunnable_query() {
-            let plan = sqlite_export_plan("SELECT id FROM users", &["id".to_string()], 1);
+            let plan = sqlite_export_plan(
+                QuerySource::Adhoc,
+                "SELECT id FROM users",
+                &["id".to_string()],
+                1,
+            );
             assert!(matches!(plan, SqliteExportPlan::RerunnableQuery { .. }));
+        }
+
+        #[test]
+        fn preview_uses_cached_result() {
+            let plan = sqlite_export_plan(
+                QuerySource::Preview,
+                "SELECT __sabiql_rowid, CASE WHEN typeof(message) = 'text' THEN hex(message) END",
+                &["message".to_string()],
+                2,
+            );
+
+            assert_eq!(plan, SqliteExportPlan::CachedResult { row_count: 2 });
         }
     }
 }

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -115,7 +115,7 @@ pub fn reduce_pagination(
             let row_count = result.row_count();
 
             if state.session.active_database_type() == Some(DatabaseType::SQLite) {
-                match sqlite_export_plan(&export_query, &result.columns, row_count) {
+                match sqlite_export_plan(result.source, &export_query, &result.columns, row_count) {
                     SqliteExportPlan::NotExportable { reason } => {
                         state.messages.set_error_at(reason, now);
                         return DispatchResult::handled();
@@ -907,6 +907,37 @@ mod tests {
 
                 assert_eq!(effects.len(), 1);
                 assert!(matches!(&effects[0], Effect::CountRowsForExport { .. }));
+            }
+
+            #[test]
+            fn preview_exports_visible_typed_values_from_cache() {
+                let mut state = sqlite_state();
+                state.query.set_current_result(Arc::new(
+                    QueryResult::success_with_values(
+                        "SELECT \"_rowid_\" AS \"__sabiql_rowid\", CASE WHEN typeof(\"message\") = 'text' THEN hex(\"message\") END AS \"message\" FROM \"logs\"".to_string(),
+                        vec!["message".to_string()],
+                        vec![vec![QueryValue::text("a\0bc")]],
+                        1,
+                        QuerySource::Preview,
+                    ),
+                ));
+
+                let effects = dispatch_query(
+                    &mut state,
+                    &Action::RequestCsvExport,
+                    Instant::now(),
+                    &AppServices::stub(),
+                )
+                .unwrap();
+
+                let Effect::ExportCsvFromCache {
+                    columns, values, ..
+                } = &effects[0]
+                else {
+                    panic!("expected cached CSV export effect");
+                };
+                assert_eq!(columns, &["message"]);
+                assert_eq!(values, &vec![vec![QueryValue::text("a\0bc")]]);
             }
         }
     }

--- a/src/infra/adapters/cached_result_exporter.rs
+++ b/src/infra/adapters/cached_result_exporter.rs
@@ -115,6 +115,23 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn writes_embedded_nul_text_without_display_escaping() {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("export.csv");
+
+            CsvCachedResultExporter
+                .export_cached_result_to_csv(
+                    path.clone(),
+                    vec!["payload".to_string()],
+                    vec![vec![QueryValue::text("a\0bc")]],
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(std::fs::read(path).unwrap(), b"payload\na\0bc\n");
+        }
+
+        #[tokio::test]
         async fn returns_error_when_file_cannot_be_created() {
             let dir = tempdir().unwrap();
             let path = dir.path().join("missing").join("export.csv");


### PR DESCRIPTION
## Problem

SQLite preview CSV exports re-executed internal preview SQL, leaking hidden rowid columns and transport encodings while losing TEXT values containing NUL bytes.

## Background

Preview results already contain visible, typed values, but the export policy treated their internal SELECT as rerunnable.

## Approach

Route SQLite preview results through the cached typed-value exporter. Keep ad-hoc SQLite queries on the existing rerunnable/cached classification and preserve the PostgreSQL export path.

Refs SAB-330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * プレビュー結果からCSVをエクスポートできるようになり、キャッシュ済みの結果を正しく利用します。
  * 型付きの値を保持したまま出力でき、文字列に含まれるヌル文字なども変換されず、元の内容で保存されます。

* **テスト**
  * プレビュー結果のCSVエクスポートと、特殊文字を含む値の出力を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->