### PR TITLE
fix(sqlite): harden connection path and read-only operations

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -820,4 +820,151 @@ mod tests {
             );
         }
     }
+
+    mod execute_access_mode {
+        use std::cell::RefCell;
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use tokio::sync::mpsc;
+
+        use crate::cmd::cache::TtlCache;
+        use crate::cmd::completion_engine::CompletionEngine;
+        use crate::cmd::effect::Effect;
+        use crate::cmd::test_fixtures;
+        use crate::domain::WriteExecutionResult;
+        use crate::model::app_state::AppState;
+        use crate::ports::outbound::connection_store::MockConnectionStore;
+        use crate::ports::outbound::metadata::MockMetadataProvider;
+        use crate::ports::outbound::query_executor::MockQueryExecutor;
+        use crate::ports::outbound::{AccessMode, RenderOutput, RenderResult, Renderer};
+        use crate::services::AppServices;
+        use crate::update::action::Action;
+
+        struct NoopRenderer;
+        impl Renderer for NoopRenderer {
+            fn draw(
+                &mut self,
+                _state: &AppState,
+                _services: &AppServices,
+                _now: std::time::Instant,
+            ) -> RenderResult<RenderOutput> {
+                Ok(RenderOutput::default())
+            }
+        }
+
+        async fn run_effect(effect: Effect, executor: MockQueryExecutor) -> Action {
+            let cache = TtlCache::new(300);
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(executor),
+                Arc::new(MockConnectionStore::new()),
+                cache,
+                tx,
+            );
+            let mut state = AppState::new("test".to_string());
+            let ce = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .run(
+                    vec![effect],
+                    &mut renderer,
+                    &mut state,
+                    &ce,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            tokio::time::timeout(Duration::from_millis(500), rx.recv())
+                .await
+                .expect("action timeout")
+                .expect("channel closed")
+        }
+
+        #[tokio::test]
+        async fn execute_adhoc_forwards_access_mode() {
+            let mut executor = MockQueryExecutor::new();
+            executor
+                .expect_execute_adhoc()
+                .once()
+                .withf(|_, _, access_mode| *access_mode == AccessMode::ReadOnly)
+                .returning(|_, _, _| Ok(test_fixtures::sample_query_result()));
+
+            let action = run_effect(
+                Effect::ExecuteAdhoc {
+                    dsn: "dsn://test".to_string(),
+                    run_id: 1,
+                    query: "SELECT 1".to_string(),
+                    access_mode: AccessMode::ReadOnly,
+                },
+                executor,
+            )
+            .await;
+
+            assert!(matches!(action, Action::QueryCompleted { run_id: 1, .. }));
+        }
+
+        #[tokio::test]
+        async fn execute_explain_forwards_access_mode() {
+            let mut executor = MockQueryExecutor::new();
+            executor
+                .expect_execute_adhoc()
+                .once()
+                .withf(|_, _, access_mode| *access_mode == AccessMode::ReadOnly)
+                .returning(|_, _, _| Ok(test_fixtures::sample_query_result()));
+
+            let action = run_effect(
+                Effect::ExecuteExplain {
+                    dsn: "dsn://test".to_string(),
+                    run_id: 2,
+                    query: "EXPLAIN SELECT 1".to_string(),
+                    source_query: "SELECT 1".to_string(),
+                    is_analyze: false,
+                    access_mode: AccessMode::ReadOnly,
+                },
+                executor,
+            )
+            .await;
+
+            assert!(matches!(action, Action::ExplainCompleted { run_id: 2, .. }));
+        }
+
+        #[tokio::test]
+        async fn execute_write_forwards_access_mode() {
+            let mut executor = MockQueryExecutor::new();
+            executor
+                .expect_execute_write()
+                .once()
+                .withf(|_, _, access_mode| *access_mode == AccessMode::ReadWrite)
+                .returning(|_, _, _| {
+                    Ok(WriteExecutionResult {
+                        affected_rows: 1,
+                        execution_time_ms: 0,
+                    })
+                });
+
+            let action = run_effect(
+                Effect::ExecuteWrite {
+                    dsn: "dsn://test".to_string(),
+                    run_id: 3,
+                    query: "INSERT INTO users VALUES (1)".to_string(),
+                    access_mode: AccessMode::ReadWrite,
+                },
+                executor,
+            )
+            .await;
+
+            assert!(matches!(
+                action,
+                Action::ExecuteWriteSucceeded {
+                    run_id: 3,
+                    affected_rows: 1,
+                    ..
+                }
+            ));
+        }
+    }
 }

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -113,14 +113,13 @@ pub async fn run(
             limit,
             offset,
             target_page,
-            read_only,
         } => {
             let executor = Arc::clone(query_executor);
             let tx = action_tx.clone();
 
             tokio::spawn(async move {
                 match executor
-                    .execute_preview(&dsn, &schema, &table, limit, offset, read_only)
+                    .execute_preview(&dsn, &schema, &table, limit, offset)
                     .await
                 {
                     Ok(result) => {
@@ -156,13 +155,13 @@ pub async fn run(
             query,
             source_query,
             is_analyze,
-            read_only,
+            access_mode,
         } => {
             let executor = Arc::clone(query_executor);
             let tx = action_tx.clone();
 
             tokio::spawn(async move {
-                match executor.execute_adhoc(&dsn, &query, read_only).await {
+                match executor.execute_adhoc(&dsn, &query, access_mode).await {
                     Ok(result) => {
                         let plan_text = sqlite_explain_query_plan_text_from_result(&result);
                         tx.send(Action::ExplainCompleted {
@@ -194,7 +193,7 @@ pub async fn run(
             dsn,
             run_id,
             query,
-            read_only,
+            access_mode,
         } => {
             let executor = Arc::clone(query_executor);
             let tx = action_tx.clone();
@@ -205,7 +204,7 @@ pub async fn run(
             let query_for_history = query.clone();
 
             tokio::spawn(async move {
-                match executor.execute_adhoc(&dsn, &query, read_only).await {
+                match executor.execute_adhoc(&dsn, &query, access_mode).await {
                     Ok(result) => {
                         if let Some(cid) = &conn_id {
                             let rows = result
@@ -263,7 +262,7 @@ pub async fn run(
             dsn,
             run_id,
             query,
-            read_only,
+            access_mode,
         } => {
             let executor = Arc::clone(query_executor);
             let tx = action_tx.clone();
@@ -274,7 +273,7 @@ pub async fn run(
             let query_for_history = query.clone();
 
             tokio::spawn(async move {
-                match executor.execute_write(&dsn, &query, read_only).await {
+                match executor.execute_write(&dsn, &query, access_mode).await {
                     Ok(result) => {
                         if let Some(cid) = &conn_id {
                             save_query_history(
@@ -326,16 +325,12 @@ pub async fn run(
             count_query,
             export_query,
             file_name,
-            read_only,
         } => {
             let executor = Arc::clone(query_executor);
             let tx = action_tx.clone();
 
             tokio::spawn(async move {
-                let row_count = executor
-                    .count_query_rows(&dsn, &count_query, read_only)
-                    .await
-                    .ok();
+                let row_count = executor.count_query_rows(&dsn, &count_query).await.ok();
                 tx.send(Action::CsvExportRowsCounted {
                     dsn,
                     run_id,
@@ -355,14 +350,13 @@ pub async fn run(
             query,
             file_name,
             row_count,
-            read_only,
         } => {
             let executor = Arc::clone(query_executor);
             let tx = action_tx.clone();
             let path = resolve_export_path(&file_name);
 
             tokio::spawn(async move {
-                match executor.export_to_csv(&dsn, &query, &path, read_only).await {
+                match executor.export_to_csv(&dsn, &query, &path).await {
                     Ok(_) => {
                         tx.send(Action::CsvExportSucceeded {
                             dsn,
@@ -720,7 +714,7 @@ mod tests {
             mock_executor
                 .expect_execute_preview()
                 .once()
-                .returning(|_, _, _, _, _, _| Ok(test_fixtures::sample_query_result()));
+                .returning(|_, _, _, _, _| Ok(test_fixtures::sample_query_result()));
 
             let cache = TtlCache::new(300);
             let (tx, mut rx) = mpsc::channel(8);
@@ -747,7 +741,6 @@ mod tests {
                         limit: 100,
                         offset: 0,
                         target_page: 0,
-                        read_only: false,
                     }],
                     &mut renderer,
                     state,
@@ -773,7 +766,7 @@ mod tests {
             mock_executor
                 .expect_execute_preview()
                 .once()
-                .returning(|_, _, _, _, _, _| {
+                .returning(|_, _, _, _, _| {
                     Err(DbOperationError::QueryFailed("syntax error".to_string()))
                 });
 
@@ -802,7 +795,6 @@ mod tests {
                         limit: 100,
                         offset: 0,
                         target_page: 0,
-                        read_only: false,
                     }],
                     &mut renderer,
                     state,

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -426,6 +426,25 @@ pub async fn run(
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::mpsc;
+
+    use crate::cmd::cache::TtlCache;
+    use crate::cmd::completion_engine::CompletionEngine;
+    use crate::cmd::effect::Effect;
+    use crate::cmd::test_fixtures;
+    use crate::domain::WriteExecutionResult;
+    use crate::model::app_state::AppState;
+    use crate::ports::outbound::connection_store::MockConnectionStore;
+    use crate::ports::outbound::metadata::MockMetadataProvider;
+    use crate::ports::outbound::query_executor::MockQueryExecutor;
+    use crate::ports::outbound::{AccessMode, RenderOutput, RenderResult, Renderer};
+    use crate::services::AppServices;
+    use crate::update::action::Action;
+
     use super::{epoch_days_to_ymd, resolve_export_path};
 
     mod export_path {
@@ -822,24 +841,7 @@ mod tests {
     }
 
     mod execute_access_mode {
-        use std::cell::RefCell;
-        use std::sync::Arc;
-        use std::time::Duration;
-
-        use tokio::sync::mpsc;
-
-        use crate::cmd::cache::TtlCache;
-        use crate::cmd::completion_engine::CompletionEngine;
-        use crate::cmd::effect::Effect;
-        use crate::cmd::test_fixtures;
-        use crate::domain::WriteExecutionResult;
-        use crate::model::app_state::AppState;
-        use crate::ports::outbound::connection_store::MockConnectionStore;
-        use crate::ports::outbound::metadata::MockMetadataProvider;
-        use crate::ports::outbound::query_executor::MockQueryExecutor;
-        use crate::ports::outbound::{AccessMode, RenderOutput, RenderResult, Renderer};
-        use crate::services::AppServices;
-        use crate::update::action::Action;
+        use super::*;
 
         struct NoopRenderer;
         impl Renderer for NoopRenderer {

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -237,10 +237,6 @@ async fn normalize_sqlite_profile(
         .expect("SQLite profile requires SQLite config")
         .path()
         .to_string();
-    validate_sqlite_database_path(validator, path.clone())
-        .await
-        .map_err(ConnectionProfileError::SqlitePath)?;
-
     let canonical_path = canonicalize_sqlite_database_path(validator, path)
         .await
         .map_err(ConnectionProfileError::SqlitePath)?;
@@ -249,6 +245,9 @@ async fn normalize_sqlite_profile(
             "SQLite database path is not valid UTF-8".to_string(),
         ))
     })?;
+    validate_sqlite_database_path(validator, canonical_path.to_string())
+        .await
+        .map_err(ConnectionProfileError::SqlitePath)?;
     let config = SqliteConnectionConfig::new(canonical_path.to_string())?;
 
     ConnectionProfile::with_id_and_config(
@@ -311,7 +310,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn sqlite_profile_is_saved_before_adapter_metadata_exists() {
+        async fn sqlite_profile_is_canonicalized_before_save() {
             let dir = tempdir().unwrap();
             let path = dir.path().join("app.db");
             fs::write(&path, b"").unwrap();

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -6,13 +6,19 @@ use tokio::sync::mpsc;
 use crate::cmd::cache::TtlCache;
 use crate::cmd::effect::Effect;
 use crate::cmd::runner::ConnectionDeps;
-use crate::cmd::sqlite_path_validate::validate_sqlite_database_path;
+use crate::cmd::sqlite_path_validate::{
+    canonicalize_sqlite_database_path, validate_sqlite_database_path,
+};
 use crate::domain::DatabaseMetadata;
+use crate::domain::SqlitePathError;
 use crate::domain::connection::{
-    ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
+    ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
+    SqliteConnectionConfig,
 };
 use crate::model::app_state::AppState;
-use crate::ports::outbound::{ConnectionStoreError, MetadataProvider, ServiceFileError};
+use crate::ports::outbound::{
+    ConnectionStoreError, MetadataProvider, ServiceFileError, SqlitePathValidator,
+};
 use crate::update::action::{Action, ConnectionTarget, ConnectionsLoadedPayload};
 
 pub(crate) async fn run(
@@ -37,30 +43,29 @@ pub(crate) async fn run(
                     return Ok(());
                 }
             };
-            let id = profile.id.clone();
-            let dsn = connection.dsn_builder.build_dsn(&profile);
-            let name = profile.name.as_str().to_string();
-            let database_type = profile.database_type();
             let store = Arc::clone(&connection.connection_store);
             let tx = action_tx.clone();
 
             if profile.database_type() == DatabaseType::SQLite {
-                let path = profile
-                    .sqlite_config()
-                    .expect("SQLite profile requires SQLite config")
-                    .path()
-                    .to_string();
-                if let Err(error) =
-                    validate_sqlite_database_path(&connection.sqlite_path_validator, path).await
+                let profile = match normalize_sqlite_profile(
+                    profile,
+                    &connection.sqlite_path_validator,
+                )
+                .await
                 {
-                    action_tx
-                        .send(Action::ConnectionSaveFailed(
-                            ConnectionProfileError::SqlitePath(error).into(),
-                        ))
-                        .await
-                        .ok();
-                    return Ok(());
-                }
+                    Ok(profile) => profile,
+                    Err(error) => {
+                        action_tx
+                            .send(Action::ConnectionSaveFailed(error.into()))
+                            .await
+                            .ok();
+                        return Ok(());
+                    }
+                };
+                let id = profile.id.clone();
+                let dsn = connection.dsn_builder.build_dsn(&profile);
+                let name = profile.name.as_str().to_string();
+                let database_type = profile.database_type();
 
                 tokio::task::spawn_blocking(move || match store.save(&profile) {
                     Ok(()) => {
@@ -79,6 +84,11 @@ pub(crate) async fn run(
                 });
                 return Ok(());
             }
+
+            let id = profile.id.clone();
+            let dsn = connection.dsn_builder.build_dsn(&profile);
+            let name = profile.name.as_str().to_string();
+            let database_type = profile.database_type();
 
             let provider = Arc::clone(metadata_provider);
             let cache = metadata_cache.clone();
@@ -218,6 +228,36 @@ pub(crate) async fn run(
     }
 }
 
+async fn normalize_sqlite_profile(
+    profile: ConnectionProfile,
+    validator: &Arc<dyn SqlitePathValidator>,
+) -> Result<ConnectionProfile, ConnectionProfileError> {
+    let path = profile
+        .sqlite_config()
+        .expect("SQLite profile requires SQLite config")
+        .path()
+        .to_string();
+    validate_sqlite_database_path(validator, path.clone())
+        .await
+        .map_err(ConnectionProfileError::SqlitePath)?;
+
+    let canonical_path = canonicalize_sqlite_database_path(validator, path)
+        .await
+        .map_err(ConnectionProfileError::SqlitePath)?;
+    let canonical_path = canonical_path.to_str().ok_or_else(|| {
+        ConnectionProfileError::SqlitePath(SqlitePathError::Io(
+            "SQLite database path is not valid UTF-8".to_string(),
+        ))
+    })?;
+    let config = SqliteConnectionConfig::new(canonical_path.to_string())?;
+
+    ConnectionProfile::with_id_and_config(
+        profile.id.clone(),
+        profile.name.as_str(),
+        ConnectionConfig::SQLite(config),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::cell::RefCell;
@@ -275,12 +315,19 @@ mod tests {
             let dir = tempdir().unwrap();
             let path = dir.path().join("app.db");
             fs::write(&path, b"").unwrap();
-            let path_str = path.to_str().unwrap().to_string();
-            let expected_dsn = format!("sqlite://{path_str}");
+            let input_path = dir.path().join("nested").join("..").join("app.db");
+            fs::create_dir(dir.path().join("nested")).unwrap();
+            let input_path = input_path.to_str().unwrap().to_string();
+            let expected_path = fs::canonicalize(&path).unwrap();
+            let expected_dsn = format!("sqlite://{}", expected_path.display());
 
             let mut mock_store = MockConnectionStore::new();
-            mock_store.expect_save().once().returning(|profile| {
+            mock_store.expect_save().once().returning(move |profile| {
                 assert_eq!(profile.database_type(), DatabaseType::SQLite);
+                assert_eq!(
+                    profile.sqlite_config().unwrap().path(),
+                    expected_path.to_str().unwrap()
+                );
                 Ok(())
             });
 
@@ -305,7 +352,7 @@ mod tests {
                         id: None,
                         name: "Local".to_string(),
                         config: ConnectionConfig::SQLite(
-                            SqliteConnectionConfig::new(path_str).unwrap(),
+                            SqliteConnectionConfig::new(input_path).unwrap(),
                         ),
                     }],
                     &mut renderer,

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -1,6 +1,6 @@
 use crate::domain::connection::{ConnectionConfig, ConnectionId};
 use crate::domain::{QueryValue, Table};
-use crate::ports::outbound::AppSettings;
+use crate::ports::outbound::{AccessMode, AppSettings};
 use crate::update::action::Action;
 
 #[derive(Debug, Clone)]
@@ -59,13 +59,12 @@ pub enum Effect {
         limit: usize,
         offset: usize,
         target_page: usize,
-        read_only: bool,
     },
     ExecuteAdhoc {
         dsn: String,
         run_id: u64,
         query: String,
-        read_only: bool,
+        access_mode: AccessMode,
     },
     ExecuteExplain {
         dsn: String,
@@ -73,13 +72,13 @@ pub enum Effect {
         query: String,
         source_query: String,
         is_analyze: bool,
-        read_only: bool,
+        access_mode: AccessMode,
     },
     ExecuteWrite {
         dsn: String,
         run_id: u64,
         query: String,
-        read_only: bool,
+        access_mode: AccessMode,
     },
     CountRowsForExport {
         dsn: String,
@@ -87,7 +86,6 @@ pub enum Effect {
         count_query: String,
         export_query: String,
         file_name: String,
-        read_only: bool,
     },
     ExportCsv {
         dsn: String,
@@ -95,7 +93,6 @@ pub enum Effect {
         query: String,
         file_name: String,
         row_count: Option<usize>,
-        read_only: bool,
     },
     ExportCsvFromCache {
         dsn: String,
@@ -156,13 +153,11 @@ pub enum Effect {
     FetchSqliteDiagnosticsCore {
         dsn: String,
         run_id: u64,
-        read_only: bool,
     },
 
     FetchSqliteDiagnosticsQuickCheck {
         dsn: String,
         run_id: u64,
-        read_only: bool,
     },
 
     // Executes effects in order (each awaits before the next),

--- a/src/app/cmd/sqlite_diagnostics.rs
+++ b/src/app/cmd/sqlite_diagnostics.rs
@@ -13,15 +13,11 @@ pub fn run(
     provider: &Arc<dyn SqliteDiagnosticsProvider>,
 ) {
     match effect {
-        Effect::FetchSqliteDiagnosticsCore {
-            dsn,
-            run_id,
-            read_only,
-        } => {
+        Effect::FetchSqliteDiagnosticsCore { dsn, run_id } => {
             let action_tx = action_tx.clone();
             let provider = Arc::clone(provider);
             tokio::spawn(async move {
-                let action = match provider.fetch_diagnostics_core(&dsn, read_only).await {
+                let action = match provider.fetch_diagnostics_core(&dsn).await {
                     Ok(snapshot) => Action::SqliteDiagnosticsCoreLoaded {
                         dsn,
                         run_id,
@@ -38,15 +34,11 @@ pub fn run(
                 let _ = action_tx.send(action).await;
             });
         }
-        Effect::FetchSqliteDiagnosticsQuickCheck {
-            dsn,
-            run_id,
-            read_only,
-        } => {
+        Effect::FetchSqliteDiagnosticsQuickCheck { dsn, run_id } => {
             let action_tx = action_tx.clone();
             let provider = Arc::clone(provider);
             tokio::spawn(async move {
-                let quick_check = provider.fetch_quick_check(&dsn, read_only).await;
+                let quick_check = provider.fetch_quick_check(&dsn).await;
                 let _ = action_tx
                     .send(Action::SqliteDiagnosticsQuickCheckLoaded {
                         dsn,
@@ -72,7 +64,7 @@ mod tests {
     async fn dispatches_core_snapshot_on_success() {
         let (tx, mut rx) = mpsc::channel(1);
         let mut provider = MockSqliteDiagnosticsProvider::new();
-        provider.expect_fetch_diagnostics_core().returning(|_, _| {
+        provider.expect_fetch_diagnostics_core().returning(|_| {
             Ok(SqliteDiagnosticsSnapshot {
                 sqlite_version: DiagnosticField::ok("3.45.0"),
                 ..Default::default()
@@ -84,7 +76,6 @@ mod tests {
             Effect::FetchSqliteDiagnosticsCore {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 run_id: 1,
-                read_only: true,
             },
             &tx,
             &provider,
@@ -106,14 +97,13 @@ mod tests {
         let mut provider = MockSqliteDiagnosticsProvider::new();
         provider
             .expect_fetch_quick_check()
-            .returning(|_, _| DiagnosticField::ok("ok"));
+            .returning(|_| DiagnosticField::ok("ok"));
 
         let provider = Arc::new(provider) as Arc<dyn SqliteDiagnosticsProvider>;
         run(
             Effect::FetchSqliteDiagnosticsQuickCheck {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 run_id: 1,
-                read_only: true,
             },
             &tx,
             &provider,
@@ -135,14 +125,13 @@ mod tests {
         let mut provider = MockSqliteDiagnosticsProvider::new();
         provider
             .expect_fetch_diagnostics_core()
-            .returning(|_, _| Err(DbOperationError::QueryFailed("boom".to_string())));
+            .returning(|_| Err(DbOperationError::QueryFailed("boom".to_string())));
 
         let provider = Arc::new(provider) as Arc<dyn SqliteDiagnosticsProvider>;
         run(
             Effect::FetchSqliteDiagnosticsCore {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 run_id: 1,
-                read_only: true,
             },
             &tx,
             &provider,

--- a/src/app/cmd/sqlite_path_validate.rs
+++ b/src/app/cmd/sqlite_path_validate.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::domain::SqlitePathError;
@@ -11,4 +12,14 @@ pub async fn validate_sqlite_database_path(
     tokio::task::spawn_blocking(move || validator.validate_database_path(&path))
         .await
         .map_err(|error| SqlitePathError::Io(format!("validation task failed: {error}")))?
+}
+
+pub async fn canonicalize_sqlite_database_path(
+    validator: &Arc<dyn SqlitePathValidator>,
+    path: String,
+) -> Result<PathBuf, SqlitePathError> {
+    let validator = Arc::clone(validator);
+    tokio::task::spawn_blocking(move || validator.canonicalize_database_path(&path))
+        .await
+        .map_err(|error| SqlitePathError::Io(format!("canonicalization task failed: {error}")))?
 }

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -179,12 +179,11 @@ impl SqliteDiagnosticsProvider for NoopSqliteDiagnosticsProvider {
     async fn fetch_diagnostics_core(
         &self,
         _dsn: &str,
-        _read_only: bool,
     ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError> {
         Ok(SqliteDiagnosticsSnapshot::default())
     }
 
-    async fn fetch_quick_check(&self, _dsn: &str, _read_only: bool) -> DiagnosticField {
+    async fn fetch_quick_check(&self, _dsn: &str) -> DiagnosticField {
         DiagnosticField::default()
     }
 }

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -1,5 +1,5 @@
 use crate::policy::password_masking::mask_password;
-use crate::ports::outbound::DbOperationError;
+use crate::ports::outbound::{DatabaseCli, DbOperationError};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ConnectionErrorKind {
@@ -151,10 +151,11 @@ impl ConnectionErrorInfo {
     pub fn from_db_operation_error(error: &DbOperationError) -> Self {
         let raw_details = error.raw_details().into_owned();
         let kind = match error {
-            DbOperationError::CommandNotFound(details) if details.starts_with("sqlite3:") => {
-                ConnectionErrorKind::SqliteCliNotFound
-            }
-            DbOperationError::CommandNotFound(_) => ConnectionErrorKind::CliNotFound,
+            DbOperationError::CommandNotFound {
+                command: DatabaseCli::Sqlite3,
+                ..
+            } => ConnectionErrorKind::SqliteCliNotFound,
+            DbOperationError::CommandNotFound { .. } => ConnectionErrorKind::CliNotFound,
             DbOperationError::ConnectionLost(_) => ConnectionErrorKind::ConnectionLost,
             DbOperationError::Timeout(_) => ConnectionErrorKind::Timeout,
             DbOperationError::UnsupportedOperation(details)
@@ -357,9 +358,10 @@ mod tests {
         #[test]
         fn from_db_operation_error_classifies_missing_sqlite_cli() {
             let info =
-                ConnectionErrorInfo::from_db_operation_error(&DbOperationError::CommandNotFound(
-                    "sqlite3: No such file or directory".to_string(),
-                ));
+                ConnectionErrorInfo::from_db_operation_error(&DbOperationError::CommandNotFound {
+                    command: DatabaseCli::Sqlite3,
+                    details: "No such file or directory".to_string(),
+                });
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteCliNotFound);
             assert_eq!(info.summary(), "sqlite3 not found");

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -4,6 +4,7 @@ use crate::ports::outbound::DbOperationError;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ConnectionErrorKind {
     CliNotFound,
+    SqliteCliNotFound,
     HostUnreachable,
     AuthFailed,
     DatabaseNotFound,
@@ -71,6 +72,7 @@ impl ConnectionErrorKind {
     pub fn summary(self) -> &'static str {
         match self {
             Self::CliNotFound => "Database CLI not found",
+            Self::SqliteCliNotFound => "sqlite3 not found",
             Self::HostUnreachable => "Could not resolve host",
             Self::AuthFailed => "Authentication failed",
             Self::DatabaseNotFound => "Database does not exist",
@@ -91,6 +93,7 @@ impl ConnectionErrorKind {
     pub fn hint(self) -> &'static str {
         match self {
             Self::CliNotFound => "Install the database CLI (e.g. psql) and add it to PATH",
+            Self::SqliteCliNotFound => "Install sqlite3 and add it to PATH",
             Self::HostUnreachable => "Check the hostname",
             Self::AuthFailed => "Check username and password",
             Self::DatabaseNotFound => "Check database name",
@@ -148,6 +151,9 @@ impl ConnectionErrorInfo {
     pub fn from_db_operation_error(error: &DbOperationError) -> Self {
         let raw_details = error.raw_details().into_owned();
         let kind = match error {
+            DbOperationError::CommandNotFound(details) if details.starts_with("sqlite3:") => {
+                ConnectionErrorKind::SqliteCliNotFound
+            }
             DbOperationError::CommandNotFound(_) => ConnectionErrorKind::CliNotFound,
             DbOperationError::ConnectionLost(_) => ConnectionErrorKind::ConnectionLost,
             DbOperationError::Timeout(_) => ConnectionErrorKind::Timeout,
@@ -278,6 +284,7 @@ mod tests {
 
         #[rstest]
         #[case(ConnectionErrorKind::CliNotFound)]
+        #[case(ConnectionErrorKind::SqliteCliNotFound)]
         #[case(ConnectionErrorKind::HostUnreachable)]
         #[case(ConnectionErrorKind::AuthFailed)]
         #[case(ConnectionErrorKind::DatabaseNotFound)]
@@ -345,6 +352,18 @@ mod tests {
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteFileNotFound);
             assert_eq!(info.summary(), "SQLite database file not found");
+        }
+
+        #[test]
+        fn from_db_operation_error_classifies_missing_sqlite_cli() {
+            let info =
+                ConnectionErrorInfo::from_db_operation_error(&DbOperationError::CommandNotFound(
+                    "sqlite3: No such file or directory".to_string(),
+                ));
+
+            assert_eq!(info.kind, ConnectionErrorKind::SqliteCliNotFound);
+            assert_eq!(info.summary(), "sqlite3 not found");
+            assert_eq!(info.hint(), "Install sqlite3 and add it to PATH");
         }
 
         #[rstest]

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -72,7 +72,7 @@ impl ConnectionErrorKind {
     pub fn summary(self) -> &'static str {
         match self {
             Self::CliNotFound => "Database CLI not found",
-            Self::SqliteCliNotFound => "sqlite3 not found",
+            Self::SqliteCliNotFound => DatabaseCli::Sqlite3.not_found_summary(),
             Self::HostUnreachable => "Could not resolve host",
             Self::AuthFailed => "Authentication failed",
             Self::DatabaseNotFound => "Database does not exist",
@@ -93,7 +93,7 @@ impl ConnectionErrorKind {
     pub fn hint(self) -> &'static str {
         match self {
             Self::CliNotFound => "Install the database CLI (e.g. psql) and add it to PATH",
-            Self::SqliteCliNotFound => "Install sqlite3 and add it to PATH",
+            Self::SqliteCliNotFound => DatabaseCli::Sqlite3.not_found_hint(),
             Self::HostUnreachable => "Check the hostname",
             Self::AuthFailed => "Check username and password",
             Self::DatabaseNotFound => "Check database name",

--- a/src/app/ports/outbound/access_mode.rs
+++ b/src/app/ports/outbound/access_mode.rs
@@ -1,0 +1,19 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessMode {
+    ReadOnly,
+    ReadWrite,
+}
+
+impl AccessMode {
+    pub fn from_read_only(read_only: bool) -> Self {
+        if read_only {
+            Self::ReadOnly
+        } else {
+            Self::ReadWrite
+        }
+    }
+
+    pub fn is_read_only(self) -> bool {
+        matches!(self, Self::ReadOnly)
+    }
+}

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -60,6 +60,9 @@ impl DbOperationError {
             Self::EmptyResponse(_) => "Database returned an empty response",
             Self::CsvParse(_) => "Failed to parse database CSV output",
             Self::CommandTagParseFailed(_) => "Failed to parse database command tag",
+            Self::CommandNotFound(details) if details.starts_with("sqlite3:") => {
+                "sqlite3 not found"
+            }
             Self::CommandNotFound(_) => "Database CLI not found",
             Self::Timeout(_) => "Operation timed out",
             Self::Canceled(_) => "Operation canceled",
@@ -88,6 +91,9 @@ impl DbOperationError {
             Self::EmptyResponse(_) => "Retry the operation and inspect the command output",
             Self::CsvParse(_) => "Check whether the adapter returned malformed CSV",
             Self::CommandTagParseFailed(_) => "Check whether the command output format changed",
+            Self::CommandNotFound(details) if details.starts_with("sqlite3:") => {
+                "Install sqlite3 and add it to PATH"
+            }
             Self::CommandNotFound(_) => "Install the database client and add it to PATH",
             Self::Timeout(_) => "Retry the operation or increase the timeout",
             Self::Canceled(_) => "Retry the operation if needed",
@@ -245,6 +251,15 @@ mod tests {
 
     mod user_messages {
         use super::*;
+
+        #[test]
+        fn sqlite_cli_not_found_has_sqlite_specific_guidance() {
+            let error =
+                DbOperationError::CommandNotFound("sqlite3: No such file or directory".to_string());
+
+            assert_eq!(error.summary(), "sqlite3 not found");
+            assert_eq!(error.hint(), "Install sqlite3 and add it to PATH");
+        }
 
         #[test]
         fn actionable_message_uses_summary_and_hint() {

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -4,6 +4,12 @@ use std::sync::Arc;
 
 use crate::policy::password_masking::mask_password;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatabaseCli {
+    Psql,
+    Sqlite3,
+}
+
 #[derive(Clone, thiserror::Error)]
 // Keep Display summary-only to avoid leaking raw command output.
 pub enum DbOperationError {
@@ -36,7 +42,10 @@ pub enum DbOperationError {
     #[error("Command tag parse failed")]
     CommandTagParseFailed(String),
     #[error("Command not found")]
-    CommandNotFound(String),
+    CommandNotFound {
+        command: DatabaseCli,
+        details: String,
+    },
     #[error("Operation timed out")]
     Timeout(String),
     #[error("Operation canceled")]
@@ -60,10 +69,11 @@ impl DbOperationError {
             Self::EmptyResponse(_) => "Database returned an empty response",
             Self::CsvParse(_) => "Failed to parse database CSV output",
             Self::CommandTagParseFailed(_) => "Failed to parse database command tag",
-            Self::CommandNotFound(details) if details.starts_with("sqlite3:") => {
-                "sqlite3 not found"
-            }
-            Self::CommandNotFound(_) => "Database CLI not found",
+            Self::CommandNotFound {
+                command: DatabaseCli::Sqlite3,
+                ..
+            } => "sqlite3 not found",
+            Self::CommandNotFound { .. } => "Database CLI not found",
             Self::Timeout(_) => "Operation timed out",
             Self::Canceled(_) => "Operation canceled",
         }
@@ -91,10 +101,11 @@ impl DbOperationError {
             Self::EmptyResponse(_) => "Retry the operation and inspect the command output",
             Self::CsvParse(_) => "Check whether the adapter returned malformed CSV",
             Self::CommandTagParseFailed(_) => "Check whether the command output format changed",
-            Self::CommandNotFound(details) if details.starts_with("sqlite3:") => {
-                "Install sqlite3 and add it to PATH"
-            }
-            Self::CommandNotFound(_) => "Install the database client and add it to PATH",
+            Self::CommandNotFound {
+                command: DatabaseCli::Sqlite3,
+                ..
+            } => "Install sqlite3 and add it to PATH",
+            Self::CommandNotFound { .. } => "Install the database client and add it to PATH",
             Self::Timeout(_) => "Retry the operation or increase the timeout",
             Self::Canceled(_) => "Retry the operation if needed",
         }
@@ -114,9 +125,9 @@ impl DbOperationError {
             | Self::MetadataParseFailed(details)
             | Self::EmptyResponse(details)
             | Self::CommandTagParseFailed(details)
-            | Self::CommandNotFound(details)
             | Self::Timeout(details)
-            | Self::Canceled(details) => Cow::Borrowed(details.as_str()),
+            | Self::Canceled(details)
+            | Self::CommandNotFound { details, .. } => Cow::Borrowed(details.as_str()),
             Self::InvalidJson(err) => Cow::Owned(err.to_string()),
             Self::CsvParse(err) => Cow::Owned(err.to_string()),
         }
@@ -206,7 +217,10 @@ mod tests {
             ))))
         )]
         #[case(DbOperationError::CommandTagParseFailed("boom".to_string()))]
-        #[case(DbOperationError::CommandNotFound("boom".to_string()))]
+        #[case(DbOperationError::CommandNotFound {
+            command: DatabaseCli::Psql,
+            details: "boom".to_string(),
+        })]
         #[case(DbOperationError::Timeout("boom".to_string()))]
         #[case(DbOperationError::Canceled("boom".to_string()))]
         fn non_empty(#[case] error: DbOperationError) {
@@ -254,8 +268,10 @@ mod tests {
 
         #[test]
         fn sqlite_cli_not_found_has_sqlite_specific_guidance() {
-            let error =
-                DbOperationError::CommandNotFound("sqlite3: No such file or directory".to_string());
+            let error = DbOperationError::CommandNotFound {
+                command: DatabaseCli::Sqlite3,
+                details: "No such file or directory".to_string(),
+            };
 
             assert_eq!(error.summary(), "sqlite3 not found");
             assert_eq!(error.hint(), "Install sqlite3 and add it to PATH");

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -10,6 +10,22 @@ pub enum DatabaseCli {
     Sqlite3,
 }
 
+impl DatabaseCli {
+    pub const fn not_found_summary(self) -> &'static str {
+        match self {
+            Self::Psql => "Database CLI not found",
+            Self::Sqlite3 => "sqlite3 not found",
+        }
+    }
+
+    pub const fn not_found_hint(self) -> &'static str {
+        match self {
+            Self::Psql => "Install the database client and add it to PATH",
+            Self::Sqlite3 => "Install sqlite3 and add it to PATH",
+        }
+    }
+}
+
 #[derive(Clone, thiserror::Error)]
 // Keep Display summary-only to avoid leaking raw command output.
 pub enum DbOperationError {
@@ -69,11 +85,7 @@ impl DbOperationError {
             Self::EmptyResponse(_) => "Database returned an empty response",
             Self::CsvParse(_) => "Failed to parse database CSV output",
             Self::CommandTagParseFailed(_) => "Failed to parse database command tag",
-            Self::CommandNotFound {
-                command: DatabaseCli::Sqlite3,
-                ..
-            } => "sqlite3 not found",
-            Self::CommandNotFound { .. } => "Database CLI not found",
+            Self::CommandNotFound { command, .. } => command.not_found_summary(),
             Self::Timeout(_) => "Operation timed out",
             Self::Canceled(_) => "Operation canceled",
         }
@@ -101,11 +113,7 @@ impl DbOperationError {
             Self::EmptyResponse(_) => "Retry the operation and inspect the command output",
             Self::CsvParse(_) => "Check whether the adapter returned malformed CSV",
             Self::CommandTagParseFailed(_) => "Check whether the command output format changed",
-            Self::CommandNotFound {
-                command: DatabaseCli::Sqlite3,
-                ..
-            } => "Install sqlite3 and add it to PATH",
-            Self::CommandNotFound { .. } => "Install the database client and add it to PATH",
+            Self::CommandNotFound { command, .. } => command.not_found_hint(),
             Self::Timeout(_) => "Retry the operation or increase the timeout",
             Self::Canceled(_) => "Retry the operation if needed",
         }

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -3,6 +3,7 @@
 //! Error variants may preserve `Error::source()` chains, but method signatures
 //! stay free of adapter-specific types.
 
+pub mod access_mode;
 pub mod cached_result_exporter;
 pub mod clipboard;
 pub mod config_writer;
@@ -23,11 +24,12 @@ pub mod sql_dialect;
 pub mod sqlite_diagnostics;
 pub mod sqlite_path_validator;
 
+pub use access_mode::AccessMode;
 pub use cached_result_exporter::CachedResultExporter;
 pub use clipboard::{ClipboardError, ClipboardWriter};
 pub use config_writer::{ConfigWriter, ConfigWriterError};
 pub use connection_store::{ConnectionStore, ConnectionStoreError};
-pub use db_operation_error::DbOperationError;
+pub use db_operation_error::{DatabaseCli, DbOperationError};
 pub use ddl_generator::DdlGenerator;
 pub use dsn_builder::DsnBuilder;
 pub use er_exporter::{ErDiagramExporter, ErExportError, ErExportResult};

--- a/src/app/ports/outbound/query_executor.rs
+++ b/src/app/ports/outbound/query_executor.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::domain::{QueryResult, WriteExecutionResult};
 
-use super::DbOperationError;
+use super::{AccessMode, DbOperationError};
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
@@ -14,32 +14,25 @@ pub trait QueryExecutor: Send + Sync {
         table: &str,
         limit: usize,
         offset: usize,
-        read_only: bool,
     ) -> Result<QueryResult, DbOperationError>;
 
     async fn execute_adhoc(
         &self,
         dsn: &str,
         query: &str,
-        read_only: bool,
+        access_mode: AccessMode,
     ) -> Result<QueryResult, DbOperationError>;
     async fn execute_write(
         &self,
         dsn: &str,
         query: &str,
-        read_only: bool,
+        access_mode: AccessMode,
     ) -> Result<WriteExecutionResult, DbOperationError>;
-    async fn count_query_rows(
-        &self,
-        dsn: &str,
-        query: &str,
-        read_only: bool,
-    ) -> Result<usize, DbOperationError>;
+    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError>;
     async fn export_to_csv(
         &self,
         dsn: &str,
         query: &str,
         path: &std::path::Path,
-        read_only: bool,
     ) -> Result<usize, DbOperationError>;
 }

--- a/src/app/ports/outbound/sqlite_diagnostics.rs
+++ b/src/app/ports/outbound/sqlite_diagnostics.rs
@@ -10,8 +10,7 @@ pub trait SqliteDiagnosticsProvider: Send + Sync {
     async fn fetch_diagnostics_core(
         &self,
         dsn: &str,
-        read_only: bool,
     ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError>;
 
-    async fn fetch_quick_check(&self, dsn: &str, read_only: bool) -> DiagnosticField;
+    async fn fetch_quick_check(&self, dsn: &str) -> DiagnosticField;
 }

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -8,6 +8,7 @@ use crate::model::browse::query_execution::{PREVIEW_PAGE_SIZE, PostDeleteRowSele
 use crate::model::shared::help::HelpOrigin;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::AdhocSuccessSnapshot;
+use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::{Action, ModalKind, TableTarget};
 use crate::update::browse::query::preview_effect_for_current_table;
@@ -271,7 +272,7 @@ pub fn reduce_execution(
                     dsn,
                     run_id,
                     query: query.clone(),
-                    read_only: state.session.is_read_only(),
+                    access_mode: AccessMode::from_read_only(state.session.is_read_only()),
                 }])
             } else {
                 DispatchResult::handled()

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -47,7 +47,6 @@ pub(super) fn preview_effect_for_current_table(
         limit: PREVIEW_PAGE_SIZE,
         offset: target_page * PREVIEW_PAGE_SIZE,
         target_page,
-        read_only: state.session.is_read_only(),
     })
 }
 

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -74,7 +74,6 @@ fn dispatch_cached_csv_export(
 }
 
 fn dispatch_rerunnable_csv_export(
-    state: &AppState,
     dsn: String,
     run_id: u64,
     export_query: String,
@@ -88,7 +87,6 @@ fn dispatch_rerunnable_csv_export(
         count_query,
         export_query,
         file_name,
-        read_only: state.session.is_read_only(),
     }])
 }
 
@@ -122,9 +120,7 @@ pub fn reduce_pagination(
                     }
                     SqliteExportPlan::RerunnableQuery { query } => {
                         let run_id = state.query.begin_running(now);
-                        return dispatch_rerunnable_csv_export(
-                            state, dsn, run_id, query, file_name,
-                        );
+                        return dispatch_rerunnable_csv_export(dsn, run_id, query, file_name);
                     }
                     SqliteExportPlan::CachedResult { row_count } => {
                         let columns = result.columns.clone();
@@ -144,7 +140,7 @@ pub fn reduce_pagination(
             }
 
             let run_id = state.query.begin_running(now);
-            dispatch_rerunnable_csv_export(state, dsn, run_id, export_query, file_name)
+            dispatch_rerunnable_csv_export(dsn, run_id, export_query, file_name)
         }
 
         Action::CsvExportRowsCounted {
@@ -188,7 +184,6 @@ pub fn reduce_pagination(
                     query: export_query.clone(),
                     file_name: file_name.clone(),
                     row_count: *row_count,
-                    read_only: state.session.is_read_only(),
                 }])
             }
         }
@@ -210,7 +205,6 @@ pub fn reduce_pagination(
                 query: export_query.clone(),
                 file_name: file_name.clone(),
                 row_count: *row_count,
-                read_only: state.session.is_read_only(),
             }])
         }
 

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -14,6 +14,7 @@ use crate::policy::write::write_guardrails::{
     ColumnDiff, RiskLevel, TargetSummary, WriteOperation, WritePreview, evaluate_guardrails,
 };
 use crate::policy::write::write_update::escape_preview_value;
+use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::browse::query::preview_effect_for_current_table;
@@ -280,7 +281,7 @@ pub fn reduce_write(
                     dsn,
                     run_id,
                     query: query.clone(),
-                    read_only: state.session.is_read_only(),
+                    access_mode: AccessMode::from_read_only(state.session.is_read_only()),
                 }])
             } else {
                 state

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -167,6 +167,9 @@ pub fn reduce_connection_setup(
             DispatchResult::handled()
         }
         Action::ConnectionSetupSave => {
+            if state.session.connection_state().is_connecting() {
+                return DispatchResult::handled();
+            }
             state.connection_setup.confirm_dropdown();
             validate_all(&mut state.connection_setup);
             if state.connection_setup.has_validation_errors() {
@@ -543,6 +546,18 @@ mod tests {
                 effects.as_slice(),
                 [Effect::SaveAndConnect { .. }]
             ));
+        }
+
+        #[test]
+        fn repeated_save_while_connecting_does_not_emit_duplicate_effect() {
+            let mut state = AppState::new("test".to_string());
+            fill_valid_form(&mut state);
+
+            reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
+            let effects = reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
+
+            assert!(effects.is_some_and(|effects| effects.is_empty()));
+            assert!(state.session.connection_state().is_connecting());
         }
 
         #[test]

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -553,7 +553,12 @@ mod tests {
             let mut state = AppState::new("test".to_string());
             fill_valid_form(&mut state);
 
-            reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
+            let first_effects = reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
+            assert!(first_effects.is_some_and(|effects| matches!(
+                effects.as_slice(),
+                [Effect::SaveAndConnect { .. }]
+            )));
+
             let effects = reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
 
             assert!(effects.is_some_and(|effects| effects.is_empty()));

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -6,6 +6,7 @@ use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
 use crate::policy::sql::statement_classifier;
 use crate::policy::write::sql_risk::{ConfirmationType, evaluate_sql_risk_for_database};
+use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
@@ -83,7 +84,7 @@ pub(super) fn reduce_analyze(
                         query: explain_query,
                         source_query: content,
                         is_analyze: true,
-                        read_only: state.session.is_read_only(),
+                        access_mode: AccessMode::from_read_only(state.session.is_read_only()),
                     }]);
                 }
             }
@@ -122,7 +123,7 @@ pub(super) fn reduce_analyze(
                     query: explain_query,
                     source_query: query,
                     is_analyze: true,
-                    read_only: state.session.is_read_only(),
+                    access_mode: AccessMode::from_read_only(state.session.is_read_only()),
                 }]);
             }
             DispatchResult::handled()

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -36,6 +36,7 @@ mod tests {
     use crate::cmd::effect::Effect;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
+    use crate::ports::outbound::AccessMode;
     use crate::services::AppServices;
     use crate::update::action::{ScrollAmount, ScrollDirection, ScrollTarget};
     use crate::update::test_fixtures;
@@ -138,7 +139,7 @@ mod tests {
                 Effect::ExecuteExplain {
                     query,
                     is_analyze: false,
-                    read_only: true,
+                    access_mode: AccessMode::ReadOnly,
                     ..
                 } if query == "EXPLAIN QUERY PLAN SELECT 1"
             ));
@@ -168,7 +169,7 @@ mod tests {
                 Effect::ExecuteExplain {
                     query,
                     is_analyze: false,
-                    read_only: true,
+                    access_mode: AccessMode::ReadOnly,
                     ..
                 } if query == "EXPLAIN QUERY PLAN DELETE FROM users"
             ));
@@ -312,7 +313,7 @@ mod tests {
                 Effect::ExecuteExplain {
                     query,
                     is_analyze: false,
-                    read_only: true,
+                    access_mode: AccessMode::ReadOnly,
                     ..
                 } if query == "EXPLAIN SELECT 1"
             ));

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -4,6 +4,7 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
+use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
@@ -62,7 +63,7 @@ pub(super) fn reduce_request(
                 query,
                 source_query: content,
                 is_analyze: false,
-                read_only: true,
+                access_mode: AccessMode::ReadOnly,
             }])
         }
         _ => DispatchResult::pass(),

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -4,6 +4,7 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::input_mode::InputMode;
+use crate::ports::outbound::AccessMode;
 use crate::update::action::{Action, ScrollAmount, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
 
@@ -53,7 +54,7 @@ pub(super) fn reduce_confirm_dialog(
                             dsn,
                             run_id,
                             query: sql,
-                            read_only: state.session.is_read_only(),
+                            access_mode: AccessMode::from_read_only(state.session.is_read_only()),
                         }])
                     } else {
                         state.result_interaction.clear_write_preview();
@@ -84,7 +85,6 @@ pub(super) fn reduce_confirm_dialog(
                             query: export_query,
                             file_name,
                             row_count,
-                            read_only: state.session.is_read_only(),
                         }])
                     } else {
                         DispatchResult::handled()

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -25,11 +25,7 @@ pub(super) fn reduce_sqlite_diagnostics(
             };
             let run_id = state.sqlite_diagnostics.begin_fetch();
             state.modal.set_mode(InputMode::SqliteDiagnostics);
-            DispatchResult::handled_with(vec![Effect::FetchSqliteDiagnosticsCore {
-                dsn,
-                run_id,
-                read_only: true,
-            }])
+            DispatchResult::handled_with(vec![Effect::FetchSqliteDiagnosticsCore { dsn, run_id }])
         }
         Action::RunSqliteDiagnosticsQuickCheck => {
             let Some(dsn) = state.session.dsn().map(String::from) else {
@@ -41,7 +37,6 @@ pub(super) fn reduce_sqlite_diagnostics(
             DispatchResult::handled_with(vec![Effect::FetchSqliteDiagnosticsQuickCheck {
                 dsn,
                 run_id,
-                read_only: true,
             }])
         }
         Action::CloseModal(ModalKind::SqliteDiagnostics) => {
@@ -120,10 +115,7 @@ mod tests {
         assert_eq!(effects.len(), 1);
         assert!(matches!(
             effects[0],
-            Effect::FetchSqliteDiagnosticsCore {
-                read_only: true,
-                ..
-            }
+            Effect::FetchSqliteDiagnosticsCore { .. }
         ));
     }
 
@@ -150,10 +142,7 @@ mod tests {
         assert!(state.sqlite_diagnostics.is_quick_check_running());
         assert!(matches!(
             effects.as_slice(),
-            [Effect::FetchSqliteDiagnosticsQuickCheck {
-                read_only: true,
-                ..
-            }]
+            [Effect::FetchSqliteDiagnosticsQuickCheck { .. }]
         ));
     }
 

--- a/src/app/update/sql_editor/helpers.rs
+++ b/src/app/update/sql_editor/helpers.rs
@@ -2,6 +2,7 @@ use std::time::Instant;
 
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
+use crate::ports::outbound::AccessMode;
 use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn start_adhoc_if_connected(
@@ -22,6 +23,6 @@ pub(super) fn start_adhoc_if_connected(
         dsn,
         run_id,
         query,
-        read_only: state.session.is_read_only(),
+        access_mode: AccessMode::from_read_only(state.session.is_read_only()),
     }])
 }

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 
 use crate::app::ports::outbound::{
-    DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor, SqlDialect,
+    AccessMode, DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor,
+    SqlDialect,
 };
 use crate::domain::connection::{ConnectionProfile, DatabaseType};
 use crate::domain::{
@@ -71,7 +72,6 @@ impl QueryExecutor for MySqlAdapter {
         _table: &str,
         _limit: usize,
         _offset: usize,
-        _read_only: bool,
     ) -> Result<QueryResult, DbOperationError> {
         Err(DbOperationError::ConnectionFailed(
             "MySQL adapter not yet implemented".to_string(),
@@ -82,7 +82,7 @@ impl QueryExecutor for MySqlAdapter {
         &self,
         _dsn: &str,
         _query: &str,
-        _read_only: bool,
+        _access_mode: AccessMode,
     ) -> Result<QueryResult, DbOperationError> {
         Err(DbOperationError::ConnectionFailed(
             "MySQL adapter not yet implemented".to_string(),
@@ -93,19 +93,14 @@ impl QueryExecutor for MySqlAdapter {
         &self,
         _dsn: &str,
         _query: &str,
-        _read_only: bool,
+        _access_mode: AccessMode,
     ) -> Result<WriteExecutionResult, DbOperationError> {
         Err(DbOperationError::ConnectionFailed(
             "MySQL adapter not yet implemented".to_string(),
         ))
     }
 
-    async fn count_query_rows(
-        &self,
-        _dsn: &str,
-        _query: &str,
-        _read_only: bool,
-    ) -> Result<usize, DbOperationError> {
+    async fn count_query_rows(&self, _dsn: &str, _query: &str) -> Result<usize, DbOperationError> {
         Err(DbOperationError::ConnectionFailed(
             "MySQL adapter not yet implemented".to_string(),
         ))
@@ -116,7 +111,6 @@ impl QueryExecutor for MySqlAdapter {
         _dsn: &str,
         _query: &str,
         _path: &std::path::Path,
-        _read_only: bool,
     ) -> Result<usize, DbOperationError> {
         Err(DbOperationError::ConnectionFailed(
             "MySQL adapter not yet implemented".to_string(),

--- a/src/infra/adapters/postgres/executor.rs
+++ b/src/infra/adapters/postgres/executor.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-use crate::app::ports::outbound::{DbOperationError, QueryExecutor};
+use crate::app::ports::outbound::{AccessMode, DbOperationError, QueryExecutor};
 use crate::domain::{QueryResult, QuerySource, WriteExecutionResult};
 
 use super::PostgresAdapter;
@@ -14,7 +14,6 @@ impl QueryExecutor for PostgresAdapter {
         table: &str,
         limit: usize,
         offset: usize,
-        read_only: bool,
     ) -> Result<QueryResult, DbOperationError> {
         // Editing a cell re-fetches the same page; stable ordering prevents the
         // edited row from shifting position after the refresh.
@@ -24,7 +23,7 @@ impl QueryExecutor for PostgresAdapter {
             .await
             .unwrap_or_default();
         let query = Self::build_preview_query(schema, table, &order_columns, limit, offset);
-        self.execute_query_raw(dsn, &query, QuerySource::Preview, read_only)
+        self.execute_query_raw(dsn, &query, QuerySource::Preview, true)
             .await
     }
 
@@ -32,9 +31,9 @@ impl QueryExecutor for PostgresAdapter {
         &self,
         dsn: &str,
         query: &str,
-        read_only: bool,
+        access_mode: AccessMode,
     ) -> Result<QueryResult, DbOperationError> {
-        self.execute_query_raw(dsn, query, QuerySource::Adhoc, read_only)
+        self.execute_query_raw(dsn, query, QuerySource::Adhoc, access_mode.is_read_only())
             .await
     }
 
@@ -42,18 +41,14 @@ impl QueryExecutor for PostgresAdapter {
         &self,
         dsn: &str,
         query: &str,
-        read_only: bool,
+        access_mode: AccessMode,
     ) -> Result<WriteExecutionResult, DbOperationError> {
-        self.execute_write_raw(dsn, query, read_only).await
+        self.execute_write_raw(dsn, query, access_mode.is_read_only())
+            .await
     }
 
-    async fn count_query_rows(
-        &self,
-        dsn: &str,
-        query: &str,
-        read_only: bool,
-    ) -> Result<usize, DbOperationError> {
-        self.count_rows(dsn, query, read_only).await
+    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
+        self.count_rows(dsn, query, true).await
     }
 
     async fn export_to_csv(
@@ -61,8 +56,7 @@ impl QueryExecutor for PostgresAdapter {
         dsn: &str,
         query: &str,
         path: &std::path::Path,
-        read_only: bool,
     ) -> Result<usize, DbOperationError> {
-        self.export_csv_to_file(dsn, query, path, read_only).await
+        self.export_csv_to_file(dsn, query, path, true).await
     }
 }

--- a/src/infra/adapters/postgres/psql/error.rs
+++ b/src/infra/adapters/postgres/psql/error.rs
@@ -1,4 +1,17 @@
-use crate::app::ports::outbound::DbOperationError;
+use crate::app::ports::outbound::{DatabaseCli, DbOperationError};
+
+pub(in crate::adapters::postgres) fn classify_cli_spawn_error(
+    error: std::io::Error,
+) -> DbOperationError {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        DbOperationError::CommandNotFound {
+            command: DatabaseCli::Psql,
+            details: error.to_string(),
+        }
+    } else {
+        DbOperationError::QueryFailed(error.to_string())
+    }
+}
 
 pub(in crate::adapters::postgres) fn classify_query_error(stderr: &str) -> DbOperationError {
     let trimmed = stderr.trim();

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -5,7 +5,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::time::timeout;
 
-use crate::app::ports::outbound::DbOperationError;
+use crate::app::ports::outbound::{DatabaseCli, DbOperationError};
 use crate::domain::{CommandTag, QueryResult, QuerySource, WriteExecutionResult};
 
 use super::super::PostgresAdapter;
@@ -141,7 +141,10 @@ impl PostgresAdapter {
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|e| DbOperationError::CommandNotFound(e.to_string()))?;
+            .map_err(|e| DbOperationError::CommandNotFound {
+                command: DatabaseCli::Psql,
+                details: e.to_string(),
+            })?;
 
         let mut stdout_handle = child.stdout.take();
         let mut stderr_handle = child.stderr.take();
@@ -416,7 +419,10 @@ impl PostgresAdapter {
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|e| DbOperationError::CommandNotFound(e.to_string()))?;
+            .map_err(|e| DbOperationError::CommandNotFound {
+                command: DatabaseCli::Psql,
+                details: e.to_string(),
+            })?;
 
         let stdout = child.stdout.take();
         let mut stderr_handle = child.stderr.take();

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -5,11 +5,11 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use tokio::time::timeout;
 
-use crate::app::ports::outbound::{DatabaseCli, DbOperationError};
+use crate::app::ports::outbound::DbOperationError;
 use crate::domain::{CommandTag, QueryResult, QuerySource, WriteExecutionResult};
 
 use super::super::PostgresAdapter;
-use super::error::classify_query_error;
+use super::error::{classify_cli_spawn_error, classify_query_error};
 use super::parser::{ParseCommandTagError, split_sql_statements};
 
 // Keep user SQL server-side: stdin scripts would let psql interpret
@@ -141,10 +141,7 @@ impl PostgresAdapter {
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|e| DbOperationError::CommandNotFound {
-                command: DatabaseCli::Psql,
-                details: e.to_string(),
-            })?;
+            .map_err(classify_cli_spawn_error)?;
 
         let mut stdout_handle = child.stdout.take();
         let mut stderr_handle = child.stderr.take();
@@ -419,10 +416,7 @@ impl PostgresAdapter {
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|e| DbOperationError::CommandNotFound {
-                command: DatabaseCli::Psql,
-                details: e.to_string(),
-            })?;
+            .map_err(classify_cli_spawn_error)?;
 
         let stdout = child.stdout.take();
         let mut stderr_handle = child.stderr.take();

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::app::ports::outbound::{
-    DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor, SqlDialect,
-    SqliteDiagnosticsProvider,
+    AccessMode, DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor,
+    SqlDialect, SqliteDiagnosticsProvider,
 };
 use crate::domain::connection::{ConnectionProfile, DatabaseType};
 use crate::domain::{
@@ -127,18 +127,23 @@ impl QueryExecutor for DbAdapterRegistry {
         table: &str,
         limit: usize,
         offset: usize,
-        read_only: bool,
     ) -> Result<QueryResult, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => {
                 self.postgres
-                    .execute_preview(dsn, schema, table, limit, offset, read_only)
+                    .execute_preview(dsn, schema, table, limit, offset)
                     .await
             }
             DatabaseType::SQLite => {
-                self.sqlite
-                    .execute_preview(dsn, schema, table, limit, offset, read_only)
-                    .await
+                QueryExecutor::execute_preview(
+                    self.sqlite.as_ref(),
+                    dsn,
+                    schema,
+                    table,
+                    limit,
+                    offset,
+                )
+                .await
             }
         }
     }
@@ -147,11 +152,13 @@ impl QueryExecutor for DbAdapterRegistry {
         &self,
         dsn: &str,
         query: &str,
-        read_only: bool,
+        access_mode: AccessMode,
     ) -> Result<QueryResult, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
-            DatabaseType::PostgreSQL => self.postgres.execute_adhoc(dsn, query, read_only).await,
-            DatabaseType::SQLite => self.sqlite.execute_adhoc(dsn, query, read_only).await,
+            DatabaseType::PostgreSQL => self.postgres.execute_adhoc(dsn, query, access_mode).await,
+            DatabaseType::SQLite => {
+                QueryExecutor::execute_adhoc(self.sqlite.as_ref(), dsn, query, access_mode).await
+            }
         }
     }
 
@@ -159,23 +166,22 @@ impl QueryExecutor for DbAdapterRegistry {
         &self,
         dsn: &str,
         query: &str,
-        read_only: bool,
+        access_mode: AccessMode,
     ) -> Result<WriteExecutionResult, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
-            DatabaseType::PostgreSQL => self.postgres.execute_write(dsn, query, read_only).await,
-            DatabaseType::SQLite => self.sqlite.execute_write(dsn, query, read_only).await,
+            DatabaseType::PostgreSQL => self.postgres.execute_write(dsn, query, access_mode).await,
+            DatabaseType::SQLite => {
+                QueryExecutor::execute_write(self.sqlite.as_ref(), dsn, query, access_mode).await
+            }
         }
     }
 
-    async fn count_query_rows(
-        &self,
-        dsn: &str,
-        query: &str,
-        read_only: bool,
-    ) -> Result<usize, DbOperationError> {
+    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
-            DatabaseType::PostgreSQL => self.postgres.count_query_rows(dsn, query, read_only).await,
-            DatabaseType::SQLite => self.sqlite.count_query_rows(dsn, query, read_only).await,
+            DatabaseType::PostgreSQL => self.postgres.count_query_rows(dsn, query).await,
+            DatabaseType::SQLite => {
+                QueryExecutor::count_query_rows(self.sqlite.as_ref(), dsn, query).await
+            }
         }
     }
 
@@ -184,15 +190,12 @@ impl QueryExecutor for DbAdapterRegistry {
         dsn: &str,
         query: &str,
         path: &Path,
-        read_only: bool,
     ) -> Result<usize, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
-            DatabaseType::PostgreSQL => {
-                self.postgres
-                    .export_to_csv(dsn, query, path, read_only)
-                    .await
+            DatabaseType::PostgreSQL => self.postgres.export_to_csv(dsn, query, path).await,
+            DatabaseType::SQLite => {
+                QueryExecutor::export_to_csv(self.sqlite.as_ref(), dsn, query, path).await
             }
-            DatabaseType::SQLite => self.sqlite.export_to_csv(dsn, query, path, read_only).await,
         }
     }
 }
@@ -471,7 +474,7 @@ mod tests {
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
 
         let result = registry
-            .execute_adhoc(&dsn, "SELECT 1 AS value", true)
+            .execute_adhoc(&dsn, "SELECT 1 AS value", AccessMode::ReadOnly)
             .await
             .unwrap();
 
@@ -501,19 +504,18 @@ impl SqliteDiagnosticsProvider for DbAdapterRegistry {
     async fn fetch_diagnostics_core(
         &self,
         dsn: &str,
-        read_only: bool,
     ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
             DatabaseType::PostgreSQL => Err(DbOperationError::ConnectionFailed(
                 "SQLite diagnostics are unavailable for non-SQLite connections".to_string(),
             )),
-            DatabaseType::SQLite => self.sqlite.fetch_diagnostics_core(dsn, read_only).await,
+            DatabaseType::SQLite => self.sqlite.fetch_diagnostics_core(dsn).await,
         }
     }
 
-    async fn fetch_quick_check(&self, dsn: &str, read_only: bool) -> DiagnosticField {
+    async fn fetch_quick_check(&self, dsn: &str) -> DiagnosticField {
         match Self::db_type_from_dsn(dsn) {
-            Ok(DatabaseType::SQLite) => self.sqlite.fetch_quick_check(dsn, read_only).await,
+            Ok(DatabaseType::SQLite) => self.sqlite.fetch_quick_check(dsn).await,
             Ok(DatabaseType::PostgreSQL) | Err(_) => DiagnosticField::err(
                 "SQLite diagnostics are unavailable for non-SQLite connections",
             ),
@@ -530,7 +532,7 @@ mod sqlite_diagnostics_registry {
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
 
         let result = registry
-            .fetch_diagnostics_core("postgres://localhost/db", true)
+            .fetch_diagnostics_core("postgres://localhost/db")
             .await;
 
         assert!(matches!(result, Err(DbOperationError::ConnectionFailed(_))));

--- a/src/infra/adapters/sqlite/diagnostics.rs
+++ b/src/infra/adapters/sqlite/diagnostics.rs
@@ -10,35 +10,18 @@ impl SqliteDiagnosticsProvider for SqliteAdapter {
     async fn fetch_diagnostics_core(
         &self,
         dsn: &str,
-        read_only: bool,
+        _read_only: bool,
     ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError> {
         let db_file = DiagnosticField::ok(Self::path_from_dsn(dsn)?);
 
-        let sqlite_version = fetch_field(
-            self,
-            dsn,
-            read_only,
-            "SELECT sqlite_version();",
-            scalar_field,
-        )
-        .await;
-        let feature_summary = fetch_feature_summary(self, dsn, read_only).await;
-        let foreign_keys =
-            fetch_field(self, dsn, read_only, "PRAGMA foreign_keys;", on_off_field).await;
-        let journal_mode =
-            fetch_field(self, dsn, read_only, "PRAGMA journal_mode;", scalar_field).await;
-        let query_only =
-            fetch_field(self, dsn, read_only, "PRAGMA query_only;", on_off_field).await;
-        let busy_timeout =
-            fetch_field(self, dsn, read_only, "PRAGMA busy_timeout;", scalar_field).await;
-        let database_list = fetch_field(
-            self,
-            dsn,
-            read_only,
-            "PRAGMA database_list;",
-            database_list_field,
-        )
-        .await;
+        let sqlite_version = fetch_field(self, dsn, "SELECT sqlite_version();", scalar_field).await;
+        let feature_summary = fetch_feature_summary(self, dsn).await;
+        let foreign_keys = fetch_field(self, dsn, "PRAGMA foreign_keys;", on_off_field).await;
+        let journal_mode = fetch_field(self, dsn, "PRAGMA journal_mode;", scalar_field).await;
+        let query_only = fetch_field(self, dsn, "PRAGMA query_only;", on_off_field).await;
+        let busy_timeout = fetch_field(self, dsn, "PRAGMA busy_timeout;", scalar_field).await;
+        let database_list =
+            fetch_field(self, dsn, "PRAGMA database_list;", database_list_field).await;
 
         Ok(SqliteDiagnosticsSnapshot {
             db_file,
@@ -53,46 +36,34 @@ impl SqliteDiagnosticsProvider for SqliteAdapter {
         })
     }
 
-    async fn fetch_quick_check(&self, dsn: &str, read_only: bool) -> DiagnosticField {
-        fetch_field(
-            self,
-            dsn,
-            read_only,
-            "PRAGMA quick_check;",
-            quick_check_field,
-        )
-        .await
+    async fn fetch_quick_check(&self, dsn: &str, _read_only: bool) -> DiagnosticField {
+        fetch_field(self, dsn, "PRAGMA quick_check;", quick_check_field).await
     }
 }
 
 async fn fetch_field(
     adapter: &SqliteAdapter,
     dsn: &str,
-    read_only: bool,
     query: &str,
     map: fn(Result<QueryResult, DbOperationError>) -> DiagnosticField,
 ) -> DiagnosticField {
-    map(adapter.execute_adhoc(dsn, query, read_only).await)
+    map(adapter.execute_adhoc(dsn, query, true).await)
 }
 
-async fn fetch_feature_summary(
-    adapter: &SqliteAdapter,
-    dsn: &str,
-    read_only: bool,
-) -> DiagnosticField {
+async fn fetch_feature_summary(adapter: &SqliteAdapter, dsn: &str) -> DiagnosticField {
     let compile_options = feature_probe(
         adapter
-            .execute_adhoc(dsn, "PRAGMA compile_options;", read_only)
+            .execute_adhoc(dsn, "PRAGMA compile_options;", true)
             .await,
     );
     let module_list = feature_probe(
         adapter
-            .execute_adhoc(dsn, "PRAGMA module_list;", read_only)
+            .execute_adhoc(dsn, "PRAGMA module_list;", true)
             .await,
     );
     let function_list = feature_probe(
         adapter
-            .execute_adhoc(dsn, "PRAGMA function_list;", read_only)
+            .execute_adhoc(dsn, "PRAGMA function_list;", true)
             .await,
     );
 
@@ -313,7 +284,7 @@ mod tests {
         );
         let adapter = SqliteAdapter::new();
 
-        let snapshot = adapter.fetch_diagnostics_core(&dsn, true).await.unwrap();
+        let snapshot = adapter.fetch_diagnostics_core(&dsn, false).await.unwrap();
 
         assert!(snapshot.db_file.is_ok());
         assert!(snapshot.sqlite_version.is_ok());
@@ -321,6 +292,7 @@ mod tests {
         assert!(snapshot.foreign_keys.is_ok());
         assert!(snapshot.journal_mode.is_ok());
         assert!(snapshot.query_only.is_ok());
+        assert_eq!(snapshot.query_only.ok_value(), Some("on"));
         assert!(snapshot.busy_timeout.is_ok());
         assert!(snapshot.database_list.is_ok());
         assert!(matches!(snapshot.quick_check, DiagnosticField::Pending));

--- a/src/infra/adapters/sqlite/diagnostics.rs
+++ b/src/infra/adapters/sqlite/diagnostics.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 
-use crate::app::ports::outbound::{DbOperationError, QueryExecutor, SqliteDiagnosticsProvider};
+use crate::app::ports::outbound::{
+    AccessMode, DbOperationError, QueryExecutor, SqliteDiagnosticsProvider,
+};
 use crate::domain::{DiagnosticField, QueryResult, SqliteDiagnosticsSnapshot};
 
 use super::SqliteAdapter;
@@ -10,7 +12,6 @@ impl SqliteDiagnosticsProvider for SqliteAdapter {
     async fn fetch_diagnostics_core(
         &self,
         dsn: &str,
-        _read_only: bool,
     ) -> Result<SqliteDiagnosticsSnapshot, DbOperationError> {
         let db_file = DiagnosticField::ok(Self::path_from_dsn(dsn)?);
 
@@ -36,7 +37,7 @@ impl SqliteDiagnosticsProvider for SqliteAdapter {
         })
     }
 
-    async fn fetch_quick_check(&self, dsn: &str, _read_only: bool) -> DiagnosticField {
+    async fn fetch_quick_check(&self, dsn: &str) -> DiagnosticField {
         fetch_field(self, dsn, "PRAGMA quick_check;", quick_check_field).await
     }
 }
@@ -47,23 +48,25 @@ async fn fetch_field(
     query: &str,
     map: fn(Result<QueryResult, DbOperationError>) -> DiagnosticField,
 ) -> DiagnosticField {
-    map(adapter.execute_adhoc(dsn, query, true).await)
+    map(QueryExecutor::execute_adhoc(adapter, dsn, query, AccessMode::ReadOnly).await)
 }
 
 async fn fetch_feature_summary(adapter: &SqliteAdapter, dsn: &str) -> DiagnosticField {
     let compile_options = feature_probe(
-        adapter
-            .execute_adhoc(dsn, "PRAGMA compile_options;", true)
-            .await,
+        QueryExecutor::execute_adhoc(
+            adapter,
+            dsn,
+            "PRAGMA compile_options;",
+            AccessMode::ReadOnly,
+        )
+        .await,
     );
     let module_list = feature_probe(
-        adapter
-            .execute_adhoc(dsn, "PRAGMA module_list;", true)
+        QueryExecutor::execute_adhoc(adapter, dsn, "PRAGMA module_list;", AccessMode::ReadOnly)
             .await,
     );
     let function_list = feature_probe(
-        adapter
-            .execute_adhoc(dsn, "PRAGMA function_list;", true)
+        QueryExecutor::execute_adhoc(adapter, dsn, "PRAGMA function_list;", AccessMode::ReadOnly)
             .await,
     );
 
@@ -284,7 +287,7 @@ mod tests {
         );
         let adapter = SqliteAdapter::new();
 
-        let snapshot = adapter.fetch_diagnostics_core(&dsn, false).await.unwrap();
+        let snapshot = adapter.fetch_diagnostics_core(&dsn).await.unwrap();
 
         assert!(snapshot.db_file.is_ok());
         assert!(snapshot.sqlite_version.is_ok());
@@ -305,7 +308,7 @@ mod tests {
         );
         let adapter = SqliteAdapter::new();
 
-        let quick_check = adapter.fetch_quick_check(&dsn, true).await;
+        let quick_check = adapter.fetch_quick_check(&dsn).await;
 
         assert!(quick_check.is_ok());
         assert!(

--- a/src/infra/adapters/sqlite/path_validation.rs
+++ b/src/infra/adapters/sqlite/path_validation.rs
@@ -22,7 +22,7 @@ impl SqlitePathValidator for FsSqlitePathValidator {
     }
 }
 
-fn validate_sqlite_database_path(path: &Path) -> Result<(), SqlitePathError> {
+pub(super) fn validate_sqlite_database_path(path: &Path) -> Result<(), SqlitePathError> {
     let display = path.display().to_string();
     let metadata = match std::fs::metadata(path) {
         Ok(metadata) => metadata,

--- a/src/infra/adapters/sqlite/sqlite3/error.rs
+++ b/src/infra/adapters/sqlite/sqlite3/error.rs
@@ -190,4 +190,17 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn non_missing_sqlite_cli_error_is_query_failed() {
+        let error = classify_cli_spawn_error(
+            DatabaseCli::Sqlite3,
+            std::io::Error::new(std::io::ErrorKind::PermissionDenied, "permission denied"),
+        );
+
+        assert!(matches!(
+            error,
+            DbOperationError::QueryFailed(details) if details == "permission denied"
+        ));
+    }
 }

--- a/src/infra/adapters/sqlite/sqlite3/error.rs
+++ b/src/infra/adapters/sqlite/sqlite3/error.rs
@@ -1,10 +1,14 @@
-use crate::app::ports::outbound::DbOperationError;
+use crate::app::ports::outbound::{DatabaseCli, DbOperationError};
 
 pub(in crate::adapters::sqlite) fn classify_cli_spawn_error(
+    command: DatabaseCli,
     error: std::io::Error,
 ) -> DbOperationError {
     if error.kind() == std::io::ErrorKind::NotFound {
-        DbOperationError::CommandNotFound(format!("sqlite3: {error}"))
+        DbOperationError::CommandNotFound {
+            command,
+            details: error.to_string(),
+        }
     } else {
         DbOperationError::QueryFailed(error.to_string())
     }
@@ -173,14 +177,17 @@ mod tests {
 
     #[test]
     fn missing_sqlite_cli_has_command_specific_details() {
-        let error = classify_cli_spawn_error(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "No such file or directory",
-        ));
+        let error = classify_cli_spawn_error(
+            DatabaseCli::Sqlite3,
+            std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory"),
+        );
 
         assert!(matches!(
             error,
-            DbOperationError::CommandNotFound(details) if details.starts_with("sqlite3:")
+            DbOperationError::CommandNotFound {
+                command: DatabaseCli::Sqlite3,
+                ..
+            }
         ));
     }
 }

--- a/src/infra/adapters/sqlite/sqlite3/error.rs
+++ b/src/infra/adapters/sqlite/sqlite3/error.rs
@@ -1,5 +1,15 @@
 use crate::app::ports::outbound::DbOperationError;
 
+pub(in crate::adapters::sqlite) fn classify_cli_spawn_error(
+    error: std::io::Error,
+) -> DbOperationError {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        DbOperationError::CommandNotFound(format!("sqlite3: {error}"))
+    } else {
+        DbOperationError::QueryFailed(error.to_string())
+    }
+}
+
 pub(in crate::adapters::sqlite) fn classify_query_error(stderr: &str) -> DbOperationError {
     let trimmed = stderr.trim();
     let Some(details) = (!trimmed.is_empty()).then_some(trimmed) else {
@@ -159,5 +169,18 @@ mod tests {
                 DbOperationError::QueryFailed(details) if details.is_empty()
             ));
         }
+    }
+
+    #[test]
+    fn missing_sqlite_cli_has_command_specific_details() {
+        let error = classify_cli_spawn_error(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "No such file or directory",
+        ));
+
+        assert!(matches!(
+            error,
+            DbOperationError::CommandNotFound(details) if details.starts_with("sqlite3:")
+        ));
     }
 }

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -154,17 +154,17 @@ impl SqliteCli {
         let mut cmd = Command::new("sqlite3");
         Self::apply_session_options(&mut cmd, read_only);
         cmd.arg("-batch").arg("-bail").arg("-csv").arg("-header");
-        cmd.arg("--")
-            .arg(sqlite_database_uri(path, read_only))
-            .arg(sql);
+        cmd.arg(sqlite_database_uri(path, read_only));
 
         let mut child = cmd
+            .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
             .map_err(|error| classify_cli_spawn_error(DatabaseCli::Sqlite3, error))?;
 
+        let stdin = child.stdin.take();
         let stdout = child.stdout.take();
         let mut stderr_handle = child.stderr.take();
 
@@ -174,25 +174,34 @@ impl SqliteCli {
         let mut writer = tokio::io::BufWriter::new(file);
 
         let result = timeout(Duration::from_secs(self.timeout_secs * 10), async {
-            if let Some(mut stdout) = stdout {
-                let mut buf = [0u8; 8192];
-                loop {
-                    let n = stdout.read(&mut buf).await?;
-                    if n == 0 {
-                        break;
+            let (stdin_result, stdout_result, stderr_result) = tokio::join!(
+                write_sql_to_stdin(stdin, sql),
+                async {
+                    if let Some(mut stdout) = stdout {
+                        let mut buf = [0u8; 8192];
+                        loop {
+                            let n = stdout.read(&mut buf).await?;
+                            if n == 0 {
+                                break;
+                            }
+                            writer.write_all(&buf[..n]).await?;
+                        }
+                        writer.flush().await?;
                     }
-                    writer.write_all(&buf[..n]).await?;
+                    Ok::<_, std::io::Error>(())
+                },
+                async {
+                    let mut buf = Vec::new();
+                    if let Some(ref mut stderr) = stderr_handle {
+                        stderr.read_to_end(&mut buf).await?;
+                    }
+                    Ok::<_, std::io::Error>(String::from_utf8_lossy(&buf).into_owned())
                 }
-                writer.flush().await?;
-            }
+            );
 
-            let stderr = {
-                let mut buf = Vec::new();
-                if let Some(ref mut stderr) = stderr_handle {
-                    stderr.read_to_end(&mut buf).await?;
-                }
-                String::from_utf8_lossy(&buf).into_owned()
-            };
+            stdin_result?;
+            stdout_result?;
+            let stderr = stderr_result?;
             let status = child.wait().await?;
             Ok::<_, std::io::Error>((status, stderr))
         })
@@ -239,10 +248,8 @@ impl SqliteCli {
         for arg in args {
             cmd.arg(arg);
         }
-        cmd.arg("--")
-            .arg(sqlite_database_uri(path, read_only))
-            .arg(sql);
-        Self::collect_output(&mut cmd, self.timeout_secs).await
+        cmd.arg(sqlite_database_uri(path, read_only));
+        Self::collect_output(&mut cmd, self.timeout_secs, sql).await
     }
 
     fn ensure_database_path(path: &str) -> Result<(), DbOperationError> {
@@ -266,19 +273,23 @@ impl SqliteCli {
     async fn collect_output(
         cmd: &mut Command,
         timeout_secs: u64,
+        sql: &str,
     ) -> Result<SqliteOutput, DbOperationError> {
         let mut child = cmd
+            .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
             .map_err(|error| classify_cli_spawn_error(DatabaseCli::Sqlite3, error))?;
 
+        let stdin = child.stdin.take();
         let mut stdout_handle = child.stdout.take();
         let mut stderr_handle = child.stderr.take();
 
         let result = timeout(Duration::from_secs(timeout_secs), async {
-            let (stdout_result, stderr_result) = tokio::join!(
+            let (stdin_result, stdout_result, stderr_result) = tokio::join!(
+                write_sql_to_stdin(stdin, sql),
                 async {
                     let mut buf = Vec::new();
                     if let Some(ref mut stdout) = stdout_handle {
@@ -295,6 +306,7 @@ impl SqliteCli {
                 }
             );
 
+            stdin_result?;
             let stdout = stdout_result?;
             let stderr = stderr_result?;
             let status = child.wait().await?;
@@ -313,9 +325,46 @@ impl SqliteCli {
     }
 }
 
+async fn write_sql_to_stdin(
+    stdin: Option<tokio::process::ChildStdin>,
+    sql: &str,
+) -> Result<(), std::io::Error> {
+    if let Some(mut stdin) = stdin {
+        if let Err(error) = stdin.write_all(sql.as_bytes()).await
+            && error.kind() != std::io::ErrorKind::BrokenPipe
+        {
+            return Err(error);
+        }
+        if let Err(error) = stdin.shutdown().await
+            && error.kind() != std::io::ErrorKind::BrokenPipe
+        {
+            return Err(error);
+        }
+    }
+    Ok(())
+}
+
 fn sqlite_database_uri(path: &str, read_only: bool) -> String {
+    sqlite_database_uri_for_platform(path, read_only, cfg!(windows))
+}
+
+fn sqlite_database_uri_for_platform(path: &str, read_only: bool, is_windows: bool) -> String {
     let mode = if read_only { "ro" } else { "rw" };
-    format!("file:{}?mode={mode}", urlencoding::encode(path))
+    let path = sqlite_uri_path(path, is_windows);
+    format!("file:{}?mode={mode}", urlencoding::encode(&path))
+}
+
+fn sqlite_uri_path(path: &str, is_windows: bool) -> String {
+    if !is_windows {
+        return path.to_string();
+    }
+
+    let path = path.replace('\\', "/");
+    if path.as_bytes().get(1) == Some(&b':') && !path.starts_with('/') {
+        format!("/{path}")
+    } else {
+        path
+    }
 }
 
 fn count_csv_records(path: &std::path::Path) -> Result<usize, csv::Error> {
@@ -2250,17 +2299,35 @@ world'), (2, 'done');
             assert!(read_only.ends_with("?mode=ro"));
         }
 
+        #[test]
+        fn windows_database_uri_normalizes_drive_paths() {
+            assert_eq!(
+                sqlite_uri_path(r"C:\Users\sabiql\database.sqlite", true),
+                "/C:/Users/sabiql/database.sqlite"
+            );
+            assert!(
+                sqlite_database_uri_for_platform(r"C:\Users\sabiql\database.sqlite", false, true,)
+                    .starts_with("file:%2FC%3A%2FUsers%2Fsabiql%2Fdatabase.sqlite?")
+            );
+        }
+
         #[tokio::test]
         async fn read_write_uri_rejects_missing_database_without_creating_file() {
             let dir = tempfile::tempdir().unwrap();
             let path = dir.path().join("missing.db");
-            let output = Command::new("sqlite3")
-                .arg("--")
+            let mut child = Command::new("sqlite3")
                 .arg(sqlite_database_uri(path.to_str().unwrap(), false))
-                .arg("CREATE TABLE users(id INTEGER)")
-                .output()
+                .stdin(Stdio::piped())
+                .spawn()
+                .unwrap();
+            let mut stdin = child.stdin.take().unwrap();
+            stdin
+                .write_all(b"CREATE TABLE users(id INTEGER)")
                 .await
                 .unwrap();
+            stdin.shutdown().await.unwrap();
+            drop(stdin);
+            let output = child.wait_with_output().await.unwrap();
 
             assert!(!output.status.success());
             assert!(!path.exists());

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::process::{ExitStatus, Stdio};
 use std::time::{Duration, Instant};
 
@@ -15,8 +16,8 @@ use crate::domain::{
     available_sqlite_rowid_alias,
 };
 
-use super::super::{SqliteAdapter, sql};
-use super::error::classify_query_error;
+use super::super::{SqliteAdapter, path_validation, sql};
+use super::error::{classify_cli_spawn_error, classify_query_error};
 use super::parser::{
     aggregate_sqlite_command_tag, append_changes_query, command_tag_result,
     is_sqlite_rerunnable_export_query, last_sqlite_result_set, parse_affected_rows,
@@ -149,6 +150,7 @@ impl SqliteCli {
         output_path: &std::path::Path,
         read_only: bool,
     ) -> Result<usize, DbOperationError> {
+        Self::ensure_database_path(path)?;
         let mut cmd = Command::new("sqlite3");
         Self::apply_session_options(&mut cmd, read_only);
         cmd.arg("-batch").arg("-bail").arg("-csv").arg("-header");
@@ -159,7 +161,7 @@ impl SqliteCli {
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|error| DbOperationError::CommandNotFound(error.to_string()))?;
+            .map_err(classify_cli_spawn_error)?;
 
         let stdout = child.stdout.take();
         let mut stderr_handle = child.stderr.take();
@@ -229,6 +231,7 @@ impl SqliteCli {
         sql: &str,
         read_only: bool,
     ) -> Result<SqliteOutput, DbOperationError> {
+        Self::ensure_database_path(path)?;
         let mut cmd = Command::new("sqlite3");
         Self::apply_session_options(&mut cmd, read_only);
         for arg in args {
@@ -236,6 +239,11 @@ impl SqliteCli {
         }
         cmd.arg("--").arg(path).arg(sql);
         Self::collect_output(&mut cmd, self.timeout_secs).await
+    }
+
+    fn ensure_database_path(path: &str) -> Result<(), DbOperationError> {
+        path_validation::validate_sqlite_database_path(Path::new(path))
+            .map_err(|error| DbOperationError::ConnectionFailed(error.to_string()))
     }
 
     fn apply_session_options(cmd: &mut Command, read_only: bool) {
@@ -260,7 +268,7 @@ impl SqliteCli {
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(|error| DbOperationError::CommandNotFound(error.to_string()))?;
+            .map_err(classify_cli_spawn_error)?;
 
         let mut stdout_handle = child.stdout.take();
         let mut stderr_handle = child.stderr.take();
@@ -382,7 +390,7 @@ impl QueryExecutor for SqliteAdapter {
         table: &str,
         limit: usize,
         offset: usize,
-        read_only: bool,
+        _read_only: bool,
     ) -> Result<QueryResult, DbOperationError> {
         Self::validate_main_schema(schema)?;
         let path = Self::path_from_dsn(dsn)?;
@@ -397,7 +405,7 @@ impl QueryExecutor for SqliteAdapter {
         let query =
             sql::build_preview_query(table, &columns, &order_columns, rowid_alias, limit, offset);
         let result = self
-            .execute_quoted_query(path, &query, QuerySource::Preview, read_only)
+            .execute_quoted_query(path, &query, QuerySource::Preview, true)
             .await?;
         Ok(match rowid_alias {
             Some(alias) => result.with_first_column_hidden(alias.to_string()),
@@ -482,11 +490,11 @@ impl QueryExecutor for SqliteAdapter {
         &self,
         dsn: &str,
         query: &str,
-        read_only: bool,
+        _read_only: bool,
     ) -> Result<usize, DbOperationError> {
         let stdout = self
             .cli
-            .execute_csv(Self::path_from_dsn(dsn)?, query, read_only)
+            .execute_csv(Self::path_from_dsn(dsn)?, query, true)
             .await?;
         parse_count_result(&stdout)
     }
@@ -496,13 +504,13 @@ impl QueryExecutor for SqliteAdapter {
         dsn: &str,
         query: &str,
         path: &std::path::Path,
-        read_only: bool,
+        _read_only: bool,
     ) -> Result<usize, DbOperationError> {
         if !is_sqlite_rerunnable_export_query(query)? {
             return Err(sqlite_export_not_rerunnable_error());
         }
         self.cli
-            .export_csv(Self::path_from_dsn(dsn)?, query, path, read_only)
+            .export_csv(Self::path_from_dsn(dsn)?, query, path, true)
             .await
     }
 }
@@ -2142,6 +2150,25 @@ world'), (2, 'done');
 
             assert!(matches!(result, Err(DbOperationError::PermissionDenied(_))));
         }
+
+        #[tokio::test]
+        async fn missing_database_is_rejected_without_creating_an_empty_file() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("missing.db");
+            let dsn = format!("sqlite://{}", path.display());
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_write(&dsn, "CREATE TABLE users(id INTEGER)", false)
+                .await;
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::ConnectionFailed(details))
+                    if details.contains("SQLite database file not found")
+            ));
+            assert!(!path.exists());
+        }
     }
 
     mod dsn_validation {
@@ -2162,6 +2189,7 @@ world'), (2, 'done');
                 .as_nanos();
             let path = format!("-sabiql-{unique}.db");
             let _cleanup = CleanupPath(path.clone());
+            std::fs::write(&path, b"").unwrap();
             let dsn = format!("sqlite://{path}");
             let adapter = SqliteAdapter::new();
 

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -10,7 +10,7 @@ use tokio::time::timeout;
 use async_trait::async_trait;
 
 use crate::app::policy::sql::sqlite_explain::is_sqlite_explain_query_plan_sql;
-use crate::app::ports::outbound::{DbOperationError, QueryExecutor};
+use crate::app::ports::outbound::{AccessMode, DatabaseCli, DbOperationError, QueryExecutor};
 use crate::domain::{
     CommandTag, QueryResult, QuerySource, TableKind, WriteExecutionResult,
     available_sqlite_rowid_alias,
@@ -154,14 +154,16 @@ impl SqliteCli {
         let mut cmd = Command::new("sqlite3");
         Self::apply_session_options(&mut cmd, read_only);
         cmd.arg("-batch").arg("-bail").arg("-csv").arg("-header");
-        cmd.arg("--").arg(path).arg(sql);
+        cmd.arg("--")
+            .arg(sqlite_database_uri(path, read_only))
+            .arg(sql);
 
         let mut child = cmd
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(classify_cli_spawn_error)?;
+            .map_err(|error| classify_cli_spawn_error(DatabaseCli::Sqlite3, error))?;
 
         let stdout = child.stdout.take();
         let mut stderr_handle = child.stderr.take();
@@ -237,7 +239,9 @@ impl SqliteCli {
         for arg in args {
             cmd.arg(arg);
         }
-        cmd.arg("--").arg(path).arg(sql);
+        cmd.arg("--")
+            .arg(sqlite_database_uri(path, read_only))
+            .arg(sql);
         Self::collect_output(&mut cmd, self.timeout_secs).await
     }
 
@@ -268,7 +272,7 @@ impl SqliteCli {
             .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
-            .map_err(classify_cli_spawn_error)?;
+            .map_err(|error| classify_cli_spawn_error(DatabaseCli::Sqlite3, error))?;
 
         let mut stdout_handle = child.stdout.take();
         let mut stderr_handle = child.stderr.take();
@@ -307,6 +311,11 @@ impl SqliteCli {
             stderr,
         })
     }
+}
+
+fn sqlite_database_uri(path: &str, read_only: bool) -> String {
+    let mode = if read_only { "ro" } else { "rw" };
+    format!("file:{}?mode={mode}", urlencoding::encode(path))
 }
 
 fn count_csv_records(path: &std::path::Path) -> Result<usize, csv::Error> {
@@ -390,7 +399,6 @@ impl QueryExecutor for SqliteAdapter {
         table: &str,
         limit: usize,
         offset: usize,
-        _read_only: bool,
     ) -> Result<QueryResult, DbOperationError> {
         Self::validate_main_schema(schema)?;
         let path = Self::path_from_dsn(dsn)?;
@@ -417,7 +425,7 @@ impl QueryExecutor for SqliteAdapter {
         &self,
         dsn: &str,
         query: &str,
-        read_only: bool,
+        access_mode: AccessMode,
     ) -> Result<QueryResult, DbOperationError> {
         let path = Self::path_from_dsn(dsn)?;
         let marker = sqlite_probe_marker();
@@ -431,7 +439,7 @@ impl QueryExecutor for SqliteAdapter {
         let start = Instant::now();
         let stdout = self
             .cli
-            .execute_quote_for_query_plan(path, &execution_query, query, read_only)
+            .execute_quote_for_query_plan(path, &execution_query, query, access_mode.is_read_only())
             .await?;
         let elapsed = start.elapsed().as_millis() as u64;
         let (stdout, changes) = strip_sqlite_probes(&stdout, &marker)?;
@@ -475,10 +483,10 @@ impl QueryExecutor for SqliteAdapter {
         &self,
         dsn: &str,
         query: &str,
-        read_only: bool,
+        access_mode: AccessMode,
     ) -> Result<WriteExecutionResult, DbOperationError> {
         let (affected_rows, execution_time_ms) = self
-            .execute_changes_query(Self::path_from_dsn(dsn)?, query, read_only)
+            .execute_changes_query(Self::path_from_dsn(dsn)?, query, access_mode.is_read_only())
             .await?;
         Ok(WriteExecutionResult {
             affected_rows,
@@ -486,12 +494,7 @@ impl QueryExecutor for SqliteAdapter {
         })
     }
 
-    async fn count_query_rows(
-        &self,
-        dsn: &str,
-        query: &str,
-        _read_only: bool,
-    ) -> Result<usize, DbOperationError> {
+    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
         let stdout = self
             .cli
             .execute_csv(Self::path_from_dsn(dsn)?, query, true)
@@ -504,7 +507,6 @@ impl QueryExecutor for SqliteAdapter {
         dsn: &str,
         query: &str,
         path: &std::path::Path,
-        _read_only: bool,
     ) -> Result<usize, DbOperationError> {
         if !is_sqlite_rerunnable_export_query(query)? {
             return Err(sqlite_export_not_rerunnable_error());
@@ -517,7 +519,7 @@ impl QueryExecutor for SqliteAdapter {
 
 #[cfg(test)]
 mod tests {
-    use crate::app::ports::outbound::{QueryExecutor, SqlDialect};
+    use crate::app::ports::outbound::{AccessMode, QueryExecutor, SqlDialect};
     use crate::domain::{
         CommandTag, DatabaseType, QuerySource, QueryValue,
         sqlite_explain_query_plan_text_from_result,
@@ -539,7 +541,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_preview(&dsn, "main", "users", 1, 1, true)
+                .execute_preview(&dsn, "main", "users", 1, 1)
                 .await
                 .unwrap();
 
@@ -559,7 +561,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_preview(&dsn, "main", "logs", 10, 0, true)
+                .execute_preview(&dsn, "main", "logs", 10, 0)
                 .await
                 .unwrap();
 
@@ -582,7 +584,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_preview(&dsn, "main", "logs", 10, 0, true)
+                .execute_preview(&dsn, "main", "logs", 10, 0)
                 .await
                 .unwrap();
 
@@ -619,9 +621,12 @@ mod tests {
                 &QueryValue::text("new"),
                 &predicate,
             );
-            let write = adapter.execute_write(&dsn, &sql, false).await.unwrap();
+            let write = adapter
+                .execute_write(&dsn, &sql, AccessMode::ReadWrite)
+                .await
+                .unwrap();
             let preview = adapter
-                .execute_preview(&dsn, "main", "logs", 10, 0, true)
+                .execute_preview(&dsn, "main", "logs", 10, 0)
                 .await
                 .unwrap();
 
@@ -645,15 +650,22 @@ mod tests {
             ];
 
             adapter
-                .execute_write(&dsn, "DELETE FROM logs WHERE rowid = 1", false)
+                .execute_write(
+                    &dsn,
+                    "DELETE FROM logs WHERE rowid = 1",
+                    AccessMode::ReadWrite,
+                )
                 .await
                 .unwrap();
-            adapter.execute_adhoc(&dsn, "VACUUM", false).await.unwrap();
+            adapter
+                .execute_adhoc(&dsn, "VACUUM", AccessMode::ReadWrite)
+                .await
+                .unwrap();
             adapter
                 .execute_write(
                     &dsn,
                     "INSERT INTO logs(message, note) VALUES ('replacement', NULL)",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
@@ -666,9 +678,12 @@ mod tests {
                 &QueryValue::text("new"),
                 &stale_pairs,
             );
-            let write = adapter.execute_write(&dsn, &sql, false).await.unwrap();
+            let write = adapter
+                .execute_write(&dsn, &sql, AccessMode::ReadWrite)
+                .await
+                .unwrap();
             let remaining = adapter
-                .execute_preview(&dsn, "main", "logs", 10, 0, true)
+                .execute_preview(&dsn, "main", "logs", 10, 0)
                 .await
                 .unwrap();
 
@@ -694,9 +709,12 @@ mod tests {
             ]];
 
             let sql = adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "logs", &rows);
-            let write = adapter.execute_write(&dsn, &sql, false).await.unwrap();
+            let write = adapter
+                .execute_write(&dsn, &sql, AccessMode::ReadWrite)
+                .await
+                .unwrap();
             let preview = adapter
-                .execute_preview(&dsn, "main", "logs", 10, 0, true)
+                .execute_preview(&dsn, "main", "logs", 10, 0)
                 .await
                 .unwrap();
 
@@ -719,24 +737,34 @@ mod tests {
             ]];
 
             adapter
-                .execute_write(&dsn, "DELETE FROM logs WHERE rowid = 1", false)
+                .execute_write(
+                    &dsn,
+                    "DELETE FROM logs WHERE rowid = 1",
+                    AccessMode::ReadWrite,
+                )
                 .await
                 .unwrap();
-            adapter.execute_adhoc(&dsn, "VACUUM", false).await.unwrap();
+            adapter
+                .execute_adhoc(&dsn, "VACUUM", AccessMode::ReadWrite)
+                .await
+                .unwrap();
             adapter
                 .execute_write(
                     &dsn,
                     "INSERT INTO logs(message) VALUES ('replacement')",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
 
             let sql =
                 adapter.build_bulk_delete_sql(DatabaseType::SQLite, "main", "logs", &stale_rows);
-            let write = adapter.execute_write(&dsn, &sql, false).await.unwrap();
+            let write = adapter
+                .execute_write(&dsn, &sql, AccessMode::ReadWrite)
+                .await
+                .unwrap();
             let remaining = adapter
-                .execute_preview(&dsn, "main", "logs", 10, 0, true)
+                .execute_preview(&dsn, "main", "logs", 10, 0)
                 .await
                 .unwrap();
 
@@ -752,9 +780,7 @@ mod tests {
             );
             let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_preview(&dsn, "other", "users", 10, 0, true)
-                .await;
+            let result = adapter.execute_preview(&dsn, "other", "users", 10, 0).await;
 
             assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
         }
@@ -770,7 +796,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let preview = adapter
-                .execute_preview(&dsn, "main", "users", 10, 0, true)
+                .execute_preview(&dsn, "main", "users", 10, 0)
                 .await
                 .unwrap();
 
@@ -790,13 +816,13 @@ mod tests {
                 )]],
             );
             let write = adapter
-                .execute_write(&dsn, &delete_sql, false)
+                .execute_write(&dsn, &delete_sql, AccessMode::ReadWrite)
                 .await
                 .unwrap();
             assert_eq!(write.affected_rows, 1);
 
             let remaining = adapter
-                .execute_preview(&dsn, "main", "users", 10, 0, true)
+                .execute_preview(&dsn, "main", "users", 10, 0)
                 .await
                 .unwrap();
             assert_eq!(remaining.row_count(), 1);
@@ -817,7 +843,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_preview(&dsn, "main", "notes_fts", 10, 0, true)
+                .execute_preview(&dsn, "main", "notes_fts", 10, 0)
                 .await
                 .unwrap();
 
@@ -840,7 +866,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_preview(&dsn, "main", "users", 10, 0, true)
+                .execute_preview(&dsn, "main", "users", 10, 0)
                 .await
                 .unwrap();
 
@@ -865,7 +891,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_preview(&dsn, "main", "users", 10, 0, true)
+                .execute_preview(&dsn, "main", "users", 10, 0)
                 .await
                 .unwrap();
 
@@ -893,7 +919,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_preview(&dsn, "main", "users", 10, 0, true)
+                .execute_preview(&dsn, "main", "users", 10, 0)
                 .await
                 .unwrap();
 
@@ -916,7 +942,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "SELECT 1 AS value", true)
+                .execute_adhoc(&dsn, "SELECT 1 AS value", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -937,7 +963,7 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "EXPLAIN QUERY PLAN SELECT * FROM users WHERE name = 'alice'",
-                    true,
+                    AccessMode::ReadOnly,
                 )
                 .await
                 .unwrap();
@@ -967,7 +993,7 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "EXPLAIN QUERY PLAN SELECT * FROM users u JOIN orders o ON u.id = o.user_id",
-                    true,
+                    AccessMode::ReadOnly,
                 )
                 .await
                 .unwrap();
@@ -1002,12 +1028,16 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "EXPLAIN QUERY PLAN DELETE FROM users WHERE name = 'alice'",
-                    true,
+                    AccessMode::ReadOnly,
                 )
                 .await
                 .unwrap();
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT COUNT(*) AS total FROM users", true)
+                .execute_adhoc(
+                    &dsn,
+                    "SELECT COUNT(*) AS total FROM users",
+                    AccessMode::ReadOnly,
+                )
                 .await
                 .unwrap();
 
@@ -1057,14 +1087,15 @@ mod tests {
             let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(setup);
             let adapter = SqliteAdapter::new();
 
-            adapter.execute_adhoc(&dsn, trigger, false).await.unwrap();
+            adapter
+                .execute_adhoc(&dsn, trigger, AccessMode::ReadWrite)
+                .await
+                .unwrap();
 
             let result = adapter
                 .execute_adhoc(
                     &dsn,
-                    "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'agent_messages_fts_ai'",
-                    true,
-                )
+                    "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'agent_messages_fts_ai'", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1102,13 +1133,16 @@ mod tests {
             let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db(setup);
             let adapter = SqliteAdapter::new();
 
-            adapter.execute_adhoc(&dsn, trigger, false).await.unwrap();
+            adapter
+                .execute_adhoc(&dsn, trigger, AccessMode::ReadWrite)
+                .await
+                .unwrap();
 
             let result = adapter
                 .execute_adhoc(
                     &dsn,
                     "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'sync_end'",
-                    true,
+                    AccessMode::ReadOnly,
                 )
                 .await
                 .unwrap();
@@ -1133,7 +1167,7 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "CREATE TRIGGER t AFTER INSERT ON users BEGIN INSERT INTO logs(id) VALUES (1);",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap_err();
@@ -1152,7 +1186,7 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "SELECT 'line 1' || char(10) || 'line 2' AS body, 'ok' AS marker",
-                    true,
+                    AccessMode::ReadOnly,
                 )
                 .await
                 .unwrap();
@@ -1173,9 +1207,7 @@ mod tests {
             let result = adapter
             .execute_adhoc(
                 &dsn,
-                "SELECT 1 AS ignored; SELECT 'line 1' || char(10) || 'line 2' AS body, 'ok' AS marker",
-                true,
-            )
+                "SELECT 1 AS ignored; SELECT 'line 1' || char(10) || 'line 2' AS body, 'ok' AS marker", AccessMode::ReadOnly)
             .await
             .unwrap();
 
@@ -1196,7 +1228,7 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "SELECT 1 AS a, 2 AS b UNION ALL SELECT 3, 4; SELECT 5 AS c, 6 AS d",
-                    true,
+                    AccessMode::ReadOnly,
                 )
                 .await
                 .unwrap();
@@ -1212,7 +1244,11 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "SELECT 1 AS a; SELECT 2 AS b WHERE false", true)
+                .execute_adhoc(
+                    &dsn,
+                    "SELECT 1 AS a; SELECT 2 AS b WHERE false",
+                    AccessMode::ReadOnly,
+                )
                 .await
                 .unwrap();
 
@@ -1229,7 +1265,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "PRAGMA table_info(users)", true)
+                .execute_adhoc(&dsn, "PRAGMA table_info(users)", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1246,7 +1282,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "PRAGMA foreign_keys", false)
+                .execute_adhoc(&dsn, "PRAGMA foreign_keys", AccessMode::ReadWrite)
                 .await
                 .unwrap();
 
@@ -1259,7 +1295,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "PRAGMA query_only", true)
+                .execute_adhoc(&dsn, "PRAGMA query_only", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1272,7 +1308,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "PRAGMA busy_timeout", true)
+                .execute_adhoc(&dsn, "PRAGMA busy_timeout", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1285,7 +1321,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "VALUES (1)", true)
+                .execute_adhoc(&dsn, "VALUES (1)", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1304,7 +1340,11 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "UPDATE users SET name = 'x' WHERE id = 1", false)
+                .execute_adhoc(
+                    &dsn,
+                    "UPDATE users SET name = 'x' WHERE id = 1",
+                    AccessMode::ReadWrite,
+                )
                 .await
                 .unwrap();
 
@@ -1323,7 +1363,11 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "REPLACE INTO users(id, name) VALUES (1, 'z')", false)
+                .execute_adhoc(
+                    &dsn,
+                    "REPLACE INTO users(id, name) VALUES (1, 'z')",
+                    AccessMode::ReadWrite,
+                )
                 .await
                 .unwrap();
 
@@ -1345,7 +1389,7 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "UPDATE users SET name = 'x' WHERE id = 1; SELECT 42",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
@@ -1368,7 +1412,7 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "UPDATE users SET name = 'x' WHERE id = 1; SELECT name FROM users",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
@@ -1394,7 +1438,7 @@ mod tests {
                     "INSERT INTO users(id, name) VALUES (2, 'b'), (3, 'c');
                      UPDATE users SET name = 'z' WHERE id IN (1, 2);
                      DELETE FROM users WHERE id = 3",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
@@ -1413,7 +1457,7 @@ mod tests {
                     &dsn,
                     "CREATE TABLE users(id INTEGER PRIMARY KEY);
                      INSERT INTO users(id) VALUES (1)",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
@@ -1436,12 +1480,12 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "BEGIN; INSERT INTO users(id) VALUES (1); ROLLBACK",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1464,12 +1508,12 @@ mod tests {
                      SAVEPOINT sp;
                      INSERT INTO users(id) VALUES (2);
                      ROLLBACK",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1493,12 +1537,12 @@ mod tests {
                      INSERT INTO users(id) VALUES (2);
                      ROLLBACK TO sp;
                      COMMIT",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1524,12 +1568,12 @@ mod tests {
                      INSERT INTO users(id) VALUES (3);
                      ROLLBACK TO sp;
                      COMMIT",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1555,12 +1599,12 @@ mod tests {
                      INSERT INTO users(id) VALUES (3);
                      ROLLBACK TO outer_sp;
                      COMMIT",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1584,12 +1628,12 @@ mod tests {
                      ROLLBACK TO sp;
                      INSERT INTO users(id) VALUES (3);
                      RELEASE sp",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1607,14 +1651,12 @@ mod tests {
             let result = adapter
                 .execute_adhoc(
                     &dsn,
-                    "SAVEPOINT sp; INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
-                    false,
-                )
+                    "SAVEPOINT sp; INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)", AccessMode::ReadWrite)
                 .await;
 
             assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
             assert!(rows.rows().is_empty());
@@ -1630,13 +1672,11 @@ mod tests {
             let result = adapter
                 .execute_adhoc(
                     &dsn,
-                    "SAVEPOINT sp; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)",
-                    false,
-                )
+                    "SAVEPOINT sp; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)", AccessMode::ReadWrite)
                 .await
                 .unwrap();
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1656,7 +1696,7 @@ mod tests {
                     &dsn,
                     "WITH payload(id) AS (VALUES (1), (2))
                      INSERT INTO users(id) SELECT id FROM payload",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
@@ -1676,13 +1716,13 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await;
 
             assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
             assert!(rows.rows().is_empty());
@@ -1701,13 +1741,13 @@ mod tests {
                     "WITH payload(id) AS (VALUES (1))
                      INSERT INTO users(id) SELECT id FROM payload;
                      INSERT INTO missing(id) VALUES (2)",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await;
 
             assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
             assert!(rows.rows().is_empty());
@@ -1722,11 +1762,13 @@ mod tests {
             let query =
                 "INSERT INTO users(id) VALUES (1) RETURNING id; INSERT INTO missing(id) VALUES (2)";
 
-            let result = adapter.execute_adhoc(&dsn, query, false).await;
+            let result = adapter
+                .execute_adhoc(&dsn, query, AccessMode::ReadWrite)
+                .await;
 
             assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
             assert!(rows.rows().is_empty());
@@ -1742,14 +1784,12 @@ mod tests {
             let result = adapter
                 .execute_adhoc(
                     &dsn,
-                    "SELECT 1 AS marker; INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
-                    false,
-                )
+                    "SELECT 1 AS marker; INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)", AccessMode::ReadWrite)
                 .await;
 
             assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
             assert!(rows.rows().is_empty());
@@ -1769,7 +1809,7 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "DELETE FROM users WHERE id = 1 -- cleanup selected row",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
@@ -1789,7 +1829,7 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "INSERT INTO users(name) VALUES ('a') RETURNING id, name",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
@@ -1813,7 +1853,7 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "UPDATE users SET name = 'x' RETURNING id, name",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
@@ -1836,7 +1876,7 @@ mod tests {
                 .execute_adhoc(
                     &dsn,
                     "DELETE FROM users WHERE id = 1 RETURNING id, name",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
@@ -1853,7 +1893,11 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "INSERT INTO returning_log(name) VALUES ('a')", false)
+                .execute_adhoc(
+                    &dsn,
+                    "INSERT INTO returning_log(name) VALUES ('a')",
+                    AccessMode::ReadWrite,
+                )
                 .await
                 .unwrap();
 
@@ -1869,7 +1913,11 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "INSERT INTO `my returning`(name) VALUES ('a')", false)
+                .execute_adhoc(
+                    &dsn,
+                    "INSERT INTO `my returning`(name) VALUES ('a')",
+                    AccessMode::ReadWrite,
+                )
                 .await
                 .unwrap();
 
@@ -1885,7 +1933,11 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "INSERT INTO [my returning](name) VALUES ('a')", false)
+                .execute_adhoc(
+                    &dsn,
+                    "INSERT INTO [my returning](name) VALUES ('a')",
+                    AccessMode::ReadWrite,
+                )
                 .await
                 .unwrap();
 
@@ -1899,7 +1951,11 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "CREATE TABLE users(id INTEGER PRIMARY KEY)", false)
+                .execute_adhoc(
+                    &dsn,
+                    "CREATE TABLE users(id INTEGER PRIMARY KEY)",
+                    AccessMode::ReadWrite,
+                )
                 .await
                 .unwrap();
 
@@ -1929,10 +1985,10 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_write(&dsn, "DELETE FROM orgs WHERE id = 1", false)
+                .execute_write(&dsn, "DELETE FROM orgs WHERE id = 1", AccessMode::ReadWrite)
                 .await;
             let children = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -1954,7 +2010,7 @@ mod tests {
                 .execute_write(
                     &dsn,
                     "INSERT INTO users(id, email) VALUES (1, 'a@example.com')",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await
                 .unwrap();
@@ -1963,7 +2019,7 @@ mod tests {
                 .execute_write(
                     &dsn,
                     "INSERT INTO users(id, email) VALUES (2, 'a@example.com')",
-                    false,
+                    AccessMode::ReadWrite,
                 )
                 .await;
 
@@ -1975,7 +2031,9 @@ mod tests {
             let (_dir, dsn) = sabiql_test_support::infra::make_sqlite_db("");
             let adapter = SqliteAdapter::new();
 
-            let result = adapter.execute_adhoc(&dsn, "SELEKT 1", true).await;
+            let result = adapter
+                .execute_adhoc(&dsn, "SELEKT 1", AccessMode::ReadOnly)
+                .await;
 
             assert!(matches!(result, Err(DbOperationError::QueryFailed(message))
                     if message.to_ascii_lowercase().contains("syntax error")));
@@ -1997,11 +2055,11 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_write(&dsn, "DELETE FROM orgs WHERE id = 1", false)
+                .execute_write(&dsn, "DELETE FROM orgs WHERE id = 1", AccessMode::ReadWrite)
                 .await
                 .unwrap();
             let children = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", true)
+                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
@@ -2020,7 +2078,11 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_write(&dsn, "DELETE FROM users WHERE id IN (1, 2)", false)
+                .execute_write(
+                    &dsn,
+                    "DELETE FROM users WHERE id IN (1, 2)",
+                    AccessMode::ReadWrite,
+                )
                 .await
                 .unwrap();
 
@@ -2038,7 +2100,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let count = adapter
-                .count_query_rows(&dsn, "SELECT COUNT(*) FROM users", true)
+                .count_query_rows(&dsn, "SELECT COUNT(*) FROM users")
                 .await
                 .unwrap();
 
@@ -2057,7 +2119,7 @@ mod tests {
             let adapter = SqliteAdapter::new();
 
             let row_count = adapter
-                .export_to_csv(&dsn, "SELECT id, name FROM users ORDER BY id", &path, true)
+                .export_to_csv(&dsn, "SELECT id, name FROM users ORDER BY id", &path)
                 .await
                 .unwrap();
             let csv = std::fs::read_to_string(path).unwrap();
@@ -2079,12 +2141,7 @@ world'), (2, 'done');
             let adapter = SqliteAdapter::new();
 
             let row_count = adapter
-                .export_to_csv(
-                    &dsn,
-                    "SELECT id, message FROM logs ORDER BY id",
-                    &path,
-                    true,
-                )
+                .export_to_csv(&dsn, "SELECT id, message FROM logs ORDER BY id", &path)
                 .await
                 .unwrap();
 
@@ -2100,7 +2157,7 @@ world'), (2, 'done');
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .export_to_csv(&dsn, "INSERT INTO users(id) VALUES (1)", &path, false)
+                .export_to_csv(&dsn, "INSERT INTO users(id) VALUES (1)", &path)
                 .await;
 
             assert!(matches!(
@@ -2118,7 +2175,7 @@ world'), (2, 'done');
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .export_to_csv(&dsn, "SELECT id FROM missing", &path, true)
+                .export_to_csv(&dsn, "SELECT id FROM missing", &path)
                 .await;
 
             assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
@@ -2131,7 +2188,7 @@ world'), (2, 'done');
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .count_query_rows(&dsn, "SELECT COUNT(*) FROM missing", true)
+                .count_query_rows(&dsn, "SELECT COUNT(*) FROM missing")
                 .await;
 
             assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
@@ -2145,7 +2202,11 @@ world'), (2, 'done');
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_write(&dsn, "INSERT INTO users(id) VALUES (1)", true)
+                .execute_write(
+                    &dsn,
+                    "INSERT INTO users(id) VALUES (1)",
+                    AccessMode::ReadOnly,
+                )
                 .await;
 
             assert!(matches!(result, Err(DbOperationError::PermissionDenied(_))));
@@ -2159,7 +2220,11 @@ world'), (2, 'done');
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_write(&dsn, "CREATE TABLE users(id INTEGER)", false)
+                .execute_write(
+                    &dsn,
+                    "CREATE TABLE users(id INTEGER)",
+                    AccessMode::ReadWrite,
+                )
                 .await;
 
             assert!(matches!(
@@ -2173,6 +2238,33 @@ world'), (2, 'done');
 
     mod dsn_validation {
         use super::*;
+
+        #[test]
+        fn database_uri_uses_non_creating_access_modes() {
+            let read_write = sqlite_database_uri("/tmp/sabiql database?.db", false);
+            let read_only = sqlite_database_uri("/tmp/sabiql database?.db", true);
+
+            assert!(read_write.starts_with("file:"));
+            assert!(read_write.contains("%3F"));
+            assert!(read_write.ends_with("?mode=rw"));
+            assert!(read_only.ends_with("?mode=ro"));
+        }
+
+        #[tokio::test]
+        async fn read_write_uri_rejects_missing_database_without_creating_file() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("missing.db");
+            let output = Command::new("sqlite3")
+                .arg("--")
+                .arg(sqlite_database_uri(path.to_str().unwrap(), false))
+                .arg("CREATE TABLE users(id INTEGER)")
+                .output()
+                .await
+                .unwrap();
+
+            assert!(!output.status.success());
+            assert!(!path.exists());
+        }
 
         #[tokio::test]
         async fn relative_path_starting_with_dash_is_opened_as_database_path() {
@@ -2194,7 +2286,7 @@ world'), (2, 'done');
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .execute_adhoc(&dsn, "SELECT 1 AS value", false)
+                .execute_adhoc(&dsn, "SELECT 1 AS value", AccessMode::ReadWrite)
                 .await;
 
             let result = result.unwrap();

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -791,7 +791,7 @@ impl MetadataProvider for SqliteAdapter {
 
 #[cfg(test)]
 mod tests {
-    use crate::app::ports::outbound::{DdlGenerator, MetadataProvider, QueryExecutor};
+    use crate::app::ports::outbound::{AccessMode, DdlGenerator, MetadataProvider, QueryExecutor};
     use crate::domain::{
         DatabaseType, FkAction, IndexType, Schema, TriggerEvent, TriggerTiming,
         UNRESOLVED_FK_COLUMN,
@@ -1843,7 +1843,10 @@ mod tests {
                 .signature
                 .clone();
 
-            adapter.execute_adhoc(&dsn, trigger, false).await.unwrap();
+            adapter
+                .execute_adhoc(&dsn, trigger, AccessMode::ReadWrite)
+                .await
+                .unwrap();
 
             let after = adapter.fetch_table_signatures(&dsn).await.unwrap();
             let after_signature = &after

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -890,7 +890,11 @@ mod tests {
 
             let result = adapter.fetch_metadata(&dsn).await;
 
-            assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+            assert!(matches!(
+                result,
+                Err(DbOperationError::ConnectionFailed(details))
+                    if details.contains("SQLite database file not found")
+            ));
             assert!(!path.exists());
         }
 

--- a/src/tests/adapter_postgres.rs
+++ b/src/tests/adapter_postgres.rs
@@ -8,7 +8,7 @@
 //! Default: `postgres://dev:dev@localhost:5433/testdb` (matches compose.yml)
 //! The database user must be able to create and drop schemas.
 
-use sabiql_app::ports::outbound::{DbOperationError, MetadataProvider, QueryExecutor};
+use sabiql_app::ports::outbound::{AccessMode, DbOperationError, MetadataProvider, QueryExecutor};
 use sabiql_infra::adapters::postgres::PostgresAdapter;
 
 use crate::tests::harness::postgres::{
@@ -83,7 +83,7 @@ mod query_execution {
             Box::pin(async move {
                 let result = db
                     .adapter()
-                    .execute_preview(db.dsn(), db.schema(), db.table(), 10, 0, false)
+                    .execute_preview(db.dsn(), db.schema(), db.table(), 10, 0)
                     .await
                     .map_err(|err| err.to_string())?;
 
@@ -103,7 +103,7 @@ mod query_execution {
         let dsn = postgres_integration_dsn();
 
         let result = adapter
-            .execute_adhoc(&dsn, "SELECT 1 AS value", false)
+            .execute_adhoc(&dsn, "SELECT 1 AS value", AccessMode::ReadWrite)
             .await
             .unwrap();
 
@@ -124,7 +124,11 @@ mod multi_statement_boundaries {
         let dsn = postgres_integration_dsn();
 
         let result = adapter
-            .execute_adhoc(&dsn, "SELECT 1 AS a; SELECT 2 AS b, 3 AS c", false)
+            .execute_adhoc(
+                &dsn,
+                "SELECT 1 AS a; SELECT 2 AS b, 3 AS c",
+                AccessMode::ReadWrite,
+            )
             .await
             .unwrap();
 
@@ -140,7 +144,10 @@ mod multi_statement_boundaries {
 
         let sql = "SELECT 1 AS id, 'Alice' AS name; \
                    SELECT 'id' AS id, 'name' AS name";
-        let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
+        let result = adapter
+            .execute_adhoc(&dsn, sql, AccessMode::ReadWrite)
+            .await
+            .unwrap();
 
         assert_eq!(result.columns, vec!["id", "name"]);
         assert_eq!(result.rows(), vec![vec!["id", "name"]]);
@@ -153,7 +160,10 @@ mod multi_statement_boundaries {
         let dsn = postgres_integration_dsn();
 
         let sql = "SELECT 1 AS a WHERE false; SELECT 2 AS b";
-        let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
+        let result = adapter
+            .execute_adhoc(&dsn, sql, AccessMode::ReadWrite)
+            .await
+            .unwrap();
 
         assert_eq!(result.columns, vec!["b"]);
         assert_eq!(result.rows(), vec![vec!["2"]]);
@@ -166,7 +176,10 @@ mod multi_statement_boundaries {
         let dsn = postgres_integration_dsn();
 
         let sql = "SELECT 1 AS a; SELECT 2 AS b WHERE false";
-        let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
+        let result = adapter
+            .execute_adhoc(&dsn, sql, AccessMode::ReadWrite)
+            .await
+            .unwrap();
 
         assert_eq!(result.columns, vec!["b"]);
         assert!(result.rows().is_empty());
@@ -183,7 +196,10 @@ mod multi_statement_boundaries {
         let sql = "CREATE TEMP TABLE boundary_probe(v int); \
                    INSERT INTO boundary_probe VALUES (7); \
                    SELECT v FROM boundary_probe";
-        let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
+        let result = adapter
+            .execute_adhoc(&dsn, sql, AccessMode::ReadWrite)
+            .await
+            .unwrap();
 
         assert_eq!(result.columns, vec!["v"]);
         assert_eq!(result.rows(), vec![vec!["7"]]);
@@ -197,7 +213,10 @@ mod multi_statement_boundaries {
 
         let sql = "CREATE TEMP TABLE tag_probe(v int); \
                    INSERT INTO tag_probe VALUES (1), (2)";
-        let result = adapter.execute_adhoc(&dsn, sql, false).await.unwrap();
+        let result = adapter
+            .execute_adhoc(&dsn, sql, AccessMode::ReadWrite)
+            .await
+            .unwrap();
 
         assert!(result.rows().is_empty());
         assert_eq!(
@@ -215,7 +234,10 @@ mod multi_statement_boundaries {
                     "CREATE TABLE \"{}\".boundary_rollback_probe(v int); SELECT no_such_column",
                     db.schema()
                 );
-                let result = db.adapter().execute_adhoc(db.dsn(), &failing, false).await;
+                let result = db
+                    .adapter()
+                    .execute_adhoc(db.dsn(), &failing, AccessMode::ReadWrite)
+                    .await;
                 if result.is_ok() {
                     return Err("expected mid-script error".to_string());
                 }
@@ -228,7 +250,7 @@ mod multi_statement_boundaries {
                             "SELECT to_regclass('{}.boundary_rollback_probe') IS NULL AS rolled_back",
                             db.schema()
                         ),
-                        false,
+                        AccessMode::ReadWrite,
                     )
                     .await
                     .map_err(|err| err.to_string())?;
@@ -262,7 +284,7 @@ mod error_paths {
         let dsn = postgres_integration_dsn();
 
         let result = adapter
-            .execute_adhoc(&dsn, "SELECT pg_sleep(5)", false)
+            .execute_adhoc(&dsn, "SELECT pg_sleep(5)", AccessMode::ReadWrite)
             .await;
 
         assert!(

--- a/src/tests/harness/postgres.rs
+++ b/src/tests/harness/postgres.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use sabiql_app::ports::outbound::{DbOperationError, QueryExecutor};
+use sabiql_app::ports::outbound::{AccessMode, DbOperationError, QueryExecutor};
 use sabiql_infra::adapters::postgres::PostgresAdapter;
 
 const DEFAULT_TEST_DSN: &str = "postgres://dev:dev@localhost:5433/testdb";
@@ -49,7 +49,7 @@ impl PostgresTestDb {
             .execute_adhoc(
                 &self.dsn,
                 &format!("DROP SCHEMA IF EXISTS \"{}\" CASCADE", self.schema),
-                false,
+                AccessMode::ReadWrite,
             )
             .await
             .map(|_| ())
@@ -69,7 +69,7 @@ impl PostgresTestDb {
             "#
         );
         self.adapter
-            .execute_adhoc(&self.dsn, &sql, false)
+            .execute_adhoc(&self.dsn, &sql, AccessMode::ReadWrite)
             .await
             .map(|_| ())
     }


### PR DESCRIPTION
## Problem

SQLite connection profiles could retain relative paths, read operations could run without a database-level read-only guard, and missing database files could be recreated by sqlite3. Repeated save actions could also enqueue duplicate profiles, while missing sqlite3 guidance remained generic.

## Background

sabiql starts sqlite3 for each operation, so the connection path and file lifecycle must remain stable across operations.

## Approach

Normalize validated SQLite paths before saving and building DSNs. Reject missing targets at the adapter boundary, force read-only execution for SQLite read paths, ignore save submissions while a connection is connecting, and surface sqlite3-specific installation guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * クエリ実行／プレビュー／CSV出力の権限モードを一貫して制御します。
  * SQLite接続プロファイル保存時に、DBパスを正規化して反映します。
  * sqlite3/psql CLI未インストール時の案内文を改善しました。
* **バグ修正**
  * 接続中の保存操作を重複して発行しないようにしました。
  * 存在しないSQLiteへの書き込みで不必要にファイルが作成される問題を修正しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->