### PR TITLE
test: reorganize SQLite SQL tests by behavior

### DIFF
--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1642,6 +1642,18 @@ CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
                     _ => panic!("expected Allow"),
                 }
             }
+
+            #[test]
+            fn select_update_where_uses_medium_risk() {
+                let result =
+                    evaluate_multi_statement("SELECT 1; UPDATE users SET x = 1 WHERE id = 1");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Medium);
+                    }
+                    _ => panic!("expected Allow"),
+                }
+            }
         }
 
         mod sqlite_transaction_policy {
@@ -1714,18 +1726,6 @@ CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
 
         mod input_validation {
             use super::*;
-
-            #[test]
-            fn risk_aggregation_select_update_where() {
-                let result =
-                    evaluate_multi_statement("SELECT 1; UPDATE users SET x = 1 WHERE id = 1");
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, RiskLevel::Medium);
-                    }
-                    _ => panic!("expected Allow"),
-                }
-            }
 
             #[test]
             fn empty_input_blocked() {
@@ -1827,240 +1827,257 @@ CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
         mod confirmation_aggregation {
             use super::*;
 
-            #[test]
-            fn do_block_requires_acknowledgment() {
-                let result = evaluate_multi_statement("DO $$ BEGIN RAISE NOTICE 'hi'; END $$");
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, RiskLevel::Low);
-                        assert!(matches!(
-                            risk.confirmation,
-                            ConfirmationType::Acknowledge {
-                                reason: AcknowledgeReason::UnknownRisk,
-                                ref label,
-                            } if label == "DO"
-                        ));
+            mod acknowledgments {
+                use super::*;
+
+                #[test]
+                fn do_block_requires_acknowledgment() {
+                    let result = evaluate_multi_statement("DO $$ BEGIN RAISE NOTICE 'hi'; END $$");
+                    match result {
+                        MultiStatementDecision::Allow { risk, .. } => {
+                            assert_eq!(risk.risk_level, RiskLevel::Low);
+                            assert!(matches!(
+                                risk.confirmation,
+                                ConfirmationType::Acknowledge {
+                                    reason: AcknowledgeReason::UnknownRisk,
+                                    ref label,
+                                } if label == "DO"
+                            ));
+                        }
+                        _ => panic!("expected Allow"),
                     }
-                    _ => panic!("expected Allow"),
+                }
+
+                #[test]
+                fn copy_requires_acknowledgment() {
+                    let result = evaluate_multi_statement("COPY users FROM '/tmp/data.csv'");
+                    match result {
+                        MultiStatementDecision::Allow { risk, .. } => {
+                            assert_eq!(risk.risk_level, RiskLevel::Low);
+                            assert!(matches!(
+                                risk.confirmation,
+                                ConfirmationType::Acknowledge {
+                                    reason: AcknowledgeReason::UnknownRisk,
+                                    ref label,
+                                } if label == "COPY"
+                            ));
+                        }
+                        _ => panic!("expected Allow"),
+                    }
+                }
+
+                #[test]
+                fn do_block_after_select_requires_acknowledgment() {
+                    let result =
+                        evaluate_multi_statement("SELECT 1; DO $$ BEGIN DELETE FROM users; END $$");
+                    match result {
+                        MultiStatementDecision::Allow { risk, .. } => {
+                            assert_eq!(risk.risk_level, RiskLevel::Low);
+                            assert!(matches!(
+                                risk.confirmation,
+                                ConfirmationType::Acknowledge {
+                                    reason: AcknowledgeReason::UnknownRisk,
+                                    ..
+                                }
+                            ));
+                        }
+                        _ => panic!("expected Allow"),
+                    }
+                }
+
+                #[rstest]
+                #[case::do_block_with_drop(
+                    "DO $$ BEGIN RAISE NOTICE 'hi'; END $$; DROP TABLE users"
+                )]
+                #[case::drop_with_unextractable_drop("DROP TABLE users; DROP TABLE a, b")]
+                #[case::mixed_acknowledge_reasons(
+                    "DO $$ BEGIN RAISE NOTICE 'hi'; END $$; DROP TABLE a, b"
+                )]
+                fn mixed_confirmations_are_blocked(#[case] sql: &str) {
+                    let result = evaluate_multi_statement(sql);
+
+                    assert!(matches!(result, MultiStatementDecision::Block { .. }));
+                }
+
+                #[rstest]
+                #[case::unknown_risk(
+                    "COPY users FROM '/tmp/a.csv'; CALL refresh()",
+                    RiskLevel::Low,
+                    AcknowledgeReason::UnknownRisk,
+                    "COPY"
+                )]
+                #[case::target_name_unavailable(
+                    "DROP TABLE a, b; TRUNCATE c, d",
+                    RiskLevel::High,
+                    AcknowledgeReason::TargetNameUnavailable,
+                    "DROP"
+                )]
+                fn same_reason_acknowledgments_aggregate_with_first_label(
+                    #[case] sql: &str,
+                    #[case] expected_risk: RiskLevel,
+                    #[case] expected_reason: AcknowledgeReason,
+                    #[case] expected_label: &str,
+                ) {
+                    let result = evaluate_multi_statement(sql);
+
+                    match result {
+                        MultiStatementDecision::Allow { risk, .. } => {
+                            assert_eq!(risk.risk_level, expected_risk);
+                            assert!(matches!(
+                                risk.confirmation,
+                                ConfirmationType::Acknowledge {
+                                    ref reason,
+                                    ref label,
+                                } if *reason == expected_reason && label == expected_label
+                            ));
+                        }
+                        _ => panic!("expected Allow"),
+                    }
+                }
+
+                #[test]
+                fn drop_multiple_targets_requires_acknowledgment() {
+                    let result = evaluate_multi_statement("DROP TABLE a, b");
+                    match result {
+                        MultiStatementDecision::Allow { risk, .. } => {
+                            assert_eq!(risk.risk_level, RiskLevel::High);
+                            assert!(matches!(
+                                risk.confirmation,
+                                ConfirmationType::Acknowledge {
+                                    reason: AcknowledgeReason::TargetNameUnavailable,
+                                    ..
+                                }
+                            ));
+                        }
+                        _ => panic!("expected Allow"),
+                    }
                 }
             }
 
-            #[test]
-            fn copy_requires_acknowledgment() {
-                let result = evaluate_multi_statement("COPY users FROM '/tmp/data.csv'");
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, RiskLevel::Low);
-                        assert!(matches!(
-                            risk.confirmation,
-                            ConfirmationType::Acknowledge {
-                                reason: AcknowledgeReason::UnknownRisk,
-                                ref label,
-                            } if label == "COPY"
-                        ));
+            mod immediate_execution {
+                use super::*;
+
+                #[test]
+                fn insert_then_select_returns_immediate() {
+                    let result = evaluate_multi_statement("INSERT INTO users VALUES (1); SELECT 1");
+                    match result {
+                        MultiStatementDecision::Allow { risk, .. } => {
+                            assert_eq!(risk.risk_level, RiskLevel::Low);
+                            assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                        }
+                        _ => panic!("expected Allow"),
                     }
-                    _ => panic!("expected Allow"),
+                }
+
+                #[test]
+                fn drop_index_returns_low_immediate_for_postgres() {
+                    let result = evaluate_multi_statement("DROP INDEX my_index");
+                    match result {
+                        MultiStatementDecision::Allow { risk, .. } => {
+                            assert_eq!(risk.risk_level, RiskLevel::Low);
+                            assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                        }
+                        _ => panic!("expected Allow"),
+                    }
+                }
+
+                #[test]
+                fn drop_owned_by_returns_low_immediate() {
+                    let result = evaluate_multi_statement("DROP OWNED BY role");
+                    match result {
+                        MultiStatementDecision::Allow { risk, .. } => {
+                            assert_eq!(risk.risk_level, RiskLevel::Low);
+                            assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                        }
+                        _ => panic!("expected Allow"),
+                    }
                 }
             }
 
-            #[test]
-            fn do_block_after_select_requires_acknowledgment() {
-                let result =
-                    evaluate_multi_statement("SELECT 1; DO $$ BEGIN DELETE FROM users; END $$");
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, RiskLevel::Low);
-                        assert!(matches!(
-                            risk.confirmation,
-                            ConfirmationType::Acknowledge {
-                                reason: AcknowledgeReason::UnknownRisk,
-                                ..
-                            }
-                        ));
+            mod sqlite_confirmation {
+                use super::*;
+
+                #[test]
+                fn sqlite_multiple_high_drops_use_first_target() {
+                    let result = evaluate_multi_statement_for_database(
+                        DatabaseType::SQLite,
+                        "DROP INDEX my_index; DROP VIEW my_view",
+                    );
+                    match result {
+                        MultiStatementDecision::Allow { statements, risk } => {
+                            assert_eq!(
+                                statements,
+                                vec!["DROP INDEX my_index", "DROP VIEW my_view"]
+                            );
+                            assert_eq!(risk.risk_level, RiskLevel::High);
+                            assert!(!risk.read_only_allowed);
+                            assert!(matches!(
+                                risk.confirmation,
+                                ConfirmationType::TableNameInput { ref target } if target == "my_index"
+                            ));
+                        }
+                        _ => panic!("expected Allow"),
                     }
-                    _ => panic!("expected Allow"),
                 }
-            }
 
-            #[rstest]
-            #[case::do_block_with_drop("DO $$ BEGIN RAISE NOTICE 'hi'; END $$; DROP TABLE users")]
-            #[case::drop_with_unextractable_drop("DROP TABLE users; DROP TABLE a, b")]
-            #[case::mixed_acknowledge_reasons(
-                "DO $$ BEGIN RAISE NOTICE 'hi'; END $$; DROP TABLE a, b"
-            )]
-            fn mixed_confirmations_are_blocked(#[case] sql: &str) {
-                let result = evaluate_multi_statement(sql);
-
-                assert!(matches!(result, MultiStatementDecision::Block { .. }));
-            }
-
-            #[rstest]
-            #[case::unknown_risk(
-                "COPY users FROM '/tmp/a.csv'; CALL refresh()",
-                RiskLevel::Low,
-                AcknowledgeReason::UnknownRisk,
-                "COPY"
-            )]
-            #[case::target_name_unavailable(
-                "DROP TABLE a, b; TRUNCATE c, d",
-                RiskLevel::High,
-                AcknowledgeReason::TargetNameUnavailable,
-                "DROP"
-            )]
-            fn same_reason_acknowledgments_aggregate_with_first_label(
-                #[case] sql: &str,
-                #[case] expected_risk: RiskLevel,
-                #[case] expected_reason: AcknowledgeReason,
-                #[case] expected_label: &str,
-            ) {
-                let result = evaluate_multi_statement(sql);
-
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, expected_risk);
-                        assert!(matches!(
-                            risk.confirmation,
-                            ConfirmationType::Acknowledge {
-                                ref reason,
-                                ref label,
-                            } if *reason == expected_reason && label == expected_label
-                        ));
-                    }
-                    _ => panic!("expected Allow"),
+                #[test]
+                fn sqlite_table_name_confirmation_label_matches_first_target_statement() {
+                    let sql = "DROP INDEX my_index; DROP VIEW my_view";
+                    assert_eq!(
+                        adhoc_label_for_table_name_confirmation(DatabaseType::SQLite, sql),
+                        Some("DROP INDEX")
+                    );
                 }
-            }
 
-            #[test]
-            fn drop_multiple_targets_requires_acknowledgment() {
-                let result = evaluate_multi_statement("DROP TABLE a, b");
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, RiskLevel::High);
-                        assert!(matches!(
-                            risk.confirmation,
-                            ConfirmationType::Acknowledge {
-                                reason: AcknowledgeReason::TargetNameUnavailable,
-                                ..
-                            }
-                        ));
+                #[test]
+                fn sqlite_drop_index_requires_table_name_input() {
+                    let result = evaluate_multi_statement_for_database(
+                        DatabaseType::SQLite,
+                        "DROP INDEX IF EXISTS my_index",
+                    );
+                    match result {
+                        MultiStatementDecision::Allow { risk, .. } => {
+                            assert_eq!(risk.risk_level, RiskLevel::High);
+                            assert!(!risk.read_only_allowed);
+                            assert!(matches!(
+                                risk.confirmation,
+                                ConfirmationType::TableNameInput { ref target } if target == "my_index"
+                            ));
+                        }
+                        _ => panic!("expected Allow"),
                     }
-                    _ => panic!("expected Allow"),
                 }
-            }
 
-            #[test]
-            fn insert_then_select_returns_immediate() {
-                let result = evaluate_multi_statement("INSERT INTO users VALUES (1); SELECT 1");
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, RiskLevel::Low);
-                        assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                #[test]
+                fn sqlite_safe_pragma_is_read_only_allowed() {
+                    let result = evaluate_multi_statement_for_database(
+                        DatabaseType::SQLite,
+                        "PRAGMA table_info(t)",
+                    );
+
+                    match result {
+                        MultiStatementDecision::Allow { risk, .. } => {
+                            assert_eq!(risk.risk_level, RiskLevel::Low);
+                            assert!(risk.read_only_allowed);
+                        }
+                        _ => panic!("expected Allow"),
                     }
-                    _ => panic!("expected Allow"),
                 }
-            }
 
-            #[test]
-            fn drop_index_returns_low_immediate_for_postgres() {
-                let result = evaluate_multi_statement("DROP INDEX my_index");
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, RiskLevel::Low);
-                        assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                #[test]
+                fn sqlite_dangerous_pragma_blocks_read_only() {
+                    let result = evaluate_multi_statement_for_database(
+                        DatabaseType::SQLite,
+                        "PRAGMA foreign_keys = OFF",
+                    );
+
+                    match result {
+                        MultiStatementDecision::Allow { risk, .. } => {
+                            assert_eq!(risk.risk_level, RiskLevel::High);
+                            assert!(!risk.read_only_allowed);
+                        }
+                        _ => panic!("expected Allow"),
                     }
-                    _ => panic!("expected Allow"),
-                }
-            }
-
-            #[test]
-            fn sqlite_multiple_high_drops_use_first_target() {
-                let result = evaluate_multi_statement_for_database(
-                    DatabaseType::SQLite,
-                    "DROP INDEX my_index; DROP VIEW my_view",
-                );
-                match result {
-                    MultiStatementDecision::Allow { statements, risk } => {
-                        assert_eq!(statements, vec!["DROP INDEX my_index", "DROP VIEW my_view"]);
-                        assert_eq!(risk.risk_level, RiskLevel::High);
-                        assert!(!risk.read_only_allowed);
-                        assert!(matches!(
-                            risk.confirmation,
-                            ConfirmationType::TableNameInput { ref target } if target == "my_index"
-                        ));
-                    }
-                    _ => panic!("expected Allow"),
-                }
-            }
-
-            #[test]
-            fn sqlite_table_name_confirmation_label_matches_first_target_statement() {
-                let sql = "DROP INDEX my_index; DROP VIEW my_view";
-                assert_eq!(
-                    adhoc_label_for_table_name_confirmation(DatabaseType::SQLite, sql),
-                    Some("DROP INDEX")
-                );
-            }
-
-            #[test]
-            fn sqlite_drop_index_requires_table_name_input() {
-                let result = evaluate_multi_statement_for_database(
-                    DatabaseType::SQLite,
-                    "DROP INDEX IF EXISTS my_index",
-                );
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, RiskLevel::High);
-                        assert!(!risk.read_only_allowed);
-                        assert!(matches!(
-                            risk.confirmation,
-                            ConfirmationType::TableNameInput { ref target } if target == "my_index"
-                        ));
-                    }
-                    _ => panic!("expected Allow"),
-                }
-            }
-
-            #[test]
-            fn drop_owned_by_returns_low_immediate() {
-                let result = evaluate_multi_statement("DROP OWNED BY role");
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, RiskLevel::Low);
-                        assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
-                    }
-                    _ => panic!("expected Allow"),
-                }
-            }
-
-            #[test]
-            fn sqlite_safe_pragma_is_read_only_allowed() {
-                let result = evaluate_multi_statement_for_database(
-                    DatabaseType::SQLite,
-                    "PRAGMA table_info(t)",
-                );
-
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, RiskLevel::Low);
-                        assert!(risk.read_only_allowed);
-                    }
-                    _ => panic!("expected Allow"),
-                }
-            }
-
-            #[test]
-            fn sqlite_dangerous_pragma_blocks_read_only() {
-                let result = evaluate_multi_statement_for_database(
-                    DatabaseType::SQLite,
-                    "PRAGMA foreign_keys = OFF",
-                );
-
-                match result {
-                    MultiStatementDecision::Allow { risk, .. } => {
-                        assert_eq!(risk.risk_level, RiskLevel::High);
-                        assert!(!risk.read_only_allowed);
-                    }
-                    _ => panic!("expected Allow"),
                 }
             }
         }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1136,869 +1136,931 @@ CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
     mod evaluate_sql_risk_tests {
         use super::*;
 
-        #[rstest]
-        #[case::select(StatementKind::Select, "SELECT 1", RiskLevel::Low)]
-        #[case::transaction(StatementKind::Transaction, "BEGIN", RiskLevel::Low)]
-        #[case::insert(StatementKind::Insert, "INSERT INTO users VALUES (1)", RiskLevel::Low)]
-        #[case::create(StatementKind::Create, "CREATE TABLE t (id INT)", RiskLevel::Low)]
-        fn low_risk_returns_immediate(
-            #[case] kind: StatementKind,
-            #[case] sql: &str,
-            #[case] expected_risk: RiskLevel,
-        ) {
-            let result = evaluate_sql_risk(&kind, sql);
-            assert_eq!(result.risk_level, expected_risk);
-            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+        mod generic_risk {
+            use super::*;
+
+            #[rstest]
+            #[case::select(StatementKind::Select, "SELECT 1", RiskLevel::Low)]
+            #[case::transaction(StatementKind::Transaction, "BEGIN", RiskLevel::Low)]
+            #[case::insert(StatementKind::Insert, "INSERT INTO users VALUES (1)", RiskLevel::Low)]
+            #[case::create(StatementKind::Create, "CREATE TABLE t (id INT)", RiskLevel::Low)]
+            fn low_risk_returns_immediate(
+                #[case] kind: StatementKind,
+                #[case] sql: &str,
+                #[case] expected_risk: RiskLevel,
+            ) {
+                let result = evaluate_sql_risk(&kind, sql);
+                assert_eq!(result.risk_level, expected_risk);
+                assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
+
+            #[rstest]
+            #[case::grant(StatementKind::Unsupported, "GRANT SELECT ON users TO role1", "GRANT")]
+            #[case::do_block(
+                StatementKind::Unsupported,
+                "DO $$ BEGIN DELETE FROM users; END $$",
+                "DO"
+            )]
+            #[case::copy(StatementKind::Unsupported, "COPY users FROM '/tmp/data.csv'", "COPY")]
+            #[case::cte_unsupported(
+                StatementKind::Unsupported,
+                "WITH c AS (SELECT 1) CALL refresh()",
+                "CALL"
+            )]
+            #[case::select_into(StatementKind::Other, "SELECT * INTO backup FROM users", "SELECT")]
+            #[case::unparseable(StatementKind::Other, "??? invalid", "INVALID")]
+            fn unassessable_requires_acknowledgment(
+                #[case] kind: StatementKind,
+                #[case] sql: &str,
+                #[case] expected_label: &str,
+            ) {
+                let result = evaluate_sql_risk(&kind, sql);
+
+                assert_eq!(result.risk_level, RiskLevel::Low);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::Acknowledge {
+                        reason: AcknowledgeReason::UnknownRisk,
+                        ref label,
+                    } if label == expected_label
+                ));
+            }
+
+            #[rstest]
+            #[case::empty("")]
+            #[case::whitespace_only("   ")]
+            #[case::comment_only("-- just a comment")]
+            #[case::block_comment_only("/* nothing */")]
+            fn empty_or_comment_only_other_returns_immediate(#[case] sql: &str) {
+                let result = evaluate_sql_risk(&StatementKind::Other, sql);
+
+                assert_eq!(result.risk_level, RiskLevel::Low);
+                assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
+
+            #[rstest]
+            #[case::drop_multiple(StatementKind::Drop, "DROP TABLE a, b", "DROP")]
+            #[case::truncate_multiple(StatementKind::Truncate, "TRUNCATE a, b", "TRUNCATE")]
+            fn high_without_target_requires_acknowledgment(
+                #[case] kind: StatementKind,
+                #[case] sql: &str,
+                #[case] expected_label: &str,
+            ) {
+                let result = evaluate_sql_risk(&kind, sql);
+
+                assert_eq!(result.risk_level, RiskLevel::High);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::Acknowledge {
+                        reason: AcknowledgeReason::TargetNameUnavailable,
+                        ref label,
+                    } if label == expected_label
+                ));
+            }
+
+            #[test]
+            fn data_modifying_cte_blocks_read_only() {
+                let sql = "WITH x AS (UPDATE users SET name='a' RETURNING *) SELECT * FROM x";
+                let result = evaluate_sql_risk(&classify(sql), sql);
+
+                assert_eq!(result.risk_level, RiskLevel::High);
+                assert!(!result.read_only_allowed);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::Acknowledge {
+                        reason: AcknowledgeReason::TargetNameUnavailable,
+                        ref label,
+                    } if label == "UPDATE (no WHERE)"
+                ));
+            }
+
+            #[rstest]
+            #[case::update_where(StatementKind::Update { has_where: true }, "UPDATE users SET x=1 WHERE id=1")]
+            #[case::delete_where(StatementKind::Delete { has_where: true }, "DELETE FROM users WHERE id=1")]
+            #[case::alter(StatementKind::Alter, "ALTER TABLE users ADD COLUMN x INT")]
+            fn medium_risk_returns_immediate(#[case] kind: StatementKind, #[case] sql: &str) {
+                let result = evaluate_sql_risk(&kind, sql);
+                assert_eq!(result.risk_level, RiskLevel::Medium);
+                assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
+
+            #[rstest]
+            #[case::update_no_where(StatementKind::Update { has_where: false }, "UPDATE users SET x=1")]
+            #[case::delete_no_where(StatementKind::Delete { has_where: false }, "DELETE FROM users")]
+            #[case::drop(StatementKind::Drop, "DROP TABLE users")]
+            #[case::truncate(StatementKind::Truncate, "TRUNCATE users")]
+            fn high_table_name_input(#[case] kind: StatementKind, #[case] sql: &str) {
+                let result = evaluate_sql_risk(&kind, sql);
+                assert_eq!(result.risk_level, RiskLevel::High);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::TableNameInput { .. }
+                ));
+            }
+
+            #[test]
+            fn drop_database_returns_high_table_name_input() {
+                let result = evaluate_sql_risk(&StatementKind::Drop, "DROP DATABASE production");
+                assert_eq!(result.risk_level, RiskLevel::High);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::TableNameInput { .. }
+                ));
+            }
+
+            #[test]
+            fn drop_table_with_leading_comment_returns_high() {
+                let result =
+                    evaluate_sql_risk(&StatementKind::Drop, "-- cleanup\nDROP TABLE production");
+                assert_eq!(result.risk_level, RiskLevel::High);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::TableNameInput { .. }
+                ));
+            }
+
+            #[rstest]
+            #[case::drop_index("DROP INDEX my_index")]
+            #[case::drop_policy("DROP POLICY p ON t")]
+            #[case::drop_view("DROP VIEW v")]
+            #[case::drop_schema("DROP SCHEMA s")]
+            #[case::drop_owned_by("DROP OWNED BY role")]
+            #[case::drop_tablespace("DROP TABLESPACE fastdisk")]
+            fn non_table_drop_returns_low_immediate(#[case] sql: &str) {
+                let result = evaluate_sql_risk(&StatementKind::Drop, sql);
+                assert_eq!(result.risk_level, RiskLevel::Low);
+                assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
         }
 
-        #[rstest]
-        #[case::grant(StatementKind::Unsupported, "GRANT SELECT ON users TO role1", "GRANT")]
-        #[case::do_block(
-            StatementKind::Unsupported,
-            "DO $$ BEGIN DELETE FROM users; END $$",
-            "DO"
-        )]
-        #[case::copy(StatementKind::Unsupported, "COPY users FROM '/tmp/data.csv'", "COPY")]
-        #[case::cte_unsupported(
-            StatementKind::Unsupported,
-            "WITH c AS (SELECT 1) CALL refresh()",
-            "CALL"
-        )]
-        #[case::select_into(StatementKind::Other, "SELECT * INTO backup FROM users", "SELECT")]
-        #[case::unparseable(StatementKind::Other, "??? invalid", "INVALID")]
-        fn unassessable_requires_acknowledgment(
-            #[case] kind: StatementKind,
-            #[case] sql: &str,
-            #[case] expected_label: &str,
-        ) {
-            let result = evaluate_sql_risk(&kind, sql);
+        mod sqlite_pragma_risk {
+            use super::*;
 
-            assert_eq!(result.risk_level, RiskLevel::Low);
-            assert!(matches!(
-                result.confirmation,
-                ConfirmationType::Acknowledge {
-                    reason: AcknowledgeReason::UnknownRisk,
-                    ref label,
-                } if label == expected_label
-            ));
+            #[test]
+            fn sqlite_read_only_pragma_returns_low_immediate() {
+                let sql = "PRAGMA table_info(users)";
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+                assert_eq!(result.risk_level, RiskLevel::Low);
+                assert!(result.read_only_allowed);
+                assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
+
+            #[test]
+            fn sqlite_allowlisted_parameterized_pragma_returns_low_immediate() {
+                let sql = "PRAGMA index_info(users_name_idx)";
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+                assert_eq!(result.risk_level, RiskLevel::Low);
+                assert!(result.read_only_allowed);
+                assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
+
+            #[rstest]
+            #[case::writable_schema("PRAGMA writable_schema = ON")]
+            #[case::writable_schema_call("PRAGMA writable_schema(ON)")]
+            #[case::foreign_keys_off("PRAGMA foreign_keys = OFF")]
+            #[case::foreign_keys_call_off("PRAGMA foreign_keys(OFF)")]
+            #[case::journal_mode("PRAGMA journal_mode = WAL")]
+            #[case::journal_mode_call("PRAGMA journal_mode(WAL)")]
+            #[case::locking_mode("PRAGMA locking_mode = EXCLUSIVE")]
+            #[case::optimize("PRAGMA optimize")]
+            #[case::incremental_vacuum("PRAGMA incremental_vacuum")]
+            #[case::wal_checkpoint("PRAGMA wal_checkpoint")]
+            fn sqlite_dangerous_pragma_requires_acknowledgment(#[case] sql: &str) {
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+                assert_eq!(result.risk_level, RiskLevel::High);
+                assert!(!result.read_only_allowed);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::Acknowledge {
+                        reason: AcknowledgeReason::TargetNameUnavailable,
+                        ref label,
+                    } if label == "PRAGMA"
+                ));
+            }
+
+            #[test]
+            fn sqlite_non_dangerous_pragma_assignment_is_medium_write() {
+                let sql = "PRAGMA user_version = 3";
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+                assert_eq!(result.risk_level, RiskLevel::Medium);
+                assert!(!result.read_only_allowed);
+                assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
+
+            #[test]
+            fn sqlite_non_allowlisted_parameterized_pragma_is_medium_write() {
+                let sql = "PRAGMA user_version(3)";
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+                assert_eq!(result.risk_level, RiskLevel::Medium);
+                assert!(!result.read_only_allowed);
+                assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
         }
 
-        #[rstest]
-        #[case::empty("")]
-        #[case::whitespace_only("   ")]
-        #[case::comment_only("-- just a comment")]
-        #[case::block_comment_only("/* nothing */")]
-        fn empty_or_comment_only_other_returns_immediate(#[case] sql: &str) {
-            let result = evaluate_sql_risk(&StatementKind::Other, sql);
+        mod sqlite_replace_risk {
+            use super::*;
 
-            assert_eq!(result.risk_level, RiskLevel::Low);
-            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            #[rstest]
+            #[case::attach("ATTACH DATABASE 'other.db' AS other", "ATTACH")]
+            #[case::detach("DETACH DATABASE other", "DETACH")]
+            #[case::vacuum("VACUUM INTO 'copy.db'", "VACUUM")]
+            #[case::reindex("REINDEX users_name_idx", "REINDEX")]
+            #[case::analyze("ANALYZE users", "ANALYZE")]
+            fn sqlite_high_risk_statements_require_acknowledgment(
+                #[case] sql: &str,
+                #[case] expected_label: &str,
+            ) {
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+                assert_eq!(result.risk_level, RiskLevel::High);
+                assert!(!result.read_only_allowed);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::Acknowledge { ref label, .. } if label == expected_label
+                ));
+            }
+
+            #[rstest]
+            #[case::insert_or_replace("INSERT OR REPLACE INTO users(id) VALUES (1)", "users")]
+            #[case::with_insert_or_replace(
+                "WITH payload(id) AS (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
+                "users"
+            )]
+            #[case::with_recursive_insert_or_replace(
+                "WITH RECURSIVE payload(id) AS (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
+                "users"
+            )]
+            #[case::with_materialized_insert_or_replace(
+                "WITH payload(id) AS MATERIALIZED (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
+                "users"
+            )]
+            #[case::with_not_materialized_insert_or_replace(
+                "WITH payload(id) AS NOT MATERIALIZED (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
+                "users"
+            )]
+            #[case::with_multiple_ctes_insert_or_replace(
+                "WITH a(id) AS (VALUES (1)), b(id) AS (VALUES (2)) INSERT OR REPLACE INTO users(id) SELECT id FROM a",
+                "users"
+            )]
+            #[case::replace("REPLACE INTO users(id) VALUES (1)", "users")]
+            #[case::with_replace(
+                "WITH payload(id) AS (VALUES (1)) REPLACE INTO users(id) SELECT id FROM payload",
+                "users"
+            )]
+            #[case::bracket_quoted("REPLACE INTO [my table](id) VALUES (1)", "my table")]
+            #[case::backtick_quoted("REPLACE INTO `my table`(id) VALUES (1)", "my table")]
+            #[case::double_quoted(r#"REPLACE INTO "my table"(id) VALUES (1)"#, "my table")]
+            #[case::double_quoted_escaped(
+                r#"REPLACE INTO "my""table"(id) VALUES (1)"#,
+                r#"my"table"#
+            )]
+            #[case::backtick_quoted_escaped("REPLACE INTO `my``table`(id) VALUES (1)", "my`table")]
+            #[case::bracket_doubled_close_is_not_escape(
+                "REPLACE INTO [my]]table](id) VALUES (1)",
+                "my"
+            )]
+            #[case::schema_qualified(
+                "INSERT OR REPLACE INTO main.[my table](id) VALUES (1)",
+                "main.my table"
+            )]
+            fn sqlite_replace_requires_table_name_input(
+                #[case] sql: &str,
+                #[case] expected_target: &str,
+            ) {
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+
+                assert_eq!(result.risk_level, RiskLevel::High);
+                assert!(!result.read_only_allowed);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::TableNameInput { ref target } if target == expected_target
+                ));
+            }
+
+            #[test]
+            fn sqlite_specific_label_detects_commented_insert_or_replace() {
+                let sql = "-- upsert\nINSERT OR REPLACE INTO users(id) VALUES (1)";
+
+                assert_eq!(sqlite_specific_label(sql), Some("REPLACE"));
+            }
+
+            #[test]
+            fn sqlite_specific_label_detects_with_insert_or_replace() {
+                let sql = "WITH payload(id) AS (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload";
+
+                assert_eq!(sqlite_specific_label(sql), Some("REPLACE"));
+            }
         }
 
-        #[rstest]
-        #[case::drop_multiple(StatementKind::Drop, "DROP TABLE a, b", "DROP")]
-        #[case::truncate_multiple(StatementKind::Truncate, "TRUNCATE a, b", "TRUNCATE")]
-        fn high_without_target_requires_acknowledgment(
-            #[case] kind: StatementKind,
-            #[case] sql: &str,
-            #[case] expected_label: &str,
-        ) {
-            let result = evaluate_sql_risk(&kind, sql);
+        mod sqlite_drop_risk {
+            use super::*;
 
-            assert_eq!(result.risk_level, RiskLevel::High);
-            assert!(matches!(
-                result.confirmation,
-                ConfirmationType::Acknowledge {
-                    reason: AcknowledgeReason::TargetNameUnavailable,
-                    ref label,
-                } if label == expected_label
-            ));
-        }
+            #[rstest]
+            #[case::drop_index("DROP INDEX my_index", "DROP INDEX")]
+            #[case::drop_index_if_exists("DROP INDEX IF EXISTS my_index", "DROP INDEX")]
+            #[case::drop_view("DROP VIEW my_view", "DROP VIEW")]
+            #[case::drop_view_if_exists("DROP VIEW IF EXISTS my_view", "DROP VIEW")]
+            #[case::drop_trigger("DROP TRIGGER my_trigger", "DROP TRIGGER")]
+            #[case::drop_trigger_if_exists("DROP TRIGGER IF EXISTS my_trigger", "DROP TRIGGER")]
+            fn sqlite_specific_label_detects_dangerous_drops(
+                #[case] sql: &str,
+                #[case] expected: &str,
+            ) {
+                assert_eq!(sqlite_specific_label(sql), Some(expected));
+            }
 
-        #[test]
-        fn data_modifying_cte_blocks_read_only() {
-            let sql = "WITH x AS (UPDATE users SET name='a' RETURNING *) SELECT * FROM x";
-            let result = evaluate_sql_risk(&classify(sql), sql);
+            #[rstest]
+            #[case::drop_index("DROP INDEX my_index", "my_index")]
+            #[case::drop_index_if_exists("DROP INDEX IF EXISTS my_index", "my_index")]
+            #[case::drop_view("DROP VIEW my_view", "my_view")]
+            #[case::drop_view_if_exists("DROP VIEW IF EXISTS my_view", "my_view")]
+            #[case::drop_trigger("DROP TRIGGER my_trigger", "my_trigger")]
+            #[case::drop_trigger_if_exists(
+                "DROP TRIGGER IF EXISTS main.my_trigger",
+                "main.my_trigger"
+            )]
+            #[case::drop_index_quoted("DROP INDEX `my index`", "my index")]
+            #[case::drop_view_quoted(r#"DROP VIEW "my view""#, "my view")]
+            #[case::drop_trigger_quoted("DROP TRIGGER [my trigger]", "my trigger")]
+            fn sqlite_dangerous_drop_requires_table_name_input(
+                #[case] sql: &str,
+                #[case] expected_target: &str,
+            ) {
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
 
-            assert_eq!(result.risk_level, RiskLevel::High);
-            assert!(!result.read_only_allowed);
-            assert!(matches!(
-                result.confirmation,
-                ConfirmationType::Acknowledge {
-                    reason: AcknowledgeReason::TargetNameUnavailable,
-                    ref label,
-                } if label == "UPDATE (no WHERE)"
-            ));
-        }
+                assert_eq!(result.risk_level, RiskLevel::High);
+                assert!(!result.read_only_allowed);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::TableNameInput { ref target } if target == expected_target
+                ));
+            }
 
-        #[rstest]
-        #[case::update_where(StatementKind::Update { has_where: true }, "UPDATE users SET x=1 WHERE id=1")]
-        #[case::delete_where(StatementKind::Delete { has_where: true }, "DELETE FROM users WHERE id=1")]
-        #[case::alter(StatementKind::Alter, "ALTER TABLE users ADD COLUMN x INT")]
-        fn medium_risk_returns_immediate(#[case] kind: StatementKind, #[case] sql: &str) {
-            let result = evaluate_sql_risk(&kind, sql);
-            assert_eq!(result.risk_level, RiskLevel::Medium);
-            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
-        }
+            #[rstest]
+            #[case::drop_policy("DROP POLICY p ON t")]
+            #[case::drop_schema("DROP SCHEMA s")]
+            fn sqlite_unhandled_drop_subtypes_fall_back_to_generic_low_immediate(
+                #[case] sql: &str,
+            ) {
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
 
-        #[rstest]
-        #[case::update_no_where(StatementKind::Update { has_where: false }, "UPDATE users SET x=1")]
-        #[case::delete_no_where(StatementKind::Delete { has_where: false }, "DELETE FROM users")]
-        #[case::drop(StatementKind::Drop, "DROP TABLE users")]
-        #[case::truncate(StatementKind::Truncate, "TRUNCATE users")]
-        fn high_table_name_input(#[case] kind: StatementKind, #[case] sql: &str) {
-            let result = evaluate_sql_risk(&kind, sql);
-            assert_eq!(result.risk_level, RiskLevel::High);
-            assert!(matches!(
-                result.confirmation,
-                ConfirmationType::TableNameInput { .. }
-            ));
-        }
+                assert_eq!(result.risk_level, RiskLevel::Low);
+                assert!(matches!(result.confirmation, ConfirmationType::Immediate));
+            }
 
-        #[test]
-        fn drop_database_returns_high_table_name_input() {
-            let result = evaluate_sql_risk(&StatementKind::Drop, "DROP DATABASE production");
-            assert_eq!(result.risk_level, RiskLevel::High);
-            assert!(matches!(
-                result.confirmation,
-                ConfirmationType::TableNameInput { .. }
-            ));
-        }
+            #[test]
+            fn sqlite_drop_multiple_index_requires_acknowledgment() {
+                let sql = "DROP INDEX a, b";
+                let result =
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
 
-        #[test]
-        fn drop_table_with_leading_comment_returns_high() {
-            let result =
-                evaluate_sql_risk(&StatementKind::Drop, "-- cleanup\nDROP TABLE production");
-            assert_eq!(result.risk_level, RiskLevel::High);
-            assert!(matches!(
-                result.confirmation,
-                ConfirmationType::TableNameInput { .. }
-            ));
-        }
-
-        #[rstest]
-        #[case::drop_index("DROP INDEX my_index")]
-        #[case::drop_policy("DROP POLICY p ON t")]
-        #[case::drop_view("DROP VIEW v")]
-        #[case::drop_schema("DROP SCHEMA s")]
-        #[case::drop_owned_by("DROP OWNED BY role")]
-        #[case::drop_tablespace("DROP TABLESPACE fastdisk")]
-        fn non_table_drop_returns_low_immediate(#[case] sql: &str) {
-            let result = evaluate_sql_risk(&StatementKind::Drop, sql);
-            assert_eq!(result.risk_level, RiskLevel::Low);
-            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
-        }
-
-        #[test]
-        fn sqlite_read_only_pragma_returns_low_immediate() {
-            let sql = "PRAGMA table_info(users)";
-            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
-
-            assert_eq!(result.risk_level, RiskLevel::Low);
-            assert!(result.read_only_allowed);
-            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
-        }
-
-        #[test]
-        fn sqlite_allowlisted_parameterized_pragma_returns_low_immediate() {
-            let sql = "PRAGMA index_info(users_name_idx)";
-            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
-
-            assert_eq!(result.risk_level, RiskLevel::Low);
-            assert!(result.read_only_allowed);
-            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
-        }
-
-        #[rstest]
-        #[case::writable_schema("PRAGMA writable_schema = ON")]
-        #[case::writable_schema_call("PRAGMA writable_schema(ON)")]
-        #[case::foreign_keys_off("PRAGMA foreign_keys = OFF")]
-        #[case::foreign_keys_call_off("PRAGMA foreign_keys(OFF)")]
-        #[case::journal_mode("PRAGMA journal_mode = WAL")]
-        #[case::journal_mode_call("PRAGMA journal_mode(WAL)")]
-        #[case::locking_mode("PRAGMA locking_mode = EXCLUSIVE")]
-        #[case::optimize("PRAGMA optimize")]
-        #[case::incremental_vacuum("PRAGMA incremental_vacuum")]
-        #[case::wal_checkpoint("PRAGMA wal_checkpoint")]
-        fn sqlite_dangerous_pragma_requires_acknowledgment(#[case] sql: &str) {
-            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
-
-            assert_eq!(result.risk_level, RiskLevel::High);
-            assert!(!result.read_only_allowed);
-            assert!(matches!(
-                result.confirmation,
-                ConfirmationType::Acknowledge {
-                    reason: AcknowledgeReason::TargetNameUnavailable,
-                    ref label,
-                } if label == "PRAGMA"
-            ));
-        }
-
-        #[test]
-        fn sqlite_non_dangerous_pragma_assignment_is_medium_write() {
-            let sql = "PRAGMA user_version = 3";
-            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
-
-            assert_eq!(result.risk_level, RiskLevel::Medium);
-            assert!(!result.read_only_allowed);
-            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
-        }
-
-        #[test]
-        fn sqlite_non_allowlisted_parameterized_pragma_is_medium_write() {
-            let sql = "PRAGMA user_version(3)";
-            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
-
-            assert_eq!(result.risk_level, RiskLevel::Medium);
-            assert!(!result.read_only_allowed);
-            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
-        }
-
-        #[rstest]
-        #[case::attach("ATTACH DATABASE 'other.db' AS other", "ATTACH")]
-        #[case::detach("DETACH DATABASE other", "DETACH")]
-        #[case::vacuum("VACUUM INTO 'copy.db'", "VACUUM")]
-        #[case::reindex("REINDEX users_name_idx", "REINDEX")]
-        #[case::analyze("ANALYZE users", "ANALYZE")]
-        fn sqlite_high_risk_statements_require_acknowledgment(
-            #[case] sql: &str,
-            #[case] expected_label: &str,
-        ) {
-            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
-
-            assert_eq!(result.risk_level, RiskLevel::High);
-            assert!(!result.read_only_allowed);
-            assert!(matches!(
-                result.confirmation,
-                ConfirmationType::Acknowledge { ref label, .. } if label == expected_label
-            ));
-        }
-
-        #[rstest]
-        #[case::insert_or_replace("INSERT OR REPLACE INTO users(id) VALUES (1)", "users")]
-        #[case::with_insert_or_replace(
-            "WITH payload(id) AS (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
-            "users"
-        )]
-        #[case::with_recursive_insert_or_replace(
-            "WITH RECURSIVE payload(id) AS (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
-            "users"
-        )]
-        #[case::with_materialized_insert_or_replace(
-            "WITH payload(id) AS MATERIALIZED (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
-            "users"
-        )]
-        #[case::with_not_materialized_insert_or_replace(
-            "WITH payload(id) AS NOT MATERIALIZED (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload",
-            "users"
-        )]
-        #[case::with_multiple_ctes_insert_or_replace(
-            "WITH a(id) AS (VALUES (1)), b(id) AS (VALUES (2)) INSERT OR REPLACE INTO users(id) SELECT id FROM a",
-            "users"
-        )]
-        #[case::replace("REPLACE INTO users(id) VALUES (1)", "users")]
-        #[case::with_replace(
-            "WITH payload(id) AS (VALUES (1)) REPLACE INTO users(id) SELECT id FROM payload",
-            "users"
-        )]
-        #[case::bracket_quoted("REPLACE INTO [my table](id) VALUES (1)", "my table")]
-        #[case::backtick_quoted("REPLACE INTO `my table`(id) VALUES (1)", "my table")]
-        #[case::double_quoted(r#"REPLACE INTO "my table"(id) VALUES (1)"#, "my table")]
-        #[case::double_quoted_escaped(r#"REPLACE INTO "my""table"(id) VALUES (1)"#, r#"my"table"#)]
-        #[case::backtick_quoted_escaped("REPLACE INTO `my``table`(id) VALUES (1)", "my`table")]
-        #[case::bracket_doubled_close_is_not_escape(
-            "REPLACE INTO [my]]table](id) VALUES (1)",
-            "my"
-        )]
-        #[case::schema_qualified(
-            "INSERT OR REPLACE INTO main.[my table](id) VALUES (1)",
-            "main.my table"
-        )]
-        fn sqlite_replace_requires_table_name_input(
-            #[case] sql: &str,
-            #[case] expected_target: &str,
-        ) {
-            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
-
-            assert_eq!(result.risk_level, RiskLevel::High);
-            assert!(!result.read_only_allowed);
-            assert!(matches!(
-                result.confirmation,
-                ConfirmationType::TableNameInput { ref target } if target == expected_target
-            ));
-        }
-
-        #[test]
-        fn sqlite_specific_label_detects_commented_insert_or_replace() {
-            let sql = "-- upsert\nINSERT OR REPLACE INTO users(id) VALUES (1)";
-
-            assert_eq!(sqlite_specific_label(sql), Some("REPLACE"));
-        }
-
-        #[test]
-        fn sqlite_specific_label_detects_with_insert_or_replace() {
-            let sql = "WITH payload(id) AS (VALUES (1)) INSERT OR REPLACE INTO users(id) SELECT id FROM payload";
-
-            assert_eq!(sqlite_specific_label(sql), Some("REPLACE"));
-        }
-
-        #[rstest]
-        #[case::drop_index("DROP INDEX my_index", "DROP INDEX")]
-        #[case::drop_index_if_exists("DROP INDEX IF EXISTS my_index", "DROP INDEX")]
-        #[case::drop_view("DROP VIEW my_view", "DROP VIEW")]
-        #[case::drop_view_if_exists("DROP VIEW IF EXISTS my_view", "DROP VIEW")]
-        #[case::drop_trigger("DROP TRIGGER my_trigger", "DROP TRIGGER")]
-        #[case::drop_trigger_if_exists("DROP TRIGGER IF EXISTS my_trigger", "DROP TRIGGER")]
-        fn sqlite_specific_label_detects_dangerous_drops(
-            #[case] sql: &str,
-            #[case] expected: &str,
-        ) {
-            assert_eq!(sqlite_specific_label(sql), Some(expected));
-        }
-
-        #[rstest]
-        #[case::drop_index("DROP INDEX my_index", "my_index")]
-        #[case::drop_index_if_exists("DROP INDEX IF EXISTS my_index", "my_index")]
-        #[case::drop_view("DROP VIEW my_view", "my_view")]
-        #[case::drop_view_if_exists("DROP VIEW IF EXISTS my_view", "my_view")]
-        #[case::drop_trigger("DROP TRIGGER my_trigger", "my_trigger")]
-        #[case::drop_trigger_if_exists("DROP TRIGGER IF EXISTS main.my_trigger", "main.my_trigger")]
-        #[case::drop_index_quoted("DROP INDEX `my index`", "my index")]
-        #[case::drop_view_quoted(r#"DROP VIEW "my view""#, "my view")]
-        #[case::drop_trigger_quoted("DROP TRIGGER [my trigger]", "my trigger")]
-        fn sqlite_dangerous_drop_requires_table_name_input(
-            #[case] sql: &str,
-            #[case] expected_target: &str,
-        ) {
-            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
-
-            assert_eq!(result.risk_level, RiskLevel::High);
-            assert!(!result.read_only_allowed);
-            assert!(matches!(
-                result.confirmation,
-                ConfirmationType::TableNameInput { ref target } if target == expected_target
-            ));
-        }
-
-        #[rstest]
-        #[case::drop_policy("DROP POLICY p ON t")]
-        #[case::drop_schema("DROP SCHEMA s")]
-        fn sqlite_unhandled_drop_subtypes_fall_back_to_generic_low_immediate(#[case] sql: &str) {
-            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
-
-            assert_eq!(result.risk_level, RiskLevel::Low);
-            assert!(matches!(result.confirmation, ConfirmationType::Immediate));
-        }
-
-        #[test]
-        fn sqlite_drop_multiple_index_requires_acknowledgment() {
-            let sql = "DROP INDEX a, b";
-            let result = evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
-
-            assert_eq!(result.risk_level, RiskLevel::High);
-            assert!(!result.read_only_allowed);
-            assert!(matches!(
-                result.confirmation,
-                ConfirmationType::Acknowledge {
-                    reason: AcknowledgeReason::TargetNameUnavailable,
-                    ref label,
-                } if label == "DROP INDEX"
-            ));
+                assert_eq!(result.risk_level, RiskLevel::High);
+                assert!(!result.read_only_allowed);
+                assert!(matches!(
+                    result.confirmation,
+                    ConfirmationType::Acknowledge {
+                        reason: AcknowledgeReason::TargetNameUnavailable,
+                        ref label,
+                    } if label == "DROP INDEX"
+                ));
+            }
         }
     }
 
     mod evaluate_multi_statement_tests {
         use super::*;
 
-        #[test]
-        fn single_select_passthrough() {
-            let result = evaluate_multi_statement("SELECT 1");
-            match result {
-                MultiStatementDecision::Allow { statements, risk } => {
-                    assert_eq!(statements, vec!["SELECT 1"]);
-                    assert_eq!(risk.confirmation, ConfirmationType::Immediate);
+        mod generic_aggregation {
+            use super::*;
+
+            #[test]
+            fn single_select_passthrough() {
+                let result = evaluate_multi_statement("SELECT 1");
+                match result {
+                    MultiStatementDecision::Allow { statements, risk } => {
+                        assert_eq!(statements, vec!["SELECT 1"]);
+                        assert_eq!(risk.confirmation, ConfirmationType::Immediate);
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
+            }
+
+            #[test]
+            fn single_insert_passthrough() {
+                let result = evaluate_multi_statement("INSERT INTO users VALUES (1)");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Low);
+                        assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                    }
+                    _ => panic!("expected Allow"),
+                }
+            }
+
+            #[test]
+            fn single_drop_passthrough() {
+                let result = evaluate_multi_statement("DROP TABLE users");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::High);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::TableNameInput { .. }
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
+                }
+            }
+
+            #[test]
+            fn tcl_only_multi_returns_immediate() {
+                let result = evaluate_multi_statement("BEGIN; COMMIT");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.confirmation, ConfirmationType::Immediate);
+                    }
+                    _ => panic!("expected Allow"),
+                }
+            }
+
+            #[test]
+            fn multiple_high_uses_first_target() {
+                let result = evaluate_multi_statement("DROP TABLE a; DROP TABLE b");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::High);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::TableNameInput { ref target } if target == "a"
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
+                }
+            }
+
+            #[test]
+            fn select_into_requires_acknowledgment() {
+                let result = evaluate_multi_statement("SELECT * INTO backup FROM users");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Low);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::Acknowledge {
+                                reason: AcknowledgeReason::UnknownRisk,
+                                ..
+                            }
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
+                }
+            }
+
+            #[test]
+            fn risk_aggregation_select_insert() {
+                let result = evaluate_multi_statement("SELECT 1; INSERT INTO users VALUES (1)");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Low);
+                        assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                    }
+                    _ => panic!("expected Allow"),
+                }
             }
         }
 
-        #[test]
-        fn single_insert_passthrough() {
-            let result = evaluate_multi_statement("INSERT INTO users VALUES (1)");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::Low);
-                    assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+        mod sqlite_transaction_policy {
+            use super::*;
+
+            #[test]
+            fn sqlite_incompatible_transaction_requires_non_atomic_acknowledgement() {
+                let result = evaluate_multi_statement_for_database(
+                    DatabaseType::SQLite,
+                    "PRAGMA foreign_keys = ON; CREATE TABLE users(id INTEGER)",
+                );
+
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::Acknowledge {
+                                reason: AcknowledgeReason::NonAtomicTransaction,
+                                ref label,
+                            } if label == "SQLite transaction"
+                        ));
+                        assert!(!risk.read_only_allowed);
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
+            }
+
+            #[test]
+            fn sqlite_incompatible_transaction_preserves_high_risk_acknowledgement() {
+                let result = evaluate_multi_statement_for_database(
+                    DatabaseType::SQLite,
+                    "PRAGMA foreign_keys = OFF; CREATE TABLE users(id INTEGER)",
+                );
+
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::Acknowledge {
+                                reason: AcknowledgeReason::TargetNameUnavailable,
+                                ref label,
+                            } if label == "PRAGMA"
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
+                }
+            }
+
+            #[test]
+            fn sqlite_incompatible_transaction_and_typed_drop_are_blocked_together() {
+                let result = evaluate_multi_statement_for_database(
+                    DatabaseType::SQLite,
+                    "PRAGMA foreign_keys = OFF; DROP TABLE users",
+                );
+
+                assert!(matches!(result, MultiStatementDecision::Block { .. }));
+            }
+
+            #[test]
+            fn sqlite_incompatible_transaction_and_typed_drop_with_non_dangerous_pragma_are_blocked()
+             {
+                let result = evaluate_multi_statement_for_database(
+                    DatabaseType::SQLite,
+                    "PRAGMA foreign_keys = ON; DROP TABLE users",
+                );
+
+                assert!(matches!(result, MultiStatementDecision::Block { .. }));
             }
         }
 
-        #[test]
-        fn single_drop_passthrough() {
-            let result = evaluate_multi_statement("DROP TABLE users");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::High);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::TableNameInput { .. }
-                    ));
+        mod input_validation {
+            use super::*;
+
+            #[test]
+            fn risk_aggregation_select_update_where() {
+                let result =
+                    evaluate_multi_statement("SELECT 1; UPDATE users SET x = 1 WHERE id = 1");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Medium);
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
+            }
+
+            #[test]
+            fn empty_input_blocked() {
+                let result = evaluate_multi_statement("");
+                assert!(matches!(result, MultiStatementDecision::Block { .. }));
+            }
+
+            #[rstest]
+            #[case::sqlite_shell(".shell echo injected")]
+            #[case::sqlite_open_after_select("SELECT 1;\n.open writable.db")]
+            #[case::psql_shell("\\! echo injected")]
+            #[case::indented_meta_command("  .output /tmp/out.csv")]
+            #[case::psql_backslash_inside_bracket_identifier("SELECT [\n\\! echo injected\n]")]
+            #[case::psql_backslash_inside_backtick_identifier("SELECT `\n\\! echo injected\n`")]
+            fn cli_meta_commands_are_blocked(#[case] sql: &str) {
+                let result = evaluate_multi_statement(sql);
+
+                assert!(matches!(
+                    result,
+                    MultiStatementDecision::Block { reason }
+                        if reason == "CLI meta-commands are not supported in SQL input"
+                ));
+            }
+
+            #[rstest]
+            #[case::dot_inside_string("SELECT '.shell echo ok'")]
+            #[case::backslash_inside_string("SELECT '\\\\! echo ok'")]
+            #[case::dot_inside_comment("-- .shell ignored\nSELECT 1")]
+            #[case::backslash_inside_block_comment("SELECT /* \\! ignored */ 1")]
+            #[case::backslash_inside_quoted_identifier(
+                r#"SELECT "table\!name" FROM "table\!name""#
+            )]
+            #[case::dot_inside_dollar_quote("SELECT $tag$\n.shell ignored\n$tag$")]
+            fn cli_meta_command_like_text_is_allowed(#[case] sql: &str) {
+                let result = evaluate_multi_statement(sql);
+
+                assert!(matches!(result, MultiStatementDecision::Allow { .. }));
+            }
+
+            #[rstest]
+            #[case::dot_inside_bracket_identifier("SELECT [\n.shell ignored] FROM t")]
+            #[case::backslash_inside_backtick_identifier("SELECT `\n\\! ignored` FROM t")]
+            fn sqlite_cli_meta_command_like_identifier_text_is_allowed(#[case] sql: &str) {
+                let result = evaluate_multi_statement_for_database(DatabaseType::SQLite, sql);
+
+                assert!(matches!(result, MultiStatementDecision::Allow { .. }));
             }
         }
 
-        #[test]
-        fn tcl_only_multi_returns_immediate() {
-            let result = evaluate_multi_statement("BEGIN; COMMIT");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.confirmation, ConfirmationType::Immediate);
+        mod quoted_identifiers {
+            use super::*;
+
+            #[rstest]
+            #[case::bracket_contains_drop("SELECT [1; DROP TABLE users]", "users")]
+            #[case::backtick_contains_drop("SELECT `1; DROP TABLE users`", "users")]
+            fn postgres_brackets_and_backticks_do_not_hide_dangerous_statements(
+                #[case] sql: &str,
+                #[case] expected_target: &str,
+            ) {
+                let result = evaluate_multi_statement(sql);
+
+                match result {
+                    MultiStatementDecision::Allow { statements, risk } => {
+                        assert_eq!(statements.len(), 2);
+                        assert_eq!(risk.risk_level, RiskLevel::High);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::TableNameInput { ref target } if target == expected_target
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
+            }
+
+            #[rstest]
+            #[case::update_backtick_where_identifier("UPDATE `where` SET x = 1", "where")]
+            #[case::delete_bracket_quoted_dot("DELETE FROM [main.users]", "main.users")]
+            #[case::drop_table_backtick_qualified("DROP TABLE main.`my.table`", "main.my.table")]
+            #[case::drop_table_bracket_reserved_word("DROP TABLE [select]", "select")]
+            fn sqlite_quoted_targets_require_table_name_input(
+                #[case] sql: &str,
+                #[case] expected_target: &str,
+            ) {
+                let result = evaluate_multi_statement_for_database(DatabaseType::SQLite, sql);
+
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::High);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::TableNameInput { ref target } if target == expected_target
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
+                }
             }
         }
 
-        #[test]
-        fn multiple_high_uses_first_target() {
-            let result = evaluate_multi_statement("DROP TABLE a; DROP TABLE b");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::High);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::TableNameInput { ref target } if target == "a"
-                    ));
+        mod confirmation_aggregation {
+            use super::*;
+
+            #[test]
+            fn do_block_requires_acknowledgment() {
+                let result = evaluate_multi_statement("DO $$ BEGIN RAISE NOTICE 'hi'; END $$");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Low);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::Acknowledge {
+                                reason: AcknowledgeReason::UnknownRisk,
+                                ref label,
+                            } if label == "DO"
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
             }
-        }
 
-        #[test]
-        fn select_into_requires_acknowledgment() {
-            let result = evaluate_multi_statement("SELECT * INTO backup FROM users");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::Low);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::Acknowledge {
-                            reason: AcknowledgeReason::UnknownRisk,
-                            ..
-                        }
-                    ));
+            #[test]
+            fn copy_requires_acknowledgment() {
+                let result = evaluate_multi_statement("COPY users FROM '/tmp/data.csv'");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Low);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::Acknowledge {
+                                reason: AcknowledgeReason::UnknownRisk,
+                                ref label,
+                            } if label == "COPY"
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
             }
-        }
 
-        #[test]
-        fn risk_aggregation_select_insert() {
-            let result = evaluate_multi_statement("SELECT 1; INSERT INTO users VALUES (1)");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::Low);
-                    assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+            #[test]
+            fn do_block_after_select_requires_acknowledgment() {
+                let result =
+                    evaluate_multi_statement("SELECT 1; DO $$ BEGIN DELETE FROM users; END $$");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Low);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::Acknowledge {
+                                reason: AcknowledgeReason::UnknownRisk,
+                                ..
+                            }
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
             }
-        }
 
-        #[test]
-        fn sqlite_incompatible_transaction_requires_non_atomic_acknowledgement() {
-            let result = evaluate_multi_statement_for_database(
-                DatabaseType::SQLite,
-                "PRAGMA foreign_keys = ON; CREATE TABLE users(id INTEGER)",
-            );
+            #[rstest]
+            #[case::do_block_with_drop("DO $$ BEGIN RAISE NOTICE 'hi'; END $$; DROP TABLE users")]
+            #[case::drop_with_unextractable_drop("DROP TABLE users; DROP TABLE a, b")]
+            #[case::mixed_acknowledge_reasons(
+                "DO $$ BEGIN RAISE NOTICE 'hi'; END $$; DROP TABLE a, b"
+            )]
+            fn mixed_confirmations_are_blocked(#[case] sql: &str) {
+                let result = evaluate_multi_statement(sql);
 
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::Acknowledge {
-                            reason: AcknowledgeReason::NonAtomicTransaction,
-                            ref label,
-                        } if label == "SQLite transaction"
-                    ));
-                    assert!(!risk.read_only_allowed);
-                }
-                _ => panic!("expected Allow"),
+                assert!(matches!(result, MultiStatementDecision::Block { .. }));
             }
-        }
 
-        #[test]
-        fn sqlite_incompatible_transaction_preserves_high_risk_acknowledgement() {
-            let result = evaluate_multi_statement_for_database(
-                DatabaseType::SQLite,
-                "PRAGMA foreign_keys = OFF; CREATE TABLE users(id INTEGER)",
-            );
+            #[rstest]
+            #[case::unknown_risk(
+                "COPY users FROM '/tmp/a.csv'; CALL refresh()",
+                RiskLevel::Low,
+                AcknowledgeReason::UnknownRisk,
+                "COPY"
+            )]
+            #[case::target_name_unavailable(
+                "DROP TABLE a, b; TRUNCATE c, d",
+                RiskLevel::High,
+                AcknowledgeReason::TargetNameUnavailable,
+                "DROP"
+            )]
+            fn same_reason_acknowledgments_aggregate_with_first_label(
+                #[case] sql: &str,
+                #[case] expected_risk: RiskLevel,
+                #[case] expected_reason: AcknowledgeReason,
+                #[case] expected_label: &str,
+            ) {
+                let result = evaluate_multi_statement(sql);
 
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::Acknowledge {
-                            reason: AcknowledgeReason::TargetNameUnavailable,
-                            ref label,
-                        } if label == "PRAGMA"
-                    ));
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, expected_risk);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::Acknowledge {
+                                ref reason,
+                                ref label,
+                            } if *reason == expected_reason && label == expected_label
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
             }
-        }
 
-        #[test]
-        fn sqlite_incompatible_transaction_and_typed_drop_are_blocked_together() {
-            let result = evaluate_multi_statement_for_database(
-                DatabaseType::SQLite,
-                "PRAGMA foreign_keys = OFF; DROP TABLE users",
-            );
-
-            assert!(matches!(result, MultiStatementDecision::Block { .. }));
-        }
-
-        #[test]
-        fn sqlite_incompatible_transaction_and_typed_drop_with_non_dangerous_pragma_are_blocked() {
-            let result = evaluate_multi_statement_for_database(
-                DatabaseType::SQLite,
-                "PRAGMA foreign_keys = ON; DROP TABLE users",
-            );
-
-            assert!(matches!(result, MultiStatementDecision::Block { .. }));
-        }
-
-        #[test]
-        fn risk_aggregation_select_update_where() {
-            let result = evaluate_multi_statement("SELECT 1; UPDATE users SET x = 1 WHERE id = 1");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::Medium);
+            #[test]
+            fn drop_multiple_targets_requires_acknowledgment() {
+                let result = evaluate_multi_statement("DROP TABLE a, b");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::High);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::Acknowledge {
+                                reason: AcknowledgeReason::TargetNameUnavailable,
+                                ..
+                            }
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
             }
-        }
 
-        #[test]
-        fn empty_input_blocked() {
-            let result = evaluate_multi_statement("");
-            assert!(matches!(result, MultiStatementDecision::Block { .. }));
-        }
-
-        #[rstest]
-        #[case::sqlite_shell(".shell echo injected")]
-        #[case::sqlite_open_after_select("SELECT 1;\n.open writable.db")]
-        #[case::psql_shell("\\! echo injected")]
-        #[case::indented_meta_command("  .output /tmp/out.csv")]
-        #[case::psql_backslash_inside_bracket_identifier("SELECT [\n\\! echo injected\n]")]
-        #[case::psql_backslash_inside_backtick_identifier("SELECT `\n\\! echo injected\n`")]
-        fn cli_meta_commands_are_blocked(#[case] sql: &str) {
-            let result = evaluate_multi_statement(sql);
-
-            assert!(matches!(
-                result,
-                MultiStatementDecision::Block { reason }
-                    if reason == "CLI meta-commands are not supported in SQL input"
-            ));
-        }
-
-        #[rstest]
-        #[case::dot_inside_string("SELECT '.shell echo ok'")]
-        #[case::backslash_inside_string("SELECT '\\\\! echo ok'")]
-        #[case::dot_inside_comment("-- .shell ignored\nSELECT 1")]
-        #[case::backslash_inside_block_comment("SELECT /* \\! ignored */ 1")]
-        #[case::backslash_inside_quoted_identifier(r#"SELECT "table\!name" FROM "table\!name""#)]
-        #[case::dot_inside_dollar_quote("SELECT $tag$\n.shell ignored\n$tag$")]
-        fn cli_meta_command_like_text_is_allowed(#[case] sql: &str) {
-            let result = evaluate_multi_statement(sql);
-
-            assert!(matches!(result, MultiStatementDecision::Allow { .. }));
-        }
-
-        #[rstest]
-        #[case::dot_inside_bracket_identifier("SELECT [\n.shell ignored] FROM t")]
-        #[case::backslash_inside_backtick_identifier("SELECT `\n\\! ignored` FROM t")]
-        fn sqlite_cli_meta_command_like_identifier_text_is_allowed(#[case] sql: &str) {
-            let result = evaluate_multi_statement_for_database(DatabaseType::SQLite, sql);
-
-            assert!(matches!(result, MultiStatementDecision::Allow { .. }));
-        }
-
-        #[rstest]
-        #[case::bracket_contains_drop("SELECT [1; DROP TABLE users]", "users")]
-        #[case::backtick_contains_drop("SELECT `1; DROP TABLE users`", "users")]
-        fn postgres_brackets_and_backticks_do_not_hide_dangerous_statements(
-            #[case] sql: &str,
-            #[case] expected_target: &str,
-        ) {
-            let result = evaluate_multi_statement(sql);
-
-            match result {
-                MultiStatementDecision::Allow { statements, risk } => {
-                    assert_eq!(statements.len(), 2);
-                    assert_eq!(risk.risk_level, RiskLevel::High);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::TableNameInput { ref target } if target == expected_target
-                    ));
+            #[test]
+            fn insert_then_select_returns_immediate() {
+                let result = evaluate_multi_statement("INSERT INTO users VALUES (1); SELECT 1");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Low);
+                        assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
             }
-        }
 
-        #[rstest]
-        #[case::update_backtick_where_identifier("UPDATE `where` SET x = 1", "where")]
-        #[case::delete_bracket_quoted_dot("DELETE FROM [main.users]", "main.users")]
-        #[case::drop_table_backtick_qualified("DROP TABLE main.`my.table`", "main.my.table")]
-        #[case::drop_table_bracket_reserved_word("DROP TABLE [select]", "select")]
-        fn sqlite_quoted_targets_require_table_name_input(
-            #[case] sql: &str,
-            #[case] expected_target: &str,
-        ) {
-            let result = evaluate_multi_statement_for_database(DatabaseType::SQLite, sql);
-
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::High);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::TableNameInput { ref target } if target == expected_target
-                    ));
+            #[test]
+            fn drop_index_returns_low_immediate_for_postgres() {
+                let result = evaluate_multi_statement("DROP INDEX my_index");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Low);
+                        assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
             }
-        }
 
-        #[test]
-        fn do_block_requires_acknowledgment() {
-            let result = evaluate_multi_statement("DO $$ BEGIN RAISE NOTICE 'hi'; END $$");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::Low);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::Acknowledge {
-                            reason: AcknowledgeReason::UnknownRisk,
-                            ref label,
-                        } if label == "DO"
-                    ));
+            #[test]
+            fn sqlite_multiple_high_drops_use_first_target() {
+                let result = evaluate_multi_statement_for_database(
+                    DatabaseType::SQLite,
+                    "DROP INDEX my_index; DROP VIEW my_view",
+                );
+                match result {
+                    MultiStatementDecision::Allow { statements, risk } => {
+                        assert_eq!(statements, vec!["DROP INDEX my_index", "DROP VIEW my_view"]);
+                        assert_eq!(risk.risk_level, RiskLevel::High);
+                        assert!(!risk.read_only_allowed);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::TableNameInput { ref target } if target == "my_index"
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
             }
-        }
 
-        #[test]
-        fn copy_requires_acknowledgment() {
-            let result = evaluate_multi_statement("COPY users FROM '/tmp/data.csv'");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::Low);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::Acknowledge {
-                            reason: AcknowledgeReason::UnknownRisk,
-                            ref label,
-                        } if label == "COPY"
-                    ));
-                }
-                _ => panic!("expected Allow"),
+            #[test]
+            fn sqlite_table_name_confirmation_label_matches_first_target_statement() {
+                let sql = "DROP INDEX my_index; DROP VIEW my_view";
+                assert_eq!(
+                    adhoc_label_for_table_name_confirmation(DatabaseType::SQLite, sql),
+                    Some("DROP INDEX")
+                );
             }
-        }
 
-        #[test]
-        fn do_block_after_select_requires_acknowledgment() {
-            let result =
-                evaluate_multi_statement("SELECT 1; DO $$ BEGIN DELETE FROM users; END $$");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::Low);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::Acknowledge {
-                            reason: AcknowledgeReason::UnknownRisk,
-                            ..
-                        }
-                    ));
+            #[test]
+            fn sqlite_drop_index_requires_table_name_input() {
+                let result = evaluate_multi_statement_for_database(
+                    DatabaseType::SQLite,
+                    "DROP INDEX IF EXISTS my_index",
+                );
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::High);
+                        assert!(!risk.read_only_allowed);
+                        assert!(matches!(
+                            risk.confirmation,
+                            ConfirmationType::TableNameInput { ref target } if target == "my_index"
+                        ));
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
             }
-        }
 
-        #[rstest]
-        #[case::do_block_with_drop("DO $$ BEGIN RAISE NOTICE 'hi'; END $$; DROP TABLE users")]
-        #[case::drop_with_unextractable_drop("DROP TABLE users; DROP TABLE a, b")]
-        #[case::mixed_acknowledge_reasons("DO $$ BEGIN RAISE NOTICE 'hi'; END $$; DROP TABLE a, b")]
-        fn mixed_confirmations_are_blocked(#[case] sql: &str) {
-            let result = evaluate_multi_statement(sql);
-
-            assert!(matches!(result, MultiStatementDecision::Block { .. }));
-        }
-
-        #[rstest]
-        #[case::unknown_risk(
-            "COPY users FROM '/tmp/a.csv'; CALL refresh()",
-            RiskLevel::Low,
-            AcknowledgeReason::UnknownRisk,
-            "COPY"
-        )]
-        #[case::target_name_unavailable(
-            "DROP TABLE a, b; TRUNCATE c, d",
-            RiskLevel::High,
-            AcknowledgeReason::TargetNameUnavailable,
-            "DROP"
-        )]
-        fn same_reason_acknowledgments_aggregate_with_first_label(
-            #[case] sql: &str,
-            #[case] expected_risk: RiskLevel,
-            #[case] expected_reason: AcknowledgeReason,
-            #[case] expected_label: &str,
-        ) {
-            let result = evaluate_multi_statement(sql);
-
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, expected_risk);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::Acknowledge {
-                            ref reason,
-                            ref label,
-                        } if *reason == expected_reason && label == expected_label
-                    ));
+            #[test]
+            fn drop_owned_by_returns_low_immediate() {
+                let result = evaluate_multi_statement("DROP OWNED BY role");
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Low);
+                        assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
             }
-        }
 
-        #[test]
-        fn drop_multiple_targets_requires_acknowledgment() {
-            let result = evaluate_multi_statement("DROP TABLE a, b");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::High);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::Acknowledge {
-                            reason: AcknowledgeReason::TargetNameUnavailable,
-                            ..
-                        }
-                    ));
+            #[test]
+            fn sqlite_safe_pragma_is_read_only_allowed() {
+                let result = evaluate_multi_statement_for_database(
+                    DatabaseType::SQLite,
+                    "PRAGMA table_info(t)",
+                );
+
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::Low);
+                        assert!(risk.read_only_allowed);
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
             }
-        }
 
-        #[test]
-        fn insert_then_select_returns_immediate() {
-            let result = evaluate_multi_statement("INSERT INTO users VALUES (1); SELECT 1");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::Low);
-                    assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
+            #[test]
+            fn sqlite_dangerous_pragma_blocks_read_only() {
+                let result = evaluate_multi_statement_for_database(
+                    DatabaseType::SQLite,
+                    "PRAGMA foreign_keys = OFF",
+                );
+
+                match result {
+                    MultiStatementDecision::Allow { risk, .. } => {
+                        assert_eq!(risk.risk_level, RiskLevel::High);
+                        assert!(!risk.read_only_allowed);
+                    }
+                    _ => panic!("expected Allow"),
                 }
-                _ => panic!("expected Allow"),
-            }
-        }
-
-        #[test]
-        fn drop_index_returns_low_immediate_for_postgres() {
-            let result = evaluate_multi_statement("DROP INDEX my_index");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::Low);
-                    assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
-                }
-                _ => panic!("expected Allow"),
-            }
-        }
-
-        #[test]
-        fn sqlite_multiple_high_drops_use_first_target() {
-            let result = evaluate_multi_statement_for_database(
-                DatabaseType::SQLite,
-                "DROP INDEX my_index; DROP VIEW my_view",
-            );
-            match result {
-                MultiStatementDecision::Allow { statements, risk } => {
-                    assert_eq!(statements, vec!["DROP INDEX my_index", "DROP VIEW my_view"]);
-                    assert_eq!(risk.risk_level, RiskLevel::High);
-                    assert!(!risk.read_only_allowed);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::TableNameInput { ref target } if target == "my_index"
-                    ));
-                }
-                _ => panic!("expected Allow"),
-            }
-        }
-
-        #[test]
-        fn sqlite_table_name_confirmation_label_matches_first_target_statement() {
-            let sql = "DROP INDEX my_index; DROP VIEW my_view";
-            assert_eq!(
-                adhoc_label_for_table_name_confirmation(DatabaseType::SQLite, sql),
-                Some("DROP INDEX")
-            );
-        }
-
-        #[test]
-        fn sqlite_drop_index_requires_table_name_input() {
-            let result = evaluate_multi_statement_for_database(
-                DatabaseType::SQLite,
-                "DROP INDEX IF EXISTS my_index",
-            );
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::High);
-                    assert!(!risk.read_only_allowed);
-                    assert!(matches!(
-                        risk.confirmation,
-                        ConfirmationType::TableNameInput { ref target } if target == "my_index"
-                    ));
-                }
-                _ => panic!("expected Allow"),
-            }
-        }
-
-        #[test]
-        fn drop_owned_by_returns_low_immediate() {
-            let result = evaluate_multi_statement("DROP OWNED BY role");
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::Low);
-                    assert!(matches!(risk.confirmation, ConfirmationType::Immediate));
-                }
-                _ => panic!("expected Allow"),
-            }
-        }
-
-        #[test]
-        fn sqlite_safe_pragma_is_read_only_allowed() {
-            let result =
-                evaluate_multi_statement_for_database(DatabaseType::SQLite, "PRAGMA table_info(t)");
-
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::Low);
-                    assert!(risk.read_only_allowed);
-                }
-                _ => panic!("expected Allow"),
-            }
-        }
-
-        #[test]
-        fn sqlite_dangerous_pragma_blocks_read_only() {
-            let result = evaluate_multi_statement_for_database(
-                DatabaseType::SQLite,
-                "PRAGMA foreign_keys = OFF",
-            );
-
-            match result {
-                MultiStatementDecision::Allow { risk, .. } => {
-                    assert_eq!(risk.risk_level, RiskLevel::High);
-                    assert!(!risk.read_only_allowed);
-                }
-                _ => panic!("expected Allow"),
             }
         }
     }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1376,10 +1376,7 @@ CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
             #[case::vacuum("VACUUM INTO 'copy.db'", "VACUUM")]
             #[case::reindex("REINDEX users_name_idx", "REINDEX")]
             #[case::analyze("ANALYZE users", "ANALYZE")]
-            fn sqlite_high_risk_statements_require_acknowledgment(
-                #[case] sql: &str,
-                #[case] expected_label: &str,
-            ) {
+            fn requires_acknowledgment(#[case] sql: &str, #[case] expected_label: &str) {
                 let result =
                     evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
 

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1367,7 +1367,7 @@ CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
             }
         }
 
-        mod sqlite_replace_risk {
+        mod sqlite_high_risk_statements {
             use super::*;
 
             #[rstest]
@@ -1390,6 +1390,10 @@ CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
                     ConfirmationType::Acknowledge { ref label, .. } if label == expected_label
                 ));
             }
+        }
+
+        mod sqlite_replace_risk {
+            use super::*;
 
             #[rstest]
             #[case::insert_or_replace("INSERT OR REPLACE INTO users(id) VALUES (1)", "users")]

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -426,241 +426,269 @@ mod tests {
         }
     }
 
-    #[test]
-    fn quote_ident_escapes_embedded_quotes() {
-        assert_eq!(quote_ident(r#"my"table"#), r#""my""table""#);
+    mod quoting {
+        use super::*;
+
+        #[test]
+        fn identifier_escapes_embedded_quotes() {
+            assert_eq!(quote_ident(r#"my"table"#), r#""my""table""#);
+        }
+
+        #[test]
+        fn literal_escapes_embedded_quotes() {
+            assert_eq!(quote_literal("O'Reilly"), "'O''Reilly'");
+        }
+
+        #[test]
+        fn sql_literal_preserves_typed_values() {
+            assert_eq!(sql_literal(&QueryValue::Null), "NULL");
+            assert_eq!(sql_literal(&QueryValue::text("NULL")), "'NULL'");
+            assert_eq!(sql_literal(&QueryValue::text("null")), "'null'");
+            assert_eq!(sql_literal(&QueryValue::Blob(vec![0, 255])), "X'00FF'");
+            assert_eq!(sql_literal(&QueryValue::SqlLiteral("42".to_string())), "42");
+            assert_eq!(
+                sql_literal(&QueryValue::SqlLiteral("1e999".to_string())),
+                "1e999"
+            );
+        }
     }
 
-    #[test]
-    fn quote_literal_escapes_embedded_quotes() {
-        assert_eq!(quote_literal("O'Reilly"), "'O''Reilly'");
+    mod metadata_queries {
+        use super::*;
+
+        #[test]
+        fn user_tables_uses_table_list_and_includes_views() {
+            assert!(user_tables_query().contains("pragma_table_list()"));
+            assert!(user_tables_query().contains("tl.schema = 'main'"));
+            assert!(user_tables_query().contains("tl.type IN ('table', 'virtual', 'view')"));
+            assert!(user_tables_query().contains("tl.type"));
+            assert!(user_tables_query().contains("tl.wr"));
+            assert!(user_tables_query().contains("tl.strict"));
+            assert!(user_tables_query().contains("name NOT LIKE 'sqlite_%'"));
+        }
+
+        #[test]
+        fn legacy_user_tables_lists_tables_and_views() {
+            assert!(legacy_user_tables_query().contains("FROM sqlite_master"));
+            assert!(legacy_user_tables_query().contains("type IN ('table', 'view')"));
+            assert!(!legacy_user_tables_query().contains("fts5_tables"));
+            assert!(legacy_user_tables_query().contains("name NOT LIKE 'sqlite_%'"));
+        }
+
+        #[test]
+        fn has_virtual_tables_detects_virtual_table_ddl() {
+            assert!(has_virtual_tables_query().contains("create%virtual%table%"));
+        }
+
+        #[test]
+        fn table_list_required_error_includes_marker_and_upgrade_guidance() {
+            let error = table_list_required_error();
+            let message = error.user_message();
+            assert!(message.contains(TABLE_LIST_REQUIRED_MARKER));
+            assert!(message.contains("3.37.0"));
+        }
+
+        #[test]
+        fn table_list_unavailable_detects_missing_pragma() {
+            assert!(is_table_list_unavailable(
+                "Error: in prepare, no such table: main.pragma_table_list"
+            ));
+            assert!(!is_table_list_unavailable("FOREIGN KEY constraint failed"));
+        }
     }
 
-    #[test]
-    fn sql_literal_preserves_typed_values() {
-        assert_eq!(sql_literal(&QueryValue::Null), "NULL");
-        assert_eq!(sql_literal(&QueryValue::text("NULL")), "'NULL'");
-        assert_eq!(sql_literal(&QueryValue::text("null")), "'null'");
-        assert_eq!(sql_literal(&QueryValue::Blob(vec![0, 255])), "X'00FF'");
-        assert_eq!(sql_literal(&QueryValue::SqlLiteral("42".to_string())), "42");
-        assert_eq!(
-            sql_literal(&QueryValue::SqlLiteral("1e999".to_string())),
-            "1e999"
-        );
+    mod explain_queries {
+        use super::*;
+
+        #[test]
+        fn wraps_select_with_query_plan() {
+            let adapter = SqliteAdapter::new();
+
+            assert_eq!(
+                adapter.build_explain_sql(DatabaseType::SQLite, "SELECT 1"),
+                Some("EXPLAIN QUERY PLAN SELECT 1".to_string())
+            );
+            assert_eq!(
+                adapter.build_explain_sql(
+                    DatabaseType::SQLite,
+                    "WITH cte AS (SELECT 1 AS n) SELECT * FROM cte"
+                ),
+                Some(
+                    "EXPLAIN QUERY PLAN WITH cte AS (SELECT 1 AS n) SELECT * FROM cte".to_string()
+                )
+            );
+        }
+
+        #[test]
+        fn wraps_dml_with_query_plan() {
+            let adapter = SqliteAdapter::new();
+
+            assert_eq!(
+                adapter.build_explain_sql(DatabaseType::SQLite, "DELETE FROM users"),
+                Some("EXPLAIN QUERY PLAN DELETE FROM users".to_string())
+            );
+            assert_eq!(
+                adapter.build_explain_sql(
+                    DatabaseType::SQLite,
+                    "UPDATE users SET name = 'a' WHERE id = 1"
+                ),
+                Some("EXPLAIN QUERY PLAN UPDATE users SET name = 'a' WHERE id = 1".to_string())
+            );
+            assert_eq!(
+                adapter.build_explain_sql(
+                    DatabaseType::SQLite,
+                    "INSERT INTO users(name) SELECT name FROM old_users"
+                ),
+                Some(
+                    "EXPLAIN QUERY PLAN INSERT INTO users(name) SELECT name FROM old_users"
+                        .to_string()
+                )
+            );
+            assert_eq!(
+                adapter
+                    .build_explain_sql(DatabaseType::SQLite, "REPLACE INTO users(id) VALUES (1)"),
+                Some("EXPLAIN QUERY PLAN REPLACE INTO users(id) VALUES (1)".to_string())
+            );
+        }
+
+        #[test]
+        fn rejects_prefixed_explain_and_analyze() {
+            let adapter = SqliteAdapter::new();
+
+            assert_eq!(
+                adapter.build_explain_sql(DatabaseType::SQLite, "EXPLAIN SELECT 1"),
+                None
+            );
+            assert_eq!(
+                adapter.build_explain_sql(DatabaseType::SQLite, "CREATE TABLE users(id INTEGER)"),
+                None
+            );
+            assert_eq!(
+                adapter.build_explain_analyze_sql(DatabaseType::SQLite, "SELECT 1"),
+                None
+            );
+        }
+
+        #[test]
+        fn passes_through_existing_query_plan_prefix() {
+            let adapter = SqliteAdapter::new();
+
+            assert_eq!(
+                adapter.build_explain_sql(
+                    DatabaseType::SQLite,
+                    "EXPLAIN QUERY PLAN SELECT * FROM users"
+                ),
+                Some("EXPLAIN QUERY PLAN SELECT * FROM users".to_string())
+            );
+        }
     }
 
-    #[test]
-    fn user_tables_query_uses_table_list_and_includes_views() {
-        assert!(user_tables_query().contains("pragma_table_list()"));
-        assert!(user_tables_query().contains("tl.schema = 'main'"));
-        assert!(user_tables_query().contains("tl.type IN ('table', 'virtual', 'view')"));
-        assert!(user_tables_query().contains("tl.type"));
-        assert!(user_tables_query().contains("tl.wr"));
-        assert!(user_tables_query().contains("tl.strict"));
-        assert!(user_tables_query().contains("name NOT LIKE 'sqlite_%'"));
+    mod preview_queries {
+        use super::*;
+
+        #[test]
+        fn row_count_quotes_table_name() {
+            assert_eq!(
+                row_count_query(r#"my"table"#),
+                r#"SELECT COUNT(*) AS count FROM "my""table""#
+            );
+        }
+
+        #[test]
+        fn orders_by_primary_key_columns_when_available() {
+            assert_eq!(
+                build_preview_query(
+                    "users",
+                    &["id".to_string(), "name".to_string()],
+                    &["id".to_string()],
+                    None,
+                    10,
+                    20
+                ),
+                concat!(
+                    r#"SELECT CASE WHEN typeof("id") = 'text' "#,
+                    r#"THEN char(1) || 'SABIQL_HEX:' || hex("id") ELSE "id" END AS "id", "#,
+                    r#"CASE WHEN typeof("name") = 'text' "#,
+                    r#"THEN char(1) || 'SABIQL_HEX:' || hex("name") ELSE "name" END AS "name" "#,
+                    r#"FROM "users" ORDER BY "id" LIMIT 10 OFFSET 20"#
+                )
+            );
+        }
+
+        #[test]
+        fn falls_back_to_star_without_columns() {
+            assert_eq!(
+                build_preview_query("users", &[], &["id".to_string()], None, 10, 20),
+                r#"SELECT * FROM "users" ORDER BY "id" LIMIT 10 OFFSET 20"#
+            );
+        }
+
+        #[test]
+        fn selects_hidden_rowid_when_available() {
+            assert_eq!(
+                build_preview_query(
+                    "logs",
+                    &["message".to_string()],
+                    &[],
+                    Some("_rowid_"),
+                    10,
+                    0
+                ),
+                concat!(
+                    r#"SELECT "_rowid_" AS "__sabiql_rowid", "#,
+                    r#"CASE WHEN typeof("message") = 'text' "#,
+                    r#"THEN char(1) || 'SABIQL_HEX:' || hex("message") ELSE "message" END AS "message" "#,
+                    r#"FROM "logs" ORDER BY "_rowid_" LIMIT 10 OFFSET 0"#
+                )
+            );
+        }
     }
 
-    #[test]
-    fn legacy_user_tables_query_lists_tables_and_views() {
-        assert!(legacy_user_tables_query().contains("FROM sqlite_master"));
-        assert!(legacy_user_tables_query().contains("type IN ('table', 'view')"));
-        assert!(!legacy_user_tables_query().contains("fts5_tables"));
-        assert!(legacy_user_tables_query().contains("name NOT LIKE 'sqlite_%'"));
+    mod text_literal_encoding {
+        use super::*;
+
+        #[test]
+        fn uses_cast_for_embedded_nul_byte() {
+            assert_eq!(
+                sql_literal(&QueryValue::text("a\0bc")),
+                "CAST(X'61006263' AS TEXT)"
+            );
+        }
     }
 
-    #[test]
-    fn has_virtual_tables_query_detects_virtual_table_ddl() {
-        assert!(has_virtual_tables_query().contains("create%virtual%table%"));
+    mod pragma_queries {
+        use super::*;
+
+        #[test]
+        fn quote_identifiers() {
+            assert_eq!(
+                table_xinfo_query(r#"my"table"#),
+                r#"PRAGMA table_xinfo("my""table")"#
+            );
+            assert_eq!(
+                table_info_query(r#"my"table"#),
+                r#"PRAGMA table_info("my""table")"#
+            );
+            assert_eq!(
+                index_list_query(r#"my"table"#),
+                r#"PRAGMA index_list("my""table")"#
+            );
+            assert_eq!(
+                foreign_key_list_query(r#"my"table"#),
+                r#"PRAGMA foreign_key_list("my""table")"#
+            );
+            assert_eq!(
+                trigger_list_query("users"),
+                "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'users' ORDER BY name"
+            );
+            assert_eq!(
+                index_xinfo_query(r#"my"index"#),
+                r#"PRAGMA index_xinfo("my""index")"#
+            );
+        }
     }
 
-    #[test]
-    fn table_list_required_error_includes_marker_and_upgrade_guidance() {
-        let error = table_list_required_error();
-        let message = error.user_message();
-        assert!(message.contains(TABLE_LIST_REQUIRED_MARKER));
-        assert!(message.contains("3.37.0"));
-    }
-
-    #[test]
-    fn is_table_list_unavailable_detects_missing_pragma() {
-        assert!(is_table_list_unavailable(
-            "Error: in prepare, no such table: main.pragma_table_list"
-        ));
-        assert!(!is_table_list_unavailable("FOREIGN KEY constraint failed"));
-    }
-
-    #[test]
-    fn explain_generation_wraps_select_with_query_plan() {
-        let adapter = SqliteAdapter::new();
-
-        assert_eq!(
-            adapter.build_explain_sql(DatabaseType::SQLite, "SELECT 1"),
-            Some("EXPLAIN QUERY PLAN SELECT 1".to_string())
-        );
-        assert_eq!(
-            adapter.build_explain_sql(
-                DatabaseType::SQLite,
-                "WITH cte AS (SELECT 1 AS n) SELECT * FROM cte"
-            ),
-            Some("EXPLAIN QUERY PLAN WITH cte AS (SELECT 1 AS n) SELECT * FROM cte".to_string())
-        );
-    }
-
-    #[test]
-    fn explain_generation_wraps_dml_with_query_plan() {
-        let adapter = SqliteAdapter::new();
-
-        assert_eq!(
-            adapter.build_explain_sql(DatabaseType::SQLite, "DELETE FROM users"),
-            Some("EXPLAIN QUERY PLAN DELETE FROM users".to_string())
-        );
-        assert_eq!(
-            adapter.build_explain_sql(
-                DatabaseType::SQLite,
-                "UPDATE users SET name = 'a' WHERE id = 1"
-            ),
-            Some("EXPLAIN QUERY PLAN UPDATE users SET name = 'a' WHERE id = 1".to_string())
-        );
-        assert_eq!(
-            adapter.build_explain_sql(
-                DatabaseType::SQLite,
-                "INSERT INTO users(name) SELECT name FROM old_users"
-            ),
-            Some(
-                "EXPLAIN QUERY PLAN INSERT INTO users(name) SELECT name FROM old_users".to_string()
-            )
-        );
-        assert_eq!(
-            adapter.build_explain_sql(DatabaseType::SQLite, "REPLACE INTO users(id) VALUES (1)"),
-            Some("EXPLAIN QUERY PLAN REPLACE INTO users(id) VALUES (1)".to_string())
-        );
-    }
-
-    #[test]
-    fn explain_generation_rejects_prefixed_explain_and_analyze() {
-        let adapter = SqliteAdapter::new();
-
-        assert_eq!(
-            adapter.build_explain_sql(DatabaseType::SQLite, "EXPLAIN SELECT 1"),
-            None
-        );
-        assert_eq!(
-            adapter.build_explain_sql(DatabaseType::SQLite, "CREATE TABLE users(id INTEGER)"),
-            None
-        );
-        assert_eq!(
-            adapter.build_explain_analyze_sql(DatabaseType::SQLite, "SELECT 1"),
-            None
-        );
-    }
-
-    #[test]
-    fn explain_generation_passes_through_existing_query_plan_prefix() {
-        let adapter = SqliteAdapter::new();
-
-        assert_eq!(
-            adapter.build_explain_sql(
-                DatabaseType::SQLite,
-                "EXPLAIN QUERY PLAN SELECT * FROM users"
-            ),
-            Some("EXPLAIN QUERY PLAN SELECT * FROM users".to_string())
-        );
-    }
-
-    #[test]
-    fn row_count_query_quotes_table_name() {
-        assert_eq!(
-            row_count_query(r#"my"table"#),
-            r#"SELECT COUNT(*) AS count FROM "my""table""#
-        );
-    }
-
-    #[test]
-    fn build_preview_query_orders_by_primary_key_columns_when_available() {
-        assert_eq!(
-            build_preview_query(
-                "users",
-                &["id".to_string(), "name".to_string()],
-                &["id".to_string()],
-                None,
-                10,
-                20
-            ),
-            concat!(
-                r#"SELECT CASE WHEN typeof("id") = 'text' "#,
-                r#"THEN char(1) || 'SABIQL_HEX:' || hex("id") ELSE "id" END AS "id", "#,
-                r#"CASE WHEN typeof("name") = 'text' "#,
-                r#"THEN char(1) || 'SABIQL_HEX:' || hex("name") ELSE "name" END AS "name" "#,
-                r#"FROM "users" ORDER BY "id" LIMIT 10 OFFSET 20"#
-            )
-        );
-    }
-
-    #[test]
-    fn build_preview_query_falls_back_to_star_without_columns() {
-        assert_eq!(
-            build_preview_query("users", &[], &["id".to_string()], None, 10, 20),
-            r#"SELECT * FROM "users" ORDER BY "id" LIMIT 10 OFFSET 20"#
-        );
-    }
-
-    #[test]
-    fn build_preview_query_selects_hidden_rowid_when_available() {
-        assert_eq!(
-            build_preview_query(
-                "logs",
-                &["message".to_string()],
-                &[],
-                Some("_rowid_"),
-                10,
-                0
-            ),
-            concat!(
-                r#"SELECT "_rowid_" AS "__sabiql_rowid", "#,
-                r#"CASE WHEN typeof("message") = 'text' "#,
-                r#"THEN char(1) || 'SABIQL_HEX:' || hex("message") ELSE "message" END AS "message" "#,
-                r#"FROM "logs" ORDER BY "_rowid_" LIMIT 10 OFFSET 0"#
-            )
-        );
-    }
-
-    #[test]
-    fn text_sql_literal_uses_cast_for_embedded_nul_byte() {
-        assert_eq!(
-            sql_literal(&QueryValue::text("a\0bc")),
-            "CAST(X'61006263' AS TEXT)"
-        );
-    }
-
-    #[test]
-    fn pragma_queries_quote_identifiers() {
-        assert_eq!(
-            table_xinfo_query(r#"my"table"#),
-            r#"PRAGMA table_xinfo("my""table")"#
-        );
-        assert_eq!(
-            table_info_query(r#"my"table"#),
-            r#"PRAGMA table_info("my""table")"#
-        );
-        assert_eq!(
-            index_list_query(r#"my"table"#),
-            r#"PRAGMA index_list("my""table")"#
-        );
-        assert_eq!(
-            foreign_key_list_query(r#"my"table"#),
-            r#"PRAGMA foreign_key_list("my""table")"#
-        );
-        assert_eq!(
-            trigger_list_query("users"),
-            "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'users' ORDER BY name"
-        );
-        assert_eq!(
-            index_xinfo_query(r#"my"index"#),
-            r#"PRAGMA index_xinfo("my""index")"#
-        );
-    }
-
-    mod sql_dialect_update {
+    mod update_sql {
         use super::*;
 
         #[test]
@@ -743,7 +771,7 @@ mod tests {
         }
     }
 
-    mod sql_dialect_bulk_delete {
+    mod bulk_delete_sql {
         use super::*;
 
         #[test]

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -1951,33 +1951,6 @@ mod tests {
             }
         }
 
-        mod dml_command_tag_comments {
-            use super::*;
-
-            #[tokio::test]
-            async fn dml_with_trailing_line_comment_returns_affected_rows() {
-                let (_dir, dsn) = test_support::make_sqlite_db(
-                    r"
-            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
-            INSERT INTO users(id, name) VALUES (1, 'a');
-            ",
-                );
-                let adapter = SqliteAdapter::new();
-
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "DELETE FROM users WHERE id = 1 -- cleanup selected row",
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .unwrap();
-
-                assert_eq!(result.row_count(), 1);
-                assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
-            }
-        }
-
         mod returning_results {
             use super::*;
 
@@ -2051,6 +2024,29 @@ mod tests {
 
         mod dml_command_tags {
             use super::*;
+
+            #[tokio::test]
+            async fn dml_with_trailing_line_comment_returns_affected_rows() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    r"
+            CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            INSERT INTO users(id, name) VALUES (1, 'a');
+            ",
+                );
+                let adapter = SqliteAdapter::new();
+
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "DELETE FROM users WHERE id = 1 -- cleanup selected row",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(result.row_count(), 1);
+                assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
+            }
 
             #[tokio::test]
             async fn with_insert_reports_affected_rows_command_tag() {

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -1546,23 +1546,26 @@ mod tests {
         mod transaction_execution {
             use super::*;
 
-            #[tokio::test]
-            async fn ddl_and_dml_still_roll_back_as_one_auto_transaction() {
-                let (_dir, dsn) = test_support::make_sqlite_db("");
-                let adapter = SqliteAdapter::new();
+            mod automatic_transactions {
+                use super::*;
 
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "CREATE TABLE users(id INTEGER PRIMARY KEY);\
+                #[tokio::test]
+                async fn ddl_and_dml_still_roll_back_as_one_auto_transaction() {
+                    let (_dir, dsn) = test_support::make_sqlite_db("");
+                    let adapter = SqliteAdapter::new();
+
+                    let result = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "CREATE TABLE users(id INTEGER PRIMARY KEY);\
                      INSERT INTO users(id) VALUES (1);\
                      INSERT INTO missing(id) VALUES (2)",
-                        AccessMode::ReadWrite,
-                    )
-                    .await;
+                            AccessMode::ReadWrite,
+                        )
+                        .await;
 
-                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-                let tables = adapter
+                    assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                    let tables = adapter
                     .execute_adhoc(
                         &dsn,
                         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'users'",
@@ -1570,170 +1573,174 @@ mod tests {
                     )
                     .await
                     .unwrap();
-                assert!(tables.rows().is_empty());
-            }
+                    assert!(tables.rows().is_empty());
+                }
 
-            #[tokio::test]
-            async fn vacuum_in_mixed_sql_runs_outside_auto_transaction() {
-                let (_dir, dsn) = test_support::make_sqlite_db("");
-                let adapter = SqliteAdapter::new();
+                #[tokio::test]
+                async fn vacuum_in_mixed_sql_runs_outside_auto_transaction() {
+                    let (_dir, dsn) = test_support::make_sqlite_db("");
+                    let adapter = SqliteAdapter::new();
 
-                adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "CREATE TABLE users(id INTEGER PRIMARY KEY);\
+                    adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "CREATE TABLE users(id INTEGER PRIMARY KEY);\
                      INSERT INTO users(id) VALUES (1);\
                      VACUUM;\
                      INSERT INTO users(id) VALUES (2)",
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .unwrap();
-                let rows = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "SELECT id FROM users ORDER BY id",
-                        AccessMode::ReadOnly,
-                    )
-                    .await
-                    .unwrap();
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .unwrap();
+                    let rows = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "SELECT id FROM users ORDER BY id",
+                            AccessMode::ReadOnly,
+                        )
+                        .await
+                        .unwrap();
 
-                assert_eq!(
-                    rows.rows(),
-                    vec![vec!["1".to_string()], vec!["2".to_string()]]
-                );
-            }
+                    assert_eq!(
+                        rows.rows(),
+                        vec![vec!["1".to_string()], vec!["2".to_string()]]
+                    );
+                }
 
-            #[tokio::test]
-            async fn journal_mode_change_in_mixed_sql_runs_outside_auto_transaction() {
-                let (_dir, dsn) = test_support::make_sqlite_db("");
-                let adapter = SqliteAdapter::new();
+                #[tokio::test]
+                async fn journal_mode_change_in_mixed_sql_runs_outside_auto_transaction() {
+                    let (_dir, dsn) = test_support::make_sqlite_db("");
+                    let adapter = SqliteAdapter::new();
 
-                adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "PRAGMA journal_mode = WAL;\
+                    adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "PRAGMA journal_mode = WAL;\
                      CREATE TABLE users(id INTEGER PRIMARY KEY);\
                      INSERT INTO users(id) VALUES (1)",
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .unwrap();
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .unwrap();
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
 
-                assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
-            }
+                    assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+                }
 
-            #[tokio::test]
-            async fn foreign_keys_change_in_mixed_sql_is_not_a_transaction_noop() {
-                let (_dir, dsn) = test_support::make_sqlite_db("");
-                let adapter = SqliteAdapter::new();
+                #[tokio::test]
+                async fn foreign_keys_change_in_mixed_sql_is_not_a_transaction_noop() {
+                    let (_dir, dsn) = test_support::make_sqlite_db("");
+                    let adapter = SqliteAdapter::new();
 
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "PRAGMA foreign_keys = ON;
+                    let result = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "PRAGMA foreign_keys = ON;
                      CREATE TABLE parent(id INTEGER PRIMARY KEY);
                      PRAGMA foreign_keys",
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .unwrap();
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .unwrap();
 
-                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+                    assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+                }
             }
 
-            #[tokio::test]
-            async fn rolled_back_dml_returns_rollback_tag() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
+            mod savepoint_rollbacks {
+                use super::*;
 
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "BEGIN; INSERT INTO users(id) VALUES (1); ROLLBACK",
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .unwrap();
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
+                #[tokio::test]
+                async fn rolled_back_dml_returns_rollback_tag() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
 
-                assert_eq!(result.command_tag, Some(CommandTag::Rollback));
-                assert!(rows.rows().is_empty());
-            }
+                    let result = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "BEGIN; INSERT INTO users(id) VALUES (1); ROLLBACK",
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .unwrap();
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
 
-            #[tokio::test]
-            async fn full_rollback_inside_savepoint_discards_outer_dml() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
+                    assert_eq!(result.command_tag, Some(CommandTag::Rollback));
+                    assert!(rows.rows().is_empty());
+                }
 
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "BEGIN;
+                #[tokio::test]
+                async fn full_rollback_inside_savepoint_discards_outer_dml() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
+
+                    let result = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "BEGIN;
                      INSERT INTO users(id) VALUES (1);
                      SAVEPOINT sp;
                      INSERT INTO users(id) VALUES (2);
                      ROLLBACK",
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .unwrap();
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .unwrap();
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
 
-                assert_eq!(result.command_tag, Some(CommandTag::Rollback));
-                assert!(rows.rows().is_empty());
-            }
+                    assert_eq!(result.command_tag, Some(CommandTag::Rollback));
+                    assert!(rows.rows().is_empty());
+                }
 
-            #[tokio::test]
-            async fn savepoint_rollback_discards_inner_dml_only() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
+                #[tokio::test]
+                async fn savepoint_rollback_discards_inner_dml_only() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
 
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "BEGIN;
+                    let result = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "BEGIN;
                      INSERT INTO users(id) VALUES (1);
                      SAVEPOINT sp;
                      INSERT INTO users(id) VALUES (2);
                      ROLLBACK TO sp;
                      COMMIT",
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .unwrap();
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .unwrap();
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
 
-                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
-            }
+                    assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+                    assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+                }
 
-            #[tokio::test]
-            async fn rollback_to_keeps_savepoint_for_later_rollback() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
+                #[tokio::test]
+                async fn rollback_to_keeps_savepoint_for_later_rollback() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
 
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "BEGIN;
+                    let result = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "BEGIN;
                      INSERT INTO users(id) VALUES (1);
                      SAVEPOINT sp;
                      INSERT INTO users(id) VALUES (2);
@@ -1741,29 +1748,29 @@ mod tests {
                      INSERT INTO users(id) VALUES (3);
                      ROLLBACK TO sp;
                      COMMIT",
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .unwrap();
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .unwrap();
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
 
-                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
-            }
+                    assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+                    assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+                }
 
-            #[tokio::test]
-            async fn rollback_to_named_outer_savepoint_discards_nested_frames() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
+                #[tokio::test]
+                async fn rollback_to_named_outer_savepoint_discards_nested_frames() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
 
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "BEGIN;
+                    let result = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "BEGIN;
                      INSERT INTO users(id) VALUES (1);
                      SAVEPOINT outer_sp;
                      INSERT INTO users(id) VALUES (2);
@@ -1771,195 +1778,180 @@ mod tests {
                      INSERT INTO users(id) VALUES (3);
                      ROLLBACK TO outer_sp;
                      COMMIT",
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .unwrap();
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .unwrap();
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
 
-                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
-            }
+                    assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+                    assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+                }
 
-            #[tokio::test]
-            async fn top_level_savepoint_rollback_to_discards_inner_dml_only() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
+                #[tokio::test]
+                async fn top_level_savepoint_rollback_to_discards_inner_dml_only() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
 
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "SAVEPOINT sp;
+                    let result = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "SAVEPOINT sp;
                      INSERT INTO users(id) VALUES (1);
                      INSERT INTO users(id) VALUES (2);
                      ROLLBACK TO sp;
                      INSERT INTO users(id) VALUES (3);
                      RELEASE sp",
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .unwrap();
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .unwrap();
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
 
-                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                assert_eq!(rows.rows(), vec![vec!["3".to_string()]]);
-            }
+                    assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+                    assert_eq!(rows.rows(), vec![vec!["3".to_string()]]);
+                }
 
-            #[tokio::test]
-            async fn top_level_savepoint_multi_write_rolls_back_when_later_statement_fails() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
+                #[tokio::test]
+                async fn top_level_savepoint_multi_write_rolls_back_when_later_statement_fails() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
 
-                let result = adapter
+                    let result = adapter
                 .execute_adhoc(
                     &dsn,
                     "SAVEPOINT sp; INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)", AccessMode::ReadWrite)
                 .await;
 
-                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
-                assert!(rows.rows().is_empty());
-            }
+                    assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
+                    assert!(rows.rows().is_empty());
+                }
 
-            #[tokio::test]
-            async fn top_level_savepoint_without_release_does_not_persist_on_success() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
+                #[tokio::test]
+                async fn top_level_savepoint_without_release_does_not_persist_on_success() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
 
-                let result = adapter
+                    let result = adapter
                 .execute_adhoc(
                     &dsn,
                     "SAVEPOINT sp; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)", AccessMode::ReadWrite)
                 .await
                 .unwrap();
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
 
-                assert_eq!(result.command_tag, Some(CommandTag::Rollback));
-                assert!(rows.rows().is_empty());
+                    assert_eq!(result.command_tag, Some(CommandTag::Rollback));
+                    assert!(rows.rows().is_empty());
+                }
             }
 
-            #[tokio::test]
-            async fn with_insert_reports_affected_rows_command_tag() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
+            mod multi_statement_atomicity {
+                use super::*;
 
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "WITH payload(id) AS (VALUES (1), (2))
-                     INSERT INTO users(id) SELECT id FROM payload",
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .unwrap();
+                #[tokio::test]
+                async fn multi_statement_dml_rolls_back_when_later_statement_fails() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
 
-                assert_eq!(result.row_count(), 2);
-                assert_eq!(result.command_tag, Some(CommandTag::Insert(2)));
-            }
+                    let result = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
+                            AccessMode::ReadWrite,
+                        )
+                        .await;
 
-            #[tokio::test]
-            async fn multi_statement_dml_rolls_back_when_later_statement_fails() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
+                    assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
+                    assert!(rows.rows().is_empty());
+                }
 
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
-                        AccessMode::ReadWrite,
-                    )
-                    .await;
+                #[tokio::test]
+                async fn with_dml_rolls_back_when_later_statement_fails() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
 
-                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
-                assert!(rows.rows().is_empty());
-            }
-
-            #[tokio::test]
-            async fn with_dml_rolls_back_when_later_statement_fails() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
-
-                let result = adapter
-                    .execute_adhoc(
-                        &dsn,
-                        "WITH payload(id) AS (VALUES (1))
+                    let result = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "WITH payload(id) AS (VALUES (1))
                      INSERT INTO users(id) SELECT id FROM payload;
                      INSERT INTO missing(id) VALUES (2)",
-                        AccessMode::ReadWrite,
-                    )
-                    .await;
+                            AccessMode::ReadWrite,
+                        )
+                        .await;
 
-                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
-                assert!(rows.rows().is_empty());
-            }
+                    assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
+                    assert!(rows.rows().is_empty());
+                }
 
-            #[tokio::test]
-            async fn returning_dml_rolls_back_when_later_statement_fails() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
-                let query = "INSERT INTO users(id) VALUES (1) RETURNING id; INSERT INTO missing(id) VALUES (2)";
+                #[tokio::test]
+                async fn returning_dml_rolls_back_when_later_statement_fails() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
+                    let query = "INSERT INTO users(id) VALUES (1) RETURNING id; INSERT INTO missing(id) VALUES (2)";
 
-                let result = adapter
-                    .execute_adhoc(&dsn, query, AccessMode::ReadWrite)
-                    .await;
+                    let result = adapter
+                        .execute_adhoc(&dsn, query, AccessMode::ReadWrite)
+                        .await;
 
-                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
-                assert!(rows.rows().is_empty());
-            }
+                    assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
+                    assert!(rows.rows().is_empty());
+                }
 
-            #[tokio::test]
-            async fn select_then_dml_rolls_back_when_later_statement_fails() {
-                let (_dir, dsn) =
-                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-                let adapter = SqliteAdapter::new();
+                #[tokio::test]
+                async fn select_then_dml_rolls_back_when_later_statement_fails() {
+                    let (_dir, dsn) =
+                        test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                    let adapter = SqliteAdapter::new();
 
-                let result = adapter
+                    let result = adapter
                 .execute_adhoc(
                     &dsn,
                     "SELECT 1 AS marker; INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)", AccessMode::ReadWrite)
                 .await;
 
-                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-                let rows = adapter
-                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                    .await
-                    .unwrap();
-                assert!(rows.rows().is_empty());
+                    assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                    let rows = adapter
+                        .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
+                    assert!(rows.rows().is_empty());
+                }
             }
         }
 
-        mod dml_command_tags {
+        mod dml_command_tag_comments {
             use super::*;
 
             #[tokio::test]
@@ -2057,8 +2049,28 @@ mod tests {
             }
         }
 
-        mod identifier_and_ddl_command_tags {
+        mod dml_command_tags {
             use super::*;
+
+            #[tokio::test]
+            async fn with_insert_reports_affected_rows_command_tag() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
+
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "WITH payload(id) AS (VALUES (1), (2))
+                     INSERT INTO users(id) SELECT id FROM payload",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(result.row_count(), 2);
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(2)));
+            }
 
             #[tokio::test]
             async fn dml_table_name_containing_returning_reports_affected_rows() {
@@ -2119,6 +2131,10 @@ mod tests {
                 assert_eq!(result.row_count(), 1);
                 assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
             }
+        }
+
+        mod ddl_command_tags {
+            use super::*;
 
             #[tokio::test]
             async fn ddl_returns_schema_refresh_command_tag() {

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -1126,6 +1126,10 @@ mod tests {
                         .split_whitespace()
                         .any(|token| token == alias.to_string())
             }
+        }
+
+        mod trigger_execution {
+            use super::*;
 
             #[tokio::test]
             async fn create_trigger_with_multi_statement_body_preserves_definition() {
@@ -1232,6 +1236,10 @@ mod tests {
 
                 assert!(matches!(error, DbOperationError::QueryFailed(_)));
             }
+        }
+
+        mod result_set_parsing {
+            use super::*;
 
             #[tokio::test]
             async fn select_preserves_quoted_newline_in_multicolumn_result() {
@@ -1951,7 +1959,7 @@ mod tests {
             }
         }
 
-        mod returning_results {
+        mod dml_command_tags {
             use super::*;
 
             #[tokio::test]
@@ -1976,6 +1984,10 @@ mod tests {
                 assert_eq!(result.row_count(), 1);
                 assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
             }
+        }
+
+        mod returning_results {
+            use super::*;
 
             #[tokio::test]
             async fn dml_returning_preserves_returned_rows() {
@@ -2043,6 +2055,10 @@ mod tests {
                 assert_eq!(result.rows(), vec![vec!["1".to_string(), "a".to_string()]]);
                 assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
             }
+        }
+
+        mod identifier_and_ddl_command_tags {
+            use super::*;
 
             #[tokio::test]
             async fn dml_table_name_containing_returning_reports_affected_rows() {

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -990,62 +990,65 @@ mod tests {
 
         use super::*;
 
-        #[tokio::test]
-        async fn select_returns_query_result() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);",
-            );
-            let adapter = SqliteAdapter::new();
+        mod query_results {
+            use super::*;
 
-            let result = adapter
-                .execute_adhoc(&dsn, "SELECT 1 AS value", AccessMode::ReadOnly)
-                .await
-                .unwrap();
+            #[tokio::test]
+            async fn select_returns_query_result() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);",
+                );
+                let adapter = SqliteAdapter::new();
 
-            assert_eq!(result.columns, vec!["value"]);
-            assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
-            assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
-        }
+                let result = adapter
+                    .execute_adhoc(&dsn, "SELECT 1 AS value", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
 
-        #[tokio::test]
-        async fn explain_query_plan_returns_readable_detail_lines() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+                assert_eq!(result.columns, vec!["value"]);
+                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
+            }
+
+            #[tokio::test]
+            async fn explain_query_plan_returns_readable_detail_lines() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
                  CREATE INDEX idx_users_name ON users(name);",
-            );
-            let adapter = SqliteAdapter::new();
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "EXPLAIN QUERY PLAN SELECT * FROM users WHERE name = 'alice'",
-                    AccessMode::ReadOnly,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "EXPLAIN QUERY PLAN SELECT * FROM users WHERE name = 'alice'",
+                        AccessMode::ReadOnly,
+                    )
+                    .await
+                    .unwrap();
 
-            let plan_text = sqlite_explain_query_plan_text_from_result(&result);
+                let plan_text = sqlite_explain_query_plan_text_from_result(&result);
 
-            assert!(!plan_text.trim().is_empty(), "plan text must not be empty");
-            assert!(
-                plan_text.to_ascii_lowercase().contains("users"),
-                "expected users table in plan, got: {plan_text}"
-            );
-            assert!(
-                !explain_plan_operation_lines(&plan_text).is_empty(),
-                "expected at least one SCAN/SEARCH operation, got: {plan_text}"
-            );
-        }
+                assert!(!plan_text.trim().is_empty(), "plan text must not be empty");
+                assert!(
+                    plan_text.to_ascii_lowercase().contains("users"),
+                    "expected users table in plan, got: {plan_text}"
+                );
+                assert!(
+                    !explain_plan_operation_lines(&plan_text).is_empty(),
+                    "expected at least one SCAN/SEARCH operation, got: {plan_text}"
+                );
+            }
 
-        #[tokio::test]
-        async fn explain_query_plan_for_join_includes_both_scan_targets() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                "CREATE TABLE users(id INTEGER PRIMARY KEY);
+            #[tokio::test]
+            async fn explain_query_plan_for_join_includes_both_scan_targets() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    "CREATE TABLE users(id INTEGER PRIMARY KEY);
                  CREATE TABLE orders(id INTEGER, user_id INTEGER);",
-            );
-            let adapter = SqliteAdapter::new();
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
+                let result = adapter
                 .execute_adhoc(
                     &dsn,
                     "EXPLAIN QUERY PLAN SELECT * FROM users u JOIN orders o ON u.id = o.user_id",
@@ -1054,79 +1057,79 @@ mod tests {
                 .await
                 .unwrap();
 
-            let plan_text = sqlite_explain_query_plan_text_from_result(&result);
-            let operation_lines = explain_plan_operation_lines(&plan_text);
+                let plan_text = sqlite_explain_query_plan_text_from_result(&result);
+                let operation_lines = explain_plan_operation_lines(&plan_text);
 
-            assert!(
-                operation_lines.len() >= 2,
-                "expected multiple plan operations, got: {plan_text}"
-            );
-            assert!(
-                plan_mentions_table_or_alias(&plan_text, "users", 'u'),
-                "expected users side in plan, got: {plan_text}"
-            );
-            assert!(
-                plan_mentions_table_or_alias(&plan_text, "orders", 'o'),
-                "expected orders side in plan, got: {plan_text}"
-            );
-        }
+                assert!(
+                    operation_lines.len() >= 2,
+                    "expected multiple plan operations, got: {plan_text}"
+                );
+                assert!(
+                    plan_mentions_table_or_alias(&plan_text, "users", 'u'),
+                    "expected users side in plan, got: {plan_text}"
+                );
+                assert!(
+                    plan_mentions_table_or_alias(&plan_text, "orders", 'o'),
+                    "expected orders side in plan, got: {plan_text}"
+                );
+            }
 
-        #[tokio::test]
-        async fn explain_query_plan_delete_does_not_modify_database() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+            #[tokio::test]
+            async fn explain_query_plan_delete_does_not_modify_database() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
                  INSERT INTO users(name) VALUES ('alice'), ('bob');
                  CREATE INDEX idx_users_name ON users(name);",
-            );
-            let adapter = SqliteAdapter::new();
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "EXPLAIN QUERY PLAN DELETE FROM users WHERE name = 'alice'",
-                    AccessMode::ReadOnly,
-                )
-                .await
-                .unwrap();
-            let rows = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "SELECT COUNT(*) AS total FROM users",
-                    AccessMode::ReadOnly,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "EXPLAIN QUERY PLAN DELETE FROM users WHERE name = 'alice'",
+                        AccessMode::ReadOnly,
+                    )
+                    .await
+                    .unwrap();
+                let rows = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "SELECT COUNT(*) AS total FROM users",
+                        AccessMode::ReadOnly,
+                    )
+                    .await
+                    .unwrap();
 
-            let plan_text = sqlite_explain_query_plan_text_from_result(&result);
+                let plan_text = sqlite_explain_query_plan_text_from_result(&result);
 
-            assert!(
-                plan_text.to_ascii_lowercase().contains("users"),
-                "expected users table in plan, got: {plan_text}"
-            );
-            assert_eq!(rows.rows(), vec![vec!["2".to_string()]]);
-        }
+                assert!(
+                    plan_text.to_ascii_lowercase().contains("users"),
+                    "expected users table in plan, got: {plan_text}"
+                );
+                assert_eq!(rows.rows(), vec![vec!["2".to_string()]]);
+            }
 
-        fn explain_plan_operation_lines(plan_text: &str) -> Vec<&str> {
-            plan_text
-                .lines()
-                .filter(|line| {
-                    let upper = line.to_ascii_uppercase();
-                    upper.contains("SCAN") || upper.contains("SEARCH")
-                })
-                .collect()
-        }
+            fn explain_plan_operation_lines(plan_text: &str) -> Vec<&str> {
+                plan_text
+                    .lines()
+                    .filter(|line| {
+                        let upper = line.to_ascii_uppercase();
+                        upper.contains("SCAN") || upper.contains("SEARCH")
+                    })
+                    .collect()
+            }
 
-        fn plan_mentions_table_or_alias(plan_text: &str, table: &str, alias: char) -> bool {
-            let lower = plan_text.to_ascii_lowercase();
-            lower.contains(table)
-                || lower
-                    .split_whitespace()
-                    .any(|token| token == alias.to_string())
-        }
+            fn plan_mentions_table_or_alias(plan_text: &str, table: &str, alias: char) -> bool {
+                let lower = plan_text.to_ascii_lowercase();
+                lower.contains(table)
+                    || lower
+                        .split_whitespace()
+                        .any(|token| token == alias.to_string())
+            }
 
-        #[tokio::test]
-        async fn create_trigger_with_multi_statement_body_preserves_definition() {
-            let setup = r"
+            #[tokio::test]
+            async fn create_trigger_with_multi_statement_body_preserves_definition() {
+                let setup = r"
             CREATE TABLE agent_messages(
                 id INTEGER PRIMARY KEY,
                 role TEXT NOT NULL,
@@ -1134,39 +1137,39 @@ mod tests {
             );
             CREATE VIRTUAL TABLE agent_messages_fts USING fts5(role, content);
             ";
-            let trigger = r"
+                let trigger = r"
             CREATE TRIGGER agent_messages_fts_ai AFTER INSERT ON agent_messages BEGIN
                 INSERT INTO agent_messages_fts(rowid, role, content)
                 VALUES (new.id, new.role, new.content);
             END
             ";
-            let (_dir, dsn) = test_support::make_sqlite_db(setup);
-            let adapter = SqliteAdapter::new();
+                let (_dir, dsn) = test_support::make_sqlite_db(setup);
+                let adapter = SqliteAdapter::new();
 
-            adapter
-                .execute_adhoc(&dsn, trigger, AccessMode::ReadWrite)
-                .await
-                .unwrap();
+                adapter
+                    .execute_adhoc(&dsn, trigger, AccessMode::ReadWrite)
+                    .await
+                    .unwrap();
 
-            let result = adapter
+                let result = adapter
                 .execute_adhoc(
                     &dsn,
                     "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'agent_messages_fts_ai'", AccessMode::ReadOnly)
                 .await
                 .unwrap();
 
-            let stored = result.rows()[0][0].replace('\n', " ");
-            let expected = trigger.trim().replace('\n', " ");
-            assert!(
-                !stored.contains("__sabiql_sqlite_probe_"),
-                "probe SQL must not appear in stored trigger definition: {stored}"
-            );
-            assert_eq!(stored, expected);
-        }
+                let stored = result.rows()[0][0].replace('\n', " ");
+                let expected = trigger.trim().replace('\n', " ");
+                assert!(
+                    !stored.contains("__sabiql_sqlite_probe_"),
+                    "probe SQL must not appear in stored trigger definition: {stored}"
+                );
+                assert_eq!(stored, expected);
+            }
 
-        #[tokio::test]
-        async fn create_trigger_referencing_new_end_preserves_definition() {
-            let setup = r"
+            #[tokio::test]
+            async fn create_trigger_referencing_new_end_preserves_definition() {
+                let setup = r"
             CREATE TABLE events(
                 id INTEGER PRIMARY KEY,
                 end INTEGER NOT NULL
@@ -1180,21 +1183,21 @@ mod tests {
                 end_value INTEGER
             );
             ";
-            let trigger = r"
+                let trigger = r"
             CREATE TRIGGER sync_end AFTER UPDATE ON events BEGIN
                 UPDATE counters SET end_value = new.end WHERE id = new.id;
                 INSERT INTO audit(event_id, end_value) VALUES (new.id, new.end);
             END
             ";
-            let (_dir, dsn) = test_support::make_sqlite_db(setup);
-            let adapter = SqliteAdapter::new();
+                let (_dir, dsn) = test_support::make_sqlite_db(setup);
+                let adapter = SqliteAdapter::new();
 
-            adapter
-                .execute_adhoc(&dsn, trigger, AccessMode::ReadWrite)
-                .await
-                .unwrap();
+                adapter
+                    .execute_adhoc(&dsn, trigger, AccessMode::ReadWrite)
+                    .await
+                    .unwrap();
 
-            let result = adapter
+                let result = adapter
                 .execute_adhoc(
                     &dsn,
                     "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'sync_end'",
@@ -1203,22 +1206,22 @@ mod tests {
                 .await
                 .unwrap();
 
-            let stored = result.rows()[0][0].replace('\n', " ");
-            let expected = trigger.trim().replace('\n', " ");
-            assert!(
-                !stored.contains("__sabiql_sqlite_probe_"),
-                "probe SQL must not appear in stored trigger definition: {stored}"
-            );
-            assert_eq!(stored, expected);
-        }
+                let stored = result.rows()[0][0].replace('\n', " ");
+                let expected = trigger.trim().replace('\n', " ");
+                assert!(
+                    !stored.contains("__sabiql_sqlite_probe_"),
+                    "probe SQL must not appear in stored trigger definition: {stored}"
+                );
+                assert_eq!(stored, expected);
+            }
 
-        #[tokio::test]
-        async fn unclosed_create_trigger_fails_before_execution() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn unclosed_create_trigger_fails_before_execution() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let error = adapter
+                let error = adapter
                 .execute_adhoc(
                     &dsn,
                     "CREATE TRIGGER t AFTER INSERT ON users BEGIN INSERT INTO logs(id) VALUES (1);",
@@ -1227,490 +1230,502 @@ mod tests {
                 .await
                 .unwrap_err();
 
-            assert!(matches!(error, DbOperationError::QueryFailed(_)));
-        }
+                assert!(matches!(error, DbOperationError::QueryFailed(_)));
+            }
 
-        #[tokio::test]
-        async fn select_preserves_quoted_newline_in_multicolumn_result() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                "CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);",
-            );
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn select_preserves_quoted_newline_in_multicolumn_result() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    "CREATE TABLE notes(id INTEGER PRIMARY KEY, body TEXT);",
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "SELECT 'line 1' || char(10) || 'line 2' AS body, 'ok' AS marker",
-                    AccessMode::ReadOnly,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "SELECT 'line 1' || char(10) || 'line 2' AS body, 'ok' AS marker",
+                        AccessMode::ReadOnly,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.columns, vec!["body", "marker"]);
-            assert_eq!(
-                result.rows(),
-                vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
-            );
-            assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
-        }
+                assert_eq!(result.columns, vec!["body", "marker"]);
+                assert_eq!(
+                    result.rows(),
+                    vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
+                );
+                assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
+            }
 
-        #[tokio::test]
-        async fn multi_select_preserves_quoted_newline_in_last_result() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn multi_select_preserves_quoted_newline_in_last_result() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
+                let result = adapter
             .execute_adhoc(
                 &dsn,
                 "SELECT 1 AS ignored; SELECT 'line 1' || char(10) || 'line 2' AS body, 'ok' AS marker", AccessMode::ReadOnly)
             .await
             .unwrap();
 
-            assert_eq!(result.columns, vec!["body", "marker"]);
-            assert_eq!(
-                result.rows(),
-                vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
-            );
-            assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
+                assert_eq!(result.columns, vec!["body", "marker"]);
+                assert_eq!(
+                    result.rows(),
+                    vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
+                );
+                assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
+            }
+
+            #[tokio::test]
+            async fn multi_select_does_not_treat_data_row_as_next_header() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
+
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "SELECT 1 AS a, 2 AS b UNION ALL SELECT 3, 4; SELECT 5 AS c, 6 AS d",
+                        AccessMode::ReadOnly,
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(result.columns, vec!["c", "d"]);
+                assert_eq!(result.rows(), vec![vec!["5".to_string(), "6".to_string()]]);
+                assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
+            }
+
+            #[tokio::test]
+            async fn multi_select_empty_trailing_result_returns_empty_result() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
+
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "SELECT 1 AS a; SELECT 2 AS b WHERE false",
+                        AccessMode::ReadOnly,
+                    )
+                    .await
+                    .unwrap();
+
+                assert!(result.columns.is_empty());
+                assert!(result.rows().is_empty());
+                assert_eq!(result.command_tag, Some(CommandTag::Select(0)));
+            }
+
+            #[tokio::test]
+            async fn pragma_result_does_not_get_select_command_tag() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
+
+                let result = adapter
+                    .execute_adhoc(&dsn, "PRAGMA table_info(users)", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
+
+                assert_eq!(
+                    result.columns,
+                    vec!["cid", "name", "type", "notnull", "dflt_value", "pk"]
+                );
+                assert_eq!(result.command_tag, None);
+            }
         }
 
-        #[tokio::test]
-        async fn multi_select_does_not_treat_data_row_as_next_header() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
+        mod session_configuration {
+            use super::*;
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "SELECT 1 AS a, 2 AS b UNION ALL SELECT 3, 4; SELECT 5 AS c, 6 AS d",
-                    AccessMode::ReadOnly,
-                )
-                .await
-                .unwrap();
+            #[tokio::test]
+            async fn enables_foreign_keys_before_user_sql() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
 
-            assert_eq!(result.columns, vec!["c", "d"]);
-            assert_eq!(result.rows(), vec![vec!["5".to_string(), "6".to_string()]]);
-            assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
+                let result = adapter
+                    .execute_adhoc(&dsn, "PRAGMA foreign_keys", AccessMode::ReadWrite)
+                    .await
+                    .unwrap();
+
+                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+            }
+
+            #[tokio::test]
+            async fn read_only_session_enables_query_only_before_user_sql() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
+
+                let result = adapter
+                    .execute_adhoc(&dsn, "PRAGMA query_only", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
+
+                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+            }
+
+            #[tokio::test]
+            async fn applies_busy_timeout_before_user_sql() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
+
+                let result = adapter
+                    .execute_adhoc(&dsn, "PRAGMA busy_timeout", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
+
+                assert_eq!(result.rows(), vec![vec![BUSY_TIMEOUT_MS.to_string()]]);
+            }
         }
 
-        #[tokio::test]
-        async fn multi_select_empty_trailing_result_returns_empty_result() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
+        mod command_tags {
+            use super::*;
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "SELECT 1 AS a; SELECT 2 AS b WHERE false",
-                    AccessMode::ReadOnly,
-                )
-                .await
-                .unwrap();
+            #[tokio::test]
+            async fn values_result_does_not_get_select_command_tag() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
 
-            assert!(result.columns.is_empty());
-            assert!(result.rows().is_empty());
-            assert_eq!(result.command_tag, Some(CommandTag::Select(0)));
-        }
+                let result = adapter
+                    .execute_adhoc(&dsn, "VALUES (1)", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
 
-        #[tokio::test]
-        async fn pragma_result_does_not_get_select_command_tag() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(result.command_tag, None);
+            }
 
-            let result = adapter
-                .execute_adhoc(&dsn, "PRAGMA table_info(users)", AccessMode::ReadOnly)
-                .await
-                .unwrap();
-
-            assert_eq!(
-                result.columns,
-                vec!["cid", "name", "type", "notnull", "dflt_value", "pk"]
-            );
-            assert_eq!(result.command_tag, None);
-        }
-
-        #[tokio::test]
-        async fn enables_foreign_keys_before_user_sql() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
-
-            let result = adapter
-                .execute_adhoc(&dsn, "PRAGMA foreign_keys", AccessMode::ReadWrite)
-                .await
-                .unwrap();
-
-            assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
-        }
-
-        #[tokio::test]
-        async fn read_only_session_enables_query_only_before_user_sql() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
-
-            let result = adapter
-                .execute_adhoc(&dsn, "PRAGMA query_only", AccessMode::ReadOnly)
-                .await
-                .unwrap();
-
-            assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
-        }
-
-        #[tokio::test]
-        async fn applies_busy_timeout_before_user_sql() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
-
-            let result = adapter
-                .execute_adhoc(&dsn, "PRAGMA busy_timeout", AccessMode::ReadOnly)
-                .await
-                .unwrap();
-
-            assert_eq!(result.rows(), vec![vec![BUSY_TIMEOUT_MS.to_string()]]);
-        }
-
-        #[tokio::test]
-        async fn values_result_does_not_get_select_command_tag() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
-
-            let result = adapter
-                .execute_adhoc(&dsn, "VALUES (1)", AccessMode::ReadOnly)
-                .await
-                .unwrap();
-
-            assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
-            assert_eq!(result.command_tag, None);
-        }
-
-        #[tokio::test]
-        async fn dml_returns_affected_rows_command_tag() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                r"
+            #[tokio::test]
+            async fn dml_returns_affected_rows_command_tag() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
             ",
-            );
-            let adapter = SqliteAdapter::new();
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "UPDATE users SET name = 'x' WHERE id = 1",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "UPDATE users SET name = 'x' WHERE id = 1",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.row_count(), 1);
-            assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
-        }
+                assert_eq!(result.row_count(), 1);
+                assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
+            }
 
-        #[tokio::test]
-        async fn replace_into_returns_insert_refresh_tag() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                r"
+            #[tokio::test]
+            async fn replace_into_returns_insert_refresh_tag() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a');
             ",
-            );
-            let adapter = SqliteAdapter::new();
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "REPLACE INTO users(id, name) VALUES (1, 'z')",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "REPLACE INTO users(id, name) VALUES (1, 'z')",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.row_count(), 1);
-            assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-        }
+                assert_eq!(result.row_count(), 1);
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+            }
 
-        #[tokio::test]
-        async fn dml_with_following_select_uses_trailing_changes_result() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                r"
+            #[tokio::test]
+            async fn dml_with_following_select_uses_trailing_changes_result() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a');
             ",
-            );
-            let adapter = SqliteAdapter::new();
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "UPDATE users SET name = 'x' WHERE id = 1; SELECT 42",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "UPDATE users SET name = 'x' WHERE id = 1; SELECT 42",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.row_count(), 1);
-            assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
-        }
+                assert_eq!(result.row_count(), 1);
+                assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
+            }
 
-        #[tokio::test]
-        async fn dml_with_following_select_preserves_result_set_and_refresh_tag() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                r"
+            #[tokio::test]
+            async fn dml_with_following_select_preserves_result_set_and_refresh_tag() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a');
             ",
-            );
-            let adapter = SqliteAdapter::new();
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "UPDATE users SET name = 'x' WHERE id = 1; SELECT name FROM users",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "UPDATE users SET name = 'x' WHERE id = 1; SELECT name FROM users",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.columns, vec!["name"]);
-            assert_eq!(result.rows(), vec![vec!["x".to_string()]]);
-            assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
-        }
+                assert_eq!(result.columns, vec!["name"]);
+                assert_eq!(result.rows(), vec![vec!["x".to_string()]]);
+                assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
+            }
 
-        #[tokio::test]
-        async fn multi_dml_uses_last_effective_refresh_tag() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                r"
+            #[tokio::test]
+            async fn multi_dml_uses_last_effective_refresh_tag() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a');
             ",
-            );
-            let adapter = SqliteAdapter::new();
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "INSERT INTO users(id, name) VALUES (2, 'b'), (3, 'c');
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "INSERT INTO users(id, name) VALUES (2, 'b'), (3, 'c');
                      UPDATE users SET name = 'z' WHERE id IN (1, 2);
                      DELETE FROM users WHERE id = 3",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.row_count(), 1);
-            assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
-        }
+                assert_eq!(result.row_count(), 1);
+                assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
+            }
 
-        #[tokio::test]
-        async fn ddl_wins_over_later_dml_for_refresh_tag() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn ddl_wins_over_later_dml_for_refresh_tag() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "CREATE TABLE users(id INTEGER PRIMARY KEY);
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "CREATE TABLE users(id INTEGER PRIMARY KEY);
                      INSERT INTO users(id) VALUES (1)",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(
-                result.command_tag,
-                Some(CommandTag::Create("TABLE".to_string()))
-            );
-            assert_eq!(result.row_count(), 0);
+                assert_eq!(
+                    result.command_tag,
+                    Some(CommandTag::Create("TABLE".to_string()))
+                );
+                assert_eq!(result.row_count(), 0);
+            }
         }
 
-        #[tokio::test]
-        async fn ddl_and_dml_still_roll_back_as_one_auto_transaction() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
+        mod transaction_execution {
+            use super::*;
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "CREATE TABLE users(id INTEGER PRIMARY KEY);\
+            #[tokio::test]
+            async fn ddl_and_dml_still_roll_back_as_one_auto_transaction() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
+
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "CREATE TABLE users(id INTEGER PRIMARY KEY);\
                      INSERT INTO users(id) VALUES (1);\
                      INSERT INTO missing(id) VALUES (2)",
-                    AccessMode::ReadWrite,
-                )
-                .await;
+                        AccessMode::ReadWrite,
+                    )
+                    .await;
 
-            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-            let tables = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'users'",
-                    AccessMode::ReadOnly,
-                )
-                .await
-                .unwrap();
-            assert!(tables.rows().is_empty());
-        }
+                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                let tables = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'users'",
+                        AccessMode::ReadOnly,
+                    )
+                    .await
+                    .unwrap();
+                assert!(tables.rows().is_empty());
+            }
 
-        #[tokio::test]
-        async fn vacuum_in_mixed_sql_runs_outside_auto_transaction() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn vacuum_in_mixed_sql_runs_outside_auto_transaction() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
 
-            adapter
-                .execute_adhoc(
-                    &dsn,
-                    "CREATE TABLE users(id INTEGER PRIMARY KEY);\
+                adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "CREATE TABLE users(id INTEGER PRIMARY KEY);\
                      INSERT INTO users(id) VALUES (1);\
                      VACUUM;\
                      INSERT INTO users(id) VALUES (2)",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
-            let rows = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "SELECT id FROM users ORDER BY id",
-                    AccessMode::ReadOnly,
-                )
-                .await
-                .unwrap();
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
+                let rows = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "SELECT id FROM users ORDER BY id",
+                        AccessMode::ReadOnly,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(
-                rows.rows(),
-                vec![vec!["1".to_string()], vec!["2".to_string()]]
-            );
-        }
+                assert_eq!(
+                    rows.rows(),
+                    vec![vec!["1".to_string()], vec!["2".to_string()]]
+                );
+            }
 
-        #[tokio::test]
-        async fn journal_mode_change_in_mixed_sql_runs_outside_auto_transaction() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn journal_mode_change_in_mixed_sql_runs_outside_auto_transaction() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
 
-            adapter
-                .execute_adhoc(
-                    &dsn,
-                    "PRAGMA journal_mode = WAL;\
+                adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "PRAGMA journal_mode = WAL;\
                      CREATE TABLE users(id INTEGER PRIMARY KEY);\
                      INSERT INTO users(id) VALUES (1)",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
 
-            assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
-        }
+                assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+            }
 
-        #[tokio::test]
-        async fn foreign_keys_change_in_mixed_sql_is_not_a_transaction_noop() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn foreign_keys_change_in_mixed_sql_is_not_a_transaction_noop() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "PRAGMA foreign_keys = ON;
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "PRAGMA foreign_keys = ON;
                      CREATE TABLE parent(id INTEGER PRIMARY KEY);
                      PRAGMA foreign_keys",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
-        }
+                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+            }
 
-        #[tokio::test]
-        async fn rolled_back_dml_returns_rollback_tag() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn rolled_back_dml_returns_rollback_tag() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "BEGIN; INSERT INTO users(id) VALUES (1); ROLLBACK",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "BEGIN; INSERT INTO users(id) VALUES (1); ROLLBACK",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.command_tag, Some(CommandTag::Rollback));
-            assert!(rows.rows().is_empty());
-        }
+                assert_eq!(result.command_tag, Some(CommandTag::Rollback));
+                assert!(rows.rows().is_empty());
+            }
 
-        #[tokio::test]
-        async fn full_rollback_inside_savepoint_discards_outer_dml() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn full_rollback_inside_savepoint_discards_outer_dml() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "BEGIN;
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "BEGIN;
                      INSERT INTO users(id) VALUES (1);
                      SAVEPOINT sp;
                      INSERT INTO users(id) VALUES (2);
                      ROLLBACK",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.command_tag, Some(CommandTag::Rollback));
-            assert!(rows.rows().is_empty());
-        }
+                assert_eq!(result.command_tag, Some(CommandTag::Rollback));
+                assert!(rows.rows().is_empty());
+            }
 
-        #[tokio::test]
-        async fn savepoint_rollback_discards_inner_dml_only() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn savepoint_rollback_discards_inner_dml_only() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "BEGIN;
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "BEGIN;
                      INSERT INTO users(id) VALUES (1);
                      SAVEPOINT sp;
                      INSERT INTO users(id) VALUES (2);
                      ROLLBACK TO sp;
                      COMMIT",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-            assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
-        }
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+                assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+            }
 
-        #[tokio::test]
-        async fn rollback_to_keeps_savepoint_for_later_rollback() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn rollback_to_keeps_savepoint_for_later_rollback() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "BEGIN;
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "BEGIN;
                      INSERT INTO users(id) VALUES (1);
                      SAVEPOINT sp;
                      INSERT INTO users(id) VALUES (2);
@@ -1718,29 +1733,29 @@ mod tests {
                      INSERT INTO users(id) VALUES (3);
                      ROLLBACK TO sp;
                      COMMIT",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-            assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
-        }
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+                assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+            }
 
-        #[tokio::test]
-        async fn rollback_to_named_outer_savepoint_discards_nested_frames() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn rollback_to_named_outer_savepoint_discards_nested_frames() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "BEGIN;
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "BEGIN;
                      INSERT INTO users(id) VALUES (1);
                      SAVEPOINT outer_sp;
                      INSERT INTO users(id) VALUES (2);
@@ -1748,362 +1763,366 @@ mod tests {
                      INSERT INTO users(id) VALUES (3);
                      ROLLBACK TO outer_sp;
                      COMMIT",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-            assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
-        }
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+                assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+            }
 
-        #[tokio::test]
-        async fn top_level_savepoint_rollback_to_discards_inner_dml_only() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn top_level_savepoint_rollback_to_discards_inner_dml_only() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "SAVEPOINT sp;
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "SAVEPOINT sp;
                      INSERT INTO users(id) VALUES (1);
                      INSERT INTO users(id) VALUES (2);
                      ROLLBACK TO sp;
                      INSERT INTO users(id) VALUES (3);
                      RELEASE sp",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-            assert_eq!(rows.rows(), vec![vec!["3".to_string()]]);
-        }
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+                assert_eq!(rows.rows(), vec![vec!["3".to_string()]]);
+            }
 
-        #[tokio::test]
-        async fn top_level_savepoint_multi_write_rolls_back_when_later_statement_fails() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn top_level_savepoint_multi_write_rolls_back_when_later_statement_fails() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
+                let result = adapter
                 .execute_adhoc(
                     &dsn,
                     "SAVEPOINT sp; INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)", AccessMode::ReadWrite)
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
-            assert!(rows.rows().is_empty());
-        }
+                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
+                assert!(rows.rows().is_empty());
+            }
 
-        #[tokio::test]
-        async fn top_level_savepoint_without_release_does_not_persist_on_success() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn top_level_savepoint_without_release_does_not_persist_on_success() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
+                let result = adapter
                 .execute_adhoc(
                     &dsn,
                     "SAVEPOINT sp; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)", AccessMode::ReadWrite)
                 .await
                 .unwrap();
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.command_tag, Some(CommandTag::Rollback));
-            assert!(rows.rows().is_empty());
-        }
+                assert_eq!(result.command_tag, Some(CommandTag::Rollback));
+                assert!(rows.rows().is_empty());
+            }
 
-        #[tokio::test]
-        async fn with_insert_reports_affected_rows_command_tag() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn with_insert_reports_affected_rows_command_tag() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "WITH payload(id) AS (VALUES (1), (2))
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "WITH payload(id) AS (VALUES (1), (2))
                      INSERT INTO users(id) SELECT id FROM payload",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.row_count(), 2);
-            assert_eq!(result.command_tag, Some(CommandTag::Insert(2)));
-        }
+                assert_eq!(result.row_count(), 2);
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(2)));
+            }
 
-        #[tokio::test]
-        async fn multi_statement_dml_rolls_back_when_later_statement_fails() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn multi_statement_dml_rolls_back_when_later_statement_fails() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
-                    AccessMode::ReadWrite,
-                )
-                .await;
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)",
+                        AccessMode::ReadWrite,
+                    )
+                    .await;
 
-            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
-            assert!(rows.rows().is_empty());
-        }
+                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
+                assert!(rows.rows().is_empty());
+            }
 
-        #[tokio::test]
-        async fn with_dml_rolls_back_when_later_statement_fails() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn with_dml_rolls_back_when_later_statement_fails() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "WITH payload(id) AS (VALUES (1))
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "WITH payload(id) AS (VALUES (1))
                      INSERT INTO users(id) SELECT id FROM payload;
                      INSERT INTO missing(id) VALUES (2)",
-                    AccessMode::ReadWrite,
-                )
-                .await;
+                        AccessMode::ReadWrite,
+                    )
+                    .await;
 
-            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
-            assert!(rows.rows().is_empty());
-        }
+                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
+                assert!(rows.rows().is_empty());
+            }
 
-        #[tokio::test]
-        async fn returning_dml_rolls_back_when_later_statement_fails() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
-            let query =
-                "INSERT INTO users(id) VALUES (1) RETURNING id; INSERT INTO missing(id) VALUES (2)";
+            #[tokio::test]
+            async fn returning_dml_rolls_back_when_later_statement_fails() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
+                let query = "INSERT INTO users(id) VALUES (1) RETURNING id; INSERT INTO missing(id) VALUES (2)";
 
-            let result = adapter
-                .execute_adhoc(&dsn, query, AccessMode::ReadWrite)
-                .await;
+                let result = adapter
+                    .execute_adhoc(&dsn, query, AccessMode::ReadWrite)
+                    .await;
 
-            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
-            assert!(rows.rows().is_empty());
-        }
+                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
+                assert!(rows.rows().is_empty());
+            }
 
-        #[tokio::test]
-        async fn select_then_dml_rolls_back_when_later_statement_fails() {
-            let (_dir, dsn) =
-                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn select_then_dml_rolls_back_when_later_statement_fails() {
+                let (_dir, dsn) =
+                    test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
+                let result = adapter
                 .execute_adhoc(
                     &dsn,
                     "SELECT 1 AS marker; INSERT INTO users(id) VALUES (1); INSERT INTO missing(id) VALUES (2)", AccessMode::ReadWrite)
                 .await;
 
-            assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-            let rows = adapter
-                .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
-                .await
-                .unwrap();
-            assert!(rows.rows().is_empty());
+                assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                let rows = adapter
+                    .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
+                    .await
+                    .unwrap();
+                assert!(rows.rows().is_empty());
+            }
         }
 
-        #[tokio::test]
-        async fn dml_with_trailing_line_comment_returns_affected_rows() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                r"
+        mod returning_results {
+            use super::*;
+
+            #[tokio::test]
+            async fn dml_with_trailing_line_comment_returns_affected_rows() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a');
             ",
-            );
-            let adapter = SqliteAdapter::new();
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "DELETE FROM users WHERE id = 1 -- cleanup selected row",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "DELETE FROM users WHERE id = 1 -- cleanup selected row",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.row_count(), 1);
-            assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
-        }
+                assert_eq!(result.row_count(), 1);
+                assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
+            }
 
-        #[tokio::test]
-        async fn dml_returning_preserves_returned_rows() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);",
-            );
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn dml_returning_preserves_returned_rows() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);",
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "INSERT INTO users(name) VALUES ('a') RETURNING id, name",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "INSERT INTO users(name) VALUES ('a') RETURNING id, name",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.columns, vec!["id", "name"]);
-            assert_eq!(result.rows(), vec![vec!["1".to_string(), "a".to_string()]]);
-            assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-        }
+                assert_eq!(result.columns, vec!["id", "name"]);
+                assert_eq!(result.rows(), vec![vec!["1".to_string(), "a".to_string()]]);
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+            }
 
-        #[tokio::test]
-        async fn update_returning_preserves_returned_rows() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                r"
+            #[tokio::test]
+            async fn update_returning_preserves_returned_rows() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
             ",
-            );
-            let adapter = SqliteAdapter::new();
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "UPDATE users SET name = 'x' RETURNING id, name",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "UPDATE users SET name = 'x' RETURNING id, name",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.rows().len(), 2);
-            assert_eq!(result.command_tag, Some(CommandTag::Update(2)));
-        }
+                assert_eq!(result.rows().len(), 2);
+                assert_eq!(result.command_tag, Some(CommandTag::Update(2)));
+            }
 
-        #[tokio::test]
-        async fn delete_returning_preserves_returned_rows() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                r"
+            #[tokio::test]
+            async fn delete_returning_preserves_returned_rows() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
             INSERT INTO users(id, name) VALUES (1, 'a'), (2, 'b');
             ",
-            );
-            let adapter = SqliteAdapter::new();
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "DELETE FROM users WHERE id = 1 RETURNING id, name",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "DELETE FROM users WHERE id = 1 RETURNING id, name",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.rows(), vec![vec!["1".to_string(), "a".to_string()]]);
-            assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
-        }
+                assert_eq!(result.rows(), vec![vec!["1".to_string(), "a".to_string()]]);
+                assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
+            }
 
-        #[tokio::test]
-        async fn dml_table_name_containing_returning_reports_affected_rows() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                "CREATE TABLE returning_log(id INTEGER PRIMARY KEY, name TEXT);",
-            );
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn dml_table_name_containing_returning_reports_affected_rows() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    "CREATE TABLE returning_log(id INTEGER PRIMARY KEY, name TEXT);",
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "INSERT INTO returning_log(name) VALUES ('a')",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "INSERT INTO returning_log(name) VALUES ('a')",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.row_count(), 1);
-            assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-        }
+                assert_eq!(result.row_count(), 1);
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+            }
 
-        #[tokio::test]
-        async fn dml_backtick_quoted_identifier_containing_returning_reports_affected_rows() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                "CREATE TABLE `my returning`(id INTEGER PRIMARY KEY, name TEXT);",
-            );
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn dml_backtick_quoted_identifier_containing_returning_reports_affected_rows() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    "CREATE TABLE `my returning`(id INTEGER PRIMARY KEY, name TEXT);",
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "INSERT INTO `my returning`(name) VALUES ('a')",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "INSERT INTO `my returning`(name) VALUES ('a')",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.row_count(), 1);
-            assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-        }
+                assert_eq!(result.row_count(), 1);
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+            }
 
-        #[tokio::test]
-        async fn dml_bracket_quoted_identifier_containing_returning_reports_affected_rows() {
-            let (_dir, dsn) = test_support::make_sqlite_db(
-                "CREATE TABLE [my returning](id INTEGER PRIMARY KEY, name TEXT);",
-            );
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn dml_bracket_quoted_identifier_containing_returning_reports_affected_rows() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    "CREATE TABLE [my returning](id INTEGER PRIMARY KEY, name TEXT);",
+                );
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "INSERT INTO [my returning](name) VALUES ('a')",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "INSERT INTO [my returning](name) VALUES ('a')",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(result.row_count(), 1);
-            assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-        }
+                assert_eq!(result.row_count(), 1);
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+            }
 
-        #[tokio::test]
-        async fn ddl_returns_schema_refresh_command_tag() {
-            let (_dir, dsn) = test_support::make_sqlite_db("");
-            let adapter = SqliteAdapter::new();
+            #[tokio::test]
+            async fn ddl_returns_schema_refresh_command_tag() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
 
-            let result = adapter
-                .execute_adhoc(
-                    &dsn,
-                    "CREATE TABLE users(id INTEGER PRIMARY KEY)",
-                    AccessMode::ReadWrite,
-                )
-                .await
-                .unwrap();
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "CREATE TABLE users(id INTEGER PRIMARY KEY)",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
 
-            assert_eq!(
-                result.command_tag,
-                Some(CommandTag::Create("TABLE".to_string()))
-            );
+                assert_eq!(
+                    result.command_tag,
+                    Some(CommandTag::Create("TABLE".to_string()))
+                );
+            }
         }
     }
 

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -840,208 +840,220 @@ mod tests {
         Ok(append_changes_query_for_plan(&plan))
     }
 
-    #[test]
-    fn split_sqlite_statements_ignores_semicolons_in_literals_and_comments() {
-        let statements = try_split_sqlite_statements(
-            "INSERT INTO logs(message) VALUES ('a;b'); -- ; ignored\nSELECT ';' AS value;",
-        )
-        .unwrap();
+    mod statement_splitting {
+        use super::*;
 
-        assert_eq!(
-            statements,
-            vec![
-                "INSERT INTO logs(message) VALUES ('a;b')",
-                "-- ; ignored\nSELECT ';' AS value"
-            ]
-        );
-    }
+        #[test]
+        fn ignores_semicolons_in_literals_and_comments() {
+            let statements = try_split_sqlite_statements(
+                "INSERT INTO logs(message) VALUES ('a;b'); -- ; ignored\nSELECT ';' AS value;",
+            )
+            .unwrap();
 
-    #[test]
-    fn split_sqlite_statements_rejects_dot_commands() {
-        let error = try_split_sqlite_statements("SELECT 1;\n.shell echo unsafe").unwrap_err();
+            assert_eq!(
+                statements,
+                vec![
+                    "INSERT INTO logs(message) VALUES ('a;b')",
+                    "-- ; ignored\nSELECT ';' AS value"
+                ]
+            );
+        }
 
-        assert!(matches!(error, DbOperationError::UnsupportedOperation(_)));
-    }
+        #[test]
+        fn rejects_dot_commands() {
+            let error = try_split_sqlite_statements("SELECT 1;\n.shell echo unsafe").unwrap_err();
 
-    #[test]
-    fn split_sqlite_statements_allows_dot_at_line_start_inside_literal() {
-        let statements =
-            try_split_sqlite_statements("SELECT '.shell echo safe\n.read file';").unwrap();
+            assert!(matches!(error, DbOperationError::UnsupportedOperation(_)));
+        }
 
-        assert_eq!(statements, vec!["SELECT '.shell echo safe\n.read file'"]);
-    }
+        #[test]
+        fn allows_dot_at_line_start_inside_literal() {
+            let statements =
+                try_split_sqlite_statements("SELECT '.shell echo safe\n.read file';").unwrap();
 
-    #[test]
-    fn split_sqlite_statements_keeps_create_trigger_body_together() {
-        let trigger = "\
+            assert_eq!(statements, vec!["SELECT '.shell echo safe\n.read file'"]);
+        }
+
+        #[test]
+        fn keeps_create_trigger_body_together() {
+            let trigger = "\
 CREATE TRIGGER agent_messages_fts_ai AFTER INSERT ON agent_messages BEGIN
     INSERT INTO agent_messages_fts(rowid, role, content)
     VALUES (new.id, new.role, new.content);
 END";
-        let sql = format!("{trigger}; SELECT 1 AS value;");
+            let sql = format!("{trigger}; SELECT 1 AS value;");
 
-        let statements = try_split_sqlite_statements(&sql).unwrap();
+            let statements = try_split_sqlite_statements(&sql).unwrap();
 
-        assert_eq!(statements.len(), 2);
-        assert_eq!(statements[0], trigger);
-        assert_eq!(statements[1], "SELECT 1 AS value");
-    }
+            assert_eq!(statements.len(), 2);
+            assert_eq!(statements[0], trigger);
+            assert_eq!(statements[1], "SELECT 1 AS value");
+        }
 
-    #[test]
-    fn split_sqlite_statements_keeps_create_trigger_with_dotted_end_reference() {
-        let trigger = "\
+        #[test]
+        fn keeps_create_trigger_with_dotted_end_reference() {
+            let trigger = "\
 CREATE TRIGGER sync_end AFTER UPDATE ON events BEGIN
     UPDATE counters SET end_value = new.end WHERE id = new.id;
     INSERT INTO audit(event_id, end_value) VALUES (new.id, new.end);
 END";
-        let sql = format!("{trigger}; SELECT 1 AS value;");
+            let sql = format!("{trigger}; SELECT 1 AS value;");
 
-        let statements = try_split_sqlite_statements(&sql).unwrap();
+            let statements = try_split_sqlite_statements(&sql).unwrap();
 
-        assert_eq!(statements.len(), 2);
-        assert_eq!(statements[0], trigger);
-        assert_eq!(statements[1], "SELECT 1 AS value");
-    }
+            assert_eq!(statements.len(), 2);
+            assert_eq!(statements[0], trigger);
+            assert_eq!(statements[1], "SELECT 1 AS value");
+        }
 
-    #[test]
-    fn split_sqlite_statements_keeps_create_trigger_with_case_end_expression() {
-        let trigger = "\
+        #[test]
+        fn keeps_create_trigger_with_case_end_expression() {
+            let trigger = "\
 CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
     UPDATE counters
     SET end_value = CASE WHEN new.end > 0 THEN new.end ELSE old.end END
     WHERE id = new.id;
     INSERT INTO audit(event_id) VALUES (new.id);
 END";
-        let sql = format!("{trigger}; SELECT 1 AS value;");
+            let sql = format!("{trigger}; SELECT 1 AS value;");
 
-        let statements = try_split_sqlite_statements(&sql).unwrap();
+            let statements = try_split_sqlite_statements(&sql).unwrap();
 
-        assert_eq!(statements.len(), 2);
-        assert_eq!(statements[0], trigger);
-        assert_eq!(statements[1], "SELECT 1 AS value");
+            assert_eq!(statements.len(), 2);
+            assert_eq!(statements[0], trigger);
+            assert_eq!(statements[1], "SELECT 1 AS value");
+        }
+
+        #[test]
+        fn rejects_unclosed_create_trigger_body() {
+            let error = try_split_sqlite_statements(
+                "CREATE TRIGGER t AFTER INSERT ON users BEGIN INSERT INTO logs(id) VALUES (1);",
+            )
+            .unwrap_err();
+
+            assert!(matches!(error, DbOperationError::QueryFailed(_)));
+        }
+
+        #[test]
+        fn rejects_incomplete_create_trigger_without_begin() {
+            let error =
+                try_split_sqlite_statements("CREATE TRIGGER t AFTER INSERT ON users").unwrap_err();
+
+            assert!(matches!(error, DbOperationError::QueryFailed(_)));
+        }
     }
 
-    #[test]
-    fn adhoc_execution_query_does_not_insert_probes_when_trigger_references_new_end() {
-        let trigger = "\
+    mod execution_probes {
+        use super::*;
+
+        #[test]
+        fn do_not_insert_probes_when_trigger_references_new_end() {
+            let trigger = "\
 CREATE TRIGGER sync_end AFTER UPDATE ON events BEGIN
     UPDATE counters SET end_value = new.end WHERE id = new.id;
     INSERT INTO audit(event_id, end_value) VALUES (new.id, new.end);
 END";
-        let marker = "probe_marker";
+            let marker = "probe_marker";
 
-        let execution_query = sqlite_adhoc_execution_query(trigger, marker).unwrap();
+            let execution_query = sqlite_adhoc_execution_query(trigger, marker).unwrap();
 
-        assert!(!execution_query.contains(marker));
-        assert_eq!(execution_query, trigger);
-    }
+            assert!(!execution_query.contains(marker));
+            assert_eq!(execution_query, trigger);
+        }
 
-    #[test]
-    fn split_sqlite_statements_rejects_unclosed_create_trigger_body() {
-        let error = try_split_sqlite_statements(
-            "CREATE TRIGGER t AFTER INSERT ON users BEGIN INSERT INTO logs(id) VALUES (1);",
-        )
-        .unwrap_err();
-
-        assert!(matches!(error, DbOperationError::QueryFailed(_)));
-    }
-
-    #[test]
-    fn split_sqlite_statements_rejects_incomplete_create_trigger_without_begin() {
-        let error =
-            try_split_sqlite_statements("CREATE TRIGGER t AFTER INSERT ON users").unwrap_err();
-
-        assert!(matches!(error, DbOperationError::QueryFailed(_)));
-    }
-
-    #[test]
-    fn adhoc_execution_query_does_not_insert_probes_inside_create_trigger() {
-        let trigger = "\
+        #[test]
+        fn do_not_insert_probes_inside_create_trigger() {
+            let trigger = "\
 CREATE TRIGGER agent_messages_fts_ai AFTER INSERT ON agent_messages BEGIN
     INSERT INTO agent_messages_fts(rowid, role, content)
     VALUES (new.id, new.role, new.content);
 END";
-        let marker = "probe_marker";
+            let marker = "probe_marker";
 
-        let execution_query = sqlite_adhoc_execution_query(trigger, marker).unwrap();
+            let execution_query = sqlite_adhoc_execution_query(trigger, marker).unwrap();
 
-        assert!(!execution_query.contains(marker));
-        assert_eq!(execution_query, trigger);
+            assert!(!execution_query.contains(marker));
+            assert_eq!(execution_query, trigger);
+        }
     }
 
-    #[test]
-    fn append_changes_wraps_multi_statement_write_without_explicit_transaction() {
-        let query = "INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2);";
+    mod changes_query {
+        use super::*;
 
-        let wrapped = append_changes_query(query).unwrap();
+        #[test]
+        fn wraps_multi_statement_write_without_explicit_transaction() {
+            let query = "INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2);";
 
-        assert_eq!(
-            wrapped,
-            "BEGIN;\nINSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)\n;\nCOMMIT\n;\nSELECT changes() AS affected_rows;"
-        );
+            let wrapped = append_changes_query(query).unwrap();
+
+            assert_eq!(
+                wrapped,
+                "BEGIN;\nINSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)\n;\nCOMMIT\n;\nSELECT changes() AS affected_rows;"
+            );
+        }
+
+        #[test]
+        fn wraps_multi_statement_replace_without_explicit_transaction() {
+            let query = "REPLACE INTO users(id) VALUES (1); SELECT * FROM missing";
+
+            let wrapped = append_changes_query(query).unwrap();
+
+            assert_eq!(
+                wrapped,
+                "BEGIN;\nREPLACE INTO users(id) VALUES (1); SELECT * FROM missing\n;\nCOMMIT\n;\nSELECT changes() AS affected_rows;"
+            );
+        }
+
+        #[test]
+        fn wraps_multi_statement_with_write_without_explicit_transaction() {
+            let query = "WITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload; SELECT * FROM missing";
+
+            let wrapped = append_changes_query(query).unwrap();
+
+            assert_eq!(
+                wrapped,
+                "BEGIN;\nWITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload; SELECT * FROM missing\n;\nCOMMIT\n;\nSELECT changes() AS affected_rows;"
+            );
+        }
+
+        #[test]
+        fn keeps_transaction_incompatible_statement_outside_auto_transaction() {
+            let query = "INSERT INTO users(id) VALUES (1); VACUUM";
+
+            let wrapped = append_changes_query(query).unwrap();
+
+            assert_eq!(
+                wrapped,
+                "INSERT INTO users(id) VALUES (1); VACUUM\n;\nSELECT changes() AS affected_rows;"
+            );
+        }
+
+        #[test]
+        fn keeps_explicit_begin_commit_transaction_control() {
+            let query = "BEGIN; INSERT INTO users(id) VALUES (1); COMMIT";
+
+            let wrapped = append_changes_query(query).unwrap();
+
+            assert_eq!(
+                wrapped,
+                "BEGIN; INSERT INTO users(id) VALUES (1); COMMIT\n;\nSELECT changes() AS affected_rows;"
+            );
+        }
+
+        #[test]
+        fn keeps_explicit_begin_end_transaction_control() {
+            let query = "BEGIN; INSERT INTO users(id) VALUES (1); END";
+
+            let wrapped = append_changes_query(query).unwrap();
+
+            assert_eq!(
+                wrapped,
+                "BEGIN; INSERT INTO users(id) VALUES (1); END\n;\nSELECT changes() AS affected_rows;"
+            );
+        }
     }
 
-    #[test]
-    fn append_changes_wraps_multi_statement_replace_without_explicit_transaction() {
-        let query = "REPLACE INTO users(id) VALUES (1); SELECT * FROM missing";
-
-        let wrapped = append_changes_query(query).unwrap();
-
-        assert_eq!(
-            wrapped,
-            "BEGIN;\nREPLACE INTO users(id) VALUES (1); SELECT * FROM missing\n;\nCOMMIT\n;\nSELECT changes() AS affected_rows;"
-        );
-    }
-
-    #[test]
-    fn append_changes_wraps_multi_statement_with_write_without_explicit_transaction() {
-        let query = "WITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload; SELECT * FROM missing";
-
-        let wrapped = append_changes_query(query).unwrap();
-
-        assert_eq!(
-            wrapped,
-            "BEGIN;\nWITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload; SELECT * FROM missing\n;\nCOMMIT\n;\nSELECT changes() AS affected_rows;"
-        );
-    }
-
-    #[test]
-    fn append_changes_keeps_transaction_incompatible_statement_outside_auto_transaction() {
-        let query = "INSERT INTO users(id) VALUES (1); VACUUM";
-
-        let wrapped = append_changes_query(query).unwrap();
-
-        assert_eq!(
-            wrapped,
-            "INSERT INTO users(id) VALUES (1); VACUUM\n;\nSELECT changes() AS affected_rows;"
-        );
-    }
-
-    #[test]
-    fn append_changes_keeps_explicit_begin_commit_transaction_control() {
-        let query = "BEGIN; INSERT INTO users(id) VALUES (1); COMMIT";
-
-        let wrapped = append_changes_query(query).unwrap();
-
-        assert_eq!(
-            wrapped,
-            "BEGIN; INSERT INTO users(id) VALUES (1); COMMIT\n;\nSELECT changes() AS affected_rows;"
-        );
-    }
-
-    #[test]
-    fn append_changes_keeps_explicit_begin_end_transaction_control() {
-        let query = "BEGIN; INSERT INTO users(id) VALUES (1); END";
-
-        let wrapped = append_changes_query(query).unwrap();
-
-        assert_eq!(
-            wrapped,
-            "BEGIN; INSERT INTO users(id) VALUES (1); END\n;\nSELECT changes() AS affected_rows;"
-        );
-    }
-
-    mod wrap_mode {
+    mod transaction_wrap_mode {
         use super::*;
 
         #[rstest]
@@ -1131,57 +1143,65 @@ END";
         }
     }
 
-    #[test]
-    fn export_guard_rejects_non_rerunnable_sql() {
-        for sql in [
-            "SELECT 1; SELECT 2",
-            "WITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload",
-            "PRAGMA foreign_keys=OFF",
-            "PRAGMA journal_mode=WAL",
-            "PRAGMA wal_checkpoint(TRUNCATE)",
-        ] {
-            assert!(!is_sqlite_rerunnable_export_query(sql).unwrap(), "{sql}");
+    mod export_guard {
+        use super::*;
+
+        #[test]
+        fn rejects_non_rerunnable_sql() {
+            for sql in [
+                "SELECT 1; SELECT 2",
+                "WITH payload(id) AS (VALUES (1)) INSERT INTO users(id) SELECT id FROM payload",
+                "PRAGMA foreign_keys=OFF",
+                "PRAGMA journal_mode=WAL",
+                "PRAGMA wal_checkpoint(TRUNCATE)",
+            ] {
+                assert!(!is_sqlite_rerunnable_export_query(sql).unwrap(), "{sql}");
+            }
+        }
+
+        #[test]
+        fn allows_read_only_sql() {
+            for sql in ["SELECT 1", "PRAGMA table_info(users)"] {
+                assert!(is_sqlite_rerunnable_export_query(sql).unwrap(), "{sql}");
+            }
         }
     }
 
-    #[test]
-    fn export_guard_allows_read_only_sql() {
-        for sql in ["SELECT 1", "PRAGMA table_info(users)"] {
-            assert!(is_sqlite_rerunnable_export_query(sql).unwrap(), "{sql}");
+    mod virtual_table_parsing {
+        use super::*;
+
+        #[test]
+        fn prefix_requires_keyword_sequence() {
+            assert!(is_create_virtual_table_prefix(
+                "CREATE VIRTUAL TABLE notes_fts USING fts5(body);"
+            ));
+            assert!(!is_create_virtual_table_prefix(
+                "CREATE TABLE docs(body TEXT DEFAULT 'create virtual table');"
+            ));
         }
-    }
 
-    #[test]
-    fn create_virtual_table_prefix_requires_keyword_sequence() {
-        assert!(is_create_virtual_table_prefix(
-            "CREATE VIRTUAL TABLE notes_fts USING fts5(body);"
-        ));
-        assert!(!is_create_virtual_table_prefix(
-            "CREATE TABLE docs(body TEXT DEFAULT 'create virtual table');"
-        ));
-    }
+        #[test]
+        fn module_name_skips_quoted_table_name() {
+            assert_eq!(
+                virtual_table_module_name(r#"CREATE VIRTUAL TABLE "using" USING fts5(body);"#),
+                Some("fts5".to_string())
+            );
+        }
 
-    #[test]
-    fn virtual_table_module_name_skips_quoted_table_name() {
-        assert_eq!(
-            virtual_table_module_name(r#"CREATE VIRTUAL TABLE "using" USING fts5(body);"#),
-            Some("fts5".to_string())
-        );
-    }
+        #[test]
+        fn module_name_reads_double_quoted_module() {
+            assert_eq!(
+                virtual_table_module_name(r#"CREATE VIRTUAL TABLE notes USING "fts5"(body);"#),
+                Some("fts5".to_string())
+            );
+        }
 
-    #[test]
-    fn virtual_table_module_name_reads_double_quoted_module() {
-        assert_eq!(
-            virtual_table_module_name(r#"CREATE VIRTUAL TABLE notes USING "fts5"(body);"#),
-            Some("fts5".to_string())
-        );
-    }
-
-    #[test]
-    fn virtual_table_module_name_rejects_unclosed_bracket_module() {
-        assert_eq!(
-            virtual_table_module_name("CREATE VIRTUAL TABLE notes USING [fts5(body);"),
-            None
-        );
+        #[test]
+        fn module_name_rejects_unclosed_bracket_module() {
+            assert_eq!(
+                virtual_table_module_name("CREATE VIRTUAL TABLE notes USING [fts5(body);"),
+                None
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

SQLite SQL tests mixed unrelated behaviors in large modules, making failures and affected areas difficult to identify.

## Approach

Organize lexer, executor, SQL dialect, and risk-policy tests by behavior while preserving existing coverage and runtime behavior.