### PR TITLE
feat: preserve SQLite numeric storage classes during inline edits

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -396,7 +396,7 @@ impl AppState {
             }
         }
 
-        supports_inline_edit(value)
+        supports_inline_edit(self.session.active_database_type_or_default(), value)
     }
 
     /// True when a run-scoped async response no longer belongs to the active

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -26,8 +26,10 @@ use crate::model::shared::ui_state::{UiState, scroll_max_offset};
 use crate::model::sql_editor::modal::SqlModalContext;
 use crate::model::sql_editor::query_history::QueryHistoryPickerState;
 use crate::model::sqlite::diagnostics::SqliteDiagnosticsState;
+use crate::policy::preview_cell_text::{preview_cell_text_diff_handling, uses_jsonb_detail_modal};
 use crate::policy::sql::result_query::is_rerunnable_select;
 use crate::policy::table_kind::max_explorer_table_label_width;
+use crate::policy::write::inline_cell_edit::supports_inline_edit;
 use crate::policy::write::write_guardrails::{PreviewWriteability, preview_writeability};
 
 pub struct AppState {
@@ -350,6 +352,53 @@ impl AppState {
             && self.visible_preview_target_read_only_reason().is_none()
     }
 
+    pub fn can_edit_selected_cell(&self) -> bool {
+        let Some(row_idx) = self.result_interaction.selection().row() else {
+            return false;
+        };
+        let Some(col_idx) = self.result_interaction.selection().cell() else {
+            return false;
+        };
+        if !self.can_write_visible_preview() {
+            return false;
+        }
+
+        let Some(result) = self.query.visible_result() else {
+            return false;
+        };
+        if row_idx >= result.values().len() {
+            return false;
+        }
+        let Some(value) = result.value_at(row_idx, col_idx) else {
+            return false;
+        };
+
+        if let Some(table_detail) = self.session.table_detail()
+            && let Some(column) = table_detail.columns.get(col_idx)
+        {
+            if table_detail
+                .primary_key
+                .as_ref()
+                .is_some_and(|pk| pk.iter().any(|name| name == &column.name))
+            {
+                return false;
+            }
+            if column.is_read_only() {
+                return false;
+            }
+
+            let handling = preview_cell_text_diff_handling(
+                self.session.active_database_type_or_default(),
+                column.data_type.as_str(),
+            );
+            if uses_jsonb_detail_modal(handling) {
+                return true;
+            }
+        }
+
+        supports_inline_edit(value)
+    }
+
     /// True when a run-scoped async response no longer belongs to the active
     /// connection and query run, and must be dropped without touching state.
     pub fn is_stale_query_run(&self, dsn: &str, run_id: u64) -> bool {
@@ -366,8 +415,8 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        ConnectionId, DatabaseMetadata, DatabaseType, QueryResult, QuerySource, Table, TableKind,
-        TableKindInfo,
+        Column, ColumnAttributes, ConnectionId, DatabaseMetadata, DatabaseType, QueryResult,
+        QuerySource, QueryValue, Table, TableKind, TableKindInfo,
     };
     use crate::model::browse::row_detail::RowDetailState;
     use crate::model::er_state::ErStatus;
@@ -411,6 +460,99 @@ mod tests {
             name: "users".to_string(),
             ..test_support::table::minimal("", "")
         }
+    }
+
+    #[test]
+    fn can_edit_selected_cell_allows_sqlite_numeric_literal() {
+        let mut state = make_state();
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "sqlite",
+            DatabaseType::SQLite,
+            "sqlite:///tmp/app.db",
+        );
+        state
+            .query
+            .set_current_result(Arc::new(QueryResult::success_with_values(
+                "SELECT id, score FROM users".to_string(),
+                vec!["id".to_string(), "score".to_string()],
+                vec![vec![
+                    QueryValue::SqlLiteral("1".to_string()),
+                    QueryValue::SqlLiteral("42".to_string()),
+                ]],
+                10,
+                QuerySource::Preview,
+            )));
+        state.query.pagination.reset_for_table("main", "users");
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "main".to_string(),
+            name: "users".to_string(),
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "INTEGER".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::PRIMARY_KEY,
+                    comment: None,
+                    ordinal_position: 1,
+                },
+                Column {
+                    name: "score".to_string(),
+                    data_type: "REAL".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::NULLABLE,
+                    comment: None,
+                    ordinal_position: 2,
+                },
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..test_support::table::minimal("", "")
+        }));
+        state.result_interaction.activate_cell(0, 1);
+
+        assert!(state.can_edit_selected_cell());
+    }
+
+    #[test]
+    fn can_edit_selected_cell_rejects_blob_cell() {
+        let mut state = make_state();
+        state
+            .query
+            .set_current_result(Arc::new(QueryResult::success_with_values(
+                "SELECT id, payload FROM users".to_string(),
+                vec!["id".to_string(), "payload".to_string()],
+                vec![vec![QueryValue::text("1"), QueryValue::Blob(vec![0, 255])]],
+                10,
+                QuerySource::Preview,
+            )));
+        state.query.pagination.reset_for_table("public", "users");
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "public".to_string(),
+            name: "users".to_string(),
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "INTEGER".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::PRIMARY_KEY,
+                    comment: None,
+                    ordinal_position: 1,
+                },
+                Column {
+                    name: "payload".to_string(),
+                    data_type: "BLOB".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::NULLABLE,
+                    comment: None,
+                    ordinal_position: 2,
+                },
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..test_support::table::minimal("", "")
+        }));
+        state.result_interaction.activate_cell(0, 1);
+
+        assert!(!state.can_edit_selected_cell());
     }
 
     mod pane_geometry {

--- a/src/app/policy/write/inline_cell_edit.rs
+++ b/src/app/policy/write/inline_cell_edit.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::num::IntErrorKind;
 
-use crate::domain::QueryValue;
+use crate::domain::{DatabaseType, QueryValue};
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum InlineCellEditError {
@@ -28,20 +28,31 @@ enum InlineCellEditKind {
     SqliteReal,
 }
 
-pub fn supports_inline_edit(value: &QueryValue) -> bool {
-    classify_inline_cell_edit(value).is_ok()
+pub fn supports_inline_edit(database_type: DatabaseType, value: &QueryValue) -> bool {
+    classify_inline_cell_edit(database_type, value).is_ok()
 }
 
-pub fn editable_inline_display_value(value: &QueryValue) -> Result<String, InlineCellEditError> {
-    classify_inline_cell_edit(value)?;
-    Ok(value.display_value())
+pub fn editable_inline_display_value(
+    database_type: DatabaseType,
+    value: &QueryValue,
+) -> Result<String, InlineCellEditError> {
+    match classify_inline_cell_edit(database_type, value)? {
+        InlineCellEditKind::Text => match value {
+            QueryValue::Text(value) => Ok(value.clone()),
+            _ => unreachable!("text edit kind must carry text value"),
+        },
+        InlineCellEditKind::SqliteInteger | InlineCellEditKind::SqliteReal => {
+            Ok(value.display_value())
+        }
+    }
 }
 
 pub fn build_edited_query_value(
+    database_type: DatabaseType,
     original: &QueryValue,
     draft: &str,
 ) -> Result<QueryValue, InlineCellEditError> {
-    match classify_inline_cell_edit(original)? {
+    match classify_inline_cell_edit(database_type, original)? {
         InlineCellEditKind::Text => Ok(QueryValue::text(draft)),
         InlineCellEditKind::SqliteInteger => parse_sqlite_integer_draft(draft),
         InlineCellEditKind::SqliteReal => parse_sqlite_real_draft(draft),
@@ -49,13 +60,14 @@ pub fn build_edited_query_value(
 }
 
 fn classify_inline_cell_edit(
+    database_type: DatabaseType,
     value: &QueryValue,
 ) -> Result<InlineCellEditKind, InlineCellEditError> {
     match value {
         QueryValue::Text(_) => Ok(InlineCellEditKind::Text),
         QueryValue::Null => Err(InlineCellEditError::NullUnsupported),
         QueryValue::Blob(_) => Err(InlineCellEditError::BlobUnsupported),
-        QueryValue::SqlLiteral(value) => {
+        QueryValue::SqlLiteral(value) if database_type == DatabaseType::SQLite => {
             if value.parse::<i64>().is_ok() {
                 Ok(InlineCellEditKind::SqliteInteger)
             } else if matches_sqlite_numeric_lexeme(value) {
@@ -64,6 +76,7 @@ fn classify_inline_cell_edit(
                 Err(InlineCellEditError::UnsupportedCellType)
             }
         }
+        QueryValue::SqlLiteral(_) => Err(InlineCellEditError::UnsupportedCellType),
     }
 }
 
@@ -179,23 +192,43 @@ mod tests {
     #[test]
     fn sql_literal_integer_is_inline_editable() {
         assert_eq!(
-            editable_inline_display_value(&QueryValue::SqlLiteral("42".to_string())).unwrap(),
+            editable_inline_display_value(
+                DatabaseType::SQLite,
+                &QueryValue::SqlLiteral("42".to_string()),
+            )
+            .unwrap(),
             "42"
         );
     }
 
     #[test]
+    fn text_with_nul_keeps_raw_value_for_editing() {
+        assert_eq!(
+            editable_inline_display_value(DatabaseType::SQLite, &QueryValue::text("a\0b")).unwrap(),
+            "a\0b"
+        );
+    }
+
+    #[test]
     fn sql_literal_real_accepts_integer_like_draft_and_keeps_real_literal() {
-        let value =
-            build_edited_query_value(&QueryValue::SqlLiteral("3.14".to_string()), "42").unwrap();
+        let value = build_edited_query_value(
+            DatabaseType::SQLite,
+            &QueryValue::SqlLiteral("3.14".to_string()),
+            "42",
+        )
+        .unwrap();
 
         assert_eq!(value, QueryValue::SqlLiteral("42.0".to_string()));
     }
 
     #[test]
     fn sql_literal_real_accepts_leading_decimal_draft() {
-        let value =
-            build_edited_query_value(&QueryValue::SqlLiteral("3.14".to_string()), ".5").unwrap();
+        let value = build_edited_query_value(
+            DatabaseType::SQLite,
+            &QueryValue::SqlLiteral("3.14".to_string()),
+            ".5",
+        )
+        .unwrap();
 
         assert_eq!(value, QueryValue::SqlLiteral("0.5".to_string()));
     }
@@ -203,6 +236,7 @@ mod tests {
     #[test]
     fn sql_literal_integer_rejects_overflow() {
         let error = build_edited_query_value(
+            DatabaseType::SQLite,
             &QueryValue::SqlLiteral("7".to_string()),
             "9223372036854775808",
         )
@@ -213,17 +247,36 @@ mod tests {
 
     #[test]
     fn sql_literal_real_rejects_non_finite_input() {
-        let error = build_edited_query_value(&QueryValue::SqlLiteral("1.0".to_string()), "1e999")
-            .unwrap_err();
+        let error = build_edited_query_value(
+            DatabaseType::SQLite,
+            &QueryValue::SqlLiteral("1.0".to_string()),
+            "1e999",
+        )
+        .unwrap_err();
 
         assert_eq!(error, InlineCellEditError::NonFiniteReal);
     }
 
     #[test]
     fn sql_literal_real_rejects_non_numeric_input() {
-        let error = build_edited_query_value(&QueryValue::SqlLiteral("1.0".to_string()), "NaN")
-            .unwrap_err();
+        let error = build_edited_query_value(
+            DatabaseType::SQLite,
+            &QueryValue::SqlLiteral("1.0".to_string()),
+            "NaN",
+        )
+        .unwrap_err();
 
         assert_eq!(error, InlineCellEditError::InvalidReal);
+    }
+
+    #[test]
+    fn postgres_sql_literal_is_not_treated_as_sqlite_numeric_cell() {
+        let error = editable_inline_display_value(
+            DatabaseType::PostgreSQL,
+            &QueryValue::SqlLiteral("42".to_string()),
+        )
+        .unwrap_err();
+
+        assert_eq!(error, InlineCellEditError::UnsupportedCellType);
     }
 }

--- a/src/app/policy/write/inline_cell_edit.rs
+++ b/src/app/policy/write/inline_cell_edit.rs
@@ -1,0 +1,229 @@
+use std::borrow::Cow;
+use std::num::IntErrorKind;
+
+use crate::domain::QueryValue;
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum InlineCellEditError {
+    #[error("NULL cells are not editable inline yet")]
+    NullUnsupported,
+    #[error("BLOB cells are not editable inline")]
+    BlobUnsupported,
+    #[error("This cell type is not editable inline")]
+    UnsupportedCellType,
+    #[error("Invalid INTEGER value")]
+    InvalidInteger,
+    #[error("INTEGER value is out of range")]
+    IntegerOverflow,
+    #[error("Invalid REAL value")]
+    InvalidReal,
+    #[error("REAL value must be finite")]
+    NonFiniteReal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InlineCellEditKind {
+    Text,
+    SqliteInteger,
+    SqliteReal,
+}
+
+pub fn supports_inline_edit(value: &QueryValue) -> bool {
+    classify_inline_cell_edit(value).is_ok()
+}
+
+pub fn editable_inline_display_value(value: &QueryValue) -> Result<String, InlineCellEditError> {
+    classify_inline_cell_edit(value)?;
+    Ok(value.display_value())
+}
+
+pub fn build_edited_query_value(
+    original: &QueryValue,
+    draft: &str,
+) -> Result<QueryValue, InlineCellEditError> {
+    match classify_inline_cell_edit(original)? {
+        InlineCellEditKind::Text => Ok(QueryValue::text(draft)),
+        InlineCellEditKind::SqliteInteger => parse_sqlite_integer_draft(draft),
+        InlineCellEditKind::SqliteReal => parse_sqlite_real_draft(draft),
+    }
+}
+
+fn classify_inline_cell_edit(
+    value: &QueryValue,
+) -> Result<InlineCellEditKind, InlineCellEditError> {
+    match value {
+        QueryValue::Text(_) => Ok(InlineCellEditKind::Text),
+        QueryValue::Null => Err(InlineCellEditError::NullUnsupported),
+        QueryValue::Blob(_) => Err(InlineCellEditError::BlobUnsupported),
+        QueryValue::SqlLiteral(value) => {
+            if value.parse::<i64>().is_ok() {
+                Ok(InlineCellEditKind::SqliteInteger)
+            } else if matches_sqlite_numeric_lexeme(value) {
+                Ok(InlineCellEditKind::SqliteReal)
+            } else {
+                Err(InlineCellEditError::UnsupportedCellType)
+            }
+        }
+    }
+}
+
+fn parse_sqlite_integer_draft(draft: &str) -> Result<QueryValue, InlineCellEditError> {
+    draft
+        .parse::<i64>()
+        .map(|value| QueryValue::SqlLiteral(value.to_string()))
+        .map_err(|error| {
+            if matches!(
+                error.kind(),
+                IntErrorKind::PosOverflow | IntErrorKind::NegOverflow
+            ) {
+                InlineCellEditError::IntegerOverflow
+            } else {
+                InlineCellEditError::InvalidInteger
+            }
+        })
+}
+
+fn parse_sqlite_real_draft(draft: &str) -> Result<QueryValue, InlineCellEditError> {
+    if !matches_sqlite_numeric_lexeme(draft) {
+        return Err(InlineCellEditError::InvalidReal);
+    }
+
+    let parseable = normalize_leading_decimal_zero(draft);
+    let value = parseable
+        .parse::<f64>()
+        .map_err(|_| InlineCellEditError::InvalidReal)?;
+    if !value.is_finite() {
+        return Err(InlineCellEditError::NonFiniteReal);
+    }
+
+    Ok(QueryValue::SqlLiteral(normalize_sqlite_real_literal(draft)))
+}
+
+fn normalize_sqlite_real_literal(draft: &str) -> String {
+    let normalized = normalize_leading_decimal_zero(draft);
+    if normalized.contains('.') || normalized.contains('e') || normalized.contains('E') {
+        normalized.into_owned()
+    } else {
+        format!("{normalized}.0")
+    }
+}
+
+fn normalize_leading_decimal_zero(value: &str) -> Cow<'_, str> {
+    if let Some(rest) = value.strip_prefix("+.") {
+        Cow::Owned(format!("+0.{rest}"))
+    } else if let Some(rest) = value.strip_prefix("-.") {
+        Cow::Owned(format!("-0.{rest}"))
+    } else if let Some(rest) = value.strip_prefix('.') {
+        Cow::Owned(format!("0.{rest}"))
+    } else {
+        Cow::Borrowed(value)
+    }
+}
+
+fn matches_sqlite_numeric_lexeme(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+
+    let mut index = 0;
+    if matches!(bytes[index], b'+' | b'-') {
+        index += 1;
+        if index == bytes.len() {
+            return false;
+        }
+    }
+
+    let integer_start = index;
+    while index < bytes.len() && bytes[index].is_ascii_digit() {
+        index += 1;
+    }
+    let integer_digits = index - integer_start;
+
+    let fractional_digits = if index < bytes.len() && bytes[index] == b'.' {
+        index += 1;
+        let fractional_start = index;
+        while index < bytes.len() && bytes[index].is_ascii_digit() {
+            index += 1;
+        }
+        index - fractional_start
+    } else {
+        0
+    };
+
+    if integer_digits == 0 && fractional_digits == 0 {
+        return false;
+    }
+
+    if index < bytes.len() && matches!(bytes[index], b'e' | b'E') {
+        index += 1;
+        if index < bytes.len() && matches!(bytes[index], b'+' | b'-') {
+            index += 1;
+        }
+        let exponent_start = index;
+        while index < bytes.len() && bytes[index].is_ascii_digit() {
+            index += 1;
+        }
+        if index == exponent_start {
+            return false;
+        }
+    }
+
+    index == bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sql_literal_integer_is_inline_editable() {
+        assert_eq!(
+            editable_inline_display_value(&QueryValue::SqlLiteral("42".to_string())).unwrap(),
+            "42"
+        );
+    }
+
+    #[test]
+    fn sql_literal_real_accepts_integer_like_draft_and_keeps_real_literal() {
+        let value =
+            build_edited_query_value(&QueryValue::SqlLiteral("3.14".to_string()), "42").unwrap();
+
+        assert_eq!(value, QueryValue::SqlLiteral("42.0".to_string()));
+    }
+
+    #[test]
+    fn sql_literal_real_accepts_leading_decimal_draft() {
+        let value =
+            build_edited_query_value(&QueryValue::SqlLiteral("3.14".to_string()), ".5").unwrap();
+
+        assert_eq!(value, QueryValue::SqlLiteral("0.5".to_string()));
+    }
+
+    #[test]
+    fn sql_literal_integer_rejects_overflow() {
+        let error = build_edited_query_value(
+            &QueryValue::SqlLiteral("7".to_string()),
+            "9223372036854775808",
+        )
+        .unwrap_err();
+
+        assert_eq!(error, InlineCellEditError::IntegerOverflow);
+    }
+
+    #[test]
+    fn sql_literal_real_rejects_non_finite_input() {
+        let error = build_edited_query_value(&QueryValue::SqlLiteral("1.0".to_string()), "1e999")
+            .unwrap_err();
+
+        assert_eq!(error, InlineCellEditError::NonFiniteReal);
+    }
+
+    #[test]
+    fn sql_literal_real_rejects_non_numeric_input() {
+        let error = build_edited_query_value(&QueryValue::SqlLiteral("1.0".to_string()), "NaN")
+            .unwrap_err();
+
+        assert_eq!(error, InlineCellEditError::InvalidReal);
+    }
+}

--- a/src/app/policy/write/mod.rs
+++ b/src/app/policy/write/mod.rs
@@ -1,3 +1,4 @@
+pub mod inline_cell_edit;
 pub mod sql_risk;
 pub mod write_guardrails;
 pub mod write_update;

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -846,7 +846,6 @@ mod tests {
             };
             match dispatched {
                 Action::OpenWritePreviewConfirm(preview) => {
-                    assert!(preview.sql.contains("CAST(X'610062' AS TEXT)"));
                     assert_eq!(preview.diff[0].before, "a\0b");
                     assert_eq!(preview.diff[0].after, "a\0b");
                 }

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -59,6 +59,7 @@ fn build_update_preview(
 
     ensure_column_writable(state, &column_name, &identity)?;
     let new_value = build_edited_query_value(
+        state.session.active_database_type_or_default(),
         row_values
             .get(col_idx)
             .ok_or(EditGuardrailError::CellIndexOutOfBounds)?,
@@ -789,6 +790,65 @@ mod tests {
                 Action::OpenWritePreviewConfirm(preview) => {
                     assert!(preview.sql.contains("SET \"score\" = 7"));
                     assert!(!preview.sql.contains("SET \"score\" = '7'"));
+                }
+                other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn sqlite_text_cell_with_nul_keeps_raw_value_into_write_preview() {
+            let mut state = AppState::new("test_project".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
+            state.query.set_current_result(Arc::new(
+                QueryResult::success_with_values(
+                    "SELECT rowid, message FROM logs".to_string(),
+                    vec!["rowid".to_string(), "message".to_string()],
+                    vec![vec![
+                        QueryValue::SqlLiteral("7".to_string()),
+                        QueryValue::text("a\0b"),
+                    ]],
+                    10,
+                    QuerySource::Preview,
+                )
+                .with_first_column_hidden("rowid".to_string()),
+            ));
+            state.session.set_table_detail_raw(Some(Table {
+                schema: "main".to_string(),
+                name: "logs".to_string(),
+                columns: vec![test_support::column::test_nullable_column(
+                    "message", "TEXT", 1,
+                )],
+                primary_key: None,
+                ..test_support::table::minimal("", "")
+            }));
+            state.query.pagination.reset_for_table("main", "logs");
+            state.modal.set_mode(InputMode::CellEdit);
+            state
+                .result_interaction
+                .begin_cell_edit(0, 0, "a\0b".to_string());
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            let dispatched = match &effects[0] {
+                Effect::DispatchActions(actions) => actions.first().expect("action"),
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+            match dispatched {
+                Action::OpenWritePreviewConfirm(preview) => {
+                    assert!(preview.sql.contains("CAST(X'610062' AS TEXT)"));
+                    assert_eq!(preview.diff[0].before, "a\0b");
+                    assert_eq!(preview.diff[0].after, "a\0b");
                 }
                 other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
             }

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+#[cfg(test)]
 use crate::domain::QueryValue;
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSelection};
@@ -10,6 +11,7 @@ use crate::policy::json::json_diff::compute_json_diff;
 use crate::policy::preview_cell_text::{
     normalize_for_write_diff, preview_cell_text_diff_handling, uses_structured_json_diff,
 };
+use crate::policy::write::inline_cell_edit::build_edited_query_value;
 use crate::policy::write::write_guardrails::{
     ColumnDiff, RiskLevel, TargetSummary, WriteOperation, WritePreview, evaluate_guardrails,
 };
@@ -56,15 +58,12 @@ fn build_update_preview(
         .clone();
 
     ensure_column_writable(state, &column_name, &identity)?;
-    let new_value = match row_values
-        .get(col_idx)
-        .ok_or(EditGuardrailError::CellIndexOutOfBounds)?
-    {
-        QueryValue::Text(_) => QueryValue::text(state.result_interaction.cell_edit().draft_value()),
-        QueryValue::Null | QueryValue::Blob(_) | QueryValue::SqlLiteral(_) => {
-            return Err(EditGuardrailError::NonTextInlineEdit);
-        }
-    };
+    let new_value = build_edited_query_value(
+        row_values
+            .get(col_idx)
+            .ok_or(EditGuardrailError::CellIndexOutOfBounds)?,
+        state.result_interaction.cell_edit().draft_value(),
+    )?;
 
     let identity_pairs = identity.identity_pairs_for_row(result, row_idx);
     if let Some(pairs) = identity_pairs.as_deref() {
@@ -580,12 +579,16 @@ mod tests {
         }
 
         #[rstest]
-        #[case(QueryValue::Null, "NULL")]
-        #[case(QueryValue::Blob(vec![0, 255]), "BLOB (2 bytes) 00 FF")]
-        #[case(QueryValue::SqlLiteral("42".to_string()), "42")]
-        fn submit_rejects_non_text_active_cell_edit(
+        #[case(QueryValue::Null, "NULL", "NULL cells are not editable inline yet")]
+        #[case(
+            QueryValue::Blob(vec![0, 255]),
+            "BLOB (2 bytes) 00 FF",
+            "BLOB cells are not editable inline"
+        )]
+        fn submit_rejects_unsupported_active_cell_edit(
             #[case] cell_value: QueryValue,
             #[case] draft: &str,
+            #[case] expected_error: &str,
         ) {
             let mut state = editable_state();
             state
@@ -614,10 +617,7 @@ mod tests {
                     .expect("reducer should handle action")
                     .is_empty()
             );
-            assert_eq!(
-                state.messages.last_error.as_deref(),
-                Some("Only text cells can be edited inline")
-            );
+            assert_eq!(state.messages.last_error.as_deref(), Some(expected_error));
         }
 
         #[test]
@@ -737,6 +737,168 @@ mod tests {
                 }
                 other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
             }
+        }
+
+        #[test]
+        fn sqlite_integer_cell_update_preview_uses_numeric_literal() {
+            let mut state = AppState::new("test_project".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    "SELECT id, score FROM users".to_string(),
+                    vec!["id".to_string(), "score".to_string()],
+                    vec![vec![
+                        QueryValue::SqlLiteral("1".to_string()),
+                        QueryValue::SqlLiteral("42".to_string()),
+                    ]],
+                    10,
+                    QuerySource::Preview,
+                )));
+            let mut detail = users_table_detail();
+            detail.schema = "main".to_string();
+            detail.columns[1].data_type = "INTEGER".to_string();
+            state.session.set_table_detail_raw(Some(detail));
+            state.query.pagination.reset_for_table("main", "users");
+            state.modal.set_mode(InputMode::CellEdit);
+            state
+                .result_interaction
+                .begin_cell_edit(0, 1, "42".to_string());
+            state
+                .result_interaction
+                .replace_cell_edit_draft("7".to_string());
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            let dispatched = match &effects[0] {
+                Effect::DispatchActions(actions) => actions.first().expect("action"),
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+            match dispatched {
+                Action::OpenWritePreviewConfirm(preview) => {
+                    assert!(preview.sql.contains("SET \"score\" = 7"));
+                    assert!(!preview.sql.contains("SET \"score\" = '7'"));
+                }
+                other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn sqlite_real_cell_integer_like_draft_keeps_real_literal() {
+            let mut state = AppState::new("test_project".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    "SELECT id, score FROM users".to_string(),
+                    vec!["id".to_string(), "score".to_string()],
+                    vec![vec![
+                        QueryValue::SqlLiteral("1".to_string()),
+                        QueryValue::SqlLiteral("3.14".to_string()),
+                    ]],
+                    10,
+                    QuerySource::Preview,
+                )));
+            let mut detail = users_table_detail();
+            detail.schema = "main".to_string();
+            detail.columns[1].data_type = "REAL".to_string();
+            state.session.set_table_detail_raw(Some(detail));
+            state.query.pagination.reset_for_table("main", "users");
+            state.modal.set_mode(InputMode::CellEdit);
+            state
+                .result_interaction
+                .begin_cell_edit(0, 1, "3.14".to_string());
+            state
+                .result_interaction
+                .replace_cell_edit_draft("42".to_string());
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            let dispatched = match &effects[0] {
+                Effect::DispatchActions(actions) => actions.first().expect("action"),
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+            match dispatched {
+                Action::OpenWritePreviewConfirm(preview) => {
+                    assert!(preview.sql.contains("SET \"score\" = 42.0"));
+                }
+                other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn sqlite_real_cell_rejects_non_finite_draft() {
+            let mut state = AppState::new("test_project".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    "SELECT id, score FROM users".to_string(),
+                    vec!["id".to_string(), "score".to_string()],
+                    vec![vec![
+                        QueryValue::SqlLiteral("1".to_string()),
+                        QueryValue::SqlLiteral("3.14".to_string()),
+                    ]],
+                    10,
+                    QuerySource::Preview,
+                )));
+            let mut detail = users_table_detail();
+            detail.schema = "main".to_string();
+            detail.columns[1].data_type = "REAL".to_string();
+            state.session.set_table_detail_raw(Some(detail));
+            state.query.pagination.reset_for_table("main", "users");
+            state.modal.set_mode(InputMode::CellEdit);
+            state
+                .result_interaction
+                .begin_cell_edit(0, 1, "3.14".to_string());
+            state
+                .result_interaction
+                .replace_cell_edit_draft("1e999".to_string());
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(
+                effects
+                    .into_effects()
+                    .expect("reducer should handle action")
+                    .is_empty()
+            );
+            assert_eq!(
+                state.messages.last_error.as_deref(),
+                Some("REAL value must be finite")
+            );
         }
 
         #[test]

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -440,8 +440,6 @@ mod tests {
         use crate::test_support;
 
         use super::*;
-        use crate::domain::DatabaseType;
-        use crate::domain::connection::ConnectionId;
 
         fn state_with_jsonb_column() -> AppState {
             let mut state = cell_edit_entry_guardrails::preview_state_with_selection();

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -60,6 +60,7 @@ fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), Edi
     }
 
     let cell_value = editable_inline_display_value(
+        state.session.active_database_type_or_default(),
         result
             .value_at(row_idx, col_idx)
             .ok_or(EditGuardrailError::CellIndexOutOfBounds)?,
@@ -143,7 +144,8 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
 mod tests {
     use super::*;
     pub use crate::domain::Column;
-    use crate::domain::{QueryResult, QuerySource, QueryValue, Table};
+    use crate::domain::connection::ConnectionId;
+    use crate::domain::{DatabaseType, QueryResult, QuerySource, QueryValue, Table};
     use crate::update::action::CursorMove;
     use rstest::rstest;
     use std::sync::Arc;
@@ -260,6 +262,12 @@ mod tests {
         #[test]
         fn sqlite_numeric_literal_enters_inline_edit() {
             let mut state = AppState::new("test".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
             state
                 .query
                 .set_current_result(Arc::new(QueryResult::success_with_values(
@@ -284,6 +292,36 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::CellEdit);
             assert_eq!(state.result_interaction.cell_edit().draft_value(), "42");
+        }
+
+        #[test]
+        fn text_with_nul_keeps_raw_draft_on_entry() {
+            let mut state = AppState::new("test".to_string());
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    String::new(),
+                    vec!["id".to_string(), "payload".to_string()],
+                    vec![vec![QueryValue::text("1"), QueryValue::text("a\0b")]],
+                    1,
+                    QuerySource::Preview,
+                )));
+            state.query.pagination.reset_for_table("public", "users");
+            state.result_interaction.activate_cell(0, 1);
+            state
+                .session
+                .set_table_detail_raw(Some(minimal_users_table()));
+
+            reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            assert_eq!(state.input_mode(), InputMode::CellEdit);
+            assert_eq!(
+                state.result_interaction.cell_edit().original_value(),
+                "a\0b"
+            );
+            assert_eq!(state.result_interaction.cell_edit().draft_value(), "a\0b");
         }
 
         #[test]

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -3,13 +3,13 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 #[cfg(test)]
 use crate::domain::ColumnAttributes;
-use crate::domain::QueryValue;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
 
 use crate::policy::preview_cell_text::{preview_cell_text_diff_handling, uses_jsonb_detail_modal};
+use crate::policy::write::inline_cell_edit::editable_inline_display_value;
 use crate::update::helpers::{EditGuardrailError, editable_preview_base, ensure_column_writable};
 
 fn cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
@@ -59,15 +59,11 @@ fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), Edi
         return Err(EditGuardrailError::StableKeyColumnsMissing);
     }
 
-    let cell_value = match result
-        .value_at(row_idx, col_idx)
-        .ok_or(EditGuardrailError::CellIndexOutOfBounds)?
-    {
-        QueryValue::Text(value) => value.clone(),
-        QueryValue::Null | QueryValue::Blob(_) | QueryValue::SqlLiteral(_) => {
-            return Err(EditGuardrailError::NonTextInlineEdit);
-        }
-    };
+    let cell_value = editable_inline_display_value(
+        result
+            .value_at(row_idx, col_idx)
+            .ok_or(EditGuardrailError::CellIndexOutOfBounds)?,
+    )?;
 
     Ok((row_idx, col_idx, cell_value))
 }
@@ -230,10 +226,12 @@ mod tests {
         }
 
         #[rstest]
-        #[case(QueryValue::Null)]
-        #[case(QueryValue::Blob(vec![0, 255]))]
-        #[case(QueryValue::SqlLiteral("42".to_string()))]
-        fn non_text_cell_blocks_cell_edit_entry(#[case] cell_value: QueryValue) {
+        #[case(QueryValue::Null, "NULL cells are not editable inline yet")]
+        #[case(QueryValue::Blob(vec![0, 255]), "BLOB cells are not editable inline")]
+        fn unsupported_cell_blocks_cell_edit_entry(
+            #[case] cell_value: QueryValue,
+            #[case] expected_error: &str,
+        ) {
             let mut state = AppState::new("test".to_string());
             state
                 .query
@@ -256,10 +254,36 @@ mod tests {
 
             assert!(effects.is_empty());
             assert_eq!(state.input_mode(), InputMode::Normal);
-            assert_eq!(
-                state.messages.last_error(),
-                Some("Only text cells can be edited inline")
-            );
+            assert_eq!(state.messages.last_error(), Some(expected_error));
+        }
+
+        #[test]
+        fn sqlite_numeric_literal_enters_inline_edit() {
+            let mut state = AppState::new("test".to_string());
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    String::new(),
+                    vec!["id".to_string(), "payload".to_string()],
+                    vec![vec![
+                        QueryValue::SqlLiteral("1".to_string()),
+                        QueryValue::SqlLiteral("42".to_string()),
+                    ]],
+                    1,
+                    QuerySource::Preview,
+                )));
+            state.query.pagination.reset_for_table("public", "users");
+            state.result_interaction.activate_cell(0, 1);
+            state
+                .session
+                .set_table_detail_raw(Some(minimal_users_table()));
+
+            reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            assert_eq!(state.input_mode(), InputMode::CellEdit);
+            assert_eq!(state.result_interaction.cell_edit().draft_value(), "42");
         }
 
         #[test]

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -6,6 +6,7 @@ use crate::domain::{QueryResult, QueryValue};
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::QueryStatus;
 use crate::model::connection::setup::{ConnectionField, ConnectionSetupState};
+use crate::policy::write::inline_cell_edit::InlineCellEditError;
 use crate::policy::write::write_guardrails::{
     PreviewWriteability, StableRowIdentity, TargetSummary, WriteOperation, WritePreview,
     evaluate_guardrails, preview_writeability, stable_row_identity_for_table,
@@ -64,8 +65,8 @@ pub enum EditGuardrailError {
     NoActiveCell,
     #[error("Cell index out of bounds")]
     CellIndexOutOfBounds,
-    #[error("Only text cells can be edited inline")]
-    NonTextInlineEdit,
+    #[error(transparent)]
+    InlineCellEdit(#[from] InlineCellEditError),
     #[error("SQLite writes require non-NULL primary key values")]
     SqliteNullPrimaryKey,
     #[error("{0}")]

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -769,6 +769,25 @@ mod tests {
                 "UPDATE \"users\"\nSET \"name\" = 'NULL'\nWHERE \"id\" = '1';"
             );
         }
+
+        #[test]
+        fn nul_text_value_uses_cast_literal() {
+            let adapter = SqliteAdapter::new();
+
+            let sql = adapter.build_update_sql(
+                DatabaseType::SQLite,
+                "main",
+                "users",
+                "name",
+                &QueryValue::text("a\0b"),
+                &[("id".into(), QueryValue::text("1"))],
+            );
+
+            assert_eq!(
+                sql,
+                "UPDATE \"users\"\nSET \"name\" = CAST(X'610062' AS TEXT)\nWHERE \"id\" = '1';"
+            );
+        }
     }
 
     mod bulk_delete_sql {

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_first_cell_active_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_first_cell_active_mode.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/render_snapshots/result_pane.rs
-assertion_line: 240
+assertion_line: 327
 expression: output
 ---
 test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
@@ -52,4 +52,4 @@ test_project | test_db | - | no dsn | localhost:5432/test
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 └───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
-Enter:Detail  i:Edit  Y:Yank Cell  yy:Yank Row  K:Row Detail  dd:Stage Del  ?:Help  Esc:Back  q:Quit
+Enter:Detail  Y:Yank Cell  yy:Yank Row  K:Row Detail  dd:Stage Del  ?:Help  Esc:Back  q:Quit

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -90,6 +90,7 @@ impl Footer {
 
                 if result_navigation && nav_mode == ResultNavMode::CellActive {
                     let can_write_preview = state.can_write_visible_preview();
+                    let can_edit_selected_cell = state.can_edit_selected_cell();
                     if state.result_interaction.cell_edit().has_pending_draft() {
                         vec![
                             result_active::EDIT.as_hint(),
@@ -100,7 +101,7 @@ impl Footer {
                         ]
                     } else if state.result_interaction.staged_delete_rows().is_empty() {
                         let mut hints = vec![result_active::DETAIL.as_hint()];
-                        if can_write_preview {
+                        if can_edit_selected_cell {
                             hints.push(result_active::EDIT.as_hint());
                         }
                         hints.extend([


### PR DESCRIPTION
## Problem

SQLite inline cell edit rejected existing INTEGER and REAL cells, so users could not correct numeric values from the result pane while preserving SQLite storage-class behavior.

## Background

The SQLite adapter already distinguishes storage classes at read time, but the edit flow only accepted text cells and would otherwise fall back to quoted string writes.

## Approach

Add a shared inline-edit policy that classifies editable cell values from their original storage class, parses SQLite numeric drafts into INTEGER or finite REAL literals before write preview generation, and aligns result-pane edit hints with per-cell editability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * SQLiteの数値セルをインライン編集できるようになりました。
  * 編集可能なセルにのみ「EDIT」ヒントが表示されます。
  * JSONBセルは専用モーダルで編集できます。

* **バグ修正**
  * NULL、BLOB、非有限値など編集できないセルを適切に拒否します。
  * NUL文字を含むテキストや数値リテラルの更新形式を改善しました。

* **テスト**
  * 数値、実数、特殊なテキスト値の編集・更新動作を追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->