### PR TITLE
feat: support editing SQLite WITHOUT ROWID tables

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -987,18 +987,12 @@ mod tests {
         }
 
         #[rstest]
-        #[case(TableKind::View, false, "view")]
-        #[case(TableKind::Virtual, false, "virtual table")]
-        #[case(TableKind::Table, true, "WITHOUT ROWID table")]
-        fn sqlite_non_rowid_targets_are_read_only(
-            #[case] kind: TableKind,
-            #[case] without_rowid: bool,
-            #[case] reason: &str,
-        ) {
+        #[case(TableKind::View, "view")]
+        #[case(TableKind::Virtual, "virtual table")]
+        fn sqlite_non_rowid_targets_are_read_only(#[case] kind: TableKind, #[case] reason: &str) {
             let mut table = test_support::table::minimal("", "");
             table.kind_info = TableKindInfo {
                 kind,
-                without_rowid,
                 ..TableKindInfo::default()
             };
             let state = sqlite_preview_state_with_table(table);
@@ -1008,6 +1002,17 @@ mod tests {
                 state.visible_preview_target_read_only_reason(),
                 Some(reason)
             );
+        }
+
+        #[test]
+        fn sqlite_without_rowid_table_with_primary_key_can_write_preview() {
+            let mut table = test_support::table::minimal("", "");
+            table.primary_key = Some(vec!["id".to_string()]);
+            table.kind_info.without_rowid = true;
+            let state = sqlite_preview_state_with_table(table);
+
+            assert!(state.can_write_visible_preview());
+            assert_eq!(state.visible_preview_target_read_only_reason(), None);
         }
 
         #[test]

--- a/src/app/policy/write/write_guardrails.rs
+++ b/src/app/policy/write/write_guardrails.rs
@@ -96,9 +96,6 @@ pub fn preview_writeability(database_type: DatabaseType, table: &Table) -> Previ
     if table.kind_info.kind == TableKind::Virtual {
         return PreviewWriteability::ReadOnly("virtual table");
     }
-    if table.kind_info.without_rowid {
-        return PreviewWriteability::ReadOnly("WITHOUT ROWID table");
-    }
     let has_primary_key = table
         .primary_key
         .as_ref()
@@ -350,24 +347,36 @@ mod tests {
         }
 
         #[rstest]
-        #[case(TableKind::View, false, "view")]
-        #[case(TableKind::Virtual, false, "virtual table")]
-        #[case(TableKind::Table, true, "WITHOUT ROWID table")]
+        #[case(TableKind::View, "view")]
+        #[case(TableKind::Virtual, "virtual table")]
         fn readonly_table_kinds_are_not_writable(
             #[case] kind: TableKind,
-            #[case] without_rowid: bool,
             #[case] reason: &'static str,
         ) {
             let mut table = primary_key_table();
             table.kind_info = TableKindInfo {
                 kind,
-                without_rowid,
                 ..TableKindInfo::default()
             };
 
             assert_eq!(
                 preview_writeability(DatabaseType::SQLite, &table),
                 PreviewWriteability::ReadOnly(reason)
+            );
+            assert_eq!(
+                stable_row_identity_for_table(DatabaseType::SQLite, &table),
+                Some(StableRowIdentity::PrimaryKey(vec!["id".to_string()]))
+            );
+        }
+
+        #[test]
+        fn sqlite_without_rowid_table_with_primary_key_is_writable() {
+            let mut table = primary_key_table();
+            table.kind_info.without_rowid = true;
+
+            assert_eq!(
+                preview_writeability(DatabaseType::SQLite, &table),
+                PreviewWriteability::Writable
             );
             assert_eq!(
                 stable_row_identity_for_table(DatabaseType::SQLite, &table),

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -712,6 +712,44 @@ mod tests {
         }
 
         #[test]
+        fn sqlite_without_rowid_table_uses_primary_key_for_update_preview() {
+            let mut state = editable_state();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("sqlite-test"),
+                "sqlite",
+                DatabaseType::SQLite,
+                "sqlite:///tmp/app.db",
+            );
+            let mut detail = users_table_detail();
+            detail.schema = "main".to_string();
+            detail.kind_info.without_rowid = true;
+            state.session.set_table_detail_raw(Some(detail));
+            state.query.pagination.reset_for_table("main", "users");
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            let dispatched = match &effects[0] {
+                Effect::DispatchActions(actions) => actions.first().expect("action"),
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+            match dispatched {
+                Action::OpenWritePreviewConfirm(preview) => {
+                    assert_eq!(
+                        preview.sql,
+                        "UPDATE \"users\" SET \"name\" = 'Bob' WHERE \"id\" = '1'"
+                    );
+                }
+                other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+            }
+        }
+
+        #[test]
         fn sqlite_rowid_table_uses_hidden_rowid_for_update_preview() {
             let mut state = sqlite_rowid_editable_state();
 

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -868,6 +868,21 @@ mod tests {
         }
 
         #[test]
+        fn sqlite_without_rowid_table_uses_primary_key_for_delete_preview() {
+            let mut state = editable_state(DatabaseType::SQLite);
+            let mut detail = state.session.table_detail().cloned().expect("table detail");
+            detail.kind_info.without_rowid = true;
+            state.session.set_table_detail_raw(Some(detail));
+
+            let result = build_bulk_delete_preview(&state, &AppServices::stub()).unwrap();
+
+            assert_eq!(
+                result.preview.sql,
+                "DELETE FROM \"users\" WHERE \"id\" = '1'"
+            );
+        }
+
+        #[test]
         fn sqlite_database_type_rejects_null_primary_key_value() {
             let mut state = editable_state(DatabaseType::SQLite);
             state

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -586,7 +586,7 @@ impl SqliteAdapter {
                 let is_generated = column.hidden == 2 || column.hidden == 3;
                 let is_read_only = is_hidden || is_generated;
                 let mut attributes = ColumnAttributes::from_parts(
-                    column.notnull == 0 && !is_pk,
+                    column.notnull == 0,
                     is_pk,
                     unique_single_columns.contains(column.name.as_str()),
                 );
@@ -1242,6 +1242,42 @@ mod tests {
 
             assert_eq!(detail.primary_key, None);
             assert_eq!(detail.columns.len(), 1);
+        }
+
+        #[tokio::test]
+        async fn primary_key_nullability_matches_sqlite_metadata() {
+            let (_dir, dsn) = test_support::make_sqlite_db(
+                r"
+            CREATE TABLE regular(key TEXT PRIMARY KEY, value TEXT);
+            CREATE TABLE without_rowid(key TEXT PRIMARY KEY, value TEXT) WITHOUT ROWID;
+            ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let regular = adapter
+                .fetch_table_detail(&dsn, "main", "regular")
+                .await
+                .unwrap();
+            let without_rowid = adapter
+                .fetch_table_detail(&dsn, "main", "without_rowid")
+                .await
+                .unwrap();
+
+            let regular_key = regular
+                .columns
+                .iter()
+                .find(|column| column.name == "key")
+                .unwrap();
+            let without_rowid_key = without_rowid
+                .columns
+                .iter()
+                .find(|column| column.name == "key")
+                .unwrap();
+
+            assert!(regular_key.is_primary_key());
+            assert!(regular_key.is_nullable());
+            assert!(without_rowid_key.is_primary_key());
+            assert!(!without_rowid_key.is_nullable());
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Problem

SQLite tables that use `WITHOUT ROWID` could not be edited even when their primary key identifies each row. SQLite primary-key nullability was also reported incorrectly.

## Approach

Allow writes to `WITHOUT ROWID` tables through their primary keys. Preserve SQLite's reported nullability and lock rowid stale-result safeguards in regression coverage.