### PR TITLE
fix: enforce SQLite safe mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,37 @@ jobs:
       - name: Run psql integration tests (Tier 2)
         run: cargo nextest run -p sabiql --run-ignored ignored-only -E 'test(tests::adapter_postgres)' --show-progress=none
 
+  sqlite-safe-mode:
+    name: SQLite Safe Mode (${{ matrix.sqlite }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sqlite: [minimum, system]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
+        with:
+          tool: nextest
+      - name: Install SQLite 3.41.1
+        if: matrix.sqlite == 'minimum'
+        run: |
+          curl --fail --location --retry 3 \
+            https://www.sqlite.org/2023/sqlite-autoconf-3410100.tar.gz \
+            --output sqlite-autoconf-3410100.tar.gz
+          tar -xzf sqlite-autoconf-3410100.tar.gz
+          cd sqlite-autoconf-3410100
+          ./configure --prefix="$HOME/.local"
+          make -j2
+          make install
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Show SQLite version
+        run: sqlite3 --version
+      - name: Run SQLite adapter tests
+        run: cargo nextest run -p sabiql-infra
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
   sqlite-safe-mode:
     name: SQLite Safe Mode (${{ matrix.sqlite }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -97,6 +99,8 @@ jobs:
             below_minimum: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sqlite: [minimum, system]
+        include:
+          - sqlite: minimum
+            archive: sqlite-autoconf-3410100.tar.gz
+            directory: sqlite-autoconf-3410100
+            sha256: 4dadfbeab9f8e16c695d4fbbc51c16b2f77fb97ff4c1c3d139919dfc038c9e33
+            below_minimum: false
+          - sqlite: below-minimum
+            archive: sqlite-autoconf-3410000.tar.gz
+            directory: sqlite-autoconf-3410000
+            sha256: 49f77ac53fd9aa5d7395f2499cb816410e5621984a121b858ccca05310b05c70
+            below_minimum: true
+          - sqlite: system
+            below_minimum: false
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -90,14 +102,15 @@ jobs:
       - uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2
         with:
           tool: nextest
-      - name: Install SQLite 3.41.1
-        if: matrix.sqlite == 'minimum'
+      - name: Install SQLite
+        if: matrix.sqlite != 'system'
         run: |
           curl --fail --location --retry 3 \
-            https://www.sqlite.org/2023/sqlite-autoconf-3410100.tar.gz \
-            --output sqlite-autoconf-3410100.tar.gz
-          tar -xzf sqlite-autoconf-3410100.tar.gz
-          cd sqlite-autoconf-3410100
+            https://www.sqlite.org/2023/${{ matrix.archive }} \
+            --output "${{ matrix.archive }}"
+          echo "${{ matrix.sha256 }}  ${{ matrix.archive }}" | sha256sum --check --status
+          tar -xzf "${{ matrix.archive }}"
+          cd "${{ matrix.directory }}"
           ./configure --prefix="$HOME/.local"
           make -j2
           make install
@@ -105,7 +118,17 @@ jobs:
       - name: Show SQLite version
         run: sqlite3 --version
       - name: Run SQLite adapter tests
+        if: matrix.below_minimum == false
         run: cargo nextest run -p sabiql-infra
+      - name: Reject SQLite below the safe mode minimum
+        if: matrix.below_minimum
+        run: |
+          SABIQL_EXPECT_SQLITE_SAFE_MODE_REJECTION=1 cargo test -p sabiql-infra \
+            adapters::sqlite::sqlite3::metadata::tests::metadata::rejects_sqlite_before_safe_mode_minimum_at_connection \
+            -- --exact
+          cargo test -p sabiql-app \
+            model::connection::error::tests::error_info::from_db_operation_error_classifies_sqlite_safe_mode_requirement \
+            -- --exact
 
   build:
     name: Build

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Built in Rust for minimal memory footprint and near-zero idle CPU. A full-featur
 
 sabiql treats the SQL modal as SQL-only input. CLI meta-commands such as psql backslash commands and sqlite3 dot commands are rejected instead of being passed to the underlying client.
 
-Read-only mode combines app-level write blocking with the database client guard available for the active adapter. PostgreSQL uses a read-only session option; SQLite uses sqlite3's read-only mode.
+Read-only mode combines app-level write blocking with the database client guard available for the active adapter. PostgreSQL uses a read-only session option. SQLite also runs every sqlite3 command in safe mode, preventing SQL from accessing files, extensions, or databases outside the selected database file.
 
-PostgreSQL multi-statement SQL runs in one transaction. SQLite multi-statement write SQL is wrapped in an explicit transaction unless the input contains transaction control or transaction-incompatible statements such as `PRAGMA journal_mode` changes and `VACUUM`.
+PostgreSQL multi-statement SQL runs in one transaction. SQLite multi-statement write SQL is wrapped in an explicit transaction unless the input contains transaction control or transaction-incompatible statements such as `PRAGMA journal_mode` changes. SQLite safe mode also rejects operations such as `ATTACH` and `VACUUM` that require capabilities unavailable in safe mode.
 
 ## Features
 ![hero_1000_20fps](https://github.com/user-attachments/assets/06e1900d-b044-4f29-a2a8-7d7bab5bd3a1)
@@ -110,7 +110,7 @@ Open Settings with `,` to switch themes, keymap presets, and the ER diagram brow
 Install the CLI for the database you want to open:
 
 - **PostgreSQL:** `psql` (PostgreSQL client)
-- **SQLite:** `sqlite3` (SQLite shell). Use 3.37.0 or later for databases with FTS, RTree, or other virtual tables.
+- **SQLite:** `sqlite3` (SQLite shell), version 3.41.1 or later.
 
 Optional:
 

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -419,11 +419,12 @@ mod tests {
         fn from_db_operation_error_classifies_sqlite_safe_mode_requirement() {
             let info = ConnectionErrorInfo::from_db_operation_error(
                 &DbOperationError::UnsupportedOperation(
-                    "SQLITE_SAFE_MODE_REQUIRED: upgrade sqlite3".to_string(),
+                    "SQLITE_SAFE_MODE_REQUIRED: sqlite3 3.41.1 or later is required for safe SQLite execution (found sqlite3 3.41.0)".to_string(),
                 ),
             );
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteVersionTooOld);
+            assert_eq!(info.summary(), "SQLite 3.41.1 or later required");
             assert_eq!(info.hint(), "Upgrade sqlite3 to use SQLite safely");
         }
 

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -78,7 +78,7 @@ impl ConnectionErrorKind {
             Self::DatabaseNotFound => "Database does not exist",
             Self::ConnectionLost => "Connection lost during operation",
             Self::Timeout => "Connection timed out",
-            Self::SqliteVersionTooOld => "SQLite 3.37 or later required",
+            Self::SqliteVersionTooOld => "SQLite 3.41.1 or later required",
             Self::SqliteFileNotFound => "SQLite database file not found",
             Self::SqlitePathIsDirectory => "SQLite path is a directory",
             Self::SqlitePathNotRegularFile => "SQLite path is not a regular file",
@@ -99,9 +99,7 @@ impl ConnectionErrorKind {
             Self::DatabaseNotFound => "Check database name",
             Self::ConnectionLost => "Reconnect and retry the operation",
             Self::Timeout => "Check network connectivity",
-            Self::SqliteVersionTooOld => {
-                "Upgrade sqlite3, or open a database without virtual tables"
-            }
+            Self::SqliteVersionTooOld => "Upgrade sqlite3 to use SQLite safely",
             Self::SqliteFileNotFound => {
                 "Check the file path — sabiql does not create new database files"
             }
@@ -159,7 +157,8 @@ impl ConnectionErrorInfo {
             DbOperationError::ConnectionLost(_) => ConnectionErrorKind::ConnectionLost,
             DbOperationError::Timeout(_) => ConnectionErrorKind::Timeout,
             DbOperationError::UnsupportedOperation(details)
-                if details.contains("SQLITE_TABLE_LIST_REQUIRED") =>
+                if details.contains("SQLITE_TABLE_LIST_REQUIRED")
+                    || details.contains("SQLITE_SAFE_MODE_REQUIRED") =>
             {
                 ConnectionErrorKind::SqliteVersionTooOld
             }
@@ -413,7 +412,19 @@ mod tests {
             );
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteVersionTooOld);
-            assert_eq!(info.summary(), "SQLite 3.37 or later required");
+            assert_eq!(info.summary(), "SQLite 3.41.1 or later required");
+        }
+
+        #[test]
+        fn from_db_operation_error_classifies_sqlite_safe_mode_requirement() {
+            let info = ConnectionErrorInfo::from_db_operation_error(
+                &DbOperationError::UnsupportedOperation(
+                    "SQLITE_SAFE_MODE_REQUIRED: upgrade sqlite3".to_string(),
+                ),
+            );
+
+            assert_eq!(info.kind, ConnectionErrorKind::SqliteVersionTooOld);
+            assert_eq!(info.hint(), "Upgrade sqlite3 to use SQLite safely");
         }
 
         #[test]

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -1,5 +1,8 @@
 use crate::policy::password_masking::mask_password;
-use crate::ports::outbound::{DatabaseCli, DbOperationError};
+use crate::ports::outbound::{
+    DatabaseCli, DbOperationError, SQLITE_SAFE_MODE_REQUIRED_MARKER,
+    SQLITE_TABLE_LIST_REQUIRED_MARKER,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ConnectionErrorKind {
@@ -157,8 +160,8 @@ impl ConnectionErrorInfo {
             DbOperationError::ConnectionLost(_) => ConnectionErrorKind::ConnectionLost,
             DbOperationError::Timeout(_) => ConnectionErrorKind::Timeout,
             DbOperationError::UnsupportedOperation(details)
-                if details.contains("SQLITE_TABLE_LIST_REQUIRED")
-                    || details.contains("SQLITE_SAFE_MODE_REQUIRED") =>
+                if details.contains(SQLITE_TABLE_LIST_REQUIRED_MARKER)
+                    || details.contains(SQLITE_SAFE_MODE_REQUIRED_MARKER) =>
             {
                 ConnectionErrorKind::SqliteVersionTooOld
             }
@@ -406,9 +409,9 @@ mod tests {
         #[test]
         fn from_db_operation_error_classifies_sqlite_table_list_requirement() {
             let info = ConnectionErrorInfo::from_db_operation_error(
-                &DbOperationError::UnsupportedOperation(
-                    "SQLITE_TABLE_LIST_REQUIRED: upgrade sqlite3".to_string(),
-                ),
+                &DbOperationError::UnsupportedOperation(format!(
+                    "{SQLITE_TABLE_LIST_REQUIRED_MARKER}: upgrade sqlite3"
+                )),
             );
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteVersionTooOld);
@@ -418,9 +421,9 @@ mod tests {
         #[test]
         fn from_db_operation_error_classifies_sqlite_safe_mode_requirement() {
             let info = ConnectionErrorInfo::from_db_operation_error(
-                &DbOperationError::UnsupportedOperation(
-                    "SQLITE_SAFE_MODE_REQUIRED: sqlite3 3.41.1 or later is required for safe SQLite execution (found sqlite3 3.41.0)".to_string(),
-                ),
+                &DbOperationError::UnsupportedOperation(format!(
+                    "{SQLITE_SAFE_MODE_REQUIRED_MARKER}: sqlite3 3.41.1 or later is required for safe SQLite execution (found sqlite3 3.41.0)"
+                )),
             );
 
             assert_eq!(info.kind, ConnectionErrorKind::SqliteVersionTooOld);

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -4,6 +4,9 @@ use std::sync::Arc;
 
 use crate::policy::password_masking::mask_password;
 
+pub const SQLITE_TABLE_LIST_REQUIRED_MARKER: &str = "SQLITE_TABLE_LIST_REQUIRED";
+pub const SQLITE_SAFE_MODE_REQUIRED_MARKER: &str = "SQLITE_SAFE_MODE_REQUIRED";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DatabaseCli {
     Psql,

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -29,7 +29,10 @@ pub use cached_result_exporter::CachedResultExporter;
 pub use clipboard::{ClipboardError, ClipboardWriter};
 pub use config_writer::{ConfigWriter, ConfigWriterError};
 pub use connection_store::{ConnectionStore, ConnectionStoreError};
-pub use db_operation_error::{DatabaseCli, DbOperationError};
+pub use db_operation_error::{
+    DatabaseCli, DbOperationError, SQLITE_SAFE_MODE_REQUIRED_MARKER,
+    SQLITE_TABLE_LIST_REQUIRED_MARKER,
+};
 pub use ddl_generator::DdlGenerator;
 pub use dsn_builder::DsnBuilder;
 pub use er_exporter::{ErDiagramExporter, ErExportError, ErExportResult};

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -1,7 +1,9 @@
 use std::fmt::Write as _;
 
 use crate::app::policy::sql::sqlite_explain::build_sqlite_explain_query_plan_sql;
-use crate::app::ports::outbound::{DbOperationError, DdlGenerator, SqlDialect};
+use crate::app::ports::outbound::{
+    DbOperationError, DdlGenerator, SQLITE_TABLE_LIST_REQUIRED_MARKER, SqlDialect,
+};
 use crate::domain::{DatabaseType, QueryValue, Table, Trigger};
 
 use super::SqliteAdapter;
@@ -85,8 +87,6 @@ fn rows_predicate(pk_pairs_per_row: &[Vec<(String, QueryValue)>]) -> String {
     }
 }
 
-pub(super) const TABLE_LIST_REQUIRED_MARKER: &str = "SQLITE_TABLE_LIST_REQUIRED";
-
 pub(super) fn user_tables_query() -> &'static str {
     r"
     SELECT tl.name,
@@ -133,7 +133,7 @@ pub(super) fn has_virtual_tables_query() -> &'static str {
 
 pub(super) fn table_list_required_error() -> DbOperationError {
     DbOperationError::UnsupportedOperation(format!(
-        "{TABLE_LIST_REQUIRED_MARKER}: This database contains virtual tables (such as FTS or RTree). \
+        "{SQLITE_TABLE_LIST_REQUIRED_MARKER}: This database contains virtual tables (such as FTS or RTree). \
          Upgrade sqlite3 to version 3.41.1 or later to browse it safely."
     ))
 }
@@ -483,7 +483,7 @@ mod tests {
         fn table_list_required_error_includes_marker_and_upgrade_guidance() {
             let error = table_list_required_error();
             let message = error.user_message();
-            assert!(message.contains(TABLE_LIST_REQUIRED_MARKER));
+            assert!(message.contains(SQLITE_TABLE_LIST_REQUIRED_MARKER));
             assert!(message.contains("3.41.1"));
         }
 

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -134,8 +134,7 @@ pub(super) fn has_virtual_tables_query() -> &'static str {
 pub(super) fn table_list_required_error() -> DbOperationError {
     DbOperationError::UnsupportedOperation(format!(
         "{TABLE_LIST_REQUIRED_MARKER}: This database contains virtual tables (such as FTS or RTree). \
-         Upgrade sqlite3 to version 3.37.0 or later to browse it safely. \
-         Databases with only regular tables can still be opened with older sqlite3 versions."
+         Upgrade sqlite3 to version 3.41.1 or later to browse it safely."
     ))
 }
 
@@ -485,7 +484,7 @@ mod tests {
             let error = table_list_required_error();
             let message = error.user_message();
             assert!(message.contains(TABLE_LIST_REQUIRED_MARKER));
-            assert!(message.contains("3.37.0"));
+            assert!(message.contains("3.41.1"));
         }
 
         #[test]

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -28,6 +28,10 @@ use super::parser::{
 };
 
 pub(in crate::adapters::sqlite) const BUSY_TIMEOUT_MS: u64 = 5_000;
+pub(in crate::adapters::sqlite) const SQLITE_SAFE_MODE_REQUIRED_MARKER: &str =
+    "SQLITE_SAFE_MODE_REQUIRED";
+
+const SQLITE_SAFE_MODE_MIN_VERSION: SqliteVersion = SqliteVersion::new(3, 41, 1);
 
 #[derive(Debug, Clone)]
 pub(in crate::adapters::sqlite) struct SqliteCli {
@@ -38,6 +42,34 @@ struct SqliteOutput {
     status: ExitStatus,
     stdout: String,
     stderr: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct SqliteVersion {
+    major: u16,
+    minor: u16,
+    patch: u16,
+}
+
+impl SqliteVersion {
+    const fn new(major: u16, minor: u16, patch: u16) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    fn parse(output: &str) -> Option<Self> {
+        let mut components = output.split_whitespace().next()?.split('.');
+        let major = components.next()?.parse().ok()?;
+        let minor = components.next()?.parse().ok()?;
+        let patch = components.next()?.parse().ok()?;
+        components
+            .next()
+            .is_none()
+            .then_some(Self::new(major, minor, patch))
+    }
 }
 
 impl SqliteCli {
@@ -59,6 +91,34 @@ impl SqliteCli {
             stdout => stdout,
         };
         serde_json::from_str(stdout).map_err(DbOperationError::from)
+    }
+
+    pub(in crate::adapters::sqlite) async fn ensure_safe_mode_supported(
+        &self,
+    ) -> Result<(), DbOperationError> {
+        let output = Command::new("sqlite3")
+            .arg("--version")
+            .output()
+            .await
+            .map_err(|error| classify_cli_spawn_error(DatabaseCli::Sqlite3, error))?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let version = SqliteVersion::parse(&stdout).ok_or_else(|| {
+            safe_mode_required_error("could not determine the installed sqlite3 version")
+        })?;
+
+        if output.status.success() && version >= SQLITE_SAFE_MODE_MIN_VERSION {
+            return Ok(());
+        }
+
+        let details = if output.status.success() {
+            format!(
+                "found sqlite3 {}.{}.{}",
+                version.major, version.minor, version.patch
+            )
+        } else {
+            "sqlite3 --version failed".to_string()
+        };
+        Err(safe_mode_required_error(&details))
     }
 
     pub(in crate::adapters::sqlite) async fn execute_csv(
@@ -259,6 +319,7 @@ impl SqliteCli {
     }
 
     fn apply_session_options(cmd: &mut Command, read_only: bool) {
+        cmd.arg("--safe");
         if read_only {
             cmd.arg("-readonly");
         }
@@ -324,6 +385,12 @@ impl SqliteCli {
             stderr,
         })
     }
+}
+
+fn safe_mode_required_error(details: &str) -> DbOperationError {
+    DbOperationError::UnsupportedOperation(format!(
+        "{SQLITE_SAFE_MODE_REQUIRED_MARKER}: sqlite3 3.41.1 or later is required for safe SQLite execution ({details})"
+    ))
 }
 
 async fn write_sql_to_stdin(
@@ -713,10 +780,6 @@ mod tests {
                 .await
                 .unwrap();
             adapter
-                .execute_adhoc(&dsn, "VACUUM", AccessMode::ReadWrite)
-                .await
-                .unwrap();
-            adapter
                 .execute_write(
                     &dsn,
                     "INSERT INTO logs(message, note) VALUES ('replacement', NULL)",
@@ -797,10 +860,6 @@ mod tests {
                     "DELETE FROM logs WHERE rowid = 1",
                     AccessMode::ReadWrite,
                 )
-                .await
-                .unwrap();
-            adapter
-                .execute_adhoc(&dsn, "VACUUM", AccessMode::ReadWrite)
                 .await
                 .unwrap();
             adapter
@@ -1345,6 +1404,13 @@ mod tests {
         mod session_configuration {
             use super::*;
 
+            fn safe_mode_error(result: Result<QueryResult, DbOperationError>, expected: &str) {
+                assert!(matches!(
+                    result,
+                    Err(DbOperationError::QueryFailed(details)) if details.contains(expected)
+                ));
+            }
+
             #[tokio::test]
             async fn enables_foreign_keys_before_user_sql() {
                 let (_dir, dsn) = test_support::make_sqlite_db("");
@@ -1382,6 +1448,51 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.rows(), vec![vec![BUSY_TIMEOUT_MS.to_string()]]);
+            }
+
+            #[tokio::test]
+            async fn safe_mode_rejects_host_side_effects_in_read_write_sessions() {
+                let (dir, dsn) = test_support::make_sqlite_db("");
+                let attached = dir.path().join("attached.db");
+                let output = dir.path().join("output.txt");
+                std::fs::write(&attached, []).unwrap();
+                let adapter = SqliteAdapter::new();
+
+                let writefile = format!("SELECT writefile('{}', 'hello')", output.display());
+                safe_mode_error(
+                    adapter
+                        .execute_adhoc(&dsn, &writefile, AccessMode::ReadWrite)
+                        .await,
+                    "cannot use the writefile() function in safe mode",
+                );
+                assert!(!output.exists());
+
+                let readfile = format!("SELECT readfile('{}')", attached.display());
+                safe_mode_error(
+                    adapter
+                        .execute_adhoc(&dsn, &readfile, AccessMode::ReadWrite)
+                        .await,
+                    "cannot use the readfile() function in safe mode",
+                );
+
+                assert!(matches!(
+                    adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "SELECT load_extension('/tmp/sabiql-extension')",
+                            AccessMode::ReadWrite,
+                        )
+                        .await,
+                    Err(DbOperationError::QueryFailed(_))
+                ));
+
+                let attach = format!("ATTACH DATABASE '{}' AS attached", attached.display());
+                safe_mode_error(
+                    adapter
+                        .execute_adhoc(&dsn, &attach, AccessMode::ReadWrite)
+                        .await,
+                    "cannot run ATTACH in safe mode",
+                );
             }
         }
 
@@ -1577,34 +1688,19 @@ mod tests {
                 }
 
                 #[tokio::test]
-                async fn vacuum_in_mixed_sql_runs_outside_auto_transaction() {
+                async fn vacuum_is_rejected_in_safe_mode() {
                     let (_dir, dsn) = test_support::make_sqlite_db("");
                     let adapter = SqliteAdapter::new();
 
-                    adapter
-                        .execute_adhoc(
-                            &dsn,
-                            "CREATE TABLE users(id INTEGER PRIMARY KEY);\
-                     INSERT INTO users(id) VALUES (1);\
-                     VACUUM;\
-                     INSERT INTO users(id) VALUES (2)",
-                            AccessMode::ReadWrite,
-                        )
-                        .await
-                        .unwrap();
-                    let rows = adapter
-                        .execute_adhoc(
-                            &dsn,
-                            "SELECT id FROM users ORDER BY id",
-                            AccessMode::ReadOnly,
-                        )
-                        .await
-                        .unwrap();
+                    let result = adapter
+                        .execute_adhoc(&dsn, "VACUUM", AccessMode::ReadWrite)
+                        .await;
 
-                    assert_eq!(
-                        rows.rows(),
-                        vec![vec!["1".to_string()], vec!["2".to_string()]]
-                    );
+                    assert!(matches!(
+                        result,
+                        Err(DbOperationError::QueryFailed(details))
+                            if details.contains("cannot run ATTACH in safe mode")
+                    ));
                 }
 
                 #[tokio::test]
@@ -2426,6 +2522,24 @@ world'), (2, 'done');
 
     mod dsn_validation {
         use super::*;
+
+        #[rstest::rstest]
+        #[case("3.41.1 2023-03-10 12:13:52", Some(SqliteVersion::new(3, 41, 1)))]
+        #[case("3.40.1", Some(SqliteVersion::new(3, 40, 1)))]
+        #[case("3.41", None)]
+        #[case("sqlite 3.41.1", None)]
+        fn parses_sqlite_cli_version(
+            #[case] output: &str,
+            #[case] expected: Option<SqliteVersion>,
+        ) {
+            assert_eq!(SqliteVersion::parse(output), expected);
+        }
+
+        #[test]
+        fn safe_mode_requires_sqlite_3_41_1_or_later() {
+            assert!(SqliteVersion::new(3, 41, 0) < SQLITE_SAFE_MODE_MIN_VERSION);
+            assert!(SqliteVersion::new(3, 41, 1) >= SQLITE_SAFE_MODE_MIN_VERSION);
+        }
 
         #[test]
         fn database_uri_uses_non_creating_access_modes() {

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -1404,10 +1404,11 @@ mod tests {
         mod session_configuration {
             use super::*;
 
-            fn safe_mode_error(result: Result<QueryResult, DbOperationError>, expected: &str) {
+            fn safe_mode_error(result: Result<QueryResult, DbOperationError>, expected: &[&str]) {
                 assert!(matches!(
                     result,
-                    Err(DbOperationError::QueryFailed(details)) if details.contains(expected)
+                    Err(DbOperationError::QueryFailed(details))
+                        if expected.iter().any(|message| details.contains(message))
                 ));
             }
 
@@ -1463,7 +1464,7 @@ mod tests {
                     adapter
                         .execute_adhoc(&dsn, &writefile, AccessMode::ReadWrite)
                         .await,
-                    "cannot use the writefile() function in safe mode",
+                    &["cannot use the writefile() function in safe mode"],
                 );
                 assert!(!output.exists());
 
@@ -1472,10 +1473,10 @@ mod tests {
                     adapter
                         .execute_adhoc(&dsn, &readfile, AccessMode::ReadWrite)
                         .await,
-                    "cannot use the readfile() function in safe mode",
+                    &["cannot use the readfile() function in safe mode"],
                 );
 
-                assert!(matches!(
+                safe_mode_error(
                     adapter
                         .execute_adhoc(
                             &dsn,
@@ -1483,15 +1484,18 @@ mod tests {
                             AccessMode::ReadWrite,
                         )
                         .await,
-                    Err(DbOperationError::QueryFailed(_))
-                ));
+                    &[
+                        "cannot use the load_extension() function in safe mode",
+                        "no such function: load_extension",
+                    ],
+                );
 
                 let attach = format!("ATTACH DATABASE '{}' AS attached", attached.display());
                 safe_mode_error(
                     adapter
                         .execute_adhoc(&dsn, &attach, AccessMode::ReadWrite)
                         .await,
-                    "cannot run ATTACH in safe mode",
+                    &["cannot run ATTACH in safe mode"],
                 );
             }
         }

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -10,7 +10,9 @@ use tokio::time::timeout;
 use async_trait::async_trait;
 
 use crate::app::policy::sql::sqlite_explain::is_sqlite_explain_query_plan_sql;
-use crate::app::ports::outbound::{AccessMode, DatabaseCli, DbOperationError, QueryExecutor};
+use crate::app::ports::outbound::{
+    AccessMode, DatabaseCli, DbOperationError, QueryExecutor, SQLITE_SAFE_MODE_REQUIRED_MARKER,
+};
 use crate::domain::{
     CommandTag, QueryResult, QuerySource, TableKind, WriteExecutionResult,
     available_sqlite_rowid_alias,
@@ -28,8 +30,6 @@ use super::parser::{
 };
 
 pub(in crate::adapters::sqlite) const BUSY_TIMEOUT_MS: u64 = 5_000;
-pub(in crate::adapters::sqlite) const SQLITE_SAFE_MODE_REQUIRED_MARKER: &str =
-    "SQLITE_SAFE_MODE_REQUIRED";
 
 const SQLITE_SAFE_MODE_MIN_VERSION: SqliteVersion = SqliteVersion::new(3, 41, 1);
 
@@ -1451,52 +1451,52 @@ mod tests {
                 assert_eq!(result.rows(), vec![vec![BUSY_TIMEOUT_MS.to_string()]]);
             }
 
+            #[rstest::rstest]
+            #[case::writefile(
+                "writefile",
+                &["cannot use the writefile() function in safe mode"],
+            )]
+            #[case::readfile(
+                "readfile",
+                &["cannot use the readfile() function in safe mode"],
+            )]
+            #[case::load_extension(
+                "load_extension",
+                &[
+                    "cannot use the load_extension() function in safe mode",
+                    "no such function: load_extension",
+                ],
+            )]
+            #[case::attach("attach", &["cannot run ATTACH in safe mode"])]
             #[tokio::test]
-            async fn safe_mode_rejects_host_side_effects_in_read_write_sessions() {
+            async fn safe_mode_rejects_host_side_effects_in_read_write_sessions(
+                #[case] side_effect: &str,
+                #[case] expected: &[&str],
+            ) {
                 let (dir, dsn) = test_support::make_sqlite_db("");
                 let attached = dir.path().join("attached.db");
                 let output = dir.path().join("output.txt");
                 std::fs::write(&attached, []).unwrap();
                 let adapter = SqliteAdapter::new();
 
-                let writefile = format!("SELECT writefile('{}', 'hello')", output.display());
+                let sql = match side_effect {
+                    "writefile" => format!("SELECT writefile('{}', 'hello')", output.display()),
+                    "readfile" => format!("SELECT readfile('{}')", attached.display()),
+                    "load_extension" => {
+                        "SELECT load_extension('/tmp/sabiql-extension')".to_string()
+                    }
+                    "attach" => format!("ATTACH DATABASE '{}' AS attached", attached.display()),
+                    _ => unreachable!(),
+                };
                 safe_mode_error(
                     adapter
-                        .execute_adhoc(&dsn, &writefile, AccessMode::ReadWrite)
+                        .execute_adhoc(&dsn, &sql, AccessMode::ReadWrite)
                         .await,
-                    &["cannot use the writefile() function in safe mode"],
+                    expected,
                 );
-                assert!(!output.exists());
-
-                let readfile = format!("SELECT readfile('{}')", attached.display());
-                safe_mode_error(
-                    adapter
-                        .execute_adhoc(&dsn, &readfile, AccessMode::ReadWrite)
-                        .await,
-                    &["cannot use the readfile() function in safe mode"],
-                );
-
-                safe_mode_error(
-                    adapter
-                        .execute_adhoc(
-                            &dsn,
-                            "SELECT load_extension('/tmp/sabiql-extension')",
-                            AccessMode::ReadWrite,
-                        )
-                        .await,
-                    &[
-                        "cannot use the load_extension() function in safe mode",
-                        "no such function: load_extension",
-                    ],
-                );
-
-                let attach = format!("ATTACH DATABASE '{}' AS attached", attached.display());
-                safe_mode_error(
-                    adapter
-                        .execute_adhoc(&dsn, &attach, AccessMode::ReadWrite)
-                        .await,
-                    &["cannot run ATTACH in safe mode"],
-                );
+                if side_effect == "writefile" {
+                    assert!(!output.exists());
+                }
             }
         }
 
@@ -1700,6 +1700,7 @@ mod tests {
                         .execute_adhoc(&dsn, "VACUUM", AccessMode::ReadWrite)
                         .await;
 
+                    // VACUUM internally attaches a temporary database, so safe mode reports ATTACH.
                     assert!(matches!(
                         result,
                         Err(DbOperationError::QueryFailed(details))

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -736,6 +736,7 @@ fn parse_fk_action(action: &str) -> Result<FkAction, DbOperationError> {
 #[async_trait]
 impl MetadataProvider for SqliteAdapter {
     async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
+        self.cli.ensure_safe_mode_supported().await?;
         let path = Self::path_from_dsn(dsn)?;
         let tables = self.list_tables(path).await?;
         let mut metadata = DatabaseMetadata::new(Self::database_name(path));

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -3,6 +3,8 @@ use std::collections::{HashMap, HashSet};
 use async_trait::async_trait;
 use serde::Deserialize;
 
+#[cfg(test)]
+use crate::app::ports::outbound::SQLITE_SAFE_MODE_REQUIRED_MARKER;
 use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
 #[cfg(test)]
 use crate::domain::TableKind;
@@ -13,8 +15,6 @@ use crate::domain::{
 };
 
 use super::super::{SqliteAdapter, schema::MAIN_SCHEMA, sql};
-#[cfg(test)]
-use super::executor::SQLITE_SAFE_MODE_REQUIRED_MARKER;
 
 mod kind_info;
 mod trigger;

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -13,6 +13,8 @@ use crate::domain::{
 };
 
 use super::super::{SqliteAdapter, schema::MAIN_SCHEMA, sql};
+#[cfg(test)]
+use super::executor::SQLITE_SAFE_MODE_REQUIRED_MARKER;
 
 mod kind_info;
 mod trigger;
@@ -882,6 +884,22 @@ mod tests {
                 empty_result,
                 Err(DbOperationError::ConnectionFailed(_))
             ));
+        }
+
+        #[tokio::test]
+        async fn rejects_sqlite_before_safe_mode_minimum_at_connection() {
+            let (_dir, dsn) = test_support::make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+            let expects_rejection =
+                std::env::var_os("SABIQL_EXPECT_SQLITE_SAFE_MODE_REJECTION").is_some();
+
+            match adapter.fetch_metadata(&dsn).await {
+                Err(DbOperationError::UnsupportedOperation(details)) if expects_rejection => {
+                    assert!(details.contains(SQLITE_SAFE_MODE_REQUIRED_MARKER));
+                }
+                Ok(_) if !expects_rejection => {}
+                result => panic!("unexpected SQLite safe mode connection result: {result:?}"),
+            }
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Problem

SQLite queries could invoke sqlite3 shell capabilities that reach outside the selected database file.

## Background

SAB-332 defines the SQL modal as an interface for the active database rather than an implicit shell escape hatch.

## Approach

Run SQLite commands in safe mode, reject unsupported CLI versions during connection, and verify the supported minimum and system SQLite paths in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - SQLiteの読み取り専用モードで、安全モードを利用するようになりました。
  - ファイル操作、拡張機能の読み込み、`ATTACH`、`VACUUM`など安全でない操作を拒否します。
  - SQLiteのバージョン要件を3.41.1以上に引き上げました。

- **バグ修正**
  - 要件未達のSQLiteに対して、原因と必要なバージョンを案内するエラーメッセージを改善しました。

- **ドキュメント**
  - Query SafetyとSQLiteの要件、安全モードの挙動に関する説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->