### PR TITLE
refactor: centralize CSV export lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,7 +2621,6 @@ dependencies = [
  "async-trait",
  "color-eyre",
  "csv",
- "dirs",
  "lru",
  "mockall",
  "nucleo-matcher",

--- a/src/app/Cargo.toml
+++ b/src/app/Cargo.toml
@@ -25,7 +25,6 @@ tokio.workspace = true
 toml.workspace = true
 unicode-casefold.workspace = true
 unicode-width.workspace = true
-dirs.workspace = true
 sabiql-domain.workspace = true
 uuid.workspace = true
 

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -1,6 +1,4 @@
-use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
 
 use color_eyre::eyre::Result;
@@ -14,9 +12,7 @@ use crate::domain::command_tag::CommandTag;
 use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
 use crate::domain::sqlite_explain_query_plan_text_from_result;
 use crate::model::app_state::AppState;
-use crate::ports::outbound::{
-    CachedResultExporter, DbOperationError, QueryExecutor, QueryHistoryStore,
-};
+use crate::ports::outbound::{CachedResultExporter, QueryExecutor, QueryHistoryStore};
 use crate::update::action::Action;
 
 fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
@@ -73,81 +69,6 @@ fn save_query_history(
             let _ = tx.send(Action::QueryHistoryAppendFailed(e)).await;
         }
     });
-}
-
-fn resolve_export_path(file_name: &str) -> PathBuf {
-    let now_sys = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default();
-    let secs = now_sys.as_secs();
-    let millis = now_sys.subsec_millis();
-    let days = secs / 86400;
-    let time_of_day = secs % 86400;
-    let hours = time_of_day / 3600;
-    let minutes = (time_of_day % 3600) / 60;
-    let seconds = time_of_day % 60;
-    let (y, m, d) = epoch_days_to_ymd(days as i64);
-    let timestamp = format!("{y:04}{m:02}{d:02}_{hours:02}{minutes:02}{seconds:02}_{millis:03}");
-    let file_stem = format!("sabiql_export_{file_name}_{timestamp}.csv");
-    let dir = dirs::download_dir()
-        .or_else(dirs::home_dir)
-        .unwrap_or_else(|| PathBuf::from("."));
-    dir.join(file_stem)
-}
-
-struct ExportTempFile {
-    path: PathBuf,
-    cleanup: bool,
-}
-
-impl ExportTempFile {
-    fn new(path: PathBuf) -> Self {
-        Self {
-            path,
-            cleanup: true,
-        }
-    }
-
-    fn disarm(&mut self) {
-        self.cleanup = false;
-    }
-}
-
-impl Drop for ExportTempFile {
-    fn drop(&mut self) {
-        if self.cleanup {
-            let _ = std::fs::remove_file(&self.path);
-        }
-    }
-}
-
-fn temporary_export_path(final_path: &Path) -> PathBuf {
-    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
-    let file_name = final_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("export.csv");
-    let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    final_path.with_file_name(format!(
-        ".{file_name}.{}.{}.part",
-        std::process::id(),
-        sequence
-    ))
-}
-
-async fn export_to_path<F, Fut>(final_path: PathBuf, export: F) -> Result<usize, DbOperationError>
-where
-    F: FnOnce(PathBuf) -> Fut,
-    Fut: Future<Output = Result<usize, DbOperationError>>,
-{
-    let temporary_path = temporary_export_path(&final_path);
-    let mut cleanup = ExportTempFile::new(temporary_path.clone());
-    let row_count = export(temporary_path.clone()).await?;
-    tokio::fs::rename(&temporary_path, &final_path)
-        .await
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    cleanup.disarm();
-    Ok(row_count)
 }
 
 #[allow(
@@ -418,18 +339,14 @@ pub async fn run(
         } => {
             let executor = Arc::clone(query_executor);
             let tx = action_tx.clone();
-            let path = resolve_export_path(&file_name);
             let export_dsn = dsn.clone();
 
             query_tasks.spawn(async move {
-                let result = export_to_path(path.clone(), |temporary_path| async move {
-                    executor
-                        .export_to_csv(&export_dsn, &query, &temporary_path)
-                        .await
-                })
-                .await;
+                let result = executor
+                    .export_to_csv(&export_dsn, &query, &file_name)
+                    .await;
                 match result {
-                    Ok(_) => {
+                    Ok(path) => {
                         tx.send(Action::CsvExportSucceeded {
                             dsn,
                             run_id,
@@ -463,23 +380,18 @@ pub async fn run(
         } => {
             let tx = action_tx.clone();
             let exporter = Arc::clone(cached_result_exporter);
-            let path = resolve_export_path(&file_name);
-            let exported_path = path.display().to_string();
 
             query_tasks.spawn(async move {
-                let result = export_to_path(path, |temporary_path| async move {
-                    exporter
-                        .export_cached_result_to_csv(temporary_path, columns, values)
-                        .await
-                })
-                .await;
+                let result = exporter
+                    .export_cached_result_to_csv(file_name, columns, values)
+                    .await;
 
                 match result {
-                    Ok(_) => {
+                    Ok(path) => {
                         tx.send(Action::CsvExportSucceeded {
                             dsn,
                             run_id,
-                            path: exported_path,
+                            path: path.display().to_string(),
                             row_count,
                         })
                         .await
@@ -519,113 +431,6 @@ mod tests {
     use crate::ports::outbound::{AccessMode, RenderOutput, RenderResult, Renderer};
     use crate::services::AppServices;
     use crate::update::action::Action;
-
-    use super::{epoch_days_to_ymd, export_to_path, resolve_export_path};
-
-    mod export_path {
-        use std::path::Path;
-
-        use super::*;
-
-        #[test]
-        fn epoch_days_to_ymd_unix_epoch() {
-            assert_eq!(epoch_days_to_ymd(0), (1970, 1, 1));
-        }
-
-        #[test]
-        fn epoch_days_to_ymd_known_date() {
-            assert_eq!(epoch_days_to_ymd(19723), (2024, 1, 1));
-        }
-
-        #[test]
-        fn epoch_days_to_ymd_leap_year_feb_29() {
-            assert_eq!(epoch_days_to_ymd(19782), (2024, 2, 29));
-        }
-
-        #[test]
-        fn epoch_days_to_ymd_year_end_dec_31() {
-            assert_eq!(epoch_days_to_ymd(19722), (2023, 12, 31));
-        }
-
-        #[test]
-        fn epoch_days_to_ymd_century_leap_year() {
-            assert_eq!(epoch_days_to_ymd(11016), (2000, 2, 29));
-        }
-
-        #[test]
-        fn epoch_days_to_ymd_non_leap_century() {
-            assert_eq!(epoch_days_to_ymd(-25508), (1900, 3, 1));
-        }
-
-        #[test]
-        fn resolve_export_path_contains_file_name() {
-            let path = resolve_export_path("users");
-            let file_name = path.file_name().unwrap().to_str().unwrap();
-            assert!(file_name.starts_with("sabiql_export_users_"));
-            assert!(
-                Path::new(file_name)
-                    .extension()
-                    .is_some_and(|ext: &std::ffi::OsStr| ext.eq_ignore_ascii_case("csv"))
-            );
-        }
-    }
-
-    mod atomic_export {
-        use std::future::pending;
-
-        use crate::ports::outbound::DbOperationError;
-        use tempfile::tempdir;
-        use tokio::sync::oneshot;
-
-        use super::*;
-
-        #[tokio::test]
-        async fn cancellation_removes_partial_temporary_file() {
-            let dir = tempdir().unwrap();
-            let final_path = dir.path().join("export.csv");
-            let (started_tx, started_rx) = oneshot::channel();
-
-            let task = tokio::spawn(export_to_path(
-                final_path.clone(),
-                move |temporary_path| async move {
-                    tokio::fs::write(temporary_path, b"partial,csv\n")
-                        .await
-                        .unwrap();
-                    started_tx.send(()).ok();
-                    pending::<Result<usize, DbOperationError>>().await
-                },
-            ));
-
-            started_rx.await.unwrap();
-            task.abort();
-            task.await.unwrap_err();
-
-            assert!(!final_path.exists());
-            assert_eq!(dir.path().read_dir().unwrap().count(), 0);
-        }
-
-        #[tokio::test]
-        async fn success_renames_temporary_file_atomically() {
-            let dir = tempdir().unwrap();
-            let final_path = dir.path().join("export.csv");
-
-            let row_count = export_to_path(final_path.clone(), |temporary_path| async move {
-                tokio::fs::write(temporary_path, b"complete,csv\n")
-                    .await
-                    .unwrap();
-                Ok(3)
-            })
-            .await
-            .unwrap();
-
-            assert_eq!(row_count, 3);
-            assert_eq!(
-                tokio::fs::read_to_string(&final_path).await.unwrap(),
-                "complete,csv\n"
-            );
-            assert_eq!(dir.path().read_dir().unwrap().count(), 1);
-        }
-    }
 
     mod explain_plan_text {
         use crate::domain::{QueryResult, QuerySource, sqlite_explain_query_plan_text_from_result};
@@ -682,7 +487,6 @@ mod tests {
     }
     mod cached_csv_export_effect {
         use std::cell::RefCell;
-        use std::path::PathBuf;
         use std::sync::Arc;
         use std::time::Duration;
 
@@ -725,10 +529,10 @@ mod tests {
         impl CachedResultExporter for FailingCachedResultExporter {
             async fn export_cached_result_to_csv(
                 &self,
-                _path: PathBuf,
+                _file_name: String,
                 _columns: Vec<String>,
                 _values: Vec<Vec<QueryValue>>,
-            ) -> Result<usize, DbOperationError> {
+            ) -> Result<std::path::PathBuf, DbOperationError> {
                 Err(DbOperationError::QueryFailed("export failed".to_string()))
             }
         }

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -495,7 +495,7 @@ mod tests {
 
     mod query_context_termination {
         use std::future::pending;
-        use std::path::Path;
+        use std::path::PathBuf;
         use std::sync::Mutex;
         use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -574,8 +574,8 @@ mod tests {
                 &self,
                 _dsn: &str,
                 _query: &str,
-                _path: &Path,
-            ) -> Result<usize, DbOperationError> {
+                _file_name: &str,
+            ) -> Result<PathBuf, DbOperationError> {
                 unreachable!("test only starts a preview")
             }
         }

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -74,14 +74,14 @@ pub struct TestCachedResultExporter;
 impl CachedResultExporter for TestCachedResultExporter {
     async fn export_cached_result_to_csv(
         &self,
-        path: PathBuf,
+        file_name: String,
         _columns: Vec<String>,
         values: Vec<Vec<QueryValue>>,
-    ) -> Result<usize, DbOperationError> {
-        tokio::fs::write(path, [])
-            .await
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-        Ok(values.len())
+    ) -> Result<PathBuf, DbOperationError> {
+        Ok(PathBuf::from(format!(
+            "/tmp/{file_name}_{}.csv",
+            values.len()
+        )))
     }
 }
 

--- a/src/app/ports/outbound/cached_result_exporter.rs
+++ b/src/app/ports/outbound/cached_result_exporter.rs
@@ -10,8 +10,8 @@ use super::DbOperationError;
 pub trait CachedResultExporter: Send + Sync {
     async fn export_cached_result_to_csv(
         &self,
-        path: PathBuf,
+        file_name: String,
         columns: Vec<String>,
         values: Vec<Vec<QueryValue>>,
-    ) -> Result<usize, DbOperationError>;
+    ) -> Result<PathBuf, DbOperationError>;
 }

--- a/src/app/ports/outbound/query_executor.rs
+++ b/src/app/ports/outbound/query_executor.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use async_trait::async_trait;
 
 use crate::domain::{QueryResult, WriteExecutionResult};
@@ -33,6 +35,6 @@ pub trait QueryExecutor: Send + Sync {
         &self,
         dsn: &str,
         query: &str,
-        path: &std::path::Path,
-    ) -> Result<usize, DbOperationError>;
+        file_name: &str,
+    ) -> Result<PathBuf, DbOperationError>;
 }

--- a/src/infra/adapters/cached_result_exporter.rs
+++ b/src/infra/adapters/cached_result_exporter.rs
@@ -1,9 +1,9 @@
-use std::path::PathBuf;
-
 use async_trait::async_trait;
 use sabiql_app::domain::QueryValue;
 use sabiql_app::ports::outbound::{CachedResultExporter, DbOperationError};
 use tokio::io::{AsyncWriteExt, BufWriter};
+
+use crate::adapters::csv_export::export_to_downloads;
 
 const CSV_FLUSH_THRESHOLD: usize = 64 * 1024;
 
@@ -14,11 +14,14 @@ pub struct CsvCachedResultExporter;
 impl CachedResultExporter for CsvCachedResultExporter {
     async fn export_cached_result_to_csv(
         &self,
-        path: PathBuf,
+        file_name: String,
         columns: Vec<String>,
         values: Vec<Vec<QueryValue>>,
-    ) -> Result<usize, DbOperationError> {
-        write_cached_result_csv(path, columns, values).await
+    ) -> Result<std::path::PathBuf, DbOperationError> {
+        export_to_downloads(&file_name, |path| {
+            write_cached_result_csv(path, columns, values)
+        })
+        .await
     }
 }
 
@@ -38,10 +41,10 @@ fn cached_csv_cell(value: &QueryValue) -> String {
 }
 
 async fn write_cached_result_csv(
-    path: PathBuf,
+    path: std::path::PathBuf,
     columns: Vec<String>,
     values: Vec<Vec<QueryValue>>,
-) -> Result<usize, DbOperationError> {
+) -> Result<(), DbOperationError> {
     let file = tokio::fs::File::create(path)
         .await
         .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
@@ -75,7 +78,7 @@ async fn write_cached_result_csv(
     file.flush()
         .await
         .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    Ok(values.len())
+    Ok(())
 }
 
 async fn write_csv_record<I>(
@@ -147,23 +150,21 @@ mod tests {
         use super::*;
 
         #[tokio::test]
-        async fn writes_columns_rows_and_returns_row_count() {
+        async fn writes_columns_and_rows() {
             let dir = tempdir().unwrap();
             let path = dir.path().join("export.csv");
 
-            let row_count = CsvCachedResultExporter
-                .export_cached_result_to_csv(
-                    path.clone(),
-                    vec!["id".to_string(), "payload".to_string()],
-                    vec![vec![
-                        QueryValue::SqlLiteral("1".to_string()),
-                        QueryValue::Blob(vec![0xAB, 0xCD]),
-                    ]],
-                )
-                .await
-                .unwrap();
+            write_cached_result_csv(
+                path.clone(),
+                vec!["id".to_string(), "payload".to_string()],
+                vec![vec![
+                    QueryValue::SqlLiteral("1".to_string()),
+                    QueryValue::Blob(vec![0xAB, 0xCD]),
+                ]],
+            )
+            .await
+            .unwrap();
 
-            assert_eq!(row_count, 1);
             assert_eq!(
                 std::fs::read_to_string(path).unwrap(),
                 "id,payload\n1,ABCD\n"
@@ -175,14 +176,13 @@ mod tests {
             let dir = tempdir().unwrap();
             let path = dir.path().join("export.csv");
 
-            CsvCachedResultExporter
-                .export_cached_result_to_csv(
-                    path.clone(),
-                    vec!["payload".to_string()],
-                    vec![vec![QueryValue::text("a\0bc")]],
-                )
-                .await
-                .unwrap();
+            write_cached_result_csv(
+                path.clone(),
+                vec!["payload".to_string()],
+                vec![vec![QueryValue::text("a\0bc")]],
+            )
+            .await
+            .unwrap();
 
             assert_eq!(std::fs::read(path).unwrap(), b"payload\na\0bc\n");
         }
@@ -193,16 +193,14 @@ mod tests {
             let path = dir.path().join("large_export.csv");
             let big_value = "x".repeat(CSV_FLUSH_THRESHOLD + 1);
 
-            let row_count = CsvCachedResultExporter
-                .export_cached_result_to_csv(
-                    path.clone(),
-                    vec!["data".to_string()],
-                    vec![vec![QueryValue::Text(big_value.clone())]],
-                )
-                .await
-                .unwrap();
+            write_cached_result_csv(
+                path.clone(),
+                vec!["data".to_string()],
+                vec![vec![QueryValue::Text(big_value.clone())]],
+            )
+            .await
+            .unwrap();
 
-            assert_eq!(row_count, 1);
             assert_eq!(
                 std::fs::read_to_string(path).unwrap(),
                 format!("data\n{big_value}\n")
@@ -214,8 +212,7 @@ mod tests {
             let dir = tempdir().unwrap();
             let path = dir.path().join("missing").join("export.csv");
 
-            let error = CsvCachedResultExporter
-                .export_cached_result_to_csv(path, vec!["id".to_string()], vec![])
+            let error = write_cached_result_csv(path, vec!["id".to_string()], vec![])
                 .await
                 .unwrap_err();
 

--- a/src/infra/adapters/csv_export.rs
+++ b/src/infra/adapters/csv_export.rs
@@ -100,24 +100,14 @@ where
     F: FnOnce(PathBuf) -> Fut,
     Fut: Future<Output = Result<(), DbOperationError>>,
 {
-    if final_path.exists() {
-        return Err(DbOperationError::QueryFailed(format!(
-            "CSV export already exists: {}",
-            final_path.display()
-        )));
-    }
-
     let temporary_path = temporary_export_path(&final_path);
     let mut temporary_file = TemporaryExportFile::new(temporary_path.clone());
     write(temporary_path.clone()).await?;
 
-    if final_path.exists() {
-        return Err(DbOperationError::QueryFailed(format!(
-            "CSV export already exists: {}",
-            final_path.display()
-        )));
-    }
-    tokio::fs::rename(&temporary_path, &final_path)
+    tokio::fs::hard_link(&temporary_path, &final_path)
+        .await
+        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    tokio::fs::remove_file(&temporary_path)
         .await
         .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
     temporary_file.disarm();
@@ -127,8 +117,10 @@ where
 #[cfg(test)]
 mod tests {
     use std::future::pending;
+    use std::sync::Arc;
 
     use tempfile::tempdir;
+    use tokio::sync::Barrier;
     use tokio::sync::oneshot;
 
     use super::*;
@@ -158,7 +150,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn success_renames_temporary_file_without_replacing_existing_file() {
+    async fn success_publishes_temporary_file_without_replacing_existing_file() {
         let dir = tempdir().unwrap();
         let final_path = dir.path().join("export.csv");
 
@@ -187,7 +179,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_and_rename_failures_leave_no_partial_file() {
+    async fn write_failure_leaves_no_partial_file() {
         let dir = tempdir().unwrap();
         let failed_write = dir.path().join("write.csv");
         let write_error = export_to_path(failed_write.clone(), |_| async {
@@ -197,7 +189,11 @@ mod tests {
         .unwrap_err();
         assert!(matches!(write_error, DbOperationError::QueryFailed(_)));
         assert_eq!(dir.path().read_dir().unwrap().count(), 0);
+    }
 
+    #[tokio::test]
+    async fn finalize_failure_leaves_no_partial_file() {
+        let dir = tempdir().unwrap();
         let rename_dir = dir.path().join("rename");
         tokio::fs::create_dir(&rename_dir).await.unwrap();
         let failed_rename = rename_dir.join("export.csv");
@@ -213,5 +209,54 @@ mod tests {
         .unwrap_err();
         assert!(matches!(rename_error, DbOperationError::QueryFailed(_)));
         assert!(!rename_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn concurrent_exports_with_same_final_path_allow_only_one_completion() {
+        let dir = tempdir().unwrap();
+        let final_path = dir.path().join("export.csv");
+        let barrier = Arc::new(Barrier::new(2));
+
+        let first = tokio::spawn(export_to_path(final_path.clone(), {
+            let barrier = Arc::clone(&barrier);
+            move |temporary_path| async move {
+                tokio::fs::write(temporary_path, b"first\n")
+                    .await
+                    .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+                barrier.wait().await;
+                Ok(())
+            }
+        }));
+        let second = tokio::spawn(export_to_path(final_path.clone(), {
+            let barrier = Arc::clone(&barrier);
+            move |temporary_path| async move {
+                tokio::fs::write(temporary_path, b"second\n")
+                    .await
+                    .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+                barrier.wait().await;
+                Ok(())
+            }
+        }));
+
+        let first = first.await.unwrap();
+        let second = second.await.unwrap();
+
+        assert!(first.is_ok() ^ second.is_ok());
+        assert!(matches!(
+            first,
+            Ok(_) | Err(DbOperationError::QueryFailed(_))
+        ));
+        assert!(matches!(
+            second,
+            Ok(_) | Err(DbOperationError::QueryFailed(_))
+        ));
+        assert!(matches!(
+            tokio::fs::read_to_string(final_path)
+                .await
+                .unwrap()
+                .as_str(),
+            "first\n" | "second\n"
+        ));
+        assert_eq!(dir.path().read_dir().unwrap().count(), 1);
     }
 }

--- a/src/infra/adapters/csv_export.rs
+++ b/src/infra/adapters/csv_export.rs
@@ -126,7 +126,7 @@ where
     F: FnOnce(PathBuf) -> Fut,
     Fut: Future<Output = Result<(), DbOperationError>>,
 {
-    export_to_path_with_cleanup(final_path, write, std::fs::remove_file).await
+    export_to_path_with_cleanup(final_path, write, |path| std::fs::remove_file(path)).await
 }
 
 async fn export_to_path_with_cleanup<F, Fut, C>(

--- a/src/infra/adapters/csv_export.rs
+++ b/src/infra/adapters/csv_export.rs
@@ -55,12 +55,12 @@ fn temporary_export_path(final_path: &Path) -> PathBuf {
     ))
 }
 
-struct TemporaryExportFile {
+struct RemoveOnDropGuard {
     path: PathBuf,
     cleanup: bool,
 }
 
-impl TemporaryExportFile {
+impl RemoveOnDropGuard {
     fn new(path: PathBuf) -> Self {
         Self {
             path,
@@ -73,33 +73,7 @@ impl TemporaryExportFile {
     }
 }
 
-impl Drop for TemporaryExportFile {
-    fn drop(&mut self) {
-        if self.cleanup {
-            let _ = std::fs::remove_file(&self.path);
-        }
-    }
-}
-
-struct PublishedExportFile {
-    path: PathBuf,
-    cleanup: bool,
-}
-
-impl PublishedExportFile {
-    fn new(path: PathBuf) -> Self {
-        Self {
-            path,
-            cleanup: true,
-        }
-    }
-
-    fn disarm(&mut self) {
-        self.cleanup = false;
-    }
-}
-
-impl Drop for PublishedExportFile {
+impl Drop for RemoveOnDropGuard {
     fn drop(&mut self) {
         if self.cleanup {
             let _ = std::fs::remove_file(&self.path);
@@ -140,13 +114,13 @@ where
     C: FnOnce(&Path) -> std::io::Result<()>,
 {
     let temporary_path = temporary_export_path(&final_path);
-    let mut temporary_file = TemporaryExportFile::new(temporary_path.clone());
+    let mut temporary_file = RemoveOnDropGuard::new(temporary_path.clone());
     write(temporary_path.clone()).await?;
 
     tokio::fs::hard_link(&temporary_path, &final_path)
         .await
         .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    let mut published_file = PublishedExportFile::new(final_path.clone());
+    let mut published_file = RemoveOnDropGuard::new(final_path.clone());
 
     if cleanup(&temporary_path).is_ok() {
         temporary_file.disarm();

--- a/src/infra/adapters/csv_export.rs
+++ b/src/infra/adapters/csv_export.rs
@@ -1,0 +1,217 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
+
+use sabiql_app::ports::outbound::DbOperationError;
+
+fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
+    let doe = (z - era * 146_097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+fn download_directory() -> PathBuf {
+    dirs::download_dir()
+        .or_else(dirs::home_dir)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+pub fn download_export_path(file_name: &str) -> PathBuf {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs();
+    let days = secs / 86_400;
+    let time_of_day = secs % 86_400;
+    let (year, month, day) = epoch_days_to_ymd(days as i64);
+    let timestamp = format!(
+        "{year:04}{month:02}{day:02}_{:02}{:02}{:02}_{:03}",
+        time_of_day / 3_600,
+        (time_of_day % 3_600) / 60,
+        time_of_day % 60,
+        now.subsec_millis()
+    );
+    download_directory().join(format!("sabiql_export_{file_name}_{timestamp}.csv"))
+}
+
+fn temporary_export_path(final_path: &Path) -> PathBuf {
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+    let file_name = final_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("export.csv");
+    final_path.with_file_name(format!(
+        ".{file_name}.{}.{}.part",
+        std::process::id(),
+        SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+struct TemporaryExportFile {
+    path: PathBuf,
+    cleanup: bool,
+}
+
+impl TemporaryExportFile {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            cleanup: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.cleanup = false;
+    }
+}
+
+impl Drop for TemporaryExportFile {
+    fn drop(&mut self) {
+        if self.cleanup {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+pub async fn export_to_downloads<F, Fut>(
+    file_name: &str,
+    write: F,
+) -> Result<PathBuf, DbOperationError>
+where
+    F: FnOnce(PathBuf) -> Fut,
+    Fut: Future<Output = Result<(), DbOperationError>>,
+{
+    export_to_path(download_export_path(file_name), write).await
+}
+
+pub async fn export_to_path<F, Fut>(
+    final_path: PathBuf,
+    write: F,
+) -> Result<PathBuf, DbOperationError>
+where
+    F: FnOnce(PathBuf) -> Fut,
+    Fut: Future<Output = Result<(), DbOperationError>>,
+{
+    if final_path.exists() {
+        return Err(DbOperationError::QueryFailed(format!(
+            "CSV export already exists: {}",
+            final_path.display()
+        )));
+    }
+
+    let temporary_path = temporary_export_path(&final_path);
+    let mut temporary_file = TemporaryExportFile::new(temporary_path.clone());
+    write(temporary_path.clone()).await?;
+
+    if final_path.exists() {
+        return Err(DbOperationError::QueryFailed(format!(
+            "CSV export already exists: {}",
+            final_path.display()
+        )));
+    }
+    tokio::fs::rename(&temporary_path, &final_path)
+        .await
+        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    temporary_file.disarm();
+    Ok(final_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::pending;
+
+    use tempfile::tempdir;
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn cancellation_removes_partial_temporary_file() {
+        let dir = tempdir().unwrap();
+        let final_path = dir.path().join("export.csv");
+        let (started_tx, started_rx) = oneshot::channel();
+        let task = tokio::spawn(export_to_path(
+            final_path.clone(),
+            move |temporary_path| async move {
+                tokio::fs::write(temporary_path, b"partial,csv\n")
+                    .await
+                    .unwrap();
+                started_tx.send(()).ok();
+                pending::<Result<(), DbOperationError>>().await
+            },
+        ));
+
+        started_rx.await.unwrap();
+        task.abort();
+        task.await.unwrap_err();
+
+        assert!(!final_path.exists());
+        assert_eq!(dir.path().read_dir().unwrap().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn success_renames_temporary_file_without_replacing_existing_file() {
+        let dir = tempdir().unwrap();
+        let final_path = dir.path().join("export.csv");
+
+        let exported_path = export_to_path(final_path.clone(), |temporary_path| async move {
+            tokio::fs::write(temporary_path, b"complete,csv\n")
+                .await
+                .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(exported_path, final_path);
+        assert_eq!(
+            tokio::fs::read_to_string(&final_path).await.unwrap(),
+            "complete,csv\n"
+        );
+
+        let error = export_to_path(final_path.clone(), |_| async { Ok(()) })
+            .await
+            .unwrap_err();
+        assert!(matches!(error, DbOperationError::QueryFailed(_)));
+        assert_eq!(
+            tokio::fs::read_to_string(final_path).await.unwrap(),
+            "complete,csv\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_and_rename_failures_leave_no_partial_file() {
+        let dir = tempdir().unwrap();
+        let failed_write = dir.path().join("write.csv");
+        let write_error = export_to_path(failed_write.clone(), |_| async {
+            Err(DbOperationError::QueryFailed("write failed".to_string()))
+        })
+        .await
+        .unwrap_err();
+        assert!(matches!(write_error, DbOperationError::QueryFailed(_)));
+        assert_eq!(dir.path().read_dir().unwrap().count(), 0);
+
+        let rename_dir = dir.path().join("rename");
+        tokio::fs::create_dir(&rename_dir).await.unwrap();
+        let failed_rename = rename_dir.join("export.csv");
+        let rename_error = export_to_path(failed_rename, |temporary_path| async move {
+            tokio::fs::write(&temporary_path, b"complete,csv\n")
+                .await
+                .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+            tokio::fs::remove_dir_all(temporary_path.parent().unwrap())
+                .await
+                .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
+        })
+        .await
+        .unwrap_err();
+        assert!(matches!(rename_error, DbOperationError::QueryFailed(_)));
+        assert!(!rename_dir.exists());
+    }
+}

--- a/src/infra/adapters/csv_export.rs
+++ b/src/infra/adapters/csv_export.rs
@@ -81,6 +81,32 @@ impl Drop for TemporaryExportFile {
     }
 }
 
+struct PublishedExportFile {
+    path: PathBuf,
+    cleanup: bool,
+}
+
+impl PublishedExportFile {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            cleanup: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.cleanup = false;
+    }
+}
+
+impl Drop for PublishedExportFile {
+    fn drop(&mut self) {
+        if self.cleanup {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
 pub async fn export_to_downloads<F, Fut>(
     file_name: &str,
     write: F,
@@ -100,6 +126,19 @@ where
     F: FnOnce(PathBuf) -> Fut,
     Fut: Future<Output = Result<(), DbOperationError>>,
 {
+    export_to_path_with_cleanup(final_path, write, std::fs::remove_file).await
+}
+
+async fn export_to_path_with_cleanup<F, Fut, C>(
+    final_path: PathBuf,
+    write: F,
+    cleanup: C,
+) -> Result<PathBuf, DbOperationError>
+where
+    F: FnOnce(PathBuf) -> Fut,
+    Fut: Future<Output = Result<(), DbOperationError>>,
+    C: FnOnce(&Path) -> std::io::Result<()>,
+{
     let temporary_path = temporary_export_path(&final_path);
     let mut temporary_file = TemporaryExportFile::new(temporary_path.clone());
     write(temporary_path.clone()).await?;
@@ -107,10 +146,12 @@ where
     tokio::fs::hard_link(&temporary_path, &final_path)
         .await
         .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    tokio::fs::remove_file(&temporary_path)
-        .await
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    temporary_file.disarm();
+    let mut published_file = PublishedExportFile::new(final_path.clone());
+
+    if cleanup(&temporary_path).is_ok() {
+        temporary_file.disarm();
+    }
+    published_file.disarm();
     Ok(final_path)
 }
 
@@ -209,6 +250,60 @@ mod tests {
         .unwrap_err();
         assert!(matches!(rename_error, DbOperationError::QueryFailed(_)));
         assert!(!rename_dir.exists());
+    }
+
+    #[tokio::test]
+    async fn temporary_cleanup_failure_keeps_published_file_successful() {
+        let dir = tempdir().unwrap();
+        let final_path = dir.path().join("export.csv");
+
+        let exported_path = export_to_path_with_cleanup(
+            final_path.clone(),
+            |temporary_path| async move {
+                tokio::fs::write(temporary_path, b"complete,csv\n")
+                    .await
+                    .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
+            },
+            |_| Err(std::io::Error::other("cleanup failed")),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(exported_path, final_path);
+        assert_eq!(
+            tokio::fs::read_to_string(final_path).await.unwrap(),
+            "complete,csv\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_publication_keeps_successful_file() {
+        let dir = tempdir().unwrap();
+        let final_path = dir.path().join("export.csv");
+        let (published_tx, published_rx) = oneshot::channel();
+
+        let task = tokio::spawn(export_to_path_with_cleanup(
+            final_path.clone(),
+            |temporary_path| async move {
+                tokio::fs::write(temporary_path, b"complete,csv\n")
+                    .await
+                    .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
+            },
+            move |temporary_path| {
+                published_tx.send(()).ok();
+                std::fs::remove_file(temporary_path)
+            },
+        ));
+
+        published_rx.await.unwrap();
+        task.abort();
+        let result = task.await.unwrap().unwrap();
+
+        assert_eq!(result, final_path);
+        assert_eq!(
+            tokio::fs::read_to_string(final_path).await.unwrap(),
+            "complete,csv\n"
+        );
     }
 
     #[tokio::test]

--- a/src/infra/adapters/mod.rs
+++ b/src/infra/adapters/mod.rs
@@ -4,6 +4,7 @@ pub mod cached_result_exporter;
 pub mod clipboard;
 pub mod config_writer;
 pub mod connection_store;
+pub(crate) mod csv_export;
 pub mod er_log_writer;
 pub mod folder_opener;
 pub mod mysql;

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -110,8 +110,8 @@ impl QueryExecutor for MySqlAdapter {
         &self,
         _dsn: &str,
         _query: &str,
-        _path: &std::path::Path,
-    ) -> Result<usize, DbOperationError> {
+        _file_name: &str,
+    ) -> Result<std::path::PathBuf, DbOperationError> {
         Err(DbOperationError::ConnectionFailed(
             "MySQL adapter not yet implemented".to_string(),
         ))

--- a/src/infra/adapters/postgres/executor.rs
+++ b/src/infra/adapters/postgres/executor.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 
+use crate::adapters::csv_export::export_to_downloads;
 use crate::app::ports::outbound::{AccessMode, DbOperationError, QueryExecutor};
 use crate::domain::{QueryResult, QuerySource, WriteExecutionResult};
 
@@ -55,8 +56,13 @@ impl QueryExecutor for PostgresAdapter {
         &self,
         dsn: &str,
         query: &str,
-        path: &std::path::Path,
-    ) -> Result<usize, DbOperationError> {
-        self.export_csv_to_file(dsn, query, path, true).await
+        file_name: &str,
+    ) -> Result<std::path::PathBuf, DbOperationError> {
+        export_to_downloads(file_name, |path| async move {
+            self.export_csv_to_file(dsn, query, &path, true)
+                .await
+                .map(|_| ())
+        })
+        .await
     }
 }

--- a/src/infra/adapters/postgres/executor.rs
+++ b/src/infra/adapters/postgres/executor.rs
@@ -59,9 +59,7 @@ impl QueryExecutor for PostgresAdapter {
         file_name: &str,
     ) -> Result<std::path::PathBuf, DbOperationError> {
         export_to_downloads(file_name, |path| async move {
-            self.export_csv_to_file(dsn, query, &path, true)
-                .await
-                .map(|_| ())
+            self.export_csv_to_file(dsn, query, &path, true).await
         })
         .await
     }

--- a/src/infra/adapters/postgres/psql/executor.rs
+++ b/src/infra/adapters/postgres/psql/executor.rs
@@ -403,7 +403,7 @@ impl PostgresAdapter {
         query: &str,
         path: &std::path::Path,
         read_only: bool,
-    ) -> Result<usize, DbOperationError> {
+    ) -> Result<(), DbOperationError> {
         let mut cmd = Command::new("psql");
         if read_only {
             Self::apply_read_only_pgoptions(&mut cmd);
@@ -427,7 +427,6 @@ impl PostgresAdapter {
         let mut writer = tokio::io::BufWriter::new(file);
 
         let result = timeout(Duration::from_secs(self.timeout_secs * 10), async {
-            let mut newline_count: usize = 0;
             if let Some(mut out) = stdout {
                 let mut buf = [0u8; 8192];
                 loop {
@@ -435,7 +434,6 @@ impl PostgresAdapter {
                     if n == 0 {
                         break;
                     }
-                    newline_count += buf[..n].iter().filter(|&&b| b == b'\n').count();
                     writer.write_all(&buf[..n]).await?;
                 }
                 writer.flush().await?;
@@ -450,7 +448,7 @@ impl PostgresAdapter {
             };
 
             let status = child.wait().await?;
-            Ok::<_, std::io::Error>((status, stderr, newline_count))
+            Ok::<_, std::io::Error>((status, stderr))
         })
         .await;
 
@@ -462,15 +460,13 @@ impl PostgresAdapter {
             }
         };
 
-        let (status, stderr, newline_count) = result;
+        let (status, stderr) = result;
         if !status.success() {
             let _ = tokio::fs::remove_file(path).await;
             return Err(Self::classify_psql_error(&stderr));
         }
 
-        // Subtract 1 for the CSV header line
-        let row_count = newline_count.saturating_sub(1);
-        Ok(row_count)
+        Ok(())
     }
 
     pub(in crate::adapters::postgres) async fn fetch_preview_order_columns(

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::app::ports::outbound::{
@@ -189,12 +189,12 @@ impl QueryExecutor for DbAdapterRegistry {
         &self,
         dsn: &str,
         query: &str,
-        path: &Path,
-    ) -> Result<usize, DbOperationError> {
+        file_name: &str,
+    ) -> Result<PathBuf, DbOperationError> {
         match Self::db_type_from_dsn(dsn)? {
-            DatabaseType::PostgreSQL => self.postgres.export_to_csv(dsn, query, path).await,
+            DatabaseType::PostgreSQL => self.postgres.export_to_csv(dsn, query, file_name).await,
             DatabaseType::SQLite => {
-                QueryExecutor::export_to_csv(self.sqlite.as_ref(), dsn, query, path).await
+                QueryExecutor::export_to_csv(self.sqlite.as_ref(), dsn, query, file_name).await
             }
         }
     }

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -9,6 +9,7 @@ use tokio::time::timeout;
 
 use async_trait::async_trait;
 
+use crate::adapters::csv_export::export_to_downloads;
 use crate::app::policy::sql::sqlite_explain::is_sqlite_explain_query_plan_sql;
 use crate::app::ports::outbound::{
     AccessMode, DatabaseCli, DbOperationError, QueryExecutor, SQLITE_SAFE_MODE_REQUIRED_MARKER,
@@ -210,7 +211,7 @@ impl SqliteCli {
         sql: &str,
         output_path: &std::path::Path,
         read_only: bool,
-    ) -> Result<usize, DbOperationError> {
+    ) -> Result<(), DbOperationError> {
         Self::ensure_database_path(path)?;
         let mut cmd = Command::new("sqlite3");
         Self::apply_session_options(&mut cmd, read_only);
@@ -287,13 +288,7 @@ impl SqliteCli {
             return Err(classify_query_error(&stderr));
         }
 
-        match count_csv_records_async(output_path).await {
-            Ok(row_count) => Ok(row_count),
-            Err(error) => {
-                let _ = tokio::fs::remove_file(output_path).await;
-                Err(error)
-            }
-        }
+        Ok(())
     }
 
     async fn run(
@@ -433,23 +428,6 @@ fn sqlite_uri_path(path: &str, is_windows: bool) -> String {
     } else {
         path
     }
-}
-
-fn count_csv_records(path: &std::path::Path) -> Result<usize, csv::Error> {
-    let mut reader = csv::ReaderBuilder::new()
-        .has_headers(true)
-        .from_path(path)?;
-    reader
-        .records()
-        .try_fold(0usize, |count, record| record.map(|_| count + 1))
-}
-
-async fn count_csv_records_async(path: &std::path::Path) -> Result<usize, DbOperationError> {
-    let path = path.to_path_buf();
-    tokio::task::spawn_blocking(move || count_csv_records(&path))
-        .await
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
 }
 
 impl SqliteAdapter {
@@ -626,14 +604,18 @@ impl QueryExecutor for SqliteAdapter {
         &self,
         dsn: &str,
         query: &str,
-        path: &std::path::Path,
-    ) -> Result<usize, DbOperationError> {
+        file_name: &str,
+    ) -> Result<std::path::PathBuf, DbOperationError> {
         if !is_sqlite_rerunnable_export_query(query)? {
             return Err(sqlite_export_not_rerunnable_error());
         }
-        self.cli
-            .export_csv(Self::path_from_dsn(dsn)?, query, path, true)
-            .await
+        let database_path = Self::path_from_dsn(dsn)?.to_string();
+        export_to_downloads(file_name, |path| async move {
+            self.cli
+                .export_csv(&database_path, query, &path, true)
+                .await
+        })
+        .await
     }
 }
 
@@ -2399,7 +2381,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn export_to_csv_writes_rows_and_returns_row_count() {
+        async fn export_to_csv_writes_rows() {
             let (dir, dsn) = test_support::make_sqlite_db(
                 r"
             CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -2409,18 +2391,23 @@ mod tests {
             let path = dir.path().join("users.csv");
             let adapter = SqliteAdapter::new();
 
-            let row_count = adapter
-                .export_to_csv(&dsn, "SELECT id, name FROM users ORDER BY id", &path)
+            adapter
+                .cli
+                .export_csv(
+                    SqliteAdapter::path_from_dsn(&dsn).unwrap(),
+                    "SELECT id, name FROM users ORDER BY id",
+                    &path,
+                    true,
+                )
                 .await
                 .unwrap();
             let csv = std::fs::read_to_string(path).unwrap();
 
-            assert_eq!(row_count, 2);
             assert_eq!(csv, "id,name\n1,a\n2,b\n");
         }
 
         #[tokio::test]
-        async fn export_to_csv_counts_records_with_embedded_newlines() {
+        async fn export_to_csv_preserves_records_with_embedded_newlines() {
             let (dir, dsn) = test_support::make_sqlite_db(
                 r"
             CREATE TABLE logs(id INTEGER PRIMARY KEY, message TEXT);
@@ -2431,12 +2418,21 @@ world'), (2, 'done');
             let path = dir.path().join("logs.csv");
             let adapter = SqliteAdapter::new();
 
-            let row_count = adapter
-                .export_to_csv(&dsn, "SELECT id, message FROM logs ORDER BY id", &path)
+            adapter
+                .cli
+                .export_csv(
+                    SqliteAdapter::path_from_dsn(&dsn).unwrap(),
+                    "SELECT id, message FROM logs ORDER BY id",
+                    &path,
+                    true,
+                )
                 .await
                 .unwrap();
 
-            assert_eq!(row_count, 2);
+            assert_eq!(
+                std::fs::read_to_string(path).unwrap(),
+                "id,message\n1,\"hello\nworld\"\n2,done\n"
+            );
         }
 
         #[tokio::test]
@@ -2447,7 +2443,7 @@ world'), (2, 'done');
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .export_to_csv(&dsn, "INSERT INTO users(id) VALUES (1)", &path)
+                .export_to_csv(&dsn, "INSERT INTO users(id) VALUES (1)", "write_export")
                 .await;
 
             assert!(matches!(
@@ -2465,7 +2461,7 @@ world'), (2, 'done');
             let adapter = SqliteAdapter::new();
 
             let result = adapter
-                .export_to_csv(&dsn, "SELECT id FROM missing", &path)
+                .export_to_csv(&dsn, "SELECT id FROM missing", "missing_export")
                 .await;
 
             assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -675,6 +675,7 @@ impl QueryExecutor for SqliteAdapter {
 mod tests {
     use std::{ffi::OsString, path::PathBuf};
 
+    use crate::adapters::csv_export::export_to_path;
     use crate::app::ports::outbound::{AccessMode, SqlDialect};
     use crate::domain::{
         CommandTag, DatabaseType, QuerySource, QueryValue,
@@ -2536,21 +2537,18 @@ world'), (2, 'done');
             let final_path = dir.path().join("export.csv");
             let adapter = SqliteAdapter::new();
 
-            let result = crate::adapters::csv_export::export_to_path(
-                final_path.clone(),
-                |temporary_path| async move {
-                    adapter
-                        .cli
-                        .export_csv_with_command(
-                            "sabiql-missing-sqlite3",
-                            SqliteAdapter::path_from_dsn(&dsn)?,
-                            "SELECT id FROM users",
-                            &temporary_path,
-                            true,
-                        )
-                        .await
-                },
-            )
+            let result = export_to_path(final_path.clone(), |temporary_path| async move {
+                adapter
+                    .cli
+                    .export_csv_with_command(
+                        "sabiql-missing-sqlite3",
+                        SqliteAdapter::path_from_dsn(&dsn)?,
+                        "SELECT id FROM users",
+                        &temporary_path,
+                        true,
+                    )
+                    .await
+            })
             .await;
 
             assert!(matches!(

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -212,8 +212,20 @@ impl SqliteCli {
         output_path: &std::path::Path,
         read_only: bool,
     ) -> Result<(), DbOperationError> {
+        self.export_csv_with_command("sqlite3", path, sql, output_path, read_only)
+            .await
+    }
+
+    async fn export_csv_with_command(
+        &self,
+        command: &str,
+        path: &str,
+        sql: &str,
+        output_path: &std::path::Path,
+        read_only: bool,
+    ) -> Result<(), DbOperationError> {
         Self::ensure_database_path(path)?;
-        let mut cmd = Command::new("sqlite3");
+        let mut cmd = Command::new(command);
         Self::apply_session_options(&mut cmd, read_only);
         cmd.arg("-batch").arg("-bail").arg("-csv").arg("-header");
         cmd.arg(sqlite_database_uri(path, read_only));
@@ -2466,6 +2478,44 @@ world'), (2, 'done');
 
             assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
             assert!(!path.exists());
+        }
+
+        #[tokio::test]
+        async fn export_to_csv_spawn_failure_leaves_no_output_files() {
+            let (dir, dsn) =
+                test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+            let final_path = dir.path().join("export.csv");
+            let adapter = SqliteAdapter::new();
+
+            let result = crate::adapters::csv_export::export_to_path(
+                final_path.clone(),
+                |temporary_path| async move {
+                    adapter
+                        .cli
+                        .export_csv_with_command(
+                            "sabiql-missing-sqlite3",
+                            SqliteAdapter::path_from_dsn(&dsn)?,
+                            "SELECT id FROM users",
+                            &temporary_path,
+                            true,
+                        )
+                        .await
+                },
+            )
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::CommandNotFound { .. })
+            ));
+            assert!(!final_path.exists());
+            assert!(!dir.path().read_dir().unwrap().any(|entry| {
+                entry
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .contains(".export.csv")
+            }));
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Problem

CSV export lifecycle management remained in the application layer, and SQLite re-read completed files solely to count their rows.

## Background

PostgreSQL, SQLite, and cached result exports need the same cancellation-safe publication behavior without leaking filesystem concerns into application effects.

## Approach

Centralize destination resolution, temporary-file cleanup, existing-file protection, and atomic finalization in the infrastructure adapter layer. Export ports now return the completed path, while the UI keeps the count obtained before export or from cached results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * クエリ結果やキャッシュ結果を、ダウンロード用のCSVファイルとして保存できるようになりました。
  * エクスポート完了後、生成されたファイルの保存先が正しく表示されます。
* **改善**
  * CSV出力時の一時ファイル処理を見直し、失敗や中断時に不完全なファイルが残りにくくなりました。
  * 同時実行時のファイル衝突を抑制し、安定してエクスポートできるようになりました。
* **バグ修正**
  * CSV出力失敗時のエラー処理と後片付けを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->