### PR TITLE
fix: preserve SQLite result fidelity

### DIFF
--- a/src/app/model/browse/row_detail.rs
+++ b/src/app/model/browse/row_detail.rs
@@ -1,3 +1,4 @@
+use crate::domain::QueryValue;
 use serde_json::Value;
 use unicode_width::UnicodeWidthStr;
 
@@ -36,6 +37,22 @@ impl RowDetailState {
             horizontal_offset: 0,
             active: true,
         }
+    }
+
+    pub fn open_with_values(columns: &[String], values: &[QueryValue]) -> Self {
+        let cells = values
+            .iter()
+            .map(QueryValue::display_value)
+            .collect::<Vec<_>>();
+        let mut state = Self::open(columns, &cells);
+        let object = columns
+            .iter()
+            .zip(values)
+            .map(|(column, value)| (column.clone(), sqlite_json_value(value)))
+            .collect();
+        state.json_text = serde_json::to_string_pretty(&Value::Object(object))
+            .unwrap_or_else(|_| "{}".to_string());
+        state
     }
 
     pub fn close(&mut self) {
@@ -117,6 +134,17 @@ impl RowDetailState {
 
     pub fn json_for_yank(&self) -> String {
         self.json_text.clone()
+    }
+}
+
+fn sqlite_json_value(value: &QueryValue) -> Value {
+    match value {
+        QueryValue::Null => Value::Null,
+        QueryValue::Text(value) => Value::String(value.clone()),
+        QueryValue::Blob(_) => Value::String(value.copy_value()),
+        QueryValue::SqlLiteral(value) => {
+            serde_json::from_str(value).unwrap_or_else(|_| Value::String(value.clone()))
+        }
     }
 }
 

--- a/src/app/model/browse/row_detail.rs
+++ b/src/app/model/browse/row_detail.rs
@@ -251,4 +251,25 @@ mod tests {
 
         assert_eq!(state.content_for_yank(), content);
     }
+
+    #[test]
+    fn typed_values_preserve_sqlite_storage_classes_in_json() {
+        let state = RowDetailState::open_with_values(
+            &[
+                "empty".to_string(),
+                "number_text".to_string(),
+                "blob".to_string(),
+            ],
+            &[
+                QueryValue::Text(String::new()),
+                QueryValue::Text("42".to_string()),
+                QueryValue::Blob(vec![0xAB, 0xCD]),
+            ],
+        );
+
+        assert_eq!(
+            state.json_for_yank(),
+            "{\n  \"blob\": \"X'ABCD'\",\n  \"empty\": \"\",\n  \"number_text\": \"42\"\n}"
+        );
+    }
 }

--- a/src/app/model/browse/row_detail.rs
+++ b/src/app/model/browse/row_detail.rs
@@ -13,15 +13,7 @@ pub struct RowDetailState {
 
 impl RowDetailState {
     pub fn open(columns: &[String], cells: &[String]) -> Self {
-        let mut display_lines = Vec::new();
-        for (col, cell) in columns.iter().zip(cells.iter()) {
-            display_lines.push(col.clone());
-            for line in cell.lines() {
-                display_lines.push(format!("  {line}"));
-            }
-            display_lines.push(String::new());
-        }
-        let display_text = display_lines.join("\n") + "\n";
+        let display_text = Self::display_text(columns, cells);
 
         let mut obj = serde_json::Map::new();
         for (col, cell) in columns.iter().zip(cells.iter()) {
@@ -44,15 +36,33 @@ impl RowDetailState {
             .iter()
             .map(QueryValue::display_value)
             .collect::<Vec<_>>();
-        let mut state = Self::open(columns, &cells);
+        let display_text = Self::display_text(columns, &cells);
         let object = columns
             .iter()
             .zip(values)
             .map(|(column, value)| (column.clone(), sqlite_json_value(value)))
             .collect();
-        state.json_text = serde_json::to_string_pretty(&Value::Object(object))
+        let json_text = serde_json::to_string_pretty(&Value::Object(object))
             .unwrap_or_else(|_| "{}".to_string());
-        state
+        Self {
+            display_text,
+            json_text,
+            scroll_offset: 0,
+            horizontal_offset: 0,
+            active: true,
+        }
+    }
+
+    fn display_text(columns: &[String], cells: &[String]) -> String {
+        let mut display_lines = Vec::new();
+        for (column, cell) in columns.iter().zip(cells.iter()) {
+            display_lines.push(column.clone());
+            for line in cell.lines() {
+                display_lines.push(format!("  {line}"));
+            }
+            display_lines.push(String::new());
+        }
+        display_lines.join("\n") + "\n"
     }
 
     pub fn close(&mut self) {
@@ -270,6 +280,27 @@ mod tests {
         assert_eq!(
             state.json_for_yank(),
             "{\n  \"blob\": \"X'ABCD'\",\n  \"empty\": \"\",\n  \"number_text\": \"42\"\n}"
+        );
+    }
+
+    #[test]
+    fn sql_literals_preserve_json_values_and_invalid_literals_as_strings() {
+        let state = RowDetailState::open_with_values(
+            &[
+                "number".to_string(),
+                "boolean".to_string(),
+                "invalid".to_string(),
+            ],
+            &[
+                QueryValue::SqlLiteral("42".to_string()),
+                QueryValue::SqlLiteral("true".to_string()),
+                QueryValue::SqlLiteral("not json".to_string()),
+            ],
+        );
+
+        assert_eq!(
+            state.json_for_yank(),
+            "{\n  \"boolean\": true,\n  \"invalid\": \"not json\",\n  \"number\": 42\n}"
         );
     }
 }

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -153,7 +153,11 @@ fn selected_cell_value(state: &AppState) -> Option<(usize, usize, String, String
     let row_idx = state.result_interaction.selection().row()?;
     let col_idx = state.result_interaction.selection().cell()?;
     let column_name = result.columns.get(col_idx)?.clone();
-    let cell_value = result.rows().get(row_idx)?.get(col_idx)?.clone();
+    let cell_value = if result.has_typed_values() {
+        result.value_at(row_idx, col_idx)?.copy_value()
+    } else {
+        result.rows().get(row_idx)?.get(col_idx)?.clone()
+    };
     let data_type = selected_column_data_type(state, col_idx).map(ToString::to_string);
     Some((row_idx, col_idx, column_name, cell_value, data_type))
 }

--- a/src/app/update/browse/result/row_detail.rs
+++ b/src/app/update/browse/result/row_detail.rs
@@ -25,7 +25,14 @@ pub fn reduce_row_detail(state: &mut AppState, action: &Action, now: Instant) ->
                 return DispatchResult::handled();
             };
 
-            state.row_detail = RowDetailState::open(&result.columns, cells);
+            state.row_detail = if result.has_typed_values() {
+                let Some(values) = result.values().get(row_idx) else {
+                    return DispatchResult::handled();
+                };
+                RowDetailState::open_with_values(&result.columns, values)
+            } else {
+                RowDetailState::open(&result.columns, cells)
+            };
             state.modal.push_mode(InputMode::RowDetail);
             DispatchResult::handled()
         }

--- a/src/app/update/browse/result/row_detail.rs
+++ b/src/app/update/browse/result/row_detail.rs
@@ -155,7 +155,7 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
-    use crate::domain::{QueryResult, QuerySource};
+    use crate::domain::{QueryResult, QuerySource, QueryValue};
 
     fn state_with_result() -> AppState {
         let mut state = AppState::new("test".to_string());
@@ -203,6 +203,30 @@ mod tests {
                 .json_for_yank()
                 .contains("\"name\": \"alice\"")
         );
+    }
+
+    #[test]
+    fn open_builds_row_detail_from_typed_values() {
+        let mut state = AppState::new("test".to_string());
+        state
+            .query
+            .set_current_result(Arc::new(QueryResult::success_with_values(
+                "SELECT payload".to_string(),
+                vec!["payload".to_string()],
+                vec![vec![QueryValue::Blob(vec![0xAB, 0xCD])]],
+                1,
+                QuerySource::Preview,
+            )));
+        state.result_interaction.activate_cell(0, 0);
+
+        reduce_row_detail(
+            &mut state,
+            &Action::OpenModal(ModalKind::RowDetail),
+            Instant::now(),
+        );
+
+        assert!(state.row_detail.content().contains("BLOB (2 bytes) AB CD"));
+        assert!(state.row_detail.json_for_yank().contains("X'ABCD'"));
     }
 
     #[test]

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -149,7 +149,9 @@ fn clipboard_unavailable() -> Action {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{Column, ColumnAttributes, DatabaseType, QueryResult, QuerySource, Table};
+    use crate::domain::{
+        Column, ColumnAttributes, DatabaseType, QueryResult, QuerySource, QueryValue, Table,
+    };
     use crate::ports::outbound::ddl_generator::DdlGenerator;
     use std::sync::Arc;
 
@@ -240,6 +242,34 @@ mod tests {
                 other => panic!("expected CopyToClipboard, got {other:?}"),
             }
             assert!(state.result_interaction.yank_flash().is_none());
+        }
+
+        #[test]
+        fn typed_blob_cell_emits_lossless_copy_effect() {
+            let mut state = AppState::new("test".to_string());
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    String::new(),
+                    vec!["payload".to_string()],
+                    vec![vec![QueryValue::Blob(vec![0xAB, 0xCD])]],
+                    1,
+                    QuerySource::Preview,
+                )));
+            state.result_interaction.activate_cell(0, 0);
+
+            let effects = reduce_yank(
+                &mut state,
+                &Action::ResultCellYank,
+                &AppServices::stub(),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(matches!(
+                &effects[0],
+                Effect::CopyToClipboard { content, .. } if content == "X'ABCD'"
+            ));
         }
 
         #[test]
@@ -341,6 +371,37 @@ mod tests {
                 other => panic!("expected CopyToClipboard, got {other:?}"),
             }
             assert!(state.result_interaction.yank_flash().is_none());
+        }
+
+        #[test]
+        fn typed_blob_row_emits_lossless_tsv_copy_effect() {
+            let mut state = AppState::new("test".to_string());
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    String::new(),
+                    vec!["id".to_string(), "payload".to_string()],
+                    vec![vec![
+                        QueryValue::Text("1".to_string()),
+                        QueryValue::Blob(vec![0xAB, 0xCD]),
+                    ]],
+                    1,
+                    QuerySource::Preview,
+                )));
+            state.result_interaction.activate_cell(0, 0);
+
+            let effects = reduce_yank(
+                &mut state,
+                &Action::ResultRowYank,
+                &AppServices::stub(),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(matches!(
+                &effects[0],
+                Effect::CopyToClipboard { content, .. } if content == "1\tX'ABCD'"
+            ));
         }
 
         #[test]

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use crate::cmd::effect::Effect;
+use crate::domain::QueryValue;
 use crate::model::app_state::AppState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::inspector_tab::InspectorTab;
@@ -22,12 +23,19 @@ pub fn reduce_yank(
                 state.result_interaction.selection().row(),
                 state.result_interaction.selection().cell(),
             ) {
-                let content = state
-                    .query
-                    .visible_result()
-                    .and_then(|r| r.rows().get(row_idx))
-                    .and_then(|row| row.get(col_idx))
-                    .cloned();
+                let content = state.query.visible_result().and_then(|result| {
+                    if result.has_typed_values() {
+                        result
+                            .value_at(row_idx, col_idx)
+                            .map(QueryValue::copy_value)
+                    } else {
+                        result
+                            .rows()
+                            .get(row_idx)
+                            .and_then(|row| row.get(col_idx))
+                            .cloned()
+                    }
+                });
                 if let Some(value) = content {
                     DispatchResult::handled_with(vec![Effect::CopyToClipboard {
                         content: value,
@@ -71,7 +79,15 @@ pub fn reduce_yank(
                 let content = state
                     .query
                     .visible_result()
-                    .and_then(|r| r.rows().get(row_idx))
+                    .and_then(|result| {
+                        if result.has_typed_values() {
+                            result.values().get(row_idx).map(|row| {
+                                row.iter().map(QueryValue::copy_value).collect::<Vec<_>>()
+                            })
+                        } else {
+                            result.rows().get(row_idx).cloned()
+                        }
+                    })
                     .map(|row| {
                         row.iter()
                             .map(|v| {

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -47,6 +47,25 @@ impl QueryValue {
             Self::Null | Self::Blob(_) => None,
         }
     }
+
+    #[must_use]
+    pub fn copy_value(&self) -> String {
+        match self {
+            Self::Null => "NULL".to_string(),
+            Self::Text(value) | Self::SqlLiteral(value) => value.clone(),
+            Self::Blob(bytes) => {
+                let hex =
+                    bytes
+                        .iter()
+                        .fold(String::with_capacity(bytes.len() * 2), |mut hex, byte| {
+                            use std::fmt::Write as _;
+                            let _ = write!(hex, "{byte:02X}");
+                            hex
+                        });
+                format!("X'{hex}'")
+            }
+        }
+    }
 }
 
 fn escape_display_text(value: &str) -> String {
@@ -92,6 +111,7 @@ pub struct QueryResult {
     values: Vec<Vec<QueryValue>>,
     hidden: HiddenQueryColumns,
     row_count: usize,
+    typed_values: bool,
 }
 
 impl QueryResult {
@@ -115,6 +135,7 @@ impl QueryResult {
             values,
             hidden: HiddenQueryColumns::default(),
             row_count,
+            typed_values: false,
             execution_time_ms,
             source,
             error: None,
@@ -142,6 +163,7 @@ impl QueryResult {
             values,
             hidden: HiddenQueryColumns::default(),
             row_count,
+            typed_values: true,
             execution_time_ms,
             source,
             error: None,
@@ -163,6 +185,7 @@ impl QueryResult {
             values: Vec::new(),
             hidden: HiddenQueryColumns::default(),
             row_count: 0,
+            typed_values: false,
             execution_time_ms,
             source,
             error: Some(error),
@@ -180,6 +203,36 @@ impl QueryResult {
     pub fn with_row_count(mut self, row_count: usize) -> Self {
         self.row_count = row_count;
         self
+    }
+
+    #[must_use]
+    pub fn with_columns_if_empty(mut self, columns: Vec<String>) -> Self {
+        if self.columns.is_empty() {
+            self.columns = columns;
+        }
+        self
+    }
+
+    #[must_use]
+    pub fn without_empty_result_sentinel(mut self) -> Self {
+        self.columns.pop();
+        for (row, values) in self.rows.iter_mut().zip(&mut self.values) {
+            let sentinel = values.pop();
+            row.pop();
+            if sentinel == Some(QueryValue::Null) {
+                values.clear();
+                row.clear();
+            }
+        }
+        self.rows.retain(|row| row.len() == self.columns.len());
+        self.values.retain(|row| row.len() == self.columns.len());
+        self.row_count = self.values.len();
+        self
+    }
+
+    #[must_use]
+    pub fn has_typed_values(&self) -> bool {
+        self.typed_values
     }
 
     #[must_use]

--- a/src/infra/adapters/cached_result_exporter.rs
+++ b/src/infra/adapters/cached_result_exporter.rs
@@ -172,6 +172,24 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn writes_header_for_empty_cached_result() {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("export.csv");
+
+            let row_count = CsvCachedResultExporter
+                .export_cached_result_to_csv(
+                    path.clone(),
+                    vec!["id".to_string(), "payload".to_string()],
+                    vec![],
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(row_count, 0);
+            assert_eq!(std::fs::read_to_string(path).unwrap(), "id,payload\n");
+        }
+
+        #[tokio::test]
         async fn writes_embedded_nul_text_without_display_escaping() {
             let dir = tempdir().unwrap();
             let path = dir.path().join("export.csv");

--- a/src/infra/adapters/cached_result_exporter.rs
+++ b/src/infra/adapters/cached_result_exporter.rs
@@ -176,16 +176,14 @@ mod tests {
             let dir = tempdir().unwrap();
             let path = dir.path().join("export.csv");
 
-            let row_count = CsvCachedResultExporter
-                .export_cached_result_to_csv(
-                    path.clone(),
-                    vec!["id".to_string(), "payload".to_string()],
-                    vec![],
-                )
-                .await
-                .unwrap();
+            write_cached_result_csv(
+                path.clone(),
+                vec!["id".to_string(), "payload".to_string()],
+                vec![],
+            )
+            .await
+            .unwrap();
 
-            assert_eq!(row_count, 0);
             assert_eq!(std::fs::read_to_string(path).unwrap(), "id,payload\n");
         }
 

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -564,8 +564,10 @@ impl QueryExecutor for SqliteAdapter {
             .await?;
         let result = result.with_columns_if_empty(columns);
         Ok(match rowid_alias {
-            Some(alias) => result.with_first_column_hidden(alias.to_string()),
-            None => result,
+            Some(alias) if !result.rows().is_empty() => {
+                result.with_first_column_hidden(alias.to_string())
+            }
+            _ => result,
         })
     }
 
@@ -1020,6 +1022,22 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn empty_rowid_table_preview_keeps_all_visible_columns() {
+            let (_dir, dsn) =
+                test_support::make_sqlite_db("CREATE TABLE users(name TEXT, email TEXT);");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .execute_preview(&dsn, "main", "users", 10, 0)
+                .await
+                .unwrap();
+
+            assert_eq!(result.columns, vec!["name", "email"]);
+            assert!(result.rows().is_empty());
+            assert_eq!(result.row_count(), 0);
+        }
+
+        #[tokio::test]
         async fn preserves_distinct_c0_text_values_in_preview() {
             let (_dir, dsn) = test_support::make_sqlite_db(
                 r"
@@ -1430,6 +1448,25 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.columns, vec!["b"]);
+                assert!(result.rows().is_empty());
+                assert_eq!(result.command_tag, Some(CommandTag::Select(0)));
+            }
+
+            #[tokio::test]
+            async fn empty_cte_select_preserves_projection_columns() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
+
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "WITH q(value) AS (VALUES (1)) SELECT value FROM q WHERE false",
+                        AccessMode::ReadOnly,
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(result.columns, vec!["value"]);
                 assert!(result.rows().is_empty());
                 assert_eq!(result.command_tag, Some(CommandTag::Select(0)));
             }

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -25,9 +25,9 @@ use super::parser::{
     SqliteStatementPlan, aggregate_sqlite_command_tag, append_changes_query_for_plan,
     command_tag_result, is_sqlite_rerunnable_export_query, last_sqlite_result_set,
     parse_affected_rows, parse_count_result, quoted_to_query_result,
-    sqlite_adhoc_execution_query_for_plan, sqlite_export_not_rerunnable_error, sqlite_probe_marker,
-    sqlite_statement_plan, sqlite_statement_tags, statement_counts_as_select_tag,
-    strip_sqlite_probes,
+    sqlite_adhoc_execution_query_for_plan, sqlite_empty_result_sentinel,
+    sqlite_export_not_rerunnable_error, sqlite_probe_marker, sqlite_statement_plan,
+    sqlite_statement_tags, statement_counts_as_select_tag, strip_sqlite_probes,
 };
 
 pub(in crate::adapters::sqlite) const BUSY_TIMEOUT_MS: u64 = 5_000;
@@ -618,10 +618,11 @@ impl QueryExecutor for SqliteAdapter {
         }
 
         let mut result = quoted_to_query_result(query, &stdout, QuerySource::Adhoc, elapsed)?;
+        let empty_sentinel = sqlite_empty_result_sentinel(&marker);
         if result
             .columns
             .last()
-            .is_some_and(|column| column.ends_with("_empty"))
+            .is_some_and(|column| column == &empty_sentinel)
         {
             result = result.without_empty_result_sentinel();
         }
@@ -2162,6 +2163,27 @@ mod tests {
 
                 assert_eq!(result.columns, vec!["id", "name"]);
                 assert_eq!(result.rows(), vec![vec!["1".to_string(), "a".to_string()]]);
+                assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
+            }
+
+            #[tokio::test]
+            async fn dml_returning_preserves_empty_suffix_column() {
+                let (_dir, dsn) = test_support::make_sqlite_db(
+                    "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);",
+                );
+                let adapter = SqliteAdapter::new();
+
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "INSERT INTO users(name) VALUES ('a') RETURNING id AS value_empty",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .unwrap();
+
+                assert_eq!(result.columns, vec!["value_empty"]);
+                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
                 assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
             }
 

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -562,6 +562,7 @@ impl QueryExecutor for SqliteAdapter {
         let result = self
             .execute_quoted_query(path, &query, QuerySource::Preview, true)
             .await?;
+        let result = result.with_columns_if_empty(columns);
         Ok(match rowid_alias {
             Some(alias) => result.with_first_column_hidden(alias.to_string()),
             None => result,
@@ -615,6 +616,13 @@ impl QueryExecutor for SqliteAdapter {
         }
 
         let mut result = quoted_to_query_result(query, &stdout, QuerySource::Adhoc, elapsed)?;
+        if result
+            .columns
+            .last()
+            .is_some_and(|column| column.ends_with("_empty"))
+        {
+            result = result.without_empty_result_sentinel();
+        }
         if let Some(tag) = tag {
             result = result.with_command_tag(tag);
         } else if statements
@@ -1408,7 +1416,7 @@ mod tests {
             }
 
             #[tokio::test]
-            async fn multi_select_empty_trailing_result_returns_empty_result() {
+            async fn multi_select_empty_trailing_result_preserves_projection_columns() {
                 let (_dir, dsn) = test_support::make_sqlite_db("");
                 let adapter = SqliteAdapter::new();
 
@@ -1421,7 +1429,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert!(result.columns.is_empty());
+                assert_eq!(result.columns, vec!["b"]);
                 assert!(result.rows().is_empty());
                 assert_eq!(result.command_tag, Some(CommandTag::Select(0)));
             }

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -749,7 +749,10 @@ pub(in crate::adapters::sqlite::sqlite3) fn sqlite_adhoc_execution_query_for_pla
         parts.push("BEGIN".to_string());
     }
     for (index, statement) in statements.iter().enumerate() {
-        if first_keyword(statement).eq_ignore_ascii_case("SELECT") {
+        if first_keyword(statement).eq_ignore_ascii_case("SELECT")
+            || (first_keyword(statement).eq_ignore_ascii_case("WITH")
+                && !is_dml_statement(statement))
+        {
             parts.push(sqlite_empty_result_frame(statement, marker));
         } else {
             parts.push((*statement).to_string());

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -728,10 +728,14 @@ fn sqlite_result_probe(marker: &str, index: usize) -> String {
 }
 
 fn sqlite_empty_result_frame(statement: &str, marker: &str) -> String {
-    let sentinel = format!("{marker}_empty");
+    let sentinel = sqlite_empty_result_sentinel(marker);
     format!(
         "SELECT _s.* FROM (SELECT 1) AS _p LEFT JOIN (SELECT _q.*, 1 AS \"{sentinel}\" FROM ({statement}) AS _q) AS _s ON true"
     )
+}
+
+pub(in crate::adapters::sqlite::sqlite3) fn sqlite_empty_result_sentinel(marker: &str) -> String {
+    format!("{marker}_empty")
 }
 
 pub(in crate::adapters::sqlite::sqlite3) fn sqlite_adhoc_execution_query_for_plan(

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -727,6 +727,13 @@ fn sqlite_result_probe(marker: &str, index: usize) -> String {
     format!("SELECT {index} AS \"{stmt_col}\", '{marker}' AS \"{marker_col}\"")
 }
 
+fn sqlite_empty_result_frame(statement: &str, marker: &str) -> String {
+    let sentinel = format!("{marker}_empty");
+    format!(
+        "SELECT _s.* FROM (SELECT 1) AS _p LEFT JOIN (SELECT _q.*, 1 AS \"{sentinel}\" FROM ({statement}) AS _q) AS _s ON true"
+    )
+}
+
 pub(in crate::adapters::sqlite::sqlite3) fn sqlite_adhoc_execution_query_for_plan(
     plan: &SqliteStatementPlan<'_>,
     marker: &str,
@@ -742,7 +749,11 @@ pub(in crate::adapters::sqlite::sqlite3) fn sqlite_adhoc_execution_query_for_pla
         parts.push("BEGIN".to_string());
     }
     for (index, statement) in statements.iter().enumerate() {
-        parts.push((*statement).to_string());
+        if first_keyword(statement).eq_ignore_ascii_case("SELECT") {
+            parts.push(sqlite_empty_result_frame(statement, marker));
+        } else {
+            parts.push((*statement).to_string());
+        }
         if plan.is_dml(index) {
             parts.push(sqlite_changes_probe(marker, index));
         }

--- a/src/infra/adapters/sqlite/sqlite3/parser/mod.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/mod.rs
@@ -8,8 +8,8 @@ pub(super) use command_tag::{
 };
 pub(super) use lexer::{
     SqliteStatementPlan, append_changes_query_for_plan, is_sqlite_rerunnable_export_query,
-    sqlite_adhoc_execution_query_for_plan, sqlite_export_not_rerunnable_error, sqlite_probe_marker,
-    sqlite_statement_plan,
+    sqlite_adhoc_execution_query_for_plan, sqlite_empty_result_sentinel,
+    sqlite_export_not_rerunnable_error, sqlite_probe_marker, sqlite_statement_plan,
 };
 pub(super) use output::{
     last_sqlite_result_set, parse_affected_rows, parse_count_result, quoted_to_query_result,


### PR DESCRIPTION
## Problem

SQLite empty results lost their columns, and copy/detail paths could infer new value types from display strings.

## Approach

Keep preview and ad-hoc result columns for zero-row SQLite SELECTs. Route SQLite typed values through cell/row copy and Row Detail JSON, including lossless BLOB copy text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - クエリ結果の型情報を保持し、NULL・テキスト・バイナリ・SQL値を適切に表示・コピーできるようになりました。
  - 行詳細やセル詳細、クリップボードへのコピーで、元の値に応じた形式を利用します。

- **バグ修正**
  - 空の検索結果でも列見出しや投影列が正しく表示されるようになりました。
  - 空結果の不要な値が除外され、CSV出力ではヘッダーのみが生成されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->