### PR TITLE
fix(sqlite): classify side-effect PRAGMAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sabiql treats the SQL modal as SQL-only input. CLI meta-commands such as psql ba
 
 Read-only mode combines app-level write blocking with the database client guard available for the active adapter. PostgreSQL uses a read-only session option; SQLite uses sqlite3's read-only mode.
 
-PostgreSQL multi-statement SQL runs in one transaction. SQLite multi-statement write SQL is wrapped in an explicit transaction unless the input contains transaction control or transaction-incompatible statements such as `PRAGMA journal_mode` changes and `VACUUM`.
+PostgreSQL multi-statement SQL runs in one transaction. SQLite wraps transactional writes, including persistent PRAGMAs such as `user_version`, unless the input contains transaction control or a session-side-effect / transaction-incompatible statement such as `PRAGMA journal_mode`, `PRAGMA foreign_keys`, `PRAGMA synchronous`, or `VACUUM`.
 
 ## Features
 ![hero_1000_20fps](https://github.com/user-attachments/assets/06e1900d-b044-4f29-a2a8-7d7bab5bd3a1)

--- a/src/app/policy/sql/sqlite_export.rs
+++ b/src/app/policy/sql/sqlite_export.rs
@@ -48,7 +48,7 @@ pub fn is_sqlite_rerunnable_export_query(query: &str) -> bool {
     }
 }
 
-fn is_sqlite_rerunnable_export_statement(statement: &str) -> bool {
+pub fn is_sqlite_rerunnable_export_statement(statement: &str) -> bool {
     if sqlite_statement_classification(statement) != SqliteStatementClassification::ReadOnly {
         return false;
     }

--- a/src/app/policy/sql/sqlite_export.rs
+++ b/src/app/policy/sql/sqlite_export.rs
@@ -1,7 +1,10 @@
 use crate::domain::{DatabaseType, QuerySource};
-use crate::policy::sql::statement_classifier::{classify, first_keyword};
+use crate::policy::sql::sqlite_transaction::{
+    SqliteStatementClassification, sqlite_statement_classification,
+};
+use crate::policy::sql::statement_classifier::first_keyword;
 use crate::policy::write::sql_risk::{
-    MultiStatementDecision, evaluate_multi_statement_for_database, evaluate_sql_risk_for_database,
+    MultiStatementDecision, evaluate_multi_statement_for_database,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -46,97 +49,13 @@ pub fn is_sqlite_rerunnable_export_query(query: &str) -> bool {
 }
 
 fn is_sqlite_rerunnable_export_statement(statement: &str) -> bool {
-    if is_write_statement(statement)
-        || is_dml_statement(statement)
-        || is_transaction_control(statement)
-    {
+    if sqlite_statement_classification(statement) != SqliteStatementClassification::ReadOnly {
         return false;
     }
-    let kind = classify(statement);
-    evaluate_sql_risk_for_database(DatabaseType::SQLite, &kind, statement).read_only_allowed
-}
-
-fn is_write_statement(statement: &str) -> bool {
     matches!(
         first_keyword(statement).as_deref(),
-        Some("INSERT" | "REPLACE" | "UPDATE" | "DELETE" | "CREATE" | "ALTER" | "DROP" | "TRUNCATE")
+        Some("SELECT" | "EXPLAIN" | "VALUES" | "WITH" | "PRAGMA")
     )
-}
-
-fn is_transaction_control(statement: &str) -> bool {
-    matches!(
-        first_keyword(statement).as_deref(),
-        Some("BEGIN" | "COMMIT" | "END" | "ROLLBACK" | "SAVEPOINT" | "RELEASE")
-    )
-}
-
-fn is_dml_statement(statement: &str) -> bool {
-    dml_keyword(statement).is_some()
-}
-
-fn dml_keyword(statement: &str) -> Option<&'static str> {
-    let keyword = first_keyword(statement)?;
-    if keyword.eq_ignore_ascii_case("INSERT") {
-        return Some("INSERT");
-    }
-    if keyword.eq_ignore_ascii_case("REPLACE") {
-        return Some("INSERT");
-    }
-    if keyword.eq_ignore_ascii_case("UPDATE") {
-        return Some("UPDATE");
-    }
-    if keyword.eq_ignore_ascii_case("DELETE") {
-        return Some("DELETE");
-    }
-    if !keyword.eq_ignore_ascii_case("WITH") {
-        return None;
-    }
-
-    let lower = statement.to_lowercase();
-    let chars: Vec<(usize, char)> = lower.char_indices().collect();
-    let mut offset = 0usize;
-    while let Some((next_keyword, end)) = next_keyword_from(&lower, &chars, offset) {
-        if next_keyword.eq_ignore_ascii_case("INSERT") {
-            return Some("INSERT");
-        }
-        if next_keyword.eq_ignore_ascii_case("REPLACE") {
-            return Some("INSERT");
-        }
-        if next_keyword.eq_ignore_ascii_case("UPDATE") {
-            return Some("UPDATE");
-        }
-        if next_keyword.eq_ignore_ascii_case("DELETE") {
-            return Some("DELETE");
-        }
-        offset = end;
-    }
-    None
-}
-
-fn next_keyword_from(
-    lower: &str,
-    chars: &[(usize, char)],
-    start: usize,
-) -> Option<(String, usize)> {
-    let mut i = 0usize;
-    while i < chars.len() {
-        if chars[i].0 < start {
-            i += 1;
-            continue;
-        }
-        if chars[i].1.is_ascii_alphabetic() {
-            let keyword_start = chars[i].0;
-            let mut j = i + 1;
-            while j < chars.len() && (chars[j].1.is_ascii_alphanumeric() || chars[j].1 == '_') {
-                j += 1;
-            }
-            let keyword = lower[keyword_start..chars[j - 1].0 + chars[j - 1].1.len_utf8()]
-                .to_ascii_uppercase();
-            return Some((keyword, chars[j - 1].0 + chars[j - 1].1.len_utf8()));
-        }
-        i += 1;
-    }
-    None
 }
 
 #[cfg(test)]
@@ -201,6 +120,18 @@ mod tests {
             assert!(!is_sqlite_rerunnable_export_query(
                 "PRAGMA foreign_keys = OFF"
             ));
+        }
+
+        #[test]
+        fn persistent_pragma_write_is_not_rerunnable() {
+            assert!(!is_sqlite_rerunnable_export_query(
+                "PRAGMA user_version = 42"
+            ));
+        }
+
+        #[test]
+        fn maintenance_statement_is_not_rerunnable() {
+            assert!(!is_sqlite_rerunnable_export_query("REINDEX users_name_idx"));
         }
 
         #[rstest]

--- a/src/app/policy/sql/sqlite_transaction.rs
+++ b/src/app/policy/sql/sqlite_transaction.rs
@@ -1,4 +1,13 @@
-use crate::policy::sql::statement_classifier::{StatementKind, first_keyword};
+use crate::policy::sql::statement_classifier::{StatementKind, classify, first_keyword};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqliteStatementClassification {
+    ReadOnly,
+    TransactionalWrite,
+    SessionSideEffect,
+    TransactionIncompatible,
+    TransactionControl,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SqliteTransactionPolicy {
@@ -19,31 +28,90 @@ impl SqliteTransactionPolicy {
     }
 }
 
-pub fn sqlite_transaction_policy(
-    statements: &[String],
-    statement_kinds: &[StatementKind],
-    has_write: bool,
+pub fn sqlite_transaction_policy(statements: &[String]) -> SqliteTransactionPolicy {
+    let classifications: Vec<_> = statements
+        .iter()
+        .map(|statement| sqlite_statement_classification(statement))
+        .collect();
+    sqlite_transaction_policy_for_classifications(statements.len(), &classifications)
+}
+
+pub fn sqlite_transaction_policy_for_classifications(
+    statement_count: usize,
+    classifications: &[SqliteStatementClassification],
 ) -> SqliteTransactionPolicy {
-    if statements.len() != statement_kinds.len() {
+    if statement_count != classifications.len() {
         return SqliteTransactionPolicy::ClassificationMismatch;
     }
-    if statements.len() < 2 || !has_write {
+    if statement_count < 2
+        || !classifications.iter().any(|classification| {
+            matches!(
+                classification,
+                SqliteStatementClassification::TransactionalWrite
+            )
+        })
+    {
         return SqliteTransactionPolicy::NotNeeded;
     }
-
-    if statement_kinds
-        .iter()
-        .any(|kind| matches!(kind, StatementKind::Transaction))
-    {
+    if classifications.iter().any(|classification| {
+        matches!(
+            classification,
+            SqliteStatementClassification::TransactionControl
+        )
+    }) {
         return SqliteTransactionPolicy::UserManaged;
     }
-    if statements
-        .iter()
-        .any(|statement| is_transaction_incompatible(statement))
-    {
+    if classifications.iter().any(|classification| {
+        matches!(
+            classification,
+            SqliteStatementClassification::SessionSideEffect
+                | SqliteStatementClassification::TransactionIncompatible
+        )
+    }) {
         return SqliteTransactionPolicy::IncompatibleStatement;
     }
     SqliteTransactionPolicy::AutoWrap
+}
+
+pub fn sqlite_statement_classification(statement: &str) -> SqliteStatementClassification {
+    if matches!(classify(statement), StatementKind::Transaction) {
+        return SqliteStatementClassification::TransactionControl;
+    }
+    if is_transaction_incompatible(statement) {
+        return SqliteStatementClassification::TransactionIncompatible;
+    }
+    if is_transactional_pragma_write(statement) {
+        return SqliteStatementClassification::TransactionalWrite;
+    }
+    if is_session_pragma_side_effect(statement) {
+        return SqliteStatementClassification::SessionSideEffect;
+    }
+    if matches!(
+        first_keyword(statement).as_deref(),
+        Some("ATTACH" | "DETACH")
+    ) {
+        return SqliteStatementClassification::SessionSideEffect;
+    }
+    if matches!(
+        first_keyword(statement).as_deref(),
+        Some("ANALYZE" | "REINDEX" | "REPLACE")
+    ) {
+        return SqliteStatementClassification::TransactionalWrite;
+    }
+    if matches!(
+        classify(statement),
+        StatementKind::Insert
+            | StatementKind::Update { .. }
+            | StatementKind::Delete { .. }
+            | StatementKind::Create
+            | StatementKind::Alter
+            | StatementKind::Drop
+            | StatementKind::Truncate
+    ) {
+        SqliteStatementClassification::TransactionalWrite
+    } else {
+        SqliteStatementClassification::ReadOnly
+    }
 }
 
 pub fn is_transaction_incompatible(statement: &str) -> bool {
@@ -53,7 +121,49 @@ pub fn is_transaction_incompatible(statement: &str) -> bool {
     let Some((name, tail)) = pragma_name_and_tail(statement) else {
         return false;
     };
-    matches!(name.as_str(), "journal_mode" | "foreign_keys") && pragma_has_value(tail)
+    matches!(
+        name.as_str(),
+        "journal_mode" | "foreign_keys" | "synchronous"
+    ) && pragma_has_value(tail)
+}
+
+fn is_transactional_pragma_write(statement: &str) -> bool {
+    let Some((name, tail)) = pragma_name_and_tail(statement) else {
+        return false;
+    };
+    matches!(name.as_str(), "application_id" | "user_version") && pragma_has_value(tail)
+}
+
+fn is_session_pragma_side_effect(statement: &str) -> bool {
+    let Some((name, tail)) = pragma_name_and_tail(statement) else {
+        return false;
+    };
+    (pragma_has_value(tail) && !is_read_only_parameterized_pragma(&name))
+        || matches!(
+            name.as_str(),
+            "optimize" | "incremental_vacuum" | "wal_checkpoint"
+        )
+}
+
+fn is_read_only_parameterized_pragma(name: &str) -> bool {
+    matches!(
+        name,
+        "table_info"
+            | "table_xinfo"
+            | "index_info"
+            | "index_xinfo"
+            | "index_list"
+            | "foreign_key_list"
+            | "database_list"
+            | "table_list"
+            | "pragma_list"
+            | "function_list"
+            | "module_list"
+            | "collation_list"
+            | "integrity_check"
+            | "quick_check"
+            | "column_info"
+    )
 }
 
 fn pragma_has_value(tail: &str) -> bool {
@@ -106,16 +216,11 @@ fn pragma_name_and_tail(statement: &str) -> Option<(String, &str)> {
 mod tests {
     use super::*;
     use crate::domain::DatabaseType;
-    use crate::policy::sql::statement_classifier::classify;
     use crate::policy::write::sql_risk::split_statements_for_database;
 
     fn policy_for(sql: &str) -> SqliteTransactionPolicy {
         let statements = split_statements_for_database(DatabaseType::SQLite, sql);
-        let kinds: Vec<_> = statements
-            .iter()
-            .map(|statement| classify(statement))
-            .collect();
-        sqlite_transaction_policy(&statements, &kinds, true)
+        sqlite_transaction_policy(&statements)
     }
 
     #[test]
@@ -160,10 +265,55 @@ mod tests {
 
     #[test]
     fn classification_mismatch_is_not_treated_as_not_needed() {
-        let statements = vec!["INSERT INTO users(id) VALUES (1)".to_string()];
         assert_eq!(
-            sqlite_transaction_policy(&statements, &[], true),
+            sqlite_transaction_policy_for_classifications(1, &[]),
             SqliteTransactionPolicy::ClassificationMismatch
+        );
+    }
+
+    #[test]
+    fn persistent_pragma_writes_are_transactional() {
+        for sql in ["PRAGMA user_version = 42", "PRAGMA application_id(7)"] {
+            assert_eq!(
+                sqlite_statement_classification(sql),
+                SqliteStatementClassification::TransactionalWrite,
+                "{sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn persistent_pragma_write_enables_auto_wrap_for_multi_statement_sql() {
+        let statements = vec![
+            "PRAGMA user_version = 42".to_string(),
+            "SELECT * FROM missing_table".to_string(),
+        ];
+
+        assert_eq!(
+            sqlite_transaction_policy(&statements),
+            SqliteTransactionPolicy::AutoWrap
+        );
+    }
+
+    #[test]
+    fn session_pragma_changes_are_not_implicitly_atomic() {
+        for sql in [
+            "PRAGMA cache_size = 2000",
+            "PRAGMA locking_mode = EXCLUSIVE",
+        ] {
+            assert_eq!(
+                sqlite_statement_classification(sql),
+                SqliteStatementClassification::SessionSideEffect,
+                "{sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn synchronous_change_is_transaction_incompatible() {
+        assert_eq!(
+            sqlite_statement_classification("PRAGMA synchronous = NORMAL"),
+            SqliteStatementClassification::TransactionIncompatible
         );
     }
 }

--- a/src/app/policy/sql/sqlite_transaction.rs
+++ b/src/app/policy/sql/sqlite_transaction.rs
@@ -192,24 +192,36 @@ fn pragma_name_and_tail(statement: &str) -> Option<(String, &str)> {
         return None;
     }
     let tail = trim_sql_prefix(trimmed.get(6..)?);
-    let (name, rest) = match tail.as_bytes().first()? {
+    let (first_name, rest) = pragma_identifier_and_tail(tail)?;
+    let rest = trim_sql_prefix(rest);
+    let (name, rest) = if let Some(rest) = rest.strip_prefix('.') {
+        let (name, rest) = pragma_identifier_and_tail(trim_sql_prefix(rest))?;
+        (name, rest)
+    } else {
+        (first_name, rest)
+    };
+    Some((name.to_ascii_lowercase(), rest))
+}
+
+fn pragma_identifier_and_tail(sql: &str) -> Option<(&str, &str)> {
+    let (name, rest) = match sql.as_bytes().first()? {
         b'"' | b'\'' | b'`' => {
-            let quote = tail.as_bytes()[0] as char;
-            let end = tail[1..].find(quote)? + 1;
-            (tail.get(1..end)?, tail.get(end + 1..)?)
+            let quote = sql.as_bytes()[0] as char;
+            let end = sql[1..].find(quote)? + 1;
+            (sql.get(1..end)?, sql.get(end + 1..)?)
         }
         b'[' => {
-            let end = tail.find(']')?;
-            (tail.get(1..end)?, tail.get(end + 1..)?)
+            let end = sql.find(']')?;
+            (sql.get(1..end)?, sql.get(end + 1..)?)
         }
         _ => {
-            let end = tail
-                .find(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_' || ch == '.'))
-                .unwrap_or(tail.len());
-            (tail.get(..end)?, tail.get(end..)?)
+            let end = sql
+                .find(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
+                .unwrap_or(sql.len());
+            (sql.get(..end)?, sql.get(end..)?)
         }
     };
-    Some((name.rsplit('.').next()?.to_ascii_lowercase(), rest))
+    (!name.is_empty()).then_some((name, rest))
 }
 
 #[cfg(test)]
@@ -273,7 +285,12 @@ mod tests {
 
     #[test]
     fn persistent_pragma_writes_are_transactional() {
-        for sql in ["PRAGMA user_version = 42", "PRAGMA application_id(7)"] {
+        for sql in [
+            "PRAGMA user_version = 42",
+            "PRAGMA application_id(7)",
+            "PRAGMA \"main\".\"user_version\" = 42",
+            "PRAGMA [main].[application_id](7)",
+        ] {
             assert_eq!(
                 sqlite_statement_classification(sql),
                 SqliteStatementClassification::TransactionalWrite,

--- a/src/app/policy/sql/sqlite_transaction.rs
+++ b/src/app/policy/sql/sqlite_transaction.rs
@@ -9,6 +9,13 @@ pub enum SqliteStatementClassification {
     TransactionControl,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SqlitePragma {
+    pub name: String,
+    pub has_value: bool,
+    pub value: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SqliteTransactionPolicy {
     AutoWrap,
@@ -43,14 +50,7 @@ pub fn sqlite_transaction_policy_for_classifications(
     if statement_count != classifications.len() {
         return SqliteTransactionPolicy::ClassificationMismatch;
     }
-    if statement_count < 2
-        || !classifications.iter().any(|classification| {
-            matches!(
-                classification,
-                SqliteStatementClassification::TransactionalWrite
-            )
-        })
-    {
+    if statement_count < 2 {
         return SqliteTransactionPolicy::NotNeeded;
     }
     if classifications.iter().any(|classification| {
@@ -70,7 +70,16 @@ pub fn sqlite_transaction_policy_for_classifications(
     }) {
         return SqliteTransactionPolicy::IncompatibleStatement;
     }
-    SqliteTransactionPolicy::AutoWrap
+    if classifications.iter().any(|classification| {
+        matches!(
+            classification,
+            SqliteStatementClassification::TransactionalWrite
+        )
+    }) {
+        SqliteTransactionPolicy::AutoWrap
+    } else {
+        SqliteTransactionPolicy::NotNeeded
+    }
 }
 
 pub fn sqlite_statement_classification(statement: &str) -> SqliteStatementClassification {
@@ -118,29 +127,29 @@ pub fn is_transaction_incompatible(statement: &str) -> bool {
     if first_keyword(statement).as_deref() == Some("VACUUM") {
         return true;
     }
-    let Some((name, tail)) = pragma_name_and_tail(statement) else {
+    let Some(pragma) = parse_sqlite_pragma(statement) else {
         return false;
     };
     matches!(
-        name.as_str(),
+        pragma.name.as_str(),
         "journal_mode" | "foreign_keys" | "synchronous"
-    ) && pragma_has_value(tail)
+    ) && pragma.has_value
 }
 
 fn is_transactional_pragma_write(statement: &str) -> bool {
-    let Some((name, tail)) = pragma_name_and_tail(statement) else {
+    let Some(pragma) = parse_sqlite_pragma(statement) else {
         return false;
     };
-    matches!(name.as_str(), "application_id" | "user_version") && pragma_has_value(tail)
+    matches!(pragma.name.as_str(), "application_id" | "user_version") && pragma.has_value
 }
 
 fn is_session_pragma_side_effect(statement: &str) -> bool {
-    let Some((name, tail)) = pragma_name_and_tail(statement) else {
+    let Some(pragma) = parse_sqlite_pragma(statement) else {
         return false;
     };
-    (pragma_has_value(tail) && !is_read_only_parameterized_pragma(&name))
+    (pragma.has_value && !is_read_only_parameterized_pragma(&pragma.name))
         || matches!(
-            name.as_str(),
+            pragma.name.as_str(),
             "optimize" | "incremental_vacuum" | "wal_checkpoint"
         )
 }
@@ -166,11 +175,6 @@ fn is_read_only_parameterized_pragma(name: &str) -> bool {
     )
 }
 
-fn pragma_has_value(tail: &str) -> bool {
-    let tail = trim_sql_prefix(tail);
-    tail.starts_with('=') || tail.starts_with('(')
-}
-
 fn trim_sql_prefix(mut sql: &str) -> &str {
     loop {
         let trimmed = sql.trim_start();
@@ -186,7 +190,7 @@ fn trim_sql_prefix(mut sql: &str) -> &str {
     }
 }
 
-fn pragma_name_and_tail(statement: &str) -> Option<(String, &str)> {
+pub fn parse_sqlite_pragma(statement: &str) -> Option<SqlitePragma> {
     let trimmed = trim_sql_prefix(statement);
     if !trimmed.get(..6)?.eq_ignore_ascii_case("PRAGMA") {
         return None;
@@ -200,7 +204,27 @@ fn pragma_name_and_tail(statement: &str) -> Option<(String, &str)> {
     } else {
         (first_name, rest)
     };
-    Some((name.to_ascii_lowercase(), rest))
+    let rest = trim_sql_prefix(rest);
+    let has_value = rest.starts_with('=') || rest.starts_with('(');
+    let value = pragma_value(rest);
+    Some(SqlitePragma {
+        name: name.to_ascii_lowercase(),
+        has_value,
+        value,
+    })
+}
+
+fn pragma_value(tail: &str) -> Option<String> {
+    let value = if let Some(value) = tail.strip_prefix('=') {
+        value
+    } else {
+        let value = tail.strip_prefix('(')?;
+        &value[..value.find(')')?]
+    };
+    value
+        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
+        .find(|part| !part.is_empty())
+        .map(str::to_ascii_lowercase)
 }
 
 fn pragma_identifier_and_tail(sql: &str) -> Option<(&str, &str)> {
@@ -313,6 +337,20 @@ mod tests {
     }
 
     #[test]
+    fn side_effect_pragma_requires_acknowledgement_without_a_transactional_write() {
+        for sql in [
+            "PRAGMA synchronous = NORMAL; SELECT 1",
+            "PRAGMA cache_size = 2000; SELECT 1",
+        ] {
+            assert_eq!(
+                policy_for(sql),
+                SqliteTransactionPolicy::IncompatibleStatement,
+                "{sql}"
+            );
+        }
+    }
+
+    #[test]
     fn session_pragma_changes_are_not_implicitly_atomic() {
         for sql in [
             "PRAGMA cache_size = 2000",
@@ -332,5 +370,26 @@ mod tests {
             sqlite_statement_classification("PRAGMA synchronous = NORMAL"),
             SqliteStatementClassification::TransactionIncompatible
         );
+    }
+
+    #[test]
+    fn quoted_schema_pragma_is_normalized_with_its_value() {
+        for (sql, expected_name, expected_value) in [
+            (
+                "PRAGMA \"main\".\"foreign_keys\" = OFF",
+                "foreign_keys",
+                Some("off"),
+            ),
+            (
+                "PRAGMA [main].[journal_mode](WAL)",
+                "journal_mode",
+                Some("wal"),
+            ),
+        ] {
+            let pragma = parse_sqlite_pragma(sql).unwrap();
+
+            assert_eq!(pragma.name, expected_name, "{sql}");
+            assert_eq!(pragma.value.as_deref(), expected_value, "{sql}");
+        }
     }
 }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1,7 +1,8 @@
 use super::write_guardrails::{self, RiskLevel};
 use crate::domain::DatabaseType;
 use crate::policy::sql::sqlite_transaction::{
-    SqliteTransactionPolicy, is_transaction_incompatible, sqlite_transaction_policy,
+    SqliteStatementClassification, SqliteTransactionPolicy, sqlite_statement_classification,
+    sqlite_transaction_policy,
 };
 use crate::policy::sql::statement_classifier::{
     StatementKind, advance_single_quote, classify, collect_top_level_tokens, drop_subtype,
@@ -512,13 +513,12 @@ pub fn evaluate_multi_statement_for_database(
         .collect();
     let has_acknowledge = !ack_reasons.is_empty();
     let mixed_ack_reasons = ack_reasons.windows(2).any(|w| w[0] != w[1]);
-    let statement_kinds: Vec<_> = decisions.iter().map(|(_, kind, _)| kind.clone()).collect();
+    let sqlite_classifications: Vec<_> = statements
+        .iter()
+        .map(|statement| sqlite_statement_classification(statement))
+        .collect();
     let transaction_policy = if database_type == DatabaseType::SQLite {
-        sqlite_transaction_policy(
-            &statements,
-            &statement_kinds,
-            decisions.iter().any(|(_, _, d)| !d.read_only_allowed),
-        )
+        sqlite_transaction_policy(&statements)
     } else {
         SqliteTransactionPolicy::NotNeeded
     };
@@ -539,7 +539,11 @@ pub fn evaluate_multi_statement_for_database(
             .enumerate()
             .any(|(index, (_, _, decision))| {
                 matches!(decision.confirmation, ConfirmationType::Acknowledge { .. })
-                    && !is_transaction_incompatible(&statements[index])
+                    && !matches!(
+                        sqlite_classifications[index],
+                        SqliteStatementClassification::SessionSideEffect
+                            | SqliteStatementClassification::TransactionIncompatible
+                    )
             });
     if (has_table_name_input && has_acknowledge)
         || mixed_ack_reasons
@@ -832,10 +836,6 @@ fn top_level_char_index(sql: &str, target: char) -> Option<usize> {
     None
 }
 
-fn top_level_contains_char(sql: &str, target: char) -> bool {
-    top_level_char_index(sql, target).is_some()
-}
-
 fn parenthesized_pragma_value(sql: &str) -> Option<String> {
     let open = top_level_char_index(sql, '(')?;
     let close = sql[open + 1..].find(')')? + open + 1;
@@ -845,45 +845,24 @@ fn parenthesized_pragma_value(sql: &str) -> Option<String> {
         .map(str::to_lowercase)
 }
 
-fn sqlite_read_only_parameterized_pragma(name: &str) -> bool {
-    matches!(
-        name,
-        "table_info"
-            | "table_xinfo"
-            | "index_info"
-            | "index_xinfo"
-            | "index_list"
-            | "foreign_key_list"
-            | "database_list"
-            | "table_list"
-            | "pragma_list"
-            | "function_list"
-            | "module_list"
-            | "collation_list"
-            | "integrity_check"
-            | "quick_check"
-            | "column_info"
-    )
-}
-
 fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
+    match sqlite_statement_classification(sql) {
+        SqliteStatementClassification::ReadOnly => return Some(low_immediate()),
+        SqliteStatementClassification::TransactionalWrite => {
+            return Some(SqlRiskDecision {
+                risk_level: RiskLevel::Medium,
+                confirmation: ConfirmationType::Immediate,
+                read_only_allowed: false,
+            });
+        }
+        SqliteStatementClassification::SessionSideEffect
+        | SqliteStatementClassification::TransactionIncompatible
+        | SqliteStatementClassification::TransactionControl => {}
+    }
+
     let tokens = top_level_token_lowers(sql);
     let name = tokens.get(1)?;
     let pragma_name = name.rsplit('.').next().unwrap_or(name);
-    let has_assignment = top_level_contains_char(sql, '=') || tokens.len() > 2;
-    let has_parenthesized_value = top_level_contains_char(sql, '(');
-    let is_read_only_parameterized =
-        has_parenthesized_value && sqlite_read_only_parameterized_pragma(pragma_name);
-    let has_side_effect_without_assignment = (has_parenthesized_value
-        && !is_read_only_parameterized)
-        || matches!(
-            pragma_name,
-            "optimize" | "incremental_vacuum" | "wal_checkpoint"
-        );
-
-    if !has_assignment && !has_side_effect_without_assignment {
-        return Some(low_immediate());
-    }
 
     let parenthesized_value = parenthesized_pragma_value(sql);
     let value = tokens

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1,8 +1,8 @@
 use super::write_guardrails::{self, RiskLevel};
 use crate::domain::DatabaseType;
 use crate::policy::sql::sqlite_transaction::{
-    SqliteStatementClassification, SqliteTransactionPolicy, sqlite_statement_classification,
-    sqlite_transaction_policy,
+    SqliteStatementClassification, SqliteTransactionPolicy, parse_sqlite_pragma,
+    sqlite_statement_classification, sqlite_transaction_policy_for_classifications,
 };
 use crate::policy::sql::statement_classifier::{
     StatementKind, advance_single_quote, classify, collect_top_level_tokens, drop_subtype,
@@ -518,7 +518,7 @@ pub fn evaluate_multi_statement_for_database(
         .map(|statement| sqlite_statement_classification(statement))
         .collect();
     let transaction_policy = if database_type == DatabaseType::SQLite {
-        sqlite_transaction_policy(&statements)
+        sqlite_transaction_policy_for_classifications(statements.len(), &sqlite_classifications)
     } else {
         SqliteTransactionPolicy::NotNeeded
     };
@@ -784,67 +784,6 @@ fn sqlite_identifier_after(sql: &str, start: usize) -> Option<String> {
     Some(parts.join("."))
 }
 
-fn top_level_char_index(sql: &str, target: char) -> Option<usize> {
-    let chars: Vec<(usize, char)> = sql.char_indices().collect();
-    let mut i = 0;
-    let mut depth: i32 = 0;
-    let mut in_string = false;
-
-    while i < chars.len() {
-        let (byte_pos, ch) = chars[i];
-
-        if let Some(next_i) = skip_line_comment(&chars, i, ch) {
-            i = next_i;
-            continue;
-        }
-        if let Some(next_i) = skip_block_comment(&chars, i, ch) {
-            i = next_i;
-            continue;
-        }
-        if let Some(next_i) = advance_single_quote(&chars, i, ch, &mut in_string) {
-            i = next_i;
-            continue;
-        }
-        if in_string {
-            i += 1;
-            continue;
-        }
-        if let Some(next_i) = skip_double_quoted_identifier(&chars, i, ch) {
-            i = next_i;
-            continue;
-        }
-        if let Some(next_i) = skip_sqlite_quoted_identifier(&chars, i, ch) {
-            i = next_i;
-            continue;
-        }
-        if let Some(next_i) = skip_dollar_quoted_string(sql, &chars, i, byte_pos, ch) {
-            i = next_i;
-            continue;
-        }
-
-        if depth == 0 && ch == target {
-            return Some(byte_pos);
-        }
-        if ch == '(' {
-            depth += 1;
-        } else if ch == ')' {
-            depth -= 1;
-        }
-        i += 1;
-    }
-
-    None
-}
-
-fn parenthesized_pragma_value(sql: &str) -> Option<String> {
-    let open = top_level_char_index(sql, '(')?;
-    let close = sql[open + 1..].find(')')? + open + 1;
-    sql[open + 1..close]
-        .split(|ch: char| !ch.is_alphanumeric() && ch != '_')
-        .find(|part| !part.is_empty())
-        .map(str::to_lowercase)
-}
-
 fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
     match sqlite_statement_classification(sql) {
         SqliteStatementClassification::ReadOnly => return Some(low_immediate()),
@@ -860,15 +799,9 @@ fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
         | SqliteStatementClassification::TransactionControl => {}
     }
 
-    let tokens = top_level_token_lowers(sql);
-    let name = tokens.get(1)?;
-    let pragma_name = name.rsplit('.').next().unwrap_or(name);
-
-    let parenthesized_value = parenthesized_pragma_value(sql);
-    let value = tokens
-        .get(2)
-        .map(String::as_str)
-        .or(parenthesized_value.as_deref());
+    let pragma = parse_sqlite_pragma(sql)?;
+    let pragma_name = pragma.name.as_str();
+    let value = pragma.value.as_deref();
     let dangerous = matches!(
         pragma_name,
         "writable_schema"
@@ -900,9 +833,11 @@ fn sqlite_pragma_risk(sql: &str) -> Option<SqlRiskDecision> {
 
 fn evaluate_sqlite_specific_risk(sql: &str) -> Option<SqlRiskDecision> {
     let effective = statement_after_leading_ctes(sql);
+    if parse_sqlite_pragma(effective).is_some() {
+        return sqlite_pragma_risk(effective);
+    }
     let tokens = top_level_token_lowers(effective);
     match tokens.first().map(String::as_str)? {
-        "pragma" => sqlite_pragma_risk(effective),
         "attach" | "detach" | "vacuum" | "reindex" | "analyze" => {
             Some(high_acknowledge_keyword(&tokens[0]))
         }
@@ -1302,6 +1237,8 @@ CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
             #[case::writable_schema_call("PRAGMA writable_schema(ON)")]
             #[case::foreign_keys_off("PRAGMA foreign_keys = OFF")]
             #[case::foreign_keys_call_off("PRAGMA foreign_keys(OFF)")]
+            #[case::quoted_schema_foreign_keys_off("PRAGMA \"main\".\"foreign_keys\" = OFF")]
+            #[case::bracket_schema_journal_mode("PRAGMA [main].[journal_mode](WAL)")]
             #[case::journal_mode("PRAGMA journal_mode = WAL")]
             #[case::journal_mode_call("PRAGMA journal_mode(WAL)")]
             #[case::locking_mode("PRAGMA locking_mode = EXCLUSIVE")]
@@ -1678,6 +1615,34 @@ CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
                         ));
                     }
                     _ => panic!("expected Allow"),
+                }
+            }
+
+            #[test]
+            fn sqlite_side_effect_without_transactional_write_requires_non_atomic_acknowledgement()
+            {
+                for sql in [
+                    "PRAGMA synchronous = NORMAL; SELECT 1",
+                    "PRAGMA cache_size = 2000; SELECT 1",
+                ] {
+                    let result = evaluate_multi_statement_for_database(DatabaseType::SQLite, sql);
+
+                    assert!(
+                        matches!(
+                            result,
+                            MultiStatementDecision::Allow {
+                                risk: SqlRiskDecision {
+                                    confirmation: ConfirmationType::Acknowledge {
+                                        reason: AcknowledgeReason::NonAtomicTransaction,
+                                        ..
+                                    },
+                                    ..
+                                },
+                                ..
+                            }
+                        ),
+                        "{sql}"
+                    );
                 }
             }
 

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -1577,24 +1577,36 @@ mod tests {
                 }
 
                 #[tokio::test]
-                async fn persistent_pragma_write_rolls_back_when_a_later_statement_fails() {
-                    let (_dir, dsn) = test_support::make_sqlite_db("");
-                    let adapter = SqliteAdapter::new();
+                async fn persistent_pragma_writes_roll_back_when_a_later_statement_fails() {
+                    for (write, read) in [
+                        ("PRAGMA user_version = 42", "PRAGMA user_version"),
+                        (
+                            "PRAGMA \"main\".\"user_version\" = 42",
+                            "PRAGMA user_version",
+                        ),
+                        ("PRAGMA [main].[application_id](7)", "PRAGMA application_id"),
+                    ] {
+                        let (_dir, dsn) = test_support::make_sqlite_db("");
+                        let adapter = SqliteAdapter::new();
 
-                    let result = adapter
-                        .execute_adhoc(
-                            &dsn,
-                            "PRAGMA user_version = 42; SELECT * FROM missing_table",
-                            AccessMode::ReadWrite,
-                        )
-                        .await;
+                        let result = adapter
+                            .execute_adhoc(
+                                &dsn,
+                                &format!("{write}; SELECT * FROM missing_table"),
+                                AccessMode::ReadWrite,
+                            )
+                            .await;
 
-                    assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
-                    let user_version = adapter
-                        .execute_adhoc(&dsn, "PRAGMA user_version", AccessMode::ReadOnly)
-                        .await
-                        .unwrap();
-                    assert_eq!(user_version.rows(), vec![vec!["0".to_string()]]);
+                        assert!(
+                            matches!(result, Err(DbOperationError::ObjectMissing(_))),
+                            "{write}"
+                        );
+                        let value = adapter
+                            .execute_adhoc(&dsn, read, AccessMode::ReadOnly)
+                            .await
+                            .unwrap();
+                        assert_eq!(value.rows(), vec![vec!["0".to_string()]], "{write}");
+                    }
                 }
 
                 #[tokio::test]

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -1577,6 +1577,27 @@ mod tests {
                 }
 
                 #[tokio::test]
+                async fn persistent_pragma_write_rolls_back_when_a_later_statement_fails() {
+                    let (_dir, dsn) = test_support::make_sqlite_db("");
+                    let adapter = SqliteAdapter::new();
+
+                    let result = adapter
+                        .execute_adhoc(
+                            &dsn,
+                            "PRAGMA user_version = 42; SELECT * FROM missing_table",
+                            AccessMode::ReadWrite,
+                        )
+                        .await;
+
+                    assert!(matches!(result, Err(DbOperationError::ObjectMissing(_))));
+                    let user_version = adapter
+                        .execute_adhoc(&dsn, "PRAGMA user_version", AccessMode::ReadOnly)
+                        .await
+                        .unwrap();
+                    assert_eq!(user_version.rows(), vec![vec!["0".to_string()]]);
+                }
+
+                #[tokio::test]
                 async fn vacuum_in_mixed_sql_runs_outside_auto_transaction() {
                     let (_dir, dsn) = test_support::make_sqlite_db("");
                     let adapter = SqliteAdapter::new();

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -1,7 +1,10 @@
 use std::borrow::Cow;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::app::policy::sql::sqlite_transaction::is_transaction_incompatible;
+use crate::app::policy::sql::sqlite_transaction::{
+    SqliteStatementClassification, SqliteTransactionPolicy, sqlite_statement_classification,
+    sqlite_transaction_policy_for_classifications,
+};
 use crate::app::ports::outbound::DbOperationError;
 
 fn is_ident_char(byte: u8) -> bool {
@@ -396,41 +399,6 @@ fn contains_sqlite_meta_command(sql: &str) -> bool {
     false
 }
 
-fn is_transaction_control(statement: &str) -> bool {
-    matches!(
-        first_keyword(statement).to_ascii_uppercase().as_str(),
-        "BEGIN" | "COMMIT" | "END" | "ROLLBACK" | "SAVEPOINT" | "RELEASE"
-    )
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SqliteStatementClass {
-    ReadOnly,
-    Dml,
-    Ddl,
-    TransactionControl,
-    TransactionIncompatible,
-}
-
-fn classify_sqlite_statement(statement: &str) -> SqliteStatementClass {
-    if is_transaction_control(statement) {
-        return SqliteStatementClass::TransactionControl;
-    }
-    if is_transaction_incompatible(statement) {
-        return SqliteStatementClass::TransactionIncompatible;
-    }
-    if is_dml_statement(statement) {
-        return SqliteStatementClass::Dml;
-    }
-    if matches!(
-        first_keyword(statement).to_ascii_uppercase().as_str(),
-        "CREATE" | "ALTER" | "DROP" | "TRUNCATE"
-    ) {
-        return SqliteStatementClass::Ddl;
-    }
-    SqliteStatementClass::ReadOnly
-}
-
 pub(in crate::adapters::sqlite::sqlite3) fn is_sqlite_rerunnable_export_query(
     query: &str,
 ) -> Result<bool, DbOperationError> {
@@ -442,76 +410,14 @@ pub(in crate::adapters::sqlite::sqlite3) fn is_sqlite_rerunnable_export_query(
 }
 
 fn is_sqlite_rerunnable_export_statement(statement: &str) -> bool {
-    if matches!(
-        classify_sqlite_statement(statement),
-        SqliteStatementClass::Dml
-            | SqliteStatementClass::Ddl
-            | SqliteStatementClass::TransactionControl
-            | SqliteStatementClass::TransactionIncompatible
-    ) {
+    if sqlite_statement_classification(statement) != SqliteStatementClassification::ReadOnly {
         return false;
     }
     match first_keyword(statement).to_ascii_uppercase().as_str() {
-        "SELECT" | "EXPLAIN" | "VALUES" => true,
+        "SELECT" | "EXPLAIN" | "VALUES" | "PRAGMA" => true,
         "WITH" => !is_dml_statement(statement),
-        "PRAGMA" => is_read_only_sqlite_pragma(statement),
         _ => false,
     }
-}
-
-fn sqlite_pragma_name(statement: &str) -> Option<String> {
-    let (_, pragma_end) = next_keyword_from(statement, 0)?;
-    let tail = statement.get(pragma_end..)?.trim_start();
-    let name: String = tail
-        .chars()
-        .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_' || *ch == '.')
-        .collect();
-    if name.is_empty() {
-        None
-    } else {
-        Some(
-            name.rsplit('.')
-                .next()
-                .unwrap_or(name.as_str())
-                .to_ascii_lowercase(),
-        )
-    }
-}
-
-fn is_read_only_parameterized_pragma(name: &str) -> bool {
-    matches!(
-        name,
-        "table_info"
-            | "table_xinfo"
-            | "index_info"
-            | "index_xinfo"
-            | "index_list"
-            | "foreign_key_list"
-            | "database_list"
-            | "table_list"
-            | "pragma_list"
-            | "function_list"
-            | "module_list"
-            | "collation_list"
-            | "integrity_check"
-            | "quick_check"
-            | "column_info"
-    )
-}
-
-fn is_read_only_sqlite_pragma(statement: &str) -> bool {
-    let Some(name) = sqlite_pragma_name(statement) else {
-        return false;
-    };
-    let has_assignment = statement.contains('=');
-    let has_parenthesized_value = statement.contains('(');
-    let side_effect_without_assignment = (has_parenthesized_value
-        && !is_read_only_parameterized_pragma(&name))
-        || matches!(
-            name.as_str(),
-            "optimize" | "incremental_vacuum" | "wal_checkpoint"
-        );
-    !has_assignment && !side_effect_without_assignment
 }
 
 pub(in crate::adapters::sqlite::sqlite3) fn sqlite_export_not_rerunnable_error() -> DbOperationError
@@ -532,7 +438,6 @@ pub(in crate::adapters::sqlite::sqlite3) enum SqliteWrapMode {
 pub(in crate::adapters::sqlite::sqlite3) struct SqliteStatementPlan<'a> {
     query: &'a str,
     statements: Vec<&'a str>,
-    classes: Vec<SqliteStatementClass>,
     wrap_mode: SqliteWrapMode,
 }
 
@@ -546,28 +451,12 @@ impl<'a> SqliteStatementPlan<'a> {
     }
 
     pub(in crate::adapters::sqlite::sqlite3) fn is_dml(&self, index: usize) -> bool {
-        self.classes[index] == SqliteStatementClass::Dml
+        is_dml_statement(self.statements[index])
     }
 
     pub(in crate::adapters::sqlite::sqlite3) fn wrap_mode(&self) -> SqliteWrapMode {
         self.wrap_mode
     }
-}
-
-fn is_write_class(class: SqliteStatementClass) -> bool {
-    matches!(class, SqliteStatementClass::Dml | SqliteStatementClass::Ddl)
-}
-
-fn should_auto_wrap_in_transaction(classes: &[SqliteStatementClass]) -> bool {
-    classes.len() > 1
-        && classes.iter().copied().any(is_write_class)
-        && classes.iter().all(|class| {
-            !matches!(
-                class,
-                SqliteStatementClass::TransactionControl
-                    | SqliteStatementClass::TransactionIncompatible
-            )
-        })
 }
 
 pub(in crate::adapters::sqlite::sqlite3) fn sqlite_statement_plan(
@@ -576,9 +465,11 @@ pub(in crate::adapters::sqlite::sqlite3) fn sqlite_statement_plan(
     let statements = try_split_sqlite_statements(query)?;
     let classes: Vec<_> = statements
         .iter()
-        .map(|statement| classify_sqlite_statement(statement))
+        .map(|statement| sqlite_statement_classification(statement))
         .collect();
-    let wrap_mode = if should_auto_wrap_in_transaction(&classes) {
+    let wrap_mode = if sqlite_transaction_policy_for_classifications(statements.len(), &classes)
+        == SqliteTransactionPolicy::AutoWrap
+    {
         SqliteWrapMode::BeginCommit
     } else {
         SqliteWrapMode::None
@@ -586,7 +477,6 @@ pub(in crate::adapters::sqlite::sqlite3) fn sqlite_statement_plan(
     Ok(SqliteStatementPlan {
         query,
         statements,
-        classes,
         wrap_mode,
     })
 }
@@ -1097,48 +987,48 @@ END";
         #[test]
         fn distinguishes_journal_mode_query_from_change() {
             assert_eq!(
-                classify_sqlite_statement("PRAGMA journal_mode"),
-                SqliteStatementClass::ReadOnly
+                sqlite_statement_classification("PRAGMA journal_mode"),
+                SqliteStatementClassification::ReadOnly
             );
             assert_eq!(
-                classify_sqlite_statement("PRAGMA main.journal_mode = WAL"),
-                SqliteStatementClass::TransactionIncompatible
+                sqlite_statement_classification("PRAGMA main.journal_mode = WAL"),
+                SqliteStatementClassification::TransactionIncompatible
             );
             assert_eq!(
-                classify_sqlite_statement("PRAGMA journal_mode(WAL)"),
-                SqliteStatementClass::TransactionIncompatible
+                sqlite_statement_classification("PRAGMA journal_mode(WAL)"),
+                SqliteStatementClassification::TransactionIncompatible
             );
             assert_eq!(
-                classify_sqlite_statement("PRAGMA foreign_keys = OFF"),
-                SqliteStatementClass::TransactionIncompatible
+                sqlite_statement_classification("PRAGMA foreign_keys = OFF"),
+                SqliteStatementClassification::TransactionIncompatible
             );
             assert_eq!(
-                classify_sqlite_statement("PRAGMA foreign_keys"),
-                SqliteStatementClass::ReadOnly
+                sqlite_statement_classification("PRAGMA foreign_keys"),
+                SqliteStatementClassification::ReadOnly
             );
             assert_eq!(
-                classify_sqlite_statement("PRAGMA \"foreign_keys\" = OFF"),
-                SqliteStatementClass::TransactionIncompatible
+                sqlite_statement_classification("PRAGMA \"foreign_keys\" = OFF"),
+                SqliteStatementClassification::TransactionIncompatible
             );
             assert_eq!(
-                classify_sqlite_statement("/* setup */ PRAGMA [foreign_keys](OFF)"),
-                SqliteStatementClass::TransactionIncompatible
+                sqlite_statement_classification("/* setup */ PRAGMA [foreign_keys](OFF)"),
+                SqliteStatementClassification::TransactionIncompatible
             );
         }
 
         #[test]
         fn classifies_vacuum_and_writes_for_auto_transaction_policy() {
             assert_eq!(
-                classify_sqlite_statement("VACUUM INTO 'backup.db'"),
-                SqliteStatementClass::TransactionIncompatible
+                sqlite_statement_classification("VACUUM INTO 'backup.db'"),
+                SqliteStatementClassification::TransactionIncompatible
             );
             assert_eq!(
-                classify_sqlite_statement("CREATE TABLE users(id INTEGER PRIMARY KEY)"),
-                SqliteStatementClass::Ddl
+                sqlite_statement_classification("CREATE TABLE users(id INTEGER PRIMARY KEY)"),
+                SqliteStatementClassification::TransactionalWrite
             );
             assert_eq!(
-                classify_sqlite_statement("BEGIN"),
-                SqliteStatementClass::TransactionControl
+                sqlite_statement_classification("BEGIN"),
+                SqliteStatementClassification::TransactionControl
             );
         }
     }

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -1,11 +1,15 @@
 use std::borrow::Cow;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use crate::app::policy::sql::sqlite_export::is_sqlite_rerunnable_export_statement;
 use crate::app::policy::sql::sqlite_transaction::{
-    SqliteStatementClassification, SqliteTransactionPolicy, sqlite_statement_classification,
+    SqliteTransactionPolicy, sqlite_statement_classification,
     sqlite_transaction_policy_for_classifications,
 };
 use crate::app::ports::outbound::DbOperationError;
+
+#[cfg(test)]
+use crate::app::policy::sql::sqlite_transaction::SqliteStatementClassification;
 
 fn is_ident_char(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || byte == b'_'
@@ -407,17 +411,6 @@ pub(in crate::adapters::sqlite::sqlite3) fn is_sqlite_rerunnable_export_query(
         && statements
             .iter()
             .all(|statement| is_sqlite_rerunnable_export_statement(statement)))
-}
-
-fn is_sqlite_rerunnable_export_statement(statement: &str) -> bool {
-    if sqlite_statement_classification(statement) != SqliteStatementClassification::ReadOnly {
-        return false;
-    }
-    match first_keyword(statement).to_ascii_uppercase().as_str() {
-        "SELECT" | "EXPLAIN" | "VALUES" | "PRAGMA" => true,
-        "WITH" => !is_dml_statement(statement),
-        _ => false,
-    }
 }
 
 pub(in crate::adapters::sqlite::sqlite3) fn sqlite_export_not_rerunnable_error() -> DbOperationError


### PR DESCRIPTION
## Problem

SQLite could classify persistent PRAGMA writes differently in the SQL modal and executor, allowing a later statement failure to leave an earlier change committed.

## Approach

Centralize SQLite statement classification for transaction policy, write safety, CSV reruns, and executor wrapping. Classify persistent PRAGMAs as transactional writes and session or transaction-incompatible PRAGMAs as non-atomic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - SQLiteの複数文実行におけるトランザクション処理を改善しました。
  - `user_version` や `application_id` などの永続設定変更も、後続処理が失敗した場合に適切にロールバックされます。
  - セッション設定変更や `ATTACH`、`VACUUM` など、安全に実行できない操作をより正確に検出します。
  - SQLiteエクスポートの再実行可否とSQLリスク評価を見直し、安全性と一貫性を向上しました。

- **ドキュメント**
  - SQLiteのクエリ安全性とトランザクション動作に関する説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->