### PR TITLE
refactor: batch SQLite metadata queries

### DIFF
--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -305,6 +305,17 @@ fn table_metadata_json(table_expr: &str, row_count: &str, include_full_detail: b
     } else {
         "json('[]')".to_string()
     };
+    let source_ddl = if include_full_detail {
+        format!(
+            r",
+            'source_ddl', (
+                SELECT sql FROM sqlite_master
+                WHERE type IN ('table', 'view') AND name = {table_expr} COLLATE NOCASE LIMIT 1
+            )"
+        )
+    } else {
+        String::new()
+    };
     format!(
         r#"json_object(
             'table', json((
@@ -330,11 +341,8 @@ fn table_metadata_json(table_expr: &str, row_count: &str, include_full_detail: b
                     ORDER BY name
                 ) AS r
             ), json('[]'))),
-            'row_count', {row_count},
-            'source_ddl', (
-                SELECT sql FROM sqlite_master
-                WHERE type IN ('table', 'view') AND name = {table_expr} COLLATE NOCASE LIMIT 1
-            )
+            'row_count', {row_count}
+            {source_ddl}
         )"#,
         referenced_columns = metadata_columns_json("r.name"),
     )
@@ -811,6 +819,16 @@ mod tests {
             assert!(query.contains(r#"WHERE "key" != 0"#));
             assert!(!query.contains("'definition'"));
             assert!(!query.contains("'coll'"));
+            assert!(!query.contains("'source_ddl'"));
+        }
+
+        #[test]
+        fn row_count_fallback_keeps_full_detail_payload() {
+            let query = table_metadata_query("users", TableMetadataQueryMode::FullWithoutRowCount);
+
+            assert!(!query.contains("SELECT COUNT(*)"));
+            assert!(query.contains("'source_ddl'"));
+            assert!(query.contains("'definition'"));
         }
     }
 

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -204,7 +204,29 @@ fn metadata_columns_json(table_expr: &str) -> String {
     )
 }
 
-fn metadata_indexes_json(table_expr: &str) -> String {
+fn metadata_indexes_json(table_expr: &str, include_full_detail: bool) -> String {
+    if !include_full_detail {
+        return format!(
+            r#"COALESCE((
+                SELECT json_group_array(json_object(
+                    'name', i.name, 'unique', i."unique", 'partial', i.partial,
+                    'columns', json(COALESCE((
+                        SELECT json_group_array(json_object(
+                            'cid', x.cid, 'name', x.name, 'key', x."key"
+                        ))
+                        FROM (
+                            SELECT * FROM pragma_index_xinfo(i.name)
+                            WHERE "key" != 0 ORDER BY seqno
+                        ) AS x
+                    ), json('[]')))
+                ))
+                FROM (
+                    SELECT * FROM pragma_index_list({table_expr})
+                    WHERE "unique" != 0 AND partial = 0 ORDER BY name
+                ) AS i
+            ), json('[]'))"#
+        );
+    }
     format!(
         r#"COALESCE((
             SELECT json_group_array(json_object(
@@ -276,7 +298,7 @@ pub(super) fn preview_metadata_query(table: &str) -> String {
 
 fn table_metadata_json(table_expr: &str, row_count: &str, include_full_detail: bool) -> String {
     let columns = metadata_columns_json(table_expr);
-    let indexes = metadata_indexes_json(table_expr);
+    let indexes = metadata_indexes_json(table_expr, include_full_detail);
     let foreign_keys = metadata_foreign_keys_json(table_expr);
     let triggers = if include_full_detail {
         format!("json({})", metadata_triggers_json(table_expr))
@@ -759,6 +781,16 @@ mod tests {
             assert!(query.contains("pragma_table_xinfo(t.name)"));
             assert!(query.contains("pragma_index_list(t.name)"));
             assert!(query.contains("pragma_foreign_key_list(t.name)"));
+        }
+
+        #[test]
+        fn completion_query_only_loads_unique_index_key_columns() {
+            let query = table_metadata_query("users", false, false);
+
+            assert!(query.contains(r#"WHERE "unique" != 0 AND partial = 0"#));
+            assert!(query.contains(r#"WHERE "key" != 0"#));
+            assert!(!query.contains("'definition'"));
+            assert!(!query.contains("'coll'"));
         }
     }
 

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -142,10 +142,6 @@ pub(super) fn is_table_list_unavailable(error: &str) -> bool {
     error.to_ascii_lowercase().contains("pragma_table_list")
 }
 
-pub(super) fn row_count_query(table: &str) -> String {
-    format!("SELECT COUNT(*) AS count FROM {}", quote_ident(table))
-}
-
 pub(super) const PREVIEW_TRANSPORT_UNISTR_PREFIX: &str = "\\u0001SABIQL_HEX:";
 pub(super) fn encode_preview_column_expr(column: &str) -> String {
     let ident = quote_ident(column);
@@ -195,60 +191,162 @@ pub(super) fn build_preview_query(
     )
 }
 
-pub(super) fn table_xinfo_query(table: &str) -> String {
-    format!("PRAGMA table_xinfo({})", quote_ident(table))
+fn metadata_columns_json(table_expr: &str) -> String {
+    format!(
+        r#"COALESCE((
+            SELECT json_group_array(json_object(
+                'cid', c.cid, 'name', c.name, 'type', c.type,
+                'notnull', c."notnull", 'dflt_value', c.dflt_value,
+                'pk', c.pk, 'hidden', c.hidden
+            ))
+            FROM (SELECT * FROM pragma_table_xinfo({table_expr}) ORDER BY cid) AS c
+        ), json('[]'))"#
+    )
 }
 
-pub(super) fn table_info_query(table: &str) -> String {
-    format!("PRAGMA table_info({})", quote_ident(table))
+fn metadata_indexes_json(table_expr: &str) -> String {
+    format!(
+        r#"COALESCE((
+            SELECT json_group_array(json_object(
+                'name', i.name, 'unique', i."unique", 'origin', i.origin,
+                'partial', i.partial,
+                'columns', json(COALESCE((
+                    SELECT json_group_array(json_object(
+                        'seqno', x.seqno, 'cid', x.cid, 'name', x.name,
+                        'desc', x."desc", 'coll', x.coll, 'key', x."key"
+                    ))
+                    FROM (SELECT * FROM pragma_index_xinfo(i.name) ORDER BY seqno) AS x
+                ), json('[]'))),
+                'definition', (
+                    SELECT m.sql FROM sqlite_master AS m
+                    WHERE m.type = 'index' AND m.name = i.name LIMIT 1
+                )
+            ))
+            FROM (SELECT * FROM pragma_index_list({table_expr}) ORDER BY name) AS i
+        ), json('[]'))"#
+    )
 }
 
-pub(super) fn table_kind_info_query(table: &str) -> String {
+fn metadata_foreign_keys_json(table_expr: &str) -> String {
+    format!(
+        r#"COALESCE((
+            SELECT json_group_array(json_object(
+                'id', f.id, 'seq', f.seq, 'table', f."table", 'from', f."from",
+                'to', f."to", 'on_update', f.on_update, 'on_delete', f.on_delete
+            ))
+            FROM (
+                SELECT * FROM pragma_foreign_key_list({table_expr}) ORDER BY id, seq
+            ) AS f
+        ), json('[]'))"#
+    )
+}
+
+fn metadata_triggers_json(table_expr: &str) -> String {
+    format!(
+        r"COALESCE((
+            SELECT json_group_array(json_object('name', m.name, 'sql', m.sql))
+            FROM (
+                SELECT name, sql FROM sqlite_master
+                WHERE type = 'trigger' AND tbl_name = {table_expr}
+                ORDER BY name
+            ) AS m
+        ), json('[]'))"
+    )
+}
+
+pub(super) fn preview_metadata_query(table: &str) -> String {
+    let table = quote_literal(table);
+    let columns = metadata_columns_json(&table);
     format!(
         r"
-        SELECT tl.type, tl.wr, tl.strict, m.sql
-        FROM pragma_table_list() AS tl
-        LEFT JOIN sqlite_master AS m
-          ON m.type IN ('table', 'view')
-         AND m.name = tl.name
-        WHERE tl.schema = 'main'
-          AND tl.name = {}
-        LIMIT 1
+        SELECT json_object(
+            'columns', json({columns}),
+            'table', json((
+                SELECT json_object('type', tl.type, 'wr', tl.wr, 'strict', tl.strict, 'sql', m.sql)
+                FROM pragma_table_list() AS tl
+                LEFT JOIN sqlite_master AS m
+                  ON m.type IN ('table', 'view') AND m.name = tl.name
+                WHERE tl.schema = 'main' AND tl.name = {table}
+                LIMIT 1
+            ))
+        ) AS payload
+        "
+    )
+}
+
+fn table_metadata_json(table_expr: &str, row_count: &str, include_triggers: bool) -> String {
+    let columns = metadata_columns_json(table_expr);
+    let indexes = metadata_indexes_json(table_expr);
+    let foreign_keys = metadata_foreign_keys_json(table_expr);
+    let triggers = if include_triggers {
+        format!("json({})", metadata_triggers_json(table_expr))
+    } else {
+        "json('[]')".to_string()
+    };
+    format!(
+        r#"json_object(
+            'table', json((
+                SELECT json_object('type', tl.type, 'wr', tl.wr, 'strict', tl.strict, 'sql', m.sql)
+                FROM pragma_table_list() AS tl
+                LEFT JOIN sqlite_master AS m
+                  ON m.type IN ('table', 'view') AND m.name = tl.name
+                WHERE tl.schema = 'main' AND tl.name = {table_expr}
+                LIMIT 1
+            )),
+            'columns', json({columns}),
+            'indexes', json({indexes}),
+            'foreign_keys', json({foreign_keys}),
+            'triggers', {triggers},
+            'referenced_columns', json(COALESCE((
+                SELECT json_group_array(json_object(
+                    'name', r.name,
+                    'columns', json({referenced_columns})
+                ))
+                FROM (
+                    SELECT DISTINCT f."table" AS name
+                    FROM pragma_foreign_key_list({table_expr}) AS f
+                    ORDER BY name
+                ) AS r
+            ), json('[]'))),
+            'row_count', {row_count},
+            'source_ddl', (
+                SELECT sql FROM sqlite_master
+                WHERE type IN ('table', 'view') AND name = {table_expr} LIMIT 1
+            )
+        )"#,
+        referenced_columns = metadata_columns_json("r.name"),
+    )
+}
+
+pub(super) fn table_metadata_query(table: &str, include_full_detail: bool) -> String {
+    let table_literal = quote_literal(table);
+    let row_count = if include_full_detail {
+        format!("(SELECT COUNT(*) FROM {})", quote_ident(table))
+    } else {
+        "NULL".to_string()
+    };
+    let payload = table_metadata_json(&table_literal, &row_count, include_full_detail);
+    format!(
+        r"
+        SELECT {payload} AS payload
         ",
-        quote_literal(table)
     )
 }
 
-pub(super) fn table_definition_query(table: &str) -> String {
+pub(super) fn table_signatures_query() -> String {
+    let payload = table_metadata_json("t.name", "NULL", true);
     format!(
-        "SELECT sql FROM sqlite_master WHERE type IN ('table', 'view') AND name = {} LIMIT 1",
-        quote_literal(table)
-    )
-}
-
-pub(super) fn index_list_query(table: &str) -> String {
-    format!("PRAGMA index_list({})", quote_ident(table))
-}
-
-pub(super) fn index_xinfo_query(index: &str) -> String {
-    format!("PRAGMA index_xinfo({})", quote_ident(index))
-}
-
-pub(super) fn index_definition_query(index: &str) -> String {
-    format!(
-        "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = {} LIMIT 1",
-        quote_literal(index)
-    )
-}
-
-pub(super) fn foreign_key_list_query(table: &str) -> String {
-    format!("PRAGMA foreign_key_list({})", quote_ident(table))
-}
-
-pub(super) fn trigger_list_query(table: &str) -> String {
-    format!(
-        "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = {} ORDER BY name",
-        quote_literal(table)
+        r"
+        SELECT t.name, {payload} AS payload
+        FROM (
+            SELECT tl.name
+            FROM pragma_table_list() AS tl
+            WHERE tl.schema = 'main'
+              AND tl.type IN ('table', 'virtual', 'view')
+              AND tl.name NOT LIKE 'sqlite_%'
+            ORDER BY tl.name
+        ) AS t
+        "
     )
 }
 
@@ -574,14 +672,6 @@ mod tests {
         use super::*;
 
         #[test]
-        fn row_count_quotes_table_name() {
-            assert_eq!(
-                row_count_query(r#"my"table"#),
-                r#"SELECT COUNT(*) AS count FROM "my""table""#
-            );
-        }
-
-        #[test]
         fn orders_by_primary_key_columns_when_available() {
             assert_eq!(
                 build_preview_query(
@@ -635,35 +725,36 @@ mod tests {
         }
     }
 
-    mod pragma_queries {
+    mod metadata_batch_queries {
         use super::*;
 
         #[test]
-        fn quote_identifiers() {
-            assert_eq!(
-                table_xinfo_query(r#"my"table"#),
-                r#"PRAGMA table_xinfo("my""table")"#
-            );
-            assert_eq!(
-                table_info_query(r#"my"table"#),
-                r#"PRAGMA table_info("my""table")"#
-            );
-            assert_eq!(
-                index_list_query(r#"my"table"#),
-                r#"PRAGMA index_list("my""table")"#
-            );
-            assert_eq!(
-                foreign_key_list_query(r#"my"table"#),
-                r#"PRAGMA foreign_key_list("my""table")"#
-            );
-            assert_eq!(
-                trigger_list_query("users"),
-                "SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = 'users' ORDER BY name"
-            );
-            assert_eq!(
-                index_xinfo_query(r#"my"index"#),
-                r#"PRAGMA index_xinfo("my""index")"#
-            );
+        fn table_detail_combines_metadata_sources() {
+            let query = table_metadata_query("users", true);
+
+            assert!(query.contains("pragma_table_xinfo('users')"));
+            assert!(query.contains("pragma_index_list('users')"));
+            assert!(query.contains("pragma_foreign_key_list('users')"));
+            assert!(query.contains("type = 'trigger'"));
+            assert!(query.contains("SELECT COUNT(*) FROM \"users\""));
+        }
+
+        #[test]
+        fn table_detail_escapes_identifier_and_literal_contexts() {
+            let query = table_metadata_query(r#"my'"table"#, true);
+
+            assert!(query.contains(r#"pragma_table_xinfo('my''"table')"#));
+            assert!(query.contains(r#"SELECT COUNT(*) FROM "my'""table""#));
+        }
+
+        #[test]
+        fn signatures_query_batches_all_tables() {
+            let query = table_signatures_query();
+
+            assert!(query.contains("SELECT t.name"));
+            assert!(query.contains("pragma_table_xinfo(t.name)"));
+            assert!(query.contains("pragma_index_list(t.name)"));
+            assert!(query.contains("pragma_foreign_key_list(t.name)"));
         }
     }
 

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -274,11 +274,11 @@ pub(super) fn preview_metadata_query(table: &str) -> String {
     )
 }
 
-fn table_metadata_json(table_expr: &str, row_count: &str, include_triggers: bool) -> String {
+fn table_metadata_json(table_expr: &str, row_count: &str, include_full_detail: bool) -> String {
     let columns = metadata_columns_json(table_expr);
     let indexes = metadata_indexes_json(table_expr);
     let foreign_keys = metadata_foreign_keys_json(table_expr);
-    let triggers = if include_triggers {
+    let triggers = if include_full_detail {
         format!("json({})", metadata_triggers_json(table_expr))
     } else {
         "json('[]')".to_string()
@@ -318,9 +318,13 @@ fn table_metadata_json(table_expr: &str, row_count: &str, include_triggers: bool
     )
 }
 
-pub(super) fn table_metadata_query(table: &str, include_full_detail: bool) -> String {
+pub(super) fn table_metadata_query(
+    table: &str,
+    include_full_detail: bool,
+    include_row_count: bool,
+) -> String {
     let table_literal = quote_literal(table);
-    let row_count = if include_full_detail {
+    let row_count = if include_row_count {
         format!("(SELECT COUNT(*) FROM {})", quote_ident(table))
     } else {
         "NULL".to_string()
@@ -730,7 +734,7 @@ mod tests {
 
         #[test]
         fn table_detail_combines_metadata_sources() {
-            let query = table_metadata_query("users", true);
+            let query = table_metadata_query("users", true, true);
 
             assert!(query.contains("pragma_table_xinfo('users')"));
             assert!(query.contains("pragma_index_list('users')"));
@@ -741,7 +745,7 @@ mod tests {
 
         #[test]
         fn table_detail_escapes_identifier_and_literal_contexts() {
-            let query = table_metadata_query(r#"my'"table"#, true);
+            let query = table_metadata_query(r#"my'"table"#, true, true);
 
             assert!(query.contains(r#"pragma_table_xinfo('my''"table')"#));
             assert!(query.contains(r#"SELECT COUNT(*) FROM "my'""table""#));

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -340,18 +340,38 @@ fn table_metadata_json(table_expr: &str, row_count: &str, include_full_detail: b
     )
 }
 
-pub(super) fn table_metadata_query(
-    table: &str,
-    include_full_detail: bool,
-    include_row_count: bool,
-) -> String {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TableMetadataQueryMode {
+    Full,
+    FullWithoutRowCount,
+    ColumnsAndFks,
+}
+
+impl TableMetadataQueryMode {
+    const fn include_full_detail(self) -> bool {
+        matches!(self, Self::Full | Self::FullWithoutRowCount)
+    }
+
+    const fn include_row_count(self) -> bool {
+        matches!(self, Self::Full)
+    }
+
+    pub(super) const fn without_row_count(self) -> Option<Self> {
+        match self {
+            Self::Full => Some(Self::FullWithoutRowCount),
+            Self::FullWithoutRowCount | Self::ColumnsAndFks => None,
+        }
+    }
+}
+
+pub(super) fn table_metadata_query(table: &str, mode: TableMetadataQueryMode) -> String {
     let table_literal = quote_literal(table);
-    let row_count = if include_row_count {
+    let row_count = if mode.include_row_count() {
         format!("(SELECT COUNT(*) FROM {})", quote_ident(table))
     } else {
         "NULL".to_string()
     };
-    let payload = table_metadata_json(&table_literal, &row_count, include_full_detail);
+    let payload = table_metadata_json(&table_literal, &row_count, mode.include_full_detail());
     format!(
         r"
         SELECT {payload} AS payload
@@ -756,7 +776,7 @@ mod tests {
 
         #[test]
         fn table_detail_combines_metadata_sources() {
-            let query = table_metadata_query("users", true, true);
+            let query = table_metadata_query("users", TableMetadataQueryMode::Full);
 
             assert!(query.contains("pragma_table_xinfo('users')"));
             assert!(query.contains("pragma_index_list('users')"));
@@ -767,7 +787,7 @@ mod tests {
 
         #[test]
         fn table_detail_escapes_identifier_and_literal_contexts() {
-            let query = table_metadata_query(r#"my'"table"#, true, true);
+            let query = table_metadata_query(r#"my'"table"#, TableMetadataQueryMode::Full);
 
             assert!(query.contains(r#"pragma_table_xinfo('my''"table')"#));
             assert!(query.contains(r#"SELECT COUNT(*) FROM "my'""table""#));
@@ -785,7 +805,7 @@ mod tests {
 
         #[test]
         fn completion_query_only_loads_unique_index_key_columns() {
-            let query = table_metadata_query("users", false, false);
+            let query = table_metadata_query("users", TableMetadataQueryMode::ColumnsAndFks);
 
             assert!(query.contains(r#"WHERE "unique" != 0 AND partial = 0"#));
             assert!(query.contains(r#"WHERE "key" != 0"#));

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -247,7 +247,7 @@ fn metadata_triggers_json(table_expr: &str) -> String {
             SELECT json_group_array(json_object('name', m.name, 'sql', m.sql))
             FROM (
                 SELECT name, sql FROM sqlite_master
-                WHERE type = 'trigger' AND tbl_name = {table_expr}
+                WHERE type = 'trigger' AND tbl_name = {table_expr} COLLATE NOCASE
                 ORDER BY name
             ) AS m
         ), json('[]'))"
@@ -266,7 +266,7 @@ pub(super) fn preview_metadata_query(table: &str) -> String {
                 FROM pragma_table_list() AS tl
                 LEFT JOIN sqlite_master AS m
                   ON m.type IN ('table', 'view') AND m.name = tl.name
-                WHERE tl.schema = 'main' AND tl.name = {table}
+                WHERE tl.schema = 'main' AND tl.name = {table} COLLATE NOCASE
                 LIMIT 1
             ))
         ) AS payload
@@ -290,7 +290,7 @@ fn table_metadata_json(table_expr: &str, row_count: &str, include_full_detail: b
                 FROM pragma_table_list() AS tl
                 LEFT JOIN sqlite_master AS m
                   ON m.type IN ('table', 'view') AND m.name = tl.name
-                WHERE tl.schema = 'main' AND tl.name = {table_expr}
+                WHERE tl.schema = 'main' AND tl.name = {table_expr} COLLATE NOCASE
                 LIMIT 1
             )),
             'columns', json({columns}),
@@ -311,7 +311,7 @@ fn table_metadata_json(table_expr: &str, row_count: &str, include_full_detail: b
             'row_count', {row_count},
             'source_ddl', (
                 SELECT sql FROM sqlite_master
-                WHERE type IN ('table', 'view') AND name = {table_expr} LIMIT 1
+                WHERE type IN ('table', 'view') AND name = {table_expr} COLLATE NOCASE LIMIT 1
             )
         )"#,
         referenced_columns = metadata_columns_json("r.name"),

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -38,6 +38,8 @@ pub(in crate::adapters::sqlite) struct SqliteCli {
     timeout_secs: u64,
     #[cfg(test)]
     environment: Vec<(std::ffi::OsString, std::ffi::OsString)>,
+    #[cfg(test)]
+    process_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
 struct SqliteOutput {
@@ -80,7 +82,15 @@ impl SqliteCli {
             timeout_secs: 30,
             #[cfg(test)]
             environment: Vec::new(),
+            #[cfg(test)]
+            process_count: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
+    }
+
+    #[cfg(test)]
+    pub(in crate::adapters::sqlite) fn process_count(&self) -> usize {
+        self.process_count
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub(in crate::adapters::sqlite) async fn execute_json<T: DeserializeOwned>(
@@ -359,6 +369,8 @@ impl SqliteCli {
     fn command_with_program(&self, program: &str) -> Command {
         #[cfg(test)]
         let command = {
+            self.process_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             let mut cmd = Command::new(program);
             for (key, value) in &self.environment {
                 cmd.env(key, value);
@@ -701,6 +713,25 @@ mod tests {
         use crate::adapters::test_support;
 
         use super::*;
+
+        #[tokio::test]
+        async fn metadata_and_rows_use_at_most_two_sqlite_processes() {
+            let (_dir, dsn) = test_support::make_sqlite_db(
+                r"
+                CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT UNIQUE, org_id INTEGER);
+                CREATE INDEX idx_users_org_id ON users(org_id);
+                INSERT INTO users(id, email, org_id) VALUES (1, 'a@example.com', 7);
+                ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            adapter
+                .execute_preview(&dsn, "main", "users", 10, 0)
+                .await
+                .unwrap();
+
+            assert_eq!(adapter.cli.process_count(), 2);
+        }
 
         #[tokio::test]
         async fn returns_columns_rows_and_respects_pagination() {

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -36,10 +36,6 @@ const SQLITE_SAFE_MODE_MIN_VERSION: SqliteVersion = SqliteVersion::new(3, 41, 1)
 #[derive(Debug, Clone)]
 pub(in crate::adapters::sqlite) struct SqliteCli {
     timeout_secs: u64,
-    #[cfg(test)]
-    environment: Vec<(std::ffi::OsString, std::ffi::OsString)>,
-    #[cfg(test)]
-    process_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
 struct SqliteOutput {
@@ -78,19 +74,7 @@ impl SqliteVersion {
 
 impl SqliteCli {
     pub(in crate::adapters::sqlite) fn new() -> Self {
-        Self {
-            timeout_secs: 30,
-            #[cfg(test)]
-            environment: Vec::new(),
-            #[cfg(test)]
-            process_count: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-        }
-    }
-
-    #[cfg(test)]
-    pub(in crate::adapters::sqlite) fn process_count(&self) -> usize {
-        self.process_count
-            .load(std::sync::atomic::Ordering::Relaxed)
+        Self { timeout_secs: 30 }
     }
 
     pub(in crate::adapters::sqlite) async fn execute_json<T: DeserializeOwned>(
@@ -244,6 +228,8 @@ impl SqliteCli {
     ) -> Result<(), DbOperationError> {
         Self::ensure_database_path(path)?;
         let mut cmd = self.command_with_program(command);
+        #[cfg(test)]
+        super::tests::configure_command(path, &mut cmd);
         Self::apply_session_options(&mut cmd, read_only);
         cmd.arg("-batch").arg("-bail").arg("-csv").arg("-header");
         cmd.arg(sqlite_database_uri(path, read_only));
@@ -330,6 +316,8 @@ impl SqliteCli {
     ) -> Result<SqliteOutput, DbOperationError> {
         Self::ensure_database_path(path)?;
         let mut cmd = self.command();
+        #[cfg(test)]
+        super::tests::configure_command(path, &mut cmd);
         Self::apply_session_options(&mut cmd, read_only);
         for arg in args {
             cmd.arg(arg);
@@ -367,19 +355,7 @@ impl SqliteCli {
     }
 
     fn command_with_program(&self, program: &str) -> Command {
-        #[cfg(test)]
-        let command = {
-            self.process_count
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            let mut cmd = Command::new(program);
-            for (key, value) in &self.environment {
-                cmd.env(key, value);
-            }
-            cmd
-        };
-        #[cfg(not(test))]
-        let command = Command::new(program);
-        command
+        Command::new(program)
     }
 
     async fn collect_output(
@@ -691,7 +667,8 @@ impl QueryExecutor for SqliteAdapter {
 
 #[cfg(test)]
 mod tests {
-    use std::{ffi::OsString, path::PathBuf};
+    use std::ffi::OsString;
+    use std::path::PathBuf;
 
     use crate::adapters::csv_export::export_to_path;
     use crate::app::ports::outbound::{AccessMode, SqlDialect};
@@ -701,13 +678,6 @@ mod tests {
     };
 
     use super::*;
-
-    impl SqliteCli {
-        fn with_environment(mut self, environment: Vec<(OsString, OsString)>) -> Self {
-            self.environment = environment;
-            self
-        }
-    }
 
     mod preview {
         use crate::adapters::test_support;
@@ -723,14 +693,14 @@ mod tests {
                 INSERT INTO users(id, email, org_id) VALUES (1, 'a@example.com', 7);
                 ",
             );
-            let adapter = SqliteAdapter::new();
+            let (adapter, process_counter) = SqliteAdapter::with_process_counter(&dsn);
 
             adapter
                 .execute_preview(&dsn, "main", "users", 10, 0)
                 .await
                 .unwrap();
 
-            assert_eq!(adapter.cli.process_count(), 2);
+            assert_eq!(process_counter.count(), 2);
         }
 
         #[tokio::test]
@@ -2679,6 +2649,7 @@ world'), (2, 'done');
 
         #[cfg(not(windows))]
         mod initialization_isolation {
+            use crate::adapters::sqlite::sqlite3::tests::TestCommandContext;
             use crate::adapters::test_support;
             use crate::app::ports::outbound::{MetadataProvider, SqliteDiagnosticsProvider};
 
@@ -2687,10 +2658,12 @@ world'), (2, 'done');
             struct InitializationArtifacts {
                 redirected_database: PathBuf,
                 redirected_output: PathBuf,
+                _command_context: TestCommandContext,
             }
 
             fn adapter_with_malicious_initialization(
                 dir: &tempfile::TempDir,
+                dsn: &str,
             ) -> (SqliteAdapter, InitializationArtifacts) {
                 let home = dir.path().join("home");
                 let xdg_config_home = dir.path().join("xdg-config");
@@ -2708,19 +2681,22 @@ world'), (2, 'done');
                 )
                 .unwrap();
 
-                let mut adapter = SqliteAdapter::new();
-                adapter.cli = SqliteCli::new().with_environment(vec![
-                    (OsString::from("HOME"), home.into_os_string()),
-                    (
-                        OsString::from("XDG_CONFIG_HOME"),
-                        xdg_config_home.into_os_string(),
-                    ),
-                ]);
+                let (adapter, command_context) = SqliteAdapter::with_test_environment(
+                    dsn,
+                    vec![
+                        (OsString::from("HOME"), home.into_os_string()),
+                        (
+                            OsString::from("XDG_CONFIG_HOME"),
+                            xdg_config_home.into_os_string(),
+                        ),
+                    ],
+                );
                 (
                     adapter,
                     InitializationArtifacts {
                         redirected_database,
                         redirected_output,
+                        _command_context: command_context,
                     },
                 )
             }
@@ -2735,7 +2711,7 @@ world'), (2, 'done');
                 let (dir, dsn) = test_support::make_sqlite_db(
                     "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO users VALUES (1, 'Ada');",
                 );
-                let (adapter, artifacts) = adapter_with_malicious_initialization(&dir);
+                let (adapter, artifacts) = adapter_with_malicious_initialization(&dir, &dsn);
 
                 let write = adapter
                     .execute_write(
@@ -2780,7 +2756,7 @@ world'), (2, 'done');
                     "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO users VALUES (1, 'Ada');",
                 );
                 let export_path = dir.path().join("users.csv");
-                let (adapter, artifacts) = adapter_with_malicious_initialization(&dir);
+                let (adapter, artifacts) = adapter_with_malicious_initialization(&dir, &dsn);
 
                 adapter
                     .cli

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -14,7 +14,9 @@ use crate::app::policy::sql::sqlite_explain::is_sqlite_explain_query_plan_sql;
 use crate::app::ports::outbound::{
     AccessMode, DatabaseCli, DbOperationError, QueryExecutor, SQLITE_SAFE_MODE_REQUIRED_MARKER,
 };
-use crate::domain::{CommandTag, QueryResult, QuerySource, TableKind, WriteExecutionResult};
+use crate::domain::{
+    CommandTag, QueryResult, QuerySource, TableKind, TableKindInfo, WriteExecutionResult,
+};
 
 use super::super::{SqliteAdapter, path_validation, sql};
 use super::error::{classify_cli_spawn_error, classify_query_error};
@@ -480,17 +482,14 @@ fn sqlite_uri_path(path: &str, is_windows: bool) -> String {
 }
 
 impl SqliteAdapter {
-    async fn preview_rowid_order_alias(
-        &self,
-        path: &str,
-        table: &str,
+    fn preview_rowid_order_alias(
         visible_columns: &[String],
         order_columns: &[String],
+        kind_info: &TableKindInfo,
     ) -> Option<&'static str> {
         if !order_columns.is_empty() {
             return None;
         }
-        let kind_info = self.table_kind_info(path, table).await.ok().flatten()?;
         if kind_info.kind != TableKind::Table || kind_info.without_rowid {
             return None;
         }
@@ -550,14 +549,9 @@ impl QueryExecutor for SqliteAdapter {
     ) -> Result<QueryResult, DbOperationError> {
         Self::validate_main_schema(schema)?;
         let path = Self::path_from_dsn(dsn)?;
-        let order_columns = self.preview_order_columns(path, table).await;
-        let columns = self
-            .preview_visible_column_names(path, table)
-            .await
-            .unwrap_or_default();
-        let rowid_order_alias = self
-            .preview_rowid_order_alias(path, table, &columns, &order_columns)
-            .await;
+        let (columns, order_columns, kind_info) = self.preview_metadata(path, table).await?;
+        let rowid_order_alias =
+            Self::preview_rowid_order_alias(&columns, &order_columns, &kind_info);
         let query = sql::build_preview_query(
             table,
             &columns,

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -146,8 +146,12 @@ impl TableDetailMode {
         matches!(self, Self::Full | Self::Signature)
     }
 
-    const fn include_row_count(self) -> bool {
-        matches!(self, Self::Full)
+    const fn query_mode(self) -> sql::TableMetadataQueryMode {
+        match self {
+            Self::Full => sql::TableMetadataQueryMode::Full,
+            Self::ColumnsAndFks => sql::TableMetadataQueryMode::ColumnsAndFks,
+            Self::Signature => sql::TableMetadataQueryMode::FullWithoutRowCount,
+        }
     }
 
     const fn include_triggers(self) -> bool {
@@ -160,6 +164,14 @@ impl TableDetailMode {
 }
 
 impl SqliteAdapter {
+    fn row_count_fallback_mode<T>(
+        mode: sql::TableMetadataQueryMode,
+        result: &Result<T, DbOperationError>,
+    ) -> Option<sql::TableMetadataQueryMode> {
+        result.as_ref().err()?;
+        mode.without_row_count()
+    }
+
     fn database_name(path: &str) -> String {
         std::path::Path::new(path)
             .file_name()
@@ -419,28 +431,17 @@ impl SqliteAdapter {
         table: &str,
         mode: TableDetailMode,
     ) -> Result<Table, DbOperationError> {
+        let query_mode = mode.query_mode();
         let metadata = self
-            .execute_json_payload(
-                path,
-                &sql::table_metadata_query(
-                    table,
-                    mode.include_triggers(),
-                    mode.include_row_count(),
-                ),
-            )
+            .execute_json_payload(path, &sql::table_metadata_query(table, query_mode))
             .await;
-        let metadata: RawTableMetadata = match metadata {
-            Err(DbOperationError::QueryFailed(_) | DbOperationError::Timeout(_))
-                if mode.include_row_count() =>
-            {
-                self.execute_json_payload(
-                    path,
-                    &sql::table_metadata_query(table, mode.include_triggers(), false),
-                )
-                .await?
-            }
-            result => result?,
-        };
+        let metadata: RawTableMetadata =
+            if let Some(fallback_mode) = Self::row_count_fallback_mode(query_mode, &metadata) {
+                self.execute_json_payload(path, &sql::table_metadata_query(table, fallback_mode))
+                    .await?
+            } else {
+                metadata?
+            };
         Self::table_from_metadata(table, mode, metadata)
     }
 
@@ -693,6 +694,18 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn lock_timeout_uses_row_count_fallback() {
+        let result: Result<(), DbOperationError> = Err(DbOperationError::LockTimeout(
+            "database is locked".to_string(),
+        ));
+
+        assert_eq!(
+            SqliteAdapter::row_count_fallback_mode(sql::TableMetadataQueryMode::Full, &result,),
+            Some(sql::TableMetadataQueryMode::FullWithoutRowCount)
+        );
+    }
 
     #[test]
     fn legacy_list_row_uses_sql_for_storage() {

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -996,6 +996,58 @@ mod tests {
         use super::*;
 
         #[tokio::test]
+        async fn inspector_metadata_uses_one_sqlite_process() {
+            let (_dir, dsn) = test_support::make_sqlite_db(
+                r"
+                CREATE TABLE organizations(id INTEGER PRIMARY KEY, name TEXT);
+                CREATE TABLE users(
+                    id INTEGER PRIMARY KEY,
+                    email TEXT UNIQUE,
+                    org_id INTEGER REFERENCES organizations(id)
+                );
+                CREATE INDEX idx_users_org_id ON users(org_id DESC);
+                CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END;
+                ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let detail = adapter
+                .fetch_table_detail(&dsn, "main", "users")
+                .await
+                .unwrap();
+
+            assert_eq!(detail.indexes.len(), 2);
+            assert_eq!(detail.foreign_keys.len(), 1);
+            assert_eq!(detail.triggers.len(), 1);
+            assert_eq!(adapter.cli.process_count(), 1);
+        }
+
+        #[tokio::test]
+        async fn completion_metadata_uses_one_sqlite_process() {
+            let (_dir, dsn) = test_support::make_sqlite_db(
+                r"
+                CREATE TABLE organizations(id INTEGER PRIMARY KEY);
+                CREATE TABLE users(
+                    id INTEGER PRIMARY KEY,
+                    email TEXT UNIQUE,
+                    org_id INTEGER REFERENCES organizations(id)
+                );
+                CREATE INDEX idx_users_org_id ON users(org_id);
+                ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let detail = adapter
+                .fetch_table_columns_and_fks(&dsn, "main", "users")
+                .await
+                .unwrap();
+
+            assert!(detail.columns[1].is_unique());
+            assert_eq!(detail.foreign_keys.len(), 1);
+            assert_eq!(adapter.cli.process_count(), 1);
+        }
+
+        #[tokio::test]
         async fn non_main_schema_returns_object_missing() {
             let (_dir, dsn) =
                 test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
@@ -1600,6 +1652,28 @@ mod tests {
         use crate::adapters::test_support;
 
         use super::*;
+
+        #[tokio::test]
+        async fn all_tables_use_one_sqlite_process() {
+            let (_dir, dsn) = test_support::make_sqlite_db(
+                r"
+                CREATE TABLE organizations(id INTEGER PRIMARY KEY);
+                CREATE TABLE users(
+                    id INTEGER PRIMARY KEY,
+                    org_id INTEGER REFERENCES organizations(id)
+                );
+                CREATE INDEX idx_users_org_id ON users(org_id);
+                CREATE TABLE events(id INTEGER PRIMARY KEY, user_id INTEGER);
+                CREATE INDEX idx_events_user_id ON events(user_id);
+                ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let signatures = adapter.fetch_table_signatures(&dsn).await.unwrap();
+
+            assert_eq!(signatures.len(), 3);
+            assert_eq!(adapter.cli.process_count(), 1);
+        }
 
         #[tokio::test]
         async fn change_with_table_shape() {

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -1045,7 +1045,7 @@ mod tests {
                 CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END;
                 ",
             );
-            let adapter = SqliteAdapter::new();
+            let (adapter, process_counter) = SqliteAdapter::with_process_counter(&dsn);
 
             let detail = adapter
                 .fetch_table_detail(&dsn, "main", "users")
@@ -1055,7 +1055,7 @@ mod tests {
             assert_eq!(detail.indexes.len(), 2);
             assert_eq!(detail.foreign_keys.len(), 1);
             assert_eq!(detail.triggers.len(), 1);
-            assert_eq!(adapter.cli.process_count(), 1);
+            assert_eq!(process_counter.count(), 1);
         }
 
         #[tokio::test]
@@ -1066,7 +1066,7 @@ mod tests {
                 SELECT * FROM json_each('invalid');
                 ",
             );
-            let adapter = SqliteAdapter::new();
+            let (adapter, process_counter) = SqliteAdapter::with_process_counter(&dsn);
 
             let detail = adapter
                 .fetch_table_detail(&dsn, "main", "broken_json")
@@ -1076,7 +1076,7 @@ mod tests {
             assert_eq!(detail.kind_info.kind, TableKind::View);
             assert!(!detail.columns.is_empty());
             assert!(detail.row_count_estimate.is_none());
-            assert_eq!(adapter.cli.process_count(), 2);
+            assert_eq!(process_counter.count(), 2);
         }
 
         #[tokio::test]
@@ -1092,7 +1092,7 @@ mod tests {
                 CREATE INDEX idx_users_org_id ON users(org_id);
                 ",
             );
-            let adapter = SqliteAdapter::new();
+            let (adapter, process_counter) = SqliteAdapter::with_process_counter(&dsn);
 
             let detail = adapter
                 .fetch_table_columns_and_fks(&dsn, "main", "users")
@@ -1101,7 +1101,7 @@ mod tests {
 
             assert!(detail.columns[1].is_unique());
             assert_eq!(detail.foreign_keys.len(), 1);
-            assert_eq!(adapter.cli.process_count(), 1);
+            assert_eq!(process_counter.count(), 1);
         }
 
         #[tokio::test]
@@ -1739,12 +1739,12 @@ mod tests {
                 CREATE INDEX idx_events_user_id ON events(user_id);
                 ",
             );
-            let adapter = SqliteAdapter::new();
+            let (adapter, process_counter) = SqliteAdapter::with_process_counter(&dsn);
 
             let signatures = adapter.fetch_table_signatures(&dsn).await.unwrap();
 
             assert_eq!(signatures.len(), 3);
-            assert_eq!(adapter.cli.process_count(), 1);
+            assert_eq!(process_counter.count(), 1);
         }
 
         #[tokio::test]

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -523,11 +523,7 @@ impl SqliteAdapter {
             columns,
             primary_key,
             foreign_keys,
-            indexes: if mode.include_indexes() {
-                indexes
-            } else {
-                Vec::new()
-            },
+            indexes,
             rls: None,
             triggers,
             row_count_estimate: metadata.row_count,

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -10,8 +10,7 @@ use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
 use crate::domain::TableKind;
 use crate::domain::{
     Column, ColumnAttributes, DatabaseMetadata, FkAction, ForeignKey, Index, IndexAttributes,
-    IndexType, Schema, Table, TableKindInfo, TableSignature, TableSummary, Trigger,
-    UNRESOLVED_FK_COLUMN,
+    IndexType, Schema, Table, TableKindInfo, TableSignature, TableSummary, UNRESOLVED_FK_COLUMN,
 };
 
 use super::super::{SqliteAdapter, schema::MAIN_SCHEMA, sql};
@@ -48,17 +47,7 @@ struct RawColumn {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-struct RawIndex {
-    name: String,
-    unique: i64,
-    origin: String,
-    #[serde(default)]
-    partial: i64,
-}
-
-#[derive(Debug, Clone, Deserialize)]
 struct RawIndexColumn {
-    seqno: i64,
     cid: i64,
     name: Option<String>,
     #[serde(default)]
@@ -66,11 +55,6 @@ struct RawIndexColumn {
     #[serde(default)]
     coll: Option<String>,
     key: i64,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-struct RawSql {
-    sql: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -95,6 +79,60 @@ struct RawRowCount {
     count: i64,
 }
 
+#[derive(Debug, Deserialize)]
+struct RawJsonPayload {
+    payload: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPreviewMetadata {
+    #[serde(default)]
+    columns: Vec<RawColumn>,
+    table: Option<RawTableKindInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawBatchIndex {
+    name: String,
+    unique: i64,
+    origin: String,
+    #[serde(default)]
+    partial: i64,
+    #[serde(default)]
+    columns: Vec<RawIndexColumn>,
+    definition: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawReferencedColumns {
+    name: String,
+    #[serde(default)]
+    columns: Vec<RawColumn>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawTableMetadata {
+    table: Option<RawTableKindInfo>,
+    #[serde(default)]
+    columns: Vec<RawColumn>,
+    #[serde(default)]
+    indexes: Vec<RawBatchIndex>,
+    #[serde(default)]
+    foreign_keys: Vec<RawForeignKey>,
+    #[serde(default)]
+    triggers: Vec<RawTrigger>,
+    #[serde(default)]
+    referenced_columns: Vec<RawReferencedColumns>,
+    row_count: Option<i64>,
+    source_ddl: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawNamedJsonPayload {
+    name: String,
+    payload: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TableDetailMode {
     Full,
@@ -116,11 +154,7 @@ impl TableDetailMode {
     }
 
     const fn include_source_ddl(self) -> bool {
-        matches!(self, Self::Full)
-    }
-
-    const fn include_kind_info(self) -> bool {
-        !matches!(self, Self::Signature)
+        matches!(self, Self::Full | Self::Signature)
     }
 }
 
@@ -166,285 +200,128 @@ impl SqliteAdapter {
         table_kind_info_from_pragma(&table.r#type, table.wr, table.strict, table.sql.as_deref())
     }
 
-    pub(in crate::adapters::sqlite) async fn table_kind_info(
+    async fn execute_json_payload<T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        query: &str,
+    ) -> Result<T, DbOperationError> {
+        let rows: Vec<RawJsonPayload> = self.cli.execute_json(path, query).await?;
+        let payload = rows.into_iter().next().ok_or_else(|| {
+            DbOperationError::MetadataParseFailed("SQLite metadata payload was empty".to_string())
+        })?;
+        serde_json::from_str(&payload.payload).map_err(DbOperationError::from)
+    }
+
+    pub(in crate::adapters::sqlite) async fn preview_metadata(
         &self,
         path: &str,
         table: &str,
-    ) -> Result<Option<TableKindInfo>, DbOperationError> {
-        let query = sql::table_kind_info_query(table);
-        match self
-            .cli
-            .execute_json::<Vec<RawTableKindInfo>>(path, &query)
-            .await
-        {
-            Ok(rows) => Ok(rows
-                .into_iter()
-                .next()
-                .map(RawTableKindInfo::into_table_kind_info)),
-            Err(DbOperationError::QueryFailed(message))
-                if sql::is_table_list_unavailable(&message) =>
-            {
-                let sql = self.table_definition(path, table).await;
-                Ok(Some(table_kind_info_from_legacy_sql(sql.as_deref())))
-            }
-            Err(error) => Err(error),
+    ) -> Result<(Vec<String>, Vec<String>, TableKindInfo), DbOperationError> {
+        let metadata: RawPreviewMetadata = self
+            .execute_json_payload(path, &sql::preview_metadata_query(table))
+            .await?;
+        if metadata.columns.is_empty() || metadata.table.is_none() {
+            return Err(DbOperationError::ObjectMissing(format!(
+                "SQLite table not found: {table}"
+            )));
         }
-    }
-
-    async fn row_count(&self, path: &str, table: &str) -> Option<i64> {
-        let rows: Result<Vec<RawRowCount>, DbOperationError> = self
-            .cli
-            .execute_json(path, &sql::row_count_query(table))
-            .await;
-        rows.ok()
-            .and_then(|rows| rows.into_iter().next())
-            .map(|row| row.count)
-    }
-
-    async fn table_definition(&self, path: &str, table: &str) -> Option<String> {
-        let rows: Result<Vec<RawSql>, DbOperationError> = self
-            .cli
-            .execute_json(path, &sql::table_definition_query(table))
-            .await;
-        rows.ok()
-            .and_then(|rows| rows.into_iter().next())
-            .and_then(|row| row.sql)
-    }
-
-    async fn columns(&self, path: &str, table: &str) -> Result<Vec<RawColumn>, DbOperationError> {
-        match self
-            .cli
-            .execute_json(path, &sql::table_xinfo_query(table))
-            .await
-        {
-            Ok(columns) => Ok(columns),
-            Err(_) => {
-                self.cli
-                    .execute_json(path, &sql::table_info_query(table))
-                    .await
-            }
-        }
-    }
-
-    pub(in crate::adapters::sqlite) async fn preview_visible_column_names(
-        &self,
-        path: &str,
-        table: &str,
-    ) -> Result<Vec<String>, DbOperationError> {
-        Ok(self
-            .columns(path, table)
-            .await?
+        let primary_key = Self::extract_primary_key(&metadata.columns);
+        let visible_columns = metadata
+            .columns
             .into_iter()
             .filter(|column| column.hidden != 1)
             .map(|column| column.name)
-            .collect())
-    }
-
-    fn extract_primary_key(columns: &[RawColumn]) -> Vec<String> {
-        let mut primary_key: Vec<(i64, String)> = columns
-            .iter()
-            .filter(|column| column.pk > 0)
-            .map(|column| (column.pk, column.name.clone()))
             .collect();
-        primary_key.sort_by_key(|(pk, _)| *pk);
-        primary_key.into_iter().map(|(_, name)| name).collect()
+        let kind_info = metadata
+            .table
+            .map(RawTableKindInfo::into_table_kind_info)
+            .unwrap_or_default();
+        Ok((visible_columns, primary_key, kind_info))
     }
 
-    async fn primary_key_columns(
-        &self,
-        path: &str,
-        table: &str,
-    ) -> Result<Vec<String>, DbOperationError> {
-        let columns = self.columns(path, table).await?;
-        Ok(Self::extract_primary_key(&columns))
-    }
-
-    pub(in crate::adapters::sqlite) fn validate_main_schema(
-        schema: &str,
-    ) -> Result<(), DbOperationError> {
-        if schema == MAIN_SCHEMA {
-            Ok(())
-        } else {
-            Err(DbOperationError::ObjectMissing(format!(
-                "SQLite schema not found: {schema}"
-            )))
-        }
-    }
-
-    pub(in crate::adapters::sqlite) async fn preview_order_columns(
-        &self,
-        path: &str,
-        table: &str,
-    ) -> Vec<String> {
-        self.primary_key_columns(path, table)
-            .await
-            .unwrap_or_default()
-    }
-
-    async fn indexes(&self, path: &str, table: &str) -> Result<Vec<Index>, DbOperationError> {
-        let raw_indexes: Vec<RawIndex> = self
-            .cli
-            .execute_json(path, &sql::index_list_query(table))
-            .await?;
-        let mut indexes = Vec::new();
-
-        for raw in raw_indexes {
-            let mut columns: Vec<RawIndexColumn> = self
-                .cli
-                .execute_json(path, &sql::index_xinfo_query(&raw.name))
-                .await?;
-            columns.sort_by_key(|col| col.seqno);
-            let has_expression = columns.iter().any(|col| col.key != 0 && col.cid == -2);
-            let has_auxiliary_columns = columns.iter().any(|col| col.key == 0);
-            let has_descending_key = columns.iter().any(|col| col.key != 0 && col.desc != 0);
-            let has_non_binary_collation = columns.iter().any(|col| {
-                col.key != 0
-                    && col
-                        .coll
-                        .as_deref()
-                        .is_some_and(|collation| !collation.eq_ignore_ascii_case("BINARY"))
-            });
-            let columns = Self::index_key_column_names(&columns);
-            let definition = self.index_definition(path, &raw.name).await;
-
-            let mut attributes = IndexAttributes::from_parts(raw.unique != 0, raw.origin == "pk");
-            if raw.partial != 0 {
-                attributes = attributes | IndexAttributes::PARTIAL;
-            }
-            if has_expression {
-                attributes = attributes | IndexAttributes::EXPRESSION;
-            }
-            if has_auxiliary_columns {
-                attributes = attributes | IndexAttributes::HAS_AUXILIARY_COLUMNS;
-            }
-            if has_descending_key {
-                attributes = attributes | IndexAttributes::DESCENDING;
-            }
-            if has_non_binary_collation {
-                attributes = attributes | IndexAttributes::NON_BINARY_COLLATION;
-            }
-
-            indexes.push(Index {
-                name: raw.name,
-                columns,
-                attributes,
-                index_type: IndexType::Unknown,
-                definition,
-            });
-        }
-
-        indexes.sort_by(|a, b| a.name.cmp(&b.name));
-        Ok(indexes)
-    }
-
-    async fn unique_single_columns(
-        &self,
-        path: &str,
-        table: &str,
-    ) -> Result<std::collections::HashSet<String>, DbOperationError> {
-        let raw_indexes: Vec<RawIndex> = self
-            .cli
-            .execute_json(path, &sql::index_list_query(table))
-            .await?;
-        let mut columns = std::collections::HashSet::new();
-
-        for raw in raw_indexes
+    fn indexes_from_batch(raw_indexes: Vec<RawBatchIndex>) -> Vec<Index> {
+        let mut indexes = raw_indexes
             .into_iter()
-            .filter(|index| index.unique != 0 && index.partial == 0)
-        {
-            let key_columns = self.index_key_columns(path, &raw.name).await?;
-            if key_columns.len() == 1 && key_columns[0] != "<expression>" {
-                columns.insert(key_columns[0].clone());
-            }
-        }
-
-        Ok(columns)
-    }
-
-    async fn index_key_columns(
-        &self,
-        path: &str,
-        index: &str,
-    ) -> Result<Vec<String>, DbOperationError> {
-        let mut columns: Vec<RawIndexColumn> = self
-            .cli
-            .execute_json(path, &sql::index_xinfo_query(index))
-            .await?;
-        columns.sort_by_key(|col| col.seqno);
-        Ok(Self::index_key_column_names(&columns))
-    }
-
-    fn index_key_column_names(columns: &[RawIndexColumn]) -> Vec<String> {
-        columns
-            .iter()
-            .filter(|col| col.key != 0)
-            .map(|col| {
-                if col.cid == -2 {
-                    "<expression>".to_string()
-                } else {
-                    col.name.clone().unwrap_or_else(|| "<unknown>".to_string())
+            .map(|raw| {
+                let has_expression = raw
+                    .columns
+                    .iter()
+                    .any(|column| column.key != 0 && column.cid == -2);
+                let has_auxiliary_columns = raw.columns.iter().any(|column| column.key == 0);
+                let has_descending_key = raw
+                    .columns
+                    .iter()
+                    .any(|column| column.key != 0 && column.desc != 0);
+                let has_non_binary_collation = raw.columns.iter().any(|column| {
+                    column.key != 0
+                        && column
+                            .coll
+                            .as_deref()
+                            .is_some_and(|collation| !collation.eq_ignore_ascii_case("BINARY"))
+                });
+                let columns = Self::index_key_column_names(&raw.columns);
+                let mut attributes =
+                    IndexAttributes::from_parts(raw.unique != 0, raw.origin == "pk");
+                if raw.partial != 0 {
+                    attributes = attributes | IndexAttributes::PARTIAL;
+                }
+                if has_expression {
+                    attributes = attributes | IndexAttributes::EXPRESSION;
+                }
+                if has_auxiliary_columns {
+                    attributes = attributes | IndexAttributes::HAS_AUXILIARY_COLUMNS;
+                }
+                if has_descending_key {
+                    attributes = attributes | IndexAttributes::DESCENDING;
+                }
+                if has_non_binary_collation {
+                    attributes = attributes | IndexAttributes::NON_BINARY_COLLATION;
+                }
+                Index {
+                    name: raw.name,
+                    columns,
+                    attributes,
+                    index_type: IndexType::Unknown,
+                    definition: raw.definition,
                 }
             })
-            .collect()
+            .collect::<Vec<_>>();
+        indexes.sort_by(|left, right| left.name.cmp(&right.name));
+        indexes
     }
 
-    async fn index_definition(&self, path: &str, index: &str) -> Option<String> {
-        let rows: Result<Vec<RawSql>, DbOperationError> = self
-            .cli
-            .execute_json(path, &sql::index_definition_query(index))
-            .await;
-        rows.ok()
-            .and_then(|rows| rows.into_iter().next())
-            .and_then(|row| row.sql)
-    }
-
-    async fn triggers(&self, path: &str, table: &str) -> Result<Vec<Trigger>, DbOperationError> {
-        let raw: Vec<RawTrigger> = self
-            .cli
-            .execute_json(path, &sql::trigger_list_query(table))
-            .await?;
-        let mut triggers = Vec::new();
-
-        for raw in raw {
-            if let Some(sql) = raw.sql {
-                triggers.push(parse_sqlite_trigger(&raw.name, &sql)?);
-            }
-        }
-
-        triggers.sort_by(|a, b| a.name.cmp(&b.name));
-        Ok(triggers)
-    }
-
-    async fn foreign_keys(
-        &self,
-        path: &str,
+    fn foreign_keys_from_batch(
         table: &str,
+        mut raw: Vec<RawForeignKey>,
+        referenced: &[RawReferencedColumns],
     ) -> Result<Vec<ForeignKey>, DbOperationError> {
-        let mut raw: Vec<RawForeignKey> = self
-            .cli
-            .execute_json(path, &sql::foreign_key_list_query(table))
-            .await?;
         raw.sort_by_key(|fk| (fk.id, fk.seq));
-
+        let referenced = referenced
+            .iter()
+            .map(|entry| (entry.name.as_str(), entry.columns.as_slice()))
+            .collect::<HashMap<_, _>>();
         let mut grouped = Vec::new();
         let mut current: Option<ForeignKey> = None;
         let mut current_id = None;
-        let mut referenced_primary_keys = HashMap::new();
-        let mut referenced_columns = HashMap::new();
 
         for fk in raw {
-            let (to_column, resolved) = self
-                .resolve_fk_target_column(
-                    path,
-                    &fk,
-                    &mut referenced_primary_keys,
-                    &mut referenced_columns,
-                )
-                .await?;
+            let referenced_columns = referenced.get(fk.table.as_str()).copied();
+            let (to_column, resolved) = if let Some(to) = &fk.to {
+                let resolved = referenced_columns.is_some_and(|columns| {
+                    !columns.is_empty()
+                        && columns
+                            .iter()
+                            .any(|column| column.name.eq_ignore_ascii_case(to))
+                });
+                (to.clone(), resolved)
+            } else {
+                let primary_key = referenced_columns.map(Self::extract_primary_key);
+                Self::primary_key_target_column(&fk, primary_key.as_ref())
+            };
 
             if current_id != Some(fk.id) {
-                if let Some(fk) = current.take() {
-                    grouped.push(fk);
+                if let Some(foreign_key) = current.take() {
+                    grouped.push(foreign_key);
                 }
                 current_id = Some(fk.id);
                 current = Some(ForeignKey {
@@ -460,53 +337,52 @@ impl SqliteAdapter {
                     reference_resolved: resolved,
                 });
             }
-
             if let Some(current) = &mut current {
                 current.from_columns.push(fk.from);
                 current.to_columns.push(to_column);
-                if !resolved {
-                    current.reference_resolved = false;
-                }
+                current.reference_resolved &= resolved;
             }
         }
-
-        if let Some(fk) = current {
-            grouped.push(fk);
+        if let Some(foreign_key) = current {
+            grouped.push(foreign_key);
         }
-
         Ok(grouped)
     }
 
-    async fn resolve_fk_target_column(
-        &self,
-        path: &str,
-        fk: &RawForeignKey,
-        referenced_primary_keys: &mut HashMap<String, Vec<String>>,
-        referenced_columns: &mut HashMap<String, HashSet<String>>,
-    ) -> Result<(String, bool), DbOperationError> {
-        if let Some(to) = &fk.to {
-            self.cache_table_columns(path, &fk.table, referenced_columns)
-                .await?;
-            if !Self::cached_table_has_columns(referenced_columns, &fk.table) {
-                return Ok((to.clone(), false));
-            }
-            let resolved = referenced_columns.get(&fk.table).is_some_and(|columns| {
-                columns.iter().any(|column| column.eq_ignore_ascii_case(to))
-            });
-            Ok((to.clone(), resolved))
-        } else if !referenced_primary_keys.contains_key(&fk.table) {
-            let columns = self.columns(path, &fk.table).await?;
-            referenced_primary_keys.insert(fk.table.clone(), Self::extract_primary_key(&columns));
-            Ok(Self::primary_key_target_column(
-                fk,
-                referenced_primary_keys.get(&fk.table),
-            ))
+    fn extract_primary_key(columns: &[RawColumn]) -> Vec<String> {
+        let mut primary_key: Vec<(i64, String)> = columns
+            .iter()
+            .filter(|column| column.pk > 0)
+            .map(|column| (column.pk, column.name.clone()))
+            .collect();
+        primary_key.sort_by_key(|(pk, _)| *pk);
+        primary_key.into_iter().map(|(_, name)| name).collect()
+    }
+
+    pub(in crate::adapters::sqlite) fn validate_main_schema(
+        schema: &str,
+    ) -> Result<(), DbOperationError> {
+        if schema == MAIN_SCHEMA {
+            Ok(())
         } else {
-            Ok(Self::primary_key_target_column(
-                fk,
-                referenced_primary_keys.get(&fk.table),
-            ))
+            Err(DbOperationError::ObjectMissing(format!(
+                "SQLite schema not found: {schema}"
+            )))
         }
+    }
+
+    fn index_key_column_names(columns: &[RawIndexColumn]) -> Vec<String> {
+        columns
+            .iter()
+            .filter(|col| col.key != 0)
+            .map(|col| {
+                if col.cid == -2 {
+                    "<expression>".to_string()
+                } else {
+                    col.name.clone().unwrap_or_else(|| "<unknown>".to_string())
+                }
+            })
+            .collect()
     }
 
     fn primary_key_target_column(
@@ -525,59 +401,43 @@ impl SqliteAdapter {
         }
     }
 
-    async fn cache_table_columns(
-        &self,
-        path: &str,
-        table: &str,
-        cache: &mut HashMap<String, HashSet<String>>,
-    ) -> Result<(), DbOperationError> {
-        if !cache.contains_key(table) {
-            let columns = self.columns(path, table).await?;
-            cache.insert(
-                table.to_string(),
-                columns.into_iter().map(|column| column.name).collect(),
-            );
-        }
-        Ok(())
-    }
-
-    fn cached_table_has_columns(cache: &HashMap<String, HashSet<String>>, table: &str) -> bool {
-        !cache.get(table).is_some_and(HashSet::is_empty)
-    }
-
     async fn table_detail_with_mode(
         &self,
         path: &str,
         table: &str,
         mode: TableDetailMode,
     ) -> Result<Table, DbOperationError> {
-        let include_indexes = mode.include_indexes();
-        let include_row_count = mode.include_row_count();
-        let include_triggers = mode.include_triggers();
-        let include_source_ddl = mode.include_source_ddl();
-        let (indexes, unique_single_columns) = if include_indexes {
-            let indexes = self.indexes(path, table).await?;
-            let unique_single_columns = indexes
-                .iter()
-                .filter(|index| {
-                    index.is_unique()
-                        && !index.is_partial()
-                        && !index.has_expression()
-                        && index.columns.len() == 1
-                })
-                .map(|index| index.columns[0].clone())
-                .collect::<std::collections::HashSet<_>>();
-            (indexes, unique_single_columns)
-        } else {
-            (Vec::new(), self.unique_single_columns(path, table).await?)
-        };
+        let metadata: RawTableMetadata = self
+            .execute_json_payload(
+                path,
+                &sql::table_metadata_query(table, mode.include_row_count()),
+            )
+            .await?;
+        Self::table_from_metadata(table, mode, metadata)
+    }
 
-        let mut raw_columns = self.columns(path, table).await?;
-        if raw_columns.is_empty() {
+    fn table_from_metadata(
+        table: &str,
+        mode: TableDetailMode,
+        metadata: RawTableMetadata,
+    ) -> Result<Table, DbOperationError> {
+        if metadata.columns.is_empty() || metadata.table.is_none() {
             return Err(DbOperationError::ObjectMissing(format!(
                 "SQLite table not found: {table}"
             )));
         }
+        let indexes = Self::indexes_from_batch(metadata.indexes);
+        let unique_single_columns = indexes
+            .iter()
+            .filter(|index| {
+                index.is_unique()
+                    && !index.is_partial()
+                    && !index.has_expression()
+                    && index.columns.len() == 1
+            })
+            .map(|index| index.columns[0].clone())
+            .collect::<HashSet<_>>();
+        let mut raw_columns = metadata.columns;
         raw_columns.sort_by_key(|column| column.cid);
         let primary_key = Self::extract_primary_key(&raw_columns);
         let columns: Vec<Column> = raw_columns
@@ -613,11 +473,24 @@ impl SqliteAdapter {
             })
             .collect();
         let primary_key = (!primary_key.is_empty()).then_some(primary_key);
-        let kind_info = if mode.include_kind_info() {
-            self.table_kind_info(path, table).await?.unwrap_or_default()
-        } else {
-            TableKindInfo::default()
-        };
+        let kind_info = metadata
+            .table
+            .map(RawTableKindInfo::into_table_kind_info)
+            .unwrap_or_default();
+        let foreign_keys = Self::foreign_keys_from_batch(
+            table,
+            metadata.foreign_keys,
+            &metadata.referenced_columns,
+        )?;
+        let mut triggers = Vec::new();
+        if mode.include_triggers() {
+            for raw in metadata.triggers {
+                if let Some(sql) = raw.sql {
+                    triggers.push(parse_sqlite_trigger(&raw.name, &sql)?);
+                }
+            }
+            triggers.sort_by(|left, right| left.name.cmp(&right.name));
+        }
 
         Ok(Table {
             schema: MAIN_SCHEMA.to_string(),
@@ -625,22 +498,18 @@ impl SqliteAdapter {
             owner: None,
             columns,
             primary_key,
-            foreign_keys: self.foreign_keys(path, table).await?,
-            indexes,
-            rls: None,
-            triggers: if include_triggers {
-                self.triggers(path, table).await?
+            foreign_keys,
+            indexes: if mode.include_indexes() {
+                indexes
             } else {
                 Vec::new()
             },
-            row_count_estimate: if include_row_count {
-                self.row_count(path, table).await
-            } else {
-                None
-            },
+            rls: None,
+            triggers,
+            row_count_estimate: metadata.row_count,
             comment: None,
-            source_ddl: if include_source_ddl {
-                self.table_definition(path, table).await
+            source_ddl: if mode.include_source_ddl() {
+                metadata.source_ddl
             } else {
                 None
             },
@@ -648,17 +517,10 @@ impl SqliteAdapter {
         })
     }
 
-    async fn signature_for_table(
-        &self,
-        path: &str,
-        table: &RawTable,
-    ) -> Result<TableSignature, DbOperationError> {
-        let detail = self
-            .table_detail_with_mode(path, &table.name, TableDetailMode::Signature)
-            .await?;
-        let kind_info = Self::kind_info_for_raw_table(table);
+    fn signature_for_table(detail: &Table) -> TableSignature {
+        let kind_info = &detail.kind_info;
         let mut parts = vec![
-            format!("sql={}", table.sql.clone().unwrap_or_default()),
+            format!("sql={}", detail.source_ddl.clone().unwrap_or_default()),
             format!("kind={:?}", kind_info.kind),
             format!("strict={}", kind_info.is_strict),
             format!("wr={}", kind_info.without_rowid),
@@ -721,11 +583,11 @@ impl SqliteAdapter {
             )
         }));
 
-        Ok(TableSignature {
+        TableSignature {
             schema: MAIN_SCHEMA.to_string(),
-            name: table.name.clone(),
+            name: detail.name.clone(),
             signature: parts.join("|"),
-        })
+        }
     }
 }
 
@@ -783,12 +645,19 @@ impl MetadataProvider for SqliteAdapter {
         dsn: &str,
     ) -> Result<Vec<TableSignature>, DbOperationError> {
         let path = Self::path_from_dsn(dsn)?;
-        let tables = self.list_tables(path).await?;
-        let mut signatures = Vec::new();
-        for table in &tables {
-            signatures.push(self.signature_for_table(path, table).await?);
-        }
-        Ok(signatures)
+        let rows: Vec<RawNamedJsonPayload> = self
+            .cli
+            .execute_json(path, &sql::table_signatures_query())
+            .await?;
+        rows.into_iter()
+            .map(|row| {
+                let metadata: RawTableMetadata =
+                    serde_json::from_str(&row.payload).map_err(DbOperationError::from)?;
+                let detail =
+                    Self::table_from_metadata(&row.name, TableDetailMode::Signature, metadata)?;
+                Ok(Self::signature_for_table(&detail))
+            })
+            .collect()
     }
 }
 
@@ -821,7 +690,6 @@ mod tests {
     fn index_key_column_names_preserves_expression_and_unknown_key_columns() {
         let columns = vec![
             RawIndexColumn {
-                seqno: 0,
                 cid: 1,
                 name: Some("email".to_string()),
                 desc: 0,
@@ -829,7 +697,6 @@ mod tests {
                 key: 1,
             },
             RawIndexColumn {
-                seqno: 1,
                 cid: -2,
                 name: None,
                 desc: 0,
@@ -837,7 +704,6 @@ mod tests {
                 key: 1,
             },
             RawIndexColumn {
-                seqno: 2,
                 cid: 99,
                 name: None,
                 desc: 0,
@@ -845,7 +711,6 @@ mod tests {
                 key: 1,
             },
             RawIndexColumn {
-                seqno: 3,
                 cid: 2,
                 name: Some("rowid".to_string()),
                 desc: 0,

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -1107,6 +1107,21 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn resolves_table_name_case_insensitively() {
+            let (_dir, dsn) =
+                test_support::make_sqlite_db("CREATE TABLE MixedCase(id INTEGER PRIMARY KEY);");
+            let adapter = SqliteAdapter::new();
+
+            let detail = adapter
+                .fetch_table_detail(&dsn, "main", "mixedcase")
+                .await
+                .unwrap();
+
+            assert_eq!(detail.primary_key, Some(vec!["id".to_string()]));
+            assert_eq!(detail.kind_info.kind, TableKind::Table);
+        }
+
+        #[tokio::test]
         async fn loads_columns_indexes_and_foreign_keys() {
             let (_dir, dsn) = test_support::make_sqlite_db(
                 r"

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -407,12 +407,28 @@ impl SqliteAdapter {
         table: &str,
         mode: TableDetailMode,
     ) -> Result<Table, DbOperationError> {
-        let metadata: RawTableMetadata = self
+        let metadata = self
             .execute_json_payload(
                 path,
-                &sql::table_metadata_query(table, mode.include_row_count()),
+                &sql::table_metadata_query(
+                    table,
+                    mode.include_triggers(),
+                    mode.include_row_count(),
+                ),
             )
-            .await?;
+            .await;
+        let metadata: RawTableMetadata = match metadata {
+            Err(DbOperationError::QueryFailed(_) | DbOperationError::Timeout(_))
+                if mode.include_row_count() =>
+            {
+                self.execute_json_payload(
+                    path,
+                    &sql::table_metadata_query(table, mode.include_triggers(), false),
+                )
+                .await?
+            }
+            result => result?,
+        };
         Self::table_from_metadata(table, mode, metadata)
     }
 
@@ -1020,6 +1036,27 @@ mod tests {
             assert_eq!(detail.foreign_keys.len(), 1);
             assert_eq!(detail.triggers.len(), 1);
             assert_eq!(adapter.cli.process_count(), 1);
+        }
+
+        #[tokio::test]
+        async fn inspector_returns_metadata_when_view_row_count_fails() {
+            let (_dir, dsn) = test_support::make_sqlite_db(
+                r"
+                CREATE VIEW broken_json AS
+                SELECT * FROM json_each('invalid');
+                ",
+            );
+            let adapter = SqliteAdapter::new();
+
+            let detail = adapter
+                .fetch_table_detail(&dsn, "main", "broken_json")
+                .await
+                .unwrap();
+
+            assert_eq!(detail.kind_info.kind, TableKind::View);
+            assert!(!detail.columns.is_empty());
+            assert!(detail.row_count_estimate.is_none());
+            assert_eq!(adapter.cli.process_count(), 2);
         }
 
         #[tokio::test]

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -95,6 +95,7 @@ struct RawPreviewMetadata {
 struct RawBatchIndex {
     name: String,
     unique: i64,
+    #[serde(default)]
     origin: String,
     #[serde(default)]
     partial: i64,
@@ -290,6 +291,17 @@ impl SqliteAdapter {
         indexes
     }
 
+    fn unique_single_columns_from_batch(raw_indexes: &[RawBatchIndex]) -> HashSet<String> {
+        raw_indexes
+            .iter()
+            .filter(|index| index.unique != 0 && index.partial == 0)
+            .filter_map(|index| {
+                let columns = Self::index_key_column_names(&index.columns);
+                (columns.len() == 1 && columns[0] != "<expression>").then(|| columns[0].clone())
+            })
+            .collect()
+    }
+
     fn foreign_keys_from_batch(
         table: &str,
         mut raw: Vec<RawForeignKey>,
@@ -442,17 +454,12 @@ impl SqliteAdapter {
                 "SQLite table not found: {table}"
             )));
         }
-        let indexes = Self::indexes_from_batch(metadata.indexes);
-        let unique_single_columns = indexes
-            .iter()
-            .filter(|index| {
-                index.is_unique()
-                    && !index.is_partial()
-                    && !index.has_expression()
-                    && index.columns.len() == 1
-            })
-            .map(|index| index.columns[0].clone())
-            .collect::<HashSet<_>>();
+        let unique_single_columns = Self::unique_single_columns_from_batch(&metadata.indexes);
+        let indexes = if mode.include_indexes() {
+            Self::indexes_from_batch(metadata.indexes)
+        } else {
+            Vec::new()
+        };
         let mut raw_columns = metadata.columns;
         raw_columns.sort_by_key(|column| column.cid);
         let primary_key = Self::extract_primary_key(&raw_columns);

--- a/src/infra/adapters/sqlite/sqlite3/mod.rs
+++ b/src/infra/adapters/sqlite/sqlite3/mod.rs
@@ -4,3 +4,94 @@ mod metadata;
 pub(super) mod parser;
 
 pub(super) use executor::SqliteCli;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+
+    use tokio::process::Command;
+
+    use super::super::SqliteAdapter;
+
+    #[derive(Default)]
+    struct TestCommandConfig {
+        environment: Vec<(OsString, OsString)>,
+        process_count: usize,
+    }
+
+    static COMMAND_CONFIGS: OnceLock<Mutex<HashMap<String, TestCommandConfig>>> = OnceLock::new();
+
+    fn command_configs() -> &'static Mutex<HashMap<String, TestCommandConfig>> {
+        COMMAND_CONFIGS.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    pub(super) fn configure_command(path: &str, command: &mut Command) {
+        let mut configs = command_configs()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(config) = configs.get_mut(path) else {
+            return;
+        };
+        config.process_count += 1;
+        for (key, value) in &config.environment {
+            command.env(key, value);
+        }
+    }
+
+    pub(super) struct TestCommandContext {
+        path: String,
+    }
+
+    impl TestCommandContext {
+        pub(super) fn count(&self) -> usize {
+            command_configs()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .get(&self.path)
+                .map_or(0, |config| config.process_count)
+        }
+    }
+
+    impl Drop for TestCommandContext {
+        fn drop(&mut self) {
+            command_configs()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .remove(&self.path);
+        }
+    }
+
+    impl SqliteAdapter {
+        pub(super) fn with_process_counter(dsn: &str) -> (Self, TestCommandContext) {
+            Self::with_test_command_config(dsn, TestCommandConfig::default())
+        }
+
+        pub(super) fn with_test_environment(
+            dsn: &str,
+            environment: Vec<(OsString, OsString)>,
+        ) -> (Self, TestCommandContext) {
+            Self::with_test_command_config(
+                dsn,
+                TestCommandConfig {
+                    environment,
+                    process_count: 0,
+                },
+            )
+        }
+
+        fn with_test_command_config(
+            dsn: &str,
+            config: TestCommandConfig,
+        ) -> (Self, TestCommandContext) {
+            let path = Self::path_from_dsn(dsn).unwrap().to_string();
+            let previous = command_configs()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .insert(path.clone(), config);
+            assert!(previous.is_none());
+            (Self::new(), TestCommandContext { path })
+        }
+    }
+}


### PR DESCRIPTION
## Problem

SQLite metadata requests currently start a new sqlite3 process for each table, index, and foreign-key lookup. Large schemas make preview, Inspector, SQL completion, and ER refresh noticeably slower.

## Background

SAB-343 aligns SQLite process boundaries with the logical request batching already used by the PostgreSQL adapter.

## Approach

Aggregate SQLite metadata into JSON bundles per logical operation while preserving the existing process-per-operation architecture and domain models. Preview uses one metadata probe, table details and completion use one process per request, and ER signatures batch all tables in one process. Regression tests lock the process budgets and existing metadata fidelity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - SQLiteのテーブル情報取得を効率化し、プレビューやインスペクターの表示を高速化しました。
  - カラム、インデックス、外部キー、トリガーなどのメタデータをまとめて取得できるようになりました。
  - テーブル一覧や署名情報の取得に必要な処理を削減し、データベース操作の負荷を軽減しました。
  - 行数取得が制限される状況でも、テーブル詳細を適切に表示できるよう改善しました。
  - 式インデックスや部分インデックスなどの情報表示精度を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->