### PR TITLE
refactor(sqlite): share statement boundary lexer

### DIFF
--- a/src/app/policy/sql/mod.rs
+++ b/src/app/policy/sql/mod.rs
@@ -2,5 +2,6 @@ pub mod lexer;
 pub mod result_query;
 pub mod sqlite_explain;
 pub mod sqlite_export;
+pub mod sqlite_lexer;
 pub mod sqlite_transaction;
 pub mod statement_classifier;

--- a/src/app/policy/sql/mod.rs
+++ b/src/app/policy/sql/mod.rs
@@ -2,6 +2,6 @@ pub mod lexer;
 pub mod result_query;
 pub mod sqlite_explain;
 pub mod sqlite_export;
-pub mod sqlite_lexer;
+pub mod sqlite_statement_splitter;
 pub mod sqlite_transaction;
 pub mod statement_classifier;

--- a/src/app/policy/sql/sqlite_lexer.rs
+++ b/src/app/policy/sql/sqlite_lexer.rs
@@ -1,0 +1,405 @@
+use super::statement_classifier::{
+    advance_single_quote, skip_block_comment, skip_double_quoted_identifier, skip_line_comment,
+    skip_sqlite_quoted_identifier,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SqliteStatementSplitError {
+    UnclosedCreateTriggerBody,
+    IncompleteCreateTrigger,
+}
+
+#[derive(Debug)]
+pub struct SqliteStatementSplit<'sql> {
+    statements: Vec<&'sql str>,
+    error: Option<SqliteStatementSplitError>,
+}
+
+impl<'sql> SqliteStatementSplit<'sql> {
+    pub fn statements(&self) -> &[&'sql str] {
+        &self.statements
+    }
+
+    pub fn into_statements(self) -> Vec<&'sql str> {
+        self.statements
+    }
+
+    pub fn error(&self) -> Option<SqliteStatementSplitError> {
+        self.error
+    }
+}
+
+pub fn split_sqlite_statements(sql: &str) -> SqliteStatementSplit<'_> {
+    // Keep offsets from the original string so Unicode input remains sliceable.
+    let chars: Vec<(usize, char)> = sql.char_indices().collect();
+    let mut statements = Vec::new();
+    let mut start = 0;
+    let mut i = 0;
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    let mut in_trigger_body = false;
+    let mut trigger_body_stmt_start = false;
+    let mut is_trigger_stmt = is_sqlite_create_trigger_prefix(&sql[start..]);
+
+    while i < chars.len() {
+        let (byte_pos, ch) = chars[i];
+
+        if let Some(next_i) = skip_line_comment(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_block_comment(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = advance_single_quote(&chars, i, ch, &mut in_string) {
+            i = next_i;
+            continue;
+        }
+        if in_string {
+            i += 1;
+            continue;
+        }
+        if let Some(next_i) = skip_double_quoted_identifier(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_sqlite_quoted_identifier(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+
+        if is_trigger_stmt && let Some((keyword, keyword_end)) = keyword_starting_at(sql, &chars, i)
+        {
+            if keyword == "BEGIN" {
+                if in_trigger_body {
+                    trigger_body_stmt_start = false;
+                } else {
+                    in_trigger_body = true;
+                    trigger_body_stmt_start = true;
+                }
+            } else if is_trigger_body_end(
+                &keyword,
+                in_trigger_body,
+                trigger_body_stmt_start,
+                sql,
+                byte_pos,
+            ) {
+                in_trigger_body = false;
+                trigger_body_stmt_start = false;
+            } else if in_trigger_body {
+                trigger_body_stmt_start = false;
+            }
+            i = keyword_end;
+            continue;
+        }
+
+        if ch == '(' {
+            depth += 1;
+        } else if ch == ')' {
+            depth -= 1;
+        }
+
+        if depth == 0 && ch == ';' {
+            if in_trigger_body {
+                trigger_body_stmt_start = true;
+            } else {
+                push_statement(sql, start, byte_pos, &mut statements);
+                start = byte_pos + 1;
+                in_trigger_body = false;
+                trigger_body_stmt_start = false;
+                is_trigger_stmt = is_sqlite_create_trigger_prefix(&sql[start..]);
+            }
+        }
+
+        i += 1;
+    }
+
+    let mut error = None;
+    if start < sql.len() {
+        let fragment = sql[start..].trim();
+        if !fragment.is_empty() {
+            statements.push(fragment);
+            if in_trigger_body {
+                error = Some(SqliteStatementSplitError::UnclosedCreateTriggerBody);
+            } else if is_sqlite_create_trigger_prefix(fragment)
+                && !contains_keyword(fragment, "BEGIN")
+            {
+                error = Some(SqliteStatementSplitError::IncompleteCreateTrigger);
+            }
+        }
+    }
+
+    statements.retain(|statement| !is_comment_only(statement));
+
+    SqliteStatementSplit { statements, error }
+}
+
+fn push_statement<'sql>(sql: &'sql str, start: usize, end: usize, statements: &mut Vec<&'sql str>) {
+    let fragment = sql[start..end].trim();
+    if !fragment.is_empty() {
+        statements.push(fragment);
+    }
+}
+
+fn is_sqlite_create_trigger_prefix(sql: &str) -> bool {
+    let trimmed = sql.trim_start();
+    let chars: Vec<(usize, char)> = trimmed.char_indices().collect();
+
+    let Some((first, second_start)) = next_keyword_from(trimmed, &chars, 0) else {
+        return false;
+    };
+    if first != "CREATE" {
+        return false;
+    }
+    let Some((second, third_start)) = next_keyword_from(trimmed, &chars, second_start) else {
+        return false;
+    };
+    match second.as_str() {
+        "TRIGGER" => true,
+        "TEMP" | "TEMPORARY" => next_keyword_from(trimmed, &chars, third_start)
+            .is_some_and(|(third, _)| third == "TRIGGER"),
+        _ => false,
+    }
+}
+
+fn next_keyword_from(sql: &str, chars: &[(usize, char)], mut i: usize) -> Option<(String, usize)> {
+    let mut in_string = false;
+    while i < chars.len() {
+        let (_, ch) = chars[i];
+        if let Some(next_i) = skip_line_comment(chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_block_comment(chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = advance_single_quote(chars, i, ch, &mut in_string) {
+            i = next_i;
+            continue;
+        }
+        if in_string {
+            i += 1;
+            continue;
+        }
+        if let Some(next_i) = skip_double_quoted_identifier(chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_sqlite_quoted_identifier(chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(keyword) = keyword_starting_at(sql, chars, i) {
+            return Some(keyword);
+        }
+        i += 1;
+    }
+    None
+}
+
+fn keyword_starting_at(sql: &str, chars: &[(usize, char)], i: usize) -> Option<(String, usize)> {
+    let (byte_pos, ch) = chars[i];
+    if !ch.is_ascii_alphabetic() {
+        return None;
+    }
+    let start = byte_pos;
+    let mut end = i;
+    while end < chars.len() && (chars[end].1.is_ascii_alphanumeric() || chars[end].1 == '_') {
+        end += 1;
+    }
+    let end_byte = chars.get(end).map_or(sql.len(), |(byte_pos, _)| *byte_pos);
+    Some((sql[start..end_byte].to_ascii_uppercase(), end))
+}
+
+fn contains_keyword(sql: &str, expected: &str) -> bool {
+    let chars: Vec<(usize, char)> = sql.char_indices().collect();
+    let mut offset = 0;
+    while let Some((keyword, end)) = next_keyword_from(sql, &chars, offset) {
+        if keyword == expected {
+            return true;
+        }
+        offset = end;
+    }
+    false
+}
+
+fn is_trigger_body_end(
+    keyword: &str,
+    in_trigger_body: bool,
+    trigger_body_stmt_start: bool,
+    sql: &str,
+    keyword_start: usize,
+) -> bool {
+    in_trigger_body
+        && trigger_body_stmt_start
+        && keyword == "END"
+        && !is_dotted_identifier_suffix(sql, keyword_start)
+}
+
+fn is_dotted_identifier_suffix(sql: &str, keyword_start: usize) -> bool {
+    let mut index = keyword_start;
+    while index > 0 {
+        index -= 1;
+        match sql.as_bytes()[index] {
+            byte if byte.is_ascii_whitespace() => {}
+            b'.' => return true,
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn is_comment_only(sql: &str) -> bool {
+    let chars: Vec<(usize, char)> = sql.char_indices().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let (_, ch) = chars[i];
+        if ch.is_whitespace() {
+            i += 1;
+            continue;
+        }
+        if let Some(next_i) = skip_line_comment(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        if let Some(next_i) = skip_block_comment(&chars, i, ch) {
+            i = next_i;
+            continue;
+        }
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::empty("", Vec::<&str>::new())]
+    #[case::whitespace("   ", Vec::<&str>::new())]
+    #[case::empty_statements("; ; SELECT 1;;", vec!["SELECT 1"])]
+    #[case::comment_only("-- comment\n/* another comment */", Vec::<&str>::new())]
+    fn handles_empty_input_and_statements(#[case] sql: &str, #[case] expected: Vec<&str>) {
+        let result = split_sqlite_statements(sql);
+
+        assert_eq!(result.statements(), expected);
+        assert_eq!(result.error(), None);
+    }
+
+    #[rstest]
+    #[case::single("SELECT 1", vec!["SELECT 1"])]
+    #[case::multiple("SELECT 1; SELECT 2", vec!["SELECT 1", "SELECT 2"])]
+    #[case::trailing_semicolon("SELECT 1;", vec!["SELECT 1"])]
+    fn splits_sqlite_statements(#[case] sql: &str, #[case] expected: Vec<&str>) {
+        let result = split_sqlite_statements(sql);
+
+        assert_eq!(result.statements(), expected);
+        assert_eq!(result.error(), None);
+    }
+
+    #[rstest]
+    #[case::single_quote("SELECT ';'; SELECT 1", vec!["SELECT ';'", "SELECT 1"])]
+    #[case::double_quote("SELECT \";\"; SELECT 1", vec!["SELECT \";\"", "SELECT 1"])]
+    #[case::backtick("SELECT `;`; SELECT 1", vec!["SELECT `;`", "SELECT 1"])]
+    #[case::bracket("SELECT [;]; SELECT 1", vec!["SELECT [;]", "SELECT 1"])]
+    fn ignores_semicolons_in_sqlite_quotes(#[case] sql: &str, #[case] expected: Vec<&str>) {
+        let result = split_sqlite_statements(sql);
+
+        assert_eq!(result.statements(), expected);
+        assert_eq!(result.error(), None);
+    }
+
+    #[rstest]
+    #[case::line_comment("SELECT 1 -- ; ignored\n; SELECT 2", vec!["SELECT 1 -- ; ignored", "SELECT 2"])]
+    #[case::block_comment("SELECT /* ; ignored */ 1; SELECT 2", vec!["SELECT /* ; ignored */ 1", "SELECT 2"])]
+    fn ignores_semicolons_in_comments(#[case] sql: &str, #[case] expected: Vec<&str>) {
+        let result = split_sqlite_statements(sql);
+
+        assert_eq!(result.statements(), expected);
+        assert_eq!(result.error(), None);
+    }
+
+    #[test]
+    fn keeps_create_trigger_body_together() {
+        let trigger = "\
+CREATE TRIGGER agent_messages_fts_ai AFTER INSERT ON agent_messages BEGIN
+    INSERT INTO agent_messages_fts(rowid, role, content)
+    VALUES (new.id, new.role, new.content);
+END";
+        let sql = format!("{trigger}; SELECT 1");
+        let result = split_sqlite_statements(&sql);
+
+        assert_eq!(result.statements(), vec![trigger, "SELECT 1"]);
+        assert_eq!(result.error(), None);
+    }
+
+    #[test]
+    fn keeps_trigger_end_column_references_inside_body() {
+        let trigger = "\
+CREATE TRIGGER sync_end AFTER UPDATE ON events BEGIN
+    UPDATE counters SET end_value = new.end WHERE id = new.id;
+    INSERT INTO audit(event_id, end_value) VALUES (new.id, old.end);
+END";
+        let sql = format!("{trigger}; SELECT 1");
+        let result = split_sqlite_statements(&sql);
+
+        assert_eq!(result.statements(), vec![trigger, "SELECT 1"]);
+        assert_eq!(result.error(), None);
+    }
+
+    #[test]
+    fn reports_unfinished_create_trigger_body_without_changing_statements() {
+        let trigger =
+            "CREATE TRIGGER t AFTER INSERT ON users BEGIN INSERT INTO logs(id) VALUES (1);";
+        let result = split_sqlite_statements(trigger);
+
+        assert_eq!(result.statements(), vec![trigger]);
+        assert_eq!(
+            result.error(),
+            Some(SqliteStatementSplitError::UnclosedCreateTriggerBody)
+        );
+    }
+
+    #[test]
+    fn reports_incomplete_create_trigger() {
+        let result = split_sqlite_statements("CREATE TRIGGER t AFTER INSERT ON users");
+
+        assert_eq!(
+            result.statements(),
+            vec!["CREATE TRIGGER t AFTER INSERT ON users"]
+        );
+        assert_eq!(
+            result.error(),
+            Some(SqliteStatementSplitError::IncompleteCreateTrigger)
+        );
+    }
+
+    #[test]
+    fn keeps_unclosed_string_as_a_statement() {
+        let result = split_sqlite_statements("SELECT 'unclosed");
+
+        assert_eq!(result.statements(), vec!["SELECT 'unclosed"]);
+        assert_eq!(result.error(), None);
+    }
+
+    #[test]
+    fn preserves_unicode_byte_boundaries() {
+        let result = split_sqlite_statements("SELECT 'İ'; SELECT 2");
+
+        assert_eq!(result.statements(), vec!["SELECT 'İ'", "SELECT 2"]);
+    }
+
+    #[test]
+    fn recognizes_temporary_trigger() {
+        let result = split_sqlite_statements(
+            "CREATE TEMPORARY TRIGGER t AFTER INSERT ON users BEGIN SELECT 1; END; SELECT 2",
+        );
+
+        assert_eq!(result.statements().len(), 2);
+        assert_eq!(result.error(), None);
+    }
+}

--- a/src/app/policy/sql/sqlite_statement_splitter.rs
+++ b/src/app/policy/sql/sqlite_statement_splitter.rs
@@ -261,14 +261,21 @@ mod tests {
     #[case::empty("", Vec::<&str>::new())]
     #[case::whitespace("   ", Vec::<&str>::new())]
     #[case::empty_statements("; ; SELECT 1;;", vec!["SELECT 1"])]
-    #[case::comment_only(
-        "-- comment\n/* another comment */",
-        vec!["-- comment\n/* another comment */"]
-    )]
     fn handles_empty_input_and_statements(#[case] sql: &str, #[case] expected: Vec<&str>) {
         let result = split_sqlite_statements(sql);
 
         assert_eq!(result.statements(), expected);
+        assert_eq!(result.error(), None);
+    }
+
+    #[test]
+    fn keeps_comment_only_input_as_a_fragment() {
+        let result = split_sqlite_statements("-- comment\n/* another comment */");
+
+        assert_eq!(
+            result.statements(),
+            vec!["-- comment\n/* another comment */"]
+        );
         assert_eq!(result.error(), None);
     }
 

--- a/src/app/policy/sql/sqlite_statement_splitter.rs
+++ b/src/app/policy/sql/sqlite_statement_splitter.rs
@@ -10,12 +10,12 @@ pub enum SqliteStatementSplitError {
 }
 
 #[derive(Debug)]
-pub struct SqliteStatementSplit<'sql> {
+pub struct SqliteStatementSplitResult<'sql> {
     statements: Vec<&'sql str>,
     error: Option<SqliteStatementSplitError>,
 }
 
-impl<'sql> SqliteStatementSplit<'sql> {
+impl<'sql> SqliteStatementSplitResult<'sql> {
     pub fn statements(&self) -> &[&'sql str] {
         &self.statements
     }
@@ -29,7 +29,7 @@ impl<'sql> SqliteStatementSplit<'sql> {
     }
 }
 
-pub fn split_sqlite_statements(sql: &str) -> SqliteStatementSplit<'_> {
+pub fn split_sqlite_statements(sql: &str) -> SqliteStatementSplitResult<'_> {
     // Keep offsets from the original string so Unicode input remains sliceable.
     let chars: Vec<(usize, char)> = sql.char_indices().collect();
     let mut statements = Vec::new();
@@ -130,9 +130,10 @@ pub fn split_sqlite_statements(sql: &str) -> SqliteStatementSplit<'_> {
         }
     }
 
-    statements.retain(|statement| !is_comment_only(statement));
-
-    SqliteStatementSplit { statements, error }
+    // Keep comment-only fragments for the sqlite3 execution plan. It has
+    // historically counted them as statement boundaries when deciding on
+    // automatic transaction wrapping.
+    SqliteStatementSplitResult { statements, error }
 }
 
 fn push_statement<'sql>(sql: &'sql str, start: usize, end: usize, statements: &mut Vec<&'sql str>) {
@@ -251,28 +252,6 @@ fn is_dotted_identifier_suffix(sql: &str, keyword_start: usize) -> bool {
     false
 }
 
-fn is_comment_only(sql: &str) -> bool {
-    let chars: Vec<(usize, char)> = sql.char_indices().collect();
-    let mut i = 0;
-    while i < chars.len() {
-        let (_, ch) = chars[i];
-        if ch.is_whitespace() {
-            i += 1;
-            continue;
-        }
-        if let Some(next_i) = skip_line_comment(&chars, i, ch) {
-            i = next_i;
-            continue;
-        }
-        if let Some(next_i) = skip_block_comment(&chars, i, ch) {
-            i = next_i;
-            continue;
-        }
-        return false;
-    }
-    true
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -282,12 +261,26 @@ mod tests {
     #[case::empty("", Vec::<&str>::new())]
     #[case::whitespace("   ", Vec::<&str>::new())]
     #[case::empty_statements("; ; SELECT 1;;", vec!["SELECT 1"])]
-    #[case::comment_only("-- comment\n/* another comment */", Vec::<&str>::new())]
+    #[case::comment_only(
+        "-- comment\n/* another comment */",
+        vec!["-- comment\n/* another comment */"]
+    )]
     fn handles_empty_input_and_statements(#[case] sql: &str, #[case] expected: Vec<&str>) {
         let result = split_sqlite_statements(sql);
 
         assert_eq!(result.statements(), expected);
         assert_eq!(result.error(), None);
+    }
+
+    #[test]
+    fn keeps_comment_only_fragment_after_statement() {
+        let result =
+            split_sqlite_statements("INSERT INTO users(id) VALUES (1); -- trailing comment");
+
+        assert_eq!(
+            result.statements(),
+            vec!["INSERT INTO users(id) VALUES (1)", "-- trailing comment"]
+        );
     }
 
     #[rstest]

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1,6 +1,6 @@
 use super::write_guardrails::{self, RiskLevel};
 use crate::domain::DatabaseType;
-use crate::policy::sql::sqlite_lexer::split_sqlite_statements;
+use crate::policy::sql::sqlite_statement_splitter::split_sqlite_statements;
 use crate::policy::sql::sqlite_transaction::{
     SqliteStatementClassification, SqliteTransactionPolicy, parse_sqlite_pragma,
     sqlite_statement_classification, sqlite_transaction_policy_for_classifications,
@@ -138,6 +138,7 @@ pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> 
         return split_sqlite_statements(sql)
             .statements()
             .iter()
+            .filter(|statement| !is_comment_only(statement))
             .map(|statement| (*statement).to_string())
             .collect();
     }
@@ -1354,6 +1355,21 @@ mod tests {
 
         mod sqlite_transaction_policy {
             use super::*;
+
+            #[test]
+            fn sqlite_policy_ignores_trailing_comment_only_fragment() {
+                let result = evaluate_multi_statement_for_database(
+                    DatabaseType::SQLite,
+                    "INSERT INTO users(id) VALUES (1); -- trailing comment",
+                );
+
+                match result {
+                    MultiStatementDecision::Allow { statements, .. } => {
+                        assert_eq!(statements, vec!["INSERT INTO users(id) VALUES (1)"]);
+                    }
+                    _ => panic!("expected Allow"),
+                }
+            }
 
             #[test]
             fn sqlite_incompatible_transaction_requires_non_atomic_acknowledgement() {

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1,5 +1,6 @@
 use super::write_guardrails::{self, RiskLevel};
 use crate::domain::DatabaseType;
+use crate::policy::sql::sqlite_lexer::split_sqlite_statements;
 use crate::policy::sql::sqlite_transaction::{
     SqliteStatementClassification, SqliteTransactionPolicy, parse_sqlite_pragma,
     sqlite_statement_classification, sqlite_transaction_policy_for_classifications,
@@ -132,127 +133,25 @@ pub fn split_statements(sql: &str) -> Vec<String> {
     split_statements_for_database(DatabaseType::PostgreSQL, sql)
 }
 
-fn is_sqlite_create_trigger_prefix(sql: &str) -> bool {
-    let trimmed = sql.trim_start();
-    let chars: Vec<(usize, char)> = trimmed.char_indices().collect();
-
-    let Some((first, second_start)) = next_keyword_from(trimmed, &chars, 0) else {
-        return false;
-    };
-    if first != "CREATE" {
-        return false;
-    }
-    let Some((second, third_start)) = next_keyword_from(trimmed, &chars, second_start) else {
-        return false;
-    };
-    match second.as_str() {
-        "TRIGGER" => true,
-        "TEMP" | "TEMPORARY" => next_keyword_from(trimmed, &chars, third_start)
-            .is_some_and(|(third, _)| third == "TRIGGER"),
-        _ => false,
-    }
-}
-
-fn next_keyword_from(sql: &str, chars: &[(usize, char)], mut i: usize) -> Option<(String, usize)> {
-    let mut in_string = false;
-    while i < chars.len() {
-        let (byte_pos, ch) = chars[i];
-        if let Some(next_i) = skip_line_comment(chars, i, ch) {
-            i = next_i;
-            continue;
-        }
-        if let Some(next_i) = skip_block_comment(chars, i, ch) {
-            i = next_i;
-            continue;
-        }
-        if let Some(next_i) = advance_single_quote(chars, i, ch, &mut in_string) {
-            i = next_i;
-            continue;
-        }
-        if in_string {
-            i += 1;
-            continue;
-        }
-        if let Some(next_i) = skip_double_quoted_identifier(chars, i, ch) {
-            i = next_i;
-            continue;
-        }
-        if let Some(next_i) = skip_sqlite_quoted_identifier(chars, i, ch) {
-            i = next_i;
-            continue;
-        }
-        if let Some(next_i) = skip_dollar_quoted_string(sql, chars, i, byte_pos, ch) {
-            i = next_i;
-            continue;
-        }
-        if let Some(keyword) = keyword_starting_at(sql, chars, i) {
-            return Some(keyword);
-        }
-        i += 1;
-    }
-    None
-}
-
-fn keyword_starting_at(sql: &str, chars: &[(usize, char)], i: usize) -> Option<(String, usize)> {
-    let (byte_pos, ch) = chars[i];
-    if !ch.is_ascii_alphabetic() {
-        return None;
-    }
-    let start = byte_pos;
-    let mut j = i;
-    while j < chars.len() {
-        let (_, c) = chars[j];
-        if c.is_ascii_alphanumeric() || c == '_' {
-            j += 1;
-        } else {
-            break;
-        }
-    }
-    Some((
-        sql[start..chars.get(j).map_or(sql.len(), |(p, _)| *p)].to_ascii_uppercase(),
-        j,
-    ))
-}
-
-fn is_dotted_identifier_suffix(sql: &str, keyword_start: usize) -> bool {
-    let mut index = keyword_start;
-    while index > 0 {
-        index -= 1;
-        match sql.as_bytes()[index] {
-            byte if byte.is_ascii_whitespace() => {}
-            b'.' => return true,
-            _ => return false,
-        }
-    }
-    false
-}
-
-fn is_sqlite_trigger_body_end(
-    keyword: &str,
-    in_trigger_body: bool,
-    trigger_body_stmt_start: bool,
-    sql: &str,
-    keyword_start: usize,
-) -> bool {
-    in_trigger_body
-        && trigger_body_stmt_start
-        && keyword == "END"
-        && !is_dotted_identifier_suffix(sql, keyword_start)
-}
-
 pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> Vec<String> {
-    // Use sql's own char_indices so byte offsets remain valid for slicing sql.
-    // to_lowercase() can change byte lengths (e.g. İ → i̇), which would corrupt offsets.
+    if database_type == DatabaseType::SQLite {
+        return split_sqlite_statements(sql)
+            .statements()
+            .iter()
+            .map(|statement| (*statement).to_string())
+            .collect();
+    }
+
+    split_postgres_statements(sql)
+}
+
+fn split_postgres_statements(sql: &str) -> Vec<String> {
     let chars: Vec<(usize, char)> = sql.char_indices().collect();
     let mut statements = Vec::new();
     let mut start = 0;
     let mut i = 0;
     let mut depth: i32 = 0;
     let mut in_string = false;
-    let mut in_trigger_body = false;
-    let mut trigger_body_stmt_start = false;
-    let mut is_trigger_stmt =
-        database_type == DatabaseType::SQLite && is_sqlite_create_trigger_prefix(&sql[start..]);
 
     while i < chars.len() {
         let (byte_pos, ch) = chars[i];
@@ -277,38 +176,8 @@ pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> 
             i = next_i;
             continue;
         }
-        if database_type == DatabaseType::SQLite
-            && let Some(next_i) = skip_sqlite_quoted_identifier(&chars, i, ch)
-        {
-            i = next_i;
-            continue;
-        }
         if let Some(next_i) = skip_dollar_quoted_string(sql, &chars, i, byte_pos, ch) {
             i = next_i;
-            continue;
-        }
-
-        if is_trigger_stmt && let Some((keyword, kw_end)) = keyword_starting_at(sql, &chars, i) {
-            if keyword == "BEGIN" {
-                if in_trigger_body {
-                    trigger_body_stmt_start = false;
-                } else {
-                    in_trigger_body = true;
-                    trigger_body_stmt_start = true;
-                }
-            } else if is_sqlite_trigger_body_end(
-                &keyword,
-                in_trigger_body,
-                trigger_body_stmt_start,
-                sql,
-                byte_pos,
-            ) {
-                in_trigger_body = false;
-                trigger_body_stmt_start = false;
-            } else if in_trigger_body {
-                trigger_body_stmt_start = false;
-            }
-            i = kw_end;
             continue;
         }
 
@@ -319,19 +188,11 @@ pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> 
         }
 
         if depth == 0 && ch == ';' {
-            if database_type == DatabaseType::SQLite && in_trigger_body {
-                trigger_body_stmt_start = true;
-            } else {
-                let fragment = sql[start..byte_pos].trim();
-                if !fragment.is_empty() {
-                    statements.push(fragment.to_string());
-                }
-                start = byte_pos + 1;
-                in_trigger_body = false;
-                trigger_body_stmt_start = false;
-                is_trigger_stmt = database_type == DatabaseType::SQLite
-                    && is_sqlite_create_trigger_prefix(&sql[start..]);
+            let fragment = sql[start..byte_pos].trim();
+            if !fragment.is_empty() {
+                statements.push(fragment.to_string());
             }
+            start = byte_pos + 1;
         }
 
         i += 1;
@@ -910,87 +771,6 @@ mod tests {
             #[case] expected: Vec<&str>,
         ) {
             assert_eq!(split_statements(sql), expected);
-        }
-
-        #[rstest]
-        #[case::backtick_quote(
-            "DROP TABLE `a;b`; SELECT 1",
-            vec!["DROP TABLE `a;b`", "SELECT 1"]
-        )]
-        #[case::bracket_quote(
-            "DROP TABLE [a;b]; SELECT 1",
-            vec!["DROP TABLE [a;b]", "SELECT 1"]
-        )]
-        fn sqlite_identifier_quotes_hide_semicolons(
-            #[case] sql: &str,
-            #[case] expected: Vec<&str>,
-        ) {
-            assert_eq!(
-                split_statements_for_database(DatabaseType::SQLite, sql),
-                expected
-            );
-        }
-
-        #[test]
-        fn sqlite_create_trigger_body_is_not_split() {
-            let trigger = "\
-CREATE TRIGGER agent_messages_fts_ai AFTER INSERT ON agent_messages BEGIN
-    INSERT INTO agent_messages_fts(rowid, role, content)
-    VALUES (new.id, new.role, new.content);
-END";
-            let sql = format!("{trigger}; SELECT 1");
-
-            let result = split_statements_for_database(DatabaseType::SQLite, &sql);
-
-            assert_eq!(result.len(), 2);
-            assert_eq!(result[0], trigger);
-            assert_eq!(result[1], "SELECT 1");
-        }
-
-        #[test]
-        fn sqlite_create_trigger_with_dotted_end_reference_is_not_split() {
-            let trigger = "\
-CREATE TRIGGER sync_end AFTER UPDATE ON events BEGIN
-    UPDATE counters SET end_value = new.end WHERE id = new.id;
-    INSERT INTO audit(event_id, end_value) VALUES (new.id, old.end);
-END";
-            let sql = format!("{trigger}; SELECT 1");
-
-            let result = split_statements_for_database(DatabaseType::SQLite, &sql);
-
-            assert_eq!(result.len(), 2);
-            assert_eq!(result[0], trigger);
-            assert_eq!(result[1], "SELECT 1");
-        }
-
-        #[test]
-        fn sqlite_create_trigger_with_case_end_is_not_split() {
-            let trigger = "\
-CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
-    UPDATE counters
-    SET end_value = CASE WHEN new.end > 0 THEN new.end ELSE old.end END
-    WHERE id = new.id;
-    INSERT INTO audit(event_id) VALUES (new.id);
-END";
-            let sql = format!("{trigger}; SELECT 1");
-
-            let result = split_statements_for_database(DatabaseType::SQLite, &sql);
-
-            assert_eq!(result.len(), 2);
-            assert_eq!(result[0], trigger);
-            assert_eq!(result[1], "SELECT 1");
-        }
-
-        #[test]
-        fn sqlite_unclosed_create_trigger_body_is_not_split() {
-            let trigger = "\
-CREATE TRIGGER normalize_events AFTER UPDATE ON events BEGIN
-    UPDATE counters SET end_value = new.end WHERE id = new.id;
-    INSERT INTO audit(event_id) VALUES (new.id);";
-
-            let result = split_statements_for_database(DatabaseType::SQLite, trigger);
-
-            assert_eq!(result, vec![trigger]);
         }
 
         #[rstest]

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::app::policy::sql::sqlite_export::is_sqlite_rerunnable_export_statement;
+use crate::app::policy::sql::sqlite_lexer::{SqliteStatementSplitError, split_sqlite_statements};
 use crate::app::policy::sql::sqlite_transaction::{
     SqliteTransactionPolicy, sqlite_statement_classification,
     sqlite_transaction_policy_for_classifications,
@@ -119,10 +120,6 @@ fn is_create_keyword_prefix(sql: &str, keyword: &str) -> bool {
     second.eq_ignore_ascii_case(keyword)
 }
 
-fn is_create_trigger_prefix(sql: &str) -> bool {
-    is_create_keyword_prefix(sql, "TRIGGER")
-}
-
 pub(in crate::adapters::sqlite::sqlite3) fn is_create_virtual_table_prefix(sql: &str) -> bool {
     let Some((first, pos)) = next_keyword_from(sql, 0) else {
         return false;
@@ -221,128 +218,21 @@ fn module_name_at(sql: &str, start: usize) -> Option<String> {
     }
 }
 
-fn is_dotted_identifier_suffix(sql: &str, keyword_start: usize) -> bool {
-    let mut index = keyword_start;
-    while index > 0 {
-        index -= 1;
-        match sql.as_bytes()[index] {
-            byte if byte.is_ascii_whitespace() => {}
-            b'.' => return true,
-            _ => return false,
-        }
-    }
-    false
-}
-
-fn is_sqlite_trigger_body_end(
-    keyword: &str,
-    in_trigger_body: bool,
-    trigger_body_stmt_start: bool,
-    sql: &str,
-    keyword_start: usize,
-) -> bool {
-    in_trigger_body
-        && trigger_body_stmt_start
-        && keyword.eq_ignore_ascii_case("END")
-        && !is_dotted_identifier_suffix(sql, keyword_start)
-}
-
 pub(in crate::adapters::sqlite::sqlite3) fn try_split_sqlite_statements(
     sql: &str,
 ) -> Result<Vec<&str>, DbOperationError> {
     reject_sqlite_meta_commands(sql)?;
-
-    let bytes = sql.as_bytes();
-    let mut statements = Vec::new();
-    let mut start = 0;
-    let mut i = 0;
-    let mut in_trigger_body = false;
-    let mut trigger_body_stmt_start = false;
-
-    while i < bytes.len() {
-        match bytes[i] {
-            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
-                while i < bytes.len() && bytes[i] != b'\n' {
-                    i += 1;
-                }
+    let split = split_sqlite_statements(sql);
+    if let Some(error) = split.error() {
+        let error = match error {
+            SqliteStatementSplitError::UnclosedCreateTriggerBody => "Unclosed CREATE TRIGGER body",
+            SqliteStatementSplitError::IncompleteCreateTrigger => {
+                "Incomplete CREATE TRIGGER statement"
             }
-            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
-                i += 2;
-                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    i += 1;
-                }
-                if i + 1 < bytes.len() {
-                    i += 2;
-                }
-            }
-            b'\'' | b'"' | b'`' => {
-                i = skip_quoted(bytes, i, bytes[i]);
-            }
-            b'[' => {
-                i = skip_bracket_quoted(bytes, i);
-            }
-            b';' if in_trigger_body => {
-                trigger_body_stmt_start = true;
-                i += 1;
-            }
-            b';' => {
-                let statement = sql[start..i].trim();
-                if !statement.is_empty() {
-                    statements.push(statement);
-                }
-                i += 1;
-                start = i;
-                in_trigger_body = false;
-                trigger_body_stmt_start = false;
-            }
-            _ => {
-                if bytes[i].is_ascii_alphabetic()
-                    && is_create_trigger_prefix(&sql[start..])
-                    && let Some((keyword, kw_end)) = next_keyword_from(sql, i)
-                {
-                    if keyword.eq_ignore_ascii_case("BEGIN") {
-                        if in_trigger_body {
-                            trigger_body_stmt_start = false;
-                        } else {
-                            in_trigger_body = true;
-                            trigger_body_stmt_start = true;
-                        }
-                    } else if is_sqlite_trigger_body_end(
-                        keyword,
-                        in_trigger_body,
-                        trigger_body_stmt_start,
-                        sql,
-                        i,
-                    ) {
-                        in_trigger_body = false;
-                        trigger_body_stmt_start = false;
-                    } else if in_trigger_body {
-                        trigger_body_stmt_start = false;
-                    }
-                    i = kw_end;
-                    continue;
-                }
-                i += 1;
-            }
-        }
+        };
+        return Err(DbOperationError::QueryFailed(error.to_string()));
     }
-
-    let tail = sql[start..].trim();
-    if !tail.is_empty() {
-        if in_trigger_body {
-            return Err(DbOperationError::QueryFailed(
-                "Unclosed CREATE TRIGGER body".to_string(),
-            ));
-        }
-        if is_create_trigger_prefix(tail) && !contains_keyword(tail, "BEGIN") {
-            return Err(DbOperationError::QueryFailed(
-                "Incomplete CREATE TRIGGER statement".to_string(),
-            ));
-        }
-        statements.push(tail);
-    }
-
-    Ok(statements)
+    Ok(split.into_statements())
 }
 
 fn reject_sqlite_meta_commands(sql: &str) -> Result<(), DbOperationError> {

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -2,7 +2,9 @@ use std::borrow::Cow;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::app::policy::sql::sqlite_export::is_sqlite_rerunnable_export_statement;
-use crate::app::policy::sql::sqlite_lexer::{SqliteStatementSplitError, split_sqlite_statements};
+use crate::app::policy::sql::sqlite_statement_splitter::{
+    SqliteStatementSplitError, split_sqlite_statements,
+};
 use crate::app::policy::sql::sqlite_transaction::{
     SqliteTransactionPolicy, sqlite_statement_classification,
     sqlite_transaction_policy_for_classifications,
@@ -849,6 +851,7 @@ END";
 
         #[rstest]
         #[case::multi_dml("INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)")]
+        #[case::trailing_comment_only("INSERT INTO users(id) VALUES (1); -- trailing comment")]
         #[case::read_only_pragma_with_writes(
             "PRAGMA journal_mode; INSERT INTO users(id) VALUES (1); INSERT INTO users(id) VALUES (2)"
         )]


### PR DESCRIPTION
## Problem

SQLite statement boundaries were implemented independently by SQL risk policy and sqlite3 execution planning, allowing future fixes to drift.

## Background

Trigger bodies, quoted identifiers, literals, comments, and semicolons affect confirmation and execution boundaries. The current behavior matched but had duplicate scanners.

## Approach

Centralize SQLite statement boundary lexing and expose statement slices plus incomplete-trigger diagnostics. Keep risk classification, transaction policy, CLI meta-command rejection, and execution SQL generation in their existing layers while adapting the adapter to preserve its existing errors.

Refs: SAB-353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - SQLiteのSQL文を、コメント・引用符・トリガー本体を考慮して正確に分割できるようになりました。
  - Unicode文字を含むSQLでも、文の境界を保持して処理できます。
  - SQLiteトリガーの記述不備を検出し、分かりやすいエラーとして通知します。

- **バグ修正**
  - SQL末尾のコメントのみの断片を無視し、不要なエラーや誤判定を防止しました。
  - 仮想テーブルや一時トリガーを含むSQLite処理の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->