### PR TITLE
fix: keep crate keywords within registry limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ license.workspace = true
 repository.workspace = true
 homepage = "https://github.com/riii111/sabiql"
 readme = "README.md"
-keywords = ["postgresql", "sqlite", "tui", "database", "cli", "sql"]
+keywords = ["postgresql", "sqlite", "tui", "database", "sql"]
 categories = ["command-line-utilities", "database"]
 
 [dependencies]


### PR DESCRIPTION
## Problem

The root crate declares six keywords, exceeding crates.io’s five-keyword limit and causing release publication to fail.

## Approach

Remove the redundant `cli` keyword while retaining PostgreSQL, SQLite, TUI, database, and SQL discovery terms.