### PR TITLE
fix(sqlite): reject fsdir access in safe mode

### DIFF
--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -23,7 +23,7 @@ use super::error::{classify_cli_spawn_error, classify_query_error};
 use super::parser::{
     SqliteStatementPlan, aggregate_sqlite_command_tag, append_changes_query_for_plan,
     command_tag_result, is_sqlite_rerunnable_export_query, last_sqlite_result_set,
-    parse_affected_rows, parse_count_result, quoted_to_query_result,
+    parse_affected_rows, parse_count_result, quoted_to_query_result, reject_sqlite_fsdir,
     sqlite_adhoc_execution_query_for_plan, sqlite_empty_result_sentinel,
     sqlite_export_not_rerunnable_error, sqlite_probe_marker, sqlite_statement_plan,
     sqlite_statement_tags, statement_counts_as_select_tag, strip_sqlite_probes,
@@ -639,6 +639,7 @@ impl QueryExecutor for SqliteAdapter {
     }
 
     async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
+        reject_sqlite_fsdir(query)?;
         let stdout = self
             .cli
             .execute_csv(Self::path_from_dsn(dsn)?, query, true)
@@ -1390,6 +1391,29 @@ mod tests {
                 if side_effect == "writefile" {
                     assert!(!output.exists());
                 }
+            }
+
+            #[rstest::rstest]
+            #[case::read_write(AccessMode::ReadWrite)]
+            #[case::read_only(AccessMode::ReadOnly)]
+            #[tokio::test]
+            async fn rejects_fsdir_before_reading_host_files(#[case] access_mode: AccessMode) {
+                let (dir, dsn) = test_support::make_sqlite_db("");
+                let outside = dir.path().join("outside.txt");
+                std::fs::write(&outside, "fsdir canary").unwrap();
+                let adapter = SqliteAdapter::new();
+                let sql = format!(
+                    "SELECT content FROM fsdir('{}') WHERE name = 'outside.txt'",
+                    outside.display()
+                );
+
+                let result = adapter.execute_adhoc(&dsn, &sql, access_mode).await;
+
+                assert!(matches!(
+                    result,
+                    Err(DbOperationError::UnsupportedOperation(details))
+                        if details == "SQLite fsdir access is not supported in safe mode"
+                ));
             }
         }
 
@@ -2346,6 +2370,25 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn count_query_rows_rejects_fsdir_before_execution() {
+            let (_dir, dsn) = test_support::make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .count_query_rows(
+                    &dsn,
+                    "SELECT COUNT(*) FROM (SELECT * FROM fsdir('/tmp')) AS files",
+                )
+                .await;
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::UnsupportedOperation(details))
+                    if details == "SQLite fsdir access is not supported in safe mode"
+            ));
+        }
+
+        #[tokio::test]
         async fn export_to_csv_writes_rows() {
             let (dir, dsn) = test_support::make_sqlite_db(
                 r"
@@ -2417,6 +2460,22 @@ world'), (2, 'done');
                 if message.contains("write or DDL")
             ));
             assert!(!path.exists());
+        }
+
+        #[tokio::test]
+        async fn export_to_csv_rejects_fsdir_before_creating_output() {
+            let (_dir, dsn) = test_support::make_sqlite_db("");
+            let adapter = SqliteAdapter::new();
+
+            let result = adapter
+                .export_to_csv(&dsn, "SELECT * FROM fsdir('/tmp')", "fsdir_export")
+                .await;
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::UnsupportedOperation(details))
+                    if details == "SQLite fsdir access is not supported in safe mode"
+            ));
         }
 
         #[tokio::test]

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -1403,7 +1403,8 @@ mod tests {
                 std::fs::write(&outside, "fsdir canary").unwrap();
                 let adapter = SqliteAdapter::new();
                 let sql = format!(
-                    "SELECT content FROM fsdir('{}') WHERE name = 'outside.txt'",
+                    "SELECT data FROM 'fsdir'('{}') WHERE name = '{}'",
+                    outside.display(),
                     outside.display()
                 );
 

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -68,50 +68,114 @@ fn bracket_identifier_matches(bytes: &[u8], start: usize, expected: &str) -> boo
         && bytes[start + 1..end - 1].eq_ignore_ascii_case(expected.as_bytes())
 }
 
-fn contains_sqlite_identifier(sql: &str, expected: &str) -> bool {
+fn skip_sqlite_trivia(bytes: &[u8], mut i: usize) -> usize {
+    loop {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+
+        if i + 1 < bytes.len() && bytes[i] == b'-' && bytes[i + 1] == b'-' {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            if i + 1 < bytes.len() {
+                i += 2;
+            }
+            continue;
+        }
+
+        return i;
+    }
+}
+
+fn is_followed_by_open_parenthesis(bytes: &[u8], end: usize) -> bool {
+    let next = skip_sqlite_trivia(bytes, end);
+    next < bytes.len() && bytes[next] == b'('
+}
+
+fn contains_sqlite_fsdir_access(sql: &str) -> bool {
     let bytes = sql.as_bytes();
     let mut i = 0;
+    let mut previous_token_was_using = false;
+    let mut create_statement = false;
+    let mut create_table_name_context = false;
 
     while i < bytes.len() {
+        let next = skip_sqlite_trivia(bytes, i);
+        if next == bytes.len() {
+            break;
+        }
+        i = next;
+
+        let start = i;
+        let mut token_was_using = false;
         match bytes[i] {
-            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
-                while i < bytes.len() && bytes[i] != b'\n' {
-                    i += 1;
-                }
-            }
-            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
-                i += 2;
-                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                    i += 1;
-                }
-                if i + 1 < bytes.len() {
-                    i += 2;
-                }
-            }
-            b'\'' => i = skip_quoted(bytes, i, b'\''),
-            b'"' | b'`' => {
-                if quoted_identifier_matches(bytes, i, bytes[i], expected) {
+            b'\'' | b'"' | b'`' => {
+                let quote = bytes[i];
+                let matches = quoted_identifier_matches(bytes, i, quote, "fsdir");
+                i = skip_quoted(bytes, i, quote);
+                if matches
+                    && (previous_token_was_using
+                        || (!create_table_name_context
+                            && is_followed_by_open_parenthesis(bytes, i)))
+                {
                     return true;
                 }
-                i = skip_quoted(bytes, i, bytes[i]);
             }
             b'[' => {
-                if bracket_identifier_matches(bytes, i, expected) {
+                let matches = bracket_identifier_matches(bytes, i, "fsdir");
+                i = skip_bracket_quoted(bytes, i);
+                if matches
+                    && (previous_token_was_using
+                        || (!create_table_name_context
+                            && is_followed_by_open_parenthesis(bytes, i)))
+                {
                     return true;
                 }
-                i = skip_bracket_quoted(bytes, i);
             }
             byte if byte.is_ascii_alphabetic() || byte == b'_' => {
-                let start = i;
                 while i < bytes.len() && is_ident_char(bytes[i]) {
                     i += 1;
                 }
-                if bytes[start..i].eq_ignore_ascii_case(expected.as_bytes()) {
+                let matches = bytes[start..i].eq_ignore_ascii_case(b"fsdir");
+                if bytes[start..i].eq_ignore_ascii_case(b"create") {
+                    create_statement = true;
+                    create_table_name_context = false;
+                } else if create_statement && bytes[start..i].eq_ignore_ascii_case(b"table") {
+                    create_table_name_context = true;
+                } else if bytes[start..i].eq_ignore_ascii_case(b"using")
+                    || bytes[start..i].eq_ignore_ascii_case(b"as")
+                {
+                    create_table_name_context = false;
+                }
+                if matches
+                    && (previous_token_was_using
+                        || (!create_table_name_context
+                            && is_followed_by_open_parenthesis(bytes, i)))
+                {
                     return true;
                 }
+                token_was_using = bytes[start..i].eq_ignore_ascii_case(b"using");
             }
-            _ => i += 1,
+            _ => {
+                if bytes[i] == b';' {
+                    create_statement = false;
+                    create_table_name_context = false;
+                } else if bytes[i] == b'(' {
+                    create_table_name_context = false;
+                }
+                i += 1;
+            }
         }
+        previous_token_was_using = token_was_using;
     }
 
     false
@@ -120,7 +184,7 @@ fn contains_sqlite_identifier(sql: &str, expected: &str) -> bool {
 pub(in crate::adapters::sqlite::sqlite3) fn reject_sqlite_fsdir(
     sql: &str,
 ) -> Result<(), DbOperationError> {
-    if contains_sqlite_identifier(sql, "fsdir") {
+    if contains_sqlite_fsdir_access(sql) {
         return Err(DbOperationError::UnsupportedOperation(
             SQLITE_FSDIR_SAFE_MODE_ERROR.to_string(),
         ));
@@ -836,9 +900,11 @@ mod tests {
         #[case::double_quoted("SELECT * FROM \"fsdir\"('/tmp')")]
         #[case::backtick_quoted("SELECT * FROM `fsdir`('/tmp')")]
         #[case::bracket_quoted("SELECT * FROM [fsdir]('/tmp')")]
+        #[case::single_quoted("SELECT * FROM 'fsdir'('/tmp')")]
         #[case::comments_between_tokens("SELECT * FROM /* ignored */ fsdir /* ignored */ ('/tmp')")]
         #[case::virtual_table_module("CREATE VIRTUAL TABLE files USING fsdir")]
-        fn rejects_fsdir_identifiers(#[case] sql: &str) {
+        #[case::single_quoted_virtual_table_module("CREATE VIRTUAL TABLE files USING 'fsdir'")]
+        fn rejects_fsdir_access(#[case] sql: &str) {
             let error = try_split_sqlite_statements(sql).unwrap_err();
 
             assert!(matches!(
@@ -854,6 +920,11 @@ mod tests {
         #[case::block_comment("/* fsdir */ SELECT 1")]
         #[case::identifier_prefix("SELECT fsdirname FROM users")]
         #[case::identifier_suffix("SELECT myfsdir FROM users")]
+        #[case::column("SELECT fsdir FROM users")]
+        #[case::alias("SELECT 1 AS fsdir")]
+        #[case::table_without_arguments("SELECT * FROM fsdir")]
+        #[case::table_definition("CREATE TABLE fsdir(name TEXT)")]
+        #[case::quoted_table_definition("CREATE TABLE IF NOT EXISTS 'fsdir'(name TEXT)")]
         #[case::other_virtual_table("SELECT * FROM json_each('{}')")]
         fn ignores_non_fsdir_occurrences(#[case] sql: &str) {
             assert!(try_split_sqlite_statements(sql).is_ok());

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -42,6 +42,92 @@ fn skip_bracket_quoted(bytes: &[u8], mut i: usize) -> usize {
     i
 }
 
+const SQLITE_FSDIR_SAFE_MODE_ERROR: &str = "SQLite fsdir access is not supported in safe mode";
+
+fn quoted_identifier_matches(bytes: &[u8], start: usize, quote: u8, expected: &str) -> bool {
+    let mut i = start + 1;
+    let content_start = i;
+    while i < bytes.len() {
+        if bytes[i] == quote {
+            if i + 1 < bytes.len() && bytes[i + 1] == quote {
+                i += 2;
+            } else {
+                return bytes[content_start..i].eq_ignore_ascii_case(expected.as_bytes());
+            }
+        } else {
+            i += 1;
+        }
+    }
+    false
+}
+
+fn bracket_identifier_matches(bytes: &[u8], start: usize, expected: &str) -> bool {
+    let end = skip_bracket_quoted(bytes, start);
+    end > start + 1
+        && end <= bytes.len()
+        && bytes[start + 1..end - 1].eq_ignore_ascii_case(expected.as_bytes())
+}
+
+fn contains_sqlite_identifier(sql: &str, expected: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'-' if i + 1 < bytes.len() && bytes[i + 1] == b'-' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                if i + 1 < bytes.len() {
+                    i += 2;
+                }
+            }
+            b'\'' => i = skip_quoted(bytes, i, b'\''),
+            b'"' | b'`' => {
+                if quoted_identifier_matches(bytes, i, bytes[i], expected) {
+                    return true;
+                }
+                i = skip_quoted(bytes, i, bytes[i]);
+            }
+            b'[' => {
+                if bracket_identifier_matches(bytes, i, expected) {
+                    return true;
+                }
+                i = skip_bracket_quoted(bytes, i);
+            }
+            byte if byte.is_ascii_alphabetic() || byte == b'_' => {
+                let start = i;
+                while i < bytes.len() && is_ident_char(bytes[i]) {
+                    i += 1;
+                }
+                if bytes[start..i].eq_ignore_ascii_case(expected.as_bytes()) {
+                    return true;
+                }
+            }
+            _ => i += 1,
+        }
+    }
+
+    false
+}
+
+pub(in crate::adapters::sqlite::sqlite3) fn reject_sqlite_fsdir(
+    sql: &str,
+) -> Result<(), DbOperationError> {
+    if contains_sqlite_identifier(sql, "fsdir") {
+        return Err(DbOperationError::UnsupportedOperation(
+            SQLITE_FSDIR_SAFE_MODE_ERROR.to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Returns the next SQL keyword and the byte offset immediately after it.
 fn next_keyword_from(sql: &str, mut i: usize) -> Option<(&str, usize)> {
     let bytes = sql.as_bytes();
@@ -251,6 +337,7 @@ pub(in crate::adapters::sqlite::sqlite3) fn try_split_sqlite_statements(
     sql: &str,
 ) -> Result<Vec<&str>, DbOperationError> {
     reject_sqlite_meta_commands(sql)?;
+    reject_sqlite_fsdir(sql)?;
 
     let bytes = sql.as_bytes();
     let mut statements = Vec::new();
@@ -743,6 +830,46 @@ mod tests {
 
     mod statement_splitting {
         use super::*;
+
+        #[rstest]
+        #[case::unquoted("SELECT * FROM fsdir('/tmp')")]
+        #[case::double_quoted("SELECT * FROM \"fsdir\"('/tmp')")]
+        #[case::backtick_quoted("SELECT * FROM `fsdir`('/tmp')")]
+        #[case::bracket_quoted("SELECT * FROM [fsdir]('/tmp')")]
+        #[case::comments_between_tokens("SELECT * FROM /* ignored */ fsdir /* ignored */ ('/tmp')")]
+        #[case::virtual_table_module("CREATE VIRTUAL TABLE files USING fsdir")]
+        fn rejects_fsdir_identifiers(#[case] sql: &str) {
+            let error = try_split_sqlite_statements(sql).unwrap_err();
+
+            assert!(matches!(
+                error,
+                DbOperationError::UnsupportedOperation(details)
+                    if details == SQLITE_FSDIR_SAFE_MODE_ERROR
+            ));
+        }
+
+        #[rstest]
+        #[case::single_quoted_literal("SELECT 'fsdir'")]
+        #[case::line_comment("-- fsdir\nSELECT 1")]
+        #[case::block_comment("/* fsdir */ SELECT 1")]
+        #[case::identifier_prefix("SELECT fsdirname FROM users")]
+        #[case::identifier_suffix("SELECT myfsdir FROM users")]
+        #[case::other_virtual_table("SELECT * FROM json_each('{}')")]
+        fn ignores_non_fsdir_occurrences(#[case] sql: &str) {
+            assert!(try_split_sqlite_statements(sql).is_ok());
+        }
+
+        #[test]
+        fn rejects_fsdir_in_any_statement_of_batch() {
+            let error =
+                try_split_sqlite_statements("SELECT 1; SELECT * FROM fsdir('/tmp')").unwrap_err();
+
+            assert!(matches!(
+                error,
+                DbOperationError::UnsupportedOperation(details)
+                    if details == SQLITE_FSDIR_SAFE_MODE_ERROR
+            ));
+        }
 
         #[test]
         fn ignores_semicolons_in_literals_and_comments() {

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -796,6 +796,9 @@ mod tests {
         #[case::comments_between_tokens("SELECT * FROM /* ignored */ fsdir /* ignored */ ('/tmp')")]
         #[case::virtual_table_module("CREATE VIRTUAL TABLE files USING fsdir")]
         #[case::single_quoted_virtual_table_module("CREATE VIRTUAL TABLE files USING 'fsdir'")]
+        #[case::double_quoted_virtual_table_module("CREATE VIRTUAL TABLE files USING \"fsdir\"")]
+        #[case::backtick_virtual_table_module("CREATE VIRTUAL TABLE files USING `fsdir`")]
+        #[case::bracket_virtual_table_module("CREATE VIRTUAL TABLE files USING [fsdir]")]
         fn rejects_fsdir_access(#[case] sql: &str) {
             let error = try_split_sqlite_statements(sql).unwrap_err();
 

--- a/src/infra/adapters/sqlite/sqlite3/parser/mod.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/mod.rs
@@ -8,7 +8,7 @@ pub(super) use command_tag::{
 };
 pub(super) use lexer::{
     SqliteStatementPlan, append_changes_query_for_plan, is_sqlite_rerunnable_export_query,
-    sqlite_adhoc_execution_query_for_plan, sqlite_empty_result_sentinel,
+    reject_sqlite_fsdir, sqlite_adhoc_execution_query_for_plan, sqlite_empty_result_sentinel,
     sqlite_export_not_rerunnable_error, sqlite_probe_marker, sqlite_statement_plan,
 };
 pub(super) use output::{


### PR DESCRIPTION
## Problem

SQLite safe mode still allows the `fsdir()` virtual table to read files outside the selected database.

## Background

The SQLite CLI safe mode blocks other host-side features, but `fsdir()` remains available even with read-only mode enabled.

## Approach

Extend the existing SQLite SQL parsing boundary to reject `fsdir` identifiers before execution while ignoring string literals and comments and covering quoted identifiers and multi-statement input. Apply the same preflight to ad-hoc execution, writes, CSV row counting, and export, with regression coverage for both access modes and other virtual table usage.

Closes SAB-349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * セーフモードで`fsdir(...)`を使用するSQLを拒否するようになりました。
  * 読み取り・書き込み、行数取得、CSV出力の各操作で安全にブロックされます。
  * 拒否対象のSQLでは、統一されたエラーメッセージが表示されます。
  * CSV出力が拒否された場合、出力ファイルは作成されません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->