### PR TITLE
refactor: avoid duplicate display rows in typed results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "unicode-segmentation",
  "unicode-width",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "unicode-width",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { version = "1", features = ["sync", "time", "io-util", "process", "rt-m
 tokio-util = "0.7"
 toml = "0.8"
 unicode-casefold = "0.2"
+unicode-segmentation = "1"
 unicode-width = "0.2"
 urlencoding = "2"
 uuid = { version = "1", features = ["v4", "v5"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -30,6 +30,7 @@ absolute-paths-allowed-crates = [
     "tokio_util",
     "toml",
     "unicode_casefold",
+    "unicode_segmentation",
     "unicode_width",
     "urlencoding",
     "uuid",

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -122,9 +122,9 @@ pub fn reduce_execution(
                             state.result_interaction.reset_interaction();
                         }
                         PostDeleteRowSelection::Select(row) => {
-                            if result.data_row_count() > 0 && !result.columns.is_empty() {
+                            if result.data_row_count() > 0 && result.column_count() > 0 {
                                 let clamped = row.min(result.data_row_count() - 1);
-                                let max_col = result.columns.len() - 1;
+                                let max_col = result.column_count() - 1;
                                 let col = preserved_result_col
                                     .unwrap_or(preserved_horizontal_offset)
                                     .min(max_col);

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -112,7 +112,7 @@ pub fn reduce_execution(
                         state
                             .query
                             .pagination
-                            .set_page_result(*page, result.rows().len() < PREVIEW_PAGE_SIZE);
+                            .set_page_result(*page, result.data_row_count() < PREVIEW_PAGE_SIZE);
                     }
                     state.query.set_current_result(Arc::clone(result));
 
@@ -122,8 +122,8 @@ pub fn reduce_execution(
                             state.result_interaction.reset_interaction();
                         }
                         PostDeleteRowSelection::Select(row) => {
-                            if !result.rows().is_empty() && !result.columns.is_empty() {
-                                let clamped = row.min(result.rows().len() - 1);
+                            if result.data_row_count() > 0 && !result.columns.is_empty() {
+                                let clamped = row.min(result.data_row_count() - 1);
                                 let max_col = result.columns.len() - 1;
                                 let col = preserved_result_col
                                     .unwrap_or(preserved_horizontal_offset)

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -156,7 +156,7 @@ fn selected_cell_value(state: &AppState) -> Option<(usize, usize, String, String
     let cell_value = if result.has_typed_values() {
         result.value_at(row_idx, col_idx)?.copy_value()
     } else {
-        result.rows().get(row_idx)?.get(col_idx)?.clone()
+        result.display_value_at(row_idx, col_idx)?
     };
     let data_type = selected_column_data_type(state, col_idx).map(ToString::to_string);
     Some((row_idx, col_idx, column_name, cell_value, data_type))

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -53,12 +53,12 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 return DispatchResult::handled();
             }
 
-            let cell_value = match result.rows().get(row_idx).and_then(|r| r.get(col_idx)) {
-                Some(v) if !v.is_empty() => v,
+            let cell_value = match result.display_value_at(row_idx, col_idx) {
+                Some(value) if !value.is_empty() => value,
                 _ => return DispatchResult::handled(),
             };
 
-            let pretty_original = match serde_json::from_str::<serde_json::Value>(cell_value) {
+            let pretty_original = match serde_json::from_str::<serde_json::Value>(&cell_value) {
                 Ok(value) => {
                     serde_json::to_string_pretty(&value).unwrap_or_else(|_| cell_value.clone())
                 }
@@ -74,7 +74,7 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 row_idx,
                 col_idx,
                 column.name.clone(),
-                cell_value.clone(),
+                cell_value,
                 pretty_original,
             );
             state.modal.push_mode(InputMode::JsonbDetail);
@@ -337,7 +337,7 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
         let original_cell = state
             .query
             .visible_result()
-            .and_then(|r| r.rows().get(row).and_then(|r| r.get(col)).cloned())
+            .and_then(|result| result.display_value_at(row, col))
             .unwrap_or_default();
         state
             .result_interaction

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -1,7 +1,7 @@
 use crate::cmd::effect::Effect;
 #[cfg(test)]
 use crate::domain::ColumnAttributes;
-use crate::domain::QuerySource;
+use crate::domain::{QuerySource, QueryValue};
 use crate::model::app_state::AppState;
 use crate::model::browse::jsonb_detail::JsonbDetailState;
 use crate::model::shared::flash_timer::FlashId;
@@ -53,9 +53,19 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 return DispatchResult::handled();
             }
 
-            let cell_value = match result.display_value_at(row_idx, col_idx) {
-                Some(value) if !value.is_empty() => value,
-                _ => return DispatchResult::handled(),
+            let cell_value = if result.has_typed_values() {
+                let Some(value) = result.value_at(row_idx, col_idx) else {
+                    return DispatchResult::handled();
+                };
+                if matches!(value, QueryValue::Null) {
+                    return DispatchResult::handled();
+                }
+                value.display_value()
+            } else {
+                match result.display_value_at(row_idx, col_idx) {
+                    Some(value) if !value.is_empty() => value,
+                    _ => return DispatchResult::handled(),
+                }
             };
 
             let pretty_original = match serde_json::from_str::<serde_json::Value>(&cell_value) {
@@ -497,6 +507,29 @@ mod tests {
             );
 
             assert!(!state.jsonb_detail.is_active());
+        }
+
+        #[test]
+        fn blocked_on_typed_null_cell() {
+            let mut state = state_with_jsonb_cell();
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    String::new(),
+                    vec!["id".to_string(), "settings".to_string()],
+                    vec![vec![QueryValue::text("1"), QueryValue::Null]],
+                    1,
+                    QuerySource::Preview,
+                )));
+
+            reduce_jsonb(
+                &mut state,
+                &Action::OpenModal(ModalKind::JsonbDetail),
+                Instant::now(),
+            );
+
+            assert!(!state.jsonb_detail.is_active());
+            assert_eq!(state.messages.last_error, None);
         }
 
         #[test]

--- a/src/app/update/browse/result/row_detail.rs
+++ b/src/app/update/browse/result/row_detail.rs
@@ -13,15 +13,11 @@ pub fn reduce_row_detail(state: &mut AppState, action: &Action, now: Instant) ->
     match action {
         Action::OpenModal(ModalKind::RowDetail) => {
             let result = match state.query.visible_result() {
-                Some(r) if !r.is_error() && !r.rows().is_empty() => r,
+                Some(r) if !r.is_error() && r.data_row_count() > 0 => r,
                 _ => return DispatchResult::handled(),
             };
 
             let Some(row_idx) = state.result_interaction.selection().row() else {
-                return DispatchResult::handled();
-            };
-
-            let Some(cells) = result.rows().get(row_idx) else {
                 return DispatchResult::handled();
             };
 
@@ -31,6 +27,9 @@ pub fn reduce_row_detail(state: &mut AppState, action: &Action, now: Instant) ->
                 };
                 RowDetailState::open_with_values(&result.columns, values)
             } else {
+                let Some(cells) = result.rows().get(row_idx) else {
+                    return DispatchResult::handled();
+                };
                 RowDetailState::open(&result.columns, cells)
             };
             state.modal.push_mode(InputMode::RowDetail);

--- a/src/app/update/browse/result/row_detail.rs
+++ b/src/app/update/browse/result/row_detail.rs
@@ -27,10 +27,10 @@ pub fn reduce_row_detail(state: &mut AppState, action: &Action, now: Instant) ->
                 };
                 RowDetailState::open_with_values(&result.columns, values)
             } else {
-                let Some(cells) = result.rows().get(row_idx) else {
+                let Some(cells) = result.display_row_at(row_idx) else {
                     return DispatchResult::handled();
                 };
-                RowDetailState::open(&result.columns, cells)
+                RowDetailState::open(&result.columns, &cells)
             };
             state.modal.push_mode(InputMode::RowDetail);
             DispatchResult::handled()

--- a/src/app/update/browse/result/scroll.rs
+++ b/src/app/update/browse/result/scroll.rs
@@ -1,3 +1,4 @@
+use crate::domain::QueryResult;
 use crate::model::app_state::AppState;
 use crate::model::shared::key_sequence::KeySequenceState;
 use crate::model::shared::viewport::{calculate_next_column_offset, calculate_prev_column_offset};
@@ -7,7 +8,10 @@ use crate::update::action::{
 use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn result_row_count(state: &AppState) -> usize {
-    state.query.visible_result().map_or(0, |r| r.rows().len())
+    state
+        .query
+        .visible_result()
+        .map_or(0, QueryResult::data_row_count)
 }
 
 pub(super) fn result_col_count(state: &AppState) -> usize {
@@ -275,7 +279,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::domain::{QueryResult, QuerySource};
+    use crate::domain::QuerySource;
     use crate::model::shared::key_sequence::Prefix;
 
     fn state_with_result_rows(rows: usize, pane_height: u16) -> AppState {

--- a/src/app/update/browse/result/yank.rs
+++ b/src/app/update/browse/result/yank.rs
@@ -29,11 +29,7 @@ pub fn reduce_yank(
                             .value_at(row_idx, col_idx)
                             .map(QueryValue::copy_value)
                     } else {
-                        result
-                            .rows()
-                            .get(row_idx)
-                            .and_then(|row| row.get(col_idx))
-                            .cloned()
+                        result.display_value_at(row_idx, col_idx)
                     }
                 });
                 if let Some(value) = content {
@@ -85,7 +81,7 @@ pub fn reduce_yank(
                                 row.iter().map(QueryValue::copy_value).collect::<Vec<_>>()
                             })
                         } else {
-                            result.rows().get(row_idx).cloned()
+                            result.display_row_at(row_idx)
                         }
                     })
                     .map(|row| {

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -213,7 +213,7 @@ pub fn build_bulk_delete_preview(
         .next()
         .unwrap();
     let (target_page, target_row) = deletion_refresh_target_bulk(
-        result.rows().len(),
+        result.data_row_count(),
         staged_count,
         first_deleted_idx,
         state.query.pagination.current_page(),

--- a/src/domain/Cargo.toml
+++ b/src/domain/Cargo.toml
@@ -14,6 +14,7 @@ path = "lib.rs"
 serde.workspace = true
 thiserror.workspace = true
 unicode-width.workspace = true
+unicode-segmentation.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/src/domain/Cargo.toml
+++ b/src/domain/Cargo.toml
@@ -13,6 +13,7 @@ path = "lib.rs"
 [dependencies]
 serde.workspace = true
 thiserror.workspace = true
+unicode-width.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/src/domain/explain_plan.rs
+++ b/src/domain/explain_plan.rs
@@ -30,14 +30,15 @@ fn sqlite_explain_plan_rows(result: &QueryResult) -> Option<Vec<SqliteExplainPla
     let parent_index = column_index(&result.columns, "parent")?;
     let detail_index = column_index(&result.columns, "detail")?;
 
-    result
-        .rows()
-        .iter()
-        .map(|row| {
+    (0..result.data_row_count())
+        .map(|row_idx| {
             Some(SqliteExplainPlanRow {
-                id: row.get(id_index)?.parse().ok()?,
-                parent: row.get(parent_index)?.parse().ok()?,
-                detail: row.get(detail_index)?.clone(),
+                id: result.display_value_at(row_idx, id_index)?.parse().ok()?,
+                parent: result
+                    .display_value_at(row_idx, parent_index)?
+                    .parse()
+                    .ok()?,
+                detail: result.display_value_at(row_idx, detail_index)?,
             })
         })
         .collect()
@@ -81,11 +82,8 @@ fn sqlite_explain_plan_text(result: &QueryResult) -> Option<String> {
 
 pub fn sqlite_explain_query_plan_text_from_result(result: &QueryResult) -> String {
     sqlite_explain_plan_text(result).unwrap_or_else(|| {
-        result
-            .rows()
-            .iter()
-            .filter_map(|row| row.first())
-            .cloned()
+        (0..result.data_row_count())
+            .filter_map(|row_idx| result.display_value_at(row_idx, 0))
             .collect::<Vec<_>>()
             .join("\n")
     })

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
-use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 use super::CommandTag;
 
@@ -134,40 +135,44 @@ fn display_width_of_first_line(value: &str, escape_nul: bool) -> usize {
 
 fn truncate_display_text(value: &str, escape_nul: bool, max_width: usize) -> String {
     let first_line = value.split('\n').next().unwrap_or(value);
-    let display_width = display_width_of_first_line(first_line, escape_nul);
-    if display_width <= max_width {
-        return if escape_nul && first_line.contains('\0') {
-            escape_display_text(first_line)
-        } else {
-            first_line.to_string()
-        };
-    }
-
-    if max_width < 3 {
-        return ".".repeat(max_width);
-    }
-
+    let budget = max_width.saturating_sub(3);
+    let mut display = String::new();
     let mut truncated = String::new();
-    let mut used_width = 0;
-    let budget = max_width - 3;
-    for ch in first_line.chars() {
-        if escape_nul && ch == '\0' {
-            if used_width + 2 > budget {
-                break;
-            }
-            truncated.push_str("\\0");
-            used_width += 2;
+    let mut display_width = 0usize;
+    let mut truncated_width = 0usize;
+
+    for grapheme in first_line.graphemes(true) {
+        let (width, is_nul) = if escape_nul && grapheme == "\0" {
+            (2, true)
         } else {
-            let width = UnicodeWidthChar::width(ch).unwrap_or(0);
-            if used_width + width > budget {
-                break;
+            (UnicodeWidthStr::width(grapheme), false)
+        };
+
+        if display_width.saturating_add(width) > max_width {
+            if max_width < 3 {
+                return ".".repeat(max_width);
             }
-            truncated.push(ch);
-            used_width += width;
+            truncated.push_str("...");
+            return truncated;
         }
+
+        if is_nul {
+            display.push_str("\\0");
+            if truncated_width.saturating_add(width) <= budget {
+                truncated.push_str("\\0");
+                truncated_width += width;
+            }
+        } else {
+            display.push_str(grapheme);
+            if truncated_width.saturating_add(width) <= budget {
+                truncated.push_str(grapheme);
+                truncated_width += width;
+            }
+        }
+        display_width += width;
     }
-    truncated.push_str("...");
-    truncated
+
+    display
 }
 
 fn blob_display_value_at_width(bytes: &[u8], max_width: usize) -> String {

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -39,6 +39,17 @@ impl QueryValue {
     }
 
     #[must_use]
+    pub fn display_value_at_width(&self, max_width: usize) -> String {
+        match self {
+            Self::Null => truncate_display_text("NULL", false, max_width),
+            Self::Text(value) | Self::SqlLiteral(value) => {
+                truncate_display_text(value, true, max_width)
+            }
+            Self::Blob(bytes) => blob_display_value_at_width(bytes, max_width),
+        }
+    }
+
+    #[must_use]
     pub fn display_width(&self) -> usize {
         match self {
             Self::Null => UnicodeWidthStr::width("NULL"),
@@ -88,33 +99,93 @@ fn escape_display_text(value: &str) -> String {
 }
 
 fn blob_display_value(bytes: &[u8]) -> String {
-    let preview = bytes
-        .iter()
-        .take(BLOB_PREVIEW_BYTES)
-        .map(|byte| format!("{byte:02X}"))
-        .collect::<Vec<_>>()
-        .join(" ");
-    if preview.is_empty() {
-        "BLOB (0 bytes)".to_string()
-    } else if bytes.len() > BLOB_PREVIEW_BYTES {
-        format!("BLOB ({} bytes) {preview} ...", bytes.len())
-    } else {
-        format!("BLOB ({} bytes) {preview}", bytes.len())
+    use std::fmt::Write as _;
+
+    let preview_bytes = bytes.len().min(BLOB_PREVIEW_BYTES);
+    let mut display = String::with_capacity(32 + preview_bytes * 3);
+    let _ = write!(display, "BLOB ({} bytes)", bytes.len());
+    if preview_bytes > 0 {
+        display.push(' ');
+        for (index, byte) in bytes.iter().take(preview_bytes).enumerate() {
+            if index > 0 {
+                display.push(' ');
+            }
+            let _ = write!(display, "{byte:02X}");
+        }
+        if bytes.len() > BLOB_PREVIEW_BYTES {
+            display.push_str(" ...");
+        }
     }
+    display
 }
 
 fn display_width_of_first_line(value: &str, escape_nul: bool) -> usize {
-    value
-        .chars()
-        .take_while(|&ch| ch != '\n')
-        .map(|ch| {
-            if escape_nul && ch == '\0' {
-                2
-            } else {
-                UnicodeWidthChar::width(ch).unwrap_or(0)
+    let first_line = value.split('\n').next().unwrap_or(value);
+    if escape_nul {
+        first_line
+            .split('\0')
+            .map(UnicodeWidthStr::width)
+            .sum::<usize>()
+            + first_line.matches('\0').count() * 2
+    } else {
+        UnicodeWidthStr::width(first_line)
+    }
+}
+
+fn truncate_display_text(value: &str, escape_nul: bool, max_width: usize) -> String {
+    let first_line = value.split('\n').next().unwrap_or(value);
+    let display_width = display_width_of_first_line(first_line, escape_nul);
+    if display_width <= max_width {
+        return if escape_nul && first_line.contains('\0') {
+            escape_display_text(first_line)
+        } else {
+            first_line.to_string()
+        };
+    }
+
+    if max_width < 3 {
+        return ".".repeat(max_width);
+    }
+
+    let mut truncated = String::new();
+    let mut used_width = 0;
+    let budget = max_width - 3;
+    for ch in first_line.chars() {
+        if escape_nul && ch == '\0' {
+            if used_width + 2 > budget {
+                break;
             }
-        })
-        .sum()
+            truncated.push_str("\\0");
+            used_width += 2;
+        } else {
+            let width = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if used_width + width > budget {
+                break;
+            }
+            truncated.push(ch);
+            used_width += width;
+        }
+    }
+    truncated.push_str("...");
+    truncated
+}
+
+fn blob_display_value_at_width(bytes: &[u8], max_width: usize) -> String {
+    let mut display = blob_display_value(bytes);
+    if display_width(&display) <= max_width {
+        return display;
+    }
+    if max_width < 3 {
+        return ".".repeat(max_width);
+    }
+
+    display.truncate(max_width - 3);
+    display.push_str("...");
+    display
+}
+
+fn display_width(value: &str) -> usize {
+    UnicodeWidthStr::width(value)
 }
 
 fn blob_display_width(bytes: &[u8]) -> usize {
@@ -341,6 +412,24 @@ impl QueryResult {
     }
 
     #[must_use]
+    pub fn display_value_at_width(
+        &self,
+        row: usize,
+        col: usize,
+        max_width: usize,
+    ) -> Option<String> {
+        if self.typed_values {
+            self.value_at(row, col)
+                .map(|value| value.display_value_at_width(max_width))
+        } else {
+            self.rows
+                .get(row)?
+                .get(col)
+                .map(|value| truncate_display_text(value, false, max_width))
+        }
+    }
+
+    #[must_use]
     pub fn display_value_at(&self, row: usize, col: usize) -> Option<String> {
         self.display_value_ref_at(row, col).map(Cow::into_owned)
     }
@@ -460,6 +549,7 @@ mod tests {
             );
 
             assert_eq!(result.data_row_count(), 1);
+            assert!(result.rows.is_empty());
             assert_eq!(result.column_count(), 1);
             assert_eq!(
                 result.display_value_ref_at(0, 0).as_deref(),
@@ -509,6 +599,13 @@ mod tests {
         }
 
         #[test]
+        fn width_limited_display_avoids_materializing_the_full_nul_text() {
+            let value = QueryValue::text("a\0bcdef");
+
+            assert_eq!(value.display_value_at_width(6), "a\\0...");
+        }
+
+        #[test]
         fn display_width_handles_large_nul_text_and_blob_without_display_materialization() {
             const SIZE: usize = 1024 * 1024;
             let text = format!("{}\0tail", "a".repeat(SIZE));
@@ -527,5 +624,10 @@ mod tests {
                 Some("BLOB (1048576 bytes) AB AB AB AB AB AB AB AB ...".len())
             );
         }
+    }
+
+    #[test]
+    fn display_width_counts_zwj_emoji_as_one_sequence() {
+        assert_eq!(QueryValue::text("👨‍👩‍👧‍👦").display_width(), 2);
     }
 }

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -400,6 +400,46 @@ mod tests {
         }
     }
 
+    mod typed_values {
+        use super::*;
+
+        #[test]
+        fn keeps_text_owned_only_by_typed_values() {
+            let text = "a".repeat(4096);
+            let result = QueryResult::success_with_values(
+                "SELECT body".to_string(),
+                vec!["body".to_string()],
+                vec![vec![QueryValue::text(text.clone())]],
+                0,
+                QuerySource::Adhoc,
+            );
+
+            assert!(result.rows().is_empty());
+            assert_eq!(result.data_row_count(), 1);
+            assert_eq!(result.column_count(), 1);
+            assert_eq!(
+                result.display_value_ref_at(0, 0).as_deref(),
+                Some(text.as_str())
+            );
+        }
+
+        #[test]
+        fn removes_sentinel_column_without_display_rows() {
+            let result = QueryResult::success_with_values(
+                "SELECT body, sentinel".to_string(),
+                vec!["body".to_string(), "sentinel".to_string()],
+                vec![vec![QueryValue::text("body"), QueryValue::text("sentinel")]],
+                0,
+                QuerySource::Adhoc,
+            )
+            .without_empty_result_sentinel();
+
+            assert_eq!(result.columns, vec!["body"]);
+            assert_eq!(result.values(), &[vec![QueryValue::text("body")]]);
+            assert!(result.rows().is_empty());
+        }
+    }
+
     mod row_count_display {
         use super::*;
 

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
 
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
 use super::CommandTag;
 
 const BLOB_PREVIEW_BYTES: usize = 8;
@@ -28,9 +30,20 @@ impl QueryValue {
     pub fn display_value_ref(&self) -> Cow<'_, str> {
         match self {
             Self::Null => Cow::Borrowed("NULL"),
-            Self::Text(value) if value.contains('\0') => Cow::Owned(escape_display_text(value)),
+            Self::Text(value) | Self::SqlLiteral(value) if value.contains('\0') => {
+                Cow::Owned(escape_display_text(value))
+            }
             Self::Text(value) | Self::SqlLiteral(value) => Cow::Borrowed(value),
             Self::Blob(bytes) => Cow::Owned(blob_display_value(bytes)),
+        }
+    }
+
+    #[must_use]
+    pub fn display_width(&self) -> usize {
+        match self {
+            Self::Null => UnicodeWidthStr::width("NULL"),
+            Self::Text(value) | Self::SqlLiteral(value) => display_width_of_first_line(value, true),
+            Self::Blob(bytes) => blob_display_width(bytes),
         }
     }
 
@@ -88,6 +101,43 @@ fn blob_display_value(bytes: &[u8]) -> String {
     } else {
         format!("BLOB ({} bytes) {preview}", bytes.len())
     }
+}
+
+fn display_width_of_first_line(value: &str, escape_nul: bool) -> usize {
+    value
+        .chars()
+        .take_while(|&ch| ch != '\n')
+        .map(|ch| {
+            if escape_nul && ch == '\0' {
+                2
+            } else {
+                UnicodeWidthChar::width(ch).unwrap_or(0)
+            }
+        })
+        .sum()
+}
+
+fn blob_display_width(bytes: &[u8]) -> usize {
+    let mut width = UnicodeWidthStr::width("BLOB (")
+        + decimal_display_width(bytes.len())
+        + UnicodeWidthStr::width(" bytes)");
+    let preview_bytes = bytes.len().min(BLOB_PREVIEW_BYTES);
+    if preview_bytes > 0 {
+        width += 1 + preview_bytes * 2 + preview_bytes.saturating_sub(1);
+        if bytes.len() > BLOB_PREVIEW_BYTES {
+            width += UnicodeWidthStr::width(" ...");
+        }
+    }
+    width
+}
+
+fn decimal_display_width(mut value: usize) -> usize {
+    let mut width = 1;
+    while value >= 10 {
+        value /= 10;
+        width += 1;
+    }
+    width
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -246,23 +296,6 @@ impl QueryResult {
     }
 
     #[must_use]
-    pub fn rows(&self) -> &[Vec<String>] {
-        &self.rows
-    }
-
-    #[must_use]
-    pub fn display_rows(&self) -> Vec<Vec<String>> {
-        if self.typed_values {
-            self.values
-                .iter()
-                .map(|row| row.iter().map(QueryValue::display_value).collect())
-                .collect()
-        } else {
-            self.rows.clone()
-        }
-    }
-
-    #[must_use]
     pub fn values(&self) -> &[Vec<QueryValue>] {
         &self.values
     }
@@ -313,6 +346,18 @@ impl QueryResult {
     }
 
     #[must_use]
+    pub fn display_width_at(&self, row: usize, col: usize) -> Option<usize> {
+        if self.typed_values {
+            self.value_at(row, col).map(QueryValue::display_width)
+        } else {
+            self.rows
+                .get(row)?
+                .get(col)
+                .map(|value| display_width_of_first_line(value, false))
+        }
+    }
+
+    #[must_use]
     pub fn display_row_at(&self, row: usize) -> Option<Vec<String>> {
         if self.typed_values {
             self.values
@@ -344,7 +389,7 @@ mod tests {
 
             assert_eq!(result.query, "SELECT 1");
             assert_eq!(result.columns, vec!["id"]);
-            assert_eq!(result.rows(), vec![vec!["1"]]);
+            assert_eq!(result.display_row_at(0), Some(vec!["1".to_string()]));
             assert_eq!(result.row_count(), 1);
             assert_eq!(result.execution_time_ms, 42);
             assert_eq!(result.source, QuerySource::Adhoc);
@@ -382,7 +427,7 @@ mod tests {
             assert!(result.is_error());
             assert_eq!(result.error.as_deref(), Some("syntax error"));
             assert!(result.columns.is_empty());
-            assert!(result.rows().is_empty());
+            assert_eq!(result.data_row_count(), 0);
             assert_eq!(result.row_count(), 0);
         }
     }
@@ -414,7 +459,6 @@ mod tests {
                 QuerySource::Adhoc,
             );
 
-            assert!(result.rows().is_empty());
             assert_eq!(result.data_row_count(), 1);
             assert_eq!(result.column_count(), 1);
             assert_eq!(
@@ -436,7 +480,7 @@ mod tests {
 
             assert_eq!(result.columns, vec!["body"]);
             assert_eq!(result.values(), &[vec![QueryValue::text("body")]]);
-            assert!(result.rows().is_empty());
+            assert_eq!(result.display_row_at(0), Some(vec!["body".to_string()]));
         }
     }
 
@@ -462,6 +506,26 @@ mod tests {
         #[test]
         fn display_value_escapes_embedded_nul_byte() {
             assert_eq!(QueryValue::text("a\0bc").display_value(), "a\\0bc");
+        }
+
+        #[test]
+        fn display_width_handles_large_nul_text_and_blob_without_display_materialization() {
+            const SIZE: usize = 1024 * 1024;
+            let text = format!("{}\0tail", "a".repeat(SIZE));
+            let blob = vec![0xAB; SIZE];
+            let result = QueryResult::success_with_values(
+                "SELECT body, payload".to_string(),
+                vec!["body".to_string(), "payload".to_string()],
+                vec![vec![QueryValue::text(text), QueryValue::Blob(blob)]],
+                0,
+                QuerySource::Adhoc,
+            );
+
+            assert_eq!(result.display_width_at(0, 0), Some(SIZE + 6));
+            assert_eq!(
+                result.display_width_at(0, 1),
+                Some("BLOB (1048576 bytes) AB AB AB AB AB AB AB AB ...".len())
+            );
         }
     }
 }

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use super::CommandTag;
 
 const BLOB_PREVIEW_BYTES: usize = 8;
@@ -19,24 +21,16 @@ impl QueryValue {
 
     #[must_use]
     pub fn display_value(&self) -> String {
+        self.display_value_ref().into_owned()
+    }
+
+    #[must_use]
+    pub fn display_value_ref(&self) -> Cow<'_, str> {
         match self {
-            Self::Null => "NULL".to_string(),
-            Self::Text(value) | Self::SqlLiteral(value) => escape_display_text(value),
-            Self::Blob(bytes) => {
-                let preview = bytes
-                    .iter()
-                    .take(BLOB_PREVIEW_BYTES)
-                    .map(|byte| format!("{byte:02X}"))
-                    .collect::<Vec<_>>()
-                    .join(" ");
-                if preview.is_empty() {
-                    "BLOB (0 bytes)".to_string()
-                } else if bytes.len() > BLOB_PREVIEW_BYTES {
-                    format!("BLOB ({} bytes) {preview} ...", bytes.len())
-                } else {
-                    format!("BLOB ({} bytes) {preview}", bytes.len())
-                }
-            }
+            Self::Null => Cow::Borrowed("NULL"),
+            Self::Text(value) if value.contains('\0') => Cow::Owned(escape_display_text(value)),
+            Self::Text(value) | Self::SqlLiteral(value) => Cow::Borrowed(value),
+            Self::Blob(bytes) => Cow::Owned(blob_display_value(bytes)),
         }
     }
 
@@ -78,6 +72,22 @@ fn escape_display_text(value: &str) -> String {
         }
     }
     escaped
+}
+
+fn blob_display_value(bytes: &[u8]) -> String {
+    let preview = bytes
+        .iter()
+        .take(BLOB_PREVIEW_BYTES)
+        .map(|byte| format!("{byte:02X}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    if preview.is_empty() {
+        "BLOB (0 bytes)".to_string()
+    } else if bytes.len() > BLOB_PREVIEW_BYTES {
+        format!("BLOB ({} bytes) {preview} ...", bytes.len())
+    } else {
+        format!("BLOB ({} bytes) {preview}", bytes.len())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -136,15 +146,11 @@ impl QueryResult {
         execution_time_ms: u64,
         source: QuerySource,
     ) -> Self {
-        let rows = values
-            .iter()
-            .map(|row| row.iter().map(QueryValue::display_value).collect())
-            .collect();
         let row_count = values.len();
         Self {
             query,
             columns,
-            rows,
+            rows: Vec::new(),
             values,
             row_count,
             typed_values: true,
@@ -199,16 +205,28 @@ impl QueryResult {
     #[must_use]
     pub fn without_empty_result_sentinel(mut self) -> Self {
         self.columns.pop();
-        for (row, values) in self.rows.iter_mut().zip(&mut self.values) {
-            let sentinel = values.pop();
-            row.pop();
-            if sentinel == Some(QueryValue::Null) {
-                values.clear();
-                row.clear();
+        if self.typed_values {
+            for values in &mut self.values {
+                let sentinel = values.pop();
+                if sentinel == Some(QueryValue::Null) {
+                    values.clear();
+                }
             }
+            self.values
+                .retain(|values| values.len() == self.columns.len());
+        } else {
+            for (row, values) in self.rows.iter_mut().zip(&mut self.values) {
+                let sentinel = values.pop();
+                row.pop();
+                if sentinel == Some(QueryValue::Null) {
+                    values.clear();
+                    row.clear();
+                }
+            }
+            self.rows.retain(|row| row.len() == self.columns.len());
+            self.values
+                .retain(|values| values.len() == self.columns.len());
         }
-        self.rows.retain(|row| row.len() == self.columns.len());
-        self.values.retain(|row| row.len() == self.columns.len());
         self.row_count = self.values.len();
         self
     }
@@ -216,6 +234,11 @@ impl QueryResult {
     #[must_use]
     pub fn has_typed_values(&self) -> bool {
         self.typed_values
+    }
+
+    #[must_use]
+    pub fn column_count(&self) -> usize {
+        self.columns.len()
     }
 
     pub fn is_error(&self) -> bool {
@@ -228,6 +251,18 @@ impl QueryResult {
     }
 
     #[must_use]
+    pub fn display_rows(&self) -> Vec<Vec<String>> {
+        if self.typed_values {
+            self.values
+                .iter()
+                .map(|row| row.iter().map(QueryValue::display_value).collect())
+                .collect()
+        } else {
+            self.rows.clone()
+        }
+    }
+
+    #[must_use]
     pub fn values(&self) -> &[Vec<QueryValue>] {
         &self.values
     }
@@ -235,6 +270,15 @@ impl QueryResult {
     #[must_use]
     pub fn row_count(&self) -> usize {
         self.row_count
+    }
+
+    #[must_use]
+    pub fn data_row_count(&self) -> usize {
+        if self.typed_values {
+            self.values.len()
+        } else {
+            self.rows.len()
+        }
     }
 
     #[must_use]
@@ -249,6 +293,34 @@ impl QueryResult {
     #[must_use]
     pub fn value_at(&self, row: usize, col: usize) -> Option<&QueryValue> {
         self.values.get(row)?.get(col)
+    }
+
+    #[must_use]
+    pub fn display_value_ref_at(&self, row: usize, col: usize) -> Option<Cow<'_, str>> {
+        if self.typed_values {
+            self.value_at(row, col).map(QueryValue::display_value_ref)
+        } else {
+            self.rows
+                .get(row)?
+                .get(col)
+                .map(|value| Cow::Borrowed(value.as_str()))
+        }
+    }
+
+    #[must_use]
+    pub fn display_value_at(&self, row: usize, col: usize) -> Option<String> {
+        self.display_value_ref_at(row, col).map(Cow::into_owned)
+    }
+
+    #[must_use]
+    pub fn display_row_at(&self, row: usize) -> Option<Vec<String>> {
+        if self.typed_values {
+            self.values
+                .get(row)
+                .map(|values| values.iter().map(QueryValue::display_value).collect())
+        } else {
+            self.rows.get(row).cloned()
+        }
     }
 }
 

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -477,7 +477,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.columns, vec!["value"]);
-        assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+        assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
     }
 
     #[tokio::test]

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -477,7 +477,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.columns, vec!["value"]);
-        assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
+        assert_eq!(result.display_row_at(0), Some(vec!["1".to_string()]));
     }
 
     #[tokio::test]

--- a/src/infra/adapters/sqlite/diagnostics.rs
+++ b/src/infra/adapters/sqlite/diagnostics.rs
@@ -92,10 +92,8 @@ fn feature_probe(result: Result<QueryResult, DbOperationError>) -> FeatureProbe 
     match result {
         Ok(query_result) if query_result.columns.is_empty() => FeatureProbe::Unavailable,
         Ok(query_result) => FeatureProbe::Available(
-            query_result
-                .rows()
-                .iter()
-                .filter_map(|row| row.first())
+            (0..query_result.data_row_count())
+                .filter_map(|row| query_result.display_value_at(row, 0))
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty())
                 .collect(),
@@ -213,12 +211,11 @@ fn on_off_field(result: Result<QueryResult, DbOperationError>) -> DiagnosticFiel
 fn database_list_field(result: Result<QueryResult, DbOperationError>) -> DiagnosticField {
     match result {
         Ok(query_result) => {
-            if query_result.rows().is_empty() {
+            if query_result.data_row_count() == 0 {
                 return DiagnosticField::err("database_list: empty result");
             }
-            let lines = query_result
-                .rows()
-                .iter()
+            let lines = (0..query_result.data_row_count())
+                .filter_map(|row| query_result.display_row_at(row))
                 .map(|row| format_database_list_row(row.as_slice()))
                 .collect::<Vec<_>>()
                 .join("\n");
@@ -231,14 +228,11 @@ fn database_list_field(result: Result<QueryResult, DbOperationError>) -> Diagnos
 fn quick_check_field(result: Result<QueryResult, DbOperationError>) -> DiagnosticField {
     match result {
         Ok(query_result) => {
-            if query_result.rows().is_empty() {
+            if query_result.data_row_count() == 0 {
                 return DiagnosticField::err("quick_check: empty result");
             }
-            let summary = query_result
-                .rows()
-                .iter()
-                .filter_map(|row| row.first())
-                .cloned()
+            let summary = (0..query_result.data_row_count())
+                .filter_map(|row| query_result.display_value_at(row, 0))
                 .collect::<Vec<_>>()
                 .join("\n");
             DiagnosticField::ok(summary)
@@ -249,10 +243,7 @@ fn quick_check_field(result: Result<QueryResult, DbOperationError>) -> Diagnosti
 
 fn first_cell(result: &QueryResult) -> Result<String, String> {
     result
-        .rows()
-        .first()
-        .and_then(|row| row.first())
-        .cloned()
+        .display_value_at(0, 0)
         .ok_or_else(|| "empty result".to_string())
 }
 

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -947,6 +947,30 @@ mod tests {
             }
 
             #[tokio::test]
+            async fn long_text_result_does_not_materialize_display_rows() {
+                let (_dir, dsn) = test_support::make_sqlite_db("");
+                let adapter = SqliteAdapter::new();
+
+                let result = adapter
+                    .execute_adhoc(
+                        &dsn,
+                        "SELECT replace(hex(zeroblob(2048)), '00', 'xx') AS body",
+                        AccessMode::ReadOnly,
+                    )
+                    .await
+                    .unwrap();
+
+                assert!(result.rows().is_empty());
+                assert_eq!(
+                    result
+                        .value_at(0, 0)
+                        .and_then(QueryValue::as_str)
+                        .map(str::len),
+                    Some(4096)
+                );
+            }
+
+            #[tokio::test]
             async fn explain_query_plan_returns_readable_detail_lines() {
                 let (_dir, dsn) = test_support::make_sqlite_db(
                     "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -720,7 +720,10 @@ mod tests {
 
             assert_eq!(result.source, QuerySource::Preview);
             assert_eq!(result.columns, vec!["id", "name"]);
-            assert_eq!(result.rows(), vec![vec!["2".to_string(), "b".to_string()]]);
+            assert_eq!(
+                result.display_rows(),
+                vec![vec!["2".to_string(), "b".to_string()]]
+            );
         }
 
         #[tokio::test]
@@ -740,7 +743,7 @@ mod tests {
 
             assert_eq!(result.columns, vec!["rowid", "message"]);
             assert_eq!(
-                result.rows()[0],
+                result.display_rows()[0],
                 vec!["user-visible".to_string(), "first".to_string()]
             );
         }
@@ -775,7 +778,7 @@ mod tests {
                 preview.value_at(0, 0),
                 Some(&QueryValue::Text("a\0bc".to_string()))
             );
-            assert_eq!(preview.rows()[0][0], "a\\0bc");
+            assert_eq!(preview.display_rows()[0][0], "a\\0bc");
 
             let delete_sql = adapter.build_bulk_delete_sql(
                 DatabaseType::SQLite,
@@ -837,7 +840,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(result.columns, vec!["name", "email"]);
-            assert!(result.rows().is_empty());
+            assert_eq!(result.data_row_count(), 0);
             assert_eq!(result.row_count(), 0);
         }
 
@@ -939,7 +942,7 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.columns, vec!["value"]);
-                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
                 assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
             }
 
@@ -1039,7 +1042,7 @@ mod tests {
                     plan_text.to_ascii_lowercase().contains("users"),
                     "expected users table in plan, got: {plan_text}"
                 );
-                assert_eq!(rows.rows(), vec![vec!["2".to_string()]]);
+                assert_eq!(rows.display_rows(), vec![vec!["2".to_string()]]);
             }
 
             fn explain_plan_operation_lines(plan_text: &str) -> Vec<&str> {
@@ -1095,7 +1098,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let stored = result.rows()[0][0].replace('\n', " ");
+                let stored = result.display_rows()[0][0].replace('\n', " ");
                 let expected = trigger.trim().replace('\n', " ");
                 assert!(
                     !stored.contains("__sabiql_sqlite_probe_"),
@@ -1143,7 +1146,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let stored = result.rows()[0][0].replace('\n', " ");
+                let stored = result.display_rows()[0][0].replace('\n', " ");
                 let expected = trigger.trim().replace('\n', " ");
                 assert!(
                     !stored.contains("__sabiql_sqlite_probe_"),
@@ -1192,7 +1195,7 @@ mod tests {
 
                 assert_eq!(result.columns, vec!["body", "marker"]);
                 assert_eq!(
-                    result.rows(),
+                    result.display_rows(),
                     vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
                 );
                 assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
@@ -1212,7 +1215,7 @@ mod tests {
 
                 assert_eq!(result.columns, vec!["body", "marker"]);
                 assert_eq!(
-                    result.rows(),
+                    result.display_rows(),
                     vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
                 );
                 assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
@@ -1233,7 +1236,10 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.columns, vec!["c", "d"]);
-                assert_eq!(result.rows(), vec![vec!["5".to_string(), "6".to_string()]]);
+                assert_eq!(
+                    result.display_rows(),
+                    vec![vec!["5".to_string(), "6".to_string()]]
+                );
                 assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
             }
 
@@ -1252,7 +1258,7 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.columns, vec!["b"]);
-                assert!(result.rows().is_empty());
+                assert_eq!(result.data_row_count(), 0);
                 assert_eq!(result.command_tag, Some(CommandTag::Select(0)));
             }
 
@@ -1271,7 +1277,7 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.columns, vec!["value"]);
-                assert!(result.rows().is_empty());
+                assert_eq!(result.data_row_count(), 0);
                 assert_eq!(result.command_tag, Some(CommandTag::Select(0)));
             }
 
@@ -1315,7 +1321,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
             }
 
             #[tokio::test]
@@ -1328,7 +1334,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
             }
 
             #[tokio::test]
@@ -1341,7 +1347,10 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert_eq!(result.rows(), vec![vec![BUSY_TIMEOUT_MS.to_string()]]);
+                assert_eq!(
+                    result.display_rows(),
+                    vec![vec![BUSY_TIMEOUT_MS.to_string()]]
+                );
             }
 
             #[rstest::rstest]
@@ -1406,7 +1415,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
                 assert_eq!(result.command_tag, None);
             }
 
@@ -1499,7 +1508,7 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.columns, vec!["name"]);
-                assert_eq!(result.rows(), vec![vec!["x".to_string()]]);
+                assert_eq!(result.display_rows(), vec![vec!["x".to_string()]]);
                 assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
             }
 
@@ -1581,7 +1590,7 @@ mod tests {
                     )
                     .await
                     .unwrap();
-                    assert!(tables.rows().is_empty());
+                    assert_eq!(tables.data_row_count(), 0);
                 }
 
                 #[tokio::test]
@@ -1613,7 +1622,7 @@ mod tests {
                             .execute_adhoc(&dsn, read, AccessMode::ReadOnly)
                             .await
                             .unwrap();
-                        assert_eq!(value.rows(), vec![vec!["0".to_string()]], "{write}");
+                        assert_eq!(value.display_rows(), vec![vec!["0".to_string()]], "{write}");
                     }
                 }
 
@@ -1654,7 +1663,7 @@ mod tests {
                         .await
                         .unwrap();
 
-                    assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+                    assert_eq!(rows.display_rows(), vec![vec!["1".to_string()]]);
                 }
 
                 #[tokio::test]
@@ -1673,7 +1682,7 @@ mod tests {
                         .await
                         .unwrap();
 
-                    assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+                    assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
                 }
             }
 
@@ -1700,7 +1709,7 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(result.command_tag, Some(CommandTag::Rollback));
-                    assert!(rows.rows().is_empty());
+                    assert_eq!(rows.data_row_count(), 0);
                 }
 
                 #[tokio::test]
@@ -1727,7 +1736,7 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(result.command_tag, Some(CommandTag::Rollback));
-                    assert!(rows.rows().is_empty());
+                    assert_eq!(rows.data_row_count(), 0);
                 }
 
                 #[tokio::test]
@@ -1755,7 +1764,7 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                    assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+                    assert_eq!(rows.display_rows(), vec![vec!["1".to_string()]]);
                 }
 
                 #[tokio::test]
@@ -1785,7 +1794,7 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                    assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+                    assert_eq!(rows.display_rows(), vec![vec!["1".to_string()]]);
                 }
 
                 #[tokio::test]
@@ -1815,7 +1824,7 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                    assert_eq!(rows.rows(), vec![vec!["1".to_string()]]);
+                    assert_eq!(rows.display_rows(), vec![vec!["1".to_string()]]);
                 }
 
                 #[tokio::test]
@@ -1843,7 +1852,7 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                    assert_eq!(rows.rows(), vec![vec!["3".to_string()]]);
+                    assert_eq!(rows.display_rows(), vec![vec!["3".to_string()]]);
                 }
 
                 #[tokio::test]
@@ -1863,7 +1872,7 @@ mod tests {
                         .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                         .await
                         .unwrap();
-                    assert!(rows.rows().is_empty());
+                    assert_eq!(rows.data_row_count(), 0);
                 }
 
                 #[tokio::test]
@@ -1884,7 +1893,7 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(result.command_tag, Some(CommandTag::Rollback));
-                    assert!(rows.rows().is_empty());
+                    assert_eq!(rows.data_row_count(), 0);
                 }
             }
 
@@ -1910,7 +1919,7 @@ mod tests {
                         .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                         .await
                         .unwrap();
-                    assert!(rows.rows().is_empty());
+                    assert_eq!(rows.data_row_count(), 0);
                 }
 
                 #[tokio::test]
@@ -1934,7 +1943,7 @@ mod tests {
                         .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                         .await
                         .unwrap();
-                    assert!(rows.rows().is_empty());
+                    assert_eq!(rows.data_row_count(), 0);
                 }
 
                 #[tokio::test]
@@ -1953,7 +1962,7 @@ mod tests {
                         .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                         .await
                         .unwrap();
-                    assert!(rows.rows().is_empty());
+                    assert_eq!(rows.data_row_count(), 0);
                 }
 
                 #[tokio::test]
@@ -1973,7 +1982,7 @@ mod tests {
                         .execute_adhoc(&dsn, "SELECT id FROM users", AccessMode::ReadOnly)
                         .await
                         .unwrap();
-                    assert!(rows.rows().is_empty());
+                    assert_eq!(rows.data_row_count(), 0);
                 }
             }
         }
@@ -1998,7 +2007,10 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.columns, vec!["id", "name"]);
-                assert_eq!(result.rows(), vec![vec!["1".to_string(), "a".to_string()]]);
+                assert_eq!(
+                    result.display_rows(),
+                    vec![vec!["1".to_string(), "a".to_string()]]
+                );
                 assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
             }
 
@@ -2019,7 +2031,7 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.columns, vec!["value_empty"]);
-                assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
                 assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
             }
 
@@ -2042,7 +2054,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert_eq!(result.rows().len(), 2);
+                assert_eq!(result.data_row_count(), 2);
                 assert_eq!(result.command_tag, Some(CommandTag::Update(2)));
             }
 
@@ -2065,7 +2077,10 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert_eq!(result.rows(), vec![vec!["1".to_string(), "a".to_string()]]);
+                assert_eq!(
+                    result.display_rows(),
+                    vec![vec!["1".to_string(), "a".to_string()]]
+                );
                 assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
             }
         }
@@ -2234,7 +2249,7 @@ mod tests {
                 result,
                 Err(DbOperationError::ForeignKeyViolation(_))
             ));
-            assert_eq!(children.rows(), vec![vec!["1".to_string()]]);
+            assert_eq!(children.display_rows(), vec![vec!["1".to_string()]]);
         }
 
         #[tokio::test]
@@ -2302,7 +2317,7 @@ mod tests {
                 .unwrap();
 
             assert_eq!(result.affected_rows, 1);
-            assert!(children.rows().is_empty());
+            assert_eq!(children.data_row_count(), 0);
         }
 
         #[tokio::test]
@@ -2644,7 +2659,7 @@ world'), (2, 'done');
                 .await;
 
             let result = result.unwrap();
-            assert_eq!(result.rows(), vec![vec!["1".to_string()]]);
+            assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
         }
 
         #[cfg(not(windows))]
@@ -2737,10 +2752,10 @@ world'), (2, 'done');
                 let diagnostics = adapter.fetch_diagnostics_core(&dsn).await.unwrap();
 
                 assert_eq!(write.affected_rows, 1);
-                assert_eq!(result.rows(), vec![vec!["Grace".to_string()]]);
+                assert_eq!(result.display_rows(), vec![vec!["Grace".to_string()]]);
                 assert_eq!(metadata.table_summaries.len(), 1);
                 assert_eq!(
-                    preview.rows(),
+                    preview.display_rows(),
                     vec![
                         vec!["1".to_string(), "Ada".to_string()],
                         vec!["2".to_string(), "Grace".to_string()]

--- a/src/infra/adapters/sqlite/sqlite3/executor.rs
+++ b/src/infra/adapters/sqlite/sqlite3/executor.rs
@@ -679,6 +679,12 @@ mod tests {
 
     use super::*;
 
+    fn display_row(result: &QueryResult, row: usize) -> Vec<String> {
+        result
+            .display_row_at(row)
+            .expect("test result should contain the requested row")
+    }
+
     mod preview {
         use crate::adapters::test_support;
 
@@ -721,8 +727,8 @@ mod tests {
             assert_eq!(result.source, QuerySource::Preview);
             assert_eq!(result.columns, vec!["id", "name"]);
             assert_eq!(
-                result.display_rows(),
-                vec![vec!["2".to_string(), "b".to_string()]]
+                display_row(&result, 0),
+                vec!["2".to_string(), "b".to_string()]
             );
         }
 
@@ -743,7 +749,7 @@ mod tests {
 
             assert_eq!(result.columns, vec!["rowid", "message"]);
             assert_eq!(
-                result.display_rows()[0],
+                display_row(&result, 0),
                 vec!["user-visible".to_string(), "first".to_string()]
             );
         }
@@ -778,7 +784,7 @@ mod tests {
                 preview.value_at(0, 0),
                 Some(&QueryValue::Text("a\0bc".to_string()))
             );
-            assert_eq!(preview.display_rows()[0][0], "a\\0bc");
+            assert_eq!(preview.display_value_at(0, 0).as_deref(), Some("a\\0bc"));
 
             let delete_sql = adapter.build_bulk_delete_sql(
                 DatabaseType::SQLite,
@@ -942,7 +948,7 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.columns, vec!["value"]);
-                assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(display_row(&result, 0), vec!["1".to_string()]);
                 assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
             }
 
@@ -960,7 +966,6 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert!(result.rows().is_empty());
                 assert_eq!(
                     result
                         .value_at(0, 0)
@@ -1066,7 +1071,7 @@ mod tests {
                     plan_text.to_ascii_lowercase().contains("users"),
                     "expected users table in plan, got: {plan_text}"
                 );
-                assert_eq!(rows.display_rows(), vec![vec!["2".to_string()]]);
+                assert_eq!(display_row(&rows, 0), vec!["2".to_string()]);
             }
 
             fn explain_plan_operation_lines(plan_text: &str) -> Vec<&str> {
@@ -1122,7 +1127,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let stored = result.display_rows()[0][0].replace('\n', " ");
+                let stored = result.display_value_at(0, 0).unwrap().replace('\n', " ");
                 let expected = trigger.trim().replace('\n', " ");
                 assert!(
                     !stored.contains("__sabiql_sqlite_probe_"),
@@ -1170,7 +1175,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let stored = result.display_rows()[0][0].replace('\n', " ");
+                let stored = result.display_value_at(0, 0).unwrap().replace('\n', " ");
                 let expected = trigger.trim().replace('\n', " ");
                 assert!(
                     !stored.contains("__sabiql_sqlite_probe_"),
@@ -1219,8 +1224,8 @@ mod tests {
 
                 assert_eq!(result.columns, vec!["body", "marker"]);
                 assert_eq!(
-                    result.display_rows(),
-                    vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
+                    display_row(&result, 0),
+                    vec!["line 1\nline 2".to_string(), "ok".to_string()]
                 );
                 assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
             }
@@ -1239,8 +1244,8 @@ mod tests {
 
                 assert_eq!(result.columns, vec!["body", "marker"]);
                 assert_eq!(
-                    result.display_rows(),
-                    vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
+                    display_row(&result, 0),
+                    vec!["line 1\nline 2".to_string(), "ok".to_string()]
                 );
                 assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
             }
@@ -1261,8 +1266,8 @@ mod tests {
 
                 assert_eq!(result.columns, vec!["c", "d"]);
                 assert_eq!(
-                    result.display_rows(),
-                    vec![vec!["5".to_string(), "6".to_string()]]
+                    display_row(&result, 0),
+                    vec!["5".to_string(), "6".to_string()]
                 );
                 assert_eq!(result.command_tag, Some(CommandTag::Select(1)));
             }
@@ -1345,7 +1350,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(display_row(&result, 0), vec!["1".to_string()]);
             }
 
             #[tokio::test]
@@ -1358,7 +1363,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(display_row(&result, 0), vec!["1".to_string()]);
             }
 
             #[tokio::test]
@@ -1371,10 +1376,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert_eq!(
-                    result.display_rows(),
-                    vec![vec![BUSY_TIMEOUT_MS.to_string()]]
-                );
+                assert_eq!(display_row(&result, 0), vec![BUSY_TIMEOUT_MS.to_string()]);
             }
 
             #[rstest::rstest]
@@ -1439,7 +1441,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(display_row(&result, 0), vec!["1".to_string()]);
                 assert_eq!(result.command_tag, None);
             }
 
@@ -1532,7 +1534,7 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.columns, vec!["name"]);
-                assert_eq!(result.display_rows(), vec![vec!["x".to_string()]]);
+                assert_eq!(display_row(&result, 0), vec!["x".to_string()]);
                 assert_eq!(result.command_tag, Some(CommandTag::Update(1)));
             }
 
@@ -1646,7 +1648,7 @@ mod tests {
                             .execute_adhoc(&dsn, read, AccessMode::ReadOnly)
                             .await
                             .unwrap();
-                        assert_eq!(value.display_rows(), vec![vec!["0".to_string()]], "{write}");
+                        assert_eq!(display_row(&value, 0), vec!["0".to_string()], "{write}");
                     }
                 }
 
@@ -1687,7 +1689,7 @@ mod tests {
                         .await
                         .unwrap();
 
-                    assert_eq!(rows.display_rows(), vec![vec!["1".to_string()]]);
+                    assert_eq!(display_row(&rows, 0), vec!["1".to_string()]);
                 }
 
                 #[tokio::test]
@@ -1706,7 +1708,7 @@ mod tests {
                         .await
                         .unwrap();
 
-                    assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
+                    assert_eq!(display_row(&result, 0), vec!["1".to_string()]);
                 }
             }
 
@@ -1788,7 +1790,7 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                    assert_eq!(rows.display_rows(), vec![vec!["1".to_string()]]);
+                    assert_eq!(display_row(&rows, 0), vec!["1".to_string()]);
                 }
 
                 #[tokio::test]
@@ -1818,7 +1820,7 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                    assert_eq!(rows.display_rows(), vec![vec!["1".to_string()]]);
+                    assert_eq!(display_row(&rows, 0), vec!["1".to_string()]);
                 }
 
                 #[tokio::test]
@@ -1848,7 +1850,7 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                    assert_eq!(rows.display_rows(), vec![vec!["1".to_string()]]);
+                    assert_eq!(display_row(&rows, 0), vec!["1".to_string()]);
                 }
 
                 #[tokio::test]
@@ -1876,7 +1878,7 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
-                    assert_eq!(rows.display_rows(), vec![vec!["3".to_string()]]);
+                    assert_eq!(display_row(&rows, 0), vec!["3".to_string()]);
                 }
 
                 #[tokio::test]
@@ -2032,8 +2034,8 @@ mod tests {
 
                 assert_eq!(result.columns, vec!["id", "name"]);
                 assert_eq!(
-                    result.display_rows(),
-                    vec![vec!["1".to_string(), "a".to_string()]]
+                    display_row(&result, 0),
+                    vec!["1".to_string(), "a".to_string()]
                 );
                 assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
             }
@@ -2055,7 +2057,7 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(result.columns, vec!["value_empty"]);
-                assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
+                assert_eq!(display_row(&result, 0), vec!["1".to_string()]);
                 assert_eq!(result.command_tag, Some(CommandTag::Insert(1)));
             }
 
@@ -2102,8 +2104,8 @@ mod tests {
                     .unwrap();
 
                 assert_eq!(
-                    result.display_rows(),
-                    vec![vec!["1".to_string(), "a".to_string()]]
+                    display_row(&result, 0),
+                    vec!["1".to_string(), "a".to_string()]
                 );
                 assert_eq!(result.command_tag, Some(CommandTag::Delete(1)));
             }
@@ -2273,7 +2275,7 @@ mod tests {
                 result,
                 Err(DbOperationError::ForeignKeyViolation(_))
             ));
-            assert_eq!(children.display_rows(), vec![vec!["1".to_string()]]);
+            assert_eq!(display_row(&children, 0), vec!["1".to_string()]);
         }
 
         #[tokio::test]
@@ -2683,7 +2685,7 @@ world'), (2, 'done');
                 .await;
 
             let result = result.unwrap();
-            assert_eq!(result.display_rows(), vec![vec!["1".to_string()]]);
+            assert_eq!(display_row(&result, 0), vec!["1".to_string()]);
         }
 
         #[cfg(not(windows))]
@@ -2776,14 +2778,14 @@ world'), (2, 'done');
                 let diagnostics = adapter.fetch_diagnostics_core(&dsn).await.unwrap();
 
                 assert_eq!(write.affected_rows, 1);
-                assert_eq!(result.display_rows(), vec![vec!["Grace".to_string()]]);
+                assert_eq!(display_row(&result, 0), vec!["Grace".to_string()]);
                 assert_eq!(metadata.table_summaries.len(), 1);
                 assert_eq!(
-                    preview.display_rows(),
-                    vec![
+                    (display_row(&preview, 0), display_row(&preview, 1)),
+                    (
                         vec!["1".to_string(), "Ada".to_string()],
                         vec!["2".to_string(), "Grace".to_string()]
-                    ]
+                    )
                 );
                 assert!(diagnostics.sqlite_version.is_ok());
                 assert_initialization_was_not_loaded(&artifacts);

--- a/src/infra/adapters/sqlite/sqlite3/parser/output.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/output.rs
@@ -483,7 +483,7 @@ mod tests {
 
             assert_eq!(result.columns, vec!["body", "marker"]);
             assert_eq!(
-                result.rows(),
+                result.display_rows(),
                 vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
             );
         }
@@ -507,7 +507,7 @@ mod tests {
 
             assert_eq!(result.columns, vec!["body", "marker"]);
             assert_eq!(
-                result.rows(),
+                result.display_rows(),
                 vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
             );
         }
@@ -521,7 +521,7 @@ mod tests {
                     .unwrap();
 
             assert_eq!(
-                result.rows(),
+                result.display_rows(),
                 vec![vec![
                     "NULL".to_string(),
                     String::new(),

--- a/src/infra/adapters/sqlite/sqlite3/parser/output.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/output.rs
@@ -483,8 +483,8 @@ mod tests {
 
             assert_eq!(result.columns, vec!["body", "marker"]);
             assert_eq!(
-                result.display_rows(),
-                vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
+                result.display_row_at(0),
+                Some(vec!["line 1\nline 2".to_string(), "ok".to_string()])
             );
         }
 
@@ -507,8 +507,8 @@ mod tests {
 
             assert_eq!(result.columns, vec!["body", "marker"]);
             assert_eq!(
-                result.display_rows(),
-                vec![vec!["line 1\nline 2".to_string(), "ok".to_string()]]
+                result.display_row_at(0),
+                Some(vec!["line 1\nline 2".to_string(), "ok".to_string()])
             );
         }
 
@@ -521,13 +521,13 @@ mod tests {
                     .unwrap();
 
             assert_eq!(
-                result.display_rows(),
-                vec![vec![
+                result.display_row_at(0),
+                Some(vec![
                     "NULL".to_string(),
                     String::new(),
                     "NULL".to_string(),
                     "BLOB (3 bytes) 00 FF 41".to_string()
-                ]]
+                ])
             );
             assert!(matches!(result.value_at(0, 0), Some(QueryValue::Null)));
             assert_eq!(

--- a/src/tests/adapter_postgres.rs
+++ b/src/tests/adapter_postgres.rs
@@ -108,8 +108,8 @@ mod query_execution {
             .unwrap();
 
         assert_eq!(result.columns, vec!["value"]);
-        assert_eq!(result.rows().len(), 1);
-        assert_eq!(result.rows()[0], vec!["1"]);
+        assert_eq!(result.data_row_count(), 1);
+        assert_eq!(result.display_row_at(0), Some(vec!["1".to_string()]));
     }
 }
 
@@ -133,7 +133,10 @@ mod multi_statement_boundaries {
             .unwrap();
 
         assert_eq!(result.columns, vec!["b", "c"]);
-        assert_eq!(result.rows(), vec![vec!["2", "3"]]);
+        assert_eq!(
+            result.display_row_at(0),
+            Some(vec!["2".to_string(), "3".to_string()])
+        );
     }
 
     #[tokio::test]
@@ -150,7 +153,10 @@ mod multi_statement_boundaries {
             .unwrap();
 
         assert_eq!(result.columns, vec!["id", "name"]);
-        assert_eq!(result.rows(), vec![vec!["id", "name"]]);
+        assert_eq!(
+            result.display_row_at(0),
+            Some(vec!["id".to_string(), "name".to_string()])
+        );
     }
 
     #[tokio::test]
@@ -166,7 +172,7 @@ mod multi_statement_boundaries {
             .unwrap();
 
         assert_eq!(result.columns, vec!["b"]);
-        assert_eq!(result.rows(), vec![vec!["2"]]);
+        assert_eq!(result.display_row_at(0), Some(vec!["2".to_string()]));
     }
 
     #[tokio::test]
@@ -182,7 +188,7 @@ mod multi_statement_boundaries {
             .unwrap();
 
         assert_eq!(result.columns, vec!["b"]);
-        assert!(result.rows().is_empty());
+        assert_eq!(result.data_row_count(), 0);
     }
 
     #[tokio::test]
@@ -202,7 +208,7 @@ mod multi_statement_boundaries {
             .unwrap();
 
         assert_eq!(result.columns, vec!["v"]);
-        assert_eq!(result.rows(), vec![vec!["7"]]);
+        assert_eq!(result.display_row_at(0), Some(vec!["7".to_string()]));
     }
 
     #[tokio::test]
@@ -218,7 +224,7 @@ mod multi_statement_boundaries {
             .await
             .unwrap();
 
-        assert!(result.rows().is_empty());
+        assert_eq!(result.data_row_count(), 0);
         assert_eq!(
             result.command_tag,
             Some(CommandTag::Create("TABLE".to_string()))
@@ -254,8 +260,11 @@ mod multi_statement_boundaries {
                     )
                     .await
                     .map_err(|err| err.to_string())?;
-                if check.rows() != vec![vec!["t"]] {
-                    return Err(format!("expected rollback marker, got {:?}", check.rows()));
+                if check.display_row_at(0) != Some(vec!["t".to_string()]) {
+                    return Err(format!(
+                        "expected rollback marker, got {:?}",
+                        check.display_row_at(0)
+                    ));
                 }
                 Ok(())
             })

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -166,7 +166,7 @@ mod cli_sqlite_startup {
             .execute_preview(&symlinked.1, "main", "items", 10, 0)
             .await
             .unwrap();
-        assert_eq!(preview.rows()[0][1], "A");
+        assert_eq!(preview.display_value_at(0, 1).as_deref(), Some("A"));
 
         let write = adapter
             .execute_write(
@@ -182,14 +182,17 @@ mod cli_sqlite_startup {
             .execute_preview(&symlinked.1, "main", "items", 10, 0)
             .await
             .unwrap();
-        assert_eq!(updated_a.rows()[0][1], "A updated");
+        assert_eq!(
+            updated_a.display_value_at(0, 1).as_deref(),
+            Some("A updated")
+        );
 
         let database_b_dsn = format!("sqlite://{}", database_b.display());
         let unchanged_b = adapter
             .execute_preview(&database_b_dsn, "main", "items", 10, 0)
             .await
             .unwrap();
-        assert_eq!(unchanged_b.rows()[0][1], "B");
+        assert_eq!(unchanged_b.display_value_at(0, 1).as_deref(), Some("B"));
 
         assert_eq!(symlinked.3.session.dsn(), Some(expected_dsn.as_str()));
     }

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -291,8 +291,6 @@ impl ResultPane {
                     .iter()
                     .zip(viewport_widths.iter())
                     .map(|(&orig_idx, &col_width)| {
-                        let display = result.display_value_ref_at(abs_row_idx, orig_idx);
-                        let val = display.as_deref().unwrap_or("");
                         let is_editing_cell = editing_cell
                             .as_ref()
                             .is_some_and(|e| e.row == abs_row_idx && e.col == orig_idx);
@@ -321,7 +319,9 @@ impl ResultPane {
                                 );
                             }
                         } else {
-                            let display = truncate_cell(val, col_width as usize);
+                            let display = result
+                                .display_value_at_width(abs_row_idx, orig_idx, col_width as usize)
+                                .unwrap_or_default();
                             cell = Cell::from(display);
                         }
                         if !is_editing_cell {

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -71,7 +71,7 @@ impl ResultPane {
             if result.is_error() {
                 Self::render_error(frame, area, result, block, theme);
                 default_result()
-            } else if result.rows().is_empty() {
+            } else if result.data_row_count() == 0 {
                 Self::render_empty(frame, area, block, theme);
                 default_result()
             } else {
@@ -201,7 +201,7 @@ impl ResultPane {
                 &stored_cache.header_min_widths[..],
             )
         } else {
-            fresh_ideal = calculate_ideal_widths(&result.columns, result.rows());
+            fresh_ideal = calculate_result_ideal_widths(result);
             fresh_min = calculate_header_min_widths(&result.columns);
             (&fresh_ideal[..], &fresh_min[..])
         };
@@ -265,13 +265,9 @@ impl ResultPane {
 
         let yank_flash_active = yank_flash.is_some_and(|f| now < f.until);
 
-        let rows: Vec<Row> = result
-            .rows()
-            .iter()
-            .enumerate()
-            .skip(scroll_offset)
+        let rows: Vec<Row> = (scroll_offset..result.data_row_count())
             .take(data_rows_visible)
-            .map(|(abs_row_idx, row)| {
+            .map(|abs_row_idx| {
                 let is_staged_for_delete = staged_delete_rows.contains(&abs_row_idx);
                 let is_active_row = active_row == Some(abs_row_idx);
                 // None = no flash; Some(None) = full row; Some(Some(c)) = cell c
@@ -295,7 +291,8 @@ impl ResultPane {
                     .iter()
                     .zip(viewport_widths.iter())
                     .map(|(&orig_idx, &col_width)| {
-                        let val = row.get(orig_idx).map_or("", String::as_str);
+                        let display = result.display_value_ref_at(abs_row_idx, orig_idx);
+                        let val = display.as_deref().unwrap_or("");
                         let is_editing_cell = editing_cell
                             .as_ref()
                             .is_some_and(|e| e.row == abs_row_idx && e.col == orig_idx);
@@ -364,7 +361,7 @@ impl ResultPane {
         frame.render_widget(table, inner);
 
         // Scroll indicators (pass inner area, not outer with border)
-        let total_rows = result.rows().len();
+        let total_rows = result.data_row_count();
         let total_cols = result.columns.len();
 
         use crate::primitives::atoms::scroll_indicator::{
@@ -399,7 +396,36 @@ impl ResultPane {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn calculate_ideal_widths(headers: &[String], rows: &[Vec<String>]) -> Vec<u16> {
+    use unicode_width::UnicodeWidthStr;
+
+    calculate_ideal_widths_with(headers, rows.len(), |row_idx, col_idx| {
+        rows.get(row_idx)
+            .and_then(|row| row.get(col_idx))
+            .map(|cell| UnicodeWidthStr::width(cell.lines().next().unwrap_or(cell)))
+    })
+}
+
+fn calculate_result_ideal_widths(result: &QueryResult) -> Vec<u16> {
+    use unicode_width::UnicodeWidthStr;
+
+    calculate_ideal_widths_with(
+        &result.columns,
+        result.data_row_count(),
+        |row_idx, col_idx| {
+            result.display_value_ref_at(row_idx, col_idx).map(|cell| {
+                UnicodeWidthStr::width(cell.lines().next().unwrap_or_else(|| cell.as_ref()))
+            })
+        },
+    )
+}
+
+fn calculate_ideal_widths_with(
+    headers: &[String],
+    row_count: usize,
+    mut cell_width: impl FnMut(usize, usize) -> Option<usize>,
+) -> Vec<u16> {
     use unicode_width::UnicodeWidthStr;
 
     const SAMPLE_ROWS: usize = 50;
@@ -410,11 +436,10 @@ pub(crate) fn calculate_ideal_widths(headers: &[String], rows: &[Vec<String>]) -
         .map(|(col_idx, header)| {
             let mut max_width = UnicodeWidthStr::width(header.as_str());
 
-            let sample_size = rows.len().min(SAMPLE_ROWS);
-            for row in rows.iter().take(sample_size) {
-                if let Some(cell) = row.get(col_idx) {
-                    let first_line = cell.lines().next().unwrap_or(cell);
-                    max_width = max_width.max(UnicodeWidthStr::width(first_line));
+            let sample_size = row_count.min(SAMPLE_ROWS);
+            for row_idx in 0..sample_size {
+                if let Some(width) = cell_width(row_idx, col_idx) {
+                    max_width = max_width.max(width);
                 }
             }
 
@@ -463,6 +488,7 @@ fn truncate_cell(s: &str, max_width: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::QueryValue;
     use rstest::rstest;
 
     mod calculate_ideal_widths_tests {
@@ -571,6 +597,21 @@ mod tests {
             assert_eq!(result[1], 15);
             // email: max(5, 17) + 2 = 19
             assert_eq!(result[2], 19);
+        }
+
+        #[test]
+        fn typed_values_supply_display_widths_without_display_rows() {
+            let result = QueryResult::success_with_values(
+                "SELECT body".to_string(),
+                vec!["body".to_string()],
+                vec![vec![QueryValue::text("hello")]],
+                0,
+                QuerySource::Preview,
+            );
+
+            assert_eq!(calculate_result_ideal_widths(&result), vec![7]);
+            assert_eq!(result.display_value_ref_at(0, 0).as_deref(), Some("hello"));
+            assert!(result.rows().is_empty());
         }
     }
 

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -362,7 +362,7 @@ impl ResultPane {
 
         // Scroll indicators (pass inner area, not outer with border)
         let total_rows = result.data_row_count();
-        let total_cols = result.columns.len();
+        let total_cols = result.column_count();
 
         use crate::primitives::atoms::scroll_indicator::{
             HorizontalScrollParams, VerticalScrollParams, render_horizontal_scroll_indicator,
@@ -408,16 +408,10 @@ pub(crate) fn calculate_ideal_widths(headers: &[String], rows: &[Vec<String>]) -
 }
 
 fn calculate_result_ideal_widths(result: &QueryResult) -> Vec<u16> {
-    use unicode_width::UnicodeWidthStr;
-
     calculate_ideal_widths_with(
         &result.columns,
         result.data_row_count(),
-        |row_idx, col_idx| {
-            result.display_value_ref_at(row_idx, col_idx).map(|cell| {
-                UnicodeWidthStr::width(cell.lines().next().unwrap_or_else(|| cell.as_ref()))
-            })
-        },
+        |row_idx, col_idx| result.display_width_at(row_idx, col_idx),
     )
 }
 
@@ -611,7 +605,7 @@ mod tests {
 
             assert_eq!(calculate_result_ideal_widths(&result), vec![7]);
             assert_eq!(result.display_value_ref_at(0, 0).as_deref(), Some("hello"));
-            assert!(result.rows().is_empty());
+            assert_eq!(result.display_row_at(0), Some(vec!["hello".to_string()]));
         }
     }
 


### PR DESCRIPTION
## Problem

Typed SQLite query results kept display strings and typed QueryValue strings for the same cells, increasing memory use for large TEXT results.

## Background

SQLite result fidelity requires typed values for NULL, BLOB, NUL-containing TEXT, and numeric storage classes, but the display table does not need a second owned copy.

## Approach

Use QueryValue as the source for typed result display, materializing display strings only at access points that need them. Preserve row shape through explicit data-row and column accessors, and update preview, detail, copy, diagnostics, explain, and write guardrail paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * クエリ結果の表示値を統一し、セル詳細・行詳細・JSON表示・コピー時に画面上の値を正しく利用するよう改善しました。
  * BLOB、NULL、改行、NUL文字、絵文字などの表示幅と切り truncation を改善しました。
  * 結果テーブルの列幅計算、スクロール、ページ移動、行削除後の表示更新を改善しました。
  * 結果が空の場合やデータ行がない場合の表示・操作の安定性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->