### PR TITLE
fix: render only visible row detail lines

### DIFF
--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -494,6 +494,38 @@ fn result_pane_row_detail_shows_scrollbars() {
 }
 
 #[test]
+fn result_pane_row_detail_renders_tail_beyond_u16_range() {
+    let (mut state, now) = row_detail_state();
+    let mut terminal = create_test_terminal_sized(100, 25);
+    let body = (0..65_550)
+        .map(|i| format!("line {i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    state
+        .query
+        .set_current_result(Arc::new(QueryResult::success(
+            "SELECT body FROM logs LIMIT 1".to_string(),
+            vec!["body".to_string()],
+            vec![vec![body]],
+            1,
+            QuerySource::Preview,
+        )));
+    state.result_interaction.activate_cell(0, 0);
+
+    dispatch_result(
+        &mut state,
+        &Action::OpenModal(ModalKind::RowDetail),
+        &AppServices::stub(),
+        now,
+    );
+    state.row_detail.scroll_down_by(usize::MAX, 1);
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    assert!(output.contains("line 65549"));
+}
+
+#[test]
 fn result_pane_row_detail_mode() {
     let (mut state, now) = row_detail_state();
     let mut terminal = create_test_terminal();

--- a/src/tests/render_snapshots/result_pane.rs
+++ b/src/tests/render_snapshots/result_pane.rs
@@ -497,7 +497,7 @@ fn result_pane_row_detail_shows_scrollbars() {
 fn result_pane_row_detail_renders_tail_beyond_u16_range() {
     let (mut state, now) = row_detail_state();
     let mut terminal = create_test_terminal_sized(100, 25);
-    let body = (0..65_550)
+    let body = (0..66_000)
         .map(|i| format!("line {i}"))
         .collect::<Vec<_>>()
         .join("\n");
@@ -522,7 +522,8 @@ fn result_pane_row_detail_renders_tail_beyond_u16_range() {
 
     let output = render_to_string(&mut terminal, &mut state);
 
-    assert!(output.contains("line 65549"));
+    assert!(state.row_detail.scroll_offset() > usize::from(u16::MAX));
+    assert!(output.contains("line 65999"));
 }
 
 #[test]

--- a/src/ui/features/browse/row_detail.rs
+++ b/src/ui/features/browse/row_detail.rs
@@ -61,6 +61,8 @@ impl RowDetail {
         );
         let mut lines: Vec<Line> = content
             .lines()
+            .skip(scroll_offset)
+            .take(viewport.content_area.height as usize)
             .map(|line| {
                 if line.starts_with("  ") {
                     Line::from(Span::styled(
@@ -87,7 +89,7 @@ impl RowDetail {
         apply_yank_flash(&mut lines, flash_active, theme);
 
         let paragraph = Paragraph::new(lines)
-            .scroll((to_u16(scroll_offset), to_u16(horizontal_offset)))
+            .scroll((0, to_u16(horizontal_offset)))
             .style(Style::default().fg(theme.semantic.text.primary));
 
         frame.render_widget(paragraph, viewport.content_area);


### PR DESCRIPTION
## Problem

Row Detail rendered every line before applying scroll, which made large values expensive and wrapped large vertical offsets through Ratatui's `u16` scroll range.

## Background

Large TEXT or JSONB values can produce more lines than the renderer's vertical offset type can represent.

## Approach

Build only the visible Row Detail lines from the current scroll offset and render them without relying on Paragraph's vertical scroll offset. Add coverage for tail rendering beyond the `u16` range.
