### PR TITLE
refactor: group render output by layout

### DIFF
--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -745,7 +745,7 @@ mod tests {
     }
 
     #[test]
-    fn line_count_uses_rendered_section_metrics() {
+    fn line_count_uses_rendered_section_dimensions() {
         let document = HelpDocument::new(
             HelpOrigin::Normal {
                 focused_pane: FocusedPane::Explorer,

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -260,7 +260,7 @@ mod tests {
     use crate::cmd::test_support::*;
     use crate::domain::{DatabaseMetadata, TableSummary};
     use crate::model::shared::render_output::{
-        BrowseRenderMetrics, DetailRenderMetrics, ExplorerRenderMetrics, JsonbDetailRenderMetrics,
+        BrowseLayout, DetailLayout, ExplorerLayout, JsonbDetailLayout,
     };
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
@@ -301,12 +301,12 @@ mod tests {
                 _now: Instant,
             ) -> RenderResult<RenderOutput> {
                 Ok(RenderOutput {
-                    browse: BrowseRenderMetrics {
-                        explorer: ExplorerRenderMetrics {
+                    browse: BrowseLayout {
+                        explorer: ExplorerLayout {
                             content_width: self.explorer_content_width,
-                            ..ExplorerRenderMetrics::default()
+                            ..ExplorerLayout::default()
                         },
-                        ..BrowseRenderMetrics::default()
+                        ..BrowseLayout::default()
                     },
                     ..RenderOutput::default()
                 })
@@ -321,11 +321,11 @@ mod tests {
                 _now: Instant,
             ) -> RenderResult<RenderOutput> {
                 Ok(RenderOutput {
-                    details: DetailRenderMetrics {
-                        jsonb: Some(JsonbDetailRenderMetrics {
+                    details: DetailLayout {
+                        jsonb: Some(JsonbDetailLayout {
                             editor_visible_rows: self.visible_rows,
                         }),
-                        ..DetailRenderMetrics::default()
+                        ..DetailLayout::default()
                     },
                     ..RenderOutput::default()
                 })

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -259,6 +259,9 @@ mod tests {
     use super::*;
     use crate::cmd::test_support::*;
     use crate::domain::{DatabaseMetadata, TableSummary};
+    use crate::model::shared::render_output::{
+        BrowseRenderMetrics, DetailRenderMetrics, ExplorerRenderMetrics, JsonbDetailRenderMetrics,
+    };
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
     use crate::ports::outbound::query_executor::MockQueryExecutor;
@@ -298,7 +301,13 @@ mod tests {
                 _now: Instant,
             ) -> RenderResult<RenderOutput> {
                 Ok(RenderOutput {
-                    explorer_content_width: self.explorer_content_width,
+                    browse: BrowseRenderMetrics {
+                        explorer: ExplorerRenderMetrics {
+                            content_width: self.explorer_content_width,
+                            ..ExplorerRenderMetrics::default()
+                        },
+                        ..BrowseRenderMetrics::default()
+                    },
                     ..RenderOutput::default()
                 })
             }
@@ -312,7 +321,12 @@ mod tests {
                 _now: Instant,
             ) -> RenderResult<RenderOutput> {
                 Ok(RenderOutput {
-                    jsonb_detail_editor_visible_rows: Some(self.visible_rows),
+                    details: DetailRenderMetrics {
+                        jsonb: Some(JsonbDetailRenderMetrics {
+                            editor_visible_rows: self.visible_rows,
+                        }),
+                        ..DetailRenderMetrics::default()
+                    },
                     ..RenderOutput::default()
                 })
             }

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -124,8 +124,8 @@ impl AppState {
         self.flash_timers.clear_expired(now);
     }
 
-    /// Writes back the pane geometry measured during a draw. Inspector viewport
-    /// plans are skipped in focus mode to keep the pre-focus plan restorable.
+    /// Writes back feedback measured during a draw. Inspector viewport plans
+    /// are skipped in focus mode to keep the pre-focus plan restorable.
     pub fn apply_render_output(&mut self, output: RenderOutput) {
         self.apply_browse_render_metrics(output.browse);
         self.apply_input_render_metrics(output.input);
@@ -520,9 +520,13 @@ mod tests {
             assert_eq!(state.ui.inspector_viewport_plan.column_count, 2);
             assert_eq!(state.ui.inspector_pane_height, 30);
         }
+    }
+
+    mod render_feedback {
+        use super::*;
 
         #[test]
-        fn confirm_preview_metrics_are_replaced_on_each_render() {
+        fn confirm_preview_metrics_are_written() {
             let mut state = make_state();
             let measured = RenderOutput {
                 overlays: OverlayRenderMetrics {
@@ -537,6 +541,19 @@ mod tests {
             };
 
             state.apply_render_output(measured);
+
+            assert_eq!(state.confirm_dialog.preview_viewport_height, Some(10));
+            assert_eq!(state.confirm_dialog.preview_content_height, Some(25));
+            assert_eq!(state.confirm_dialog.preview_scroll, 4);
+        }
+
+        #[test]
+        fn confirm_preview_metrics_clear_without_measurement() {
+            let mut state = make_state();
+            state.confirm_dialog.preview_viewport_height = Some(10);
+            state.confirm_dialog.preview_content_height = Some(25);
+            state.confirm_dialog.preview_scroll = 4;
+
             state.apply_render_output(RenderOutput::default());
 
             assert_eq!(state.confirm_dialog.preview_viewport_height, None);

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -18,7 +18,10 @@ use crate::model::shared::flash_timer::FlashTimerStore;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::message::MessageState;
 use crate::model::shared::modal::ModalState;
-use crate::model::shared::render_output::RenderOutput;
+use crate::model::shared::render_output::{
+    BrowseRenderMetrics, DetailRenderMetrics, InputRenderMetrics, OverlayRenderMetrics,
+    PickersRenderMetrics, RenderOutput,
+};
 use crate::model::shared::settings::SettingsState;
 use crate::model::shared::ui_state::{UiState, scroll_max_offset};
 use crate::model::sql_editor::modal::SqlModalContext;
@@ -124,13 +127,21 @@ impl AppState {
     /// Writes back the pane geometry measured during a draw. Inspector viewport
     /// plans are skipped in focus mode to keep the pre-focus plan restorable.
     pub fn apply_render_output(&mut self, output: RenderOutput) {
+        self.apply_browse_render_metrics(output.browse);
+        self.apply_input_render_metrics(output.input);
+        self.apply_picker_render_metrics(output.pickers);
+        self.apply_detail_render_metrics(output.details);
+        self.apply_overlay_render_metrics(output.overlays);
+    }
+
+    fn apply_browse_render_metrics(&mut self, metrics: BrowseRenderMetrics) {
         if !self.ui.is_focus_mode() {
-            self.ui.inspector_viewport_plan = output.inspector_viewport_plan;
+            self.ui.inspector_viewport_plan = metrics.inspector.viewport_plan;
         }
-        self.ui.result_viewport_plan = output.result_viewport_plan;
-        self.ui.result_widths_cache = output.result_widths_cache;
-        self.ui.explorer_pane_height = output.explorer_pane_height;
-        self.ui.explorer_content_width = output.explorer_content_width;
+        self.ui.result_viewport_plan = metrics.result.viewport_plan;
+        self.ui.result_widths_cache = metrics.result.widths_cache;
+        self.ui.explorer_pane_height = metrics.explorer.pane_height;
+        self.ui.explorer_content_width = metrics.explorer.content_width;
         let max_name_width = self
             .tables()
             .iter()
@@ -139,54 +150,56 @@ impl AppState {
             .unwrap_or(0);
         let max_offset = scroll_max_offset(max_name_width, self.ui.explorer_content_width);
         self.ui.explorer_horizontal_offset = self.ui.explorer_horizontal_offset.min(max_offset);
-        self.ui.inspector_pane_height = output.inspector_pane_height;
-        self.ui.result_pane_height = output.result_pane_height;
-        if let Some(width) = output.command_line_visible_width {
+        self.ui.inspector_pane_height = metrics.inspector.pane_height;
+        self.ui.result_pane_height = metrics.result.pane_height;
+    }
+
+    fn apply_input_render_metrics(&mut self, metrics: InputRenderMetrics) {
+        if let Some(width) = metrics.command_line_visible_width {
             self.command_line_visible_width = width;
         }
-        if let Some(height) = output.connection_list_pane_height {
+    }
+
+    fn apply_picker_render_metrics(&mut self, metrics: PickersRenderMetrics) {
+        if let Some(height) = metrics.connection_list_pane_height {
             self.ui.connection_list_pane_height = height;
         }
-        if let Some(height) = output.table_picker_pane_height {
-            self.ui.table_picker.pane_height = height;
+        if let Some(table) = metrics.table {
+            self.ui.table_picker.pane_height = table.pane_height;
+            self.ui.table_picker.filter_visible_width = table.filter_visible_width;
         }
-        if let Some(width) = output.table_picker_filter_visible_width {
-            self.ui.table_picker.filter_visible_width = width;
+        if let Some(er) = metrics.er {
+            self.ui.er_picker.pane_height = er.pane_height;
+            self.ui.er_picker.filter_visible_width = er.filter_visible_width;
         }
-        if let Some(height) = output.er_picker_pane_height {
-            self.ui.er_picker.pane_height = height;
+        if let Some(query_history) = metrics.query_history {
+            self.query_history_picker.pane_height = query_history.pane_height;
+            self.query_history_picker.filter_visible_width = query_history.filter_visible_width;
         }
-        if let Some(width) = output.er_picker_filter_visible_width {
-            self.ui.er_picker.filter_visible_width = width;
+    }
+
+    fn apply_detail_render_metrics(&mut self, metrics: DetailRenderMetrics) {
+        if let Some(jsonb) = metrics.jsonb {
+            self.ui.jsonb_detail_editor_visible_rows = jsonb.editor_visible_rows;
+            self.jsonb_detail
+                .editor_mut()
+                .update_scroll(jsonb.editor_visible_rows);
         }
-        if let Some(height) = output.query_history_picker_pane_height {
-            self.query_history_picker.pane_height = height;
-        }
-        if let Some(width) = output.query_history_picker_filter_visible_width {
-            self.query_history_picker.filter_visible_width = width;
-        }
-        if let Some(visible_rows) = output.jsonb_detail_editor_visible_rows {
-            self.ui.jsonb_detail_editor_visible_rows = visible_rows;
-            self.jsonb_detail.editor_mut().update_scroll(visible_rows);
-        }
-        if let Some(visible_rows) = output.row_detail_content_visible_rows {
-            self.ui.row_detail_content_visible_rows = visible_rows;
-        }
-        if let Some(visible_columns) = output.row_detail_content_visible_columns {
-            self.ui.row_detail_content_visible_columns = visible_columns;
-        }
-        if output.row_detail_content_visible_rows.is_some()
-            || output.row_detail_content_visible_columns.is_some()
-        {
+        if let Some(row) = metrics.row {
+            self.ui.row_detail_content_visible_rows = row.visible_rows;
+            self.ui.row_detail_content_visible_columns = row.visible_columns;
             self.row_detail.clamp_scroll(
                 self.ui.row_detail_content_visible_rows,
                 self.ui.row_detail_content_visible_columns,
             );
         }
-        self.confirm_dialog.preview_viewport_height = output.confirm_preview_viewport_height;
-        self.confirm_dialog.preview_content_height = output.confirm_preview_content_height;
-        self.confirm_dialog.preview_scroll = output.confirm_preview_scroll;
-        if let Some(height) = output.explain_compare_viewport_height {
+    }
+
+    fn apply_overlay_render_metrics(&mut self, metrics: OverlayRenderMetrics) {
+        self.confirm_dialog.preview_viewport_height = metrics.confirm_preview.viewport_height;
+        self.confirm_dialog.preview_content_height = metrics.confirm_preview.content_height;
+        self.confirm_dialog.preview_scroll = metrics.confirm_preview.scroll;
+        if let Some(height) = metrics.explain_compare_viewport_height {
             self.explain.compare_viewport_height = Some(height);
         }
     }
@@ -320,6 +333,7 @@ mod tests {
     use crate::model::browse::row_detail::RowDetailState;
     use crate::model::er_state::ErStatus;
     use crate::model::shared::focused_pane::FocusedPane;
+    use crate::model::shared::render_output::RowDetailRenderMetrics;
     use crate::update::action::Action;
     use crate::update::dispatch_metadata;
     use rstest::rstest;
@@ -458,7 +472,13 @@ mod tests {
             state.row_detail = RowDetailState::open(&["id".to_string()], &["1".to_string()]);
             state.row_detail.scroll_down_by(10, 1);
             let output = RenderOutput {
-                row_detail_content_visible_rows: Some(3),
+                details: DetailRenderMetrics {
+                    row: Some(RowDetailRenderMetrics {
+                        visible_rows: 3,
+                        visible_columns: 80,
+                    }),
+                    ..DetailRenderMetrics::default()
+                },
                 ..RenderOutput::default()
             };
 

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -19,8 +19,7 @@ use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::message::MessageState;
 use crate::model::shared::modal::ModalState;
 use crate::model::shared::render_output::{
-    BrowseRenderMetrics, DetailRenderMetrics, InputRenderMetrics, OverlayRenderMetrics,
-    PickersRenderMetrics, RenderOutput,
+    BrowseLayout, DetailLayout, InputLayout, OverlayLayout, PickerLayouts, RenderOutput,
 };
 use crate::model::shared::settings::SettingsState;
 use crate::model::shared::ui_state::{UiState, scroll_max_offset};
@@ -124,24 +123,24 @@ impl AppState {
         self.flash_timers.clear_expired(now);
     }
 
-    /// Writes back feedback measured during a draw. Inspector viewport plans
-    /// are skipped in focus mode to keep the pre-focus plan restorable.
+    /// Applies layout data produced during a draw. Inspector viewport plans are
+    /// skipped in focus mode to keep the pre-focus plan restorable.
     pub fn apply_render_output(&mut self, output: RenderOutput) {
-        self.apply_browse_render_metrics(output.browse);
-        self.apply_input_render_metrics(output.input);
-        self.apply_picker_render_metrics(output.pickers);
-        self.apply_detail_render_metrics(output.details);
-        self.apply_overlay_render_metrics(output.overlays);
+        self.apply_browse_layout(output.browse);
+        self.apply_input_layout(output.input);
+        self.apply_picker_layouts(output.pickers);
+        self.apply_detail_layout(output.details);
+        self.apply_overlay_layout(output.overlays);
     }
 
-    fn apply_browse_render_metrics(&mut self, metrics: BrowseRenderMetrics) {
+    fn apply_browse_layout(&mut self, layout: BrowseLayout) {
         if !self.ui.is_focus_mode() {
-            self.ui.inspector_viewport_plan = metrics.inspector.viewport_plan;
+            self.ui.inspector_viewport_plan = layout.inspector.viewport_plan;
         }
-        self.ui.result_viewport_plan = metrics.result.viewport_plan;
-        self.ui.result_widths_cache = metrics.result.widths_cache;
-        self.ui.explorer_pane_height = metrics.explorer.pane_height;
-        self.ui.explorer_content_width = metrics.explorer.content_width;
+        self.ui.result_viewport_plan = layout.result.viewport_plan;
+        self.ui.result_widths_cache = layout.result.widths_cache;
+        self.ui.explorer_pane_height = layout.explorer.pane_height;
+        self.ui.explorer_content_width = layout.explorer.content_width;
         let max_name_width = self
             .tables()
             .iter()
@@ -150,42 +149,42 @@ impl AppState {
             .unwrap_or(0);
         let max_offset = scroll_max_offset(max_name_width, self.ui.explorer_content_width);
         self.ui.explorer_horizontal_offset = self.ui.explorer_horizontal_offset.min(max_offset);
-        self.ui.inspector_pane_height = metrics.inspector.pane_height;
-        self.ui.result_pane_height = metrics.result.pane_height;
+        self.ui.inspector_pane_height = layout.inspector.pane_height;
+        self.ui.result_pane_height = layout.result.pane_height;
     }
 
-    fn apply_input_render_metrics(&mut self, metrics: InputRenderMetrics) {
-        if let Some(width) = metrics.command_line_visible_width {
+    fn apply_input_layout(&mut self, layout: InputLayout) {
+        if let Some(width) = layout.command_line_visible_width {
             self.command_line_visible_width = width;
         }
     }
 
-    fn apply_picker_render_metrics(&mut self, metrics: PickersRenderMetrics) {
-        if let Some(height) = metrics.connection_list_pane_height {
+    fn apply_picker_layouts(&mut self, layouts: PickerLayouts) {
+        if let Some(height) = layouts.connection_list_pane_height {
             self.ui.connection_list_pane_height = height;
         }
-        if let Some(table) = metrics.table {
+        if let Some(table) = layouts.table {
             self.ui.table_picker.pane_height = table.pane_height;
             self.ui.table_picker.filter_visible_width = table.filter_visible_width;
         }
-        if let Some(er) = metrics.er {
+        if let Some(er) = layouts.er {
             self.ui.er_picker.pane_height = er.pane_height;
             self.ui.er_picker.filter_visible_width = er.filter_visible_width;
         }
-        if let Some(query_history) = metrics.query_history {
+        if let Some(query_history) = layouts.query_history {
             self.query_history_picker.pane_height = query_history.pane_height;
             self.query_history_picker.filter_visible_width = query_history.filter_visible_width;
         }
     }
 
-    fn apply_detail_render_metrics(&mut self, metrics: DetailRenderMetrics) {
-        if let Some(jsonb) = metrics.jsonb {
+    fn apply_detail_layout(&mut self, layout: DetailLayout) {
+        if let Some(jsonb) = layout.jsonb {
             self.ui.jsonb_detail_editor_visible_rows = jsonb.editor_visible_rows;
             self.jsonb_detail
                 .editor_mut()
                 .update_scroll(jsonb.editor_visible_rows);
         }
-        if let Some(row) = metrics.row {
+        if let Some(row) = layout.row {
             self.ui.row_detail_content_visible_rows = row.visible_rows;
             self.ui.row_detail_content_visible_columns = row.visible_columns;
             self.row_detail.clamp_scroll(
@@ -195,11 +194,11 @@ impl AppState {
         }
     }
 
-    fn apply_overlay_render_metrics(&mut self, metrics: OverlayRenderMetrics) {
-        self.confirm_dialog.preview_viewport_height = metrics.confirm_preview.viewport_height;
-        self.confirm_dialog.preview_content_height = metrics.confirm_preview.content_height;
-        self.confirm_dialog.preview_scroll = metrics.confirm_preview.scroll;
-        if let Some(height) = metrics.explain_compare_viewport_height {
+    fn apply_overlay_layout(&mut self, layout: OverlayLayout) {
+        self.confirm_dialog.preview_viewport_height = layout.confirm_preview.viewport_height;
+        self.confirm_dialog.preview_content_height = layout.confirm_preview.content_height;
+        self.confirm_dialog.preview_scroll = layout.confirm_preview.scroll;
+        if let Some(height) = layout.explain_compare_viewport_height {
             self.explain.compare_viewport_height = Some(height);
         }
     }
@@ -334,7 +333,7 @@ mod tests {
     use crate::model::er_state::ErStatus;
     use crate::model::shared::focused_pane::FocusedPane;
     use crate::model::shared::render_output::{
-        ConfirmPreviewRenderMetrics, InspectorRenderMetrics, RowDetailRenderMetrics,
+        ConfirmPreviewLayout, InspectorLayout, RowDetailLayout,
     };
     use crate::model::shared::viewport::ViewportPlan;
     use crate::update::action::Action;
@@ -475,12 +474,12 @@ mod tests {
             state.row_detail = RowDetailState::open(&["id".to_string()], &["1".to_string()]);
             state.row_detail.scroll_down_by(10, 1);
             let output = RenderOutput {
-                details: DetailRenderMetrics {
-                    row: Some(RowDetailRenderMetrics {
+                details: DetailLayout {
+                    row: Some(RowDetailLayout {
                         visible_rows: 3,
                         visible_columns: 80,
                     }),
-                    ..DetailRenderMetrics::default()
+                    ..DetailLayout::default()
                 },
                 ..RenderOutput::default()
             };
@@ -502,15 +501,15 @@ mod tests {
             };
             state.toggle_focus();
             let output = RenderOutput {
-                browse: BrowseRenderMetrics {
-                    inspector: InspectorRenderMetrics {
+                browse: BrowseLayout {
+                    inspector: InspectorLayout {
                         viewport_plan: ViewportPlan {
                             column_count: 9,
                             ..ViewportPlan::default()
                         },
                         pane_height: 30,
                     },
-                    ..BrowseRenderMetrics::default()
+                    ..BrowseLayout::default()
                 },
                 ..RenderOutput::default()
             };
@@ -522,25 +521,25 @@ mod tests {
         }
     }
 
-    mod render_feedback {
+    mod render_output {
         use super::*;
 
         #[test]
-        fn confirm_preview_metrics_are_written() {
+        fn confirm_preview_layout_is_applied() {
             let mut state = make_state();
-            let measured = RenderOutput {
-                overlays: OverlayRenderMetrics {
-                    confirm_preview: ConfirmPreviewRenderMetrics {
+            let output = RenderOutput {
+                overlays: OverlayLayout {
+                    confirm_preview: ConfirmPreviewLayout {
                         viewport_height: Some(10),
                         content_height: Some(25),
                         scroll: 4,
                     },
-                    ..OverlayRenderMetrics::default()
+                    ..OverlayLayout::default()
                 },
                 ..RenderOutput::default()
             };
 
-            state.apply_render_output(measured);
+            state.apply_render_output(output);
 
             assert_eq!(state.confirm_dialog.preview_viewport_height, Some(10));
             assert_eq!(state.confirm_dialog.preview_content_height, Some(25));
@@ -548,7 +547,7 @@ mod tests {
         }
 
         #[test]
-        fn confirm_preview_metrics_clear_without_measurement() {
+        fn confirm_preview_layout_is_reset_when_not_rendered() {
             let mut state = make_state();
             state.confirm_dialog.preview_viewport_height = Some(10);
             state.confirm_dialog.preview_content_height = Some(25);
@@ -562,17 +561,17 @@ mod tests {
         }
 
         #[test]
-        fn explain_compare_height_changes_only_when_measured() {
+        fn explain_compare_height_changes_only_when_present() {
             let mut state = make_state();
-            let measured = RenderOutput {
-                overlays: OverlayRenderMetrics {
+            let output = RenderOutput {
+                overlays: OverlayLayout {
                     explain_compare_viewport_height: Some(12),
-                    ..OverlayRenderMetrics::default()
+                    ..OverlayLayout::default()
                 },
                 ..RenderOutput::default()
             };
 
-            state.apply_render_output(measured);
+            state.apply_render_output(output);
             state.apply_render_output(RenderOutput::default());
 
             assert_eq!(state.explain.compare_viewport_height, Some(12));

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -333,7 +333,10 @@ mod tests {
     use crate::model::browse::row_detail::RowDetailState;
     use crate::model::er_state::ErStatus;
     use crate::model::shared::focused_pane::FocusedPane;
-    use crate::model::shared::render_output::RowDetailRenderMetrics;
+    use crate::model::shared::render_output::{
+        ConfirmPreviewRenderMetrics, InspectorRenderMetrics, RowDetailRenderMetrics,
+    };
+    use crate::model::shared::viewport::ViewportPlan;
     use crate::update::action::Action;
     use crate::update::dispatch_metadata;
     use rstest::rstest;
@@ -488,6 +491,74 @@ mod tests {
                 state.row_detail.scroll_offset(),
                 state.row_detail.line_count().saturating_sub(3)
             );
+        }
+
+        #[test]
+        fn focus_mode_preserves_inspector_viewport_plan() {
+            let mut state = make_state();
+            state.ui.inspector_viewport_plan = ViewportPlan {
+                column_count: 2,
+                ..ViewportPlan::default()
+            };
+            state.toggle_focus();
+            let output = RenderOutput {
+                browse: BrowseRenderMetrics {
+                    inspector: InspectorRenderMetrics {
+                        viewport_plan: ViewportPlan {
+                            column_count: 9,
+                            ..ViewportPlan::default()
+                        },
+                        pane_height: 30,
+                    },
+                    ..BrowseRenderMetrics::default()
+                },
+                ..RenderOutput::default()
+            };
+
+            state.apply_render_output(output);
+
+            assert_eq!(state.ui.inspector_viewport_plan.column_count, 2);
+            assert_eq!(state.ui.inspector_pane_height, 30);
+        }
+
+        #[test]
+        fn confirm_preview_metrics_are_replaced_on_each_render() {
+            let mut state = make_state();
+            let measured = RenderOutput {
+                overlays: OverlayRenderMetrics {
+                    confirm_preview: ConfirmPreviewRenderMetrics {
+                        viewport_height: Some(10),
+                        content_height: Some(25),
+                        scroll: 4,
+                    },
+                    ..OverlayRenderMetrics::default()
+                },
+                ..RenderOutput::default()
+            };
+
+            state.apply_render_output(measured);
+            state.apply_render_output(RenderOutput::default());
+
+            assert_eq!(state.confirm_dialog.preview_viewport_height, None);
+            assert_eq!(state.confirm_dialog.preview_content_height, None);
+            assert_eq!(state.confirm_dialog.preview_scroll, 0);
+        }
+
+        #[test]
+        fn explain_compare_height_changes_only_when_measured() {
+            let mut state = make_state();
+            let measured = RenderOutput {
+                overlays: OverlayRenderMetrics {
+                    explain_compare_viewport_height: Some(12),
+                    ..OverlayRenderMetrics::default()
+                },
+                ..RenderOutput::default()
+            };
+
+            state.apply_render_output(measured);
+            state.apply_render_output(RenderOutput::default());
+
+            assert_eq!(state.explain.compare_viewport_height, Some(12));
         }
     }
 

--- a/src/app/model/shared/render_output.rs
+++ b/src/app/model/shared/render_output.rs
@@ -1,83 +1,83 @@
 use crate::model::shared::viewport::{ColumnWidthsCache, ViewportPlan};
 
-/// Feedback measured during a draw. Owned by the model so state write-back
+/// Layout data produced during a draw. Owned by the model so state write-back
 /// stays port-agnostic; the renderer port re-exports this type as its output.
 #[derive(Default)]
 pub struct RenderOutput {
-    pub browse: BrowseRenderMetrics,
-    pub input: InputRenderMetrics,
-    pub pickers: PickersRenderMetrics,
-    pub details: DetailRenderMetrics,
-    pub overlays: OverlayRenderMetrics,
+    pub browse: BrowseLayout,
+    pub input: InputLayout,
+    pub pickers: PickerLayouts,
+    pub details: DetailLayout,
+    pub overlays: OverlayLayout,
 }
 
 #[derive(Default)]
-pub struct BrowseRenderMetrics {
-    pub explorer: ExplorerRenderMetrics,
-    pub inspector: InspectorRenderMetrics,
-    pub result: ResultRenderMetrics,
+pub struct BrowseLayout {
+    pub explorer: ExplorerLayout,
+    pub inspector: InspectorLayout,
+    pub result: ResultLayout,
 }
 
 #[derive(Default)]
-pub struct ExplorerRenderMetrics {
+pub struct ExplorerLayout {
     pub pane_height: u16,
     pub content_width: usize,
 }
 
 #[derive(Default)]
-pub struct InspectorRenderMetrics {
+pub struct InspectorLayout {
     pub viewport_plan: ViewportPlan,
     pub pane_height: u16,
 }
 
 #[derive(Default)]
-pub struct ResultRenderMetrics {
+pub struct ResultLayout {
     pub viewport_plan: ViewportPlan,
     pub widths_cache: ColumnWidthsCache,
     pub pane_height: u16,
 }
 
 #[derive(Default)]
-pub struct InputRenderMetrics {
+pub struct InputLayout {
     pub command_line_visible_width: Option<usize>,
 }
 
 #[derive(Default)]
-pub struct PickersRenderMetrics {
+pub struct PickerLayouts {
     pub connection_list_pane_height: Option<u16>,
-    pub table: Option<PickerRenderMetrics>,
-    pub er: Option<PickerRenderMetrics>,
-    pub query_history: Option<PickerRenderMetrics>,
+    pub table: Option<PickerLayout>,
+    pub er: Option<PickerLayout>,
+    pub query_history: Option<PickerLayout>,
 }
 
-pub struct PickerRenderMetrics {
+pub struct PickerLayout {
     pub pane_height: u16,
     pub filter_visible_width: usize,
 }
 
 #[derive(Default)]
-pub struct DetailRenderMetrics {
-    pub jsonb: Option<JsonbDetailRenderMetrics>,
-    pub row: Option<RowDetailRenderMetrics>,
+pub struct DetailLayout {
+    pub jsonb: Option<JsonbDetailLayout>,
+    pub row: Option<RowDetailLayout>,
 }
 
-pub struct JsonbDetailRenderMetrics {
+pub struct JsonbDetailLayout {
     pub editor_visible_rows: usize,
 }
 
-pub struct RowDetailRenderMetrics {
+pub struct RowDetailLayout {
     pub visible_rows: usize,
     pub visible_columns: usize,
 }
 
 #[derive(Default)]
-pub struct OverlayRenderMetrics {
-    pub confirm_preview: ConfirmPreviewRenderMetrics,
+pub struct OverlayLayout {
+    pub confirm_preview: ConfirmPreviewLayout,
     pub explain_compare_viewport_height: Option<u16>,
 }
 
 #[derive(Default)]
-pub struct ConfirmPreviewRenderMetrics {
+pub struct ConfirmPreviewLayout {
     pub viewport_height: Option<u16>,
     pub content_height: Option<u16>,
     pub scroll: u16,

--- a/src/app/model/shared/render_output.rs
+++ b/src/app/model/shared/render_output.rs
@@ -1,6 +1,6 @@
 use crate::model::shared::viewport::{ColumnWidthsCache, ViewportPlan};
 
-/// Geometry measured during a draw. Owned by the model so state write-back
+/// Feedback measured during a draw. Owned by the model so state write-back
 /// stays port-agnostic; the renderer port re-exports this type as its output.
 #[derive(Default)]
 pub struct RenderOutput {

--- a/src/app/model/shared/render_output.rs
+++ b/src/app/model/shared/render_output.rs
@@ -1,30 +1,84 @@
 use crate::model::shared::viewport::{ColumnWidthsCache, ViewportPlan};
 
-/// Pane geometry measured during a draw. Owned by the model so state
-/// write-back (`AppState::apply_render_output`) stays port-agnostic; the
-/// renderer port re-exports this type as its output.
+/// Geometry measured during a draw. Owned by the model so state write-back
+/// stays port-agnostic; the renderer port re-exports this type as its output.
 #[derive(Default)]
 pub struct RenderOutput {
-    pub inspector_viewport_plan: ViewportPlan,
-    pub result_viewport_plan: ViewportPlan,
-    pub result_widths_cache: ColumnWidthsCache,
-    pub explorer_pane_height: u16,
-    pub explorer_content_width: usize,
-    pub inspector_pane_height: u16,
-    pub result_pane_height: u16,
+    pub browse: BrowseRenderMetrics,
+    pub input: InputRenderMetrics,
+    pub pickers: PickersRenderMetrics,
+    pub details: DetailRenderMetrics,
+    pub overlays: OverlayRenderMetrics,
+}
+
+#[derive(Default)]
+pub struct BrowseRenderMetrics {
+    pub explorer: ExplorerRenderMetrics,
+    pub inspector: InspectorRenderMetrics,
+    pub result: ResultRenderMetrics,
+}
+
+#[derive(Default)]
+pub struct ExplorerRenderMetrics {
+    pub pane_height: u16,
+    pub content_width: usize,
+}
+
+#[derive(Default)]
+pub struct InspectorRenderMetrics {
+    pub viewport_plan: ViewportPlan,
+    pub pane_height: u16,
+}
+
+#[derive(Default)]
+pub struct ResultRenderMetrics {
+    pub viewport_plan: ViewportPlan,
+    pub widths_cache: ColumnWidthsCache,
+    pub pane_height: u16,
+}
+
+#[derive(Default)]
+pub struct InputRenderMetrics {
     pub command_line_visible_width: Option<usize>,
+}
+
+#[derive(Default)]
+pub struct PickersRenderMetrics {
     pub connection_list_pane_height: Option<u16>,
-    pub table_picker_pane_height: Option<u16>,
-    pub table_picker_filter_visible_width: Option<usize>,
-    pub er_picker_pane_height: Option<u16>,
-    pub er_picker_filter_visible_width: Option<usize>,
-    pub query_history_picker_pane_height: Option<u16>,
-    pub query_history_picker_filter_visible_width: Option<usize>,
-    pub jsonb_detail_editor_visible_rows: Option<usize>,
-    pub row_detail_content_visible_rows: Option<usize>,
-    pub row_detail_content_visible_columns: Option<usize>,
-    pub confirm_preview_viewport_height: Option<u16>,
-    pub confirm_preview_content_height: Option<u16>,
-    pub confirm_preview_scroll: u16,
+    pub table: Option<PickerRenderMetrics>,
+    pub er: Option<PickerRenderMetrics>,
+    pub query_history: Option<PickerRenderMetrics>,
+}
+
+pub struct PickerRenderMetrics {
+    pub pane_height: u16,
+    pub filter_visible_width: usize,
+}
+
+#[derive(Default)]
+pub struct DetailRenderMetrics {
+    pub jsonb: Option<JsonbDetailRenderMetrics>,
+    pub row: Option<RowDetailRenderMetrics>,
+}
+
+pub struct JsonbDetailRenderMetrics {
+    pub editor_visible_rows: usize,
+}
+
+pub struct RowDetailRenderMetrics {
+    pub visible_rows: usize,
+    pub visible_columns: usize,
+}
+
+#[derive(Default)]
+pub struct OverlayRenderMetrics {
+    pub confirm_preview: ConfirmPreviewRenderMetrics,
     pub explain_compare_viewport_height: Option<u16>,
+}
+
+#[derive(Default)]
+pub struct ConfirmPreviewRenderMetrics {
+    pub viewport_height: Option<u16>,
+    pub content_height: Option<u16>,
+    pub scroll: u16,
 }

--- a/src/app/model/shared/ui_state.rs
+++ b/src/app/model/shared/ui_state.rs
@@ -469,7 +469,7 @@ mod tests {
         }
     }
 
-    mod pane_metrics {
+    mod pane_dimensions {
         use super::*;
 
         #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -414,18 +414,18 @@ mod tests {
             );
         }
 
-        fn help_metrics(state: &AppState) -> (usize, usize) {
+        fn help_dimensions(state: &AppState) -> (usize, usize) {
             let document = HelpDocument::from_state(state);
             (document.line_count(), document.content_width())
         }
 
         fn help_max_scroll(state: &AppState) -> usize {
-            let (line_count, content_width) = help_metrics(state);
+            let (line_count, content_width) = help_dimensions(state);
             state.ui.help_max_scroll(line_count, content_width)
         }
 
         fn help_max_horizontal_scroll(state: &AppState) -> usize {
-            let (line_count, content_width) = help_metrics(state);
+            let (line_count, content_width) = help_dimensions(state);
             state
                 .ui
                 .help_max_horizontal_scroll(line_count, content_width)

--- a/src/tests/harness/mod.rs
+++ b/src/tests/harness/mod.rs
@@ -69,28 +69,7 @@ pub fn render_and_get_buffer_at_with_theme(
                 now,
                 theme,
             );
-            state.ui.inspector_viewport_plan = output.inspector_viewport_plan;
-            state.ui.result_viewport_plan = output.result_viewport_plan;
-            state.ui.result_widths_cache = output.result_widths_cache;
-            state.ui.inspector_pane_height = output.inspector_pane_height;
-            state.ui.result_pane_height = output.result_pane_height;
-            if let Some(rows) = output.jsonb_detail_editor_visible_rows {
-                state.ui.jsonb_detail_editor_visible_rows = rows;
-            }
-            if let Some(rows) = output.row_detail_content_visible_rows {
-                state.ui.row_detail_content_visible_rows = rows;
-            }
-            if let Some(columns) = output.row_detail_content_visible_columns {
-                state.ui.row_detail_content_visible_columns = columns;
-            }
-            if output.row_detail_content_visible_rows.is_some()
-                || output.row_detail_content_visible_columns.is_some()
-            {
-                state.row_detail.clamp_scroll(
-                    state.ui.row_detail_content_visible_rows,
-                    state.ui.row_detail_content_visible_columns,
-                );
-            }
+            state.apply_render_output(output);
         })
         .unwrap();
 

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -8,7 +8,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use crate::app::model::app_state::AppState;
 use crate::app::model::browse::jsonb_detail::JsonbDetailMode;
 use crate::app::model::shared::flash_timer::FlashId;
-use crate::app::model::shared::render_output::JsonbDetailRenderMetrics;
+use crate::app::model::shared::render_output::JsonbDetailLayout;
 use crate::app::model::shared::text_input::TextInputLike;
 use crate::primitives::atoms::scroll_indicator::{
     VerticalScrollParams, clamp_scroll_offset, render_vertical_scroll_indicator_bar,
@@ -28,7 +28,7 @@ impl JsonbDetail {
         state: &AppState,
         now: std::time::Instant,
         theme: &ThemePalette,
-    ) -> Option<JsonbDetailRenderMetrics> {
+    ) -> Option<JsonbDetailLayout> {
         if !state.jsonb_detail.is_active() {
             return None;
         }
@@ -86,7 +86,7 @@ impl JsonbDetail {
             Self::render_search(frame, search_area, state, theme);
         }
 
-        Some(JsonbDetailRenderMetrics {
+        Some(JsonbDetailLayout {
             editor_visible_rows: editor_area.height as usize,
         })
     }

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -8,6 +8,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use crate::app::model::app_state::AppState;
 use crate::app::model::browse::jsonb_detail::JsonbDetailMode;
 use crate::app::model::shared::flash_timer::FlashId;
+use crate::app::model::shared::render_output::JsonbDetailRenderMetrics;
 use crate::app::model::shared::text_input::TextInputLike;
 use crate::primitives::atoms::scroll_indicator::{
     VerticalScrollParams, clamp_scroll_offset, render_vertical_scroll_indicator_bar,
@@ -19,9 +20,6 @@ use crate::primitives::atoms::{
 use crate::primitives::molecules::{FooterHintBar, render_modal};
 use crate::theme::ThemePalette;
 
-pub struct JsonbDetailRenderMetrics {
-    pub editor_visible_rows: usize,
-}
 pub struct JsonbDetail;
 
 impl JsonbDetail {

--- a/src/ui/features/browse/row_detail.rs
+++ b/src/ui/features/browse/row_detail.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::Paragraph;
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::flash_timer::FlashId;
-use crate::app::model::shared::render_output::RowDetailRenderMetrics;
+use crate::app::model::shared::render_output::RowDetailLayout;
 use crate::app::update::input::keybindings::{ModeRow, ROW_DETAIL_FOOTER_ROWS};
 use crate::primitives::atoms::apply_yank_flash;
 use crate::primitives::atoms::scroll_indicator::{
@@ -24,7 +24,7 @@ impl RowDetail {
         state: &AppState,
         now: std::time::Instant,
         theme: &ThemePalette,
-    ) -> Option<RowDetailRenderMetrics> {
+    ) -> Option<RowDetailLayout> {
         if !state.row_detail.is_active() {
             return None;
         }
@@ -116,7 +116,7 @@ impl RowDetail {
             );
         }
 
-        Some(RowDetailRenderMetrics {
+        Some(RowDetailLayout {
             visible_rows: viewport.content_area.height as usize,
             visible_columns: viewport.content_area.width as usize,
         })

--- a/src/ui/features/browse/row_detail.rs
+++ b/src/ui/features/browse/row_detail.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::Paragraph;
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::flash_timer::FlashId;
+use crate::app::model::shared::render_output::RowDetailRenderMetrics;
 use crate::app::update::input::keybindings::{ModeRow, ROW_DETAIL_FOOTER_ROWS};
 use crate::primitives::atoms::apply_yank_flash;
 use crate::primitives::atoms::scroll_indicator::{
@@ -14,11 +15,6 @@ use crate::primitives::atoms::scroll_indicator::{
 };
 use crate::primitives::molecules::{FooterHintBar, render_modal};
 use crate::theme::ThemePalette;
-
-pub struct RowDetailRenderMetrics {
-    pub visible_rows: usize,
-    pub visible_columns: usize,
-}
 
 pub struct RowDetail;
 

--- a/src/ui/features/overlays/confirm_dialog.rs
+++ b/src/ui/features/overlays/confirm_dialog.rs
@@ -4,6 +4,7 @@ use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::confirm_dialog::ConfirmIntent;
+use crate::app::model::shared::render_output::ConfirmPreviewRenderMetrics;
 use crate::app::policy::json::json_diff::JsonDiffLine;
 use crate::app::policy::write::write_guardrails::{RiskLevel, WriteOperation};
 use crate::app::policy::write::write_update::escape_preview_value;
@@ -14,18 +15,12 @@ use crate::theme::ThemePalette;
 
 pub struct ConfirmDialog;
 
-pub struct ConfirmPreviewMetrics {
-    pub viewport_height: Option<u16>,
-    pub content_height: Option<u16>,
-    pub scroll: u16,
-}
-
 impl ConfirmDialog {
     pub fn render(
         frame: &mut Frame,
         state: &AppState,
         theme: &ThemePalette,
-    ) -> ConfirmPreviewMetrics {
+    ) -> ConfirmPreviewRenderMetrics {
         if state.result_interaction.pending_write_preview().is_some() {
             Self::render_write_preview(frame, state, theme)
         } else {
@@ -45,7 +40,7 @@ impl ConfirmDialog {
         frame: &mut Frame,
         state: &AppState,
         theme: &ThemePalette,
-    ) -> ConfirmPreviewMetrics {
+    ) -> ConfirmPreviewRenderMetrics {
         let dialog = &state.confirm_dialog;
         let hint = FooterHintBar::new([("Enter", "Confirm"), ("Esc", "Cancel")]);
 
@@ -97,7 +92,7 @@ impl ConfirmDialog {
             .alignment(Alignment::Left)
             .wrap(Wrap { trim: false });
         frame.render_widget(message_para, inner);
-        ConfirmPreviewMetrics {
+        ConfirmPreviewRenderMetrics {
             viewport_height: None,
             content_height: None,
             scroll: 0,
@@ -108,7 +103,7 @@ impl ConfirmDialog {
         frame: &mut Frame,
         state: &AppState,
         theme: &ThemePalette,
-    ) -> ConfirmPreviewMetrics {
+    ) -> ConfirmPreviewRenderMetrics {
         let preview = state
             .result_interaction
             .pending_write_preview()
@@ -265,7 +260,7 @@ impl ConfirmDialog {
             .wrap(Wrap { trim: false })
             .scroll((scroll, 0));
         frame.render_widget(para, inner);
-        ConfirmPreviewMetrics {
+        ConfirmPreviewRenderMetrics {
             viewport_height: Some(inner.height),
             content_height: Some(wrapped_height),
             scroll,

--- a/src/ui/features/overlays/confirm_dialog.rs
+++ b/src/ui/features/overlays/confirm_dialog.rs
@@ -4,7 +4,7 @@ use ratatui::widgets::{Paragraph, Wrap};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::confirm_dialog::ConfirmIntent;
-use crate::app::model::shared::render_output::ConfirmPreviewRenderMetrics;
+use crate::app::model::shared::render_output::ConfirmPreviewLayout;
 use crate::app::policy::json::json_diff::JsonDiffLine;
 use crate::app::policy::write::write_guardrails::{RiskLevel, WriteOperation};
 use crate::app::policy::write::write_update::escape_preview_value;
@@ -20,7 +20,7 @@ impl ConfirmDialog {
         frame: &mut Frame,
         state: &AppState,
         theme: &ThemePalette,
-    ) -> ConfirmPreviewRenderMetrics {
+    ) -> ConfirmPreviewLayout {
         if state.result_interaction.pending_write_preview().is_some() {
             Self::render_write_preview(frame, state, theme)
         } else {
@@ -40,7 +40,7 @@ impl ConfirmDialog {
         frame: &mut Frame,
         state: &AppState,
         theme: &ThemePalette,
-    ) -> ConfirmPreviewRenderMetrics {
+    ) -> ConfirmPreviewLayout {
         let dialog = &state.confirm_dialog;
         let hint = FooterHintBar::new([("Enter", "Confirm"), ("Esc", "Cancel")]);
 
@@ -92,7 +92,7 @@ impl ConfirmDialog {
             .alignment(Alignment::Left)
             .wrap(Wrap { trim: false });
         frame.render_widget(message_para, inner);
-        ConfirmPreviewRenderMetrics {
+        ConfirmPreviewLayout {
             viewport_height: None,
             content_height: None,
             scroll: 0,
@@ -103,7 +103,7 @@ impl ConfirmDialog {
         frame: &mut Frame,
         state: &AppState,
         theme: &ThemePalette,
-    ) -> ConfirmPreviewRenderMetrics {
+    ) -> ConfirmPreviewLayout {
         let preview = state
             .result_interaction
             .pending_write_preview()
@@ -260,7 +260,7 @@ impl ConfirmDialog {
             .wrap(Wrap { trim: false })
             .scroll((scroll, 0));
         frame.render_widget(para, inner);
-        ConfirmPreviewRenderMetrics {
+        ConfirmPreviewLayout {
             viewport_height: Some(inner.height),
             content_height: Some(wrapped_height),
             scroll,

--- a/src/ui/features/pickers/er_table_picker.rs
+++ b/src/ui/features/pickers/er_table_picker.rs
@@ -5,7 +5,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem, ListState, Paragraph};
 
 use crate::app::model::app_state::AppState;
-use crate::app::model::shared::render_output::PickerRenderMetrics;
+use crate::app::model::shared::render_output::PickerLayout;
 use crate::app::update::input::keybindings;
 use crate::domain::er::er_output_filename;
 use crate::primitives::molecules::{FooterHintBar, render_filter_input_line, render_modal};
@@ -14,11 +14,7 @@ use crate::theme::ThemePalette;
 pub struct ErTablePicker;
 
 impl ErTablePicker {
-    pub fn render(
-        frame: &mut Frame,
-        state: &AppState,
-        theme: &ThemePalette,
-    ) -> PickerRenderMetrics {
+    pub fn render(frame: &mut Frame, state: &AppState, theme: &ThemePalette) -> PickerLayout {
         let selected_count = state.ui.er_selected_tables.len();
         let total_count = state.tables().len();
         let filtered_count = state.er_filtered_tables().len();
@@ -147,7 +143,7 @@ impl ErTablePicker {
             .with_selected(selected)
             .with_offset(state.ui.er_picker.scroll_offset());
         frame.render_stateful_widget(list, list_area, &mut list_state);
-        PickerRenderMetrics {
+        PickerLayout {
             pane_height: list_area.height,
             filter_visible_width: visible_width,
         }

--- a/src/ui/features/pickers/er_table_picker.rs
+++ b/src/ui/features/pickers/er_table_picker.rs
@@ -5,12 +5,11 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{List, ListItem, ListState, Paragraph};
 
 use crate::app::model::app_state::AppState;
+use crate::app::model::shared::render_output::PickerRenderMetrics;
 use crate::app::update::input::keybindings;
 use crate::domain::er::er_output_filename;
-use crate::theme::ThemePalette;
-
-use crate::features::pickers::PickerRenderMetrics;
 use crate::primitives::molecules::{FooterHintBar, render_filter_input_line, render_modal};
+use crate::theme::ThemePalette;
 
 pub struct ErTablePicker;
 

--- a/src/ui/features/pickers/mod.rs
+++ b/src/ui/features/pickers/mod.rs
@@ -2,8 +2,3 @@ pub mod command_palette;
 pub mod er_table_picker;
 pub mod query_history_picker;
 pub mod table_picker;
-
-pub struct PickerRenderMetrics {
-    pub pane_height: u16,
-    pub filter_visible_width: usize,
-}

--- a/src/ui/features/pickers/query_history_picker.rs
+++ b/src/ui/features/pickers/query_history_picker.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wra
 use unicode_width::UnicodeWidthStr;
 
 use crate::app::model::app_state::AppState;
-use crate::app::model::shared::render_output::PickerRenderMetrics;
+use crate::app::model::shared::render_output::PickerLayout;
 use crate::app::model::sql_editor::query_history::GroupedEntry;
 use crate::domain::query_history::{Iso8601Timestamp, QueryResultStatus};
 use crate::primitives::molecules::{FooterHintBar, render_filter_input_line, render_modal};
@@ -78,11 +78,7 @@ struct PreviewData<'a> {
 pub struct QueryHistoryPicker;
 
 impl QueryHistoryPicker {
-    pub fn render(
-        frame: &mut Frame,
-        state: &AppState,
-        theme: &ThemePalette,
-    ) -> PickerRenderMetrics {
+    pub fn render(frame: &mut Frame, state: &AppState, theme: &ThemePalette) -> PickerLayout {
         let filter_is_empty = state
             .query_history_picker
             .filter_input()
@@ -161,7 +157,7 @@ impl QueryHistoryPicker {
             if let Some(pa) = preview_area {
                 render_empty_preview(frame, pa, theme);
             }
-            return PickerRenderMetrics {
+            return PickerLayout {
                 pane_height: list_area.height,
                 filter_visible_width: visible_width,
             };
@@ -200,7 +196,7 @@ impl QueryHistoryPicker {
             .with_selected(Some(selected_idx))
             .with_offset(scroll_offset);
         frame.render_stateful_widget(list, list_area, &mut list_state);
-        PickerRenderMetrics {
+        PickerLayout {
             pane_height: list_area.height,
             filter_visible_width: visible_width,
         }

--- a/src/ui/features/pickers/query_history_picker.rs
+++ b/src/ui/features/pickers/query_history_picker.rs
@@ -3,13 +3,12 @@ use ratatui::layout::{Constraint, Layout};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap};
-
-use crate::app::model::app_state::AppState;
-use crate::app::model::sql_editor::query_history::GroupedEntry;
-use crate::domain::query_history::{Iso8601Timestamp, QueryResultStatus};
 use unicode_width::UnicodeWidthStr;
 
-use crate::features::pickers::PickerRenderMetrics;
+use crate::app::model::app_state::AppState;
+use crate::app::model::shared::render_output::PickerRenderMetrics;
+use crate::app::model::sql_editor::query_history::GroupedEntry;
+use crate::domain::query_history::{Iso8601Timestamp, QueryResultStatus};
 use crate::primitives::molecules::{FooterHintBar, render_filter_input_line, render_modal};
 use crate::primitives::utils::text_utils::truncate_to_width_with;
 use crate::theme::{StatusTone, ThemePalette};

--- a/src/ui/features/pickers/table_picker.rs
+++ b/src/ui/features/pickers/table_picker.rs
@@ -4,7 +4,7 @@ use ratatui::style::Style;
 use ratatui::widgets::{List, ListItem, ListState};
 
 use crate::app::model::app_state::AppState;
-use crate::features::pickers::PickerRenderMetrics;
+use crate::app::model::shared::render_output::PickerRenderMetrics;
 use crate::primitives::molecules::{FooterHintBar, render_filter_input_line, render_modal};
 use crate::theme::ThemePalette;
 

--- a/src/ui/features/pickers/table_picker.rs
+++ b/src/ui/features/pickers/table_picker.rs
@@ -4,18 +4,14 @@ use ratatui::style::Style;
 use ratatui::widgets::{List, ListItem, ListState};
 
 use crate::app::model::app_state::AppState;
-use crate::app::model::shared::render_output::PickerRenderMetrics;
+use crate::app::model::shared::render_output::PickerLayout;
 use crate::primitives::molecules::{FooterHintBar, render_filter_input_line, render_modal};
 use crate::theme::ThemePalette;
 
 pub struct TablePicker;
 
 impl TablePicker {
-    pub fn render(
-        frame: &mut Frame,
-        state: &AppState,
-        theme: &ThemePalette,
-    ) -> PickerRenderMetrics {
+    pub fn render(frame: &mut Frame, state: &AppState, theme: &ThemePalette) -> PickerLayout {
         let filtered_count = state.filtered_tables().len();
         let (_, inner) = render_modal(
             frame,
@@ -59,7 +55,7 @@ impl TablePicker {
             .with_selected(selected)
             .with_offset(state.ui.table_picker.scroll_offset());
         frame.render_stateful_widget(list, list_area, &mut list_state);
-        PickerRenderMetrics {
+        PickerLayout {
             pane_height: list_area.height,
             filter_visible_width: visible_width,
         }

--- a/src/ui/shell/layout.rs
+++ b/src/ui/shell/layout.rs
@@ -5,22 +5,25 @@ use ratatui::layout::{Constraint, Layout, Rect};
 
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::input_mode::InputMode;
+use crate::app::model::shared::render_output::{
+    BrowseRenderMetrics, ConfirmPreviewRenderMetrics, DetailRenderMetrics, ExplorerRenderMetrics,
+    InputRenderMetrics, InspectorRenderMetrics, OverlayRenderMetrics, PickersRenderMetrics,
+    ResultRenderMetrics,
+};
 use crate::app::model::shared::ui_state::explorer_content_width_from_pane_width;
-use crate::app::model::shared::viewport::ViewportPlan;
 use crate::app::ports::outbound::RenderOutput;
 use crate::app::services::AppServices;
 use crate::features::browse::explorer::Explorer;
 use crate::features::browse::inspector::Inspector;
-use crate::features::browse::jsonb_detail::{JsonbDetail, JsonbDetailRenderMetrics};
+use crate::features::browse::jsonb_detail::JsonbDetail;
 use crate::features::browse::result::ResultPane;
-use crate::features::browse::row_detail::{RowDetail, RowDetailRenderMetrics};
+use crate::features::browse::row_detail::RowDetail;
 use crate::features::connections::error::ConnectionError;
 use crate::features::connections::selector::ConnectionSelector;
 use crate::features::connections::setup::ConnectionSetup;
-use crate::features::overlays::confirm_dialog::{ConfirmDialog, ConfirmPreviewMetrics};
+use crate::features::overlays::confirm_dialog::ConfirmDialog;
 use crate::features::overlays::help::HelpOverlay;
 use crate::features::overlays::settings::SettingsOverlay;
-use crate::features::pickers::PickerRenderMetrics;
 use crate::features::pickers::command_palette::CommandPalette;
 use crate::features::pickers::er_table_picker::ErTablePicker;
 use crate::features::pickers::query_history_picker::QueryHistoryPicker;
@@ -84,7 +87,7 @@ impl MainLayout {
         .areas(area);
 
         Header::render(frame, header_area, state, theme);
-        let output = Self::render_browse_mode(frame, main_area, state, services, now, theme);
+        let browse = Self::render_browse_mode(frame, main_area, state, services, now, theme);
 
         Footer::render(frame, footer_area, state, services, time_ms, theme);
         let command_line_visible_width = CommandLine::render(frame, cmdline_area, state, theme);
@@ -93,46 +96,24 @@ impl MainLayout {
             _ => None,
         };
 
-        let split_metrics = |metrics: PickerRenderMetrics| {
-            (
-                Some(metrics.pane_height),
-                Some(metrics.filter_visible_width),
-            )
+        let table_picker = match state.input_mode() {
+            InputMode::TablePicker => Some(TablePicker::render(frame, state, theme)),
+            _ => None,
         };
 
-        let (table_picker_pane_height, table_picker_filter_visible_width) = match state.input_mode()
-        {
-            InputMode::TablePicker => split_metrics(TablePicker::render(frame, state, theme)),
-            _ => (None, None),
+        let er_picker = match state.input_mode() {
+            InputMode::ErTablePicker => Some(ErTablePicker::render(frame, state, theme)),
+            _ => None,
         };
 
-        let (er_picker_pane_height, er_picker_filter_visible_width) = match state.input_mode() {
-            InputMode::ErTablePicker => split_metrics(ErTablePicker::render(frame, state, theme)),
-            _ => (None, None),
+        let query_history_picker = match state.input_mode() {
+            InputMode::QueryHistoryPicker => Some(QueryHistoryPicker::render(frame, state, theme)),
+            _ => None,
         };
 
-        let (query_history_picker_pane_height, query_history_picker_filter_visible_width) =
-            match state.input_mode() {
-                InputMode::QueryHistoryPicker => {
-                    split_metrics(QueryHistoryPicker::render(frame, state, theme))
-                }
-                _ => (None, None),
-            };
-
-        let (
-            confirm_preview_viewport_height,
-            confirm_preview_content_height,
-            confirm_preview_scroll,
-        ) = match state.input_mode() {
-            InputMode::ConfirmDialog => {
-                let ConfirmPreviewMetrics {
-                    viewport_height,
-                    content_height,
-                    scroll,
-                } = ConfirmDialog::render(frame, state, theme);
-                (viewport_height, content_height, scroll)
-            }
-            _ => (None, None, 0),
+        let confirm_preview = match state.input_mode() {
+            InputMode::ConfirmDialog => ConfirmDialog::render(frame, state, theme),
+            _ => ConfirmPreviewRenderMetrics::default(),
         };
 
         let explain_compare_viewport_height = if matches!(state.input_mode(), InputMode::SqlModal) {
@@ -141,28 +122,17 @@ impl MainLayout {
             None
         };
 
-        let jsonb_detail_editor_visible_rows = match state.input_mode() {
+        let jsonb_detail = match state.input_mode() {
             InputMode::JsonbDetail | InputMode::JsonbEdit => {
-                JsonbDetail::render(frame, state, now, theme).map(
-                    |JsonbDetailRenderMetrics {
-                         editor_visible_rows,
-                     }| editor_visible_rows,
-                )
+                JsonbDetail::render(frame, state, now, theme)
             }
             _ => None,
         };
 
-        let (row_detail_content_visible_rows, row_detail_content_visible_columns) =
-            match state.input_mode() {
-                InputMode::RowDetail => RowDetail::render(frame, state, now, theme).map_or(
-                    (None, None),
-                    |RowDetailRenderMetrics {
-                         visible_rows,
-                         visible_columns,
-                     }| (Some(visible_rows), Some(visible_columns)),
-                ),
-                _ => (None, None),
-            };
+        let row_detail = match state.input_mode() {
+            InputMode::RowDetail => RowDetail::render(frame, state, now, theme),
+            _ => None,
+        };
 
         match state.input_mode() {
             InputMode::CommandPalette => CommandPalette::render(frame, state, theme),
@@ -174,22 +144,24 @@ impl MainLayout {
         }
 
         RenderOutput {
-            command_line_visible_width: Some(command_line_visible_width),
-            connection_list_pane_height,
-            table_picker_pane_height,
-            table_picker_filter_visible_width,
-            er_picker_pane_height,
-            er_picker_filter_visible_width,
-            query_history_picker_pane_height,
-            query_history_picker_filter_visible_width,
-            jsonb_detail_editor_visible_rows,
-            row_detail_content_visible_rows,
-            row_detail_content_visible_columns,
-            confirm_preview_viewport_height,
-            confirm_preview_content_height,
-            confirm_preview_scroll,
-            explain_compare_viewport_height,
-            ..output
+            browse,
+            input: InputRenderMetrics {
+                command_line_visible_width: Some(command_line_visible_width),
+            },
+            pickers: PickersRenderMetrics {
+                connection_list_pane_height,
+                table: table_picker,
+                er: er_picker,
+                query_history: query_history_picker,
+            },
+            details: DetailRenderMetrics {
+                jsonb: jsonb_detail,
+                row: row_detail,
+            },
+            overlays: OverlayRenderMetrics {
+                confirm_preview,
+                explain_compare_viewport_height,
+            },
         }
     }
 
@@ -200,19 +172,18 @@ impl MainLayout {
         services: &AppServices,
         now: Instant,
         theme: &ThemePalette,
-    ) -> RenderOutput {
+    ) -> BrowseRenderMetrics {
         if state.ui.is_focus_mode() {
             let (result_plan, result_widths_cache) =
                 ResultPane::render(frame, main_area, state, now, theme);
-            RenderOutput {
-                inspector_viewport_plan: ViewportPlan::default(),
-                result_viewport_plan: result_plan,
-                result_widths_cache,
-                explorer_pane_height: 0,
-                explorer_content_width: 0,
-                inspector_pane_height: 0,
-                result_pane_height: main_area.height,
-                ..RenderOutput::default()
+            BrowseRenderMetrics {
+                explorer: ExplorerRenderMetrics::default(),
+                inspector: InspectorRenderMetrics::default(),
+                result: ResultRenderMetrics {
+                    viewport_plan: result_plan,
+                    widths_cache: result_widths_cache,
+                    pane_height: main_area.height,
+                },
             }
         } else {
             let [left_area, right_area] =
@@ -230,15 +201,20 @@ impl MainLayout {
             let (result_plan, result_widths_cache) =
                 ResultPane::render(frame, result_area, state, now, theme);
 
-            RenderOutput {
-                inspector_viewport_plan: inspector_plan,
-                result_viewport_plan: result_plan,
-                result_widths_cache,
-                explorer_pane_height: left_area.height,
-                explorer_content_width: explorer_content_width_from_pane_width(left_area.width),
-                inspector_pane_height: inspector_area.height,
-                result_pane_height: result_area.height,
-                ..RenderOutput::default()
+            BrowseRenderMetrics {
+                explorer: ExplorerRenderMetrics {
+                    pane_height: left_area.height,
+                    content_width: explorer_content_width_from_pane_width(left_area.width),
+                },
+                inspector: InspectorRenderMetrics {
+                    viewport_plan: inspector_plan,
+                    pane_height: inspector_area.height,
+                },
+                result: ResultRenderMetrics {
+                    viewport_plan: result_plan,
+                    widths_cache: result_widths_cache,
+                    pane_height: result_area.height,
+                },
             }
         }
     }

--- a/src/ui/shell/layout.rs
+++ b/src/ui/shell/layout.rs
@@ -6,9 +6,8 @@ use ratatui::layout::{Constraint, Layout, Rect};
 use crate::app::model::app_state::AppState;
 use crate::app::model::shared::input_mode::InputMode;
 use crate::app::model::shared::render_output::{
-    BrowseRenderMetrics, ConfirmPreviewRenderMetrics, DetailRenderMetrics, ExplorerRenderMetrics,
-    InputRenderMetrics, InspectorRenderMetrics, OverlayRenderMetrics, PickersRenderMetrics,
-    ResultRenderMetrics,
+    BrowseLayout, ConfirmPreviewLayout, DetailLayout, ExplorerLayout, InputLayout, InspectorLayout,
+    OverlayLayout, PickerLayouts, ResultLayout,
 };
 use crate::app::model::shared::ui_state::explorer_content_width_from_pane_width;
 use crate::app::ports::outbound::RenderOutput;
@@ -113,7 +112,7 @@ impl MainLayout {
 
         let confirm_preview = match state.input_mode() {
             InputMode::ConfirmDialog => ConfirmDialog::render(frame, state, theme),
-            _ => ConfirmPreviewRenderMetrics::default(),
+            _ => ConfirmPreviewLayout::default(),
         };
 
         let explain_compare_viewport_height = if matches!(state.input_mode(), InputMode::SqlModal) {
@@ -145,20 +144,20 @@ impl MainLayout {
 
         RenderOutput {
             browse,
-            input: InputRenderMetrics {
+            input: InputLayout {
                 command_line_visible_width: Some(command_line_visible_width),
             },
-            pickers: PickersRenderMetrics {
+            pickers: PickerLayouts {
                 connection_list_pane_height,
                 table: table_picker,
                 er: er_picker,
                 query_history: query_history_picker,
             },
-            details: DetailRenderMetrics {
+            details: DetailLayout {
                 jsonb: jsonb_detail,
                 row: row_detail,
             },
-            overlays: OverlayRenderMetrics {
+            overlays: OverlayLayout {
                 confirm_preview,
                 explain_compare_viewport_height,
             },
@@ -172,14 +171,14 @@ impl MainLayout {
         services: &AppServices,
         now: Instant,
         theme: &ThemePalette,
-    ) -> BrowseRenderMetrics {
+    ) -> BrowseLayout {
         if state.ui.is_focus_mode() {
             let (result_plan, result_widths_cache) =
                 ResultPane::render(frame, main_area, state, now, theme);
-            BrowseRenderMetrics {
-                explorer: ExplorerRenderMetrics::default(),
-                inspector: InspectorRenderMetrics::default(),
-                result: ResultRenderMetrics {
+            BrowseLayout {
+                explorer: ExplorerLayout::default(),
+                inspector: InspectorLayout::default(),
+                result: ResultLayout {
                     viewport_plan: result_plan,
                     widths_cache: result_widths_cache,
                     pane_height: main_area.height,
@@ -201,16 +200,16 @@ impl MainLayout {
             let (result_plan, result_widths_cache) =
                 ResultPane::render(frame, result_area, state, now, theme);
 
-            BrowseRenderMetrics {
-                explorer: ExplorerRenderMetrics {
+            BrowseLayout {
+                explorer: ExplorerLayout {
                     pane_height: left_area.height,
                     content_width: explorer_content_width_from_pane_width(left_area.width),
                 },
-                inspector: InspectorRenderMetrics {
+                inspector: InspectorLayout {
                     viewport_plan: inspector_plan,
                     pane_height: inspector_area.height,
                 },
-                result: ResultRenderMetrics {
+                result: ResultLayout {
                     viewport_plan: result_plan,
                     widths_cache: result_widths_cache,
                     pane_height: result_area.height,


### PR DESCRIPTION
## Problem

Layout results from unrelated UI regions were flattened into one DTO, obscuring ownership and allowing incomplete value combinations.

## Background

SAB-245. PR #413 already centralized render-output application in AppState; the remaining debt was the output structure itself.

## Terminology

Metrics commonly suggests telemetry or aggregated measurements. These values are transient layout results computed for each draw, such as pane dimensions, visible ranges, and viewport plans, so grouped render output uses Layout and scalar sizing helpers use dimensions.

## Approach

Group render output by browse panes, inputs, pickers, detail views, and overlays. Share model-owned layout types across rendering and state application, and route snapshot rendering through the same application boundary.