### PR TITLE
feat: fix header connection context positioning

### DIFF
--- a/src/tests/render_snapshots/initial_state.rs
+++ b/src/tests/render_snapshots/initial_state.rs
@@ -50,3 +50,18 @@ fn header_truncates_connection_name_at_narrow_width() {
 
     insta::assert_snapshot!(output);
 }
+
+#[test]
+fn header_shows_read_only_badge_at_narrow_width() {
+    let mut state = connected_state();
+    state.session.dsn = Some("postgresql://localhost/test".to_string());
+    state.session.read_only = true;
+    state
+        .session
+        .mark_effective_user_loaded(Some("app_user".to_string()));
+    let mut terminal = create_test_terminal_sized(80, 20);
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_delete_preview_low_risk.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_delete_preview_low_risk.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_jsonb_and_string_mixed.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_jsonb_and_string_mixed.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_jsonb_key_order_normalized.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_jsonb_key_order_normalized.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_jsonb_structured_diff_with_ellipsis.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_jsonb_structured_diff_with_ellipsis.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_long_jsonb.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_long_jsonb.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_multi_column.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_multi_column.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_narrow_terminal.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_narrow_terminal.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | l…
+te… ▸ … ▸ - no dsn | localhost:5432/test
 ┌╭ Confirm UPDATE: users ─────────────╮]
 ││                                    │┐
 ││ ✓ LOW RISK                         ││

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_rich.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_rich.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_scrollable.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__confirm_dialogs__confirm_dialog_update_preview_scrollable.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/confirm_dialogs.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_collapsed.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_collapsed.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded_long_details_capped.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded_long_details_capped.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded_with_tabs.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_error_expanded_with_tabs.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_head.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_middle.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_cursor_at_tail.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_host_focused.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_host_focused.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_password_focused.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_empty_password_focused.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_form.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_omits_empty_optional_fields.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_omits_empty_optional_fields.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_uses_postgres_conninfo_escaping.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_uses_postgres_conninfo_escaping.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_with_max_length_fields.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_with_max_length_fields.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_wraps_across_multiple_rows_for_long_conninfo.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_preview_wraps_across_multiple_rows_for_long_conninfo.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_ssl_mode_ide_hint.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_with_validation_errors.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_with_validation_errors.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__footer_shows_success_message.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__footer_shows_success_message.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_flow.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__confirm_dialog_delete_active_connection.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__confirm_dialog_delete_active_connection.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__confirm_dialog_delete_inactive_connection.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__confirm_dialog_delete_inactive_connection.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_active_service.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_active_service.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_long_service_name.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_long_service_name.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_multibyte_service_name.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_multibyte_service_name.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_multiple_connections.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_multiple_connections.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_service_entries.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_management__connection_selector_with_service_entries.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/connection_management.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_all_selected.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_all_selected.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_filtered.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_filtered.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_modal.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_modal.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_multi_select.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_multi_select.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_single_select.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_table_picker_single_select.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_waiting_progress.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__er_diagram__er_waiting_progress.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/er_diagram.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__explorer_shows_not_connected_when_no_active_connection.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__explorer_shows_not_connected_when_no_active_connection.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/initial_state.rs
 expression: output
 ---
-test_project | - | - | no dsn | -                                                                                                                                    
+test_project ▸ - ▸ -                                                                                                                                       no dsn | -
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__header_shows_effective_user_at_normal_width.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__header_shows_effective_user_at_normal_width.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/initial_state.rs
 expression: output
 ---
-test_project | test_db | - | connected | user: app_user | localhost:5432/test                                                                                        
+test_project ▸ test_db ▸ -                                                                                           connected | user: app_user | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__header_shows_read_only_badge_at_narrow_width.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__header_shows_read_only_badge_at_narrow_width.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/render_snapshots/initial_state.rs
+expression: output
+---
+test_proje… ▸ … ▸ - connected | user: app_user | localhost:5432/test | READ-ONLY
+┌ [1] Explorer ────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                 
+│> public.users    │┌ [2] Inspector ───────────────────────────────────────────┐
+│  public.posts    ││(select a table)                                          │
+│  public.comments ││                                                          │
+│                  ││                                                          │
+│                  ││                                                          │
+│                  ││                                                          │
+│                  ││                                                          │
+│                  │└──────────────────────────────────────────────────────────┘
+│                  │┌ [3] Result ──────────────────────────────────────────────┐
+│                  ││(select a table to preview)                               │
+│                  ││                                                          │
+│                  ││                                                          │
+│                  ││                                                          │
+│                  ││                                                          │
+│                  ││                                                          │
+└──────────────────┘└──────────────────────────────────────────────────────────┘
+r:Reload  s:SQL  e:ER Diagram  c:Connections  ^P:Tables  ^O:History  ^R:Read-Wri

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__header_truncates_connection_name_at_narrow_width.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__header_truncates_connection_name_at_narrow_width.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/initial_state.rs
 expression: output
 ---
-test_project | test_db | - | connected | user: app_user | v…
+connected | user: app_user | very-long-connection-name-that…
 ┌ [1] Explorer┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]  
 │> public.use │┌ [2] Inspector ────────────────────────────┐
 │  public.pos ││(select a table)                           │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__initial_state_no_metadata.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__initial_state__initial_state_no_metadata.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/initial_state.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_caps_wide_comment.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_caps_wide_comment.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                     
+test_project ▸ test_db ▸ -                                                        no dsn | localhost:5432/test
 ┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
 │> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
 │  public.posts            ││Type           Null   PK   Default   Comment                                    │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_keeps_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_keeps_horizontal_scroll.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                     
+test_project ▸ test_db ▸ -                                                        no dsn | localhost:5432/test
 ┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
 │> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
 │  public.posts            ││Name    Type           Null   PK   Default   Comment                            │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_right_edge_truncates_cjk_comment.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_columns_narrow_pane_right_edge_truncates_cjk_comment.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                     
+test_project ▸ test_db ▸ -                                                        no dsn | localhost:5432/test
 ┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
 │> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
 │  public.posts            ││Type      Null   PK   Default   Comment                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_foreign_keys_tab_with_data.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name                  Columns         References                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_indexes_tab_with_data.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name              Columns   Type    Unique                                                                                │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_shows_owner_and_comment.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_shows_owner_and_comment.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_with_no_metadata.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_info_tab_with_no_metadata.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   (none)                                                                                                           │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_empty.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_empty.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││No triggers                                                                                                               │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_with_data.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/inspector.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Name                            Timing             Event                    Function                    SecDef            │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_line_input.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_line_input.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_palette_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_palette_overlay.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 414
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_filtered_current_result.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_filtered_current_result.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 433
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_long_key_rows.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 446
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__help_overlay_narrow_horizontal_scroll.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5…
+test_project ▸ t… ▸ - no dsn | localhost:5432/test
 ┌ [1] Explor┐[Info] [Cols] [Idx] [FK] [RLS] [Trig]
 │> publi╭ Help ───────────────────────────╮──────┐
 │  publi│                             Ret▲│      │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_empty.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_empty.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_filter_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_filter_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_with_entries.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__query_history_picker_with_entries.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 470
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 485
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram_custom_browser.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_er_diagram_custom_browser.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 503
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_keymap.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__settings_overlay_keymap.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_analyze_unknown_risk_acknowledge.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_analyze_unknown_risk_acknowledge.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_empty.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_empty.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_narrow_stacked.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_narrow_stacked.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/te…
+test_project ▸ - ▸ -  no dsn | localhost:5432/test
 ┌ [1] Explor┐[Info] [Cols] [Idx] [FK] [RLS] [Trig]
 │ Press 'r' │┌ [2] Inspector ────────────────────┐
 │           ││(select a table)                   │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_right_only.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_right_only.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_unavailable.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_unavailable.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_with_verdict.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_compare_tab_with_verdict.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_completion_popup_with_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_completion_popup_with_scroll.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 95
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_confirming_high_matched.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_confirming_high_matched.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_confirming_high_unmatched.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_confirming_high_unmatched.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_head.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 172
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_middle.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 186
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_cursor_at_tail.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 200
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_error_with_message.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_error_with_message.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_high_risk_without_target_acknowledge.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_high_risk_without_target_acknowledge.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_ide_editing.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_ide_editing.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 215
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_cursor_at_tail.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_initial.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_normal_initial.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_placeholder.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_placeholder.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_with_error.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_with_error.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_with_plan_text.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_plan_tab_with_plan_text.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_ddl_create_table.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_ddl_create_table.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_dml_with_command_tag.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_dml_with_command_tag.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_select.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_success_select.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | - | - | no dsn | localhost:5432/test                                                                                                                  
+test_project ▸ - ▸ -                                                                                                                     no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_unknown_risk_acknowledge.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_unknown_risk_acknowledge.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_with_completion.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__sql_modal_with_completion.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/overlays.rs
-assertion_line: 26
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__table_picker_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__table_picker_overlay.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/overlays.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_active_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_active_mode.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/result_pane.rs
-assertion_line: 235
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_active_pending_draft.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_active_pending_draft.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_head.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_head.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_middle.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_middle.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_tail.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_cursor_at_tail.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_cell_edit_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_first_cell_active_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_first_cell_active_mode.snap
@@ -1,9 +1,8 @@
 ---
 source: src/tests/render_snapshots/result_pane.rs
-assertion_line: 221
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_jsonb_detail_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_jsonb_detail_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_jsonb_detail_shows_vertical_scrollbar.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_jsonb_detail_shows_vertical_scrollbar.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                           
+test_project ▸ test_db ▸ -                                              no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                
 │> public.users         │┌ [2] Inspector ──────────────────────────────────────────────────────────┐
 │  public.posts         ││Owner:   postgres                                                        │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_jsonb_edit_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_jsonb_edit_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_narrow_pane_keeps_horizontal_scroll.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_narrow_pane_keeps_horizontal_scroll.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                     
+test_project ▸ test_db ▸ -                                                        no dsn | localhost:5432/test
 ┌ [1] Explorer ────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                       
 │> public.users            │┌ [2] Inspector ─────────────────────────────────────────────────────────────────┐
 │  public.posts            ││Owner:   postgres                                                               │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_right_edge_peeks_truncated_previous_column.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_right_edge_peeks_truncated_previous_column.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_row_detail_mode.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_row_detail_mode.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_row_detail_shows_scrollbars.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_row_detail_shows_scrollbars.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                           
+test_project ▸ test_db ▸ -                                              no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                
 │> public.users         │┌ [2] Inspector ──────────────────────────────────────────────────────────┐
 │  public.posts         ││(select a table)                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_scrolled_past_wide_column_fills_width.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_scrolled_past_wide_column_fills_width.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_staged_delete_row.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__result_pane__result_pane_staged_delete_row.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/result_pane.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__empty_query_result.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__empty_query_result.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/table_explorer.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__error_message_in_footer.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__error_message_in_footer.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/table_explorer.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_mode_fullscreen_result.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_mode_fullscreen_result.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/table_explorer.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [3] Result (2 rows, 15ms) ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │id   name    email                                                                                                                                                 │
 │1    Alice   alice@example.com                                                                                                                                     │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_on_result_pane.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__focus_on_result_pane.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/table_explorer.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││(select a table)                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__table_selection_with_preview.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__table_selection_with_preview.snap
@@ -2,7 +2,7 @@
 source: src/tests/render_snapshots/table_explorer.rs
 expression: output
 ---
-test_project | test_db | - | no dsn | localhost:5432/test                                                                                                            
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │  public.posts                         ││Owner:   postgres                                                                                                         │

--- a/src/tests/render_snapshots/style_assertions.rs
+++ b/src/tests/render_snapshots/style_assertions.rs
@@ -343,6 +343,27 @@ fn header_status_uses_success_warning_and_error_colors() {
 }
 
 #[test]
+fn read_only_header_uses_warning_badge_style() {
+    let mut state = connected_state();
+    state.session.dsn = Some("postgresql://localhost/test".to_string());
+    state.session.read_only = true;
+    let mut terminal = create_test_terminal();
+
+    let buffer = render_and_get_buffer(&mut terminal, &mut state);
+    let start = find_row0_text_start(&buffer, "READ-ONLY")
+        .expect("Expected READ-ONLY badge text in header");
+
+    for offset in 0.."READ-ONLY".len() {
+        let cell = buffer
+            .cell((start + offset as u16, 0))
+            .expect("READ-ONLY badge cell in row 0");
+        assert_eq!(cell.fg, Color::Black);
+        assert_eq!(cell.bg, DEFAULT_THEME.semantic.status.warning);
+        assert!(cell.modifier.contains(Modifier::BOLD));
+    }
+}
+
+#[test]
 fn help_overlay_uses_section_header_and_scrollbar_colors() {
     let mut state = connected_state();
     let now = test_instant();

--- a/src/ui/shell/header.rs
+++ b/src/ui/shell/header.rs
@@ -1,6 +1,6 @@
 use ratatui::Frame;
 use ratatui::layout::Rect;
-use ratatui::style::Style;
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use unicode_width::UnicodeWidthStr;
@@ -10,7 +10,8 @@ use crate::domain::MetadataState;
 use crate::primitives::utils::text_utils::truncate_to_width_with;
 use crate::theme::ThemePalette;
 
-const HEADER_SEPARATOR_WIDTH: usize = 3;
+const LEFT_SEPARATOR: &str = " ▸ ";
+const RIGHT_SEPARATOR: &str = " | ";
 
 pub struct Header;
 
@@ -33,24 +34,25 @@ impl Header {
             }
         };
 
-        let mut items = vec![
-            HeaderItem::new(&state.runtime.project_name, item_style, 3),
-            HeaderItem::new(db_name, item_style, 2),
-            HeaderItem::new(table, Style::default().fg(theme.semantic.text.primary), 1),
-            HeaderItem::new(
-                status_text,
-                Style::default().fg(status_color),
-                usize::MAX - 1,
-            ),
+        let left_items = vec![
+            HeaderItem::new(&state.runtime.project_name, item_style, 2),
+            HeaderItem::new(db_name, item_style, 1),
+            HeaderItem::new(table, Style::default().fg(theme.semantic.text.primary), 0),
         ];
+
+        let mut right_items = vec![HeaderItem::new(
+            status_text,
+            Style::default().fg(status_color),
+            2,
+        )];
         if let Some(effective_user) = state.session.effective_user() {
-            items.push(HeaderItem::new(
+            right_items.push(HeaderItem::new(
                 &format!("user: {effective_user}"),
                 item_style,
-                4,
+                1,
             ));
         }
-        items.push(HeaderItem::new(
+        right_items.push(HeaderItem::new(
             state
                 .session
                 .active_connection_name
@@ -60,23 +62,30 @@ impl Header {
             0,
         ));
         if state.session.read_only {
-            items.push(HeaderItem::new(
+            right_items.push(HeaderItem::new(
                 "READ-ONLY",
-                Style::default().fg(theme.semantic.status.warning),
-                usize::MAX,
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(theme.semantic.status.warning)
+                    .add_modifier(Modifier::BOLD),
+                3,
             ));
         }
 
-        let items = fit_header_items(items, area.width as usize);
-        let mut line = Line::from(Vec::with_capacity(items.len() * 2));
-        for (index, item) in items.into_iter().enumerate() {
-            if index > 0 {
-                line.push_span(Span::styled(" | ", sep_style));
-            }
-            line.push_span(Span::styled(item.content, item.style));
+        let layout = layout_header(left_items, right_items, area.width as usize);
+        if layout.left_width > 0 {
+            frame.render_widget(
+                Paragraph::new(header_line(layout.left_items, LEFT_SEPARATOR, sep_style)),
+                Rect::new(area.x, area.y, layout.left_width as u16, area.height),
+            );
         }
-
-        frame.render_widget(Paragraph::new(line), area);
+        if layout.right_width > 0 {
+            let right_x = area.x.saturating_add(layout.right_start as u16);
+            frame.render_widget(
+                Paragraph::new(header_line(layout.right_items, RIGHT_SEPARATOR, sep_style)),
+                Rect::new(right_x, area.y, layout.right_width as u16, area.height),
+            );
+        }
     }
 }
 
@@ -96,13 +105,57 @@ impl HeaderItem {
     }
 }
 
-fn fit_header_items(mut items: Vec<HeaderItem>, max_width: usize) -> Vec<HeaderItem> {
+struct HeaderLayout {
+    left_items: Vec<HeaderItem>,
+    right_items: Vec<HeaderItem>,
+    left_width: usize,
+    right_width: usize,
+    right_start: usize,
+}
+
+fn layout_header(
+    left_items: Vec<HeaderItem>,
+    right_items: Vec<HeaderItem>,
+    max_width: usize,
+) -> HeaderLayout {
+    let right_items = fit_header_items(right_items, max_width, RIGHT_SEPARATOR);
+    let right_width = header_items_width(&right_items, RIGHT_SEPARATOR);
+    let gap_width = usize::from(right_width > 0 && right_width < max_width);
+    let left_max_width = max_width.saturating_sub(right_width + gap_width);
+    let left_items = fit_header_items(left_items, left_max_width, LEFT_SEPARATOR);
+    let left_width = header_items_width(&left_items, LEFT_SEPARATOR);
+
+    HeaderLayout {
+        left_items,
+        right_items,
+        left_width,
+        right_width,
+        right_start: max_width.saturating_sub(right_width),
+    }
+}
+
+fn header_line(items: Vec<HeaderItem>, separator: &str, separator_style: Style) -> Line<'static> {
+    let mut line = Line::from(Vec::with_capacity(items.len() * 2));
+    for (index, item) in items.into_iter().enumerate() {
+        if index > 0 {
+            line.push_span(Span::styled(separator.to_string(), separator_style));
+        }
+        line.push_span(Span::styled(item.content, item.style));
+    }
+    line
+}
+
+fn fit_header_items(
+    mut items: Vec<HeaderItem>,
+    max_width: usize,
+    separator: &str,
+) -> Vec<HeaderItem> {
     let mut keep = vec![true; items.len()];
     let mut item_count = items.len();
     let mut removal_order: Vec<usize> = (0..items.len()).collect();
     removal_order.sort_by_key(|&index| items[index].truncation_rank);
     for index in removal_order {
-        if min_header_width(item_count) <= max_width {
+        if min_header_width(item_count, UnicodeWidthStr::width(separator)) <= max_width {
             break;
         }
         keep[index] = false;
@@ -114,7 +167,8 @@ fn fit_header_items(mut items: Vec<HeaderItem>, max_width: usize) -> Vec<HeaderI
         .filter_map(|(index, item)| keep[index].then_some(item))
         .collect();
 
-    let separators_width = HEADER_SEPARATOR_WIDTH.saturating_mul(items.len().saturating_sub(1));
+    let separators_width =
+        UnicodeWidthStr::width(separator).saturating_mul(items.len().saturating_sub(1));
     let mut widths: Vec<usize> = items
         .iter()
         .map(|item| UnicodeWidthStr::width(item.content.as_str()))
@@ -140,71 +194,118 @@ fn fit_header_items(mut items: Vec<HeaderItem>, max_width: usize) -> Vec<HeaderI
     items
 }
 
-fn min_header_width(item_count: usize) -> usize {
-    item_count.saturating_add(HEADER_SEPARATOR_WIDTH.saturating_mul(item_count.saturating_sub(1)))
+fn header_items_width(items: &[HeaderItem], separator: &str) -> usize {
+    UnicodeWidthStr::width(
+        items
+            .iter()
+            .map(|item| item.content.as_str())
+            .collect::<Vec<_>>()
+            .join(separator)
+            .as_str(),
+    )
+}
+
+fn min_header_width(item_count: usize, separator_width: usize) -> usize {
+    item_count.saturating_add(separator_width.saturating_mul(item_count.saturating_sub(1)))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn truncates_connection_name_before_effective_user() {
-        let items = fit_header_items(
-            vec![
-                HeaderItem::new("project", Style::default(), 3),
-                HeaderItem::new("database", Style::default(), 2),
-                HeaderItem::new("public.long_table_name", Style::default(), 1),
-                HeaderItem::new("connected", Style::default(), usize::MAX),
-                HeaderItem::new("user: postgres", Style::default(), 4),
-                HeaderItem::new("very-long-connection-name", Style::default(), 0),
-            ],
-            50,
-        );
-        let text = items
-            .iter()
-            .map(|item| item.content.as_str())
-            .collect::<Vec<_>>()
-            .join(" | ");
+    fn item(content: &str, truncation_rank: usize) -> HeaderItem {
+        HeaderItem::new(content, Style::default(), truncation_rank)
+    }
 
-        assert!(text.contains("user: postgres"));
-        assert!(UnicodeWidthStr::width(text.as_str()) <= 50);
+    #[test]
+    fn keeps_right_group_at_the_right_edge_when_table_length_changes() {
+        let right_items = vec![
+            item("connected", 2),
+            item("user: postgres", 1),
+            item("connection", 0),
+        ];
+        let short_table = layout_header(
+            vec![item("project", 2), item("database", 1), item("users", 0)],
+            right_items,
+            80,
+        );
+        let long_table = layout_header(
+            vec![
+                item("project", 2),
+                item("database", 1),
+                item("public.a_very_long_table_name", 0),
+            ],
+            vec![
+                item("connected", 2),
+                item("user: postgres", 1),
+                item("connection", 0),
+            ],
+            80,
+        );
+
+        assert_eq!(short_table.right_start, long_table.right_start);
+        assert_eq!(short_table.right_width, long_table.right_width);
+        assert_ne!(
+            long_table.left_items[2].content,
+            short_table.left_items[2].content
+        );
+    }
+
+    #[test]
+    fn preserves_read_only_before_status_at_narrow_width() {
+        let items = fit_header_items(
+            vec![item("connected", 2), item("READ-ONLY", 3)],
+            4,
+            RIGHT_SEPARATOR,
+        );
+
+        assert_eq!(items.len(), 1);
+        assert!(items[0].content.starts_with('R'));
+        assert!(UnicodeWidthStr::width(items[0].content.as_str()) <= 4);
+    }
+
+    #[test]
+    fn measures_unicode_and_never_exceeds_width() {
+        let items = fit_header_items(vec![item("接続名", 0)], 4, RIGHT_SEPARATOR);
+
+        assert!(UnicodeWidthStr::width(items[0].content.as_str()) <= 4);
+    }
+
+    #[test]
+    fn handles_extreme_widths_without_overlap() {
+        for width in [0, 1, 2, 4, 60] {
+            let layout = layout_header(
+                vec![item("project", 2), item("database", 1), item("table", 0)],
+                vec![item("connected", 2), item("READ-ONLY", 3)],
+                width,
+            );
+
+            let gap_width = usize::from(layout.right_width > 0 && layout.right_width < width);
+            assert!(layout.left_width + gap_width <= layout.right_start);
+            assert!(layout.right_start + layout.right_width <= width);
+        }
     }
 
     #[test]
     fn drops_items_when_separators_cannot_fit() {
         let items = fit_header_items(
             vec![
-                HeaderItem::new("project", Style::default(), 3),
-                HeaderItem::new("database", Style::default(), 2),
-                HeaderItem::new("table", Style::default(), 1),
-                HeaderItem::new("connected", Style::default(), usize::MAX),
-                HeaderItem::new("connection", Style::default(), 0),
+                item("project", 3),
+                item("database", 2),
+                item("table", 1),
+                item("connected", usize::MAX),
+                item("connection", 0),
             ],
             2,
+            RIGHT_SEPARATOR,
         );
         let text = items
             .iter()
             .map(|item| item.content.as_str())
             .collect::<Vec<_>>()
-            .join(" | ");
+            .join(RIGHT_SEPARATOR);
 
         assert_eq!(items.len(), 1);
         assert!(UnicodeWidthStr::width(text.as_str()) <= 2);
-    }
-
-    #[test]
-    fn preserves_read_only_status_at_extreme_width() {
-        let items = fit_header_items(
-            vec![
-                HeaderItem::new("connected", Style::default(), usize::MAX - 1),
-                HeaderItem::new("READ-ONLY", Style::default(), usize::MAX),
-            ],
-            4,
-        );
-
-        assert_eq!(items.len(), 1);
-        assert!(items[0].content.starts_with('R'));
-        assert!(UnicodeWidthStr::width(items[0].content.as_str()) <= 4);
     }
 }

--- a/src/ui/shell/header.rs
+++ b/src/ui/shell/header.rs
@@ -217,6 +217,34 @@ mod tests {
         HeaderItem::new(content, Style::default(), truncation_rank)
     }
 
+    fn left_items() -> Vec<HeaderItem> {
+        vec![item("project", 2), item("database", 1), item("table", 0)]
+    }
+
+    fn right_items() -> Vec<HeaderItem> {
+        vec![item("connected", 2), item("READ-ONLY", 3)]
+    }
+
+    fn contents(items: &[HeaderItem]) -> Vec<&str> {
+        items.iter().map(|item| item.content.as_str()).collect()
+    }
+
+    fn assert_layout_fits(layout: &HeaderLayout, max_width: usize) {
+        let gap_width = usize::from(layout.right_width > 0 && layout.right_width < max_width);
+
+        assert_eq!(
+            layout.left_width,
+            header_items_width(&layout.left_items, LEFT_SEPARATOR)
+        );
+        assert_eq!(
+            layout.right_width,
+            header_items_width(&layout.right_items, RIGHT_SEPARATOR)
+        );
+        assert!(layout.left_width + gap_width <= layout.right_start);
+        assert!(layout.right_start + layout.right_width <= max_width);
+        assert!(layout.left_width + gap_width + layout.right_width <= max_width);
+    }
+
     #[test]
     fn keeps_right_group_at_the_right_edge_when_table_length_changes() {
         let right_items = vec![
@@ -273,16 +301,46 @@ mod tests {
 
     #[test]
     fn handles_extreme_widths_without_overlap() {
-        for width in [0, 1, 2, 4, 60] {
-            let layout = layout_header(
-                vec![item("project", 2), item("database", 1), item("table", 0)],
-                vec![item("connected", 2), item("READ-ONLY", 3)],
-                width,
-            );
+        let left_required_width = header_items_width(&left_items(), LEFT_SEPARATOR);
+        let right_required_width = header_items_width(&right_items(), RIGHT_SEPARATOR);
+        let boundary = left_required_width + right_required_width + 1;
+        let boundary_widths = [boundary - 1, boundary, boundary + 1];
+        let boundary_layouts =
+            boundary_widths.map(|width| layout_header(left_items(), right_items(), width));
 
-            let gap_width = usize::from(layout.right_width > 0 && layout.right_width < width);
-            assert!(layout.left_width + gap_width <= layout.right_start);
-            assert!(layout.right_start + layout.right_width <= width);
+        for (&width, layout) in boundary_widths.iter().zip(&boundary_layouts) {
+            assert_layout_fits(layout, width);
+
+            let repeated = layout_header(left_items(), right_items(), width);
+            assert_eq!(contents(&layout.left_items), contents(&repeated.left_items));
+            assert_eq!(
+                contents(&layout.right_items),
+                contents(&repeated.right_items)
+            );
+        }
+
+        assert_eq!(
+            contents(&boundary_layouts[0].left_items),
+            vec!["project", "database", "tab…"]
+        );
+        assert_eq!(
+            contents(&boundary_layouts[0].right_items),
+            vec!["connected", "READ-ONLY"]
+        );
+        for layout in &boundary_layouts[1..] {
+            assert_eq!(
+                contents(&layout.left_items),
+                vec!["project", "database", "table"]
+            );
+            assert_eq!(
+                contents(&layout.right_items),
+                vec!["connected", "READ-ONLY"]
+            );
+        }
+
+        for width in [0, 1, 2, 4, boundary + 12] {
+            let layout = layout_header(left_items(), right_items(), width);
+            assert_layout_fits(&layout, width);
         }
     }
 


### PR DESCRIPTION
## Problem

Changing the selected table can move the connection context across the Header, making stable connection information harder to scan.

## Background

The Header previously laid out location and connection information as one truncatable sequence, so variable table names affected the position and retention of later items.

## Approach

Render the current-location and connection-context groups independently, anchor the connection context to the terminal right edge, and apply display-width-aware priority rules for narrow terminals. Use breadcrumb separators for the location group, a warning badge for READ-ONLY, and add boundary, style, and snapshot coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearly styled **READ-ONLY** badge to the header, using bold text and a warning background.
  * Preserved the read-only indicator in narrow terminal widths when space is limited.

* **Bug Fixes**
  * Improved header layout so connection details remain aligned to the right.
  * Improved handling of long names, narrow widths, and Unicode characters to prevent overlap or inconsistent truncation.

* **Tests**
  * Added coverage for read-only badge rendering, styling, alignment, and narrow-width layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->