### PR TITLE
fix: harden experimental Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,19 @@ jobs:
       - name: Reject unreferenced snapshots
         run: cargo insta test --unreferenced=reject -p sabiql
 
+  windows-test:
+    name: Windows Test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: windows-test
+      - run: cargo test --workspace --all-features
+      - run: cargo test -p sabiql --no-default-features
+      - run: cargo run --all-features -- --version
+
   integration:
     name: Integration Test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: short
@@ -16,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: rustfmt
@@ -26,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: clippy
@@ -39,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2
@@ -67,6 +76,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -80,6 +91,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2
@@ -95,6 +108,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo build --workspace --release
@@ -105,6 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2
         with:
           tool: cargo-audit
@@ -116,6 +133,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2
         with:
           tool: cargo-machete

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -136,6 +138,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -159,6 +163,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ brew install riii111/sabiql/sabiql
 # Cargo (crates.io)
 cargo install sabiql
 
+# Windows x86_64 (experimental)
+# Download sabiql-x86_64-pc-windows-msvc.zip from GitHub Releases,
+# extract sabiql.exe, and add its directory to PATH.
+
 # Arch Linux (AUR)
 paru -S sabiql  # or yay -S sabiql
 
@@ -79,6 +83,9 @@ On first run, enter your connection details. They are saved to your platform con
 
 - macOS: `~/Library/Application Support/sabiql/connections.toml`
 - Linux: `~/.config/sabiql/connections.toml`
+- Windows: `%APPDATA%\sabiql\connections.toml`
+
+Windows releases are build- and unit-tested in CI. Native `psql.exe`, terminal, and Graphviz integration remain experimental.
 
 Press `?` for help.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ On first run, enter your connection details. They are saved to your platform con
 - Linux: `~/.config/sabiql/connections.toml`
 - Windows: `%APPDATA%\sabiql\connections.toml`
 
-Windows releases are build- and unit-tested in CI. Native `psql.exe`, terminal, and Graphviz integration remain experimental.
+Windows support is experimental.
 
 Press `?` for help.
 

--- a/src/infra/adapters/pg_service.rs
+++ b/src/infra/adapters/pg_service.rs
@@ -37,10 +37,11 @@ fn find_service_file() -> Result<PathBuf, ServiceFileError> {
         )));
     }
 
-    if let Some(path) = user_service_file_path()
+    let user_service_path = user_service_file_path();
+    if let Some(path) = &user_service_path
         && path.is_file()
     {
-        return Ok(path);
+        return Ok(path.clone());
     }
 
     if let Some(output) = std::process::Command::new("pg_config")
@@ -56,9 +57,19 @@ fn find_service_file() -> Result<PathBuf, ServiceFileError> {
         }
     }
 
-    Err(ServiceFileError::NotFound(
-        "No pg_service.conf found (checked PGSERVICEFILE, the platform user config path, and pg_config --sysconfdir)".to_string(),
-    ))
+    Err(ServiceFileError::NotFound(service_file_not_found_message(
+        user_service_path.as_deref(),
+    )))
+}
+
+fn service_file_not_found_message(user_service_path: Option<&Path>) -> String {
+    let user_path_hint = user_service_path.map_or_else(
+        || "the platform user config path".to_string(),
+        |path| path.display().to_string(),
+    );
+    format!(
+        "No pg_service.conf found (checked PGSERVICEFILE, {user_path_hint}, and pg_config --sysconfdir)"
+    )
 }
 
 #[cfg(target_os = "windows")]
@@ -333,6 +344,15 @@ application_name=myapp
         let path = unix_user_service_file_path(&home_dir);
 
         assert_eq!(path, home_dir.join(".pg_service.conf"));
+    }
+
+    #[test]
+    fn not_found_message_includes_resolved_user_service_file_path() {
+        let path = Path::new(r"C:\Users\test\AppData\Roaming\postgresql\.pg_service.conf");
+
+        let message = service_file_not_found_message(Some(path));
+
+        assert!(message.contains(&path.display().to_string()));
     }
 
     #[test]

--- a/src/infra/adapters/pg_service.rs
+++ b/src/infra/adapters/pg_service.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::app::ports::outbound::service_file::{PgServiceEntryReader, ServiceFileError};
@@ -37,11 +37,10 @@ fn find_service_file() -> Result<PathBuf, ServiceFileError> {
         )));
     }
 
-    if let Some(home) = home_dir() {
-        let path = home.join(".pg_service.conf");
-        if path.is_file() {
-            return Ok(path);
-        }
+    if let Some(path) = user_service_file_path()
+        && path.is_file()
+    {
+        return Ok(path);
     }
 
     if let Some(output) = std::process::Command::new("pg_config")
@@ -58,12 +57,28 @@ fn find_service_file() -> Result<PathBuf, ServiceFileError> {
     }
 
     Err(ServiceFileError::NotFound(
-        "No pg_service.conf found (checked $PGSERVICEFILE, ~/.pg_service.conf, pg_config --sysconfdir)".to_string(),
+        "No pg_service.conf found (checked PGSERVICEFILE, the platform user config path, and pg_config --sysconfdir)".to_string(),
     ))
 }
 
-fn home_dir() -> Option<PathBuf> {
-    dirs::home_dir()
+#[cfg(target_os = "windows")]
+fn user_service_file_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|path| windows_user_service_file_path(&path))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn user_service_file_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|path| unix_user_service_file_path(&path))
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn windows_user_service_file_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("postgresql").join(".pg_service.conf")
+}
+
+#[cfg(any(not(target_os = "windows"), test))]
+fn unix_user_service_file_path(home_dir: &Path) -> PathBuf {
+    home_dir.join(".pg_service.conf")
 }
 
 fn parse(content: &str) -> Vec<ServiceEntry> {
@@ -300,6 +315,24 @@ application_name=myapp
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].host, Some("localhost".to_string()));
         assert_eq!(entries[0].dbname, None);
+    }
+
+    #[test]
+    fn windows_user_service_file_uses_postgresql_appdata_directory() {
+        let config_dir = PathBuf::from(r"C:\Users\test\AppData\Roaming");
+
+        let path = windows_user_service_file_path(&config_dir);
+
+        assert_eq!(path, config_dir.join("postgresql").join(".pg_service.conf"));
+    }
+
+    #[test]
+    fn unix_user_service_file_uses_home_directory() {
+        let home_dir = PathBuf::from("/home/test");
+
+        let path = unix_user_service_file_path(&home_dir);
+
+        assert_eq!(path, home_dir.join(".pg_service.conf"));
     }
 
     #[test]

--- a/src/infra/export/graphviz.rs
+++ b/src/infra/export/graphviz.rs
@@ -4,9 +4,7 @@ use crate::app::ports::outbound::ErExportError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum GraphvizError {
-    #[error(
-        "Graphviz (dot) not found. Please install Graphviz (e.g., brew install graphviz on macOS)"
-    )]
+    #[error("Graphviz (dot) not found. Install Graphviz and ensure dot is available on PATH")]
     NotInstalled,
     #[error("Graphviz failed (exit code {0:?}). Check DOT syntax.")]
     CommandFailed(Option<i32>),
@@ -59,7 +57,8 @@ mod tests {
 
             let message = format!("{error}");
 
-            assert!(message.contains("brew install graphviz"));
+            assert!(message.contains("Install Graphviz"));
+            assert!(message.contains("PATH"));
         }
 
         #[test]


### PR DESCRIPTION
## Problem

Windows release assets are now published even though pull request CI only exercises Linux, and Windows users can miss their standard PostgreSQL service file. The boundary between build availability and verified runtime support is also not visible.

## Background

The v1.15.0 release successfully produced a Windows binary, but a successful artifact build does not validate Windows-specific filesystem conventions or CLI startup behavior.

## Approach

Add pull request-time Windows tests across feature configurations and a CLI smoke check. Follow PostgreSQL's per-user service-file convention on Windows, and document the experimental Windows install/runtime boundary with platform-neutral Graphviz guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental Windows installation instructions and configuration guidance.
  * Added Windows CI coverage for workspace tests and version verification.

* **Bug Fixes**
  * Improved PostgreSQL service-file discovery across Windows and Unix systems.
  * Enhanced missing service-file errors with the expected user configuration path.
  * Updated Graphviz setup guidance to require the `dot` executable on `PATH`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->