### PR TITLE
fix: guard unsupported actions at reducer boundaries

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,3 +15,8 @@
 
 ## Screenshots
 <!-- Screenshots/GIF. Optional -->
+
+## Linear Issue Link (optional)
+<!-- (Maintainers only) Delete this entire section if there are no related Linear issues -->
+
+- https://linear.app/sabiql/issue/SAB-XXX

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -37,7 +37,11 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled()
         }
         Action::ErOpenDiagram => {
-            if !state.session.active_db_capabilities().supports_er_diagram() {
+            if !state
+                .session
+                .active_engine_feature_profile()
+                .supports_er_diagram()
+            {
                 state.messages.set_error_at(
                     "ER diagrams are not available for this connection".to_string(),
                     now,
@@ -70,7 +74,11 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled_with(vec![Effect::SmartErRefresh { dsn, run_id }])
         }
         Action::ErGenerateFromCache => {
-            if !state.session.active_db_capabilities().supports_er_diagram() {
+            if !state
+                .session
+                .active_engine_feature_profile()
+                .supports_er_diagram()
+            {
                 state.messages.set_error_at(
                     "ER diagrams are not available for this connection".to_string(),
                     now,

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -37,6 +37,13 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled()
         }
         Action::ErOpenDiagram => {
+            if !state.session.active_db_capabilities().supports_er_diagram() {
+                state.messages.set_error_at(
+                    "ER diagrams are not available for this connection".to_string(),
+                    now,
+                );
+                return DispatchResult::handled();
+            }
             if state.er_preparation.is_busy() {
                 return DispatchResult::handled();
             }
@@ -63,6 +70,13 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled_with(vec![Effect::SmartErRefresh { dsn, run_id }])
         }
         Action::ErGenerateFromCache => {
+            if !state.session.active_db_capabilities().supports_er_diagram() {
+                state.messages.set_error_at(
+                    "ER diagrams are not available for this connection".to_string(),
+                    now,
+                );
+                return DispatchResult::handled();
+            }
             if !state.er_preparation.can_generate_from_cache() {
                 return DispatchResult::handled();
             }

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -42,6 +42,17 @@ mod tests {
         state
     }
 
+    fn state_with_sqlite_dsn(dsn: &str) -> AppState {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "sqlite",
+            DatabaseType::SQLite,
+            dsn,
+        );
+        state
+    }
+
     fn set_active_run_id(state: &mut AppState, run_id: u64) {
         for _ in 0..run_id {
             let _ = state.er_preparation.start_waiting_run();
@@ -163,6 +174,22 @@ mod tests {
             assert!(effects.is_empty());
             assert!(state.messages.last_error.is_some());
         }
+
+        #[test]
+        fn sqlite_connection_returns_error_without_refresh_effect() {
+            let mut state = state_with_sqlite_dsn("sqlite:///tmp/app.db");
+            state.session.set_metadata(Some(make_metadata(1)));
+
+            let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.messages.last_error.as_deref(),
+                Some("ER diagrams are not available for this connection")
+            );
+        }
     }
 
     mod er_generate_from_cache {
@@ -202,6 +229,28 @@ mod tests {
                 .expect("reducer should handle action");
 
             assert!(effects.is_empty());
+        }
+
+        #[test]
+        fn sqlite_connection_returns_error_without_generate_effect() {
+            let mut state = state_with_sqlite_dsn("sqlite:///tmp/app.db");
+            state.er_preparation.mark_idle();
+            state
+                .session
+                .set_metadata(Some(Arc::new(DatabaseMetadata::new("test".to_string()))));
+            state
+                .er_preparation
+                .set_targets(vec!["public.users".to_string()]);
+
+            let effects = reduce_er(&mut state, &Action::ErGenerateFromCache, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.messages.last_error.as_deref(),
+                Some("ER diagrams are not available for this connection")
+            );
         }
     }
 

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -859,6 +859,23 @@ mod tests {
         use super::*;
 
         #[test]
+        fn sqlite_connection_rejects_compare_edit_query_with_error() {
+            let mut state = sql_modal_state();
+            activate_sqlite_connection(&mut state);
+            state.sql_modal.set_active_tab(SqlModalTab::Compare);
+
+            let effects = reduce_explain(&mut state, &Action::CompareEditQuery, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.messages.last_error.as_deref(),
+                Some("Plan comparison is not available for this connection")
+            );
+        }
+
+        #[test]
         fn two_explains_auto_advance_returns_comparable_slots() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -35,6 +35,7 @@ mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
     use crate::model::shared::input_mode::InputMode;
+    use crate::model::shared::text_input::TextInputLike;
     use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
     use crate::ports::outbound::AccessMode;
     use crate::services::AppServices;
@@ -861,14 +862,29 @@ mod tests {
         #[test]
         fn sqlite_connection_rejects_compare_edit_query_with_error() {
             let mut state = sql_modal_state();
-            activate_sqlite_connection(&mut state);
+            state
+                .explain
+                .set_plan("stale plan".to_string(), false, 1, "SELECT stale");
+            state
+                .sql_modal
+                .editor
+                .set_content("SELECT current".to_string());
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
 
-            let effects = reduce_explain(&mut state, &Action::CompareEditQuery, Instant::now())
-                .into_effects()
-                .expect("reducer should handle action");
+            activate_sqlite_connection(&mut state);
+            let editor_before = state.sql_modal.editor.content().to_string();
+            let status_before = state.sql_modal.status().clone();
+            let active_tab_before = state.sql_modal.active_tab();
 
-            assert!(effects.is_empty());
+            assert_eq!(
+                state.explain.right().map(|slot| slot.full_query.as_str()),
+                Some("SELECT stale")
+            );
+            reduce_explain(&mut state, &Action::CompareEditQuery, Instant::now());
+
+            assert_eq!(state.sql_modal.editor.content(), editor_before);
+            assert_eq!(state.sql_modal.status(), &status_before);
+            assert_eq!(state.sql_modal.active_tab(), active_tab_before);
             assert_eq!(
                 state.messages.last_error.as_deref(),
                 Some("Plan comparison is not available for this connection")

--- a/src/app/update/explain/tabs.rs
+++ b/src/app/update/explain/tabs.rs
@@ -9,7 +9,7 @@ pub(super) fn reduce_tabs(state: &mut AppState, action: &Action, now: Instant) -
         Action::CompareEditQuery => {
             if !state
                 .session
-                .active_db_capabilities()
+                .active_engine_feature_profile()
                 .supports_plan_comparison()
             {
                 state.messages.set_error_at(

--- a/src/app/update/explain/tabs.rs
+++ b/src/app/update/explain/tabs.rs
@@ -4,9 +4,20 @@ use crate::model::app_state::AppState;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn reduce_tabs(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
+pub(super) fn reduce_tabs(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::CompareEditQuery => {
+            if !state
+                .session
+                .active_db_capabilities()
+                .supports_plan_comparison()
+            {
+                state.messages.set_error_at(
+                    "Plan comparison is not available for this connection".to_string(),
+                    now,
+                );
+                return DispatchResult::handled();
+            }
             if let Some(ref right) = state.explain.right {
                 let query = right.full_query.clone();
                 state.sql_modal.load_query_for_editing(query);

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -34,7 +34,7 @@ pub(super) fn reduce_sqlite_diagnostics(
         Action::RunSqliteDiagnosticsQuickCheck => {
             if !state
                 .session
-                .active_db_capabilities()
+                .active_engine_feature_profile()
                 .supports_sqlite_diagnostics()
             {
                 state.messages.set_error_at(

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -9,7 +9,7 @@ use crate::update::dispatch_result::DispatchResult;
 pub(super) fn reduce_sqlite_diagnostics(
     state: &mut AppState,
     action: &Action,
-    _now: Instant,
+    now: Instant,
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::SqliteDiagnostics) => {
@@ -18,6 +18,10 @@ pub(super) fn reduce_sqlite_diagnostics(
                 .active_engine_feature_profile()
                 .supports_sqlite_diagnostics()
             {
+                state.messages.set_error_at(
+                    "SQLite diagnostics are not available for this connection".to_string(),
+                    now,
+                );
                 return DispatchResult::handled();
             }
             let Some(dsn) = state.session.dsn().map(String::from) else {
@@ -28,6 +32,17 @@ pub(super) fn reduce_sqlite_diagnostics(
             DispatchResult::handled_with(vec![Effect::FetchSqliteDiagnosticsCore { dsn, run_id }])
         }
         Action::RunSqliteDiagnosticsQuickCheck => {
+            if !state
+                .session
+                .active_db_capabilities()
+                .supports_sqlite_diagnostics()
+            {
+                state.messages.set_error_at(
+                    "SQLite diagnostics are not available for this connection".to_string(),
+                    now,
+                );
+                return DispatchResult::handled();
+            }
             let Some(dsn) = state.session.dsn().map(String::from) else {
                 return DispatchResult::handled();
             };
@@ -147,7 +162,7 @@ mod tests {
     }
 
     #[test]
-    fn open_is_ignored_for_postgres_connection() {
+    fn open_returns_error_for_postgres_connection() {
         let mut state = AppState::new("test".to_string());
         state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
@@ -165,6 +180,43 @@ mod tests {
 
         assert_eq!(state.input_mode(), InputMode::Normal);
         assert!(effects.is_empty());
+        assert_eq!(
+            state.messages.last_error.as_deref(),
+            Some("SQLite diagnostics are not available for this connection")
+        );
+    }
+
+    #[test]
+    fn quick_check_returns_error_for_postgres_connection() {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            DatabaseType::PostgreSQL,
+            "postgres://localhost/db",
+        );
+        let run_id = state.sqlite_diagnostics.begin_fetch();
+        state.sqlite_diagnostics.set_core_loaded(
+            run_id,
+            SqliteDiagnosticsSnapshot {
+                quick_check: DiagnosticField::Pending,
+                ..Default::default()
+            },
+        );
+
+        let effects = reduce_sqlite_diagnostics(
+            &mut state,
+            &Action::RunSqliteDiagnosticsQuickCheck,
+            Instant::now(),
+        )
+        .unwrap();
+
+        assert!(effects.is_empty());
+        assert!(!state.sqlite_diagnostics.is_quick_check_running());
+        assert_eq!(
+            state.messages.last_error.as_deref(),
+            Some("SQLite diagnostics are not available for this connection")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem
Unsupported ER, plan comparison, and SQLite diagnostics actions could still reach deep reducers through direct dispatch.

## Background
Input and palette guards are not a complete boundary because other action sources can dispatch the same actions.

## Approach
Add capability checks at reducer boundaries for ER lifecycle, plan comparison editing, and diagnostics actions. Unsupported requests now produce consistent user-facing errors without starting effects, and reducer tests cover direct dispatch and stale comparison state.

## Linear Issue Link

- https://linear.app/sabiql/issue/SAB-362