### PR TITLE
refactor: centralize JSON presentation policy

### DIFF
--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -1,11 +1,13 @@
 use unicode_width::UnicodeWidthStr;
 
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::connection::setup::ConnectionField;
 use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::help::{HelpOrigin, JsonbHelpMode, SqlHelpMode};
 use crate::model::shared::settings::KeymapPreset;
+use crate::policy::preview_cell_text::CellPresentationPolicy;
 use crate::update::action::{Action, ModalKind};
 #[allow(
     clippy::wildcard_imports,
@@ -33,6 +35,10 @@ impl HelpDocument {
             filter.cursor(),
             state.settings.saved_keymap_preset(),
             state.session.active_engine_feature_profile(),
+            state
+                .session
+                .active_database_type()
+                .map(|database_type| CellPresentationPolicy::new(database_type, "jsonb", "")),
         )
     }
 
@@ -47,6 +53,11 @@ impl HelpDocument {
             filter_cursor,
             origin.keymap_preset(),
             &EngineFeatureProfile::postgres_like(),
+            Some(CellPresentationPolicy::new(
+                DatabaseType::PostgreSQL,
+                "jsonb",
+                "",
+            )),
         )
     }
 
@@ -56,10 +67,15 @@ impl HelpDocument {
         filter_cursor: usize,
         keymap_preset: KeymapPreset,
         engine_feature_profile: &EngineFeatureProfile,
+        cell_presentation_policy: Option<CellPresentationPolicy>,
     ) -> Self {
         let normalized = filter.trim().to_lowercase();
         let mut sections = vec![current_section(origin, engine_feature_profile)];
-        sections.extend(reference_sections(keymap_preset, engine_feature_profile));
+        sections.extend(reference_sections(
+            keymap_preset,
+            engine_feature_profile,
+            cell_presentation_policy,
+        ));
 
         if !normalized.is_empty() {
             sections = sections
@@ -327,6 +343,7 @@ fn command_line_rows(engine_feature_profile: &EngineFeatureProfile) -> Vec<HelpR
 fn reference_sections(
     keymap_preset: KeymapPreset,
     engine_feature_profile: &EngineFeatureProfile,
+    cell_presentation_policy: Option<CellPresentationPolicy>,
 ) -> Vec<HelpSection> {
     let mut open_switch_rows = vec![
         table_picker(keymap_preset),
@@ -352,7 +369,7 @@ fn reference_sections(
         &result_active::UNSTAGE_DELETE,
         &inspector_ddl::YANK,
     ]);
-    if engine_feature_profile.supports_jsonb_detail() {
+    if cell_presentation_policy.is_some_and(CellPresentationPolicy::uses_jsonb_detail_modal) {
         data_action_rows.extend(rows_from_mode_row_refs(&[&jsonb_detail::YANK]));
     }
 
@@ -363,7 +380,7 @@ fn reference_sections(
     if engine_feature_profile.supports_er_diagram() {
         search_filter_rows.insert(1, row_from_mode_row(&er_picker::TYPE_FILTER));
     }
-    if engine_feature_profile.supports_jsonb_detail() {
+    if cell_presentation_policy.is_some_and(CellPresentationPolicy::uses_jsonb_detail_modal) {
         search_filter_rows.extend(rows_from_bindings(JSONB_SEARCH_KEYS));
     }
     search_filter_rows.extend(rows_from_mode_rows(HELP_ROWS));
@@ -374,7 +391,7 @@ fn reference_sections(
         rows_from_bindings(CELL_EDIT_KEYS),
         rows_from_bindings(SQL_MODAL_CONFIRMING_KEYS),
     ]);
-    if engine_feature_profile.supports_jsonb_detail() {
+    if cell_presentation_policy.is_some_and(CellPresentationPolicy::uses_jsonb_detail_modal) {
         editing_rows.extend(rows_from_mode_rows(JSONB_EDIT_ROWS));
     }
 
@@ -396,7 +413,7 @@ fn reference_sections(
     if engine_feature_profile.supports_er_diagram() {
         advanced_rows.extend(rows_from_mode_rows(er_picker_rows(keymap_preset)));
     }
-    if engine_feature_profile.supports_jsonb_detail() {
+    if cell_presentation_policy.is_some_and(CellPresentationPolicy::uses_jsonb_detail_modal) {
         advanced_rows.extend(rows_from_mode_rows(JSONB_DETAIL_ROWS));
     }
     advanced_rows.extend(rows_from_mode_rows(ROW_DETAIL_ROWS));
@@ -448,6 +465,12 @@ fn reference_sections(
     .into_iter()
     .filter(|section| !section.rows.is_empty())
     .collect()
+}
+
+fn jsonb_detail_available(database_type: Option<DatabaseType>) -> bool {
+    database_type.is_some_and(|database_type| {
+        CellPresentationPolicy::new(database_type, "jsonb", "").uses_jsonb_detail_modal()
+    })
 }
 
 fn sql_current_rows(
@@ -638,7 +661,7 @@ fn merge_rows(groups: &[Vec<HelpRow>]) -> Vec<HelpRow> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{ConnectionId, DatabaseType};
+    use crate::domain::ConnectionId;
     use crate::model::browse::jsonb_detail::JsonbDetailMode;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::sql_editor::modal::SqlModalTab;
@@ -980,6 +1003,31 @@ mod tests {
                 .iter()
                 .any(|description| description.contains("JSONB"))
         );
+    }
+
+    #[test]
+    fn jsonb_help_rows_follow_cell_presentation_policy() {
+        for database_type in [DatabaseType::PostgreSQL, DatabaseType::SQLite] {
+            let mut state = AppState::new("test".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "database",
+                database_type,
+                "database",
+            );
+            let origin = HelpOrigin::from_state(&state);
+            state.ui.help_mut().open(origin);
+
+            let document = HelpDocument::from_state(&state);
+            let descriptions = row_descriptions(&document);
+            let help_includes_jsonb = descriptions
+                .iter()
+                .any(|description| description.contains("JSONB"));
+            let policy_allows_jsonb =
+                CellPresentationPolicy::new(database_type, "jsonb", "").uses_jsonb_detail_modal();
+
+            assert_eq!(help_includes_jsonb, policy_allows_jsonb);
+        }
     }
 
     #[test]

--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -467,12 +467,6 @@ fn reference_sections(
     .collect()
 }
 
-fn jsonb_detail_available(database_type: Option<DatabaseType>) -> bool {
-    database_type.is_some_and(|database_type| {
-        CellPresentationPolicy::new(database_type, "jsonb", "").uses_jsonb_detail_modal()
-    })
-}
-
 fn sql_current_rows(
     mode: SqlHelpMode,
     keymap_preset: KeymapPreset,

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -28,7 +28,7 @@ use crate::model::shared::ui_state::{UiState, scroll_max_offset};
 use crate::model::sql_editor::modal::SqlModalContext;
 use crate::model::sql_editor::query_history::QueryHistoryPickerState;
 use crate::model::sqlite::diagnostics::SqliteDiagnosticsState;
-use crate::policy::preview_cell_text::{preview_cell_text_diff_handling, uses_jsonb_detail_modal};
+use crate::policy::preview_cell_text::CellPresentationPolicy;
 use crate::policy::sql::result_query::is_rerunnable_select;
 use crate::policy::table_kind::max_explorer_table_label_width;
 use crate::policy::write::inline_cell_edit::supports_inline_edit;
@@ -414,11 +414,12 @@ impl AppState {
                 return false;
             }
 
-            let handling = preview_cell_text_diff_handling(
+            let policy = CellPresentationPolicy::new(
                 self.session.active_database_type_or_default(),
                 column.data_type.as_str(),
+                value.as_str().unwrap_or_default(),
             );
-            if uses_jsonb_detail_modal(handling) {
+            if policy.uses_jsonb_detail_modal() {
                 return true;
             }
         }

--- a/src/app/policy/preview_cell_text/diff.rs
+++ b/src/app/policy/preview_cell_text/diff.rs
@@ -22,11 +22,12 @@ mod tests {
     use super::*;
     use crate::domain::DatabaseType;
 
-    use super::super::handling::preview_cell_text_diff_handling;
+    use super::super::handling::CellPresentationPolicy;
 
     #[test]
     fn jsonb_column_normalizes_key_order() {
-        let handling = preview_cell_text_diff_handling(DatabaseType::PostgreSQL, "jsonb");
+        let handling =
+            CellPresentationPolicy::new(DatabaseType::PostgreSQL, "jsonb", "").diff_handling();
         let pg_style = r#"{"industries": ["tech"], "company_size": "enterprise"}"#;
         let serde_style = r#"{"company_size":"enterprise","industries":["tech"]}"#;
         assert_eq!(
@@ -37,7 +38,8 @@ mod tests {
 
     #[test]
     fn text_column_preserves_json_like_string() {
-        let handling = preview_cell_text_diff_handling(DatabaseType::PostgreSQL, "text");
+        let handling =
+            CellPresentationPolicy::new(DatabaseType::PostgreSQL, "text", "").diff_handling();
         let spaced = r#"{ "a": 1 }"#;
         let compact = r#"{"a":1}"#;
         assert_eq!(normalize_for_write_diff(spaced, handling), spaced);
@@ -49,14 +51,16 @@ mod tests {
 
     #[test]
     fn sqlite_text_column_preserves_json_like_string() {
-        let handling = preview_cell_text_diff_handling(DatabaseType::SQLite, "TEXT");
+        let handling =
+            CellPresentationPolicy::new(DatabaseType::SQLite, "TEXT", "").diff_handling();
         let original = r#"{"items":["admin","writer"]}"#;
         assert_eq!(normalize_for_write_diff(original, handling), original);
     }
 
     #[test]
     fn sqlite_jsonb_declared_type_stays_raw() {
-        let handling = preview_cell_text_diff_handling(DatabaseType::SQLite, "jsonb");
+        let handling =
+            CellPresentationPolicy::new(DatabaseType::SQLite, "jsonb", "").diff_handling();
         let pg_style = r#"{"industries": ["tech"], "company_size": "enterprise"}"#;
         let serde_style = r#"{"company_size":"enterprise","industries":["tech"]}"#;
         assert_eq!(

--- a/src/app/policy/preview_cell_text/display.rs
+++ b/src/app/policy/preview_cell_text/display.rs
@@ -41,17 +41,15 @@ pub fn format_for_cell_detail(
 
 #[cfg(test)]
 mod tests {
-    use super::super::handling::preview_cell_text_display_handling;
+    use super::super::handling::CellPresentationPolicy;
     use super::*;
     use crate::domain::DatabaseType;
 
     #[test]
     fn postgresql_json_column_pretty_prints() {
-        let handling = preview_cell_text_display_handling(
-            DatabaseType::PostgreSQL,
-            "json",
-            r#"{"b":2,"a":1}"#,
-        );
+        let handling =
+            CellPresentationPolicy::new(DatabaseType::PostgreSQL, "json", r#"{"b":2,"a":1}"#)
+                .display_handling();
         assert_eq!(handling, PreviewCellTextDisplayHandling::PostgreSqlJson);
         let formatted = format_for_cell_detail(r#"{"b":2,"a":1}"#, handling);
         assert_eq!(formatted.content, "{\n  \"a\": 1,\n  \"b\": 2\n}");
@@ -60,11 +58,12 @@ mod tests {
 
     #[test]
     fn sqlite_text_json_value_pretty_prints() {
-        let handling = preview_cell_text_display_handling(
+        let handling = CellPresentationPolicy::new(
             DatabaseType::SQLite,
             "TEXT",
             r#"{"items":["admin","writer"]}"#,
-        );
+        )
+        .display_handling();
         assert_eq!(
             format_for_cell_detail(r#"{"items":["admin","writer"]}"#, handling),
             CellDetailDisplay {
@@ -75,7 +74,7 @@ mod tests {
         assert_eq!(
             format_for_cell_detail(
                 "42",
-                preview_cell_text_display_handling(DatabaseType::SQLite, "TEXT", "42",)
+                CellPresentationPolicy::new(DatabaseType::SQLite, "TEXT", "42").display_handling()
             ),
             CellDetailDisplay {
                 content: "42".to_string(),
@@ -87,7 +86,8 @@ mod tests {
     #[test]
     fn sqlite_json_declared_type_stays_raw() {
         let handling =
-            preview_cell_text_display_handling(DatabaseType::SQLite, "json", r#"{"b":2,"a":1}"#);
+            CellPresentationPolicy::new(DatabaseType::SQLite, "json", r#"{"b":2,"a":1}"#)
+                .display_handling();
         let value = r#"{"b":2,"a":1}"#;
         assert_eq!(
             format_for_cell_detail(value, handling),
@@ -101,7 +101,8 @@ mod tests {
     #[test]
     fn sqlite_jsonb_declared_type_stays_raw() {
         let handling =
-            preview_cell_text_display_handling(DatabaseType::SQLite, "jsonb", r#"{"b":2,"a":1}"#);
+            CellPresentationPolicy::new(DatabaseType::SQLite, "jsonb", r#"{"b":2,"a":1}"#)
+                .display_handling();
         let value = r#"{"b":2,"a":1}"#;
         assert_eq!(
             format_for_cell_detail(value, handling),
@@ -114,11 +115,12 @@ mod tests {
 
     #[test]
     fn postgresql_text_json_container_pretty_prints() {
-        let handling = preview_cell_text_display_handling(
+        let handling = CellPresentationPolicy::new(
             DatabaseType::PostgreSQL,
             "text",
             r#"{"items":["admin","writer"]}"#,
-        );
+        )
+        .display_handling();
         assert_eq!(
             handling,
             PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText

--- a/src/app/policy/preview_cell_text/handling.rs
+++ b/src/app/policy/preview_cell_text/handling.rs
@@ -15,39 +15,50 @@ pub enum PreviewCellTextDisplayHandling {
     PostgreSqlJsonb,
 }
 
-pub fn preview_cell_text_diff_handling(
-    database_type: DatabaseType,
-    column_data_type: &str,
-) -> PreviewCellTextDiffHandling {
-    match (database_type, column_data_type) {
-        (DatabaseType::PostgreSQL, "jsonb") => PreviewCellTextDiffHandling::PostgreSqlJsonb,
-        _ => PreviewCellTextDiffHandling::RawText,
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CellPresentationPolicy {
+    diff_handling: PreviewCellTextDiffHandling,
+    display_handling: PreviewCellTextDisplayHandling,
 }
 
-pub fn preview_cell_text_display_handling(
-    database_type: DatabaseType,
-    column_data_type: &str,
-    value: &str,
-) -> PreviewCellTextDisplayHandling {
-    match database_type {
-        DatabaseType::SQLite if has_sqlite_text_affinity(column_data_type) => {
-            PreviewCellTextDisplayHandling::SqliteText
-        }
-        DatabaseType::SQLite => PreviewCellTextDisplayHandling::RawText,
-        DatabaseType::PostgreSQL => match column_data_type {
-            "jsonb" => PreviewCellTextDisplayHandling::PostgreSqlJsonb,
-            "json" => PreviewCellTextDisplayHandling::PostgreSqlJson,
-            _ if looks_like_json_container(value) => {
-                PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
+impl CellPresentationPolicy {
+    pub fn new(database_type: DatabaseType, column_data_type: &str, value: &str) -> Self {
+        let diff_handling = match (database_type, column_data_type) {
+            (DatabaseType::PostgreSQL, "jsonb") => PreviewCellTextDiffHandling::PostgreSqlJsonb,
+            _ => PreviewCellTextDiffHandling::RawText,
+        };
+        let display_handling = match database_type {
+            DatabaseType::SQLite if has_sqlite_text_affinity(column_data_type) => {
+                PreviewCellTextDisplayHandling::SqliteText
             }
-            _ => PreviewCellTextDisplayHandling::RawText,
-        },
-    }
-}
+            DatabaseType::SQLite => PreviewCellTextDisplayHandling::RawText,
+            DatabaseType::PostgreSQL => match column_data_type {
+                "jsonb" => PreviewCellTextDisplayHandling::PostgreSqlJsonb,
+                "json" => PreviewCellTextDisplayHandling::PostgreSqlJson,
+                _ if looks_like_json_container(value) => {
+                    PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
+                }
+                _ => PreviewCellTextDisplayHandling::RawText,
+            },
+        };
 
-pub fn uses_jsonb_detail_modal(diff_handling: PreviewCellTextDiffHandling) -> bool {
-    diff_handling == PreviewCellTextDiffHandling::PostgreSqlJsonb
+        Self {
+            diff_handling,
+            display_handling,
+        }
+    }
+
+    pub fn diff_handling(self) -> PreviewCellTextDiffHandling {
+        self.diff_handling
+    }
+
+    pub fn display_handling(self) -> PreviewCellTextDisplayHandling {
+        self.display_handling
+    }
+
+    pub fn uses_jsonb_detail_modal(self) -> bool {
+        self.diff_handling == PreviewCellTextDiffHandling::PostgreSqlJsonb
+    }
 }
 
 fn looks_like_json_container(value: &str) -> bool {
@@ -67,39 +78,39 @@ mod tests {
     #[test]
     fn sqlite_columns_always_use_raw_text() {
         assert_eq!(
-            preview_cell_text_diff_handling(DatabaseType::SQLite, "TEXT"),
+            CellPresentationPolicy::new(DatabaseType::SQLite, "TEXT", "").diff_handling(),
             PreviewCellTextDiffHandling::RawText
         );
         assert_eq!(
-            preview_cell_text_diff_handling(DatabaseType::SQLite, "json"),
+            CellPresentationPolicy::new(DatabaseType::SQLite, "json", "").diff_handling(),
             PreviewCellTextDiffHandling::RawText
         );
         assert_eq!(
-            preview_cell_text_diff_handling(DatabaseType::SQLite, "jsonb"),
+            CellPresentationPolicy::new(DatabaseType::SQLite, "jsonb", "").diff_handling(),
             PreviewCellTextDiffHandling::RawText
         );
-        assert!(!uses_jsonb_detail_modal(preview_cell_text_diff_handling(
-            DatabaseType::SQLite,
-            "jsonb"
-        )));
+        assert!(
+            !CellPresentationPolicy::new(DatabaseType::SQLite, "jsonb", "")
+                .uses_jsonb_detail_modal()
+        );
     }
 
     #[test]
     fn postgresql_jsonb_uses_semantic_handling() {
         assert_eq!(
-            preview_cell_text_diff_handling(DatabaseType::PostgreSQL, "jsonb"),
+            CellPresentationPolicy::new(DatabaseType::PostgreSQL, "jsonb", "").diff_handling(),
             PreviewCellTextDiffHandling::PostgreSqlJsonb
         );
-        assert!(uses_jsonb_detail_modal(preview_cell_text_diff_handling(
-            DatabaseType::PostgreSQL,
-            "jsonb"
-        )));
+        assert!(
+            CellPresentationPolicy::new(DatabaseType::PostgreSQL, "jsonb", "")
+                .uses_jsonb_detail_modal()
+        );
     }
 
     #[test]
     fn postgresql_json_uses_raw_text_for_diff() {
         assert_eq!(
-            preview_cell_text_diff_handling(DatabaseType::PostgreSQL, "json"),
+            CellPresentationPolicy::new(DatabaseType::PostgreSQL, "json", "").diff_handling(),
             PreviewCellTextDiffHandling::RawText
         );
     }
@@ -107,7 +118,7 @@ mod tests {
     #[test]
     fn postgresql_text_uses_raw_text_for_diff() {
         assert_eq!(
-            preview_cell_text_diff_handling(DatabaseType::PostgreSQL, "text"),
+            CellPresentationPolicy::new(DatabaseType::PostgreSQL, "text", "").diff_handling(),
             PreviewCellTextDiffHandling::RawText
         );
     }
@@ -115,15 +126,13 @@ mod tests {
     #[test]
     fn sqlite_text_affinity_uses_text_display_handling() {
         assert_eq!(
-            preview_cell_text_display_handling(
-                DatabaseType::SQLite,
-                "TEXT",
-                r#"{"items":["admin"]}"#
-            ),
+            CellPresentationPolicy::new(DatabaseType::SQLite, "TEXT", r#"{"items":["admin"]}"#)
+                .display_handling(),
             PreviewCellTextDisplayHandling::SqliteText
         );
         assert_eq!(
-            preview_cell_text_display_handling(DatabaseType::SQLite, "varchar(255)", "42"),
+            CellPresentationPolicy::new(DatabaseType::SQLite, "varchar(255)", "42")
+                .display_handling(),
             PreviewCellTextDisplayHandling::SqliteText
         );
     }
@@ -131,11 +140,12 @@ mod tests {
     #[test]
     fn sqlite_non_text_affinity_uses_raw_display_handling() {
         assert_eq!(
-            preview_cell_text_display_handling(DatabaseType::SQLite, "INTEGER", "42"),
+            CellPresentationPolicy::new(DatabaseType::SQLite, "INTEGER", "42").display_handling(),
             PreviewCellTextDisplayHandling::RawText
         );
         assert_eq!(
-            preview_cell_text_display_handling(DatabaseType::SQLite, "json", r#"{"a":1}"#),
+            CellPresentationPolicy::new(DatabaseType::SQLite, "json", r#"{"a":1}"#)
+                .display_handling(),
             PreviewCellTextDisplayHandling::RawText
         );
     }
@@ -143,11 +153,8 @@ mod tests {
     #[test]
     fn postgresql_text_json_container_uses_json_like_display_handling() {
         assert_eq!(
-            preview_cell_text_display_handling(
-                DatabaseType::PostgreSQL,
-                "text",
-                r#"{"items":["admin"]}"#
-            ),
+            CellPresentationPolicy::new(DatabaseType::PostgreSQL, "text", r#"{"items":["admin"]}"#)
+                .display_handling(),
             PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
         );
     }

--- a/src/app/policy/preview_cell_text/mod.rs
+++ b/src/app/policy/preview_cell_text/mod.rs
@@ -4,6 +4,4 @@ mod handling;
 
 pub use diff::{normalize_for_write_diff, uses_structured_json_diff};
 pub use display::format_for_cell_detail;
-pub use handling::{
-    preview_cell_text_diff_handling, preview_cell_text_display_handling, uses_jsonb_detail_modal,
-};
+pub use handling::CellPresentationPolicy;

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -9,7 +9,7 @@ use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::json::json_diff::compute_json_diff;
 use crate::policy::preview_cell_text::{
-    normalize_for_write_diff, preview_cell_text_diff_handling, uses_structured_json_diff,
+    CellPresentationPolicy, normalize_for_write_diff, uses_structured_json_diff,
 };
 use crate::policy::write::inline_cell_edit::build_inline_edited_value;
 use crate::policy::write::write_guardrails::{
@@ -107,7 +107,8 @@ fn build_update_preview(
                 .table_detail()
                 .and_then(|td| td.columns.get(col_idx))
                 .map_or("", |c| c.data_type.as_str());
-            let handling = preview_cell_text_diff_handling(database_type, column_data_type);
+            let handling =
+                CellPresentationPolicy::new(database_type, column_data_type, "").diff_handling();
             let before = normalize_for_write_diff(
                 state.result_interaction.cell_edit().original_value(),
                 handling,

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -6,10 +6,7 @@ use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::shared::detail_view::DetailDisplayMode;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
-use crate::policy::preview_cell_text::{
-    format_for_cell_detail, preview_cell_text_diff_handling, preview_cell_text_display_handling,
-    uses_jsonb_detail_modal,
-};
+use crate::policy::preview_cell_text::{CellPresentationPolicy, format_for_cell_detail};
 use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, InputTarget, ModalKind, ScrollDirection, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
@@ -32,9 +29,8 @@ pub fn reduce_cell_detail(state: &mut AppState, action: &Action, now: Instant) -
 
             let database_type = state.session.active_database_type_or_default();
             let column_data_type = data_type.as_deref().unwrap_or("");
-            let display_handling =
-                preview_cell_text_display_handling(database_type, column_data_type, &cell_value);
-            let display = format_for_cell_detail(&cell_value, display_handling);
+            let policy = CellPresentationPolicy::new(database_type, column_data_type, &cell_value);
+            let display = format_for_cell_detail(&cell_value, policy.display_handling());
             let display_mode = if display.formatted_json {
                 DetailDisplayMode::FormattedJson
             } else {
@@ -169,11 +165,12 @@ fn selected_cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
     let Some(column_data_type) = selected_column_data_type(state, col_idx) else {
         return false;
     };
-    let handling = preview_cell_text_diff_handling(
+    let policy = CellPresentationPolicy::new(
         state.session.active_database_type_or_default(),
         column_data_type,
+        "",
     );
-    uses_jsonb_detail_modal(handling)
+    policy.uses_jsonb_detail_modal()
 }
 
 fn selected_column_data_type(state: &AppState, col_idx: usize) -> Option<&str> {

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -8,7 +8,7 @@ use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
 
-use crate::policy::preview_cell_text::{preview_cell_text_diff_handling, uses_jsonb_detail_modal};
+use crate::policy::preview_cell_text::CellPresentationPolicy;
 use crate::policy::write::inline_cell_edit::text_for_inline_edit;
 use crate::update::helpers::{EditGuardrailError, editable_preview_base, ensure_column_writable};
 
@@ -25,11 +25,12 @@ fn cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
     let Some(column) = td.columns.get(col_idx) else {
         return false;
     };
-    let handling = preview_cell_text_diff_handling(
+    let policy = CellPresentationPolicy::new(
         state.session.active_database_type_or_default(),
         column.data_type.as_str(),
+        "",
     );
-    uses_jsonb_detail_modal(handling)
+    policy.uses_jsonb_detail_modal()
 }
 
 fn editable_cell_context(state: &AppState) -> Result<(usize, usize, String), EditGuardrailError> {

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -9,7 +9,7 @@ use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::KeySequenceState;
 use crate::model::shared::text_input::{TextInputEditing, TextInputLike};
 use crate::model::shared::ui_state::DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS;
-use crate::policy::preview_cell_text::{preview_cell_text_diff_handling, uses_jsonb_detail_modal};
+use crate::policy::preview_cell_text::CellPresentationPolicy;
 use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
@@ -47,9 +47,8 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
             let Some(column) = table_detail.columns.get(col_idx) else {
                 return DispatchResult::handled();
             };
-            let handling =
-                preview_cell_text_diff_handling(database_type, column.data_type.as_str());
-            if !uses_jsonb_detail_modal(handling) {
+            let policy = CellPresentationPolicy::new(database_type, column.data_type.as_str(), "");
+            if !policy.uses_jsonb_detail_modal() {
                 return DispatchResult::handled();
             }
 


### PR DESCRIPTION
## Problem

JSON-specific detail and edit routing used separate decisions, so Help could diverge from the actual JSON detail and edit routing.

## Background

Static connection capabilities do not capture JSON UI decisions that depend on the selected column type and value.

## Approach

Derive Help visibility from the same context-aware `CellPresentationPolicy` used by cell detail and edit routing, while preserving the engine feature profile for unrelated static UI capabilities.

## Linear Issue Link

- https://linear.app/sabiql/issue/SAB-363