### PR TITLE
refactor: centralize static feature availability

### DIFF
--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -6,7 +6,7 @@ use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::help::{HelpOrigin, JsonbHelpMode, SqlHelpMode};
 use crate::model::shared::settings::KeymapPreset;
-use crate::update::action::{Action, ModalKind};
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 #[allow(
     clippy::wildcard_imports,
     reason = "help catalog enumerates nearly every keybindings table; explicit list is churn"
@@ -57,9 +57,10 @@ impl HelpDocument {
         keymap_preset: KeymapPreset,
         engine_feature_profile: &EngineFeatureProfile,
     ) -> Self {
+        let feature_policy = FeaturePolicy::new(engine_feature_profile);
         let normalized = filter.trim().to_lowercase();
-        let mut sections = vec![current_section(origin, engine_feature_profile)];
-        sections.extend(reference_sections(keymap_preset, engine_feature_profile));
+        let mut sections = vec![current_section(origin, &feature_policy)];
+        sections.extend(reference_sections(keymap_preset, &feature_policy));
 
         if !normalized.is_empty() {
             sections = sections
@@ -210,10 +211,7 @@ impl HelpRow {
     }
 }
 
-fn current_section(
-    origin: HelpOrigin,
-    engine_feature_profile: &EngineFeatureProfile,
-) -> HelpSection {
+fn current_section(origin: HelpOrigin, feature_policy: &FeaturePolicy) -> HelpSection {
     let rows = match origin {
         HelpOrigin::Normal {
             focused_pane: FocusedPane::Result,
@@ -280,7 +278,7 @@ fn current_section(
             &global::CONNECTIONS,
             &global::SQL,
         ]),
-        HelpOrigin::CommandLine => command_line_rows(engine_feature_profile),
+        HelpOrigin::CommandLine => command_line_rows(feature_policy),
         HelpOrigin::CellEdit => rows_from_bindings(CELL_EDIT_KEYS),
         HelpOrigin::TablePicker => rows_from_mode_rows(TABLE_PICKER_ROWS),
         HelpOrigin::CommandPalette => rows_from_mode_rows(COMMAND_PALETTE_ROWS),
@@ -289,21 +287,23 @@ fn current_section(
         HelpOrigin::SqlModal {
             mode,
             keymap_preset,
-        } => sql_current_rows(mode, keymap_preset, engine_feature_profile),
+        } => sql_current_rows(mode, keymap_preset, feature_policy),
         HelpOrigin::ConnectionSetup {
             keymap_preset,
             focused_field,
         } => connection_setup_current_rows(keymap_preset, focused_field),
         HelpOrigin::ConnectionError => rows_from_mode_rows(CONNECTION_ERROR_ROWS),
-        HelpOrigin::SqliteDiagnostics => rows_from_mode_rows(SQLITE_DIAGNOSTICS_ROWS),
+        HelpOrigin::SqliteDiagnostics => {
+            rows_from_mode_rows_if_visible(SQLITE_DIAGNOSTICS_ROWS, feature_policy)
+        }
         HelpOrigin::ConfirmDialog => rows_from_bindings(CONFIRM_DIALOG_KEYS),
         HelpOrigin::ConnectionSelector => rows_from_mode_rows(CONNECTION_SELECTOR_ROWS),
         HelpOrigin::ErTablePicker { keymap_preset } => {
-            rows_from_mode_rows(er_picker_rows(keymap_preset))
+            rows_from_mode_rows_if_visible(er_picker_rows(keymap_preset), feature_policy)
         }
         HelpOrigin::QueryHistoryPicker => rows_from_mode_rows(QUERY_HISTORY_PICKER_ROWS),
-        HelpOrigin::JsonbDetail { mode } => jsonb_current_rows(mode),
-        HelpOrigin::JsonbEdit => rows_from_mode_rows(JSONB_EDIT_ROWS),
+        HelpOrigin::JsonbDetail { mode } => jsonb_current_rows(mode, feature_policy),
+        HelpOrigin::JsonbEdit => rows_from_mode_rows_if_visible(JSONB_EDIT_ROWS, feature_policy),
         HelpOrigin::CellDetail { searching: true } => rows_from_bindings(CELL_DETAIL_SEARCH_KEYS),
         HelpOrigin::CellDetail { searching: false } => rows_from_mode_rows(CELL_DETAIL_ROWS),
         HelpOrigin::RowDetail => rows_from_mode_rows(ROW_DETAIL_ROWS),
@@ -315,18 +315,17 @@ fn current_section(
     }
 }
 
-fn command_line_rows(engine_feature_profile: &EngineFeatureProfile) -> Vec<HelpRow> {
-    rows_from_binding_iter(COMMAND_LINE_KEYS.iter().filter(|binding| {
-        !matches!(
-            binding.action,
-            Action::OpenModal(ModalKind::ErTablePicker) if !engine_feature_profile.supports_er_diagram()
-        )
-    }))
+fn command_line_rows(feature_policy: &FeaturePolicy) -> Vec<HelpRow> {
+    rows_from_binding_iter(
+        COMMAND_LINE_KEYS
+            .iter()
+            .filter(|binding| feature_policy.is_visible(binding.feature_requirement())),
+    )
 }
 
 fn reference_sections(
     keymap_preset: KeymapPreset,
-    engine_feature_profile: &EngineFeatureProfile,
+    feature_policy: &FeaturePolicy,
 ) -> Vec<HelpSection> {
     let mut open_switch_rows = vec![
         table_picker(keymap_preset),
@@ -336,10 +335,10 @@ fn reference_sections(
         &global::PANE_SWITCH,
         &global::INSPECTOR_TABS,
     ];
-    if engine_feature_profile.supports_er_diagram() {
+    if feature_policy.is_visible(global::ER_DIAGRAM.feature_requirement()) {
         open_switch_rows.insert(2, &global::ER_DIAGRAM);
     }
-    if engine_feature_profile.supports_sqlite_diagnostics() {
+    if feature_policy.is_visible(sqlite_diagnostics(keymap_preset).feature_requirement()) {
         open_switch_rows.insert(2, sqlite_diagnostics(keymap_preset));
     }
 
@@ -352,52 +351,67 @@ fn reference_sections(
         &result_active::UNSTAGE_DELETE,
         &inspector_ddl::YANK,
     ]);
-    if engine_feature_profile.supports_jsonb_detail() {
-        data_action_rows.extend(rows_from_mode_row_refs(&[&jsonb_detail::YANK]));
+    if feature_policy.is_visible(jsonb_detail::YANK.feature_requirement()) {
+        data_action_rows.extend(rows_from_mode_row_refs_if_visible(
+            &[&jsonb_detail::YANK],
+            feature_policy,
+        ));
     }
 
     let mut search_filter_rows = rows_from_mode_row_refs(&[
         &table_picker::TYPE_FILTER,
         &query_history_picker::TYPE_FILTER,
     ]);
-    if engine_feature_profile.supports_er_diagram() {
+    if feature_policy.is_visible(er_picker::TYPE_FILTER.feature_requirement()) {
         search_filter_rows.insert(1, row_from_mode_row(&er_picker::TYPE_FILTER));
     }
-    if engine_feature_profile.supports_jsonb_detail() {
-        search_filter_rows.extend(rows_from_bindings(JSONB_SEARCH_KEYS));
+    if feature_policy.is_visible(jsonb_search::TYPE_SEARCH.feature_requirement()) {
+        search_filter_rows.extend(rows_from_bindings_if_visible(
+            JSONB_SEARCH_KEYS,
+            feature_policy,
+        ));
     }
     search_filter_rows.extend(rows_from_mode_rows(HELP_ROWS));
 
     let mut editing_rows = merge_rows(&[
-        sql_current_rows(SqlHelpMode::Normal, keymap_preset, engine_feature_profile),
-        sql_current_rows(SqlHelpMode::Insert, keymap_preset, engine_feature_profile),
+        sql_current_rows(SqlHelpMode::Normal, keymap_preset, feature_policy),
+        sql_current_rows(SqlHelpMode::Insert, keymap_preset, feature_policy),
         rows_from_bindings(CELL_EDIT_KEYS),
-        rows_from_bindings(SQL_MODAL_CONFIRMING_KEYS),
+        rows_from_bindings_if_visible(SQL_MODAL_CONFIRMING_KEYS, feature_policy),
     ]);
-    if engine_feature_profile.supports_jsonb_detail() {
-        editing_rows.extend(rows_from_mode_rows(JSONB_EDIT_ROWS));
+    if feature_policy.is_visible(jsonb_edit::ESC_NORMAL.feature_requirement()) {
+        editing_rows.extend(rows_from_mode_rows_if_visible(
+            JSONB_EDIT_ROWS,
+            feature_policy,
+        ));
     }
 
     let mut advanced_rows = Vec::new();
-    if engine_feature_profile.supports_explain() {
+    if feature_policy.is_visible(FeatureRequirement::Explain) {
         advanced_rows.extend(sql_current_rows(
             SqlHelpMode::Plan,
             keymap_preset,
-            engine_feature_profile,
+            feature_policy,
         ));
     }
-    if engine_feature_profile.supports_plan_comparison() {
+    if feature_policy.is_visible(FeatureRequirement::PlanComparison) {
         advanced_rows.extend(sql_current_rows(
             SqlHelpMode::Compare,
             keymap_preset,
-            engine_feature_profile,
+            feature_policy,
         ));
     }
-    if engine_feature_profile.supports_er_diagram() {
-        advanced_rows.extend(rows_from_mode_rows(er_picker_rows(keymap_preset)));
+    if feature_policy.is_visible(FeatureRequirement::ErDiagram) {
+        advanced_rows.extend(rows_from_mode_rows_if_visible(
+            er_picker_rows(keymap_preset),
+            feature_policy,
+        ));
     }
-    if engine_feature_profile.supports_jsonb_detail() {
-        advanced_rows.extend(rows_from_mode_rows(JSONB_DETAIL_ROWS));
+    if feature_policy.is_visible(FeatureRequirement::JsonbDetail) {
+        advanced_rows.extend(rows_from_mode_rows_if_visible(
+            JSONB_DETAIL_ROWS,
+            feature_policy,
+        ));
     }
     advanced_rows.extend(rows_from_mode_rows(ROW_DETAIL_ROWS));
 
@@ -453,35 +467,41 @@ fn reference_sections(
 fn sql_current_rows(
     mode: SqlHelpMode,
     keymap_preset: KeymapPreset,
-    engine_feature_profile: &EngineFeatureProfile,
+    feature_policy: &FeaturePolicy,
 ) -> Vec<HelpRow> {
     match mode {
-        SqlHelpMode::Normal => rows_from_binding_refs(&[
-            &sql_modal_normal::RUN,
-            &sql_modal_normal::YANK,
-            &sql_modal_normal::ENTER_INSERT,
-            &sql_modal_normal::APPEND,
-            &sql_modal_normal::MOVE,
-            &sql_modal_normal::HOME_END,
-            &sql_modal_normal::VIEWPORT,
-            &sql_modal_normal::CLOSE,
-            &sql_modal_normal::CLEAR,
-            sql_modal_normal_query_history(keymap_preset),
-        ]),
+        SqlHelpMode::Normal => rows_from_binding_refs_if_visible(
+            &[
+                &sql_modal_normal::RUN,
+                &sql_modal_normal::YANK,
+                &sql_modal_normal::ENTER_INSERT,
+                &sql_modal_normal::APPEND,
+                &sql_modal_normal::MOVE,
+                &sql_modal_normal::HOME_END,
+                &sql_modal_normal::VIEWPORT,
+                &sql_modal_normal::CLOSE,
+                &sql_modal_normal::CLEAR,
+                sql_modal_normal_query_history(keymap_preset),
+            ],
+            feature_policy,
+        ),
         SqlHelpMode::Insert | SqlHelpMode::Running => match keymap_preset {
-            KeymapPreset::Default => rows_from_bindings(SQL_MODAL_KEYS),
-            KeymapPreset::Ide => rows_from_binding_refs(&[
-                &sql_modal::RUN,
-                &sql_modal::ESC_NORMAL,
-                &sql_modal::MOVE,
-                &sql_modal::HOME_END,
-                &sql_modal::TAB,
-                &sql_modal::CLEAR,
-            ]),
+            KeymapPreset::Default => rows_from_bindings_if_visible(SQL_MODAL_KEYS, feature_policy),
+            KeymapPreset::Ide => rows_from_binding_refs_if_visible(
+                &[
+                    &sql_modal::RUN,
+                    &sql_modal::ESC_NORMAL,
+                    &sql_modal::MOVE,
+                    &sql_modal::HOME_END,
+                    &sql_modal::TAB,
+                    &sql_modal::CLEAR,
+                ],
+                feature_policy,
+            ),
         },
         SqlHelpMode::Plan => {
             let mut bindings: Vec<&KeyBinding> = vec![sql_modal_plan_explain(keymap_preset)];
-            if engine_feature_profile.supports_explain_analyze() {
+            if feature_policy.is_visible(sql_modal_plan::ANALYZE.feature_requirement()) {
                 bindings.push(&sql_modal_plan::ANALYZE);
             }
             bindings.extend([
@@ -491,11 +511,11 @@ fn sql_current_rows(
                 &sql_modal_plan::BACKTAB,
                 &sql_modal_plan::CLOSE,
             ]);
-            rows_from_binding_refs(&bindings)
+            rows_from_binding_refs_if_visible(&bindings, feature_policy)
         }
         SqlHelpMode::Compare => {
             let mut bindings: Vec<&KeyBinding> = vec![sql_modal_compare_explain(keymap_preset)];
-            if engine_feature_profile.supports_explain_analyze() {
+            if feature_policy.is_visible(sql_modal_compare::ANALYZE.feature_requirement()) {
                 bindings.push(&sql_modal_compare::ANALYZE);
             }
             bindings.extend([
@@ -506,9 +526,11 @@ fn sql_current_rows(
                 &sql_modal_compare::BACKTAB,
                 &sql_modal_compare::CLOSE,
             ]);
-            rows_from_binding_refs(&bindings)
+            rows_from_binding_refs_if_visible(&bindings, feature_policy)
         }
-        SqlHelpMode::Confirm => rows_from_bindings(SQL_MODAL_CONFIRMING_KEYS),
+        SqlHelpMode::Confirm => {
+            rows_from_bindings_if_visible(SQL_MODAL_CONFIRMING_KEYS, feature_policy)
+        }
     }
 }
 
@@ -544,11 +566,11 @@ fn connection_setup_current_rows(
     rows
 }
 
-fn jsonb_current_rows(mode: JsonbHelpMode) -> Vec<HelpRow> {
+fn jsonb_current_rows(mode: JsonbHelpMode, feature_policy: &FeaturePolicy) -> Vec<HelpRow> {
     match mode {
-        JsonbHelpMode::Detail => rows_from_mode_rows(JSONB_DETAIL_ROWS),
-        JsonbHelpMode::Search => rows_from_bindings(JSONB_SEARCH_KEYS),
-        JsonbHelpMode::Edit => rows_from_mode_rows(JSONB_EDIT_ROWS),
+        JsonbHelpMode::Detail => rows_from_mode_rows_if_visible(JSONB_DETAIL_ROWS, feature_policy),
+        JsonbHelpMode::Search => rows_from_bindings_if_visible(JSONB_SEARCH_KEYS, feature_policy),
+        JsonbHelpMode::Edit => rows_from_mode_rows_if_visible(JSONB_EDIT_ROWS, feature_policy),
     }
 }
 
@@ -563,8 +585,31 @@ fn rows_from_bindings(bindings: &[KeyBinding]) -> Vec<HelpRow> {
     rows_from_binding_iter(bindings.iter())
 }
 
+fn rows_from_bindings_if_visible(
+    bindings: &[KeyBinding],
+    feature_policy: &FeaturePolicy,
+) -> Vec<HelpRow> {
+    rows_from_binding_iter(
+        bindings
+            .iter()
+            .filter(|binding| feature_policy.is_visible(binding.feature_requirement())),
+    )
+}
+
 fn rows_from_binding_refs(bindings: &[&KeyBinding]) -> Vec<HelpRow> {
     rows_from_binding_iter(bindings.iter().copied())
+}
+
+fn rows_from_binding_refs_if_visible(
+    bindings: &[&KeyBinding],
+    feature_policy: &FeaturePolicy,
+) -> Vec<HelpRow> {
+    rows_from_binding_iter(
+        bindings
+            .iter()
+            .copied()
+            .filter(|binding| feature_policy.is_visible(binding.feature_requirement())),
+    )
 }
 
 fn rows_from_binding_iter<'a>(bindings: impl IntoIterator<Item = &'a KeyBinding>) -> Vec<HelpRow> {
@@ -613,8 +658,28 @@ fn rows_from_mode_rows(rows: &[ModeRow]) -> Vec<HelpRow> {
     rows.iter().map(row_from_mode_row).collect()
 }
 
+fn rows_from_mode_rows_if_visible(
+    rows: &[ModeRow],
+    feature_policy: &FeaturePolicy,
+) -> Vec<HelpRow> {
+    rows.iter()
+        .filter(|row| feature_policy.is_visible(row.feature_requirement()))
+        .map(row_from_mode_row)
+        .collect()
+}
+
 fn rows_from_mode_row_refs(rows: &[&ModeRow]) -> Vec<HelpRow> {
     rows.iter().map(|&row| row_from_mode_row(row)).collect()
+}
+
+fn rows_from_mode_row_refs_if_visible(
+    rows: &[&ModeRow],
+    feature_policy: &FeaturePolicy,
+) -> Vec<HelpRow> {
+    rows.iter()
+        .filter(|row| feature_policy.is_visible(row.feature_requirement()))
+        .map(|&row| row_from_mode_row(row))
+        .collect()
 }
 
 fn row_from_mode_row(row: &ModeRow) -> HelpRow {

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -166,6 +166,7 @@ pub async fn run(
                             dsn,
                             run_id,
                             error: e,
+                            is_analyze,
                         })
                         .await
                         .ok();

--- a/src/app/policy/feature_policy.rs
+++ b/src/app/policy/feature_policy.rs
@@ -14,7 +14,6 @@ pub enum FeatureRequirement {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FeatureAvailability {
     Hidden,
-    Disabled(String),
     Enabled,
 }
 

--- a/src/app/policy/feature_policy.rs
+++ b/src/app/policy/feature_policy.rs
@@ -1,0 +1,113 @@
+use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeatureRequirement {
+    None,
+    ErDiagram,
+    JsonbDetail,
+    SqliteDiagnostics,
+    Explain,
+    ExplainAnalyze,
+    PlanComparison,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FeatureAvailability {
+    Hidden,
+    Disabled(String),
+    Enabled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FeaturePolicy {
+    profile: EngineFeatureProfile,
+}
+
+impl FeaturePolicy {
+    pub fn new(profile: &EngineFeatureProfile) -> Self {
+        Self { profile: *profile }
+    }
+
+    pub fn availability(&self, requirement: FeatureRequirement) -> FeatureAvailability {
+        let supported = match requirement {
+            FeatureRequirement::None => true,
+            FeatureRequirement::ErDiagram => self.profile.supports_er_diagram(),
+            FeatureRequirement::JsonbDetail => self.profile.supports_jsonb_detail(),
+            FeatureRequirement::SqliteDiagnostics => self.profile.supports_sqlite_diagnostics(),
+            FeatureRequirement::Explain => self.profile.supports_explain(),
+            FeatureRequirement::ExplainAnalyze => self.profile.supports_explain_analyze(),
+            FeatureRequirement::PlanComparison => self.profile.supports_plan_comparison(),
+        };
+
+        if supported {
+            FeatureAvailability::Enabled
+        } else {
+            FeatureAvailability::Hidden
+        }
+    }
+
+    pub fn is_visible(&self, requirement: FeatureRequirement) -> bool {
+        !matches!(self.availability(requirement), FeatureAvailability::Hidden)
+    }
+
+    pub fn is_enabled(&self, requirement: FeatureRequirement) -> bool {
+        matches!(self.availability(requirement), FeatureAvailability::Enabled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn postgres_profile_enables_postgres_features_and_hides_sqlite_diagnostics() {
+        let policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+
+        assert_eq!(
+            policy.availability(FeatureRequirement::ErDiagram),
+            FeatureAvailability::Enabled
+        );
+        assert_eq!(
+            policy.availability(FeatureRequirement::JsonbDetail),
+            FeatureAvailability::Enabled
+        );
+        assert_eq!(
+            policy.availability(FeatureRequirement::ExplainAnalyze),
+            FeatureAvailability::Enabled
+        );
+        assert_eq!(
+            policy.availability(FeatureRequirement::SqliteDiagnostics),
+            FeatureAvailability::Hidden
+        );
+    }
+
+    #[test]
+    fn sqlite_profile_enables_diagnostics_and_hides_postgres_features() {
+        let policy = FeaturePolicy::new(&EngineFeatureProfile::sqlite_like());
+
+        assert_eq!(
+            policy.availability(FeatureRequirement::SqliteDiagnostics),
+            FeatureAvailability::Enabled
+        );
+        assert_eq!(
+            policy.availability(FeatureRequirement::ErDiagram),
+            FeatureAvailability::Hidden
+        );
+        assert_eq!(
+            policy.availability(FeatureRequirement::JsonbDetail),
+            FeatureAvailability::Hidden
+        );
+        assert_eq!(
+            policy.availability(FeatureRequirement::PlanComparison),
+            FeatureAvailability::Hidden
+        );
+    }
+
+    #[test]
+    fn unrequired_operations_are_enabled() {
+        let policy = FeaturePolicy::new(&EngineFeatureProfile::disconnected());
+
+        assert!(policy.is_visible(FeatureRequirement::None));
+        assert!(policy.is_enabled(FeatureRequirement::None));
+    }
+}

--- a/src/app/policy/mod.rs
+++ b/src/app/policy/mod.rs
@@ -1,3 +1,4 @@
+pub mod feature_policy;
 pub mod json;
 pub(crate) mod password_masking;
 pub(crate) mod preview_cell_text;
@@ -6,4 +7,5 @@ pub mod sqlite_path;
 pub mod table_kind;
 pub mod write;
 
+pub use feature_policy::{FeatureAvailability, FeaturePolicy, FeatureRequirement};
 pub use password_masking::mask_password;

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -496,6 +496,7 @@ pub enum Action {
         dsn: String,
         run_id: u64,
         error: DbOperationError,
+        is_analyze: bool,
     },
     CompareEditQuery,
 
@@ -690,6 +691,8 @@ impl Action {
             Self::OpenModal(ModalKind::SqliteDiagnostics)
             | Self::ToggleModal(ModalKind::SqliteDiagnostics)
             | Self::RunSqliteDiagnosticsQuickCheck
+            | Self::SqliteDiagnosticsCoreLoaded { .. }
+            | Self::SqliteDiagnosticsQuickCheckLoaded { .. }
             | Self::Scroll {
                 target: ScrollTarget::SqliteDiagnostics,
                 ..
@@ -727,9 +730,56 @@ impl Action {
                 target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
                 ..
             } => JsonbDetail,
-            Self::ExplainRequest => Explain,
-            Self::ExplainAnalyzeRequest | Self::ExplainAnalyzeConfirm => ExplainAnalyze,
-            Self::CompareEditQuery => PlanComparison,
+            Self::ExplainRequest
+            | Self::Scroll {
+                target: ScrollTarget::ExplainPlan,
+                ..
+            }
+            | Self::ExplainCompleted {
+                is_analyze: false, ..
+            }
+            | Self::ExplainFailed {
+                is_analyze: false, ..
+            } => Explain,
+            Self::ExplainAnalyzeRequest
+            | Self::ExplainAnalyzeConfirm
+            | Self::ExplainAnalyzeCancel
+            | Self::TextInput {
+                target: InputTarget::SqlModalAnalyzeHighRisk,
+                ..
+            }
+            | Self::TextBackspace {
+                target: InputTarget::SqlModalAnalyzeHighRisk,
+            }
+            | Self::TextDelete {
+                target: InputTarget::SqlModalAnalyzeHighRisk,
+            }
+            | Self::TextKill {
+                target: InputTarget::SqlModalAnalyzeHighRisk,
+                ..
+            }
+            | Self::TextYank {
+                target: InputTarget::SqlModalAnalyzeHighRisk,
+            }
+            | Self::TextMoveCursor {
+                target: InputTarget::SqlModalAnalyzeHighRisk,
+                ..
+            }
+            | Self::Scroll {
+                target: ScrollTarget::ExplainConfirm,
+                ..
+            }
+            | Self::ExplainCompleted {
+                is_analyze: true, ..
+            }
+            | Self::ExplainFailed {
+                is_analyze: true, ..
+            } => ExplainAnalyze,
+            Self::CompareEditQuery
+            | Self::Scroll {
+                target: ScrollTarget::ExplainCompare,
+                ..
+            } => PlanComparison,
             _ => None,
         }
     }
@@ -760,6 +810,62 @@ mod tests {
     })]
     fn non_scroll_action_returns_false(#[case] action: Action) {
         assert!(!action.is_scroll());
+    }
+
+    #[test]
+    fn completion_actions_keep_feature_requirements() {
+        assert_eq!(
+            Action::ExplainCompleted {
+                dsn: "dsn".to_string(),
+                run_id: 1,
+                query: "SELECT 1".to_string(),
+                plan_text: "plan".to_string(),
+                is_analyze: true,
+                execution_time_ms: 1,
+            }
+            .feature_requirement(),
+            FeatureRequirement::ExplainAnalyze
+        );
+        assert_eq!(
+            Action::ExplainFailed {
+                dsn: "dsn".to_string(),
+                run_id: 1,
+                error: DbOperationError::QueryFailed("error".to_string()),
+                is_analyze: false,
+            }
+            .feature_requirement(),
+            FeatureRequirement::Explain
+        );
+        assert_eq!(
+            Action::SqliteDiagnosticsCoreLoaded {
+                dsn: "sqlite://test.db".to_string(),
+                run_id: 1,
+                snapshot: Box::new(SqliteDiagnosticsSnapshot::default()),
+            }
+            .feature_requirement(),
+            FeatureRequirement::SqliteDiagnostics
+        );
+        assert_eq!(
+            Action::ExplainAnalyzeCancel.feature_requirement(),
+            FeatureRequirement::ExplainAnalyze
+        );
+        assert_eq!(
+            Action::Scroll {
+                target: ScrollTarget::ExplainCompare,
+                direction: ScrollDirection::Down,
+                amount: ScrollAmount::Line,
+            }
+            .feature_requirement(),
+            FeatureRequirement::PlanComparison
+        );
+        assert_eq!(
+            Action::TextInput {
+                target: InputTarget::SqlModalAnalyzeHighRisk,
+                ch: 'x',
+            }
+            .feature_requirement(),
+            FeatureRequirement::ExplainAnalyze
+        );
     }
 
     mod shared_scroll_helpers {

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -4,8 +4,10 @@ use crate::domain::connection::{
     ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
 };
 use crate::domain::query_history::QueryHistoryEntry;
+use crate::model::app_state::AppState;
 use crate::model::connection::error::ConnectionErrorInfo;
 use crate::model::shared::focused_pane::FocusedPane;
+use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::Prefix;
 use crate::model::sql_editor::completion::CompletionCandidate;
 use crate::policy::FeatureRequirement;
@@ -781,6 +783,17 @@ impl Action {
                 ..
             } => PlanComparison,
             _ => None,
+        }
+    }
+
+    pub fn feature_requirement_for_state(&self, state: &AppState) -> FeatureRequirement {
+        match self {
+            Self::Paste(_) => match state.input_mode() {
+                InputMode::ErTablePicker => FeatureRequirement::ErDiagram,
+                InputMode::JsonbDetail | InputMode::JsonbEdit => FeatureRequirement::JsonbDetail,
+                _ => FeatureRequirement::None,
+            },
+            _ => self.feature_requirement(),
         }
     }
 }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -8,6 +8,7 @@ use crate::model::connection::error::ConnectionErrorInfo;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::key_sequence::Prefix;
 use crate::model::sql_editor::completion::CompletionCandidate;
+use crate::policy::FeatureRequirement;
 use crate::policy::write::write_guardrails::WritePreview;
 use crate::ports::outbound::clipboard::ClipboardError;
 use crate::ports::outbound::connection_store::ConnectionStoreError;
@@ -640,6 +641,97 @@ impl Action {
 
     pub fn is_scroll(&self) -> bool {
         matches!(self, Self::Scroll { .. })
+    }
+
+    pub fn feature_requirement(&self) -> FeatureRequirement {
+        use FeatureRequirement::{
+            ErDiagram, Explain, ExplainAnalyze, JsonbDetail, None, PlanComparison,
+            SqliteDiagnostics,
+        };
+
+        match self {
+            Self::OpenModal(ModalKind::ErTablePicker)
+            | Self::ToggleModal(ModalKind::ErTablePicker)
+            | Self::ErToggleSelection
+            | Self::ErSelectAll
+            | Self::ErConfirmSelection
+            | Self::ErOpenDiagram
+            | Self::ErGenerateFromCache
+            | Self::SmartErRefreshCompleted(_)
+            | Self::SmartErRefreshFailed(_)
+            | Self::ErDiagramOpened(_)
+            | Self::ErDiagramFailed(_)
+            | Self::ErLogWriteFailed(_)
+            | Self::TextInput {
+                target: InputTarget::ErFilter,
+                ..
+            }
+            | Self::TextBackspace {
+                target: InputTarget::ErFilter,
+            }
+            | Self::TextDelete {
+                target: InputTarget::ErFilter,
+            }
+            | Self::TextKill {
+                target: InputTarget::ErFilter,
+                ..
+            }
+            | Self::TextYank {
+                target: InputTarget::ErFilter,
+            }
+            | Self::TextMoveCursor {
+                target: InputTarget::ErFilter,
+                ..
+            }
+            | Self::ListSelect {
+                target: ListTarget::ErTablePicker,
+                ..
+            } => ErDiagram,
+            Self::OpenModal(ModalKind::SqliteDiagnostics)
+            | Self::ToggleModal(ModalKind::SqliteDiagnostics)
+            | Self::RunSqliteDiagnosticsQuickCheck
+            | Self::Scroll {
+                target: ScrollTarget::SqliteDiagnostics,
+                ..
+            } => SqliteDiagnostics,
+            Self::OpenModal(ModalKind::JsonbDetail)
+            | Self::ToggleModal(ModalKind::JsonbDetail)
+            | Self::JsonbYankAll
+            | Self::JsonbYankSuccess
+            | Self::JsonbEnterEdit
+            | Self::JsonbAppendInsert
+            | Self::JsonbExitEdit
+            | Self::JsonbEnterSearch
+            | Self::JsonbExitSearch
+            | Self::JsonbSearchNext
+            | Self::JsonbSearchPrev
+            | Self::JsonbSearchSubmit
+            | Self::TextInput {
+                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                ..
+            }
+            | Self::TextBackspace {
+                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+            }
+            | Self::TextDelete {
+                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+            }
+            | Self::TextKill {
+                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                ..
+            }
+            | Self::TextYank {
+                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+            }
+            | Self::TextMoveCursor {
+                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                ..
+            } => JsonbDetail,
+            Self::ExplainRequest => Explain,
+            Self::ExplainAnalyzeRequest | Self::ExplainAnalyzeConfirm => ExplainAnalyze,
+            Self::CompareEditQuery => PlanComparison,
+            _ => None,
+        }
     }
 }
 

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -5,6 +5,7 @@ use crate::domain::connection::{
 };
 use crate::domain::query_history::QueryHistoryEntry;
 use crate::model::app_state::AppState;
+use crate::model::browse::jsonb_detail::JsonbDetailMode;
 use crate::model::connection::error::ConnectionErrorInfo;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
@@ -788,6 +789,15 @@ impl Action {
 
     pub fn feature_requirement_for_state(&self, state: &AppState) -> FeatureRequirement {
         match self {
+            Self::JsonbExitEdit if state.input_mode() == InputMode::JsonbEdit => {
+                FeatureRequirement::None
+            }
+            Self::JsonbExitSearch
+                if state.input_mode() == InputMode::JsonbDetail
+                    && state.jsonb_detail.mode() == JsonbDetailMode::Searching =>
+            {
+                FeatureRequirement::None
+            }
             Self::Paste(_) => match state.input_mode() {
                 InputMode::ErTablePicker => FeatureRequirement::ErDiagram,
                 InputMode::JsonbDetail | InputMode::JsonbEdit => FeatureRequirement::JsonbDetail,
@@ -886,6 +896,30 @@ mod tests {
             }
             .feature_requirement(),
             FeatureRequirement::ExplainAnalyze
+        );
+    }
+
+    #[test]
+    fn jsonb_cleanup_actions_are_allowed_on_preserved_surfaces() {
+        let mut edit_state = AppState::new("test".to_string());
+        edit_state.modal.set_mode(InputMode::JsonbEdit);
+        assert_eq!(
+            Action::JsonbExitEdit.feature_requirement_for_state(&edit_state),
+            FeatureRequirement::None
+        );
+
+        let mut search_state = AppState::new("test".to_string());
+        search_state.modal.set_mode(InputMode::JsonbDetail);
+        search_state.jsonb_detail.enter_search();
+        assert_eq!(
+            Action::JsonbExitSearch.feature_requirement_for_state(&search_state),
+            FeatureRequirement::None
+        );
+
+        let normal_state = AppState::new("test".to_string());
+        assert_eq!(
+            Action::JsonbExitEdit.feature_requirement_for_state(&normal_state),
+            FeatureRequirement::JsonbDetail
         );
     }
 

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -793,6 +793,14 @@ impl Action {
                 InputMode::JsonbDetail | InputMode::JsonbEdit => FeatureRequirement::JsonbDetail,
                 _ => FeatureRequirement::None,
             },
+            Self::BeginKeySequence(Prefix::G)
+                if matches!(
+                    state.input_mode(),
+                    InputMode::JsonbDetail | InputMode::JsonbEdit
+                ) =>
+            {
+                FeatureRequirement::JsonbDetail
+            }
             _ => self.feature_requirement(),
         }
     }

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -10,6 +10,7 @@ use crate::model::shared::key_sequence::KeySequenceState;
 use crate::model::shared::text_input::{TextInputEditing, TextInputLike};
 use crate::model::shared::ui_state::DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS;
 use crate::policy::preview_cell_text::{preview_cell_text_diff_handling, uses_jsonb_detail_modal};
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
@@ -21,6 +22,10 @@ use std::time::Instant;
 pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::JsonbDetail) => {
+            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+            if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
+                return DispatchResult::handled();
+            }
             let result = match state.query.visible_result() {
                 Some(r) if r.source == QuerySource::Preview && !r.is_error() => r,
                 _ => return DispatchResult::handled(),
@@ -400,6 +405,7 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
 #[cfg(test)]
 mod tests {
     use crate::test_support;
+    use crate::update::test_fixtures;
 
     use super::*;
     pub use crate::domain::Column;
@@ -430,6 +436,7 @@ mod tests {
 
     fn state_with_jsonb_value(cell_value: &str) -> AppState {
         let mut state = AppState::new("test".to_string());
+        test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
         state
             .query
             .set_current_result(Arc::new(QueryResult::success(

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -10,7 +10,6 @@ use crate::model::shared::key_sequence::KeySequenceState;
 use crate::model::shared::text_input::{TextInputEditing, TextInputLike};
 use crate::model::shared::ui_state::DEFAULT_JSONB_DETAIL_EDITOR_VISIBLE_ROWS;
 use crate::policy::preview_cell_text::CellPresentationPolicy;
-use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::ports::outbound::ClipboardError;
 use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
@@ -22,10 +21,6 @@ use std::time::Instant;
 pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::JsonbDetail) => {
-            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
-            if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
-                return DispatchResult::handled();
-            }
             let result = match state.query.visible_result() {
                 Some(r) if r.source == QuerySource::Preview && !r.is_error() => r,
                 _ => return DispatchResult::handled(),

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -2,6 +2,7 @@ use std::time::Instant;
 
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::update::action::{Action, ErDiagramInfo};
 use crate::update::dispatch_result::DispatchResult;
 
@@ -37,6 +38,10 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled()
         }
         Action::ErOpenDiagram => {
+            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+            if !feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
+                return DispatchResult::handled();
+            }
             if state.er_preparation.is_busy() {
                 return DispatchResult::handled();
             }
@@ -63,6 +68,10 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled_with(vec![Effect::SmartErRefresh { dsn, run_id }])
         }
         Action::ErGenerateFromCache => {
+            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+            if !feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
+                return DispatchResult::handled();
+            }
             if !state.er_preparation.can_generate_from_cache() {
                 return DispatchResult::handled();
             }

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -2,9 +2,9 @@ use std::time::Instant;
 
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
-use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::update::action::{Action, ErDiagramInfo};
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::require_er_diagram_enabled;
 
 pub(super) fn reduce_diagram_lifecycle(
     state: &mut AppState,
@@ -38,13 +38,8 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled()
         }
         Action::ErOpenDiagram => {
-            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
-            if !feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
-                state.messages.set_error_at(
-                    "ER diagrams are not available for this connection".to_string(),
-                    now,
-                );
-                return DispatchResult::handled();
+            if let Some(result) = require_er_diagram_enabled(state, now) {
+                return result;
             }
             if state.er_preparation.is_busy() {
                 return DispatchResult::handled();
@@ -72,13 +67,8 @@ pub(super) fn reduce_diagram_lifecycle(
             DispatchResult::handled_with(vec![Effect::SmartErRefresh { dsn, run_id }])
         }
         Action::ErGenerateFromCache => {
-            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
-            if !feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
-                state.messages.set_error_at(
-                    "ER diagrams are not available for this connection".to_string(),
-                    now,
-                );
-                return DispatchResult::handled();
+            if let Some(result) = require_er_diagram_enabled(state, now) {
+                return result;
             }
             if !state.er_preparation.can_generate_from_cache() {
                 return DispatchResult::handled();

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -117,6 +117,9 @@ mod tests {
         #[test]
         fn no_dsn_returns_error() {
             let mut state = AppState::new("test".to_string());
+            state
+                .session
+                .set_active_engine_feature_profile_for_test(DatabaseType::PostgreSQL);
             state.session.set_metadata(Some(make_metadata(5)));
 
             let effects = reduce_er(&mut state, &Action::ErOpenDiagram, Instant::now())

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -13,7 +13,7 @@ use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::{
     begin_explain_running, finish_explain_unsupported_analyze, is_multi_statement,
-    reject_unsupported_explain_analyze, show_explain_error_on_plan,
+    show_explain_error_on_plan,
 };
 
 pub(super) fn reduce_analyze(
@@ -24,9 +24,6 @@ pub(super) fn reduce_analyze(
 ) -> DispatchResult {
     match action {
         Action::ExplainAnalyzeRequest => {
-            if reject_unsupported_explain_analyze(state) {
-                return DispatchResult::handled();
-            }
             let content = state.sql_modal.editor.content().trim().to_string();
             if content.is_empty() {
                 return DispatchResult::handled();
@@ -93,9 +90,6 @@ pub(super) fn reduce_analyze(
         }
 
         Action::ExplainAnalyzeConfirm => {
-            if reject_unsupported_explain_analyze(state) {
-                return DispatchResult::handled();
-            }
             let query = match state.sql_modal.status() {
                 SqlModalStatus::ConfirmingAnalyzeHigh {
                     query,

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -114,23 +114,3 @@ pub(super) fn finish_explain_error(state: &mut AppState, error: impl Into<String
     state.sql_modal.set_active_tab(SqlModalTab::Plan);
     state.query.mark_idle();
 }
-
-pub(super) fn reject_unsupported_explain_analyze(state: &mut AppState) -> bool {
-    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
-    if feature_policy.is_enabled(FeatureRequirement::ExplainAnalyze) {
-        return false;
-    }
-
-    apply_explain_unsupported_analyze_state(state);
-    true
-}
-
-pub(super) fn reject_unsupported_explain(state: &mut AppState) -> bool {
-    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
-    if feature_policy.is_enabled(FeatureRequirement::Explain) {
-        return false;
-    }
-
-    mark_explain_unavailable(state);
-    true
-}

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -5,6 +5,7 @@ use crate::model::app_state::AppState;
 use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
 use crate::policy::sql::statement_classifier;
 use crate::policy::write::sql_risk::split_statements_for_database;
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 
 pub(super) fn explain_unsupported_query_message(database_type: DatabaseType) -> &'static str {
     match database_type {
@@ -47,11 +48,8 @@ pub(super) fn mark_explain_unsupported_analyze(state: &mut AppState) {
 }
 
 fn apply_explain_unsupported_analyze_state(state: &mut AppState) {
-    if state
-        .session
-        .active_engine_feature_profile()
-        .supports_explain()
-    {
+    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    if feature_policy.is_enabled(FeatureRequirement::Explain) {
         mark_explain_unsupported_analyze(state);
     } else {
         mark_explain_unavailable(state);
@@ -118,11 +116,8 @@ pub(super) fn finish_explain_error(state: &mut AppState, error: impl Into<String
 }
 
 pub(super) fn reject_unsupported_explain_analyze(state: &mut AppState) -> bool {
-    if state
-        .session
-        .active_engine_feature_profile()
-        .supports_explain_analyze()
-    {
+    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    if feature_policy.is_enabled(FeatureRequirement::ExplainAnalyze) {
         return false;
     }
 
@@ -131,11 +126,8 @@ pub(super) fn reject_unsupported_explain_analyze(state: &mut AppState) -> bool {
 }
 
 pub(super) fn reject_unsupported_explain(state: &mut AppState) -> bool {
-    if state
-        .session
-        .active_engine_feature_profile()
-        .supports_explain()
-    {
+    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    if feature_policy.is_enabled(FeatureRequirement::Explain) {
         return false;
     }
 

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -57,6 +57,10 @@ mod tests {
         test_fixtures::activate_sqlite_connection(state, "sqlite:///tmp/app.db");
     }
 
+    fn reduce_at_boundary(state: &mut AppState, action: Action) -> Vec<Effect> {
+        crate::update::reducer::reduce(state, action, Instant::now(), &AppServices::stub())
+    }
+
     mod explain_request {
         use super::*;
 
@@ -104,19 +108,10 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
 
-            let effects = dispatch_explain(
-                &mut state,
-                &Action::ExplainRequest,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects = reduce_at_boundary(&mut state, Action::ExplainRequest);
 
             assert!(effects.is_empty());
-            assert_eq!(
-                state.explain.error.as_deref(),
-                Some("EXPLAIN is unavailable for this database")
-            );
+            assert!(state.explain.error.is_none());
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
@@ -244,20 +239,11 @@ mod tests {
                 .set_content("DELETE FROM users".to_string());
             activate_sqlite_connection(&mut state);
 
-            let effects = dispatch_explain(
-                &mut state,
-                &Action::ExplainAnalyzeRequest,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects = reduce_at_boundary(&mut state, Action::ExplainAnalyzeRequest);
 
             assert!(effects.is_empty());
-            assert_eq!(
-                state.explain.error.as_deref(),
-                Some("EXPLAIN ANALYZE is not supported for SQLite")
-            );
-            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
+            assert!(state.explain.error.is_none());
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
             assert!(!matches!(
                 state.sql_modal.status(),
                 SqlModalStatus::ConfirmingAnalyzeHigh { .. }
@@ -367,19 +353,10 @@ mod tests {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
 
-            let effects = dispatch_explain(
-                &mut state,
-                &Action::ExplainAnalyzeRequest,
-                Instant::now(),
-                &AppServices::stub(),
-            )
-            .unwrap();
+            let effects = reduce_at_boundary(&mut state, Action::ExplainAnalyzeRequest);
 
             assert!(effects.is_empty());
-            assert_eq!(
-                state.explain.error.as_deref(),
-                Some("EXPLAIN is unavailable for this database")
-            );
+            assert!(state.explain.error.is_none());
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
         }
 
@@ -882,15 +859,12 @@ mod tests {
                 state.explain.right().map(|slot| slot.full_query.as_str()),
                 Some("SELECT stale")
             );
-            reduce_explain(&mut state, &Action::CompareEditQuery, Instant::now());
+            reduce_at_boundary(&mut state, Action::CompareEditQuery);
 
             assert_eq!(state.sql_modal.editor.content(), editor_before);
             assert_eq!(state.sql_modal.status(), &status_before);
             assert_eq!(state.sql_modal.active_tab(), active_tab_before);
-            assert_eq!(
-                state.messages.last_error.as_deref(),
-                Some("Plan comparison is not available for this connection")
-            );
+            assert!(state.messages.last_error.is_none());
         }
 
         #[test]

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -40,6 +40,7 @@ mod tests {
     use crate::ports::outbound::AccessMode;
     use crate::services::AppServices;
     use crate::update::action::{ScrollAmount, ScrollDirection, ScrollTarget};
+    use crate::update::reducer::reduce;
     use crate::update::test_fixtures;
     use std::time::Instant;
 
@@ -58,7 +59,7 @@ mod tests {
     }
 
     fn reduce_at_boundary(state: &mut AppState, action: Action) -> Vec<Effect> {
-        crate::update::reducer::reduce(state, action, Instant::now(), &AppServices::stub())
+        reduce(state, action, Instant::now(), &AppServices::stub())
     }
 
     mod explain_request {

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -817,6 +817,7 @@ mod tests {
                     dsn: "dsn://test".to_string(),
                     run_id: 1,
                     error: DbOperationError::QueryFailed("syntax error".to_string()),
+                    is_analyze: false,
                 },
                 Instant::now(),
             );
@@ -846,6 +847,7 @@ mod tests {
                     dsn: "dsn://stale".to_string(),
                     run_id: 1,
                     error: DbOperationError::QueryFailed("syntax error".to_string()),
+                    is_analyze: false,
                 },
                 Instant::now(),
             );

--- a/src/app/update/explain/output.rs
+++ b/src/app/update/explain/output.rs
@@ -33,7 +33,9 @@ pub(super) fn reduce_output(
             DispatchResult::handled()
         }
 
-        Action::ExplainFailed { dsn, run_id, error } => {
+        Action::ExplainFailed {
+            dsn, run_id, error, ..
+        } => {
             if state.is_stale_query_run(dsn, *run_id) {
                 return DispatchResult::handled();
             }

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -12,7 +12,7 @@ use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::{
     begin_explain_running, is_multi_statement, mark_explain_unavailable,
-    mark_explain_unsupported_query, reject_unsupported_explain, show_explain_error_on_plan,
+    mark_explain_unsupported_query, show_explain_error_on_plan,
 };
 
 pub(super) fn reduce_request(
@@ -23,9 +23,6 @@ pub(super) fn reduce_request(
 ) -> DispatchResult {
     match action {
         Action::ExplainRequest => {
-            if reject_unsupported_explain(state) {
-                return DispatchResult::handled();
-            }
             let content = state.sql_modal.editor.content().trim().to_string();
             if content.is_empty() {
                 return DispatchResult::handled();

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -4,6 +4,7 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
@@ -46,10 +47,8 @@ pub(super) fn reduce_request(
                 .build_explain_sql(database_type, &content)
             {
                 Some(query) => query,
-                None if state
-                    .session
-                    .active_engine_feature_profile()
-                    .supports_explain() =>
+                None if FeaturePolicy::new(state.session.active_engine_feature_profile())
+                    .is_enabled(FeatureRequirement::Explain) =>
                 {
                     mark_explain_unsupported_query(state, &content);
                     return DispatchResult::handled();

--- a/src/app/update/explain/tabs.rs
+++ b/src/app/update/explain/tabs.rs
@@ -1,21 +1,12 @@
 use std::time::Instant;
 
 use crate::model::app_state::AppState;
-use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
-pub(super) fn reduce_tabs(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
+pub(super) fn reduce_tabs(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
     match action {
         Action::CompareEditQuery => {
-            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
-            if !feature_policy.is_enabled(FeatureRequirement::PlanComparison) {
-                state.messages.set_error_at(
-                    "Plan comparison is not available for this connection".to_string(),
-                    now,
-                );
-                return DispatchResult::handled();
-            }
             if let Some(ref right) = state.explain.right {
                 let query = right.full_query.clone();
                 state.sql_modal.load_query_for_editing(query);

--- a/src/app/update/explain/tabs.rs
+++ b/src/app/update/explain/tabs.rs
@@ -1,12 +1,17 @@
 use std::time::Instant;
 
 use crate::model::app_state::AppState;
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn reduce_tabs(state: &mut AppState, action: &Action, _now: Instant) -> DispatchResult {
     match action {
         Action::CompareEditQuery => {
+            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+            if !feature_policy.is_enabled(FeatureRequirement::PlanComparison) {
+                return DispatchResult::handled();
+            }
             if let Some(ref right) = state.explain.right {
                 let query = right.full_query.clone();
                 state.sql_modal.load_query_for_editing(query);

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use unicode_casefold::UnicodeCaseFold;
 
 use crate::domain::DatabaseType;
@@ -11,7 +13,25 @@ use crate::policy::write::write_guardrails::{
     PreviewWriteability, StableRowIdentity, TargetSummary, WriteOperation, WritePreview,
     evaluate_guardrails, preview_writeability, stable_row_identity_for_table,
 };
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::services::AppServices;
+use crate::update::dispatch_result::DispatchResult;
+
+pub(crate) fn require_er_diagram_enabled(
+    state: &mut AppState,
+    now: Instant,
+) -> Option<DispatchResult> {
+    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    if feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
+        return None;
+    }
+
+    state.messages.set_error_at(
+        "ER diagrams are not available for this connection".to_string(),
+        now,
+    );
+    Some(DispatchResult::handled())
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum EditGuardrailError {

--- a/src/app/update/input/handlers/editors.rs
+++ b/src/app/update/input/handlers/editors.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::policy::FeaturePolicy;
 use crate::update::action::{Action, InputTarget};
 use crate::update::input::keybindings;
@@ -40,12 +38,6 @@ pub fn handle_cell_edit_keys(combo: KeyCombo) -> Action {
         },
         _ => Action::None,
     }
-}
-
-#[cfg(test)]
-pub fn handle_command_line_mode(combo: KeyCombo) -> Action {
-    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
-    handle_command_line_mode_with_policy(combo, &feature_policy)
 }
 
 pub fn handle_command_line_mode_with_policy(
@@ -89,11 +81,17 @@ pub fn handle_command_line_mode_with_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
     use crate::update::input::keybindings::Key;
     use rstest::rstest;
 
     fn combo(k: Key) -> KeyCombo {
         KeyCombo::plain(k)
+    }
+
+    fn handle_command_line_mode(combo: KeyCombo) -> Action {
+        let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+        handle_command_line_mode_with_policy(combo, &feature_policy)
     }
 
     mod cell_edit_mode {

--- a/src/app/update/input/handlers/editors.rs
+++ b/src/app/update/input/handlers/editors.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
+use crate::policy::FeaturePolicy;
 use crate::update::action::{Action, InputTarget};
 use crate::update::input::keybindings;
 use crate::update::input::keybindings::{Key, KeyCombo};
@@ -39,9 +42,20 @@ pub fn handle_cell_edit_keys(combo: KeyCombo) -> Action {
     }
 }
 
+#[cfg(test)]
 pub fn handle_command_line_mode(combo: KeyCombo) -> Action {
+    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+    handle_command_line_mode_with_policy(combo, &feature_policy)
+}
+
+pub fn handle_command_line_mode_with_policy(
+    combo: KeyCombo,
+    feature_policy: &FeaturePolicy,
+) -> Action {
     use crate::update::action::CursorMove;
-    if let Some(action) = keymap::resolve(&combo, keybindings::COMMAND_LINE_KEYS) {
+    if let Some(action) =
+        keymap::resolve_with_policy(&combo, keybindings::COMMAND_LINE_KEYS, feature_policy)
+    {
         return action;
     }
     match combo.key {

--- a/src/app/update/input/handlers/jsonb.rs
+++ b/src/app/update/input/handlers/jsonb.rs
@@ -1,4 +1,7 @@
+#[cfg(test)]
+use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::model::shared::key_sequence::Prefix;
+use crate::policy::FeaturePolicy;
 use crate::update::action::{Action, CursorMove, InputTarget};
 use crate::update::input::keybindings::{
     JSONB_DETAIL, JSONB_EDIT, JSONB_SEARCH_KEYS, Key, KeyCombo, Modifiers,
@@ -10,16 +13,27 @@ use crate::update::input::vim::{
 
 use super::interaction::InputInteraction;
 
+#[cfg(test)]
 pub fn handle_jsonb_detail_keys(
     combo: KeyCombo,
     interaction: InputInteraction,
     pending_prefix: Option<Prefix>,
 ) -> Action {
+    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+    handle_jsonb_detail_keys_with_policy(combo, interaction, pending_prefix, &feature_policy)
+}
+
+pub fn handle_jsonb_detail_keys_with_policy(
+    combo: KeyCombo,
+    interaction: InputInteraction,
+    pending_prefix: Option<Prefix>,
+    feature_policy: &FeaturePolicy,
+) -> Action {
     if matches!(
         interaction,
         InputInteraction::FormEditing(InputTarget::JsonbSearch)
     ) {
-        return handle_search_input(combo);
+        return handle_search_input(combo, feature_policy);
     }
 
     if let Some(prefix) = pending_prefix {
@@ -66,15 +80,15 @@ pub fn handle_jsonb_detail_keys(
         return action;
     }
 
-    if let Some(action) = JSONB_DETAIL.resolve(&combo) {
+    if let Some(action) = JSONB_DETAIL.resolve_with_policy(&combo, feature_policy) {
         return action;
     }
     Action::None
 }
 
-fn handle_search_input(combo: KeyCombo) -> Action {
+fn handle_search_input(combo: KeyCombo, feature_policy: &FeaturePolicy) -> Action {
     // Command keys (Enter/Esc) resolved from SSOT keybindings
-    if let Some(action) = keymap::resolve(&combo, JSONB_SEARCH_KEYS) {
+    if let Some(action) = keymap::resolve_with_policy(&combo, JSONB_SEARCH_KEYS, feature_policy) {
         return action;
     }
     // Text input fallthrough
@@ -109,7 +123,16 @@ fn handle_search_input(combo: KeyCombo) -> Action {
     }
 }
 
+#[cfg(test)]
 pub fn handle_jsonb_edit_keys(combo: KeyCombo) -> Action {
+    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+    handle_jsonb_edit_keys_with_policy(combo, &feature_policy)
+}
+
+pub fn handle_jsonb_edit_keys_with_policy(
+    combo: KeyCombo,
+    feature_policy: &FeaturePolicy,
+) -> Action {
     if let Some(action) = action_for_key(
         &combo,
         VimSurfaceContext::JsonbDetail(JsonbDetailVimContext::Editing),
@@ -117,7 +140,7 @@ pub fn handle_jsonb_edit_keys(combo: KeyCombo) -> Action {
         return action;
     }
 
-    if let Some(action) = JSONB_EDIT.resolve(&combo) {
+    if let Some(action) = JSONB_EDIT.resolve_with_policy(&combo, feature_policy) {
         return action;
     }
     match combo.key {

--- a/src/app/update/input/handlers/jsonb.rs
+++ b/src/app/update/input/handlers/jsonb.rs
@@ -1,6 +1,6 @@
 use crate::model::shared::key_sequence::Prefix;
 use crate::policy::{FeaturePolicy, FeatureRequirement};
-use crate::update::action::{Action, CursorMove, InputTarget};
+use crate::update::action::{Action, CursorMove, InputTarget, ModalKind};
 use crate::update::input::keybindings::{
     JSONB_DETAIL, JSONB_EDIT, JSONB_SEARCH_KEYS, Key, KeyCombo, Modifiers,
 };
@@ -18,7 +18,7 @@ pub fn handle_jsonb_detail_keys_with_policy(
     feature_policy: &FeaturePolicy,
 ) -> Action {
     if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
-        return Action::None;
+        return disabled_jsonb_detail_exit_action(combo, interaction);
     }
 
     if matches!(
@@ -120,7 +120,9 @@ pub fn handle_jsonb_edit_keys_with_policy(
     feature_policy: &FeaturePolicy,
 ) -> Action {
     if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
-        return Action::None;
+        return (combo.modifiers.is_empty() && combo.key == Key::Esc)
+            .then_some(Action::JsonbExitEdit)
+            .unwrap_or(Action::None);
     }
 
     if let Some(action) = action_for_key(
@@ -176,6 +178,23 @@ pub fn handle_jsonb_edit_keys_with_policy(
             target: InputTarget::JsonbEdit,
             ch: '\t',
         },
+        _ => Action::None,
+    }
+}
+
+fn disabled_jsonb_detail_exit_action(combo: KeyCombo, interaction: InputInteraction) -> Action {
+    if !combo.modifiers.is_empty() {
+        return Action::None;
+    }
+
+    match (interaction, combo.key) {
+        (InputInteraction::Viewing, Key::Esc | Key::Char('q')) => {
+            Action::CloseModal(ModalKind::JsonbDetail)
+        }
+        (InputInteraction::FormEditing(InputTarget::JsonbSearch), Key::Esc) => {
+            Action::JsonbExitSearch
+        }
+        (InputInteraction::VimEditing(InputTarget::JsonbEdit), Key::Esc) => Action::JsonbExitEdit,
         _ => Action::None,
     }
 }
@@ -334,6 +353,34 @@ mod tests {
         }
 
         #[test]
+        fn sqlite_jsonb_detail_keeps_escape_close_action() {
+            let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::sqlite_like());
+
+            let result = handle_jsonb_detail_keys_with_policy(
+                combo(Key::Esc),
+                InputInteraction::Viewing,
+                None,
+                &feature_policy,
+            );
+
+            assert!(matches!(result, Action::CloseModal(ModalKind::JsonbDetail)));
+        }
+
+        #[test]
+        fn sqlite_jsonb_detail_keeps_search_escape_action() {
+            let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::sqlite_like());
+
+            let result = handle_jsonb_detail_keys_with_policy(
+                combo(Key::Esc),
+                InputInteraction::FormEditing(InputTarget::JsonbSearch),
+                None,
+                &feature_policy,
+            );
+
+            assert!(matches!(result, Action::JsonbExitSearch));
+        }
+
+        #[test]
         fn gg_moves_to_first_line() {
             let result = handle_jsonb_detail_keys(
                 combo(Key::Char('g')),
@@ -465,6 +512,15 @@ mod tests {
                     direction: CursorMove::Up,
                 }
             ));
+        }
+
+        #[test]
+        fn sqlite_jsonb_edit_keeps_escape_normal_action() {
+            let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::sqlite_like());
+
+            let result = handle_jsonb_edit_keys_with_policy(combo(Key::Esc), &feature_policy);
+
+            assert!(matches!(result, Action::JsonbExitEdit));
         }
     }
 }

--- a/src/app/update/input/handlers/jsonb.rs
+++ b/src/app/update/input/handlers/jsonb.rs
@@ -120,9 +120,11 @@ pub fn handle_jsonb_edit_keys_with_policy(
     feature_policy: &FeaturePolicy,
 ) -> Action {
     if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
-        return (combo.modifiers.is_empty() && combo.key == Key::Esc)
-            .then_some(Action::JsonbExitEdit)
-            .unwrap_or(Action::None);
+        return if combo.modifiers.is_empty() && combo.key == Key::Esc {
+            Action::JsonbExitEdit
+        } else {
+            Action::None
+        };
     }
 
     if let Some(action) = action_for_key(

--- a/src/app/update/input/handlers/jsonb.rs
+++ b/src/app/update/input/handlers/jsonb.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::model::shared::key_sequence::Prefix;
 use crate::policy::FeaturePolicy;
 use crate::update::action::{Action, CursorMove, InputTarget};
@@ -12,16 +10,6 @@ use crate::update::input::vim::{
 };
 
 use super::interaction::InputInteraction;
-
-#[cfg(test)]
-pub fn handle_jsonb_detail_keys(
-    combo: KeyCombo,
-    interaction: InputInteraction,
-    pending_prefix: Option<Prefix>,
-) -> Action {
-    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
-    handle_jsonb_detail_keys_with_policy(combo, interaction, pending_prefix, &feature_policy)
-}
 
 pub fn handle_jsonb_detail_keys_with_policy(
     combo: KeyCombo,
@@ -123,12 +111,6 @@ fn handle_search_input(combo: KeyCombo, feature_policy: &FeaturePolicy) -> Actio
     }
 }
 
-#[cfg(test)]
-pub fn handle_jsonb_edit_keys(combo: KeyCombo) -> Action {
-    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
-    handle_jsonb_edit_keys_with_policy(combo, &feature_policy)
-}
-
 pub fn handle_jsonb_edit_keys_with_policy(
     combo: KeyCombo,
     feature_policy: &FeaturePolicy,
@@ -193,6 +175,7 @@ pub fn handle_jsonb_edit_keys_with_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
     use crate::update::action::CursorMove;
     use crate::update::input::keybindings::Key;
 
@@ -202,6 +185,20 @@ mod tests {
 
     fn combo_ctrl(k: Key) -> KeyCombo {
         KeyCombo::ctrl(k)
+    }
+
+    fn handle_jsonb_detail_keys(
+        combo: KeyCombo,
+        interaction: InputInteraction,
+        pending_prefix: Option<Prefix>,
+    ) -> Action {
+        let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+        handle_jsonb_detail_keys_with_policy(combo, interaction, pending_prefix, &feature_policy)
+    }
+
+    fn handle_jsonb_edit_keys(combo: KeyCombo) -> Action {
+        let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+        handle_jsonb_edit_keys_with_policy(combo, &feature_policy)
     }
 
     mod jsonb_detail {

--- a/src/app/update/input/handlers/jsonb.rs
+++ b/src/app/update/input/handlers/jsonb.rs
@@ -1,5 +1,5 @@
 use crate::model::shared::key_sequence::Prefix;
-use crate::policy::FeaturePolicy;
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::update::action::{Action, CursorMove, InputTarget};
 use crate::update::input::keybindings::{
     JSONB_DETAIL, JSONB_EDIT, JSONB_SEARCH_KEYS, Key, KeyCombo, Modifiers,
@@ -17,6 +17,10 @@ pub fn handle_jsonb_detail_keys_with_policy(
     pending_prefix: Option<Prefix>,
     feature_policy: &FeaturePolicy,
 ) -> Action {
+    if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
+        return Action::None;
+    }
+
     if matches!(
         interaction,
         InputInteraction::FormEditing(InputTarget::JsonbSearch)
@@ -115,6 +119,10 @@ pub fn handle_jsonb_edit_keys_with_policy(
     combo: KeyCombo,
     feature_policy: &FeaturePolicy,
 ) -> Action {
+    if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
+        return Action::None;
+    }
+
     if let Some(action) = action_for_key(
         &combo,
         VimSurfaceContext::JsonbDetail(JsonbDetailVimContext::Editing),
@@ -309,6 +317,20 @@ mod tests {
                 handle_jsonb_detail_keys(combo(Key::Char('g')), InputInteraction::Viewing, None);
 
             assert!(matches!(result, Action::BeginKeySequence(Prefix::G)));
+        }
+
+        #[test]
+        fn sqlite_jsonb_detail_ignores_g() {
+            let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::sqlite_like());
+
+            let result = handle_jsonb_detail_keys_with_policy(
+                combo(Key::Char('g')),
+                InputInteraction::Viewing,
+                None,
+                &feature_policy,
+            );
+
+            assert!(matches!(result, Action::None));
         }
 
         #[test]

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -27,6 +27,12 @@ pub fn handle_event(event: InputEvent, state: &AppState) -> Action {
 }
 
 fn handle_paste_event(text: String, state: &AppState) -> Action {
+    let action = Action::Paste(text);
+    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    if !feature_policy.is_enabled(action.feature_requirement_for_state(state)) {
+        return Action::None;
+    }
+
     match state.input_mode() {
         InputMode::TablePicker
         | InputMode::ErTablePicker
@@ -37,7 +43,7 @@ fn handle_paste_event(text: String, state: &AppState) -> Action {
         | InputMode::QueryHistoryPicker
         | InputMode::JsonbEdit
         | InputMode::JsonbDetail
-        | InputMode::CellDetail => Action::Paste(text),
+        | InputMode::CellDetail => action,
         _ => Action::None,
     }
 }
@@ -430,6 +436,7 @@ mod tests {
 
     mod paste_event {
         use super::*;
+        use crate::update::test_fixtures;
 
         fn make_state(mode: InputMode) -> AppState {
             let mut state = AppState::new("test".to_string());
@@ -457,11 +464,32 @@ mod tests {
 
         #[test]
         fn er_table_picker_pastes_text() {
-            let state = make_state(InputMode::ErTablePicker);
+            let mut state = make_state(InputMode::ErTablePicker);
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
 
             let result = handle_paste_event("public.users".to_string(), &state);
 
             assert!(matches!(result, Action::Paste(t) if t == "public.users"));
+        }
+
+        #[test]
+        fn sqlite_ignores_er_table_picker_paste() {
+            let mut state = make_state(InputMode::ErTablePicker);
+            test_fixtures::activate_sqlite_connection(&mut state, "sqlite://test.db");
+
+            let result = handle_paste_event("public.users".to_string(), &state);
+
+            assert!(matches!(result, Action::None));
+        }
+
+        #[test]
+        fn sqlite_ignores_jsonb_edit_paste() {
+            let mut state = make_state(InputMode::JsonbEdit);
+            test_fixtures::activate_sqlite_connection(&mut state, "sqlite://test.db");
+
+            let result = handle_paste_event("{}".to_string(), &state);
+
+            assert!(matches!(result, Action::None));
         }
 
         #[test]

--- a/src/app/update/input/handlers/mod.rs
+++ b/src/app/update/input/handlers/mod.rs
@@ -11,6 +11,7 @@ mod sql_modal;
 
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
+use crate::policy::FeaturePolicy;
 use crate::ports::inbound::{InputEvent, KeyCombo};
 use crate::update::action::Action;
 use crate::update::input::keybindings::readline_action_for;
@@ -42,6 +43,7 @@ fn handle_paste_event(text: String, state: &AppState) -> Action {
 }
 
 fn handle_key_event(combo: KeyCombo, state: &AppState) -> Action {
+    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
     let interaction = resolve_input_interaction(state);
     match interaction {
         InputInteraction::FormEditing(target) => {
@@ -56,16 +58,20 @@ fn handle_key_event(combo: KeyCombo, state: &AppState) -> Action {
     }
     match state.input_mode() {
         InputMode::Normal => normal::handle_normal_mode(combo, state),
-        InputMode::CommandLine => editors::handle_command_line_mode(combo),
+        InputMode::CommandLine => {
+            editors::handle_command_line_mode_with_policy(combo, &feature_policy)
+        }
         InputMode::CellEdit => editors::handle_cell_edit_keys(combo),
         InputMode::TablePicker => pickers::handle_table_picker_keys(combo),
         InputMode::CommandPalette => pickers::handle_command_palette_keys(combo),
         InputMode::Settings => pickers::handle_settings_keys(combo, state),
-        InputMode::Help => overlays::handle_help_keys(combo, interaction),
+        InputMode::Help => {
+            overlays::handle_help_keys_with_policy(combo, interaction, &feature_policy)
+        }
         InputMode::SqlModal => {
             let completion_visible = state.sql_modal.completion().visible
                 && !state.sql_modal.completion().candidates.is_empty();
-            sql_modal::handle_sql_modal_keys_with_prefix(
+            sql_modal::handle_sql_modal_keys_with_feature_policy(
                 combo,
                 completion_visible,
                 state.sql_modal.status(),
@@ -75,25 +81,25 @@ fn handle_key_event(combo: KeyCombo, state: &AppState) -> Action {
                     .normalize_sql_modal_tab(state.sql_modal.active_tab()),
                 state.ui.key_sequence().pending_prefix(),
                 state.settings.saved_keymap_preset(),
-                state
-                    .session
-                    .active_engine_feature_profile()
-                    .supports_explain_analyze(),
+                &feature_policy,
             )
         }
         InputMode::ConnectionSetup => connections::handle_connection_setup_keys(combo, state),
         InputMode::ConnectionError => connections::handle_connection_error_keys(combo),
         InputMode::ConfirmDialog => overlays::handle_confirm_dialog_keys(combo),
-        InputMode::SqliteDiagnostics => overlays::handle_sqlite_diagnostics_keys(combo),
+        InputMode::SqliteDiagnostics => {
+            overlays::handle_sqlite_diagnostics_keys_with_policy(combo, &feature_policy)
+        }
         InputMode::ConnectionSelector => connections::handle_connection_selector_keys(combo),
         InputMode::ErTablePicker => pickers::handle_er_table_picker_keys(combo, state),
         InputMode::QueryHistoryPicker => pickers::handle_query_history_picker_keys(combo),
-        InputMode::JsonbDetail => jsonb::handle_jsonb_detail_keys(
+        InputMode::JsonbDetail => jsonb::handle_jsonb_detail_keys_with_policy(
             combo,
             interaction,
             state.ui.key_sequence().pending_prefix(),
+            &feature_policy,
         ),
-        InputMode::JsonbEdit => jsonb::handle_jsonb_edit_keys(combo),
+        InputMode::JsonbEdit => jsonb::handle_jsonb_edit_keys_with_policy(combo, &feature_policy),
         InputMode::CellDetail => {
             let is_searching = state.cell_detail.search().is_active();
             cell_detail::handle_cell_detail_keys(combo, is_searching)
@@ -120,7 +126,24 @@ mod tests {
 
     mod mode_dispatch {
         use super::*;
+        use crate::domain::{ConnectionId, DatabaseType};
         use crate::model::sql_editor::modal::SqlModalTab;
+        use crate::update::test_fixtures;
+
+        fn sqlite_connected_state() -> AppState {
+            let mut state = AppState::new("test".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "database",
+                DatabaseType::SQLite,
+                "sqlite://test.db",
+            );
+            state
+        }
+
+        fn combo_ctrl_shift(key: Key) -> KeyCombo {
+            KeyCombo::ctrl_shift(key)
+        }
 
         fn make_state(mode: InputMode) -> AppState {
             let mut state = AppState::new("test".to_string());
@@ -165,6 +188,41 @@ mod tests {
             let result = handle_key_event(combo(Key::Char('/')), &state);
 
             assert!(matches!(result, Action::CellDetailEnterSearch));
+        }
+
+        #[test]
+        fn engine_specific_global_features_follow_the_active_profile() {
+            let state = sqlite_connected_state();
+
+            assert!(matches!(
+                handle_key_event(combo(Key::Char('e')), &state),
+                Action::None
+            ));
+            assert!(matches!(
+                handle_key_event(combo_ctrl_shift(Key::Char('d')), &state),
+                Action::OpenModal(ModalKind::SqliteDiagnostics)
+            ));
+
+            let mut postgres_state = AppState::new("test".to_string());
+            test_fixtures::activate_postgres_connection(
+                &mut postgres_state,
+                "postgres://localhost/test",
+            );
+            assert!(matches!(
+                handle_key_event(combo_ctrl_shift(Key::Char('d')), &postgres_state),
+                Action::None
+            ));
+        }
+
+        #[test]
+        fn postgres_input_keeps_er_diagram_available() {
+            let mut state = make_state(InputMode::Normal);
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
+
+            assert!(matches!(
+                handle_key_event(combo(Key::Char('e')), &state),
+                Action::OpenModal(ModalKind::ErTablePicker)
+            ));
         }
     }
 

--- a/src/app/update/input/handlers/normal.rs
+++ b/src/app/update/input/handlers/normal.rs
@@ -1,6 +1,7 @@
 use crate::model::app_state::AppState;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::key_sequence::Prefix;
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::update::action::{Action, ModalKind};
 use crate::update::input::keybindings::{self as kb, Key, KeyCombo, Modifiers};
 use crate::update::input::vim::{
@@ -12,6 +13,7 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
     let result_navigation = browse_ctx.is_result();
     let inspector_navigation = browse_ctx.is_inspector();
     let keymap_preset = state.settings.saved_keymap_preset();
+    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
 
     // Key sequence FSM: two-key sequences (zz, zt, zb)
     // Must be resolved before Ctrl/global actions so that the second key is
@@ -62,16 +64,9 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
     }
 
     // Global actions (predicate-based, no modifiers)
-    if let Some(action) = kb::global_action_for(&combo, keymap_preset) {
+    if let Some(action) = kb::global_action_for_with_policy(&combo, keymap_preset, &feature_policy)
+    {
         if matches!(action, Action::RequestCsvExport) && !state.can_request_csv_export() {
-            return Action::None;
-        }
-        if matches!(action, Action::OpenModal(ModalKind::SqliteDiagnostics))
-            && !state
-                .session
-                .active_engine_feature_profile()
-                .supports_sqlite_diagnostics()
-        {
             return Action::None;
         }
         return action;
@@ -136,12 +131,7 @@ pub fn handle_normal_mode(combo: KeyCombo, state: &AppState) -> Action {
             Action::UnstageLastStagedRow
         }
         Key::Char('s') => Action::OpenModal(ModalKind::SqlModal),
-        Key::Char('e')
-            if state
-                .session
-                .active_engine_feature_profile()
-                .supports_er_diagram() =>
-        {
+        Key::Char('e') if feature_policy.is_enabled(FeatureRequirement::ErDiagram) => {
             Action::OpenModal(ModalKind::ErTablePicker)
         }
         Key::Char('c') if state.ui.focused_pane() == FocusedPane::Explorer => {

--- a/src/app/update/input/handlers/overlays.rs
+++ b/src/app/update/input/handlers/overlays.rs
@@ -1,23 +1,41 @@
+#[cfg(test)]
+use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
+use crate::policy::FeaturePolicy;
 use crate::update::action::{Action, CursorMove, InputTarget};
 use crate::update::input::keybindings::{self, Key, KeyCombo, Modifiers};
 use crate::update::input::keymap;
 
 use super::interaction::InputInteraction;
 
+#[cfg(test)]
 pub fn handle_help_keys(combo: KeyCombo, interaction: InputInteraction) -> Action {
+    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+    handle_help_keys_with_policy(combo, interaction, &feature_policy)
+}
+
+pub fn handle_help_keys_with_policy(
+    combo: KeyCombo,
+    interaction: InputInteraction,
+    feature_policy: &FeaturePolicy,
+) -> Action {
     match interaction {
-        InputInteraction::Viewing => handle_help_viewing_keys(combo),
-        InputInteraction::FormEditing(InputTarget::HelpFilter) => handle_help_editing_keys(combo),
+        InputInteraction::Viewing => handle_help_viewing_keys(combo, feature_policy),
+        InputInteraction::FormEditing(InputTarget::HelpFilter) => {
+            handle_help_editing_keys(combo, feature_policy)
+        }
         InputInteraction::FormEditing(_) | InputInteraction::VimEditing(_) => Action::None,
     }
 }
 
-fn handle_help_viewing_keys(combo: KeyCombo) -> Action {
-    keymap::resolve_mode(&combo, keybindings::HELP_VIEWING_ROWS).unwrap_or(Action::None)
+fn handle_help_viewing_keys(combo: KeyCombo, feature_policy: &FeaturePolicy) -> Action {
+    keymap::resolve_mode_with_policy(&combo, keybindings::HELP_VIEWING_ROWS, feature_policy)
+        .unwrap_or(Action::None)
 }
 
-fn handle_help_editing_keys(combo: KeyCombo) -> Action {
-    if let Some(action) = keymap::resolve_mode(&combo, keybindings::HELP_EDITING_ROWS) {
+fn handle_help_editing_keys(combo: KeyCombo, feature_policy: &FeaturePolicy) -> Action {
+    if let Some(action) =
+        keymap::resolve_mode_with_policy(&combo, keybindings::HELP_EDITING_ROWS, feature_policy)
+    {
         return action;
     }
 
@@ -53,9 +71,18 @@ pub fn handle_confirm_dialog_keys(combo: KeyCombo) -> Action {
     keymap::resolve(&combo, keybindings::CONFIRM_DIALOG_KEYS).unwrap_or(Action::None)
 }
 
+#[cfg(test)]
 pub fn handle_sqlite_diagnostics_keys(combo: KeyCombo) -> Action {
+    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::sqlite_like());
+    handle_sqlite_diagnostics_keys_with_policy(combo, &feature_policy)
+}
+
+pub fn handle_sqlite_diagnostics_keys_with_policy(
+    combo: KeyCombo,
+    feature_policy: &FeaturePolicy,
+) -> Action {
     keybindings::SQLITE_DIAGNOSTICS
-        .resolve(&combo)
+        .resolve_with_policy(&combo, feature_policy)
         .unwrap_or(Action::None)
 }
 

--- a/src/app/update/input/handlers/overlays.rs
+++ b/src/app/update/input/handlers/overlays.rs
@@ -1,17 +1,9 @@
-#[cfg(test)]
-use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::policy::FeaturePolicy;
 use crate::update::action::{Action, CursorMove, InputTarget};
 use crate::update::input::keybindings::{self, Key, KeyCombo, Modifiers};
 use crate::update::input::keymap;
 
 use super::interaction::InputInteraction;
-
-#[cfg(test)]
-pub fn handle_help_keys(combo: KeyCombo, interaction: InputInteraction) -> Action {
-    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
-    handle_help_keys_with_policy(combo, interaction, &feature_policy)
-}
 
 pub fn handle_help_keys_with_policy(
     combo: KeyCombo,
@@ -71,12 +63,6 @@ pub fn handle_confirm_dialog_keys(combo: KeyCombo) -> Action {
     keymap::resolve(&combo, keybindings::CONFIRM_DIALOG_KEYS).unwrap_or(Action::None)
 }
 
-#[cfg(test)]
-pub fn handle_sqlite_diagnostics_keys(combo: KeyCombo) -> Action {
-    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::sqlite_like());
-    handle_sqlite_diagnostics_keys_with_policy(combo, &feature_policy)
-}
-
 pub fn handle_sqlite_diagnostics_keys_with_policy(
     combo: KeyCombo,
     feature_policy: &FeaturePolicy,
@@ -89,6 +75,7 @@ pub fn handle_sqlite_diagnostics_keys_with_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
     use crate::update::action::ModalKind;
     use crate::update::action::{
         CursorMove, InputTarget, ScrollAmount, ScrollDirection, ScrollTarget,
@@ -102,6 +89,16 @@ mod tests {
 
     fn combo_ctrl(k: Key) -> KeyCombo {
         KeyCombo::ctrl(k)
+    }
+
+    fn handle_help_keys(combo: KeyCombo, interaction: InputInteraction) -> Action {
+        let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+        handle_help_keys_with_policy(combo, interaction, &feature_policy)
+    }
+
+    fn handle_sqlite_diagnostics_keys(combo: KeyCombo) -> Action {
+        let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::sqlite_like());
+        handle_sqlite_diagnostics_keys_with_policy(combo, &feature_policy)
     }
 
     mod help {

--- a/src/app/update/input/handlers/pickers.rs
+++ b/src/app/update/input/handlers/pickers.rs
@@ -1,7 +1,8 @@
 use crate::model::app_state::AppState;
+use crate::policy::FeaturePolicy;
 use crate::update::action::{Action, InputTarget};
 use crate::update::input::keybindings::{self, Key, KeyCombo, Modifiers};
-use crate::update::input::keymap::resolve_mode;
+use crate::update::input::keymap::resolve_mode_with_policy;
 
 pub fn handle_table_picker_keys(combo: KeyCombo) -> Action {
     if let Some(action) = keybindings::TABLE_PICKER.resolve(&combo) {
@@ -82,9 +83,11 @@ pub fn handle_query_history_picker_keys(combo: KeyCombo) -> Action {
 }
 
 pub fn handle_er_table_picker_keys(combo: KeyCombo, state: &AppState) -> Action {
-    if let Some(action) = resolve_mode(
+    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    if let Some(action) = resolve_mode_with_policy(
         &combo,
         keybindings::er_picker_rows(state.settings.saved_keymap_preset()),
+        &feature_policy,
     ) {
         return action;
     }
@@ -378,8 +381,11 @@ mod tests {
     mod er_table_picker {
         use super::*;
 
+        use crate::update::test_fixtures;
         fn state() -> AppState {
-            AppState::new("test".to_string())
+            let mut state = AppState::new("test".to_string());
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
+            state
         }
 
         fn state_with_preset(preset: KeymapPreset) -> AppState {

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::model::shared::key_sequence::Prefix;
 use crate::model::shared::settings::KeymapPreset;
 use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
@@ -14,47 +12,6 @@ use crate::update::input::keybindings::{
 use crate::update::input::vim::{
     SqlModalVimContext, VimSurfaceContext, action_for_input, action_for_key,
 };
-
-#[cfg(test)]
-pub fn handle_sql_modal_keys(
-    combo: KeyCombo,
-    completion_visible: bool,
-    status: &SqlModalStatus,
-    active_tab: SqlModalTab,
-) -> Action {
-    handle_sql_modal_keys_with_prefix(
-        combo,
-        completion_visible,
-        status,
-        active_tab,
-        None,
-        KeymapPreset::Default,
-        true,
-    )
-}
-
-#[cfg(test)]
-pub fn handle_sql_modal_keys_with_prefix(
-    combo: KeyCombo,
-    completion_visible: bool,
-    status: &SqlModalStatus,
-    active_tab: SqlModalTab,
-    pending_prefix: Option<Prefix>,
-    keymap_preset: KeymapPreset,
-    supports_explain_analyze: bool,
-) -> Action {
-    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
-    handle_sql_modal_keys_internal(
-        combo,
-        completion_visible,
-        status,
-        active_tab,
-        pending_prefix,
-        keymap_preset,
-        &feature_policy,
-        supports_explain_analyze,
-    )
-}
 
 pub fn handle_sql_modal_keys_with_feature_policy(
     combo: KeyCombo,
@@ -435,6 +392,7 @@ fn handle_sql_modal_keys_internal(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
     use crate::update::action::CursorMove;
     use crate::update::input::keybindings::{Key, KeyCombo};
     use rstest::rstest;
@@ -449,6 +407,45 @@ mod tests {
 
     fn combo_alt(k: Key) -> KeyCombo {
         KeyCombo::alt(k)
+    }
+
+    fn handle_sql_modal_keys(
+        combo: KeyCombo,
+        completion_visible: bool,
+        status: &SqlModalStatus,
+        active_tab: SqlModalTab,
+    ) -> Action {
+        handle_sql_modal_keys_with_prefix(
+            combo,
+            completion_visible,
+            status,
+            active_tab,
+            None,
+            KeymapPreset::Default,
+            true,
+        )
+    }
+
+    fn handle_sql_modal_keys_with_prefix(
+        combo: KeyCombo,
+        completion_visible: bool,
+        status: &SqlModalStatus,
+        active_tab: SqlModalTab,
+        pending_prefix: Option<Prefix>,
+        keymap_preset: KeymapPreset,
+        supports_explain_analyze: bool,
+    ) -> Action {
+        let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+        handle_sql_modal_keys_internal(
+            combo,
+            completion_visible,
+            status,
+            active_tab,
+            pending_prefix,
+            keymap_preset,
+            &feature_policy,
+            supports_explain_analyze,
+        )
     }
 
     #[derive(Debug, PartialEq)]

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -1,6 +1,9 @@
+#[cfg(test)]
+use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::model::shared::key_sequence::Prefix;
 use crate::model::shared::settings::KeymapPreset;
 use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::update::action::{
     Action, InputTarget, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget,
 };
@@ -30,6 +33,7 @@ pub fn handle_sql_modal_keys(
     )
 }
 
+#[cfg(test)]
 pub fn handle_sql_modal_keys_with_prefix(
     combo: KeyCombo,
     completion_visible: bool,
@@ -37,6 +41,50 @@ pub fn handle_sql_modal_keys_with_prefix(
     active_tab: SqlModalTab,
     pending_prefix: Option<Prefix>,
     keymap_preset: KeymapPreset,
+    supports_explain_analyze: bool,
+) -> Action {
+    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+    handle_sql_modal_keys_internal(
+        combo,
+        completion_visible,
+        status,
+        active_tab,
+        pending_prefix,
+        keymap_preset,
+        &feature_policy,
+        supports_explain_analyze,
+    )
+}
+
+pub fn handle_sql_modal_keys_with_feature_policy(
+    combo: KeyCombo,
+    completion_visible: bool,
+    status: &SqlModalStatus,
+    active_tab: SqlModalTab,
+    pending_prefix: Option<Prefix>,
+    keymap_preset: KeymapPreset,
+    feature_policy: &FeaturePolicy,
+) -> Action {
+    handle_sql_modal_keys_internal(
+        combo,
+        completion_visible,
+        status,
+        active_tab,
+        pending_prefix,
+        keymap_preset,
+        feature_policy,
+        feature_policy.is_enabled(FeatureRequirement::ExplainAnalyze),
+    )
+}
+
+fn handle_sql_modal_keys_internal(
+    combo: KeyCombo,
+    completion_visible: bool,
+    status: &SqlModalStatus,
+    active_tab: SqlModalTab,
+    pending_prefix: Option<Prefix>,
+    keymap_preset: KeymapPreset,
+    feature_policy: &FeaturePolicy,
     supports_explain_analyze: bool,
 ) -> Action {
     use crate::update::action::CursorMove;
@@ -77,7 +125,9 @@ pub fn handle_sql_modal_keys_with_prefix(
             SqlModalTab::Compare => sql_modal_compare_explain(keymap_preset),
             SqlModalTab::Sql | SqlModalTab::Plan => sql_modal_plan_explain(keymap_preset),
         };
-        if explain_binding.combos.contains(&combo) {
+        if explain_binding.combos.contains(&combo)
+            && feature_policy.is_enabled(explain_binding.feature_requirement())
+        {
             return Action::ExplainRequest;
         }
 
@@ -117,7 +167,11 @@ pub fn handle_sql_modal_keys_with_prefix(
 
             return match combo.key {
                 Key::Char('e') if alt && supports_explain_analyze => Action::ExplainAnalyzeRequest,
-                Key::Char('e') if plain => Action::CompareEditQuery,
+                Key::Char('e')
+                    if plain && feature_policy.is_enabled(FeatureRequirement::PlanComparison) =>
+                {
+                    Action::CompareEditQuery
+                }
                 _ => Action::None,
             };
         }

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -4,10 +4,12 @@ mod normal;
 mod overlays;
 mod readline;
 
+use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::model::shared::settings::KeymapPreset;
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 pub use crate::ports::inbound::{Key, KeyCombo, Modifiers};
 use crate::update::action::{Action, ModalKind};
-use crate::update::input::keymap::resolve_mode;
+use crate::update::input::keymap::{resolve_mode, resolve_mode_with_policy};
 pub use connections::*;
 pub use editors::*;
 pub use normal::*;
@@ -27,6 +29,10 @@ pub struct KeyBinding {
 impl KeyBinding {
     pub const fn as_hint(&self) -> (&'static str, &'static str) {
         (self.key_short, self.desc_short)
+    }
+
+    pub fn feature_requirement(&self) -> FeatureRequirement {
+        self.action.feature_requirement()
     }
 }
 
@@ -51,6 +57,14 @@ impl ModeRow {
     pub const fn as_hint(&self) -> (&'static str, &'static str) {
         (self.key_short, self.desc_short)
     }
+
+    pub fn feature_requirement(&self) -> FeatureRequirement {
+        self.bindings
+            .iter()
+            .map(|binding| binding.action.feature_requirement())
+            .find(|requirement| *requirement != FeatureRequirement::None)
+            .unwrap_or(FeatureRequirement::None)
+    }
 }
 
 pub struct ModeBindings {
@@ -60,6 +74,14 @@ pub struct ModeBindings {
 impl ModeBindings {
     pub fn resolve(&self, combo: &KeyCombo) -> Option<Action> {
         resolve_mode(combo, self.rows)
+    }
+
+    pub fn resolve_with_policy(
+        &self,
+        combo: &KeyCombo,
+        feature_policy: &FeaturePolicy,
+    ) -> Option<Action> {
+        resolve_mode_with_policy(combo, self.rows, feature_policy)
     }
 }
 
@@ -121,15 +143,27 @@ pub const HELP_KEY_INDENT_WIDTH: usize = 2;
 pub const HELP_KEY_DESC_GAP: usize = 2;
 
 pub fn global_action_for(combo: &KeyCombo, preset: KeymapPreset) -> Option<Action> {
+    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
+    global_action_for_with_policy(combo, preset, &feature_policy)
+}
+
+pub fn global_action_for_with_policy(
+    combo: &KeyCombo,
+    preset: KeymapPreset,
+    feature_policy: &FeaturePolicy,
+) -> Option<Action> {
     normal::global_keys_for(preset)
         .iter()
         .filter(|binding| {
-            !matches!(
-                &binding.action,
-                Action::OpenModal(
-                    ModalKind::SqlModal | ModalKind::ErTablePicker | ModalKind::ConnectionSelector
+            feature_policy.is_enabled(binding.feature_requirement())
+                && !matches!(
+                    &binding.action,
+                    Action::OpenModal(
+                        ModalKind::SqlModal
+                            | ModalKind::ErTablePicker
+                            | ModalKind::ConnectionSelector
+                    )
                 )
-            )
         })
         .find(|binding| binding.combos.contains(combo))
         .map(|binding| binding.action.clone())
@@ -583,5 +617,33 @@ mod tests {
                 assert_eq!(ALL_MODE_BINDINGS.len(), 13);
             }
         }
+    }
+
+    #[test]
+    fn feature_requirements_are_attached_to_feature_bindings() {
+        assert_eq!(
+            global::ER_DIAGRAM.feature_requirement(),
+            FeatureRequirement::ErDiagram
+        );
+        assert_eq!(
+            global::SQLITE_DIAGNOSTICS.feature_requirement(),
+            FeatureRequirement::SqliteDiagnostics
+        );
+        assert_eq!(
+            sql_modal_plan::EXPLAIN.feature_requirement(),
+            FeatureRequirement::Explain
+        );
+        assert_eq!(
+            sql_modal_plan::ANALYZE.feature_requirement(),
+            FeatureRequirement::ExplainAnalyze
+        );
+        assert_eq!(
+            sql_modal_compare::EDIT_QUERY.feature_requirement(),
+            FeatureRequirement::PlanComparison
+        );
+        assert_eq!(
+            JSONB_DETAIL_ROWS[0].feature_requirement(),
+            FeatureRequirement::JsonbDetail
+        );
     }
 }

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -4,7 +4,6 @@ mod normal;
 mod overlays;
 mod readline;
 
-use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::model::shared::settings::KeymapPreset;
 use crate::policy::{FeaturePolicy, FeatureRequirement};
 pub use crate::ports::inbound::{Key, KeyCombo, Modifiers};
@@ -141,11 +140,6 @@ pub const ALL_MODE_BINDINGS: &[(&str, &ModeBindings)] = &[
 
 pub const HELP_KEY_INDENT_WIDTH: usize = 2;
 pub const HELP_KEY_DESC_GAP: usize = 2;
-
-pub fn global_action_for(combo: &KeyCombo, preset: KeymapPreset) -> Option<Action> {
-    let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
-    global_action_for_with_policy(combo, preset, &feature_policy)
-}
 
 pub fn global_action_for_with_policy(
     combo: &KeyCombo,

--- a/src/app/update/input/keymap.rs
+++ b/src/app/update/input/keymap.rs
@@ -1,4 +1,5 @@
 use super::keybindings::{KeyBinding, KeyCombo, ModeRow};
+use crate::policy::FeaturePolicy;
 use crate::update::action::Action;
 
 pub fn resolve(combo: &KeyCombo, bindings: &[KeyBinding]) -> Option<Action> {
@@ -9,8 +10,41 @@ pub fn resolve(combo: &KeyCombo, bindings: &[KeyBinding]) -> Option<Action> {
         .map(|kb| kb.action.clone())
 }
 
+pub fn resolve_with_policy(
+    combo: &KeyCombo,
+    bindings: &[KeyBinding],
+    feature_policy: &FeaturePolicy,
+) -> Option<Action> {
+    bindings
+        .iter()
+        .filter(|kb| {
+            !matches!(kb.action, Action::None)
+                && feature_policy.is_enabled(kb.feature_requirement())
+        })
+        .find(|kb| kb.combos.contains(combo))
+        .map(|kb| kb.action.clone())
+}
+
 pub fn resolve_mode(combo: &KeyCombo, rows: &[ModeRow]) -> Option<Action> {
     for row in rows {
+        for eb in row.bindings {
+            if !matches!(eb.action, Action::None) && eb.combos.contains(combo) {
+                return Some(eb.action.clone());
+            }
+        }
+    }
+    None
+}
+
+pub fn resolve_mode_with_policy(
+    combo: &KeyCombo,
+    rows: &[ModeRow],
+    feature_policy: &FeaturePolicy,
+) -> Option<Action> {
+    for row in rows {
+        if !feature_policy.is_enabled(row.feature_requirement()) {
+            continue;
+        }
         for eb in row.bindings {
             if !matches!(eb.action, Action::None) && eb.combos.contains(combo) {
                 return Some(eb.action.clone());

--- a/src/app/update/input/palette.rs
+++ b/src/app/update/input/palette.rs
@@ -1,7 +1,8 @@
 use super::keybindings::{KeyBinding, global};
 use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::model::shared::settings::KeymapPreset;
-use crate::update::action::{Action, ModalKind};
+use crate::policy::FeaturePolicy;
+use crate::update::action::Action;
 
 // Deliberate opt-in list in display order — not derived from GLOBAL_KEYS, so an
 // entry never appears in the palette by accident. A test forces every global
@@ -68,28 +69,20 @@ pub fn palette_commands(
     preset: KeymapPreset,
     engine_feature_profile: &EngineFeatureProfile,
 ) -> impl Iterator<Item = &'static KeyBinding> {
+    let feature_policy = FeaturePolicy::new(engine_feature_profile);
     palette_commands_for(preset)
         .iter()
-        .filter(|kb| palette_command_supported(kb, engine_feature_profile))
+        .filter(move |kb| palette_command_supported(kb, &feature_policy))
 }
 
-fn palette_command_supported(
-    kb: &KeyBinding,
-    engine_feature_profile: &EngineFeatureProfile,
-) -> bool {
-    !matches!(
-        kb.action,
-        Action::OpenModal(ModalKind::ErTablePicker) if !engine_feature_profile.supports_er_diagram()
-    ) && !matches!(
-        kb.action,
-        Action::OpenModal(ModalKind::SqliteDiagnostics)
-            if !engine_feature_profile.supports_sqlite_diagnostics()
-    )
+fn palette_command_supported(kb: &KeyBinding, feature_policy: &FeaturePolicy) -> bool {
+    feature_policy.is_enabled(kb.feature_requirement())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::update::action::ModalKind;
     use crate::update::input::keybindings::{
         GLOBAL_KEYS, IDE_GLOBAL_KEYS, same_payload_free_action,
     };

--- a/src/app/update/modal/er_picker.rs
+++ b/src/app/update/modal/er_picker.rs
@@ -4,9 +4,9 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::text_input::{TextInputEditing, TextInputState};
-use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::update::action::{Action, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
+use crate::update::helpers::require_er_diagram_enabled;
 
 pub(super) fn reduce_er_picker(
     state: &mut AppState,
@@ -15,13 +15,8 @@ pub(super) fn reduce_er_picker(
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::ErTablePicker) => {
-            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
-            if !feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
-                state.messages.set_error_at(
-                    "ER diagrams are not available for this connection".to_string(),
-                    now,
-                );
-                return DispatchResult::handled();
+            if let Some(result) = require_er_diagram_enabled(state, now) {
+                return result;
             }
             if state.session.metadata().is_none() {
                 state.ui.request_er_picker_after_metadata();

--- a/src/app/update/modal/er_picker.rs
+++ b/src/app/update/modal/er_picker.rs
@@ -4,6 +4,7 @@ use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::text_input::{TextInputEditing, TextInputState};
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::update::action::{Action, InputTarget, ModalKind};
 use crate::update::dispatch_result::DispatchResult;
 
@@ -14,11 +15,8 @@ pub(super) fn reduce_er_picker(
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::ErTablePicker) => {
-            if !state
-                .session
-                .active_engine_feature_profile()
-                .supports_er_diagram()
-            {
+            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+            if !feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
                 state.messages.set_error_at(
                     "ER diagrams are not available for this connection".to_string(),
                     now,

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -3,25 +3,16 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
-use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::update::action::{Action, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
 
 pub(super) fn reduce_sqlite_diagnostics(
     state: &mut AppState,
     action: &Action,
-    now: Instant,
+    _now: Instant,
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::SqliteDiagnostics) => {
-            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
-            if !feature_policy.is_enabled(FeatureRequirement::SqliteDiagnostics) {
-                state.messages.set_error_at(
-                    "SQLite diagnostics are not available for this connection".to_string(),
-                    now,
-                );
-                return DispatchResult::handled();
-            }
             let Some(dsn) = state.session.dsn().map(String::from) else {
                 return DispatchResult::handled();
             };
@@ -30,14 +21,6 @@ pub(super) fn reduce_sqlite_diagnostics(
             DispatchResult::handled_with(vec![Effect::FetchSqliteDiagnosticsCore { dsn, run_id }])
         }
         Action::RunSqliteDiagnosticsQuickCheck => {
-            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
-            if !feature_policy.is_enabled(FeatureRequirement::SqliteDiagnostics) {
-                state.messages.set_error_at(
-                    "SQLite diagnostics are not available for this connection".to_string(),
-                    now,
-                );
-                return DispatchResult::handled();
-            }
             let Some(dsn) = state.session.dsn().map(String::from) else {
                 return DispatchResult::handled();
             };
@@ -107,19 +90,20 @@ mod tests {
     use super::*;
     use crate::domain::connection::DatabaseType;
     use crate::domain::{ConnectionId, DiagnosticField, SqliteDiagnosticsSnapshot};
+    use crate::services::AppServices;
     use crate::update::test_fixtures;
+
+    fn reduce_at_boundary(state: &mut AppState, action: Action) -> Vec<Effect> {
+        crate::update::reducer::reduce(state, action, Instant::now(), &AppServices::stub())
+    }
 
     #[test]
     fn open_starts_split_fetch_for_sqlite_connection() {
         let mut state = AppState::new("test".to_string());
         test_fixtures::activate_sqlite_connection(&mut state, "sqlite:///tmp/app.db");
 
-        let effects = reduce_sqlite_diagnostics(
-            &mut state,
-            &Action::OpenModal(ModalKind::SqliteDiagnostics),
-            Instant::now(),
-        )
-        .unwrap();
+        let effects =
+            reduce_at_boundary(&mut state, Action::OpenModal(ModalKind::SqliteDiagnostics));
 
         assert_eq!(state.input_mode(), InputMode::SqliteDiagnostics);
         assert_eq!(effects.len(), 1);
@@ -142,12 +126,7 @@ mod tests {
             },
         );
 
-        let effects = reduce_sqlite_diagnostics(
-            &mut state,
-            &Action::RunSqliteDiagnosticsQuickCheck,
-            Instant::now(),
-        )
-        .unwrap();
+        let effects = reduce_at_boundary(&mut state, Action::RunSqliteDiagnosticsQuickCheck);
 
         assert!(state.sqlite_diagnostics.is_quick_check_running());
         assert!(matches!(
@@ -157,7 +136,7 @@ mod tests {
     }
 
     #[test]
-    fn open_returns_error_for_postgres_connection() {
+    fn open_is_a_noop_for_postgres_connection() {
         let mut state = AppState::new("test".to_string());
         state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
@@ -166,23 +145,16 @@ mod tests {
             "postgres://localhost/db",
         );
 
-        let effects = reduce_sqlite_diagnostics(
-            &mut state,
-            &Action::OpenModal(ModalKind::SqliteDiagnostics),
-            Instant::now(),
-        )
-        .unwrap();
+        let effects =
+            reduce_at_boundary(&mut state, Action::OpenModal(ModalKind::SqliteDiagnostics));
 
         assert_eq!(state.input_mode(), InputMode::Normal);
         assert!(effects.is_empty());
-        assert_eq!(
-            state.messages.last_error.as_deref(),
-            Some("SQLite diagnostics are not available for this connection")
-        );
+        assert!(state.messages.last_error.is_none());
     }
 
     #[test]
-    fn quick_check_returns_error_for_postgres_connection() {
+    fn quick_check_is_a_noop_for_postgres_connection() {
         let mut state = AppState::new("test".to_string());
         state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
@@ -199,19 +171,11 @@ mod tests {
             },
         );
 
-        let effects = reduce_sqlite_diagnostics(
-            &mut state,
-            &Action::RunSqliteDiagnosticsQuickCheck,
-            Instant::now(),
-        )
-        .unwrap();
+        let effects = reduce_at_boundary(&mut state, Action::RunSqliteDiagnosticsQuickCheck);
 
         assert!(effects.is_empty());
         assert!(!state.sqlite_diagnostics.is_quick_check_running());
-        assert_eq!(
-            state.messages.last_error.as_deref(),
-            Some("SQLite diagnostics are not available for this connection")
-        );
+        assert!(state.messages.last_error.is_none());
     }
 
     #[test]

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -91,10 +91,11 @@ mod tests {
     use crate::domain::connection::DatabaseType;
     use crate::domain::{ConnectionId, DiagnosticField, SqliteDiagnosticsSnapshot};
     use crate::services::AppServices;
+    use crate::update::reducer::reduce;
     use crate::update::test_fixtures;
 
     fn reduce_at_boundary(state: &mut AppState, action: Action) -> Vec<Effect> {
-        crate::update::reducer::reduce(state, action, Instant::now(), &AppServices::stub())
+        reduce(state, action, Instant::now(), &AppServices::stub())
     }
 
     #[test]

--- a/src/app/update/modal/sqlite_diagnostics.rs
+++ b/src/app/update/modal/sqlite_diagnostics.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
+use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::update::action::{Action, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget};
 use crate::update::dispatch_result::DispatchResult;
 
@@ -13,11 +14,8 @@ pub(super) fn reduce_sqlite_diagnostics(
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::SqliteDiagnostics) => {
-            if !state
-                .session
-                .active_engine_feature_profile()
-                .supports_sqlite_diagnostics()
-            {
+            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+            if !feature_policy.is_enabled(FeatureRequirement::SqliteDiagnostics) {
                 return DispatchResult::handled();
             }
             let Some(dsn) = state.session.dsn().map(String::from) else {
@@ -28,6 +26,10 @@ pub(super) fn reduce_sqlite_diagnostics(
             DispatchResult::handled_with(vec![Effect::FetchSqliteDiagnosticsCore { dsn, run_id }])
         }
         Action::RunSqliteDiagnosticsQuickCheck => {
+            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+            if !feature_policy.is_enabled(FeatureRequirement::SqliteDiagnostics) {
+                return DispatchResult::handled();
+            }
             let Some(dsn) = state.session.dsn().map(String::from) else {
                 return DispatchResult::handled();
             };
@@ -165,6 +167,27 @@ mod tests {
 
         assert_eq!(state.input_mode(), InputMode::Normal);
         assert!(effects.is_empty());
+    }
+
+    #[test]
+    fn quick_check_is_ignored_for_postgres_connection() {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            DatabaseType::PostgreSQL,
+            "postgres://localhost/db",
+        );
+
+        let effects = reduce_sqlite_diagnostics(
+            &mut state,
+            &Action::RunSqliteDiagnosticsQuickCheck,
+            Instant::now(),
+        )
+        .unwrap();
+
+        assert!(effects.is_empty());
+        assert!(!state.sqlite_diagnostics.is_quick_check_running());
     }
 
     #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -29,7 +29,7 @@ pub fn reduce(
     services: &AppServices,
 ) -> Vec<Effect> {
     let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
-    if !feature_policy.is_enabled(action.feature_requirement()) {
+    if !feature_policy.is_enabled(action.feature_requirement_for_state(state)) {
         return vec![];
     }
 
@@ -298,6 +298,7 @@ mod tests {
         use crate::domain::{DiagnosticField, SqliteDiagnosticsSnapshot};
         use crate::model::er_state::ErStatus;
         use crate::model::shared::flash_timer::FlashId;
+        use crate::model::shared::text_input::TextInputLike;
         use crate::update::action::{ErDiagramInfo, ScrollAmount, ScrollDirection, ScrollTarget};
 
         fn assert_unsupported_action_is_a_noop(state: &mut AppState, action: Action) {
@@ -347,6 +348,26 @@ mod tests {
             test_fixtures::activate_sqlite_connection(&mut jsonb_state, "sqlite://test.db");
             assert_unsupported_action_is_a_noop(&mut jsonb_state, Action::JsonbYankSuccess);
             assert_unsupported_action_is_a_noop(&mut jsonb_state, Action::JsonbEnterEdit);
+
+            let mut er_state = create_test_state();
+            test_fixtures::activate_sqlite_connection(&mut er_state, "sqlite://test.db");
+            er_state.modal.set_mode(InputMode::ErTablePicker);
+            er_state.ui.er_picker_mut().insert_filter_str("before");
+            assert_unsupported_action_is_a_noop(&mut er_state, Action::Paste("after".to_string()));
+            assert_eq!(er_state.ui.er_picker().filter_input().content(), "before");
+
+            let mut jsonb_edit_state = create_test_state();
+            test_fixtures::activate_sqlite_connection(&mut jsonb_edit_state, "sqlite://test.db");
+            jsonb_edit_state.modal.set_mode(InputMode::JsonbEdit);
+            jsonb_edit_state
+                .jsonb_detail
+                .editor_mut()
+                .set_content("before".to_string());
+            assert_unsupported_action_is_a_noop(
+                &mut jsonb_edit_state,
+                Action::Paste("after".to_string()),
+            );
+            assert_eq!(jsonb_edit_state.jsonb_detail.editor().content(), "before");
 
             let mut analyze_state = create_test_state();
             test_fixtures::activate_sqlite_connection(&mut analyze_state, "sqlite://test.db");

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -1533,6 +1533,22 @@ mod tests {
         }
 
         #[test]
+        fn unsupported_er_open_direct_dispatch_has_no_side_effect() {
+            let mut state = create_test_state();
+            test_fixtures::activate_sqlite_connection(&mut state, "sqlite://test.db");
+
+            let effects = reduce(
+                &mut state,
+                Action::ErOpenDiagram,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.is_empty());
+            assert_eq!(state.er_preparation.status(), ErStatus::Idle);
+        }
+
+        #[test]
         fn always_emits_smart_refresh_even_with_pending_tables() {
             let mut state = create_test_state();
             test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
@@ -1589,6 +1605,7 @@ mod tests {
         #[test]
         fn no_metadata_returns_error() {
             let mut state = create_test_state();
+            test_fixtures::activate_postgres_connection(&mut state, "postgres://localhost/test");
             let _ = state.sql_modal.begin_prefetch();
             let now = Instant::now();
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -298,6 +298,7 @@ mod tests {
         use crate::domain::{DiagnosticField, SqliteDiagnosticsSnapshot};
         use crate::model::er_state::ErStatus;
         use crate::model::shared::flash_timer::FlashId;
+        use crate::model::shared::key_sequence::Prefix;
         use crate::model::shared::text_input::TextInputLike;
         use crate::update::action::{ErDiagramInfo, ScrollAmount, ScrollDirection, ScrollTarget};
 
@@ -368,6 +369,15 @@ mod tests {
                 Action::Paste("after".to_string()),
             );
             assert_eq!(jsonb_edit_state.jsonb_detail.editor().content(), "before");
+
+            let mut jsonb_detail_state = create_test_state();
+            test_fixtures::activate_sqlite_connection(&mut jsonb_detail_state, "sqlite://test.db");
+            jsonb_detail_state.modal.set_mode(InputMode::JsonbDetail);
+            assert_unsupported_action_is_a_noop(
+                &mut jsonb_detail_state,
+                Action::BeginKeySequence(Prefix::G),
+            );
+            assert_eq!(jsonb_detail_state.ui.key_sequence(), KeySequenceState::Idle);
 
             let mut analyze_state = create_test_state();
             test_fixtures::activate_sqlite_connection(&mut analyze_state, "sqlite://test.db");

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -17,6 +17,7 @@ use crate::model::app_state::AppState;
 use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::KeySequenceState;
+use crate::policy::FeaturePolicy;
 use crate::services::AppServices;
 use crate::update::action::{Action, TableTarget};
 use crate::update::query_context::termination_effects;
@@ -27,6 +28,11 @@ pub fn reduce(
     now: Instant,
     services: &AppServices,
 ) -> Vec<Effect> {
+    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    if !feature_policy.is_enabled(action.feature_requirement()) {
+        return vec![];
+    }
+
     // Mark dirty for all state-changing actions (except None and Render)
     let should_mark_dirty = !matches!(action, Action::None | Action::Render);
 
@@ -284,6 +290,133 @@ mod tests {
             reduce(&mut state, action, now, &AppServices::stub());
 
             assert_eq!(state.ui.explorer_selected(), 0);
+        }
+    }
+
+    mod feature_policy_guard {
+        use super::*;
+        use crate::domain::{DiagnosticField, SqliteDiagnosticsSnapshot};
+        use crate::model::er_state::ErStatus;
+        use crate::model::shared::flash_timer::FlashId;
+        use crate::update::action::{ErDiagramInfo, ScrollAmount, ScrollDirection, ScrollTarget};
+
+        fn assert_unsupported_action_is_a_noop(state: &mut AppState, action: Action) {
+            let now = Instant::now();
+            state.clear_dirty();
+            state
+                .messages
+                .set_success_at("existing message".to_string(), now);
+            state.result_interaction.start_yank_operator();
+            let er_status = state.er_preparation.status();
+            let jsonb_flash_active = state.flash_timers.is_active(FlashId::JsonbDetail, now);
+
+            let effects = reduce(state, action, now, &AppServices::stub());
+
+            assert!(effects.is_empty());
+            assert!(!state.render_dirty);
+            assert_eq!(state.messages.last_success(), Some("existing message"));
+            assert!(state.messages.last_error().is_none());
+            assert!(state.result_interaction.is_yank_operator_pending());
+            assert_eq!(state.er_preparation.status(), er_status);
+            assert_eq!(
+                state.flash_timers.is_active(FlashId::JsonbDetail, now),
+                jsonb_flash_active
+            );
+        }
+
+        #[test]
+        fn unsupported_er_completion_is_a_total_noop() {
+            let mut state = create_test_state();
+            test_fixtures::activate_sqlite_connection(&mut state, "sqlite://test.db");
+            state.er_preparation.mark_rendering();
+
+            assert_unsupported_action_is_a_noop(
+                &mut state,
+                Action::ErDiagramOpened(ErDiagramInfo {
+                    path: "diagram.svg".to_string(),
+                    table_count: 1,
+                    total_tables: 1,
+                }),
+            );
+            assert_eq!(state.er_preparation.status(), ErStatus::Rendering);
+        }
+
+        #[test]
+        fn unsupported_jsonb_and_analyze_actions_are_total_noops() {
+            let mut jsonb_state = create_test_state();
+            test_fixtures::activate_sqlite_connection(&mut jsonb_state, "sqlite://test.db");
+            assert_unsupported_action_is_a_noop(&mut jsonb_state, Action::JsonbYankSuccess);
+            assert_unsupported_action_is_a_noop(&mut jsonb_state, Action::JsonbEnterEdit);
+
+            let mut analyze_state = create_test_state();
+            test_fixtures::activate_sqlite_connection(&mut analyze_state, "sqlite://test.db");
+            assert_unsupported_action_is_a_noop(&mut analyze_state, Action::ExplainAnalyzeCancel);
+            assert_unsupported_action_is_a_noop(
+                &mut analyze_state,
+                Action::TextInput {
+                    target: InputTarget::SqlModalAnalyzeHighRisk,
+                    ch: 'x',
+                },
+            );
+
+            let mut compare_state = create_test_state();
+            test_fixtures::activate_sqlite_connection(&mut compare_state, "sqlite://test.db");
+            assert_unsupported_action_is_a_noop(
+                &mut compare_state,
+                Action::Scroll {
+                    target: ScrollTarget::ExplainCompare,
+                    direction: ScrollDirection::Down,
+                    amount: ScrollAmount::Line,
+                },
+            );
+        }
+
+        #[test]
+        fn unsupported_completion_actions_are_total_noops() {
+            let mut explain_state = create_test_state();
+            test_fixtures::activate_sqlite_connection(&mut explain_state, "sqlite://test.db");
+            let now = Instant::now();
+            let _ = explain_state.query.begin_running(now);
+            assert_unsupported_action_is_a_noop(
+                &mut explain_state,
+                Action::ExplainCompleted {
+                    dsn: "sqlite://test.db".to_string(),
+                    run_id: 1,
+                    query: "SELECT 1".to_string(),
+                    plan_text: "QUERY PLAN".to_string(),
+                    is_analyze: true,
+                    execution_time_ms: 1,
+                },
+            );
+            assert!(explain_state.explain.plan_text().is_none());
+            assert_unsupported_action_is_a_noop(
+                &mut explain_state,
+                Action::ExplainFailed {
+                    dsn: "sqlite://test.db".to_string(),
+                    run_id: 1,
+                    error: DbOperationError::QueryFailed("error".to_string()),
+                    is_analyze: true,
+                },
+            );
+
+            let mut diagnostics_state = create_test_state();
+            test_fixtures::activate_postgres_connection(
+                &mut diagnostics_state,
+                "postgres://localhost/test",
+            );
+            let run_id = diagnostics_state.sqlite_diagnostics.begin_fetch();
+            assert_unsupported_action_is_a_noop(
+                &mut diagnostics_state,
+                Action::SqliteDiagnosticsCoreLoaded {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    snapshot: Box::new(SqliteDiagnosticsSnapshot {
+                        quick_check: DiagnosticField::ok("ok"),
+                        ..Default::default()
+                    }),
+                },
+            );
+            assert!(diagnostics_state.sqlite_diagnostics.is_loading());
         }
     }
 
@@ -1536,15 +1669,20 @@ mod tests {
         fn unsupported_er_open_direct_dispatch_has_no_side_effect() {
             let mut state = create_test_state();
             test_fixtures::activate_sqlite_connection(&mut state, "sqlite://test.db");
+            let now = Instant::now();
+            state.clear_dirty();
+            state
+                .messages
+                .set_success_at("existing message".to_string(), now);
+            state.result_interaction.start_yank_operator();
 
-            let effects = reduce(
-                &mut state,
-                Action::ErOpenDiagram,
-                Instant::now(),
-                &AppServices::stub(),
-            );
+            let effects = reduce(&mut state, Action::ErOpenDiagram, now, &AppServices::stub());
 
             assert!(effects.is_empty());
+            assert!(!state.render_dirty);
+            assert_eq!(state.messages.last_success(), Some("existing message"));
+            assert!(state.messages.last_error().is_none());
+            assert!(state.result_interaction.is_yank_operator_pending());
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
         }
 

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -12,6 +12,7 @@ use crate::app::model::shared::text_input::TextInputState;
 use crate::app::model::sql_editor::modal::{HIGH_RISK_INPUT_VISIBLE_WIDTH, SqlModalStatus};
 use crate::app::policy::sql::sqlite_explain::SQLITE_EXPLAIN_QUERY_PLAN_PREFIX;
 use crate::app::policy::write::sql_risk::AcknowledgeReason;
+use crate::app::policy::{FeaturePolicy, FeatureRequirement};
 use crate::app::update::input::keybindings::sql_modal_plan_explain;
 use crate::domain::DatabaseType;
 use crate::primitives::atoms::{apply_yank_flash, text_cursor_spans};
@@ -24,11 +25,8 @@ pub fn render(
     now: Instant,
     theme: &ThemePalette,
 ) -> u16 {
-    if !state
-        .session
-        .active_engine_feature_profile()
-        .supports_explain()
-    {
+    let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+    if !feature_policy.is_enabled(FeatureRequirement::Explain) {
         let placeholder = Line::from(Span::styled(
             " EXPLAIN is unavailable for this database",
             Style::default().fg(theme.semantic.text.placeholder),

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -16,6 +16,7 @@ use crate::app::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::app::model::shared::settings::KeymapPreset;
 use crate::app::model::sql_editor::modal::{SQL_MODAL_HEIGHT_PERCENT, SqlModalStatus, SqlModalTab};
 use crate::app::policy::write::sql_risk::AcknowledgeReason;
+use crate::app::policy::{FeaturePolicy, FeatureRequirement};
 use crate::app::update::input::keybindings::{
     sql_modal, sql_modal_compare, sql_modal_normal, sql_modal_plan, sql_modal_plan_explain,
 };
@@ -41,6 +42,7 @@ impl SqlModal {
             SqlModalStatus::ConfirmingHigh { .. } | SqlModalStatus::ConfirmingRisk { .. }
         );
         let engine_feature_profile = state.session.active_engine_feature_profile();
+        let feature_policy = FeaturePolicy::new(engine_feature_profile);
         let active_tab =
             engine_feature_profile.normalize_sql_modal_tab(state.sql_modal.active_tab());
 
@@ -101,7 +103,7 @@ impl SqlModal {
         } else {
             let hint = match state.sql_modal.status() {
                 SqlModalStatus::Editing => {
-                    Self::editing_hint(engine_feature_profile, state.settings.saved_keymap_preset())
+                    Self::editing_hint(&feature_policy, state.settings.saved_keymap_preset())
                 }
                 SqlModalStatus::Running => FooterHintBar::message("Running\u{2026}"),
                 SqlModalStatus::ConfirmingAnalyzeHigh {
@@ -123,6 +125,7 @@ impl SqlModal {
                         active_tab,
                         compare_can_yank,
                         engine_feature_profile,
+                        &feature_policy,
                         state.settings.saved_keymap_preset(),
                     )
                 }
@@ -256,11 +259,12 @@ impl SqlModal {
         tab: SqlModalTab,
         compare_can_yank: bool,
         engine_feature_profile: &EngineFeatureProfile,
+        feature_policy: &FeaturePolicy,
         keymap_preset: KeymapPreset,
     ) -> FooterHintBar {
         match tab {
             SqlModalTab::Sql if engine_feature_profile.supported_sql_modal_tabs().len() == 1 => {
-                if engine_feature_profile.supports_explain() {
+                if feature_policy.is_enabled(FeatureRequirement::Explain) {
                     FooterHintBar::new([
                         sql_modal_normal::RUN.as_hint(),
                         sql_modal_plan_explain(keymap_preset).as_hint(),
@@ -280,19 +284,22 @@ impl SqlModal {
                 ("Tab/⇧Tab", sql_modal_plan::TAB.as_hint().1),
                 sql_modal_plan::CLOSE.as_hint(),
             ]),
-            SqlModalTab::Compare if compare_can_yank => FooterHintBar::new([
-                sql_modal_compare::EDIT_QUERY.as_hint(),
-                sql_modal_compare::YANK.as_hint(),
-                ("Tab/⇧Tab", sql_modal_compare::TAB.as_hint().1),
-                sql_modal_compare::CLOSE.as_hint(),
-            ]),
-            SqlModalTab::Compare => FooterHintBar::new([
-                sql_modal_compare::EDIT_QUERY.as_hint(),
-                ("Tab/⇧Tab", sql_modal_compare::TAB.as_hint().1),
-                sql_modal_compare::CLOSE.as_hint(),
-            ]),
+            SqlModalTab::Compare => {
+                let mut hints = Vec::new();
+                if feature_policy.is_enabled(FeatureRequirement::PlanComparison) {
+                    hints.push(sql_modal_compare::EDIT_QUERY.as_hint());
+                }
+                if compare_can_yank {
+                    hints.push(sql_modal_compare::YANK.as_hint());
+                }
+                hints.extend([
+                    ("Tab/⇧Tab", sql_modal_compare::TAB.as_hint().1),
+                    sql_modal_compare::CLOSE.as_hint(),
+                ]);
+                FooterHintBar::new(hints)
+            }
             SqlModalTab::Sql => {
-                if engine_feature_profile.supports_explain() {
+                if feature_policy.is_enabled(FeatureRequirement::Explain) {
                     FooterHintBar::new([
                         sql_modal_normal::RUN.as_hint(),
                         sql_modal_plan_explain(keymap_preset).as_hint(),
@@ -312,11 +319,11 @@ impl SqlModal {
         }
     }
 
-    fn editing_hint(
-        engine_feature_profile: &EngineFeatureProfile,
-        keymap_preset: KeymapPreset,
-    ) -> FooterHintBar {
-        match (engine_feature_profile.supports_explain(), keymap_preset) {
+    fn editing_hint(feature_policy: &FeaturePolicy, keymap_preset: KeymapPreset) -> FooterHintBar {
+        match (
+            feature_policy.is_enabled(FeatureRequirement::Explain),
+            keymap_preset,
+        ) {
             (true, KeymapPreset::Default) => FooterHintBar::new([
                 sql_modal::RUN.as_hint(),
                 sql_modal_plan::EXPLAIN.as_hint(),

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -13,6 +13,7 @@ use crate::app::model::shared::help::HelpMode;
 use crate::app::model::shared::input_mode::InputMode;
 use crate::app::model::shared::ui_state::ResultNavMode;
 use crate::app::model::sql_editor::modal::SqlModalStatus;
+use crate::app::policy::{FeaturePolicy, FeatureRequirement};
 use crate::app::update::input::keybindings::{
     ModeRow, ROW_DETAIL_FOOTER_ROWS, cell_detail, cell_detail_search, cell_edit, command_palette,
     command_palette as command_palette_key, connection_error, connection_selector,
@@ -150,13 +151,14 @@ impl Footer {
                 } else {
                     // Actions → Navigation → Help → Close/Cancel → Quit
                     let capabilities = state.session.active_engine_feature_profile();
+                    let feature_policy = FeaturePolicy::new(capabilities);
                     let active_inspector_tab =
                         capabilities.normalize_inspector_tab(state.ui.inspector_tab());
                     let mut list = vec![global::RELOAD.as_hint(), global::SQL.as_hint()];
-                    if capabilities.supports_er_diagram() {
+                    if feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
                         list.push(global::ER_DIAGRAM.as_hint());
                     }
-                    if capabilities.supports_sqlite_diagnostics() {
+                    if feature_policy.is_enabled(FeatureRequirement::SqliteDiagnostics) {
                         list.push(sqlite_diagnostics(keymap_preset).as_hint());
                     }
                     if state.ui.focused_pane() == FocusedPane::Explorer {
@@ -300,8 +302,15 @@ impl Footer {
                 ]
             }
             InputMode::SqliteDiagnostics => {
-                let mut hints = vec![sqlite_diagnostics::SCROLL.as_hint()];
-                if state.sqlite_diagnostics.can_run_quick_check() {
+                let feature_policy =
+                    FeaturePolicy::new(state.session.active_engine_feature_profile());
+                let mut hints = Vec::new();
+                if feature_policy.is_enabled(FeatureRequirement::SqliteDiagnostics) {
+                    hints.push(sqlite_diagnostics::SCROLL.as_hint());
+                }
+                if feature_policy.is_enabled(FeatureRequirement::SqliteDiagnostics)
+                    && state.sqlite_diagnostics.can_run_quick_check()
+                {
                     hints.push(sqlite_diagnostics::RUN_QUICK_CHECK.as_hint());
                 }
                 hints.extend([
@@ -310,20 +319,32 @@ impl Footer {
                 ]);
                 hints
             }
-            InputMode::ErTablePicker => vec![
-                er_picker::ENTER_GENERATE.as_hint(),
-                er_picker::SELECT.as_hint(),
-                er_picker_select_all(state.settings.saved_keymap_preset()).as_hint(),
-                er_picker::TYPE_FILTER.as_hint(),
-                er_picker::ESC_CLOSE.as_hint(),
-            ],
+            InputMode::ErTablePicker => {
+                let feature_policy =
+                    FeaturePolicy::new(state.session.active_engine_feature_profile());
+                let mut hints = Vec::new();
+                if feature_policy.is_enabled(FeatureRequirement::ErDiagram) {
+                    hints.extend([
+                        er_picker::ENTER_GENERATE.as_hint(),
+                        er_picker::SELECT.as_hint(),
+                        er_picker_select_all(state.settings.saved_keymap_preset()).as_hint(),
+                        er_picker::TYPE_FILTER.as_hint(),
+                    ]);
+                }
+                hints.push(er_picker::ESC_CLOSE.as_hint());
+                hints
+            }
             InputMode::QueryHistoryPicker => vec![
                 query_history_picker::ENTER_SELECT.as_hint(),
                 query_history_picker::TYPE_FILTER.as_hint(),
                 query_history_picker::ESC_CLOSE.as_hint(),
             ],
             InputMode::JsonbDetail => {
-                if matches!(state.jsonb_detail.mode(), JsonbDetailMode::Searching) {
+                let feature_policy =
+                    FeaturePolicy::new(state.session.active_engine_feature_profile());
+                if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
+                    vec![]
+                } else if matches!(state.jsonb_detail.mode(), JsonbDetailMode::Searching) {
                     vec![
                         jsonb_search::TYPE_SEARCH.as_hint(),
                         jsonb_search::CONFIRM.as_hint(),
@@ -340,11 +361,19 @@ impl Footer {
                     ]
                 }
             }
-            InputMode::JsonbEdit => vec![
-                jsonb_edit::ESC_NORMAL.as_hint(),
-                jsonb_edit::MOVE.as_hint(),
-                jsonb_edit::HOME_END.as_hint(),
-            ],
+            InputMode::JsonbEdit => {
+                let feature_policy =
+                    FeaturePolicy::new(state.session.active_engine_feature_profile());
+                if feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
+                    vec![
+                        jsonb_edit::ESC_NORMAL.as_hint(),
+                        jsonb_edit::MOVE.as_hint(),
+                        jsonb_edit::HOME_END.as_hint(),
+                    ]
+                } else {
+                    vec![]
+                }
+            }
             InputMode::CellDetail => {
                 if state.cell_detail.search().is_active() {
                     vec![

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -450,7 +450,7 @@ mod tests {
     use crate::app::model::shared::ui_state::FocusMode;
     use crate::app::model::sql_editor::modal::SqlModalStatus;
     use crate::app::update::input::keybindings::{
-        connection_setup, global, help, result_active, row_detail,
+        connection_setup, global, help, jsonb_detail, jsonb_edit, result_active, row_detail,
     };
     use rstest::rstest;
 

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -343,7 +343,7 @@ impl Footer {
                 let feature_policy =
                     FeaturePolicy::new(state.session.active_engine_feature_profile());
                 if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
-                    vec![]
+                    vec![jsonb_detail::CLOSE.as_hint()]
                 } else if matches!(state.jsonb_detail.mode(), JsonbDetailMode::Searching) {
                     vec![
                         jsonb_search::TYPE_SEARCH.as_hint(),
@@ -371,7 +371,7 @@ impl Footer {
                         jsonb_edit::HOME_END.as_hint(),
                     ]
                 } else {
-                    vec![]
+                    vec![jsonb_edit::ESC_NORMAL.as_hint()]
                 }
             }
             InputMode::CellDetail => {
@@ -519,6 +519,29 @@ mod tests {
         assert_eq!(
             hints.contains(&global::ER_DIAGRAM.as_hint()),
             expected_visible
+        );
+    }
+
+    #[test]
+    fn unsupported_jsonb_modes_keep_exit_hints() {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            DatabaseType::SQLite,
+            "sqlite://test.db",
+        );
+
+        state.modal.set_mode(InputMode::JsonbDetail);
+        assert_eq!(
+            Footer::get_context_hints(&state),
+            vec![jsonb_detail::CLOSE.as_hint()]
+        );
+
+        state.modal.set_mode(InputMode::JsonbEdit);
+        assert_eq!(
+            Footer::get_context_hints(&state),
+            vec![jsonb_edit::ESC_NORMAL.as_hint()]
         );
     }
 


### PR DESCRIPTION
## Problem

Feature availability was decided independently by Help, Footer, Command Palette, input handlers, and reducers, allowing unsupported actions to mutate state through direct dispatch or input paths.

## Background

SAB-365 builds on the static engine feature profile introduced by SAB-364. State-dependent actions must remain consistent when a connection switch leaves a feature-specific surface active.

## Approach

Centralize static availability through FeaturePolicy and FeatureRequirement, including state-dependent paste and key-sequence actions. Apply the same policy to feature-facing UI, input handlers, and reducer guards so unsupported actions are hidden and have no side effects.

## Linear Issue Link (optional)

- Implements https://linear.app/sabiql/issue/SAB-365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent feature-aware controls across keybindings, actions, help content, modals, menus, and footer hints.
  * Unsupported options such as ER diagrams, JSONB details, SQLite diagnostics, EXPLAIN, and plan comparison are now hidden or unavailable when not supported.
* **Bug Fixes**
  * Prevented unsupported actions from producing side effects.
  * Preserved EXPLAIN ANALYZE state when execution fails.
  * Improved handling of unavailable database-specific features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->