### PR TITLE
ci: update Dependabot branches automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -33,7 +34,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "$EVENT_NAME" = "push" ]; then
+          if [ "$EVENT_NAME" = "push" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "sqlite_safe_mode=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/update-dependabot-branches.yml
+++ b/.github/workflows/update-dependabot-branches.yml
@@ -14,10 +14,10 @@ permissions:
 
 jobs:
   update-branches:
-    name: Update open Dependabot pull requests
+    name: Rebase stale Dependabot pull requests
     runs-on: ubuntu-latest
     steps:
-      - name: Update pull request branches
+      - name: Ask Dependabot to rebase stale pull requests
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
@@ -29,20 +29,18 @@ jobs:
             --state open \
             --author 'app/dependabot' \
             --limit 100 \
-            --json number,headRefOid \
-            --jq '.[] | [.number, .headRefOid] | @tsv' |
-          while IFS=$'\t' read -r number head_sha; do
+            --json number,mergeStateStatus \
+            --jq '.[] | select(.mergeStateStatus == "BEHIND") | .number' |
+          while IFS= read -r number; do
             [ -n "$number" ] || continue
 
             if response=$(gh api \
-              --method PUT \
+              --method POST \
               --repo "$GH_REPO" \
               -H 'Accept: application/vnd.github+json' \
-              "/repos/$GH_REPO/pulls/$number/update-branch" \
-              -f "expected_head_sha=$head_sha" 2>&1); then
-              echo "Requested an update for Dependabot PR #$number: $response"
-            elif grep -q 'HTTP 422' <<< "$response"; then
-              echo "::notice::Skipped Dependabot PR #$number because its branch could not be updated: $response"
+              "/repos/$GH_REPO/issues/$number/comments" \
+              -f 'body=@dependabot rebase' 2>&1); then
+              echo "Requested a rebase for Dependabot PR #$number: $response"
             else
               echo "$response" >&2
               exit 1

--- a/.github/workflows/update-dependabot-branches.yml
+++ b/.github/workflows/update-dependabot-branches.yml
@@ -10,6 +10,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: write
+  contents: write
   pull-requests: write
 
 jobs:
@@ -17,7 +19,7 @@ jobs:
     name: Rebase stale Dependabot pull requests
     runs-on: ubuntu-latest
     steps:
-      - name: Ask Dependabot to rebase stale pull requests
+      - name: Update stale pull request branches and run CI
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
@@ -29,20 +31,39 @@ jobs:
             --state open \
             --author 'app/dependabot' \
             --limit 100 \
-            --json number,mergeStateStatus \
-            --jq '.[] | select(.mergeStateStatus == "BEHIND") | .number' |
-          while IFS= read -r number; do
+            --json number,headRefName,headRefOid,mergeStateStatus \
+            --jq '.[] | select(.mergeStateStatus == "BEHIND") | [.number, .headRefName, .headRefOid] | @tsv' |
+          while IFS=$'\t' read -r number head_ref head_sha; do
             [ -n "$number" ] || continue
 
             if response=$(gh api \
-              --method POST \
+              --method PUT \
               --repo "$GH_REPO" \
               -H 'Accept: application/vnd.github+json' \
-              "/repos/$GH_REPO/issues/$number/comments" \
-              -f 'body=@dependabot rebase' 2>&1); then
-              echo "Requested a rebase for Dependabot PR #$number: $response"
+              "/repos/$GH_REPO/pulls/$number/update-branch" \
+              -f "expected_head_sha=$head_sha" 2>&1); then
+              echo "Requested an update for Dependabot PR #$number: $response"
             else
               echo "$response" >&2
               exit 1
             fi
+
+            updated_head=''
+            for _ in $(seq 1 30); do
+              updated_head=$(gh api \
+                --repo "$GH_REPO" \
+                "/repos/$GH_REPO/pulls/$number" \
+                --jq '.head.sha')
+              if [ "$updated_head" != "$head_sha" ]; then
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "$updated_head" = "$head_sha" ]; then
+              echo "::error::Dependabot PR #$number did not receive an updated head"
+              exit 1
+            fi
+
+            gh workflow run ci.yml --repo "$GH_REPO" --ref "$head_ref"
           done

--- a/.github/workflows/update-dependabot-branches.yml
+++ b/.github/workflows/update-dependabot-branches.yml
@@ -1,0 +1,50 @@
+name: Update Dependabot branches
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: update-dependabot-branches
+  cancel-in-progress: false
+
+permissions:
+  pull-requests: write
+
+jobs:
+  update-branches:
+    name: Update open Dependabot pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update pull request branches
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh pr list \
+            --repo "$GH_REPO" \
+            --state open \
+            --author 'app/dependabot' \
+            --limit 100 \
+            --json number,headRefOid \
+            --jq '.[] | [.number, .headRefOid] | @tsv' |
+          while IFS=$'\t' read -r number head_sha; do
+            [ -n "$number" ] || continue
+
+            if response=$(gh api \
+              --method PUT \
+              --repo "$GH_REPO" \
+              -H 'Accept: application/vnd.github+json' \
+              "/repos/$GH_REPO/pulls/$number/update-branch" \
+              -f "expected_head_sha=$head_sha" 2>&1); then
+              echo "Requested an update for Dependabot PR #$number: $response"
+            elif grep -q 'HTTP 422' <<< "$response"; then
+              echo "::notice::Skipped Dependabot PR #$number because its branch could not be updated: $response"
+            else
+              echo "$response" >&2
+              exit 1
+            fi
+          done

--- a/.github/workflows/update-dependabot-branches.yml
+++ b/.github/workflows/update-dependabot-branches.yml
@@ -43,6 +43,8 @@ jobs:
               "/repos/$GH_REPO/pulls/$number/update-branch" \
               -f "expected_head_sha=$head_sha" 2>&1); then
               echo "Requested an update for Dependabot PR #$number: $response"
+            elif grep -q 'HTTP 422' <<< "$response"; then
+              echo "::notice::Dependabot PR #$number was updated concurrently or has a merge conflict: $response"
             else
               echo "$response" >&2
               exit 1

--- a/.github/workflows/update-dependabot-branches.yml
+++ b/.github/workflows/update-dependabot-branches.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   actions: write
+  checks: read
   contents: write
   pull-requests: write
 
@@ -26,10 +27,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          required_checks=$(gh api \
-            --repo "$GH_REPO" \
-            "repos/$GH_REPO/branches/main/protection/required_status_checks" \
-            --jq '.contexts[]')
+          # Keep this list aligned with main's protected required status checks.
+          required_checks=$'Format\nLint\nTest\nBuild\nSecurity Audit'
           failures=0
 
           dependabot_prs=$(gh pr list \
@@ -51,16 +50,31 @@ jobs:
                 "/repos/$GH_REPO/pulls/$number/update-branch" \
                 -f "expected_head_sha=$head_sha" 2>&1); then
                 echo "Requested an update for Dependabot PR #$number: $response"
+                update_wait_failed=false
+                update_observed=false
                 for _ in $(seq 1 30); do
-                  updated_head=$(gh api \
+                  if ! updated_head=$(gh api \
                     --repo "$GH_REPO" \
                     "/repos/$GH_REPO/pulls/$number" \
-                    --jq '.head.sha') || break
+                    --jq '.head.sha'); then
+                    echo "::error::Could not observe the updated head for Dependabot PR #$number"
+                    failures=$((failures + 1))
+                    update_wait_failed=true
+                    break
+                  fi
                   if [ "$updated_head" != "$head_sha" ]; then
+                    update_observed=true
                     break
                   fi
                   sleep 2
                 done
+                if [ "$update_observed" != true ]; then
+                  if [ "$update_wait_failed" = false ]; then
+                    echo "::error::Dependabot PR #$number did not receive an updated head"
+                    failures=$((failures + 1))
+                  fi
+                  continue
+                fi
               elif grep -q 'HTTP 422' <<< "$response"; then
                 echo "::notice::Dependabot PR #$number has a merge conflict or was updated concurrently: $response"
               else

--- a/.github/workflows/update-dependabot-branches.yml
+++ b/.github/workflows/update-dependabot-branches.yml
@@ -26,46 +26,91 @@ jobs:
         run: |
           set -euo pipefail
 
-          gh pr list \
+          required_checks=$(gh api \
+            --repo "$GH_REPO" \
+            "repos/$GH_REPO/branches/main/protection/required_status_checks" \
+            --jq '.contexts[]')
+          failures=0
+
+          dependabot_prs=$(gh pr list \
             --repo "$GH_REPO" \
             --state open \
             --author 'app/dependabot' \
             --limit 100 \
             --json number,headRefName,headRefOid,mergeStateStatus \
-            --jq '.[] | select(.mergeStateStatus == "BEHIND") | [.number, .headRefName, .headRefOid] | @tsv' |
-          while IFS=$'\t' read -r number head_ref head_sha; do
+            --jq '.[] | [.number, .headRefName, .headRefOid, .mergeStateStatus] | @tsv')
+
+          while IFS=$'\t' read -r number head_ref head_sha merge_state; do
             [ -n "$number" ] || continue
 
-            if response=$(gh api \
-              --method PUT \
-              --repo "$GH_REPO" \
-              -H 'Accept: application/vnd.github+json' \
-              "/repos/$GH_REPO/pulls/$number/update-branch" \
-              -f "expected_head_sha=$head_sha" 2>&1); then
-              echo "Requested an update for Dependabot PR #$number: $response"
-            elif grep -q 'HTTP 422' <<< "$response"; then
-              echo "::notice::Dependabot PR #$number was updated concurrently or has a merge conflict: $response"
-            else
-              echo "$response" >&2
-              exit 1
+            if [ "$merge_state" = "BEHIND" ]; then
+              if response=$(gh api \
+                --method PUT \
+                --repo "$GH_REPO" \
+                -H 'Accept: application/vnd.github+json' \
+                "/repos/$GH_REPO/pulls/$number/update-branch" \
+                -f "expected_head_sha=$head_sha" 2>&1); then
+                echo "Requested an update for Dependabot PR #$number: $response"
+                for _ in $(seq 1 30); do
+                  updated_head=$(gh api \
+                    --repo "$GH_REPO" \
+                    "/repos/$GH_REPO/pulls/$number" \
+                    --jq '.head.sha') || break
+                  if [ "$updated_head" != "$head_sha" ]; then
+                    break
+                  fi
+                  sleep 2
+                done
+              elif grep -q 'HTTP 422' <<< "$response"; then
+                echo "::notice::Dependabot PR #$number has a merge conflict or was updated concurrently: $response"
+              else
+                echo "::error::Could not update Dependabot PR #$number: $response"
+                failures=$((failures + 1))
+              fi
             fi
 
-            updated_head=''
-            for _ in $(seq 1 30); do
-              updated_head=$(gh api \
+            if ! current_pr=$(gh api \
                 --repo "$GH_REPO" \
                 "/repos/$GH_REPO/pulls/$number" \
-                --jq '.head.sha')
-              if [ "$updated_head" != "$head_sha" ]; then
-                break
-              fi
-              sleep 2
-            done
+                --jq '{head_sha: .head.sha, head_ref: .head.ref}' 2>&1); then
+              echo "::error::Could not inspect Dependabot PR #$number: $current_pr"
+              failures=$((failures + 1))
+              continue
+            fi
+            current_head=$(jq -r '.head_sha' <<< "$current_pr")
+            current_ref=$(jq -r '.head_ref' <<< "$current_pr")
 
-            if [ "$updated_head" = "$head_sha" ]; then
-              echo "::error::Dependabot PR #$number did not receive an updated head"
-              exit 1
+            if ! check_runs=$(gh api \
+              --paginate \
+              --slurp \
+              --repo "$GH_REPO" \
+              "/repos/$GH_REPO/commits/$current_head/check-runs" \
+              --jq 'map(.check_runs[]) | .[] | [.name, .status, (.conclusion // "")] | @tsv' 2>&1); then
+              echo "::error::Could not inspect checks for Dependabot PR #$number: $check_runs"
+              failures=$((failures + 1))
+              continue
             fi
 
-            gh workflow run ci.yml --repo "$GH_REPO" --ref "$head_ref"
-          done
+            needs_ci=false
+            while IFS= read -r required_check; do
+              [ -n "$required_check" ] || continue
+              if ! awk -F '\t' -v name="$required_check" '$1 == name { found = 1 } END { exit !found }' <<< "$check_runs"; then
+                needs_ci=true
+                break
+              fi
+            done <<< "$required_checks"
+
+            if [ "$needs_ci" = true ]; then
+              if response=$(gh workflow run ci.yml --repo "$GH_REPO" --ref "$current_ref" 2>&1); then
+                echo "Dispatched CI for Dependabot PR #$number at $current_head: $response"
+              else
+                echo "::error::Could not dispatch CI for Dependabot PR #$number: $response"
+                failures=$((failures + 1))
+              fi
+            fi
+          done <<< "$dependabot_prs"
+
+          if [ "$failures" -gt 0 ]; then
+            echo "::error::$failures Dependabot PR operation(s) failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Problem
Dependabot pull requests can become stale after another pull request updates `main`, leaving auto-merge pending until the branch is updated manually.

## Background
The protected `main` branch requires pull request branches to be up to date, but the existing auto-merge workflow only enables auto-merge.

## Approach
Update stale Dependabot branches whenever `main` changes, wait for the asynchronous update to complete, and dispatch the existing CI workflow on the updated branch. This avoids relying on approval-required `pull_request/synchronize` runs created by `GITHUB_TOKEN`.
