### PR TITLE
feat(mysql): add TLS certificate verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,6 +2633,7 @@ dependencies = [
  "toml",
  "unicode-casefold",
  "unicode-width",
+ "url",
  "uuid",
 ]
 

--- a/compose.mysql-tls.yml
+++ b/compose.mysql-tls.yml
@@ -1,0 +1,9 @@
+services:
+  mysql:
+    volumes:
+      - ./.tmp/mysql/tls:/etc/mysql/tls:ro
+    command:
+      - mysqld
+      - --ssl-ca=/etc/mysql/tls/ca.pem
+      - --ssl-cert=/etc/mysql/tls/server-cert.pem
+      - --ssl-key=/etc/mysql/tls/server-key.pem

--- a/scripts/mysql-docker-cli.sh
+++ b/scripts/mysql-docker-cli.sh
@@ -17,6 +17,10 @@ for argument in "$@"; do
     esac
 done
 
+if [[ -n "${SABIQL_MYSQL_TEST_TLS_DIR:-}" ]]; then
+    mount_args+=(--volume "$SABIQL_MYSQL_TEST_TLS_DIR:$SABIQL_MYSQL_TEST_TLS_DIR:ro")
+fi
+
 docker_args=(--rm --interactive)
 if [[ -t 0 && -t 1 ]]; then
     docker_args+=(--tty)

--- a/scripts/mysql_integration.sh
+++ b/scripts/mysql_integration.sh
@@ -4,7 +4,9 @@ set -Eeuo pipefail
 readonly script_dir="$(cd "$(dirname "$0")" && pwd)"
 readonly repo_root="$(cd "$script_dir/.." && pwd)"
 readonly compose_file="$repo_root/compose.yml"
+readonly tls_compose_file="$repo_root/compose.mysql-tls.yml"
 readonly temp_dir="$repo_root/.tmp/mysql"
+readonly tls_dir="$temp_dir/tls"
 readonly mysql_image="mysql:8.4.10"
 readonly mysql_host="${SABIQL_MYSQL_TEST_HOST:-host.docker.internal}"
 readonly mysql_port="${SABIQL_MYSQL_TEST_PORT:-3306}"
@@ -23,7 +25,7 @@ cleanup() {
         rm -rf -- "$mysql_bin_dir"
     fi
     rm -rf -- "$temp_dir"
-    docker compose --file "$compose_file" rm --force --stop mysql >/dev/null 2>&1 || true
+    docker compose --file "$compose_file" --file "$tls_compose_file" rm --force --stop mysql >/dev/null 2>&1 || true
 }
 
 trap cleanup EXIT
@@ -46,6 +48,31 @@ create_option_file() {
         printf 'password = %s\n' "$(quote_option_value "$mysql_password")"
         printf 'database = %s\n' "$(quote_option_value "$mysql_database")"
     } >"$mysql_option_file"
+}
+
+create_tls_material() {
+    mkdir -p -- "$tls_dir"
+    openssl genrsa -out "$tls_dir/ca-key.pem" 2048 >/dev/null 2>&1
+    openssl req -x509 -new -key "$tls_dir/ca-key.pem" -sha256 -days 1 \
+        -subj '/CN=sabiql-test-ca' -out "$tls_dir/ca.pem" >/dev/null 2>&1
+    openssl genrsa -out "$tls_dir/server-key.pem" 2048 >/dev/null 2>&1
+    openssl req -new -key "$tls_dir/server-key.pem" -subj '/CN=localhost' \
+        -out "$tls_dir/server.csr" >/dev/null 2>&1
+    printf '%s\n' '[v3_server]' 'subjectAltName = DNS:localhost,IP:127.0.0.1' \
+        >"$tls_dir/server-ext.cnf"
+    openssl x509 -req -in "$tls_dir/server.csr" -CA "$tls_dir/ca.pem" \
+        -CAkey "$tls_dir/ca-key.pem" -CAcreateserial -out "$tls_dir/server-cert.pem" \
+        -days 1 -sha256 -extfile "$tls_dir/server-ext.cnf" -extensions v3_server \
+        >/dev/null 2>&1
+    openssl genrsa -out "$tls_dir/client-key.pem" 2048 >/dev/null 2>&1
+    openssl req -new -key "$tls_dir/client-key.pem" -subj '/CN=sabiql-client' \
+        -out "$tls_dir/client.csr" >/dev/null 2>&1
+    openssl x509 -req -in "$tls_dir/client.csr" -CA "$tls_dir/ca.pem" \
+        -CAkey "$tls_dir/ca-key.pem" -CAcreateserial -out "$tls_dir/client-cert.pem" \
+        -days 1 -sha256 >/dev/null 2>&1
+    chmod 644 "$tls_dir"/*.pem
+    rm -f -- "$tls_dir/ca-key.pem" "$tls_dir/server.csr" "$tls_dir/server-ext.cnf" \
+        "$tls_dir/client.csr" "$tls_dir/ca.srl"
 }
 
 install_cli_wrapper() {
@@ -92,6 +119,10 @@ run_tests() {
     export SABIQL_MYSQL_TEST_DATABASE="$mysql_database"
     export SABIQL_MYSQL_TEST_USER="$mysql_user"
     export SABIQL_MYSQL_TEST_PASSWORD="$mysql_password"
+    export SABIQL_MYSQL_TEST_TLS_DIR="$tls_dir"
+    export SABIQL_MYSQL_TEST_SSL_CA="$tls_dir/ca.pem"
+    export SABIQL_MYSQL_TEST_SSL_CERT="$tls_dir/client-cert.pem"
+    export SABIQL_MYSQL_TEST_SSL_KEY="$tls_dir/client-key.pem"
     export SABIQL_MYSQL_TRANSCRIPT=1
     cargo nextest run -p sabiql --run-ignored ignored-only \
         -E 'test(tests::adapter_mysql)' \
@@ -104,15 +135,16 @@ case "${1:-test}" in
     test)
         mkdir -p -- "$temp_dir"
         export TMPDIR="$temp_dir"
-        docker compose --file "$compose_file" rm --force --stop mysql >/dev/null 2>&1 || true
-        docker compose --file "$compose_file" up --detach --wait mysql
+        docker compose --file "$compose_file" --file "$tls_compose_file" rm --force --stop mysql >/dev/null 2>&1 || true
+        create_tls_material
+        docker compose --file "$compose_file" --file "$tls_compose_file" up --detach --wait mysql
         install_cli_wrapper
         create_option_file
         assert_versions
         run_tests
         ;;
     stop)
-        docker compose --file "$compose_file" rm --force --stop mysql
+        docker compose --file "$compose_file" --file "$tls_compose_file" rm --force --stop mysql
         ;;
     *)
         echo "usage: $0 [test|stop]" >&2

--- a/src/app/Cargo.toml
+++ b/src/app/Cargo.toml
@@ -23,6 +23,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
+url.workspace = true
 unicode-casefold.workspace = true
 unicode-width.workspace = true
 sabiql-domain.workspace = true

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -19,7 +19,9 @@ use crate::model::app_state::AppState;
 use crate::ports::outbound::{
     ConnectionStoreError, MetadataProvider, ServiceFileError, SqlitePathValidator,
 };
-use crate::update::action::{Action, ConnectionTarget, ConnectionsLoadedPayload};
+use crate::update::action::{
+    Action, ConnectionSaveError, ConnectionTarget, ConnectionsLoadedPayload,
+};
 
 pub(crate) async fn run(
     effect: Effect,
@@ -114,7 +116,12 @@ pub(crate) async fn run(
                             }
                         },
                         Err(e) => {
-                            tx.send(Action::ConnectionSaveFailed(e.into())).await.ok();
+                            tx.send(Action::ConnectionSaveFailed(ConnectionSaveError::Probe {
+                                error: e,
+                                dsn: target.dsn.clone(),
+                            }))
+                            .await
+                            .ok();
                         }
                     }
                 });
@@ -509,7 +516,8 @@ mod tests {
                 .unwrap();
             assert!(matches!(
                 action,
-                Action::ConnectionSaveFailed(ConnectionSaveError::Metadata(_))
+                Action::ConnectionSaveFailed(ConnectionSaveError::Probe { dsn, .. })
+                    if dsn == "mysql://user:secret@localhost:3306?ssl-mode=REQUIRED"
             ));
         }
 

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -4,6 +4,8 @@ use crate::ports::outbound::{
     MYSQL_SERVER_VERSION_REQUIRED_MARKER, MYSQL_SQL_MODE_UNSUPPORTED_MARKER,
     SQLITE_SAFE_MODE_REQUIRED_MARKER, SQLITE_TABLE_LIST_REQUIRED_MARKER,
 };
+use sabiql_domain::connection::MySqlSslMode;
+use url::Url;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ConnectionErrorKind {
@@ -199,8 +201,7 @@ fn is_mysql_client_certificate_error(value: &str) -> bool {
 }
 
 fn is_mysql_hostname_verification_error(value: &str) -> bool {
-    value.contains("error:0a000086:ssl routines::certificate verify failed")
-        || value.contains("hostname mismatch")
+    value.contains("hostname mismatch")
         || value.contains("host name mismatch")
         || value.contains("hostname does not match")
         || value.contains("host name does not match")
@@ -220,6 +221,32 @@ fn is_mysql_ca_verification_error(value: &str) -> bool {
         || value.contains("self-signed certificate")
         || value.contains("unknown ca")
         || value.contains("certificate signature failure")
+}
+
+fn is_mysql_ambiguous_certificate_verification_error(value: &str) -> bool {
+    value
+        .to_ascii_lowercase()
+        .contains("error:0a000086:ssl routines::certificate verify failed")
+}
+
+fn mysql_ssl_mode_from_dsn(dsn: &str) -> Option<MySqlSslMode> {
+    let url = Url::parse(dsn).ok()?;
+    if url.scheme() != "mysql" {
+        return None;
+    }
+    url.query_pairs().find_map(|(key, value)| {
+        if key != "ssl-mode" {
+            return None;
+        }
+        Some(match value.as_ref() {
+            "DISABLED" => MySqlSslMode::Disabled,
+            "PREFERRED" => MySqlSslMode::Preferred,
+            "REQUIRED" => MySqlSslMode::Required,
+            "VERIFY_CA" => MySqlSslMode::VerifyCa,
+            "VERIFY_IDENTITY" => MySqlSslMode::VerifyIdentity,
+            _ => return None,
+        })
+    })
 }
 
 fn is_mysql_tls_handshake_error(value: &str) -> bool {
@@ -300,6 +327,27 @@ impl ConnectionErrorInfo {
             }
             _ => ConnectionErrorKind::Unknown,
         };
+        Self::with_kind(kind, raw_details)
+    }
+
+    pub fn from_db_operation_error_with_dsn(error: &DbOperationError, dsn: &str) -> Self {
+        let raw_details = error.raw_details().into_owned();
+        let kind = mysql_ssl_mode_from_dsn(dsn)
+            .and_then(|ssl_mode| match (ssl_mode, error) {
+                (MySqlSslMode::VerifyCa, DbOperationError::ConnectionFailed(_))
+                    if is_mysql_ambiguous_certificate_verification_error(&raw_details) =>
+                {
+                    Some(ConnectionErrorKind::MySqlCaVerificationFailed)
+                }
+                (MySqlSslMode::VerifyIdentity, DbOperationError::ConnectionFailed(_))
+                    if is_mysql_ambiguous_certificate_verification_error(&raw_details) =>
+                {
+                    Some(ConnectionErrorKind::MySqlHostnameVerificationFailed)
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| Self::from_db_operation_error(error).kind);
+
         Self::with_kind(kind, raw_details)
     }
 
@@ -439,7 +487,7 @@ mod tests {
                 ConnectionErrorKind::classify(
                     "ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed"
                 ),
-                ConnectionErrorKind::MySqlHostnameVerificationFailed
+                ConnectionErrorKind::MySqlTlsHandshakeFailed
             );
             assert_eq!(
                 ConnectionErrorKind::classify(
@@ -529,6 +577,28 @@ mod tests {
             assert_eq!(
                 info.masked_details(),
                 "FATAL: database \"nonexistent\" does not exist"
+            );
+        }
+
+        #[test]
+        fn from_db_operation_error_with_dsn_uses_mysql_tls_mode_for_ambiguous_verification() {
+            let error = DbOperationError::ConnectionFailed(
+                "ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed"
+                    .to_string(),
+            );
+            let ca = ConnectionErrorInfo::from_db_operation_error_with_dsn(
+                &error,
+                "mysql://user:password@localhost:3306/app?ssl-mode=VERIFY_CA",
+            );
+            let identity = ConnectionErrorInfo::from_db_operation_error_with_dsn(
+                &error,
+                "mysql://user:password@localhost:3306/app?ssl-mode=VERIFY_IDENTITY",
+            );
+
+            assert_eq!(ca.kind, ConnectionErrorKind::MySqlCaVerificationFailed);
+            assert_eq!(
+                identity.kind,
+                ConnectionErrorKind::MySqlHostnameVerificationFailed
             );
         }
 

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -199,7 +199,8 @@ fn is_mysql_client_certificate_error(value: &str) -> bool {
 }
 
 fn is_mysql_hostname_verification_error(value: &str) -> bool {
-    value.contains("hostname mismatch")
+    value.contains("error:0a000086:ssl routines::certificate verify failed")
+        || value.contains("hostname mismatch")
         || value.contains("host name mismatch")
         || value.contains("hostname does not match")
         || value.contains("host name does not match")
@@ -218,9 +219,6 @@ fn is_mysql_ca_verification_error(value: &str) -> bool {
     value.contains("unable to get local issuer")
         || value.contains("self-signed certificate")
         || value.contains("unknown ca")
-        || value.contains("certificate verify failed")
-        || value.contains("certificate verification failure")
-        || value.contains("certificate validation failure")
         || value.contains("certificate signature failure")
 }
 
@@ -434,6 +432,12 @@ mod tests {
             assert_eq!(
                 ConnectionErrorKind::classify(
                     "ERROR 2026 (HY000): TLS/SSL error: certificate verify failed: hostname mismatch"
+                ),
+                ConnectionErrorKind::MySqlHostnameVerificationFailed
+            );
+            assert_eq!(
+                ConnectionErrorKind::classify(
+                    "ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed"
                 ),
                 ConnectionErrorKind::MySqlHostnameVerificationFailed
             );

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -12,6 +12,10 @@ pub enum ConnectionErrorKind {
     MySqlCliVersionUnsupported,
     MySqlServerVersionUnsupported,
     MySqlSqlModeUnsupported,
+    MySqlTlsHandshakeFailed,
+    MySqlCaVerificationFailed,
+    MySqlHostnameVerificationFailed,
+    MySqlClientCertificateRejected,
     SqliteCliNotFound,
     HostUnreachable,
     AuthFailed,
@@ -60,6 +64,22 @@ impl ConnectionErrorKind {
             return Self::AuthFailed;
         }
 
+        if is_mysql_client_certificate_error(&stderr_lower) {
+            return Self::MySqlClientCertificateRejected;
+        }
+
+        if is_mysql_hostname_verification_error(&stderr_lower) {
+            return Self::MySqlHostnameVerificationFailed;
+        }
+
+        if is_mysql_ca_verification_error(&stderr_lower) {
+            return Self::MySqlCaVerificationFailed;
+        }
+
+        if is_mysql_tls_handshake_error(&stderr_lower) {
+            return Self::MySqlTlsHandshakeFailed;
+        }
+
         if stderr_lower.contains("does not exist")
             && (stderr_lower.contains("database") || stderr_lower.contains("fatal:"))
         {
@@ -94,6 +114,10 @@ impl ConnectionErrorKind {
             Self::MySqlCliVersionUnsupported => "Unsupported MySQL CLI version",
             Self::MySqlServerVersionUnsupported => "Unsupported MySQL server version",
             Self::MySqlSqlModeUnsupported => "Unsupported MySQL sql_mode",
+            Self::MySqlTlsHandshakeFailed => "MySQL TLS handshake failed",
+            Self::MySqlCaVerificationFailed => "MySQL server certificate could not be verified",
+            Self::MySqlHostnameVerificationFailed => "MySQL server hostname could not be verified",
+            Self::MySqlClientCertificateRejected => "MySQL client certificate was rejected",
             Self::SqliteCliNotFound => DatabaseCli::Sqlite3.not_found_summary(),
             Self::HostUnreachable => "Could not resolve host",
             Self::AuthFailed => "Authentication failed",
@@ -121,6 +145,18 @@ impl ConnectionErrorKind {
             Self::MySqlServerVersionUnsupported => "Connect to an Oracle MySQL 8.4 server",
             Self::MySqlSqlModeUnsupported => {
                 "Disable NO_BACKSLASH_ESCAPES and ANSI_QUOTES for this connection"
+            }
+            Self::MySqlTlsHandshakeFailed => {
+                "Check that the server and client support the selected TLS settings"
+            }
+            Self::MySqlCaVerificationFailed => {
+                "Check the CA certificate path and server certificate"
+            }
+            Self::MySqlHostnameVerificationFailed => {
+                "Use the hostname covered by the server certificate"
+            }
+            Self::MySqlClientCertificateRejected => {
+                "Check the client certificate, key, and server account requirements"
             }
             Self::SqliteCliNotFound => DatabaseCli::Sqlite3.not_found_hint(),
             Self::HostUnreachable => "Check the hostname",
@@ -151,6 +187,42 @@ impl ConnectionErrorKind {
 fn is_mysql_connect_timeout_message(value: &str) -> bool {
     value.contains("can't connect to mysql server")
         && (value.contains("(110)") || value.contains("(10060)"))
+}
+
+fn is_mysql_client_certificate_error(value: &str) -> bool {
+    (value.contains("certificate")
+        && (value.contains("certificate required")
+            || value.contains("client certificate")
+            || value.contains("peer did not return a certificate")
+            || value.contains("bad certificate")))
+        || value.contains("tlsv1 alert certificate required")
+}
+
+fn is_mysql_hostname_verification_error(value: &str) -> bool {
+    value.contains("hostname mismatch")
+        || value.contains("host name mismatch")
+        || value.contains("hostname does not match")
+        || value.contains("subject alternative name")
+        || (value.contains("verify identity") && value.contains("certificate"))
+}
+
+fn is_mysql_ca_verification_error(value: &str) -> bool {
+    value.contains("unable to get local issuer")
+        || value.contains("self-signed certificate")
+        || value.contains("unknown ca")
+        || value.contains("certificate verify failed")
+        || value.contains("certificate verification failure")
+        || value.contains("certificate validation failure")
+        || value.contains("certificate signature failure")
+}
+
+fn is_mysql_tls_handshake_error(value: &str) -> bool {
+    value.contains("tls/ssl error")
+        || value.contains("ssl handshake")
+        || value.contains("tls handshake")
+        || value.contains("handshake failure")
+        || value.contains("ssl connection error")
+        || value.contains("tlsv1 alert")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -348,6 +420,34 @@ mod tests {
                 ConnectionErrorKind::Timeout
             );
         }
+
+        #[test]
+        fn stderr_as_mysql_tls_error() {
+            assert_eq!(
+                ConnectionErrorKind::classify(
+                    "ERROR 2026 (HY000): TLS/SSL error: certificate verify failed: hostname mismatch"
+                ),
+                ConnectionErrorKind::MySqlHostnameVerificationFailed
+            );
+            assert_eq!(
+                ConnectionErrorKind::classify(
+                    "ERROR 2026 (HY000): TLS/SSL error: unable to get local issuer certificate"
+                ),
+                ConnectionErrorKind::MySqlCaVerificationFailed
+            );
+            assert_eq!(
+                ConnectionErrorKind::classify(
+                    "ERROR 2026 (HY000): TLS/SSL error: peer did not return a certificate"
+                ),
+                ConnectionErrorKind::MySqlClientCertificateRejected
+            );
+            assert_eq!(
+                ConnectionErrorKind::classify(
+                    "ERROR 2026 (HY000): TLS/SSL error: handshake failure"
+                ),
+                ConnectionErrorKind::MySqlTlsHandshakeFailed
+            );
+        }
     }
 
     mod error_kind {
@@ -366,6 +466,10 @@ mod tests {
         #[case(ConnectionErrorKind::MySqlCliVersionUnsupported)]
         #[case(ConnectionErrorKind::MySqlServerVersionUnsupported)]
         #[case(ConnectionErrorKind::MySqlSqlModeUnsupported)]
+        #[case(ConnectionErrorKind::MySqlTlsHandshakeFailed)]
+        #[case(ConnectionErrorKind::MySqlCaVerificationFailed)]
+        #[case(ConnectionErrorKind::MySqlHostnameVerificationFailed)]
+        #[case(ConnectionErrorKind::MySqlClientCertificateRejected)]
         #[case(ConnectionErrorKind::SqliteVersionTooOld)]
         #[case(ConnectionErrorKind::SqliteFileNotFound)]
         #[case(ConnectionErrorKind::SqlitePathIsDirectory)]

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -202,6 +202,14 @@ fn is_mysql_hostname_verification_error(value: &str) -> bool {
     value.contains("hostname mismatch")
         || value.contains("host name mismatch")
         || value.contains("hostname does not match")
+        || value.contains("host name does not match")
+        || value.contains("hostname verification failed")
+        || value.contains("host name verification failed")
+        || value.contains("certificate name mismatch")
+        || value.contains("certificate does not match")
+        || value.contains("does not match certificate")
+        || value.contains("not valid for the requested host")
+        || value.contains("not valid for hostname")
         || value.contains("subject alternative name")
         || (value.contains("verify identity") && value.contains("certificate"))
 }
@@ -426,6 +434,12 @@ mod tests {
             assert_eq!(
                 ConnectionErrorKind::classify(
                     "ERROR 2026 (HY000): TLS/SSL error: certificate verify failed: hostname mismatch"
+                ),
+                ConnectionErrorKind::MySqlHostnameVerificationFailed
+            );
+            assert_eq!(
+                ConnectionErrorKind::classify(
+                    "ERROR 2026 (HY000): TLS/SSL error: Certificate validation failure: host name does not match certificate"
                 ),
                 ConnectionErrorKind::MySqlHostnameVerificationFailed
             );

--- a/src/app/model/connection/setup.rs
+++ b/src/app/model/connection/setup.rs
@@ -21,12 +21,18 @@ pub enum ConnectionField {
     User,
     Password,
     SslMode,
+    SslCa,
+    SslCert,
+    SslKey,
 }
 
 impl ConnectionField {
-    pub fn fields_for(database_type: DatabaseType) -> &'static [Self] {
+    pub fn fields_for(
+        database_type: DatabaseType,
+        mysql_ssl_mode: MySqlSslMode,
+    ) -> &'static [Self] {
         match database_type {
-            DatabaseType::PostgreSQL | DatabaseType::MySQL => &[
+            DatabaseType::PostgreSQL => &[
                 Self::DatabaseType,
                 Self::Name,
                 Self::Host,
@@ -37,6 +43,43 @@ impl ConnectionField {
                 Self::SslMode,
             ],
             DatabaseType::SQLite => &[Self::DatabaseType, Self::Name, Self::SqlitePath],
+            DatabaseType::MySQL => match mysql_ssl_mode {
+                MySqlSslMode::Disabled => &[
+                    Self::DatabaseType,
+                    Self::Name,
+                    Self::Host,
+                    Self::Port,
+                    Self::Database,
+                    Self::User,
+                    Self::Password,
+                    Self::SslMode,
+                ],
+                MySqlSslMode::Preferred | MySqlSslMode::Required => &[
+                    Self::DatabaseType,
+                    Self::Name,
+                    Self::Host,
+                    Self::Port,
+                    Self::Database,
+                    Self::User,
+                    Self::Password,
+                    Self::SslMode,
+                    Self::SslCert,
+                    Self::SslKey,
+                ],
+                MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity => &[
+                    Self::DatabaseType,
+                    Self::Name,
+                    Self::Host,
+                    Self::Port,
+                    Self::Database,
+                    Self::User,
+                    Self::Password,
+                    Self::SslMode,
+                    Self::SslCa,
+                    Self::SslCert,
+                    Self::SslKey,
+                ],
+            },
         }
     }
 
@@ -50,7 +93,7 @@ impl ConnectionField {
     pub fn max_chars(self) -> Option<usize> {
         match self {
             Self::Name => Some(50),
-            Self::SqlitePath => Some(4096),
+            Self::SqlitePath | Self::SslCa | Self::SslCert | Self::SslKey => Some(4096),
             Self::Host | Self::Database | Self::User | Self::Password => Some(255),
             Self::Port => Some(5),
             Self::DatabaseType | Self::SslMode => None,
@@ -85,6 +128,9 @@ impl ConnectionField {
             Self::User => "User:",
             Self::Password => "Password:",
             Self::SslMode => "SSL Mode:",
+            Self::SslCa => "CA Path:",
+            Self::SslCert => "Cert Path:",
+            Self::SslKey => "Key Path:",
         }
     }
 }
@@ -131,6 +177,9 @@ pub struct ConnectionSetupState {
     pub(crate) database: TextInputState,
     pub(crate) user: TextInputState,
     pub(crate) password: TextInputState,
+    pub(crate) ssl_ca: TextInputState,
+    pub(crate) ssl_cert: TextInputState,
+    pub(crate) ssl_key: TextInputState,
     pub(crate) ssl_mode: SslMode,
     pub(crate) mysql_ssl_mode: MySqlSslMode,
 
@@ -155,6 +204,9 @@ impl Default for ConnectionSetupState {
             database: TextInputState::default(),
             user: TextInputState::default(),
             password: TextInputState::default(),
+            ssl_ca: TextInputState::default(),
+            ssl_cert: TextInputState::default(),
+            ssl_key: TextInputState::default(),
             ssl_mode: SslMode::Prefer,
             mysql_ssl_mode: MySqlSslMode::Preferred,
             focused_field: ConnectionField::DatabaseType,
@@ -236,6 +288,9 @@ impl ConnectionSetupState {
             ConnectionField::Database => Some(&self.database),
             ConnectionField::User => Some(&self.user),
             ConnectionField::Password => Some(&self.password),
+            ConnectionField::SslCa => Some(&self.ssl_ca),
+            ConnectionField::SslCert => Some(&self.ssl_cert),
+            ConnectionField::SslKey => Some(&self.ssl_key),
         }
     }
 
@@ -253,6 +308,9 @@ impl ConnectionSetupState {
             ConnectionField::Database => Some(&mut self.database),
             ConnectionField::User => Some(&mut self.user),
             ConnectionField::Password => Some(&mut self.password),
+            ConnectionField::SslCa => Some(&mut self.ssl_ca),
+            ConnectionField::SslCert => Some(&mut self.ssl_cert),
+            ConnectionField::SslKey => Some(&mut self.ssl_key),
         }
     }
 
@@ -285,7 +343,7 @@ impl ConnectionSetupState {
     }
 
     pub fn visible_fields(&self) -> &'static [ConnectionField] {
-        ConnectionField::fields_for(self.database_type)
+        ConnectionField::fields_for(self.database_type, self.mysql_ssl_mode)
     }
 
     pub fn next_field(&self) -> Option<ConnectionField> {
@@ -402,6 +460,7 @@ impl ConnectionSetupState {
                     MySqlSslMode::all_variants().get(self.ssl_dropdown.selected_index)
                 {
                     self.mysql_ssl_mode = *mode;
+                    self.retain_validation_errors_for_visible_fields();
                 }
             } else if let Some(mode) = SslMode::all_variants().get(self.ssl_dropdown.selected_index)
             {
@@ -467,20 +526,33 @@ impl ConnectionSetupState {
             DatabaseType::SQLite => ConnectionConfig::SQLite(SqliteConnectionConfig::new(
                 self.sqlite_path.content().to_string(),
             )?),
-            DatabaseType::MySQL => ConnectionConfig::MySQL(MySqlConnectionConfig::new(
-                self.host.content().trim().to_string(),
-                self.port
-                    .content()
-                    .parse()
-                    .expect("port validated before building connection config"),
-                match self.database.content().trim() {
-                    "" => None,
-                    database => Some(database.to_string()),
-                },
-                self.user.content().trim().to_string(),
-                self.password.content().to_string(),
-                self.mysql_ssl_mode,
-            )),
+            DatabaseType::MySQL => ConnectionConfig::MySQL(
+                MySqlConnectionConfig::new(
+                    self.host.content().trim().to_string(),
+                    self.port
+                        .content()
+                        .parse()
+                        .expect("port validated before building connection config"),
+                    match self.database.content().trim() {
+                        "" => None,
+                        database => Some(database.to_string()),
+                    },
+                    self.user.content().trim().to_string(),
+                    self.password.content().to_string(),
+                    self.mysql_ssl_mode,
+                )
+                .with_tls_paths(
+                    (!matches!(self.mysql_ssl_mode, MySqlSslMode::Disabled))
+                        .then(|| optional_path(&self.ssl_ca))
+                        .flatten(),
+                    (!matches!(self.mysql_ssl_mode, MySqlSslMode::Disabled))
+                        .then(|| optional_path(&self.ssl_cert))
+                        .flatten(),
+                    (!matches!(self.mysql_ssl_mode, MySqlSslMode::Disabled))
+                        .then(|| optional_path(&self.ssl_key))
+                        .flatten(),
+                ),
+            ),
         })
     }
 }
@@ -544,10 +616,23 @@ impl From<&ConnectionProfile> for ConnectionSetupState {
                 state.password =
                     TextInputState::new(&config.password, config.password.chars().count());
                 state.mysql_ssl_mode = config.ssl_mode;
+                if let Some(path) = config.ssl_ca.as_deref() {
+                    state.ssl_ca = TextInputState::new(path, path.chars().count());
+                }
+                if let Some(path) = config.ssl_cert.as_deref() {
+                    state.ssl_cert = TextInputState::new(path, path.chars().count());
+                }
+                if let Some(path) = config.ssl_key.as_deref() {
+                    state.ssl_key = TextInputState::new(path, path.chars().count());
+                }
             }
         }
         state
     }
+}
+
+fn optional_path(input: &TextInputState) -> Option<String> {
+    (!input.content().trim().is_empty()).then(|| input.content().to_string())
 }
 
 #[cfg(test)]
@@ -568,6 +653,9 @@ mod tests {
         #[case(ConnectionField::User, false)]
         #[case(ConnectionField::Password, false)]
         #[case(ConnectionField::SslMode, false)]
+        #[case(ConnectionField::SslCa, false)]
+        #[case(ConnectionField::SslCert, false)]
+        #[case(ConnectionField::SslKey, false)]
         fn is_required_returns_correct_value(
             #[case] field: ConnectionField,
             #[case] expected: bool,
@@ -576,7 +664,8 @@ mod tests {
         }
         #[test]
         fn fields_for_returns_postgres_fields_in_order() {
-            let fields = ConnectionField::fields_for(DatabaseType::PostgreSQL);
+            let fields =
+                ConnectionField::fields_for(DatabaseType::PostgreSQL, MySqlSslMode::Preferred);
             assert_eq!(fields.len(), 8);
             assert_eq!(fields[0], ConnectionField::DatabaseType);
             assert_eq!(fields[7], ConnectionField::SslMode);
@@ -585,7 +674,7 @@ mod tests {
         #[test]
         fn fields_for_returns_sqlite_fields_in_order() {
             assert_eq!(
-                ConnectionField::fields_for(DatabaseType::SQLite),
+                ConnectionField::fields_for(DatabaseType::SQLite, MySqlSslMode::Preferred),
                 &[
                     ConnectionField::DatabaseType,
                     ConnectionField::Name,
@@ -597,7 +686,7 @@ mod tests {
         #[test]
         fn fields_for_returns_mysql_fields_in_order() {
             assert_eq!(
-                ConnectionField::fields_for(DatabaseType::MySQL),
+                ConnectionField::fields_for(DatabaseType::MySQL, MySqlSslMode::Preferred),
                 &[
                     ConnectionField::DatabaseType,
                     ConnectionField::Name,
@@ -607,6 +696,8 @@ mod tests {
                     ConnectionField::User,
                     ConnectionField::Password,
                     ConnectionField::SslMode,
+                    ConnectionField::SslCert,
+                    ConnectionField::SslKey,
                 ]
             );
         }
@@ -648,6 +739,20 @@ mod tests {
                 ConnectionField::User.placeholder_for(DatabaseType::MySQL),
                 ""
             );
+        }
+
+        #[test]
+        fn mysql_tls_fields_follow_selected_mode() {
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::MySQL);
+            assert!(!state.visible_fields().contains(&ConnectionField::SslCa));
+            assert!(state.visible_fields().contains(&ConnectionField::SslCert));
+
+            state.mysql_ssl_mode = MySqlSslMode::VerifyIdentity;
+            assert!(state.visible_fields().contains(&ConnectionField::SslCa));
+
+            state.mysql_ssl_mode = MySqlSslMode::Disabled;
+            assert!(!state.visible_fields().contains(&ConnectionField::SslCert));
         }
     }
 

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -33,6 +33,11 @@ pub enum ConnectionSaveError {
     Store(#[from] ConnectionStoreError),
     #[error("{0}")]
     Metadata(#[from] DbOperationError),
+    #[error("{error}")]
+    Probe {
+        error: DbOperationError,
+        dsn: String,
+    },
 }
 
 #[derive(Debug, Clone, thiserror::Error)]

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -118,7 +118,7 @@ pub(super) fn reduce_loading(
                 return DispatchResult::handled();
             }
 
-            let error_info = ConnectionErrorInfo::from_db_operation_error(error);
+            let error_info = ConnectionErrorInfo::from_db_operation_error_with_dsn(error, dsn);
             state.connection_error.set_error(error_info);
             let was_connected = state.session.connection_state().is_connected();
             state.session.mark_connection_failed(error.masked_details());

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -173,9 +173,9 @@ pub fn reduce_connection_lifecycle(
             if state.session.dsn_matches(&target.dsn) {
                 state.session.mark_connection_failed(error.user_message());
             }
-            state
-                .connection_error
-                .set_error(ConnectionErrorInfo::from_db_operation_error(error));
+            state.connection_error.set_error(
+                ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
+            );
             state.modal.replace_mode(InputMode::ConnectionError);
             DispatchResult::handled()
         }

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -270,12 +270,23 @@ pub fn reduce_connection_setup(
             if !state.session.connection_state().is_connected() {
                 state.session.mark_disconnected();
             }
-            if let ConnectionSaveError::Metadata(error) = e
-                && state.connection_setup.database_type() == DatabaseType::MySQL
-            {
-                state
-                    .connection_error
-                    .set_error(ConnectionErrorInfo::from_db_operation_error(error));
+            let mysql_error = match e {
+                ConnectionSaveError::Probe { error, dsn }
+                    if state.connection_setup.database_type() == DatabaseType::MySQL =>
+                {
+                    Some(ConnectionErrorInfo::from_db_operation_error_with_dsn(
+                        error, dsn,
+                    ))
+                }
+                ConnectionSaveError::Metadata(error)
+                    if state.connection_setup.database_type() == DatabaseType::MySQL =>
+                {
+                    Some(ConnectionErrorInfo::from_db_operation_error(error))
+                }
+                _ => None,
+            };
+            if let Some(error_info) = mysql_error {
+                state.connection_error.set_error(error_info);
                 state.modal.replace_mode(InputMode::ConnectionError);
                 return DispatchResult::handled();
             }
@@ -591,10 +602,13 @@ mod tests {
         use std::sync::Arc;
 
         use super::*;
+        use crate::domain::connection::MySqlSslMode;
         use crate::domain::{
             DatabaseMetadata, MetadataState, QueryResult, QuerySource, TableSummary,
         };
         use crate::model::connection::cache::ConnectionCache;
+        use crate::model::connection::error::ConnectionErrorKind;
+        use crate::ports::outbound::DbOperationError;
 
         fn fill_valid_form(state: &mut AppState) {
             state
@@ -641,6 +655,34 @@ mod tests {
                 ConnectionState::Connecting
             );
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
+        }
+
+        #[test]
+        fn mysql_probe_failure_uses_tls_mode_to_classify_hostname_verification() {
+            let mut state = AppState::new("test".to_string());
+            state
+                .connection_setup
+                .set_database_type(DatabaseType::MySQL);
+            state.connection_setup.mysql_ssl_mode = MySqlSslMode::VerifyIdentity;
+
+            let error = DbOperationError::ConnectionFailed(
+                "ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed"
+                    .to_string(),
+            );
+            let dsn =
+                "mysql://user:password@localhost:3306/app?ssl-mode=VERIFY_IDENTITY".to_string();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionSaveFailed(ConnectionSaveError::Probe { error, dsn }),
+                Instant::now(),
+            );
+
+            assert_eq!(state.modal.active_mode(), InputMode::ConnectionError);
+            assert_eq!(
+                state.connection_error.error_info().unwrap().kind,
+                ConnectionErrorKind::MySqlHostnameVerificationFailed
+            );
         }
 
         #[test]

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use unicode_casefold::UnicodeCaseFold;
 
 use crate::domain::DatabaseType;
-use crate::domain::connection::{MySqlConnectionConfig, SqliteConnectionConfig};
+use crate::domain::connection::{MySqlConnectionConfig, MySqlSslMode, SqliteConnectionConfig};
 use crate::domain::{QueryResult, QueryValue};
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::QueryStatus;
@@ -472,6 +472,36 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
         ConnectionField::User if state.database_type() == DatabaseType::MySQL => {
             require_non_empty(state, field, "Required");
         }
+        ConnectionField::SslCa if state.database_type() == DatabaseType::MySQL => {
+            let path = text_input_content(state, field).to_string();
+            if matches!(
+                state.mysql_ssl_mode(),
+                MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity
+            ) && path.trim().is_empty()
+            {
+                state.set_validation_error(field, "Required for this TLS mode");
+            } else if path.chars().any(char::is_control) {
+                state.set_validation_error(field, "Invalid path");
+            }
+        }
+        ConnectionField::SslCert | ConnectionField::SslKey
+            if state.database_type() == DatabaseType::MySQL =>
+        {
+            let path = text_input_content(state, field).to_string();
+            if path.chars().any(char::is_control) {
+                state.set_validation_error(field, "Invalid path");
+            }
+            let other_field = match field {
+                ConnectionField::SslCert => ConnectionField::SslKey,
+                ConnectionField::SslKey => ConnectionField::SslCert,
+                _ => unreachable!(),
+            };
+            let other_path = text_input_content(state, other_field).to_string();
+            if path.trim().is_empty() != other_path.trim().is_empty() {
+                state.set_validation_error(field, "Both client paths are required");
+                state.set_validation_error(other_field, "Both client paths are required");
+            }
+        }
         ConnectionField::Name => {
             let name = text_input_content(state, field).trim().to_string();
             if name.is_empty() {
@@ -482,12 +512,15 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
         | ConnectionField::Host
         | ConnectionField::User
         | ConnectionField::Password
-        | ConnectionField::SslMode => {}
+        | ConnectionField::SslMode
+        | ConnectionField::SslCa
+        | ConnectionField::SslCert
+        | ConnectionField::SslKey => {}
     }
 }
 
 pub fn validate_all(state: &mut ConnectionSetupState) {
-    let active_fields = ConnectionField::fields_for(state.database_type());
+    let active_fields = ConnectionField::fields_for(state.database_type(), state.mysql_ssl_mode());
     state.retain_validation_errors_for_visible_fields();
     for field in active_fields {
         validate_field(state, *field);
@@ -745,6 +778,41 @@ mod tests {
         assert_eq!(
             state.validation_error(ConnectionField::Host),
             Some("Invalid host")
+        );
+    }
+
+    #[test]
+    fn mysql_verification_requires_ca_path() {
+        let mut state = ConnectionSetupState::default();
+        state.set_database_type(DatabaseType::MySQL);
+        state.mysql_ssl_mode = MySqlSslMode::VerifyCa;
+
+        validate_all(&mut state);
+
+        assert_eq!(
+            state.validation_error(ConnectionField::SslCa),
+            Some("Required for this TLS mode")
+        );
+    }
+
+    #[test]
+    fn mysql_client_certificate_and_key_are_a_pair() {
+        let mut state = ConnectionSetupState::default();
+        state.set_database_type(DatabaseType::MySQL);
+        state
+            .input_mut(ConnectionField::SslCert)
+            .unwrap()
+            .set_content("client.pem".to_string());
+
+        validate_all(&mut state);
+
+        assert_eq!(
+            state.validation_error(ConnectionField::SslCert),
+            Some("Both client paths are required")
+        );
+        assert_eq!(
+            state.validation_error(ConnectionField::SslKey),
+            Some("Both client paths are required")
         );
     }
 

--- a/src/domain/connection/config.rs
+++ b/src/domain/connection/config.rs
@@ -10,11 +10,21 @@ pub enum MySqlSslMode {
     #[default]
     Preferred,
     Required,
+    #[serde(rename = "VERIFY_CA")]
+    VerifyCa,
+    #[serde(rename = "VERIFY_IDENTITY")]
+    VerifyIdentity,
 }
 
 impl MySqlSslMode {
     pub const fn all_variants() -> &'static [Self] {
-        &[Self::Disabled, Self::Preferred, Self::Required]
+        &[
+            Self::Disabled,
+            Self::Preferred,
+            Self::Required,
+            Self::VerifyCa,
+            Self::VerifyIdentity,
+        ]
     }
 }
 
@@ -24,6 +34,8 @@ impl std::fmt::Display for MySqlSslMode {
             Self::Disabled => "DISABLED",
             Self::Preferred => "PREFERRED",
             Self::Required => "REQUIRED",
+            Self::VerifyCa => "VERIFY_CA",
+            Self::VerifyIdentity => "VERIFY_IDENTITY",
         })
     }
 }
@@ -66,6 +78,12 @@ pub struct MySqlConnectionConfig {
     pub username: String,
     pub password: String,
     pub ssl_mode: MySqlSslMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssl_ca: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssl_cert: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ssl_key: Option<String>,
 }
 
 impl MySqlConnectionConfig {
@@ -84,7 +102,23 @@ impl MySqlConnectionConfig {
             username: username.into(),
             password: password.into(),
             ssl_mode,
+            ssl_ca: None,
+            ssl_cert: None,
+            ssl_key: None,
         }
+    }
+
+    #[must_use]
+    pub fn with_tls_paths(
+        mut self,
+        ssl_ca: Option<String>,
+        ssl_cert: Option<String>,
+        ssl_key: Option<String>,
+    ) -> Self {
+        self.ssl_ca = ssl_ca;
+        self.ssl_cert = ssl_cert;
+        self.ssl_key = ssl_key;
+        self
     }
 
     pub fn is_valid_host(host: &str) -> bool {
@@ -219,6 +253,18 @@ impl ConnectionConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mysql_tls_modes_use_mysql_option_names() {
+        assert_eq!(
+            serde_json::to_string(&MySqlSslMode::VerifyCa).unwrap(),
+            "\"VERIFY_CA\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MySqlSslMode::VerifyIdentity).unwrap(),
+            "\"VERIFY_IDENTITY\""
+        );
+    }
 
     mod sqlite_deserialize {
         use super::*;

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -2076,15 +2076,15 @@ mod probe_tests {
     }
 
     #[test]
-    fn classifies_mysql_tls_probe_hostname_failure_for_connection_error() {
+    fn classifies_mysql_tls_probe_failure_for_connection_error() {
         let error = classify_mysql_probe_failure(
-            "ERROR 2026 (HY000): TLS/SSL error: Certificate validation failure: host name does not match certificate"
+            "ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed"
                 .to_string(),
         );
 
         assert_eq!(
             ConnectionErrorInfo::from_db_operation_error(&error).kind,
-            ConnectionErrorKind::MySqlHostnameVerificationFailed
+            ConnectionErrorKind::MySqlTlsHandshakeFailed
         );
     }
 }
@@ -2343,12 +2343,12 @@ mod query_tests {
     #[test]
     fn classifies_mysql_tls_query_failures_as_connection_errors() {
         let error = classify_mysql_query_failure(
-            b"ERROR 2026 (HY000): TLS/SSL error: Certificate validation failure: host name does not match certificate",
+            b"ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed",
         );
 
         assert_eq!(
             ConnectionErrorInfo::from_db_operation_error(&error).kind,
-            ConnectionErrorKind::MySqlHostnameVerificationFailed
+            ConnectionErrorKind::MySqlTlsHandshakeFailed
         );
         assert!(matches!(error, DbOperationError::ConnectionFailed(_)));
     }

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -1239,7 +1239,9 @@ fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {
     let details = clean_mysql_stderr(stderr, "mysql query failed");
     let lower = details.to_ascii_lowercase();
     let error_code = mysql_server_error_code(&lower);
-    if is_mysql_connect_timeout_message(&details)
+    if is_mysql_tls_error(&lower) {
+        DbOperationError::ConnectionFailed(details)
+    } else if is_mysql_connect_timeout_message(&details)
         || lower.contains("connect timeout")
         || lower.contains("connection timed out")
     {
@@ -1268,6 +1270,28 @@ fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {
     } else {
         DbOperationError::QueryFailed(details)
     }
+}
+
+fn is_mysql_tls_error(lowercase_details: &str) -> bool {
+    [
+        "error 2026",
+        "tls/ssl error",
+        "ssl connection error",
+        "ssl handshake",
+        "tls handshake",
+        "handshake failure",
+        "tlsv1 alert",
+        "certificate verify failed",
+        "certificate verification failure",
+        "certificate validation failure",
+        "unable to get local issuer",
+        "self-signed certificate",
+        "unknown ca",
+        "certificate required",
+        "peer did not return a certificate",
+    ]
+    .iter()
+    .any(|marker| lowercase_details.contains(marker))
 }
 
 fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
@@ -1788,6 +1812,8 @@ fn parse_mysql_field(
 
 #[cfg(test)]
 mod probe_tests {
+    use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+
     use super::*;
 
     #[test]
@@ -2048,10 +2074,25 @@ mod probe_tests {
             DbOperationError::ConnectionFailed(_)
         ));
     }
+
+    #[test]
+    fn classifies_mysql_tls_probe_hostname_failure_for_connection_error() {
+        let error = classify_mysql_probe_failure(
+            "ERROR 2026 (HY000): TLS/SSL error: Certificate validation failure: host name does not match certificate"
+                .to_string(),
+        );
+
+        assert_eq!(
+            ConnectionErrorInfo::from_db_operation_error(&error).kind,
+            ConnectionErrorKind::MySqlHostnameVerificationFailed
+        );
+    }
 }
 
 #[cfg(test)]
 mod query_tests {
+    use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+
     use super::*;
 
     #[test]
@@ -2297,6 +2338,19 @@ mod query_tests {
         ));
         let masked = classify_mysql_query_failure(b"ERROR password=secret");
         assert!(!masked.masked_details().contains("secret"));
+    }
+
+    #[test]
+    fn classifies_mysql_tls_query_failures_as_connection_errors() {
+        let error = classify_mysql_query_failure(
+            b"ERROR 2026 (HY000): TLS/SSL error: Certificate validation failure: host name does not match certificate",
+        );
+
+        assert_eq!(
+            ConnectionErrorInfo::from_db_operation_error(&error).kind,
+            ConnectionErrorKind::MySqlHostnameVerificationFailed
+        );
+        assert!(matches!(error, DbOperationError::ConnectionFailed(_)));
     }
 }
 

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -122,6 +122,7 @@ impl QueryExecutor for MySqlAdapter {
         validate_mysql_adhoc_query(query)?;
         let target = parse_mysql_dsn(dsn)?;
         validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
 
         #[expect(
             clippy::disallowed_methods,
@@ -228,6 +229,7 @@ impl ConnectionProbe for MySqlAdapter {
     async fn probe(&self, dsn: &str) -> Result<(), DbOperationError> {
         let target = parse_mysql_dsn(dsn)?;
         validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
         self.check_cli_version().await?;
 
         let option_file = MySqlOptionFile::create(&target)?;
@@ -289,6 +291,9 @@ struct MySqlDsn {
     username: String,
     password: String,
     ssl_mode: MySqlSslMode,
+    ssl_ca: Option<String>,
+    ssl_cert: Option<String>,
+    ssl_key: Option<String>,
 }
 
 fn build_mysql_dsn(config: &MySqlConnectionConfig) -> String {
@@ -314,6 +319,15 @@ fn build_mysql_dsn(config: &MySqlConnectionConfig) -> String {
     }
     url.query_pairs_mut()
         .append_pair("ssl-mode", &config.ssl_mode.to_string());
+    if let Some(path) = config.ssl_ca.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-ca", path);
+    }
+    if let Some(path) = config.ssl_cert.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-cert", path);
+    }
+    if let Some(path) = config.ssl_key.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-key", path);
+    }
     url.to_string()
 }
 
@@ -343,6 +357,15 @@ fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
         .find_map(|(key, value)| (key == "ssl-mode").then(|| parse_ssl_mode(&value)))
         .transpose()?
         .unwrap_or_default();
+    let ssl_ca = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-ca").then(|| value.into_owned()));
+    let ssl_cert = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-cert").then(|| value.into_owned()));
+    let ssl_key = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-key").then(|| value.into_owned()));
 
     Ok(MySqlDsn {
         host,
@@ -351,6 +374,9 @@ fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
         username,
         password,
         ssl_mode,
+        ssl_ca,
+        ssl_cert,
+        ssl_key,
     })
 }
 
@@ -366,6 +392,8 @@ fn parse_ssl_mode(value: &str) -> Result<MySqlSslMode, DbOperationError> {
         "DISABLED" => Ok(MySqlSslMode::Disabled),
         "PREFERRED" => Ok(MySqlSslMode::Preferred),
         "REQUIRED" => Ok(MySqlSslMode::Required),
+        "VERIFY_CA" => Ok(MySqlSslMode::VerifyCa),
+        "VERIFY_IDENTITY" => Ok(MySqlSslMode::VerifyIdentity),
         _ => Err(DbOperationError::ConnectionFailed(
             "Invalid MySQL TLS mode".to_string(),
         )),
@@ -394,6 +422,81 @@ fn validate_mysql_values(target: &MySqlDsn) -> Result<(), DbOperationError> {
         return Err(DbOperationError::ConnectionFailed(
             "MySQL connection settings contain a control character".to_string(),
         ));
+    }
+    Ok(())
+}
+
+fn validate_mysql_tls_files(target: &MySqlDsn) -> Result<(), DbOperationError> {
+    let has_tls_path =
+        target.ssl_ca.is_some() || target.ssl_cert.is_some() || target.ssl_key.is_some();
+    if target.ssl_mode == MySqlSslMode::Disabled && has_tls_path {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL TLS paths require an enabled TLS mode".to_string(),
+        ));
+    }
+    if matches!(
+        target.ssl_mode,
+        MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity
+    ) && target.ssl_ca.is_none()
+    {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL CA path is required for certificate verification".to_string(),
+        ));
+    }
+    if target.ssl_cert.is_some() != target.ssl_key.is_some() {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL client certificate and key must be specified together".to_string(),
+        ));
+    }
+
+    for (kind, path) in [
+        ("CA", target.ssl_ca.as_deref()),
+        ("client certificate", target.ssl_cert.as_deref()),
+        ("client key", target.ssl_key.as_deref()),
+    ] {
+        let Some(path) = path else { continue };
+        let metadata = fs::metadata(path).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} path cannot be accessed: {error}"
+            ))
+        })?;
+        if !metadata.is_file() {
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} path is not a regular file"
+            )));
+        }
+        let contents = fs::read(path).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!("MySQL {kind} cannot be read: {error}"))
+        })?;
+        let text = String::from_utf8_lossy(&contents);
+        if matches!(kind, "CA" | "client certificate") && !text.contains("BEGIN CERTIFICATE") {
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} is not a PEM certificate"
+            )));
+        }
+        if kind == "client key" {
+            if text.contains("BEGIN ENCRYPTED PRIVATE KEY")
+                || text
+                    .lines()
+                    .any(|line| line.trim().eq_ignore_ascii_case("Proc-Type: 4,ENCRYPTED"))
+            {
+                return Err(DbOperationError::ConnectionFailed(
+                    "Encrypted MySQL client keys are not supported".to_string(),
+                ));
+            }
+            if ![
+                "BEGIN PRIVATE KEY",
+                "BEGIN RSA PRIVATE KEY",
+                "BEGIN EC PRIVATE KEY",
+            ]
+            .iter()
+            .any(|marker| text.contains(marker))
+            {
+                return Err(DbOperationError::ConnectionFailed(
+                    "MySQL client key is not a PEM private key".to_string(),
+                ));
+            }
+        }
     }
     Ok(())
 }
@@ -526,6 +629,7 @@ struct MySqlOptionFile {
 
 impl MySqlOptionFile {
     fn create(target: &MySqlDsn) -> Result<Self, DbOperationError> {
+        validate_mysql_tls_files(target)?;
         let sequence = OPTION_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
         let mut path = std::env::temp_dir();
         path.push(format!(
@@ -574,6 +678,15 @@ fn serialize_option_file(target: &MySqlDsn) -> String {
         push_option(&mut contents, "database", database);
     }
     push_option(&mut contents, "ssl-mode", &target.ssl_mode.to_string());
+    if let Some(path) = target.ssl_ca.as_deref() {
+        push_option(&mut contents, "ssl-ca", path);
+    }
+    if let Some(path) = target.ssl_cert.as_deref() {
+        push_option(&mut contents, "ssl-cert", path);
+    }
+    if let Some(path) = target.ssl_key.as_deref() {
+        push_option(&mut contents, "ssl-key", path);
+    }
     contents
 }
 
@@ -1699,6 +1812,29 @@ mod probe_tests {
     }
 
     #[test]
+    fn builds_and_parses_mysql_dsn_with_tls_paths() {
+        let config = MySqlConnectionConfig::new(
+            "db.example",
+            3307,
+            Some("app".to_string()),
+            "user",
+            "password",
+            MySqlSslMode::VerifyIdentity,
+        )
+        .with_tls_paths(
+            Some(r"C:\certs\ca #1.pem".to_string()),
+            Some(r"C:\certs\client.pem".to_string()),
+            Some(r"C:\certs\client-key.pem".to_string()),
+        );
+        let parsed = parse_mysql_dsn(&build_mysql_dsn(&config)).unwrap();
+
+        assert_eq!(parsed.ssl_mode, MySqlSslMode::VerifyIdentity);
+        assert_eq!(parsed.ssl_ca.as_deref(), Some(r"C:\certs\ca #1.pem"));
+        assert_eq!(parsed.ssl_cert.as_deref(), Some(r"C:\certs\client.pem"));
+        assert_eq!(parsed.ssl_key.as_deref(), Some(r"C:\certs\client-key.pem"));
+    }
+
+    #[test]
     fn ipv6_host_round_trip_serializes_without_url_brackets() {
         let config = MySqlConnectionConfig::new(
             "::1",
@@ -1723,6 +1859,9 @@ mod probe_tests {
             username: "user".to_string(),
             password: "p a#ss;=\"\\word".to_string(),
             ssl_mode: MySqlSslMode::Preferred,
+            ssl_ca: None,
+            ssl_cert: None,
+            ssl_key: None,
         };
         let contents = serialize_option_file(&target);
 
@@ -1737,6 +1876,82 @@ mod probe_tests {
     }
 
     #[test]
+    fn option_file_serializes_tls_paths_without_option_syntax_confusion() {
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(r"C:\certs\ca #1.pem".to_string()),
+            ssl_cert: Some(r"C:\certs\client.pem".to_string()),
+            ssl_key: Some(r"C:\certs\client-key.pem".to_string()),
+        };
+
+        let contents = serialize_option_file(&target);
+
+        assert!(contents.contains("ssl-mode = \"VERIFY_CA\"\n"));
+        assert!(contents.contains("ssl-ca = \"C:\\\\certs\\\\ca #1.pem\"\n"));
+        assert!(contents.contains("ssl-cert = \"C:\\\\certs\\\\client.pem\"\n"));
+        assert!(contents.contains("ssl-key = \"C:\\\\certs\\\\client-key.pem\"\n"));
+    }
+
+    #[test]
+    fn rejects_encrypted_client_keys_before_process_start() {
+        let directory = tempfile::tempdir().unwrap();
+        let ca = directory.path().join("ca.pem");
+        let cert = directory.path().join("client.pem");
+        let key = directory.path().join("client-key.pem");
+        fs::write(&ca, "-----BEGIN CERTIFICATE-----\nca\n").unwrap();
+        fs::write(&cert, "-----BEGIN CERTIFICATE-----\ncert\n").unwrap();
+        fs::write(&key, "-----BEGIN ENCRYPTED PRIVATE KEY-----\nsecret\n").unwrap();
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(ca.display().to_string()),
+            ssl_cert: Some(cert.display().to_string()),
+            ssl_key: Some(key.display().to_string()),
+        };
+
+        let result = validate_mysql_tls_files(&target);
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::ConnectionFailed(details))
+                if details == "Encrypted MySQL client keys are not supported"
+        ));
+    }
+
+    #[test]
+    fn rejects_traditional_encrypted_client_keys_before_process_start() {
+        let directory = tempfile::tempdir().unwrap();
+        let ca = directory.path().join("ca.pem");
+        let cert = directory.path().join("client.pem");
+        let key = directory.path().join("client-key.pem");
+        fs::write(&ca, "-----BEGIN CERTIFICATE-----\nca\n").unwrap();
+        fs::write(&cert, "-----BEGIN CERTIFICATE-----\ncert\n").unwrap();
+        fs::write(&key, "Proc-Type: 4,ENCRYPTED\nDEK-Info: AES-256-CBC,x\n").unwrap();
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(ca.display().to_string()),
+            ssl_cert: Some(cert.display().to_string()),
+            ssl_key: Some(key.display().to_string()),
+        };
+
+        assert!(validate_mysql_tls_files(&target).is_err());
+    }
+
+    #[test]
     fn option_file_is_owner_only_and_removed_on_drop() {
         let target = MySqlDsn {
             host: "localhost".to_string(),
@@ -1745,6 +1960,9 @@ mod probe_tests {
             username: "user".to_string(),
             password: "secret".to_string(),
             ssl_mode: MySqlSslMode::Disabled,
+            ssl_ca: None,
+            ssl_cert: None,
+            ssl_key: None,
         };
         let option_file = MySqlOptionFile::create(&target).unwrap();
         assert!(option_file.path.is_absolute());

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -52,6 +52,12 @@ pub struct ConnectionConfigEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mysql_ssl_mode: Option<MySqlSslMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mysql_ssl_ca: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mysql_ssl_cert: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mysql_ssl_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
 }
 
@@ -92,6 +98,9 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
             password: None,
             ssl_mode: None,
             mysql_ssl_mode: None,
+            mysql_ssl_ca: None,
+            mysql_ssl_cert: None,
+            mysql_ssl_key: None,
             path: None,
         };
         match &profile.config {
@@ -113,6 +122,9 @@ impl From<&ConnectionProfile> for ConnectionConfigEntry {
                 entry.username = Some(config.username.clone());
                 entry.password = Some(config.password.clone());
                 entry.mysql_ssl_mode = Some(config.ssl_mode);
+                entry.mysql_ssl_ca.clone_from(&config.ssl_ca);
+                entry.mysql_ssl_cert.clone_from(&config.ssl_cert);
+                entry.mysql_ssl_key.clone_from(&config.ssl_key);
             }
         }
         entry
@@ -153,14 +165,21 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
                 Self::with_id_and_config(
                     id,
                     name.as_str().to_string(),
-                    ConnectionConfig::MySQL(MySqlConnectionConfig::new(
-                        required_mysql_host(entry.host.as_ref())?,
-                        entry.port.unwrap_or(3306),
-                        database,
-                        required_mysql_field(entry.username.as_ref(), "username")?,
-                        entry.password.clone().unwrap_or_default(),
-                        entry.mysql_ssl_mode.unwrap_or_default(),
-                    )),
+                    ConnectionConfig::MySQL(
+                        MySqlConnectionConfig::new(
+                            required_mysql_host(entry.host.as_ref())?,
+                            entry.port.unwrap_or(3306),
+                            database,
+                            required_mysql_field(entry.username.as_ref(), "username")?,
+                            entry.password.clone().unwrap_or_default(),
+                            entry.mysql_ssl_mode.unwrap_or_default(),
+                        )
+                        .with_tls_paths(
+                            entry.mysql_ssl_ca.clone(),
+                            entry.mysql_ssl_cert.clone(),
+                            entry.mysql_ssl_key.clone(),
+                        ),
+                    ),
                 )
             }
         }
@@ -237,6 +256,9 @@ mod tests {
             password: None,
             ssl_mode: Some(SslMode::Prefer),
             mysql_ssl_mode: None,
+            mysql_ssl_ca: None,
+            mysql_ssl_cert: None,
+            mysql_ssl_key: None,
             path: None,
         }
     }
@@ -253,6 +275,9 @@ mod tests {
             password: None,
             ssl_mode: None,
             mysql_ssl_mode: None,
+            mysql_ssl_ca: None,
+            mysql_ssl_cert: None,
+            mysql_ssl_key: None,
             path: path.map(str::to_string),
         }
     }
@@ -269,6 +294,9 @@ mod tests {
             password: Some("p@ss#word".to_string()),
             ssl_mode: None,
             mysql_ssl_mode: Some(MySqlSslMode::Required),
+            mysql_ssl_ca: None,
+            mysql_ssl_cert: None,
+            mysql_ssl_key: None,
             path: None,
         }
     }
@@ -378,6 +406,27 @@ mod tests {
         assert_eq!(serialized.mysql_ssl_mode, Some(MySqlSslMode::Required));
         assert_eq!(serialized.port, Some(3306));
         assert_eq!(serialized.password.as_deref(), Some("p@ss#word"));
+    }
+
+    #[test]
+    fn mysql_entry_round_trips_certificate_paths() {
+        let mut entry = mysql_entry(Some("app"));
+        entry.mysql_ssl_mode = Some(MySqlSslMode::VerifyIdentity);
+        entry.mysql_ssl_ca = Some("/tmp/ca #1.pem".to_string());
+        entry.mysql_ssl_cert = Some(r"C:\certs\client.pem".to_string());
+        entry.mysql_ssl_key = Some(r"C:\certs\client-key.pem".to_string());
+
+        let profile = ConnectionProfile::try_from(&entry).unwrap();
+        let config = profile.mysql_config().unwrap();
+        assert_eq!(config.ssl_mode, MySqlSslMode::VerifyIdentity);
+        assert_eq!(config.ssl_ca.as_deref(), Some("/tmp/ca #1.pem"));
+        assert_eq!(config.ssl_cert.as_deref(), Some(r"C:\certs\client.pem"));
+        assert_eq!(config.ssl_key.as_deref(), Some(r"C:\certs\client-key.pem"));
+
+        let serialized = ConnectionConfigEntry::from(&profile);
+        assert_eq!(serialized.mysql_ssl_ca, entry.mysql_ssl_ca);
+        assert_eq!(serialized.mysql_ssl_cert, entry.mysql_ssl_cert);
+        assert_eq!(serialized.mysql_ssl_key, entry.mysql_ssl_key);
     }
 
     #[test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -3,12 +3,27 @@
 //! Start the exact fixture and CLI wrapper with:
 //! bash scripts/mysql_integration.sh test
 
+use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
 use sabiql_app::ports::outbound::{
-    AccessMode, DbOperationError, MYSQL_SQL_MODE_UNSUPPORTED_MARKER, QueryExecutor,
+    AccessMode, ConnectionProbe, DbOperationError, DsnBuilder, MYSQL_SQL_MODE_UNSUPPORTED_MARKER,
+    QueryExecutor,
 };
 use sabiql_domain::QueryValue;
 
-use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, with_mysql_test_db};
+use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, mysql_tls_config, with_mysql_test_db};
+use sabiql_domain::connection::{
+    ConnectionConfig, ConnectionId, ConnectionProfile, MySqlConnectionConfig, MySqlSslMode,
+};
+use sabiql_infra::adapters::mysql::MySqlAdapter;
+
+fn mysql_tls_profile(name: &str, config: MySqlConnectionConfig) -> ConnectionProfile {
+    ConnectionProfile::with_id_and_config(
+        ConnectionId::new(),
+        name,
+        ConnectionConfig::MySQL(config),
+    )
+    .unwrap()
+}
 
 #[tokio::test]
 #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
@@ -32,6 +47,61 @@ async fn connects_to_oracle_mysql_84_fixture() {
         })
     })
     .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn connects_to_oracle_mysql_84_fixture_with_ca_and_client_certificate() {
+    let config = mysql_tls_config();
+    let profile = mysql_tls_profile("mysql-tls-integration", config);
+    let adapter = MySqlAdapter::new();
+    let dsn = adapter.build_dsn(&profile);
+
+    adapter.probe(&dsn).await.unwrap();
+    let result = adapter
+        .execute_adhoc(
+            &dsn,
+            &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
+            AccessMode::ReadWrite,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.values(), [[QueryValue::Text("1".to_string())]]);
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn rejects_oracle_mysql_84_fixture_with_wrong_ca() {
+    let mut config = mysql_tls_config();
+    config.ssl_ca = config.ssl_cert.clone();
+    let profile = mysql_tls_profile("mysql-tls-wrong-ca", config);
+    let adapter = MySqlAdapter::new();
+    let error = adapter
+        .probe(&adapter.build_dsn(&profile))
+        .await
+        .unwrap_err();
+    assert_eq!(
+        ConnectionErrorInfo::from_db_operation_error(&error).kind,
+        ConnectionErrorKind::MySqlCaVerificationFailed
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn rejects_oracle_mysql_84_fixture_with_wrong_hostname() {
+    let mut config = mysql_tls_config();
+    config.host = "host.docker.internal".to_string();
+    config.ssl_mode = MySqlSslMode::VerifyIdentity;
+    let profile = mysql_tls_profile("mysql-tls-wrong-host", config);
+    let adapter = MySqlAdapter::new();
+    let error = adapter
+        .probe(&adapter.build_dsn(&profile))
+        .await
+        .unwrap_err();
+    assert_eq!(
+        ConnectionErrorInfo::from_db_operation_error(&error).kind,
+        ConnectionErrorKind::MySqlHostnameVerificationFailed
+    );
 }
 
 #[tokio::test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -98,9 +98,12 @@ async fn rejects_oracle_mysql_84_fixture_with_wrong_hostname() {
         .probe(&adapter.build_dsn(&profile))
         .await
         .unwrap_err();
+    let error_info = ConnectionErrorInfo::from_db_operation_error(&error);
     assert_eq!(
-        ConnectionErrorInfo::from_db_operation_error(&error).kind,
-        ConnectionErrorKind::MySqlHostnameVerificationFailed
+        error_info.kind,
+        ConnectionErrorKind::MySqlHostnameVerificationFailed,
+        "masked connection error details: {}",
+        error_info.masked_details()
     );
 }
 

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -76,12 +76,10 @@ async fn rejects_oracle_mysql_84_fixture_with_wrong_ca() {
     config.ssl_ca = config.ssl_cert.clone();
     let profile = mysql_tls_profile("mysql-tls-wrong-ca", config);
     let adapter = MySqlAdapter::new();
-    let error = adapter
-        .probe(&adapter.build_dsn(&profile))
-        .await
-        .unwrap_err();
+    let dsn = adapter.build_dsn(&profile);
+    let error = adapter.probe(&dsn).await.unwrap_err();
     assert_eq!(
-        ConnectionErrorInfo::from_db_operation_error(&error).kind,
+        ConnectionErrorInfo::from_db_operation_error_with_dsn(&error, &dsn).kind,
         ConnectionErrorKind::MySqlCaVerificationFailed
     );
 }
@@ -94,11 +92,9 @@ async fn rejects_oracle_mysql_84_fixture_with_wrong_hostname() {
     config.ssl_mode = MySqlSslMode::VerifyIdentity;
     let profile = mysql_tls_profile("mysql-tls-wrong-host", config);
     let adapter = MySqlAdapter::new();
-    let error = adapter
-        .probe(&adapter.build_dsn(&profile))
-        .await
-        .unwrap_err();
-    let error_info = ConnectionErrorInfo::from_db_operation_error(&error);
+    let dsn = adapter.build_dsn(&profile);
+    let error = adapter.probe(&dsn).await.unwrap_err();
+    let error_info = ConnectionErrorInfo::from_db_operation_error_with_dsn(&error, &dsn);
     assert_eq!(
         error_info.kind,
         ConnectionErrorKind::MySqlHostnameVerificationFailed,

--- a/src/tests/harness/mysql.rs
+++ b/src/tests/harness/mysql.rs
@@ -120,6 +120,30 @@ pub fn mysql_integration_config() -> MySqlConnectionConfig {
     )
 }
 
+pub fn mysql_tls_config() -> MySqlConnectionConfig {
+    MySqlConnectionConfig::new(
+        std::env::var("SABIQL_MYSQL_TEST_HOST")
+            .unwrap_or_else(|_| "host.docker.internal".to_string()),
+        std::env::var("SABIQL_MYSQL_TEST_PORT")
+            .ok()
+            .and_then(|port| port.parse().ok())
+            .unwrap_or(3306),
+        Some(
+            std::env::var("SABIQL_MYSQL_TEST_DATABASE")
+                .unwrap_or_else(|_| "sabiql_test".to_string()),
+        ),
+        std::env::var("SABIQL_MYSQL_TEST_USER").unwrap_or_else(|_| "sabiql".to_string()),
+        std::env::var("SABIQL_MYSQL_TEST_PASSWORD")
+            .unwrap_or_else(|_| "p a#ss;=\"word".to_string()),
+        MySqlSslMode::VerifyCa,
+    )
+    .with_tls_paths(
+        Some(std::env::var("SABIQL_MYSQL_TEST_SSL_CA").expect("TLS CA path")),
+        Some(std::env::var("SABIQL_MYSQL_TEST_SSL_CERT").expect("TLS client certificate path")),
+        Some(std::env::var("SABIQL_MYSQL_TEST_SSL_KEY").expect("TLS client key path")),
+    )
+}
+
 fn serialize_option_file(config: &MySqlConnectionConfig) -> String {
     let mut contents = String::from("[client]\n");
     push_option(&mut contents, "host", &config.host);

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__connection_flow__connection_setup_mysql_form.snap
@@ -19,23 +19,23 @@ test_project ▸ - ▸ -                                                        
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
-│                                       ││                                                                                                                          │
 │                                       ││          ╭ New Connection ────────────────────────────────────────────╮                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  Type:       [ MySQL                    ▼ ]                │                                                  │
 │                                       ││          │  Name:       [                            ]                │                                                  │
 │                                       ││          │  Host:       [ localhost                  ]                │                                                  │
 │                                       ││          │  Port:       [ 3306                       ]                │                                                  │
-│                                       │└──────────│  Database:   [ app                        ]                │──────────────────────────────────────────────────┘
-│                                       │┌ [3] Resul│  User:       [ mysql_user                 ]                │──────────────────────────────────────────────────┐
-│                                       ││(select a │  Password:   [ empty = no password        ]                │                                                  │
-│                                       ││          │  SSL Mode:   [ PREFERRED                ▼ ]                │                                                  │
+│                                       ││          │  Database:   [ app                        ]                │                                                  │
+│                                       │└──────────│  User:       [ mysql_user                 ]                │──────────────────────────────────────────────────┘
+│                                       │┌ [3] Resul│  Password:   [ empty = no password        ]                │──────────────────────────────────────────────────┐
+│                                       ││(select a │  SSL Mode:   [ PREFERRED                ▼ ]                │                                                  │
+│                                       ││          │  Cert Path:  [                            ]                │                                                  │
+│                                       ││          │  Key Path:   [                            ]                │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          │  → stub-dsn                                                │                                                  │
 │                                       ││          │  Note: Connection info is stored locally in plain text     │                                                  │
 │                                       ││          │                                                            │                                                  │
 │                                       ││          ╰ Tab/⇧Tab: Field │ Enter: Toggle │ ^S: Connect │ Esc: Cancel╯                                                  │
-│                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -451,6 +451,8 @@ fn mysql_ssl_mode_label(mode: MySqlSslMode) -> &'static str {
         MySqlSslMode::Disabled => "DISABLED",
         MySqlSslMode::Preferred => "PREFERRED",
         MySqlSslMode::Required => "REQUIRED",
+        MySqlSslMode::VerifyCa => "VERIFY_CA",
+        MySqlSslMode::VerifyIdentity => "VERIFY_IDENTITY",
     }
 }
 


### PR DESCRIPTION
## Problem
MySQL connections can request encryption but cannot verify server certificates or provide client certificate paths.

## Background
SAB-380 / MYSQL-CON-02 adds certificate-verified TLS connections for Oracle MySQL 8.4.

## Approach
Add VERIFY_CA and VERIFY_IDENTITY, conditional TLS path fields with persisted paths, preflight PEM and unencrypted-key validation, option-file wiring, classified TLS errors, and Oracle MySQL 8.4 integration coverage reusing the existing fixture.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-380