### PR TITLE
feat(mysql): scope query history by database

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -6,10 +6,9 @@ use tokio::sync::mpsc;
 
 use crate::cmd::effect::Effect;
 use crate::cmd::query_task::QueryTaskRegistry;
-use crate::domain::ConnectionId;
 use crate::domain::QuerySource;
 use crate::domain::command_tag::CommandTag;
-use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope, QueryResultStatus};
 use crate::domain::sqlite_explain_query_plan_text_from_result;
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{CachedResultExporter, QueryExecutor, QueryHistoryStore};
@@ -48,24 +47,25 @@ fn save_query_history(
     query_history_store: &Arc<dyn QueryHistoryStore>,
     action_tx: &mpsc::Sender<Action>,
     project_name: &str,
-    connection_id: &ConnectionId,
+    scope: &QueryHistoryScope,
     query: &str,
     result_status: QueryResultStatus,
     affected_rows: Option<u64>,
 ) {
     let store = Arc::clone(query_history_store);
     let tx = action_tx.clone();
-    let entry = QueryHistoryEntry::new(
+    let entry = QueryHistoryEntry::new_with_database(
         query.to_string(),
         utc_now_iso8601(),
-        connection_id.clone(),
+        scope.connection_id.clone(),
+        scope.database.clone(),
         result_status,
         affected_rows,
     );
     let project = project_name.to_string();
-    let conn_id = connection_id.clone();
+    let scope = scope.clone();
     tokio::spawn(async move {
-        if let Err(e) = store.append(&project, &conn_id, &entry).await {
+        if let Err(e) = store.append(&project, &scope, &entry).await {
             let _ = tx.send(Action::QueryHistoryAppendFailed(e)).await;
         }
     });
@@ -187,13 +187,13 @@ pub async fn run(
             let history_store = Arc::clone(query_history_store);
             let history_tx = action_tx.clone();
             let project = state.runtime.project_name().to_string();
-            let conn_id = state.session.active_connection_id().cloned();
+            let history_scope = state.session.query_history_scope();
             let query_for_history = query.clone();
 
             query_tasks.spawn(async move {
                 match executor.execute_adhoc(&dsn, &query, access_mode).await {
                     Ok(result) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             let rows = result
                                 .command_tag
                                 .as_ref()
@@ -202,7 +202,7 @@ pub async fn run(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Success,
                                 rows,
@@ -219,12 +219,12 @@ pub async fn run(
                         .ok();
                     }
                     Err(e) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             save_query_history(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Failed,
                                 None,
@@ -256,18 +256,18 @@ pub async fn run(
             let history_store = Arc::clone(query_history_store);
             let history_tx = action_tx.clone();
             let project = state.runtime.project_name().to_string();
-            let conn_id = state.session.active_connection_id().cloned();
+            let history_scope = state.session.query_history_scope();
             let query_for_history = query.clone();
 
             query_tasks.spawn(async move {
                 match executor.execute_write(&dsn, &query, access_mode).await {
                     Ok(result) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             save_query_history(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Success,
                                 Some(result.affected_rows as u64),
@@ -282,12 +282,12 @@ pub async fn run(
                         .ok();
                     }
                     Err(e) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             save_query_history(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Failed,
                                 None,

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -1,4 +1,5 @@
 use crate::domain::connection::{ConnectionConfig, ConnectionId};
+use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{QueryValue, Table};
 use crate::ports::outbound::{AccessMode, AppSettings};
 use crate::update::action::{Action, ConnectionTarget};
@@ -158,7 +159,7 @@ pub enum Effect {
 
     LoadQueryHistory {
         project_name: String,
-        connection_id: ConnectionId,
+        scope: QueryHistoryScope,
     },
 
     SaveSettings {

--- a/src/app/cmd/sql_editor/query_history.rs
+++ b/src/app/cmd/sql_editor/query_history.rs
@@ -14,21 +14,24 @@ pub fn run(
     match effect {
         Effect::LoadQueryHistory {
             project_name,
-            connection_id,
+            scope,
         } => {
             let store = Arc::clone(query_history_store);
             let tx = action_tx.clone();
 
-            let conn_id = connection_id.clone();
+            let scope_for_action = scope.clone();
             tokio::spawn(async move {
-                match store.load(&project_name, &connection_id).await {
+                match store.load(&project_name, &scope).await {
                     Ok(entries) => {
-                        tx.send(Action::QueryHistoryLoaded(conn_id, entries))
-                            .await
-                            .ok();
+                        tx.send(Action::QueryHistoryLoaded(
+                            scope_for_action.clone(),
+                            entries,
+                        ))
+                        .await
+                        .ok();
                     }
                     Err(e) => {
-                        tx.send(Action::QueryHistoryLoadFailed(conn_id, e))
+                        tx.send(Action::QueryHistoryLoadFailed(scope_for_action, e))
                             .await
                             .ok();
                     }

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -9,10 +9,10 @@ use crate::cmd::runner::{
 };
 use crate::domain::SqliteDiagnosticsSnapshot;
 use crate::domain::connection::{ConnectionProfile, ServiceEntry};
-use crate::domain::query_history::QueryHistoryEntry;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 use crate::domain::{
-    ConnectionId, DatabaseMetadata, DiagnosticField, ErTableInfo, QueryResult, QuerySource,
-    QueryValue, SqlitePathError, classify_sqlite_metadata_error, classify_sqlite_read_error,
+    DatabaseMetadata, DiagnosticField, ErTableInfo, QueryResult, QuerySource, QueryValue,
+    SqlitePathError, classify_sqlite_metadata_error, classify_sqlite_read_error,
 };
 use crate::ports::outbound::DbOperationError;
 use crate::ports::outbound::{
@@ -158,7 +158,7 @@ impl QueryHistoryStore for NoopQueryHistoryStore {
     async fn append(
         &self,
         _project_name: &str,
-        _connection_id: &ConnectionId,
+        _scope: &QueryHistoryScope,
         _entry: &QueryHistoryEntry,
     ) -> Result<(), QueryHistoryError> {
         Ok(())
@@ -167,7 +167,7 @@ impl QueryHistoryStore for NoopQueryHistoryStore {
     async fn load(
         &self,
         _project_name: &str,
-        _connection_id: &ConnectionId,
+        _scope: &QueryHistoryScope,
     ) -> Result<Vec<QueryHistoryEntry>, QueryHistoryError> {
         Ok(Vec::new())
     }

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::sync::Arc;
 
+use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{
     ConnectionId, DatabaseMetadata, DatabaseType, MetadataState, QueryResult, Table, TableSummary,
 };
@@ -634,6 +635,15 @@ impl BrowseSession {
             .and_then(|connection| connection.database.as_deref())
     }
 
+    pub fn query_history_scope(&self) -> Option<QueryHistoryScope> {
+        let connection_id = self.active_connection_id()?.clone();
+        let database = match self.active_database_type() {
+            Some(DatabaseType::MySQL) => self.active_database().map(str::to_owned),
+            Some(DatabaseType::PostgreSQL | DatabaseType::SQLite) | None => None,
+        };
+        Some(QueryHistoryScope::new(connection_id, database))
+    }
+
     pub fn active_engine_feature_profile(&self) -> &EngineFeatureProfile {
         &self.active_engine_feature_profile
     }
@@ -1234,6 +1244,42 @@ mod tests {
             session.restore_from_cache(&cache, &mut query);
 
             assert!(session.database_name().is_none());
+        }
+    }
+
+    mod query_history_scope_tests {
+        use super::*;
+
+        #[test]
+        fn mysql_scope_includes_selected_database() {
+            let mut session = BrowseSession::default();
+            session.activate_connection_with_target(
+                &ConnectionId::from_string("mysql"),
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://localhost/app",
+                Some("app"),
+            );
+
+            let scope = session.query_history_scope().unwrap();
+
+            assert_eq!(scope.database.as_deref(), Some("app"));
+        }
+
+        #[test]
+        fn postgres_and_sqlite_scopes_omit_database() {
+            for database_type in [DatabaseType::PostgreSQL, DatabaseType::SQLite] {
+                let mut session = BrowseSession::default();
+                session.activate_connection_with_target(
+                    &ConnectionId::from_string("connection"),
+                    "connection",
+                    database_type,
+                    "dsn://connection",
+                    Some("database"),
+                );
+
+                assert_eq!(session.query_history_scope().unwrap().database, None);
+            }
         }
     }
 

--- a/src/app/ports/outbound/query_history.rs
+++ b/src/app/ports/outbound/query_history.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::domain::connection::ConnectionId;
-use crate::domain::query_history::QueryHistoryEntry;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum QueryHistoryError {
@@ -40,14 +39,14 @@ pub trait QueryHistoryStore: Send + Sync {
     async fn append(
         &self,
         project_name: &str,
-        connection_id: &ConnectionId,
+        scope: &QueryHistoryScope,
         entry: &QueryHistoryEntry,
     ) -> Result<(), QueryHistoryError>;
 
     async fn load(
         &self,
         project_name: &str,
-        connection_id: &ConnectionId,
+        scope: &QueryHistoryScope,
     ) -> Result<Vec<QueryHistoryEntry>, QueryHistoryError>;
 }
 

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::domain::connection::{
     ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
 };
-use crate::domain::query_history::QueryHistoryEntry;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 use crate::model::app_state::AppState;
 use crate::model::browse::jsonb_detail::JsonbDetailMode;
 use crate::model::connection::error::ConnectionErrorInfo;
@@ -625,8 +625,8 @@ pub enum Action {
     ToggleReadOnly,
 
     // Query history
-    QueryHistoryLoaded(ConnectionId, Vec<QueryHistoryEntry>),
-    QueryHistoryLoadFailed(ConnectionId, QueryHistoryError),
+    QueryHistoryLoaded(QueryHistoryScope, Vec<QueryHistoryEntry>),
+    QueryHistoryLoadFailed(QueryHistoryScope, QueryHistoryError),
     QueryHistoryAppendFailed(QueryHistoryError),
     QueryHistoryConfirmSelection,
 

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -7,6 +7,7 @@ use crate::update::action::ConnectionTarget;
 use crate::update::query_context::termination_effects;
 
 fn reset_connection_scoped_state(state: &mut AppState) {
+    state.query_history_picker.reset();
     state.sql_modal.reset_prefetch();
     state.explain.reset_for_connection_change();
     state.er_preparation.reset();

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -295,6 +295,7 @@ mod tests {
 
     use super::*;
     use crate::domain::connection::DatabaseType;
+    use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
     use crate::domain::{ConnectionId, DatabaseMetadata, MetadataState};
     use crate::model::connection::cache::ConnectionCache;
     use crate::model::connection::error::ConnectionErrorKind;
@@ -1611,6 +1612,15 @@ mod tests {
             ]);
             state.ui.set_database_picker(true);
             state.modal.set_mode(InputMode::TablePicker);
+            state
+                .query_history_picker
+                .replace_entries(&[QueryHistoryEntry::new(
+                    "SELECT old_database".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    id,
+                    QueryResultStatus::Success,
+                    None,
+                )]);
 
             let effects = reduce_app(
                 &mut state,
@@ -1629,10 +1639,55 @@ mod tests {
             assert!(state.session.metadata().is_none());
             assert!(state.session.is_read_only());
             assert_eq!(state.input_mode(), InputMode::Normal);
+            assert!(state.query_history_picker.entries().is_empty());
             assert!(
                 !effects
                     .iter()
                     .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
+        }
+
+        #[test]
+        fn database_switch_closes_query_history_picker_and_discards_entries() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, Some("app"));
+            state.session.activate_connection_with_target(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+            state.session.mark_probe_connected(true);
+            state.modal.set_mode(InputMode::QueryHistoryPicker);
+            state
+                .query_history_picker
+                .replace_entries(&[QueryHistoryEntry::new_with_database(
+                    "SELECT from app".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    id,
+                    Some("app".to_string()),
+                    QueryResultStatus::Success,
+                    None,
+                )]);
+
+            let effects = reduce_app(
+                &mut state,
+                Action::SwitchMySqlDatabase {
+                    database: "analytics".to_string(),
+                },
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.session.active_database(), Some("analytics"));
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert!(state.query_history_picker.entries().is_empty());
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ClearCompletionEngineCache))
             );
         }
 

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -1066,7 +1066,9 @@ mod tests {
 
     mod query_history_picker {
         use super::*;
-        use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
+        use crate::domain::query_history::{
+            QueryHistoryEntry, QueryHistoryScope, QueryResultStatus,
+        };
         use crate::model::shared::text_input::TextInputLike;
         use crate::ports::outbound::query_history::QueryHistoryError;
 
@@ -1080,6 +1082,10 @@ mod tests {
             )
         }
 
+        fn scope(conn_id: &ConnectionId, database: Option<&str>) -> QueryHistoryScope {
+            QueryHistoryScope::new(conn_id.clone(), database.map(str::to_owned))
+        }
+
         fn connected_state() -> AppState {
             let mut state = create_test_state();
             state.session.activate_connection_with_dsn(
@@ -1088,6 +1094,20 @@ mod tests {
                 DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
             );
+            state.runtime.project_name = "test-project".to_string();
+            state
+        }
+
+        fn mysql_connected_state(database: &str) -> AppState {
+            let mut state = create_test_state();
+            state.session.activate_connection_with_target(
+                &ConnectionId::from_string("mysql-conn"),
+                "mysql",
+                DatabaseType::MySQL,
+                &format!("mysql://localhost/{database}"),
+                Some(database),
+            );
+            state.session.mark_probe_connected(true);
             state.runtime.project_name = "test-project".to_string();
             state
         }
@@ -1171,6 +1191,24 @@ mod tests {
             }
 
             #[test]
+            fn open_for_mysql_captures_selected_database_in_scope() {
+                let mut state = mysql_connected_state("analytics");
+
+                let effects = super::dispatch_modal(
+                    &mut state,
+                    &Action::OpenModal(ModalKind::QueryHistoryPicker),
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert!(matches!(
+                    &effects[0],
+                    Effect::LoadQueryHistory { scope, .. }
+                        if scope.database.as_deref() == Some("analytics")
+                ));
+            }
+
+            #[test]
             fn close_restores_origin_mode() {
                 let mut state = connected_state();
                 state.modal.set_mode(InputMode::SqlModal);
@@ -1200,7 +1238,7 @@ mod tests {
 
                 let effects = super::dispatch_modal(
                     &mut state,
-                    &Action::QueryHistoryLoaded(conn_id, entries),
+                    &Action::QueryHistoryLoaded(scope(&conn_id, None), entries),
                     Instant::now(),
                 )
                 .unwrap();
@@ -1218,7 +1256,32 @@ mod tests {
 
                 super::dispatch_modal(
                     &mut state,
-                    &Action::QueryHistoryLoaded(stale_conn, entries),
+                    &Action::QueryHistoryLoaded(scope(&stale_conn, None), entries),
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert!(state.query_history_picker.entries().is_empty());
+            }
+
+            #[test]
+            fn loaded_ignores_stale_mysql_database_scope() {
+                let mut state = mysql_connected_state("analytics");
+                state.modal.set_mode(InputMode::QueryHistoryPicker);
+                let conn_id = ConnectionId::from_string("mysql-conn");
+                let stale_scope = scope(&conn_id, Some("app"));
+                let entries = vec![QueryHistoryEntry::new_with_database(
+                    "SELECT 1".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    conn_id,
+                    Some("app".to_string()),
+                    QueryResultStatus::Success,
+                    None,
+                )];
+
+                super::dispatch_modal(
+                    &mut state,
+                    &Action::QueryHistoryLoaded(stale_scope, entries),
                     Instant::now(),
                 )
                 .unwrap();
@@ -1234,7 +1297,7 @@ mod tests {
 
                 super::dispatch_modal(
                     &mut state,
-                    &Action::QueryHistoryLoaded(conn_id, entries),
+                    &Action::QueryHistoryLoaded(scope(&conn_id, None), entries),
                     Instant::now(),
                 )
                 .unwrap();
@@ -1251,7 +1314,7 @@ mod tests {
                 super::dispatch_modal(
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
-                        ConnectionId::from_string("test-conn"),
+                        scope(&ConnectionId::from_string("test-conn"), None),
                         QueryHistoryError::Io(Arc::new(std::io::Error::other("disk error"))),
                     ),
                     now,
@@ -1273,7 +1336,7 @@ mod tests {
                 super::dispatch_modal(
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
-                        ConnectionId::from_string("test-conn"),
+                        scope(&ConnectionId::from_string("test-conn"), None),
                         QueryHistoryError::Io(Arc::new(std::io::Error::other("stale error"))),
                     ),
                     now,
@@ -1292,7 +1355,7 @@ mod tests {
                 super::dispatch_modal(
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
-                        ConnectionId::from_string("old-conn"),
+                        scope(&ConnectionId::from_string("old-conn"), None),
                         QueryHistoryError::Io(Arc::new(std::io::Error::other("stale error"))),
                     ),
                     now,

--- a/src/app/update/modal/query_history.rs
+++ b/src/app/update/modal/query_history.rs
@@ -35,10 +35,13 @@ pub(super) fn reduce_query_history_picker(
             state.query_history_picker.reset();
             state.modal.push_mode(InputMode::QueryHistoryPicker);
 
-            let conn_id = state.session.active_connection_id().unwrap();
+            let scope = state
+                .session
+                .query_history_scope()
+                .expect("active connection checked above");
             DispatchResult::handled_with(vec![Effect::LoadQueryHistory {
                 project_name: state.runtime.project_name.clone(),
-                connection_id: conn_id.clone(),
+                scope,
             }])
         }
         Action::CloseModal(ModalKind::QueryHistoryPicker) => {
@@ -46,21 +49,21 @@ pub(super) fn reduce_query_history_picker(
             state.query_history_picker.reset();
             DispatchResult::handled()
         }
-        Action::QueryHistoryLoaded(conn_id, entries) => {
+        Action::QueryHistoryLoaded(scope, entries) => {
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
                 return DispatchResult::handled();
             }
-            if state.session.active_connection_id() != Some(conn_id) {
+            if state.session.query_history_scope().as_ref() != Some(scope) {
                 return DispatchResult::handled();
             }
             state.query_history_picker.replace_entries(entries);
             DispatchResult::handled()
         }
-        Action::QueryHistoryLoadFailed(conn_id, e) => {
+        Action::QueryHistoryLoadFailed(scope, e) => {
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
                 return DispatchResult::handled();
             }
-            if state.session.active_connection_id() != Some(conn_id) {
+            if state.session.query_history_scope().as_ref() != Some(scope) {
                 return DispatchResult::handled();
             }
             state.messages.set_error_at(e.to_string(), now);

--- a/src/domain/query_history.rs
+++ b/src/domain/query_history.rs
@@ -2,6 +2,21 @@ use serde::{Deserialize, Serialize};
 
 use super::connection::ConnectionId;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryHistoryScope {
+    pub connection_id: ConnectionId,
+    pub database: Option<String>,
+}
+
+impl QueryHistoryScope {
+    pub fn new(connection_id: ConnectionId, database: Option<String>) -> Self {
+        Self {
+            connection_id,
+            database,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Iso8601Timestamp(String);
@@ -39,6 +54,8 @@ pub struct QueryHistoryEntry {
     pub query: String,
     pub executed_at: Iso8601Timestamp,
     pub connection_id: ConnectionId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
     pub result_status: QueryResultStatus,
     pub affected_rows: Option<u64>,
 }
@@ -51,10 +68,29 @@ impl QueryHistoryEntry {
         result_status: QueryResultStatus,
         affected_rows: Option<u64>,
     ) -> Self {
+        Self::new_with_database(
+            query,
+            executed_at,
+            connection_id,
+            None,
+            result_status,
+            affected_rows,
+        )
+    }
+
+    pub fn new_with_database(
+        query: String,
+        executed_at: String,
+        connection_id: ConnectionId,
+        database: Option<String>,
+        result_status: QueryResultStatus,
+        affected_rows: Option<u64>,
+    ) -> Self {
         Self {
             query,
             executed_at: Iso8601Timestamp::new(executed_at),
             connection_id,
+            database,
             result_status,
             affected_rows,
         }
@@ -115,5 +151,37 @@ mod tests {
         assert!(json.contains("\"executed_at\":\"2026-03-13T12:00:00Z\""));
         assert!(json.contains("\"connection_id\":\"abc-123\""));
         assert!(json.contains("\"result_status\":\"Success\""));
+    }
+
+    #[test]
+    fn serde_reads_entries_without_database() {
+        let json = r#"{
+            "query":"SELECT 1",
+            "executed_at":"2026-03-13T12:00:00Z",
+            "connection_id":"abc-123",
+            "result_status":"Success",
+            "affected_rows":null
+        }"#;
+
+        let entry: QueryHistoryEntry = serde_json::from_str(json).unwrap();
+
+        assert_eq!(entry.database, None);
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_database() {
+        let entry = QueryHistoryEntry::new_with_database(
+            "SELECT 1".to_string(),
+            "2026-03-13T12:00:00Z".to_string(),
+            ConnectionId::from_string("abc-123"),
+            Some("analytics".to_string()),
+            QueryResultStatus::Success,
+            None,
+        );
+
+        let json = serde_json::to_string(&entry).unwrap();
+        let deserialized: QueryHistoryEntry = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.database.as_deref(), Some("analytics"));
     }
 }

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -4,8 +4,7 @@ use async_trait::async_trait;
 
 use crate::app::ports::outbound::{QueryHistoryError, QueryHistoryStore};
 use crate::config::cache::{CacheDirError, get_cache_dir};
-use crate::domain::connection::ConnectionId;
-use crate::domain::query_history::QueryHistoryEntry;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 
 const MAX_HISTORY_ENTRIES: usize = 1000;
 
@@ -80,11 +79,11 @@ impl QueryHistoryStore for FileQueryHistoryStore {
     async fn append(
         &self,
         project_name: &str,
-        connection_id: &ConnectionId,
+        scope: &QueryHistoryScope,
         entry: &QueryHistoryEntry,
     ) -> Result<(), QueryHistoryError> {
         let history_dir = self.resolve_history_dir(project_name)?;
-        let path = history_dir.join(format!("{connection_id}.jsonl"));
+        let path = history_dir.join(format!("{}.jsonl", scope.connection_id));
         let line = serde_json::to_string(entry)?;
 
         tokio::task::spawn_blocking(move || {
@@ -99,10 +98,11 @@ impl QueryHistoryStore for FileQueryHistoryStore {
     async fn load(
         &self,
         project_name: &str,
-        connection_id: &ConnectionId,
+        scope: &QueryHistoryScope,
     ) -> Result<Vec<QueryHistoryEntry>, QueryHistoryError> {
         let history_dir = self.resolve_history_dir(project_name)?;
-        let path = history_dir.join(format!("{connection_id}.jsonl"));
+        let path = history_dir.join(format!("{}.jsonl", scope.connection_id));
+        let database = scope.database.clone();
 
         tokio::task::spawn_blocking(move || {
             if !path.exists() {
@@ -114,6 +114,7 @@ impl QueryHistoryStore for FileQueryHistoryStore {
                 .lines()
                 .filter(|line| !line.trim().is_empty())
                 .filter_map(|line| serde_json::from_str(line).ok())
+                .filter(|entry: &QueryHistoryEntry| entry.database == database)
                 .collect();
 
             Ok(entries)
@@ -125,6 +126,7 @@ impl QueryHistoryStore for FileQueryHistoryStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::connection::ConnectionId;
     use crate::domain::query_history::QueryResultStatus;
     use tempfile::TempDir;
 
@@ -138,6 +140,14 @@ mod tests {
         )
     }
 
+    fn scope(connection_id: &ConnectionId) -> QueryHistoryScope {
+        QueryHistoryScope::new(connection_id.clone(), None)
+    }
+
+    fn database_scope(connection_id: &ConnectionId, database: &str) -> QueryHistoryScope {
+        QueryHistoryScope::new(connection_id.clone(), Some(database.to_string()))
+    }
+
     #[tokio::test]
     async fn append_and_load_succeed_for_cli_sqlite_connection_id() {
         use sabiql_app::cmd::cli_sqlite::connection_id_for_path;
@@ -149,7 +159,7 @@ mod tests {
         assert!(!conn_id.as_str().contains('/'));
 
         store
-            .append("test", &conn_id, &make_entry("SELECT 1"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 1"))
             .await
             .unwrap();
 
@@ -157,7 +167,7 @@ mod tests {
         let path = history_dir.join(format!("{conn_id}.jsonl"));
         assert!(path.is_file());
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].query, "SELECT 1");
     }
@@ -169,7 +179,10 @@ mod tests {
         let conn_id = ConnectionId::from_string("test-conn");
 
         let entry = make_entry("SELECT 1");
-        store.append("test", &conn_id, &entry).await.unwrap();
+        store
+            .append("test", &scope(&conn_id), &entry)
+            .await
+            .unwrap();
 
         let history_dir = tmp.path().join("history");
         let path = history_dir.join(format!("{conn_id}.jsonl"));
@@ -186,24 +199,82 @@ mod tests {
         let conn_id = ConnectionId::from_string("test-conn");
 
         store
-            .append("test", &conn_id, &make_entry("SELECT 1"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 1"))
             .await
             .unwrap();
         store
-            .append("test", &conn_id, &make_entry("SELECT 2"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 2"))
             .await
             .unwrap();
         store
-            .append("test", &conn_id, &make_entry("SELECT 3"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 3"))
             .await
             .unwrap();
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
 
         assert_eq!(entries.len(), 3);
         assert_eq!(entries[0].query, "SELECT 1");
         assert_eq!(entries[1].query, "SELECT 2");
         assert_eq!(entries[2].query, "SELECT 3");
+    }
+
+    #[tokio::test]
+    async fn load_filters_entries_by_database_scope() {
+        let tmp = TempDir::new().unwrap();
+        let store = FileQueryHistoryStore::with_base_dir(tmp.path().to_path_buf());
+        let conn_id = ConnectionId::from_string("test-conn");
+        let app_scope = database_scope(&conn_id, "app");
+        let analytics_scope = database_scope(&conn_id, "analytics");
+
+        store
+            .append(
+                "test",
+                &app_scope,
+                &QueryHistoryEntry::new_with_database(
+                    "SELECT app".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    conn_id.clone(),
+                    Some("app".to_string()),
+                    QueryResultStatus::Success,
+                    None,
+                ),
+            )
+            .await
+            .unwrap();
+        store
+            .append(
+                "test",
+                &analytics_scope,
+                &QueryHistoryEntry::new_with_database(
+                    "SELECT analytics".to_string(),
+                    "2026-03-13T12:01:00Z".to_string(),
+                    conn_id.clone(),
+                    Some("analytics".to_string()),
+                    QueryResultStatus::Success,
+                    None,
+                ),
+            )
+            .await
+            .unwrap();
+
+        let app_entries = store.load("test", &app_scope).await.unwrap();
+        let analytics_entries = store.load("test", &analytics_scope).await.unwrap();
+
+        assert_eq!(
+            app_entries
+                .iter()
+                .map(|entry| entry.query.as_str())
+                .collect::<Vec<_>>(),
+            ["SELECT app"]
+        );
+        assert_eq!(
+            analytics_entries
+                .iter()
+                .map(|entry| entry.query.as_str())
+                .collect::<Vec<_>>(),
+            ["SELECT analytics"]
+        );
     }
 
     #[tokio::test]
@@ -215,12 +286,16 @@ mod tests {
         // Write 1001 entries
         for i in 0..1001 {
             store
-                .append("test", &conn_id, &make_entry(&format!("SELECT {i}")))
+                .append(
+                    "test",
+                    &scope(&conn_id),
+                    &make_entry(&format!("SELECT {i}")),
+                )
                 .await
                 .unwrap();
         }
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
 
         assert_eq!(entries.len(), MAX_HISTORY_ENTRIES);
         // Oldest entry (SELECT 0) should be trimmed, newest (SELECT 1000) should remain
@@ -234,7 +309,7 @@ mod tests {
         let store = FileQueryHistoryStore::with_base_dir(tmp.path().to_path_buf());
         let conn_id = ConnectionId::from_string("nonexistent");
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
 
         assert!(entries.is_empty());
     }
@@ -247,7 +322,7 @@ mod tests {
 
         // Write a valid entry
         store
-            .append("test", &conn_id, &make_entry("SELECT 1"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 1"))
             .await
             .unwrap();
 
@@ -261,11 +336,11 @@ mod tests {
 
         // Write another valid entry
         store
-            .append("test", &conn_id, &make_entry("SELECT 2"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 2"))
             .await
             .unwrap();
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
 
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].query, "SELECT 1");
@@ -280,12 +355,16 @@ mod tests {
 
         for i in 0..5 {
             store
-                .append("test", &conn_id, &make_entry(&format!("SELECT {i}")))
+                .append(
+                    "test",
+                    &scope(&conn_id),
+                    &make_entry(&format!("SELECT {i}")),
+                )
                 .await
                 .unwrap();
         }
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
         assert_eq!(entries.len(), 5);
         assert_eq!(entries[0].query, "SELECT 0");
         assert_eq!(entries[4].query, "SELECT 4");
@@ -299,12 +378,16 @@ mod tests {
 
         for i in 0..MAX_HISTORY_ENTRIES {
             store
-                .append("test", &conn_id, &make_entry(&format!("SELECT {i}")))
+                .append(
+                    "test",
+                    &scope(&conn_id),
+                    &make_entry(&format!("SELECT {i}")),
+                )
                 .await
                 .unwrap();
         }
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
         assert_eq!(entries.len(), MAX_HISTORY_ENTRIES);
         assert_eq!(entries[0].query, "SELECT 0");
         assert_eq!(
@@ -322,12 +405,16 @@ mod tests {
         let total = MAX_HISTORY_ENTRIES + 5;
         for i in 0..total {
             store
-                .append("test", &conn_id, &make_entry(&format!("SELECT {i}")))
+                .append(
+                    "test",
+                    &scope(&conn_id),
+                    &make_entry(&format!("SELECT {i}")),
+                )
                 .await
                 .unwrap();
         }
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
         assert_eq!(entries.len(), MAX_HISTORY_ENTRIES);
         // Oldest 5 entries (0..5) should be trimmed
         assert_eq!(entries[0].query, "SELECT 5");
@@ -346,7 +433,11 @@ mod tests {
         // Fill to just above the limit so trim fires on next append
         for i in 0..MAX_HISTORY_ENTRIES {
             store
-                .append("test", &conn_id, &make_entry(&format!("SELECT {i}")))
+                .append(
+                    "test",
+                    &scope(&conn_id),
+                    &make_entry(&format!("SELECT {i}")),
+                )
                 .await
                 .unwrap();
         }
@@ -358,12 +449,12 @@ mod tests {
 
         // append should still succeed (trim failure is best-effort)
         let result = store
-            .append("test", &conn_id, &make_entry("SELECT final"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT final"))
             .await;
         assert!(result.is_ok());
 
         // The entry was written even though trim failed
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
         assert!(entries.len() > MAX_HISTORY_ENTRIES);
         assert_eq!(entries.last().unwrap().query, "SELECT final");
     }
@@ -385,7 +476,7 @@ mod tests {
         // Malformed line should be skipped
         writeln!(file, "not valid json").unwrap();
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
 
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].query, "SELECT 1");


### PR DESCRIPTION
## Problem
Query history is currently separated only by ConnectionId, so queries from different MySQL databases on the same connection are mixed.

## Background
Switching databases on the same connection can also allow a stale history load to update the picker.

## Approach
Carry a connection/database `QueryHistoryScope` through effects, actions, and the store while keeping JSONL files keyed only by connection. Persist the execution database for MySQL, filter loads by scope, clear the picker on database switches, and ignore stale scope responses. PostgreSQL and SQLite continue to use a database-less scope, and legacy entries remain readable.

## Linear Issue
- Implements https://linear.app/sabiql/issue/SAB-387