### PR TITLE
feat(mysql): browse tables and preview rows

### DIFF
--- a/scripts/init-mysql.sql
+++ b/scripts/init-mysql.sql
@@ -8,7 +8,12 @@ CREATE TABLE mysql_cli_fixture (
     empty_text TEXT NOT NULL,
     unicode_text TEXT NOT NULL,
     json_value JSON NOT NULL,
-    blob_value BLOB NOT NULL
+    blob_value BLOB NOT NULL,
+    invisible_value INT INVISIBLE,
+    generated_value INT GENERATED ALWAYS AS (id * 2) STORED,
+    unsigned_value BIGINT UNSIGNED NOT NULL,
+    precise_decimal DECIMAL(65, 30) NOT NULL,
+    scientific_value DOUBLE NOT NULL
 ) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
 
 INSERT INTO mysql_cli_fixture (
@@ -17,14 +22,46 @@ INSERT INTO mysql_cli_fixture (
     empty_text,
     unicode_text,
     json_value,
-    blob_value
+    blob_value,
+    unsigned_value,
+    precise_decimal,
+    scientific_value
 ) VALUES (
     1,
     NULL,
     '',
     '日本語の値 🐬',
     '{"array":[1,true],"text":"空文字ではない"}',
-    X'00FF10'
+    X'00FF10',
+    18446744073709551615,
+    12345678901234567890123456789012345.123456789012345678901234567890,
+    1.23e100
 );
+
+CREATE TABLE mysql_preview_composite (
+    first_key INT NOT NULL,
+    second_key INT NOT NULL,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (second_key, first_key)
+) CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_preview_composite (first_key, second_key, payload)
+VALUES (1, 20, 'first'), (2, 10, 'second');
+
+CREATE TABLE mysql_preview_no_pk (
+    duplicate_value VARCHAR(20) NOT NULL,
+    payload TEXT NOT NULL
+) CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_preview_no_pk (duplicate_value, payload)
+VALUES ('same', 'first'), ('same', 'second');
+
+CREATE TABLE mysql_preview_empty (
+    id INT PRIMARY KEY,
+    payload TEXT
+) CHARACTER SET utf8mb4;
+
+CREATE VIEW mysql_preview_view AS
+SELECT id, unicode_text FROM mysql_cli_fixture;
 
 GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO 'sabiql'@'%';

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::connection::error::ConnectionErrorInfo;
 use crate::model::er_state::ErStatus;
@@ -140,12 +139,6 @@ pub(super) fn reduce_loading(
             })
         }
         Action::LoadMetadata => {
-            if state.session.active_database_type() == Some(DatabaseType::MySQL) {
-                state
-                    .messages
-                    .set_error_at("MySQL metadata is not available yet".to_string(), now);
-                return DispatchResult::handled();
-            }
             if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.session.begin_metadata_refresh();
                 DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
@@ -154,12 +147,6 @@ pub(super) fn reduce_loading(
             }
         }
         Action::ReloadMetadata => {
-            if state.session.active_database_type() == Some(DatabaseType::MySQL) {
-                state
-                    .messages
-                    .set_error_at("MySQL metadata is not available yet".to_string(), now);
-                return DispatchResult::handled();
-            }
             if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.session.begin_reload();
                 state.sql_modal.reset_prefetch();

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -158,7 +158,7 @@ mod tests {
         }
 
         #[test]
-        fn mysql_metadata_actions_are_suppressed() {
+        fn mysql_metadata_actions_start_fetches() {
             let mut state = AppState::new("test".to_string());
             state.session.activate_connection_with_target(
                 &ConnectionId::new(),
@@ -176,12 +176,17 @@ mod tests {
                     .into_effects()
                     .unwrap();
 
-                assert!(effects.is_empty());
+                assert!(effects.iter().any(contains_fetch_metadata));
             }
-            assert_eq!(
-                state.messages.last_error(),
-                Some("MySQL metadata is not available yet")
-            );
+            assert!(state.messages.last_error().is_none());
+        }
+
+        fn contains_fetch_metadata(effect: &Effect) -> bool {
+            match effect {
+                Effect::FetchMetadata { .. } => true,
+                Effect::Sequence(effects) => effects.iter().any(contains_fetch_metadata),
+                _ => false,
+            }
         }
     }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -169,6 +169,12 @@ pub fn reduce_connection_lifecycle(
                         database_generation: state.session.database_generation(),
                     });
                 }
+            } else {
+                let metadata_run_id = state.session.begin_metadata_refresh();
+                effects.push(Effect::FetchMetadata {
+                    dsn: dsn.clone(),
+                    run_id: metadata_run_id,
+                });
             }
             DispatchResult::handled_with(termination_effects(&state.query, effects))
         }
@@ -201,9 +207,16 @@ pub fn reduce_connection_lifecycle(
             reset_for_database_switch(state, &target);
             state.ui.set_database_picker(false);
             state.modal.set_mode(InputMode::Normal);
+            let metadata_run_id = state.session.begin_metadata_refresh();
             DispatchResult::handled_with(termination_effects(
                 &state.query,
-                vec![Effect::ClearCompletionEngineCache],
+                vec![
+                    Effect::ClearCompletionEngineCache,
+                    Effect::FetchMetadata {
+                        dsn: target.dsn,
+                        run_id: metadata_run_id,
+                    },
+                ],
             ))
         }
 
@@ -1630,7 +1643,7 @@ mod tests {
             assert!(state.session.is_read_only());
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(
-                !effects
+                effects
                     .iter()
                     .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
             );

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -29,15 +29,14 @@ use uuid::Uuid;
 use crate::app::ports::outbound::{
     AccessMode, ConnectionProbe, DatabaseCli, DbOperationError, DdlGenerator, DsnBuilder,
     MYSQL_CLI_VERSION_REQUIRED_MARKER, MYSQL_SERVER_VERSION_REQUIRED_MARKER,
-    MYSQL_SQL_MODE_UNSUPPORTED_MARKER, MetadataProvider, QueryExecutor, SqlDialect,
+    MYSQL_SQL_MODE_UNSUPPORTED_MARKER, QueryExecutor, SqlDialect,
 };
 use crate::domain::connection::{
     ConnectionProfile, DatabaseType, MySqlConnectionConfig, MySqlSslMode,
 };
-use crate::domain::{
-    DatabaseMetadata, QueryResult, QuerySource, QueryValue, Table, TableSignature,
-    WriteExecutionResult,
-};
+use crate::domain::{QueryResult, QuerySource, QueryValue, Table, WriteExecutionResult};
+
+mod metadata;
 
 pub struct MySqlAdapter;
 
@@ -59,57 +58,48 @@ impl Default for MySqlAdapter {
 }
 
 #[async_trait]
-impl MetadataProvider for MySqlAdapter {
-    async fn fetch_metadata(&self, _dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL metadata is not implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_detail(
-        &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-    ) -> Result<Table, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL metadata is not implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_columns_and_fks(
-        &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-    ) -> Result<Table, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL metadata is not implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_signatures(
-        &self,
-        _dsn: &str,
-    ) -> Result<Vec<TableSignature>, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL metadata is not implemented".to_string(),
-        ))
-    }
-}
-
-#[async_trait]
 impl QueryExecutor for MySqlAdapter {
     async fn execute_preview(
         &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-        _limit: usize,
-        _offset: usize,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+        limit: usize,
+        offset: usize,
     ) -> Result<QueryResult, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL query execution is not implemented".to_string(),
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures mysql execution time at the I/O boundary"
+        )]
+        let start = Instant::now();
+        let preview = metadata::fetch_preview_metadata(dsn, schema, table).await?;
+        let query = metadata::build_preview_query(
+            schema,
+            table,
+            &preview.order_columns,
+            &preview.visible_columns,
+            limit,
+            offset,
+        );
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc(&option_file.path, &query).await;
+        drop(option_file);
+        let result_set = result?;
+        let values = metadata::convert_preview_values(&result_set, &preview.visible_columns)?;
+        let elapsed = start.elapsed().as_millis() as u64;
+
+        Ok(QueryResult::success_with_values(
+            query,
+            preview
+                .visible_columns
+                .iter()
+                .map(|column| column.name.clone())
+                .collect(),
+            values,
+            elapsed,
+            QuerySource::Preview,
         ))
     }
 

--- a/src/infra/adapters/mysql/metadata.rs
+++ b/src/infra/adapters/mysql/metadata.rs
@@ -1,0 +1,731 @@
+use async_trait::async_trait;
+
+use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
+use crate::domain::{
+    Column, ColumnAttributes, DatabaseMetadata, QueryValue, Schema, Table, TableKind,
+    TableKindInfo, TableSignature, TableSummary,
+};
+
+use super::{
+    MySqlAdapter, MySqlOptionFile, MysqlResultSet, parse_mysql_dsn, run_mysql_adhoc,
+    validate_mysql_values,
+};
+
+const TABLES_QUERY: &str = "SELECT TABLE_NAME, TABLE_TYPE, TABLE_ROWS FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') UNION ALL SELECT NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')) ORDER BY TABLE_NAME";
+
+#[derive(Debug, Clone)]
+struct MysqlColumnMetadata {
+    name: String,
+    data_type: String,
+    nullable: bool,
+    default: Option<String>,
+    comment: Option<String>,
+    ordinal_position: i32,
+    primary_key_position: Option<i32>,
+    invisible: bool,
+    generated: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PreviewMetadata {
+    pub visible_columns: Vec<Column>,
+    pub order_columns: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct MysqlTableMetadata {
+    name: String,
+    kind: TableKind,
+    row_count_estimate: Option<i64>,
+}
+
+#[async_trait]
+impl MetadataProvider for MySqlAdapter {
+    async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
+        let database = selected_database(dsn)?;
+        let result = execute_metadata_query(dsn, TABLES_QUERY).await?;
+        let tables = parse_table_metadata(&result)?;
+        let mut metadata = DatabaseMetadata::new(database.clone());
+        metadata.schemas = vec![Schema::new(database.clone())];
+        metadata.table_summaries = tables
+            .into_iter()
+            .map(|table| table_summary(&database, table))
+            .collect();
+        Ok(metadata)
+    }
+
+    async fn fetch_table_detail(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Table, DbOperationError> {
+        fetch_table(dsn, schema, table).await
+    }
+
+    async fn fetch_table_columns_and_fks(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Table, DbOperationError> {
+        fetch_table(dsn, schema, table).await
+    }
+
+    async fn fetch_table_signatures(
+        &self,
+        dsn: &str,
+    ) -> Result<Vec<TableSignature>, DbOperationError> {
+        let metadata = self.fetch_metadata(dsn).await?;
+        Ok(metadata
+            .table_summaries
+            .into_iter()
+            .map(|summary| TableSignature {
+                schema: summary.schema,
+                name: summary.name,
+                signature: format!("{:?}", summary.kind_info.kind),
+            })
+            .collect())
+    }
+}
+
+pub(super) async fn fetch_preview_metadata(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<PreviewMetadata, DbOperationError> {
+    find_table(dsn, schema, table).await?;
+    let column_metadata = fetch_columns(dsn, schema, table).await?;
+    let columns = column_metadata
+        .iter()
+        .map(column_from_metadata)
+        .collect::<Vec<_>>();
+    let visible_columns = columns
+        .iter()
+        .filter(|column| !column.is_hidden())
+        .cloned()
+        .collect::<Vec<_>>();
+    if visible_columns.is_empty() {
+        return Err(DbOperationError::MetadataParseFailed(format!(
+            "MySQL object has no visible columns: {schema}.{table}"
+        )));
+    }
+    let order_columns = primary_key_names(&column_metadata);
+    let order_columns = if order_columns.is_empty() {
+        visible_columns
+            .iter()
+            .map(|column| column.name.clone())
+            .collect()
+    } else {
+        order_columns
+    };
+    Ok(PreviewMetadata {
+        visible_columns,
+        order_columns,
+    })
+}
+
+pub(super) fn build_preview_query(
+    schema: &str,
+    table: &str,
+    order_columns: &[String],
+    visible_columns: &[Column],
+    limit: usize,
+    offset: usize,
+) -> String {
+    let columns = visible_columns
+        .iter()
+        .map(|column| quote_identifier(&column.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let order_by = order_columns
+        .iter()
+        .map(|column| quote_identifier(column))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "SELECT {columns} FROM {}.{} ORDER BY {order_by} LIMIT {limit} OFFSET {offset}",
+        quote_identifier(schema),
+        quote_identifier(table),
+    )
+}
+
+pub(super) fn convert_preview_values(
+    result: &MysqlResultSet,
+    columns: &[Column],
+) -> Result<Vec<Vec<QueryValue>>, DbOperationError> {
+    if result.values.is_empty() {
+        if result.columns.is_empty() || result.columns.len() == columns.len() {
+            return Ok(Vec::new());
+        }
+        return Err(DbOperationError::MetadataParseFailed(
+            "MySQL preview returned an unexpected column count".to_string(),
+        ));
+    }
+    if result.columns.len() != columns.len() {
+        return Err(DbOperationError::MetadataParseFailed(
+            "MySQL preview returned an unexpected column count".to_string(),
+        ));
+    }
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != columns.len() {
+                return Err(DbOperationError::MetadataParseFailed(
+                    "MySQL preview returned an unexpected row width".to_string(),
+                ));
+            }
+            row.iter()
+                .zip(columns)
+                .map(|(value, column)| Ok(convert_preview_value(value, &column.data_type)))
+                .collect()
+        })
+        .collect()
+}
+
+fn convert_preview_value(value: &QueryValue, data_type: &str) -> QueryValue {
+    let QueryValue::Text(value) = value else {
+        return value.clone();
+    };
+    if is_binary_type(data_type)
+        && let Some(bytes) = decode_hex(value)
+    {
+        return QueryValue::Blob(bytes);
+    }
+    if is_numeric_type(data_type) && is_sql_numeric_literal(value) {
+        return QueryValue::SqlLiteral(value.clone());
+    }
+    QueryValue::Text(value.clone())
+}
+
+async fn fetch_table(dsn: &str, schema: &str, table: &str) -> Result<Table, DbOperationError> {
+    let table_metadata = find_table(dsn, schema, table).await?;
+    let columns = fetch_columns(dsn, schema, table).await?;
+    let primary_key = primary_key_names(&columns);
+    let columns = columns.iter().map(column_from_metadata).collect::<Vec<_>>();
+    Ok(Table {
+        schema: schema.to_string(),
+        name: table_metadata.name,
+        owner: None,
+        columns,
+        primary_key: (!primary_key.is_empty()).then_some(primary_key),
+        foreign_keys: Vec::new(),
+        indexes: Vec::new(),
+        rls: None,
+        triggers: Vec::new(),
+        row_count_estimate: table_metadata.row_count_estimate,
+        comment: None,
+        source_ddl: None,
+        kind_info: TableKindInfo {
+            kind: table_metadata.kind,
+            ..TableKindInfo::default()
+        },
+    })
+}
+
+async fn find_table(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<MysqlTableMetadata, DbOperationError> {
+    let database = selected_database(dsn)?;
+    if schema != database {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    let result = execute_metadata_query(dsn, TABLES_QUERY).await?;
+    parse_table_metadata(&result)?
+        .into_iter()
+        .find(|candidate| candidate.name == table)
+        .ok_or_else(|| {
+            DbOperationError::ObjectMissing(format!("MySQL table not found: {schema}.{table}"))
+        })
+}
+
+async fn fetch_columns(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
+    let query = format!(
+        "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = DATABASE() AND kcu.TABLE_SCHEMA = c.TABLE_SCHEMA AND kcu.TABLE_NAME = c.TABLE_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME AND kcu.CONSTRAINT_NAME = 'PRIMARY' WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = {} ORDER BY c.ORDINAL_POSITION",
+        quote_string(table)
+    );
+    let result = execute_metadata_query(dsn, &query).await?;
+    let database = selected_database(dsn)?;
+    if schema != database {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    let columns = parse_column_metadata(&result)?;
+    if columns.is_empty() {
+        return Err(DbOperationError::MetadataParseFailed(format!(
+            "MySQL object has no column metadata: {schema}.{table}"
+        )));
+    }
+    Ok(columns)
+}
+
+async fn execute_metadata_query(
+    dsn: &str,
+    query: &str,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let target = parse_mysql_dsn(dsn)?;
+    validate_mysql_values(&target)?;
+    let option_file = MySqlOptionFile::create(&target)?;
+    let result = run_mysql_adhoc(&option_file.path, query).await;
+    drop(option_file);
+    result
+}
+
+fn selected_database(dsn: &str) -> Result<String, DbOperationError> {
+    parse_mysql_dsn(dsn)?.database.ok_or_else(|| {
+        DbOperationError::UnsupportedOperation(
+            "MySQL metadata requires a selected database".to_string(),
+        )
+    })
+}
+
+fn parse_table_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlTableMetadata>, DbOperationError> {
+    expect_columns(result, &["TABLE_NAME", "TABLE_TYPE", "TABLE_ROWS"])?;
+    let tables = result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != 3 {
+                return Err(metadata_shape_error("TABLES row"));
+            }
+            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
+                return Ok(None);
+            }
+            let name = required_text(&row[0], "TABLE_NAME")?.to_string();
+            let kind = match required_text(&row[1], "TABLE_TYPE")? {
+                "BASE TABLE" => TableKind::Table,
+                "VIEW" => TableKind::View,
+                value => {
+                    return Err(DbOperationError::MetadataParseFailed(format!(
+                        "unexpected MySQL table type: {value}"
+                    )));
+                }
+            };
+            let row_count_estimate = optional_text(&row[2], "TABLE_ROWS")?
+                .map(|value| {
+                    value.parse::<i64>().map_err(|_| {
+                        DbOperationError::MetadataParseFailed(
+                            "invalid MySQL TABLE_ROWS value".to_string(),
+                        )
+                    })
+                })
+                .transpose()?;
+            Ok(Some(MysqlTableMetadata {
+                name,
+                kind,
+                row_count_estimate,
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(tables.into_iter().flatten().collect())
+}
+
+fn parse_column_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &[
+            "COLUMN_NAME",
+            "COLUMN_TYPE",
+            "IS_NULLABLE",
+            "COLUMN_DEFAULT",
+            "EXTRA",
+            "COLUMN_COMMENT",
+            "ORDINAL_POSITION",
+            "PRIMARY_KEY_POSITION",
+        ],
+    )?;
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != 8 {
+                return Err(metadata_shape_error("COLUMNS row"));
+            }
+            let extra = required_text(&row[4], "EXTRA")?;
+            Ok(MysqlColumnMetadata {
+                name: required_text(&row[0], "COLUMN_NAME")?.to_string(),
+                data_type: required_text(&row[1], "COLUMN_TYPE")?.to_string(),
+                nullable: required_text(&row[2], "IS_NULLABLE")? == "YES",
+                default: optional_text(&row[3], "COLUMN_DEFAULT")?.map(str::to_string),
+                comment: optional_text(&row[5], "COLUMN_COMMENT")?
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string),
+                ordinal_position: parse_positive_i32(&row[6], "ORDINAL_POSITION")?,
+                primary_key_position: optional_text(&row[7], "PRIMARY_KEY_POSITION")?
+                    .map(|value| parse_positive_i32_text(value, "PRIMARY_KEY_POSITION"))
+                    .transpose()?,
+                invisible: extra
+                    .split_ascii_whitespace()
+                    .any(|word| word.eq_ignore_ascii_case("INVISIBLE")),
+                generated: extra
+                    .split_ascii_whitespace()
+                    .any(|word| word.eq_ignore_ascii_case("GENERATED")),
+            })
+        })
+        .collect()
+}
+
+fn column_from_metadata(metadata: &MysqlColumnMetadata) -> Column {
+    let primary_key = metadata.primary_key_position.is_some();
+    let attributes = ColumnAttributes::from_parts(metadata.nullable, primary_key, false)
+        | if metadata.invisible {
+            ColumnAttributes::HIDDEN | ColumnAttributes::READ_ONLY
+        } else {
+            ColumnAttributes::empty()
+        }
+        | if metadata.generated {
+            ColumnAttributes::GENERATED | ColumnAttributes::READ_ONLY
+        } else {
+            ColumnAttributes::empty()
+        };
+    Column {
+        name: metadata.name.clone(),
+        data_type: metadata.data_type.clone(),
+        default: metadata.default.clone(),
+        attributes,
+        comment: metadata.comment.clone(),
+        ordinal_position: metadata.ordinal_position,
+    }
+}
+
+fn primary_key_names(columns: &[MysqlColumnMetadata]) -> Vec<String> {
+    let mut columns = columns
+        .iter()
+        .filter_map(|column| {
+            column
+                .primary_key_position
+                .map(|position| (position, column.name.clone()))
+        })
+        .collect::<Vec<_>>();
+    columns.sort_by_key(|(position, _)| *position);
+    columns.into_iter().map(|(_, name)| name).collect()
+}
+
+fn table_summary(database: &str, table: MysqlTableMetadata) -> TableSummary {
+    TableSummary::new(
+        database.to_string(),
+        table.name,
+        table.row_count_estimate,
+        false,
+    )
+    .with_kind_info(TableKindInfo {
+        kind: table.kind,
+        ..TableKindInfo::default()
+    })
+}
+
+fn expect_columns(result: &MysqlResultSet, expected: &[&str]) -> Result<(), DbOperationError> {
+    if result.columns == expected {
+        Ok(())
+    } else {
+        Err(metadata_shape_error("MySQL metadata columns"))
+    }
+}
+
+fn required_text<'a>(value: &'a QueryValue, field: &str) -> Result<&'a str, DbOperationError> {
+    optional_text(value, field)?.ok_or_else(|| {
+        DbOperationError::MetadataParseFailed(format!("MySQL metadata field is NULL: {field}"))
+    })
+}
+
+fn optional_text<'a>(
+    value: &'a QueryValue,
+    field: &str,
+) -> Result<Option<&'a str>, DbOperationError> {
+    match value {
+        QueryValue::Null => Ok(None),
+        QueryValue::Text(value) | QueryValue::SqlLiteral(value) => Ok(Some(value)),
+        QueryValue::Blob(_) => Err(DbOperationError::MetadataParseFailed(format!(
+            "MySQL metadata field is binary: {field}"
+        ))),
+    }
+}
+
+fn parse_positive_i32(value: &QueryValue, field: &str) -> Result<i32, DbOperationError> {
+    parse_positive_i32_text(required_text(value, field)?, field)
+}
+
+fn parse_positive_i32_text(value: &str, field: &str) -> Result<i32, DbOperationError> {
+    let value = value.parse::<i32>().map_err(|_| {
+        DbOperationError::MetadataParseFailed(format!("invalid MySQL metadata integer: {field}"))
+    })?;
+    if value > 0 {
+        Ok(value)
+    } else {
+        Err(DbOperationError::MetadataParseFailed(format!(
+            "invalid MySQL metadata ordinal: {field}"
+        )))
+    }
+}
+
+fn metadata_shape_error(field: &str) -> DbOperationError {
+    DbOperationError::MetadataParseFailed(format!("unexpected MySQL metadata shape: {field}"))
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("`{}`", value.replace('`', "``"))
+}
+
+fn quote_string(value: &str) -> String {
+    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "''"))
+}
+
+fn is_binary_type(data_type: &str) -> bool {
+    let name = data_type
+        .split(['(', ' '])
+        .next()
+        .unwrap_or(data_type)
+        .to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        "binary" | "varbinary" | "tinyblob" | "blob" | "mediumblob" | "longblob" | "bit"
+    )
+}
+
+fn is_numeric_type(data_type: &str) -> bool {
+    let name = data_type
+        .split(['(', ' '])
+        .next()
+        .unwrap_or(data_type)
+        .to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        "tinyint"
+            | "smallint"
+            | "mediumint"
+            | "int"
+            | "integer"
+            | "bigint"
+            | "decimal"
+            | "dec"
+            | "numeric"
+            | "fixed"
+            | "float"
+            | "double"
+            | "real"
+    )
+}
+
+fn decode_hex(value: &str) -> Option<Vec<u8>> {
+    let hex = value.strip_prefix("0x")?;
+    if hex.len() % 2 != 0 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    (0..hex.len())
+        .step_by(2)
+        .map(|index| u8::from_str_radix(&hex[index..index + 2], 16).ok())
+        .collect()
+}
+
+fn is_sql_numeric_literal(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+    let mut index = usize::from(matches!(bytes[0], b'+' | b'-'));
+    let integer_start = index;
+    while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+        index += 1;
+    }
+    let has_integer = index > integer_start;
+    let mut has_fraction = false;
+    if bytes.get(index) == Some(&b'.') {
+        has_fraction = true;
+        index += 1;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+    }
+    if !has_integer && !has_fraction {
+        return false;
+    }
+    if matches!(bytes.get(index), Some(b'e' | b'E')) {
+        index += 1;
+        if matches!(bytes.get(index), Some(b'+' | b'-')) {
+            index += 1;
+        }
+        let exponent_start = index;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+        if exponent_start == index {
+            return false;
+        }
+    }
+    index == bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
+        MysqlResultSet {
+            columns: columns.iter().map(|value| (*value).to_string()).collect(),
+            values,
+        }
+    }
+
+    fn column(name: &str, data_type: &str) -> Column {
+        Column {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            default: None,
+            attributes: ColumnAttributes::empty(),
+            comment: None,
+            ordinal_position: 1,
+        }
+    }
+
+    #[test]
+    fn preview_conversion_keeps_text_hex_and_decodes_binary_hex() {
+        let result = result(
+            &["text_value", "binary_value"],
+            vec![vec![
+                QueryValue::Text("0x41".to_string()),
+                QueryValue::Text("0x00FF".to_string()),
+            ]],
+        );
+        let columns = vec![
+            column("text_value", "varchar(20)"),
+            column("binary_value", "blob"),
+        ];
+
+        let values = convert_preview_values(&result, &columns).expect("conversion succeeds");
+
+        assert_eq!(values[0][0], QueryValue::Text("0x41".to_string()));
+        assert_eq!(values[0][1], QueryValue::Blob(vec![0, 255]));
+    }
+
+    #[test]
+    fn preview_conversion_keeps_numeric_server_literals_without_rounding() {
+        let result = result(
+            &["unsigned_value", "decimal_value", "float_value"],
+            vec![vec![
+                QueryValue::Text("18446744073709551615".to_string()),
+                QueryValue::Text("12345678901234567890.12345678901234567890".to_string()),
+                QueryValue::Text("1.23e+100".to_string()),
+            ]],
+        );
+        let columns = vec![
+            column("unsigned_value", "bigint unsigned"),
+            column("decimal_value", "decimal(65,30)"),
+            column("float_value", "double"),
+        ];
+
+        let values = convert_preview_values(&result, &columns).expect("conversion succeeds");
+
+        assert_eq!(values[0][0].as_str(), Some("18446744073709551615"));
+        assert!(matches!(values[0][0], QueryValue::SqlLiteral(_)));
+        assert!(matches!(values[0][1], QueryValue::SqlLiteral(_)));
+        assert!(matches!(values[0][2], QueryValue::SqlLiteral(_)));
+    }
+
+    #[test]
+    fn numeric_literal_validation_rejects_partial_values() {
+        assert!(is_sql_numeric_literal("1."));
+        assert!(is_sql_numeric_literal(".5"));
+        assert!(is_sql_numeric_literal("-1.2e-3"));
+        assert!(!is_sql_numeric_literal("1e"));
+        assert!(!is_sql_numeric_literal("nan"));
+    }
+
+    #[test]
+    fn preview_query_lists_visible_columns_and_orders_by_primary_key() {
+        let columns = vec![column("id", "int"), column("display", "text")];
+
+        let query = build_preview_query("app", "items", &["id".to_string()], &columns, 500, 1000);
+
+        assert_eq!(
+            query,
+            "SELECT `id`, `display` FROM `app`.`items` ORDER BY `id` LIMIT 500 OFFSET 1000"
+        );
+    }
+
+    #[test]
+    fn metadata_parser_preserves_column_and_composite_key_order() {
+        let result = result(
+            &[
+                "COLUMN_NAME",
+                "COLUMN_TYPE",
+                "IS_NULLABLE",
+                "COLUMN_DEFAULT",
+                "EXTRA",
+                "COLUMN_COMMENT",
+                "ORDINAL_POSITION",
+                "PRIMARY_KEY_POSITION",
+            ],
+            vec![
+                vec![
+                    QueryValue::Text("first_key".to_string()),
+                    QueryValue::Text("int".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("2".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("second_key".to_string()),
+                    QueryValue::Text("int".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Text("1".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("generated_value".to_string()),
+                    QueryValue::Text("int".to_string()),
+                    QueryValue::Text("YES".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("STORED GENERATED".to_string()),
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text("3".to_string()),
+                    QueryValue::Null,
+                ],
+            ],
+        );
+
+        let parsed = parse_column_metadata(&result).expect("metadata parses");
+        assert_eq!(primary_key_names(&parsed), ["second_key", "first_key"]);
+        assert_eq!(
+            parsed
+                .iter()
+                .map(|column| column.ordinal_position)
+                .collect::<Vec<_>>(),
+            [1, 2, 3]
+        );
+        assert!(column_from_metadata(&parsed[2]).is_generated());
+    }
+
+    #[test]
+    fn empty_table_list_sentinel_parses_as_no_tables() {
+        let result = result(
+            &["TABLE_NAME", "TABLE_TYPE", "TABLE_ROWS"],
+            vec![vec![QueryValue::Null, QueryValue::Null, QueryValue::Null]],
+        );
+
+        assert!(
+            parse_table_metadata(&result)
+                .expect("empty table metadata parses")
+                .is_empty()
+        );
+    }
+}

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -484,12 +484,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mysql_dsn_is_dispatched_to_mysql_adapter() {
+    async fn mysql_dsn_requires_a_selected_database_for_metadata() {
         let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
 
-        let result = registry.fetch_metadata("mysql://localhost/db").await;
+        let result = registry.fetch_metadata("mysql://localhost").await;
 
-        assert!(matches!(result, Err(DbOperationError::ConnectionFailed(_))));
+        assert!(matches!(
+            result,
+            Err(DbOperationError::UnsupportedOperation(_))
+        ));
     }
 
     #[test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -4,11 +4,17 @@
 //! bash scripts/mysql_integration.sh test
 
 use sabiql_app::ports::outbound::{
-    AccessMode, DbOperationError, MYSQL_SQL_MODE_UNSUPPORTED_MARKER, QueryExecutor,
+    AccessMode, DbOperationError, MYSQL_SQL_MODE_UNSUPPORTED_MARKER, MetadataProvider,
+    QueryExecutor,
 };
-use sabiql_domain::QueryValue;
+use sabiql_domain::{QueryValue, TableKind};
 
 use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, with_mysql_test_db};
+
+const MYSQL_COMPOSITE_TABLE: &str = "mysql_preview_composite";
+const MYSQL_NO_PK_TABLE: &str = "mysql_preview_no_pk";
+const MYSQL_EMPTY_TABLE: &str = "mysql_preview_empty";
+const MYSQL_VIEW: &str = "mysql_preview_view";
 
 #[tokio::test]
 #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
@@ -62,6 +68,224 @@ async fn preserves_xml_value_boundaries_for_real_mysql_results() {
         }
         Ok(())
     }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn loads_mysql_tables_views_and_column_attributes() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let metadata = db
+                .adapter()
+                .fetch_metadata(db.dsn())
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if metadata
+                .schemas
+                .iter()
+                .map(|schema| schema.name.as_str())
+                .collect::<Vec<_>>()
+                != ["sabiql_test"]
+            {
+                return Err(format!("unexpected MySQL schemas: {:?}", metadata.schemas));
+            }
+            let view = metadata
+                .table_summaries
+                .iter()
+                .find(|summary| summary.name == MYSQL_VIEW)
+                .ok_or_else(|| "MySQL view was not listed".to_string())?;
+            if view.kind_info.kind != TableKind::View {
+                return Err(format!("unexpected MySQL view kind: {:?}", view.kind_info));
+            }
+
+            let detail = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_FIXTURE_TABLE)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            let names = detail
+                .columns
+                .iter()
+                .map(|column| column.name.as_str())
+                .collect::<Vec<_>>();
+            if names
+                != [
+                    "id",
+                    "nullable_text",
+                    "empty_text",
+                    "unicode_text",
+                    "json_value",
+                    "blob_value",
+                    "invisible_value",
+                    "generated_value",
+                    "unsigned_value",
+                    "precise_decimal",
+                    "scientific_value",
+                ]
+            {
+                return Err(format!("unexpected MySQL column order: {names:?}"));
+            }
+            let invisible = detail
+                .columns
+                .iter()
+                .find(|column| column.name == "invisible_value")
+                .ok_or_else(|| "invisible MySQL column was not returned".to_string())?;
+            if !invisible.is_hidden() || !invisible.is_read_only() {
+                return Err(format!(
+                    "unexpected invisible column attributes: {invisible:?}"
+                ));
+            }
+            let generated = detail
+                .columns
+                .iter()
+                .find(|column| column.name == "generated_value")
+                .ok_or_else(|| "generated MySQL column was not returned".to_string())?;
+            if !generated.is_generated() || !generated.is_read_only() {
+                return Err(format!(
+                    "unexpected generated column attributes: {generated:?}"
+                ));
+            }
+            if detail.primary_key != Some(vec!["id".to_string()]) {
+                return Err(format!(
+                    "unexpected MySQL primary key: {:?}",
+                    detail.primary_key
+                ));
+            }
+
+            let composite = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_COMPOSITE_TABLE)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if composite.primary_key
+                != Some(vec!["second_key".to_string(), "first_key".to_string()])
+            {
+                return Err(format!(
+                    "unexpected composite primary key: {:?}",
+                    composite.primary_key
+                ));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn previews_mysql_rows_with_visible_columns_types_and_pagination() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_FIXTURE_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if result
+                .columns
+                .iter()
+                .any(|column| column == "invisible_value")
+            {
+                return Err(format!(
+                    "invisible column reached preview: {:?}",
+                    result.columns
+                ));
+            }
+            if result.columns
+                != [
+                    "id",
+                    "nullable_text",
+                    "empty_text",
+                    "unicode_text",
+                    "json_value",
+                    "blob_value",
+                    "generated_value",
+                    "unsigned_value",
+                    "precise_decimal",
+                    "scientific_value",
+                ]
+            {
+                return Err(format!("unexpected preview columns: {:?}", result.columns));
+            }
+            let values = result.values();
+            if values.len() != 1
+                || values[0][5] != QueryValue::Blob(vec![0, 255, 16])
+                || values[0][7] != QueryValue::SqlLiteral("18446744073709551615".to_string())
+                || values[0][8]
+                    != QueryValue::SqlLiteral(
+                        "12345678901234567890123456789012345.123456789012345678901234567890"
+                            .to_string(),
+                    )
+            {
+                return Err(format!("unexpected typed preview values: {values:?}"));
+            }
+            if !result.query.contains("ORDER BY `id`")
+                || !result.query.contains("LIMIT 10 OFFSET 0")
+            {
+                return Err(format!("unexpected preview SQL: {}", result.query));
+            }
+
+            let page = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_NO_PK_TABLE, 1, 1)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if !page
+                .query
+                .contains("ORDER BY `duplicate_value`, `payload` LIMIT 1 OFFSET 1")
+            {
+                return Err(format!("unexpected no-PK preview SQL: {}", page.query));
+            }
+
+            let composite = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_COMPOSITE_TABLE, 1, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if !composite
+                .query
+                .contains("ORDER BY `second_key`, `first_key` LIMIT 1 OFFSET 0")
+            {
+                return Err(format!(
+                    "unexpected composite preview SQL: {}",
+                    composite.query
+                ));
+            }
+
+            let view = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_VIEW, 10, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if view.columns != ["id", "unicode_text"] {
+                return Err(format!(
+                    "unexpected view preview columns: {:?}",
+                    view.columns
+                ));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn previews_empty_mysql_table_with_metadata_columns() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_EMPTY_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if result.columns != ["id", "payload"] || !result.values().is_empty() {
+                return Err(format!("unexpected empty preview: {result:?}"));
+            }
+            Ok(())
+        })
+    })
     .await;
 }
 

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__mysql_explorer_requests_metadata_load.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__mysql_explorer_requests_metadata_load.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 test_project ▸ app ▸ -                                                                                                                             not loaded | mysql
 ┌ [1] Explorer ─────────────────────────┐[Info]                                                                                                                      
-│ MySQL metadata is not available yet   │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/table_explorer.rs
+++ b/src/tests/render_snapshots/table_explorer.rs
@@ -123,7 +123,7 @@ fn sqlite_explorer_shows_table_kind_suffixes() {
 }
 
 #[test]
-fn mysql_explorer_explains_metadata_is_not_available() {
+fn mysql_explorer_requests_metadata_load() {
     let mut state = create_test_state();
     state.session.activate_connection_with_target(
         &ConnectionId::from_string("mysql-test"),

--- a/src/ui/features/browse/explorer.rs
+++ b/src/ui/features/browse/explorer.rs
@@ -10,7 +10,6 @@ use crate::app::model::shared::ui_state::{
     explorer_content_width_from_inner_width, scroll_max_offset, text_display_width,
 };
 use crate::app::policy::table_kind::{explorer_table_label, max_explorer_table_label_width};
-use crate::domain::DatabaseType;
 use crate::domain::MetadataState;
 use crate::theme::ThemePalette;
 
@@ -66,10 +65,6 @@ impl Explorer {
                 ListItem::new(" Select a database in connection settings"),
                 ListItem::new(" (c: connections)"),
             ]
-        } else if state.session.active_database_type() == Some(DatabaseType::MySQL)
-            && state.session.connection_state().is_connected()
-        {
-            vec![ListItem::new(" MySQL metadata is not available yet")]
         } else {
             match &state.session.metadata_state() {
                 MetadataState::Loading => {


### PR DESCRIPTION
## Problem

MySQL connections can execute SQL but the Explorer cannot load database metadata or preview table rows.

## Background

MySQL metadata and preview execution were still stubbed, leaving connected users without table and view discovery.

## Approach

Query INFORMATION_SCHEMA for the selected database, preserve column and primary-key order, and expose table/view metadata through the existing Explorer. Build preview SQL from visible columns and metadata-derived ordering, then preserve numeric literals and decode only binary hexadecimal values.

## Linear Issue Link (optional)

- Implements https://linear.app/sabiql/issue/SAB-379