### PR TITLE
feat(mysql): enforce read-only SQL policy

### DIFF
--- a/src/app/policy/sql/mysql_statement.rs
+++ b/src/app/policy/sql/mysql_statement.rs
@@ -780,6 +780,99 @@ pub fn has_top_level_into_clause(sql: &str) -> Result<bool, MysqlLexError> {
     }))
 }
 
+pub fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MysqlLexError> {
+    if has_mysql_version_comment(sql)? {
+        return Ok(true);
+    }
+
+    let tokens = lex_mysql_statement(sql)?;
+    for (index, token) in tokens.iter().enumerate() {
+        if matches!(&token.kind, TokenKind::Word(word) if word == "INTO") {
+            return Ok(true);
+        }
+        if matches!(&token.kind, TokenKind::Word(word) if matches!(
+            word.as_str(),
+            "GET_LOCK" | "RELEASE_LOCK" | "RELEASE_ALL_LOCKS"
+        )) {
+            return Ok(true);
+        }
+        if matches!(&token.kind, TokenKind::Symbol(':'))
+            && matches!(
+                tokens.get(index + 1).map(|token| &token.kind),
+                Some(TokenKind::Symbol('='))
+            )
+        {
+            return Ok(true);
+        }
+        if word_at(&tokens, index) == Some("FOR")
+            && matches!(word_at(&tokens, index + 1), Some("UPDATE" | "SHARE"))
+        {
+            return Ok(true);
+        }
+        if word_at(&tokens, index) == Some("LOCK")
+            && word_at(&tokens, index + 1) == Some("IN")
+            && word_at(&tokens, index + 2) == Some("SHARE")
+            && word_at(&tokens, index + 3) == Some("MODE")
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn word_at(tokens: &[Token], index: usize) -> Option<&str> {
+    match tokens.get(index)?.kind {
+        TokenKind::Word(ref word) => Some(word),
+        _ => None,
+    }
+}
+
+pub fn has_mysql_version_comment(sql: &str) -> Result<bool, MysqlLexError> {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    let mut quote = None;
+
+    while index < bytes.len() {
+        if let Some(delimiter) = quote {
+            if bytes[index] == b'\\' && delimiter != b'`' {
+                index = (index + 2).min(bytes.len());
+            } else if bytes[index] == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                } else {
+                    quote = None;
+                    index += 1;
+                }
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if is_line_comment_start(bytes, index) {
+            index = skip_line_comment(bytes, index);
+            continue;
+        }
+        if bytes.get(index..index + 2) == Some(b"/*") {
+            if bytes.get(index + 2) == Some(&b'!') {
+                return Ok(true);
+            }
+            index = skip_block_comment(bytes, index)?;
+            continue;
+        }
+        if matches!(bytes[index], b'\'' | b'"' | b'`') {
+            quote = Some(bytes[index]);
+        }
+        index += 1;
+    }
+
+    if quote.is_some() {
+        return Err(MysqlLexError(
+            "unterminated MySQL quoted literal".to_string(),
+        ));
+    }
+    Ok(false)
+}
+
 pub fn target_is_selected_database(
     statement: &MysqlStatement,
     selected_database: Option<&str>,

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1,9 +1,9 @@
 use super::write_guardrails::{self, RiskLevel};
 use crate::domain::DatabaseType;
 use crate::policy::sql::mysql_statement::{
-    MysqlStatement, MysqlStatementKind, classify_mysql_statement, has_top_level_into_clause,
-    split_mysql_statements, statement_contains_unsupported_mysql_control,
-    target_is_selected_database,
+    MysqlStatement, MysqlStatementKind, classify_mysql_statement, has_mysql_read_only_side_effect,
+    has_top_level_into_clause, split_mysql_statements,
+    statement_contains_unsupported_mysql_control, target_is_selected_database,
 };
 use crate::policy::sql::sqlite_statement_splitter::split_sqlite_statements;
 use crate::policy::sql::sqlite_transaction::{
@@ -68,6 +68,56 @@ mod mysql_tests {
             mysql("/*!80000 SELECT 1 */"),
             MultiStatementDecision::Allow { .. }
         ));
+    }
+
+    #[test]
+    fn read_only_allows_only_side_effect_free_mysql_reads() {
+        for sql in [
+            "SELECT 1",
+            "TABLE items",
+            "SHOW TABLES",
+            "DESCRIBE items",
+            "WITH rows AS (SELECT 1) SELECT * FROM rows",
+        ] {
+            let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
+                panic!("{sql}");
+            };
+            assert!(risk.read_only_allowed, "{sql}");
+        }
+
+        for sql in [
+            "SELECT * FROM items FOR UPDATE",
+            "SELECT * FROM items FOR SHARE",
+            "SELECT * FROM items LOCK IN SHARE MODE",
+            "SELECT @value := value FROM items",
+            "SELECT GET_LOCK('sabiql', 0)",
+            "SELECT RELEASE_LOCK('sabiql')",
+            "SELECT RELEASE_ALL_LOCKS()",
+            "/*!80000 SELECT 1 */",
+        ] {
+            let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
+                panic!("{sql}");
+            };
+            assert!(!risk.read_only_allowed, "{sql}");
+        }
+    }
+
+    #[test]
+    fn explain_targets_share_the_read_only_allowlist() {
+        for sql in ["SELECT 1", "TABLE items", "SHOW TABLES", "DESCRIBE items"] {
+            assert!(evaluate_mysql_explain_target(sql, false).is_some(), "{sql}");
+        }
+        for sql in [
+            "UPDATE items SET value = 1",
+            "SELECT * FROM items FOR UPDATE",
+            "SELECT * FROM items INTO OUTFILE '/tmp/items'",
+            "SELECT 1; SELECT 2",
+        ] {
+            assert!(evaluate_mysql_explain_target(sql, false).is_none(), "{sql}");
+        }
+        assert!(evaluate_mysql_explain_target("SELECT 1", true).is_some());
+        assert!(evaluate_mysql_explain_target("TABLE items", true).is_some());
+        assert!(evaluate_mysql_explain_target("SHOW TABLES", true).is_none());
     }
 
     #[test]
@@ -232,15 +282,17 @@ fn mysql_statement_risk(statement: &MysqlStatement) -> SqlRiskDecision {
         MysqlStatementKind::Select
         | MysqlStatementKind::Table
         | MysqlStatementKind::Show
-        | MysqlStatementKind::Describe
-        | MysqlStatementKind::Begin
+        | MysqlStatementKind::Describe => {
+            mysql_low(!has_mysql_read_only_side_effect(&statement.sql).unwrap_or(true))
+        }
+        MysqlStatementKind::Begin
         | MysqlStatementKind::StartTransaction
         | MysqlStatementKind::Commit
         | MysqlStatementKind::Rollback
         | MysqlStatementKind::Savepoint
         | MysqlStatementKind::RollbackToSavepoint
-        | MysqlStatementKind::ReleaseSavepoint => mysql_low(true),
-        MysqlStatementKind::Insert
+        | MysqlStatementKind::ReleaseSavepoint
+        | MysqlStatementKind::Insert
         | MysqlStatementKind::CreateTable { .. }
         | MysqlStatementKind::CreateView
         | MysqlStatementKind::CreateIndex => mysql_low(false),
@@ -746,6 +798,9 @@ pub fn evaluate_sql_risk_for_database(
     kind: &StatementKind,
     sql: &str,
 ) -> SqlRiskDecision {
+    if database_type == DatabaseType::MySQL {
+        return evaluate_mysql_statement_risk(sql);
+    }
     if database_type == DatabaseType::SQLite
         && let Some(decision) = evaluate_sqlite_specific_risk(sql)
     {
@@ -811,6 +866,47 @@ pub fn evaluate_sql_risk_for_database(
             None => high_acknowledge(kind),
         },
     }
+}
+
+fn evaluate_mysql_statement_risk(sql: &str) -> SqlRiskDecision {
+    if let Ok(statement) = classify_mysql_statement(sql) {
+        return mysql_statement_risk(&statement);
+    }
+
+    SqlRiskDecision {
+        risk_level: RiskLevel::Low,
+        confirmation: ConfirmationType::Acknowledge {
+            reason: AcknowledgeReason::UnknownRisk,
+            label: first_keyword(sql).unwrap_or_else(|| "SQL".to_string()),
+        },
+        read_only_allowed: false,
+    }
+}
+
+pub fn evaluate_mysql_explain_target(sql: &str, analyze: bool) -> Option<SqlRiskDecision> {
+    let statements = split_mysql_statements(sql).ok()?;
+    if statements.len() != 1 {
+        return None;
+    }
+    let statement = classify_mysql_statement(&statements[0]).ok()?;
+    let allowed_kind = if analyze {
+        matches!(
+            statement.kind,
+            MysqlStatementKind::Select | MysqlStatementKind::Table
+        )
+    } else {
+        matches!(
+            statement.kind,
+            MysqlStatementKind::Select
+                | MysqlStatementKind::Table
+                | MysqlStatementKind::Show
+                | MysqlStatementKind::Describe
+        )
+    };
+    let risk = mysql_statement_risk(&statement);
+    allowed_kind
+        .then_some(risk)
+        .filter(|risk| risk.read_only_allowed)
 }
 
 pub fn evaluate_multi_statement(sql: &str) -> MultiStatementDecision {

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -112,8 +112,11 @@ mod mysql_tests {
             "SELECT * FROM items FOR UPDATE",
             "SELECT * FROM items INTO OUTFILE '/tmp/items'",
             "SELECT 1; SELECT 2",
+            "SELECT 1\nsystem echo unsafe",
+            "SELECT 1\n\\! echo unsafe",
         ] {
             assert!(evaluate_mysql_explain_target(sql, false).is_none(), "{sql}");
+            assert!(evaluate_mysql_explain_target(sql, true).is_none(), "{sql}");
         }
         assert!(evaluate_mysql_explain_target("SELECT 1", true).is_some());
         assert!(evaluate_mysql_explain_target("TABLE items", true).is_some());
@@ -884,6 +887,9 @@ fn evaluate_mysql_statement_risk(sql: &str) -> SqlRiskDecision {
 }
 
 pub fn evaluate_mysql_explain_target(sql: &str, analyze: bool) -> Option<SqlRiskDecision> {
+    if statement_contains_unsupported_mysql_control(sql) {
+        return None;
+    }
     let statements = split_mysql_statements(sql).ok()?;
     if statements.len() != 1 {
         return None;

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -1,11 +1,14 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
 use crate::policy::sql::statement_classifier;
-use crate::policy::write::sql_risk::{ConfirmationType, evaluate_sql_risk_for_database};
+use crate::policy::write::sql_risk::{
+    ConfirmationType, evaluate_mysql_explain_target, evaluate_sql_risk_for_database,
+};
 use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
@@ -42,8 +45,19 @@ pub(super) fn reduce_analyze(
                 );
                 return DispatchResult::handled();
             }
-            let kind = statement_classifier::classify(&content);
-            let risk = evaluate_sql_risk_for_database(database_type, &kind, &content);
+            let risk = if database_type == DatabaseType::MySQL {
+                let Some(risk) = evaluate_mysql_explain_target(&content, true) else {
+                    show_explain_error_on_plan(
+                        state,
+                        "MySQL EXPLAIN ANALYZE only supports side-effect-free SELECT or TABLE statements",
+                    );
+                    return DispatchResult::handled();
+                };
+                risk
+            } else {
+                let kind = statement_classifier::classify(&content);
+                evaluate_sql_risk_for_database(database_type, &kind, &content)
+            };
 
             if state.session.is_read_only() && !risk.read_only_allowed {
                 show_explain_error_on_plan(
@@ -103,6 +117,12 @@ pub(super) fn reduce_analyze(
                 && let Some(dsn) = state.session.dsn().map(String::from)
             {
                 let database_type = state.session.active_database_type_or_default();
+                if database_type == DatabaseType::MySQL
+                    && evaluate_mysql_explain_target(&query, true).is_none()
+                {
+                    finish_explain_unsupported_analyze(state);
+                    return DispatchResult::handled();
+                }
                 let Some(explain_query) = services
                     .sql_dialect
                     .build_explain_analyze_sql(database_type, &query)

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -1,9 +1,11 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
+use crate::policy::write::sql_risk::evaluate_mysql_explain_target;
 use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
@@ -36,6 +38,15 @@ pub(super) fn reduce_request(
             let database_type = state.session.active_database_type_or_default();
             if is_multi_statement(database_type, &content) {
                 show_explain_error_on_plan(state, "EXPLAIN does not support multiple statements");
+                return DispatchResult::handled();
+            }
+            if database_type == DatabaseType::MySQL
+                && evaluate_mysql_explain_target(&content, false).is_none()
+            {
+                show_explain_error_on_plan(
+                    state,
+                    "MySQL EXPLAIN only supports side-effect-free read statements",
+                );
                 return DispatchResult::handled();
             }
 


### PR DESCRIPTION
## Problem
MySQL read-only mode did not distinguish side-effectful read syntax from safe read statements.

## Background
The MySQL multi-statement classifier already owns MySQL lexical boundaries, but the generic EXPLAIN ANALYZE risk path could bypass those rules.

## Approach
Reuse the MySQL lexer to reject locking reads, INTO clauses, user-variable assignment, advisory locks, and executable version comments from the read-only allowlist. Route MySQL EXPLAIN and EXPLAIN ANALYZE through the same policy while preserving normal-mode risk decisions and existing PostgreSQL/SQLite behavior.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-390