### PR TITLE
feat(mysql): display trigger metadata and server DDL

### DIFF
--- a/scripts/init-mysql.sql
+++ b/scripts/init-mysql.sql
@@ -38,6 +38,11 @@ INSERT INTO mysql_cli_fixture (
     1.23e100
 );
 
+CREATE DEFINER='sabiql'@'%' TRIGGER mysql_cli_fixture_audit
+BEFORE UPDATE ON mysql_cli_fixture
+FOR EACH ROW
+SET NEW.empty_text = NEW.empty_text;
+
 CREATE TABLE mysql_preview_composite (
     first_key INT NOT NULL,
     second_key INT NOT NULL,

--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -81,8 +81,8 @@ pub struct InspectorTriggerRow {
     pub name: String,
     pub timing: String,
     pub events: String,
-    pub function_name: String,
-    pub security_definer: bool,
+    pub definition: String,
+    pub security_context: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -248,8 +248,8 @@ impl InspectorViewModel {
                             .map(ToString::to_string)
                             .collect::<Vec<_>>()
                             .join("/"),
-                        function_name: trigger.function_name.clone(),
-                        security_definer: trigger.security_definer,
+                        definition: trigger.definition.clone(),
+                        security_context: trigger.security_context.clone(),
                     })
                     .collect();
                 (
@@ -500,8 +500,8 @@ mod tests {
                 name: "users_updated".to_string(),
                 timing: TriggerTiming::Before,
                 events: vec![TriggerEvent::Update],
-                function_name: "set_updated_at".to_string(),
-                security_definer: false,
+                definition: "set_updated_at".to_string(),
+                security_context: Some("INVOKER".to_string()),
             }],
             row_count_estimate: Some(3),
             comment: Some("Users".to_string()),

--- a/src/app/model/shared/engine_feature_profile.rs
+++ b/src/app/model/shared/engine_feature_profile.rs
@@ -108,6 +108,8 @@ const MYSQL_INSPECTOR: InspectorProfile = InspectorProfile::new(
         InspectorTab::Columns,
         InspectorTab::Indexes,
         InspectorTab::ForeignKeys,
+        InspectorTab::Triggers,
+        InspectorTab::Ddl,
     ],
     &[
         InspectorInfoField::Comment,
@@ -442,7 +444,7 @@ mod tests {
     }
 
     #[test]
-    fn mysql_profile_exposes_browse_metadata_and_plan_only() {
+    fn mysql_profile_exposes_browse_metadata_ddl_and_plan() {
         let profile = EngineFeatureProfile::mysql_like();
 
         assert!(profile.supports_explain());
@@ -458,6 +460,8 @@ mod tests {
                 InspectorTab::Columns,
                 InspectorTab::Indexes,
                 InspectorTab::ForeignKeys,
+                InspectorTab::Triggers,
+                InspectorTab::Ddl,
             ]
         );
         assert_eq!(

--- a/src/app/update/browse/query/mod.rs
+++ b/src/app/update/browse/query/mod.rs
@@ -146,8 +146,8 @@ pub(super) mod tests {
                 name: "trg".to_string(),
                 timing: TriggerTiming::After,
                 events: vec![TriggerEvent::Update],
-                function_name: "f".to_string(),
-                security_definer: false,
+                definition: "f".to_string(),
+                security_context: None,
             }],
             ..test_support::table::minimal("", "")
         }

--- a/src/domain/trigger.rs
+++ b/src/domain/trigger.rs
@@ -85,8 +85,8 @@ pub struct Trigger {
     pub name: String,
     pub timing: TriggerTiming,
     pub events: Vec<TriggerEvent>,
-    pub function_name: String,
-    pub security_definer: bool,
+    pub definition: String,
+    pub security_context: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -229,8 +229,8 @@ impl QueryExecutor for MySqlAdapter {
 }
 
 impl DdlGenerator for MySqlAdapter {
-    fn generate_ddl(&self, _database_type: DatabaseType, _table: &Table) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+    fn generate_ddl(&self, _database_type: DatabaseType, table: &Table) -> String {
+        table.source_ddl().unwrap_or_default().to_string()
     }
 }
 

--- a/src/infra/adapters/mysql/metadata.rs
+++ b/src/infra/adapters/mysql/metadata.rs
@@ -4,6 +4,7 @@ use crate::app::ports::outbound::{AccessMode, DbOperationError, MetadataProvider
 use crate::domain::{
     Column, ColumnAttributes, DatabaseMetadata, FkAction, ForeignKey, Index, IndexAttributes,
     IndexType, QueryValue, Schema, Table, TableKind, TableKindInfo, TableSignature, TableSummary,
+    Trigger, TriggerEvent, TriggerTiming,
 };
 
 use super::{
@@ -62,6 +63,15 @@ struct MysqlTableMetadata {
     kind: TableKind,
     row_count_estimate: Option<i64>,
     comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct MysqlTriggerMetadata {
+    name: String,
+    timing: TriggerTiming,
+    event: TriggerEvent,
+    definition: String,
+    security_context: Option<String>,
 }
 
 #[async_trait]
@@ -245,6 +255,8 @@ async fn fetch_table(
     let columns = fetch_columns(dsn, schema, table).await?;
     let indexes = fetch_indexes(dsn, schema, table).await?;
     let foreign_keys = fetch_foreign_keys(dsn, schema, table, summaries).await?;
+    let triggers = fetch_triggers(dsn, schema, table).await?;
+    let source_ddl = fetch_source_ddl(dsn, table, table_metadata.kind).await?;
     let primary_key = primary_key_names(&columns);
     let columns = columns.iter().map(column_from_metadata).collect::<Vec<_>>();
     Ok(Table {
@@ -256,10 +268,10 @@ async fn fetch_table(
         foreign_keys,
         indexes,
         rls: None,
-        triggers: Vec::new(),
+        triggers,
         row_count_estimate: table_metadata.row_count_estimate,
         comment: table_metadata.comment,
-        source_ddl: None,
+        source_ddl: Some(source_ddl),
         kind_info: TableKindInfo {
             kind: table_metadata.kind,
             ..TableKindInfo::default()
@@ -462,6 +474,142 @@ async fn fetch_foreign_keys(
         ));
     }
     foreign_keys_from_metadata(raw, summaries)
+}
+
+async fn fetch_triggers(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<Trigger>, DbOperationError> {
+    if schema != selected_database(dsn)? {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    let result = execute_metadata_query(dsn, &triggers_query(table)).await?;
+    triggers_from_metadata(parse_trigger_metadata(&result)?)
+}
+
+async fn fetch_source_ddl(
+    dsn: &str,
+    table: &str,
+    kind: TableKind,
+) -> Result<String, DbOperationError> {
+    let result = execute_metadata_query(dsn, &show_create_query(table, kind)).await?;
+    parse_source_ddl(&result, kind)
+}
+
+fn triggers_query(table: &str) -> String {
+    format!(
+        "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {}) ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION",
+        quote_string(table),
+        quote_string(table),
+    )
+}
+
+fn show_create_query(table: &str, kind: TableKind) -> String {
+    let object_type = if kind == TableKind::View {
+        "VIEW"
+    } else {
+        "TABLE"
+    };
+    format!("SHOW CREATE {object_type} {}", quote_identifier(table))
+}
+
+fn parse_trigger_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlTriggerMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &[
+            "TRIGGER_NAME",
+            "ACTION_TIMING",
+            "EVENT_MANIPULATION",
+            "ACTION_STATEMENT",
+            "DEFINER",
+        ],
+    )?;
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != 5 {
+                return Err(metadata_shape_error("TRIGGERS row"));
+            }
+            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
+                return Ok(None);
+            }
+            let timing = required_text(&row[1], "ACTION_TIMING")?
+                .parse::<TriggerTiming>()
+                .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
+            let event = required_text(&row[2], "EVENT_MANIPULATION")?
+                .parse::<TriggerEvent>()
+                .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
+            Ok(Some(MysqlTriggerMetadata {
+                name: required_text(&row[0], "TRIGGER_NAME")?.to_string(),
+                timing,
+                event,
+                definition: required_text(&row[3], "ACTION_STATEMENT")?.to_string(),
+                security_context: optional_text(&row[4], "DEFINER")?.map(str::to_string),
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|rows| rows.into_iter().flatten().collect())
+}
+
+fn triggers_from_metadata(
+    raw: Vec<MysqlTriggerMetadata>,
+) -> Result<Vec<Trigger>, DbOperationError> {
+    let mut triggers = Vec::new();
+    for metadata in raw {
+        if let Some(trigger) = triggers
+            .iter_mut()
+            .find(|trigger: &&mut Trigger| trigger.name == metadata.name)
+        {
+            if trigger.timing != metadata.timing
+                || trigger.definition != metadata.definition
+                || trigger.security_context != metadata.security_context
+            {
+                return Err(metadata_shape_error("TRIGGERS definition"));
+            }
+            trigger.events.push(metadata.event);
+        } else {
+            triggers.push(Trigger {
+                name: metadata.name,
+                timing: metadata.timing,
+                events: vec![metadata.event],
+                definition: metadata.definition,
+                security_context: metadata.security_context,
+            });
+        }
+    }
+    Ok(triggers)
+}
+
+fn parse_source_ddl(result: &MysqlResultSet, kind: TableKind) -> Result<String, DbOperationError> {
+    let expected_columns = if kind == TableKind::View {
+        ["View", "Create View"]
+    } else {
+        ["Table", "Create Table"]
+    };
+    if result.columns.len() < 2
+        || result.columns[0] != expected_columns[0]
+        || result.columns[1] != expected_columns[1]
+        || result.values.len() != 1
+    {
+        return Err(metadata_shape_error("SHOW CREATE result"));
+    }
+    let row = &result.values[0];
+    if row.len() != result.columns.len() {
+        return Err(metadata_shape_error("SHOW CREATE row"));
+    }
+    let ddl = required_text(&row[1], expected_columns[1])?;
+    if ddl.is_empty() {
+        return Err(DbOperationError::MetadataParseFailed(
+            "MySQL SHOW CREATE returned empty DDL".to_string(),
+        ));
+    }
+    Ok(ddl.to_string())
 }
 
 fn parse_column_metadata(
@@ -904,6 +1052,100 @@ mod tests {
             comment: None,
             ordinal_position: 1,
         }
+    }
+
+    #[test]
+    fn trigger_metadata_preserves_action_definer_and_event_order() {
+        let result = result(
+            &[
+                "TRIGGER_NAME",
+                "ACTION_TIMING",
+                "EVENT_MANIPULATION",
+                "ACTION_STATEMENT",
+                "DEFINER",
+            ],
+            vec![
+                vec![
+                    QueryValue::Text("audit_changes".to_string()),
+                    QueryValue::Text("BEFORE".to_string()),
+                    QueryValue::Text("INSERT".to_string()),
+                    QueryValue::Text("BEGIN\n  SET @seen = 1;\nEND".to_string()),
+                    QueryValue::Text("sabiql@%".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("audit_changes".to_string()),
+                    QueryValue::Text("BEFORE".to_string()),
+                    QueryValue::Text("UPDATE".to_string()),
+                    QueryValue::Text("BEGIN\n  SET @seen = 1;\nEND".to_string()),
+                    QueryValue::Text("sabiql@%".to_string()),
+                ],
+            ],
+        );
+
+        let triggers = triggers_from_metadata(parse_trigger_metadata(&result).unwrap()).unwrap();
+
+        assert_eq!(triggers.len(), 1);
+        assert_eq!(
+            triggers[0].events,
+            [TriggerEvent::Insert, TriggerEvent::Update]
+        );
+        assert_eq!(triggers[0].definition, "BEGIN\n  SET @seen = 1;\nEND");
+        assert_eq!(triggers[0].security_context.as_deref(), Some("sabiql@%"));
+    }
+
+    #[test]
+    fn empty_trigger_sentinel_returns_no_triggers() {
+        let result = result(
+            &[
+                "TRIGGER_NAME",
+                "ACTION_TIMING",
+                "EVENT_MANIPULATION",
+                "ACTION_STATEMENT",
+                "DEFINER",
+            ],
+            vec![vec![
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+            ]],
+        );
+
+        assert!(parse_trigger_metadata(&result).unwrap().is_empty());
+    }
+
+    #[test]
+    fn show_create_query_uses_object_kind_and_identifier_quoting() {
+        assert_eq!(
+            show_create_query("table`name", TableKind::Table),
+            "SHOW CREATE TABLE `table``name`"
+        );
+        assert_eq!(
+            show_create_query("view_name", TableKind::View),
+            "SHOW CREATE VIEW `view_name`"
+        );
+    }
+
+    #[test]
+    fn show_create_parser_preserves_view_ddl_and_extra_server_columns() {
+        let ddl = "CREATE ALGORITHM=UNDEFINED VIEW `v` AS select 1";
+        let result = result(
+            &[
+                "View",
+                "Create View",
+                "character_set_client",
+                "collation_connection",
+            ],
+            vec![vec![
+                QueryValue::Text("v".to_string()),
+                QueryValue::Text(ddl.to_string()),
+                QueryValue::Text("utf8mb4".to_string()),
+                QueryValue::Text("utf8mb4_0900_ai_ci".to_string()),
+            ]],
+        );
+
+        assert_eq!(parse_source_ddl(&result, TableKind::View).unwrap(), ddl);
     }
 
     #[test]

--- a/src/infra/adapters/postgres/psql/parser/metadata.rs
+++ b/src/infra/adapters/postgres/psql/parser/metadata.rs
@@ -327,8 +327,8 @@ impl PostgresAdapter {
             name: String,
             timing: String,
             events: Vec<String>,
-            function_name: String,
-            security_definer: bool,
+            definition: String,
+            security_context: Option<String>,
         }
 
         let raw: Vec<RawTrigger> = serde_json::from_str(trimmed)?;
@@ -352,8 +352,8 @@ impl PostgresAdapter {
                     name: t.name,
                     timing,
                     events,
-                    function_name: t.function_name,
-                    security_definer: t.security_definer,
+                    definition: t.definition,
+                    security_context: t.security_context,
                 })
             })
             .collect::<Result<Vec<_>, MetadataParseError>>()
@@ -763,8 +763,8 @@ mod tests {
                 "name": "audit_trigger",
                 "timing": "AFTER",
                 "events": ["INSERT", "UPDATE"],
-                "function_name": "audit_func",
-                "security_definer": true
+                "definition": "audit_func",
+                "security_context": "DEFINER"
             }]"#;
 
             let result = PostgresAdapter::parse_triggers(json).unwrap();
@@ -777,8 +777,8 @@ mod tests {
                 trigger.events,
                 vec![TriggerEvent::Insert, TriggerEvent::Update]
             );
-            assert_eq!(trigger.function_name, "audit_func");
-            assert!(trigger.security_definer);
+            assert_eq!(trigger.definition, "audit_func");
+            assert_eq!(trigger.security_context.as_deref(), Some("DEFINER"));
         }
 
         #[rstest]
@@ -792,7 +792,7 @@ mod tests {
             let json = format!(
                 r#"[{{
                     "name": "test", "timing": "{timing}", "events": ["INSERT"],
-                    "function_name": "func", "security_definer": false
+                    "definition": "func", "security_context": "INVOKER"
                 }}]"#
             );
 
@@ -806,8 +806,8 @@ mod tests {
                 "name": "test",
                 "timing": "UNKNOWN",
                 "events": ["INSERT"],
-                "function_name": "func",
-                "security_definer": false
+                "definition": "func",
+                "security_context": "INVOKER"
             }]"#;
 
             let result = PostgresAdapter::parse_triggers(json);
@@ -824,8 +824,8 @@ mod tests {
                 "name": "multi_event",
                 "timing": "BEFORE",
                 "events": ["INSERT", "DELETE", "UPDATE", "TRUNCATE"],
-                "function_name": "func",
-                "security_definer": false
+                "definition": "func",
+                "security_context": "INVOKER"
             }]"#;
 
             let result = PostgresAdapter::parse_triggers(json).unwrap();
@@ -854,17 +854,17 @@ mod tests {
         }
 
         #[test]
-        fn security_definer_false_stays_false() {
+        fn invoker_security_context_stays_invoker() {
             let json = r#"[{
                 "name": "test",
                 "timing": "AFTER",
                 "events": ["INSERT"],
-                "function_name": "func",
-                "security_definer": false
+                "definition": "func",
+                "security_context": "INVOKER"
             }]"#;
 
             let result = PostgresAdapter::parse_triggers(json).unwrap();
-            assert!(!result[0].security_definer);
+            assert_eq!(result[0].security_context.as_deref(), Some("INVOKER"));
         }
 
         #[test]
@@ -873,8 +873,8 @@ mod tests {
                 "name": "test",
                 "timing": "AFTER",
                 "events": ["INSERT", "MERGE"],
-                "function_name": "func",
-                "security_definer": false
+                "definition": "func",
+                "security_context": "INVOKER"
             }]"#;
 
             let result = PostgresAdapter::parse_triggers(json);

--- a/src/infra/adapters/postgres/sql/query.rs
+++ b/src/infra/adapters/postgres/sql/query.rs
@@ -299,8 +299,8 @@ impl PostgresAdapter {
                         CASE WHEN (tg.tgtype & 16) != 0 THEN 'UPDATE' END,
                         CASE WHEN (tg.tgtype & 32) != 0 THEN 'TRUNCATE' END
                     ], NULL) AS events,
-                    p.proname AS function_name,
-                    p.prosecdef AS security_definer
+                    p.proname AS definition,
+                    CASE WHEN p.prosecdef THEN 'DEFINER' ELSE 'INVOKER' END AS security_context
                 FROM pg_trigger tg
                 JOIN pg_class c ON c.oid = tg.tgrelid
                 JOIN pg_namespace n ON n.oid = c.relnamespace

--- a/src/infra/adapters/sqlite/sql.rs
+++ b/src/infra/adapters/sqlite/sql.rs
@@ -424,8 +424,8 @@ fn append_trigger_ddls(ddl: &mut String, triggers: &[Trigger]) {
     for trigger in triggers {
         ddl.push('\n');
         ddl.push('\n');
-        ddl.push_str(trigger.function_name.trim());
-        if !trigger.function_name.trim_end().ends_with(';') {
+        ddl.push_str(trigger.definition.trim());
+        if !trigger.definition.trim_end().ends_with(';') {
             ddl.push(';');
         }
     }
@@ -1111,10 +1111,9 @@ mod tests {
                 name: "users_audit".to_string(),
                 timing: TriggerTiming::After,
                 events: vec![TriggerEvent::Insert],
-                function_name:
-                    "CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END"
-                        .to_string(),
-                security_definer: false,
+                definition: "CREATE TRIGGER users_audit AFTER INSERT ON users BEGIN SELECT 1; END"
+                    .to_string(),
+                security_context: None,
             });
 
             let ddl = adapter.generate_ddl(DatabaseType::SQLite, &table);

--- a/src/infra/adapters/sqlite/sqlite3/metadata.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata.rs
@@ -599,7 +599,7 @@ impl SqliteAdapter {
                     .map(ToString::to_string)
                     .collect::<Vec<_>>()
                     .join(","),
-                trigger.function_name
+                trigger.definition
             )
         }));
 
@@ -1972,7 +1972,7 @@ mod tests {
             assert_eq!(detail.triggers[0].events, vec![TriggerEvent::Insert]);
             assert!(
                 !detail.triggers[0]
-                    .function_name
+                    .definition
                     .to_ascii_uppercase()
                     .contains("TEMP")
             );

--- a/src/infra/adapters/sqlite/sqlite3/metadata/trigger.rs
+++ b/src/infra/adapters/sqlite/sqlite3/metadata/trigger.rs
@@ -254,8 +254,8 @@ pub(super) fn parse_sqlite_trigger(
         name: trigger_name.to_string(),
         timing,
         events,
-        function_name: sql.to_string(),
-        security_definer: false,
+        definition: sql.to_string(),
+        security_context: None,
     })
 }
 
@@ -271,8 +271,8 @@ mod tests {
         assert_eq!(trigger.name, "users_audit");
         assert_eq!(trigger.timing, TriggerTiming::After);
         assert_eq!(trigger.events, vec![TriggerEvent::Insert]);
-        assert_eq!(trigger.function_name, sql);
-        assert!(!trigger.security_definer);
+        assert_eq!(trigger.definition, sql);
+        assert_eq!(trigger.security_context, None);
     }
 
     #[test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -5,10 +5,13 @@
 
 use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
 use sabiql_app::ports::outbound::{
-    AccessMode, ConnectionProbe, DbOperationError, DsnBuilder, MYSQL_SQL_MODE_UNSUPPORTED_MARKER,
-    MetadataProvider, QueryExecutor,
+    AccessMode, ConnectionProbe, DbOperationError, DdlGenerator, DsnBuilder,
+    MYSQL_SQL_MODE_UNSUPPORTED_MARKER, MetadataProvider, QueryExecutor,
 };
-use sabiql_domain::{CommandTag, FkAction, IndexType, QueryValue, RefreshScope, TableKind};
+use sabiql_domain::{
+    CommandTag, FkAction, IndexType, QueryValue, RefreshScope, TableKind, TriggerEvent,
+    TriggerTiming,
+};
 
 use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, mysql_tls_config, with_mysql_test_db};
 use sabiql_domain::connection::{
@@ -228,6 +231,49 @@ async fn loads_mysql_tables_views_and_column_attributes() {
                 return Err(format!(
                     "unexpected MySQL table info: comment={:?}, rows={:?}",
                     detail.comment, detail.row_count_estimate
+                ));
+            }
+            if detail.source_ddl().is_none()
+                || db
+                    .adapter()
+                    .generate_ddl(sabiql_domain::DatabaseType::MySQL, &detail)
+                    != detail.source_ddl().unwrap()
+            {
+                return Err(format!(
+                    "unexpected MySQL table DDL: {:?}",
+                    detail.source_ddl()
+                ));
+            }
+            if detail.triggers.len() != 1 {
+                return Err(format!("unexpected MySQL triggers: {:?}", detail.triggers));
+            }
+            let trigger = &detail.triggers[0];
+            if trigger.name != "mysql_cli_fixture_audit"
+                || trigger.timing != TriggerTiming::Before
+                || trigger.events != [TriggerEvent::Update]
+                || trigger.definition != "SET NEW.empty_text = NEW.empty_text"
+                || trigger.security_context.as_deref() != Some("sabiql@%")
+            {
+                return Err(format!("unexpected MySQL trigger: {trigger:?}"));
+            }
+
+            let view_detail = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_VIEW)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if view_detail.source_ddl().is_none()
+                || !view_detail
+                    .source_ddl()
+                    .is_some_and(|ddl| ddl.contains("CREATE") && ddl.contains(MYSQL_VIEW))
+                || db
+                    .adapter()
+                    .generate_ddl(sabiql_domain::DatabaseType::MySQL, &view_detail)
+                    != view_detail.source_ddl().unwrap()
+            {
+                return Err(format!(
+                    "unexpected MySQL view DDL: {:?}",
+                    view_detail.source_ddl()
                 ));
             }
 

--- a/src/tests/harness/fixtures.rs
+++ b/src/tests/harness/fixtures.rs
@@ -106,8 +106,8 @@ pub fn sample_table_detail() -> Table {
         name: "audit_users".to_string(),
         timing: TriggerTiming::After,
         events: vec![TriggerEvent::Insert, TriggerEvent::Update],
-        function_name: "audit_func".to_string(),
-        security_definer: false,
+        definition: "audit_func".to_string(),
+        security_context: Some("INVOKER".to_string()),
     }];
     table.row_count_estimate = Some(100);
     table.comment = Some("User accounts".to_string());

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_with_data.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__inspector__inspector_triggers_tab_with_data.snap
@@ -5,8 +5,8 @@ expression: output
 test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
 ┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
 │> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
-│  public.posts                         ││Name                            Timing             Event                    Function                    SecDef            │
-│  public.comments                      ││audit_users                     AFTER              INSERT/UPDATE            audit_func                                    │
+│  public.posts                         ││Name                            Timing             Event                    Function                    Security          │
+│  public.comments                      ││audit_users                     AFTER              INSERT/UPDATE            audit_func                  INVOKER           │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__mysql_explorer_requests_metadata_load.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__mysql_explorer_requests_metadata_load.snap
@@ -4,7 +4,7 @@ assertion_line: 140
 expression: output
 ---
 test_project ▸ app ▸ -                                                                                                                             not loaded | mysql
-┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK]                                                                                                    
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [Trig] [DDL]                                                                                       
 │ Press 'r' to load metadata            │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 │                                       ││(select a table)                                                                                                          │
 │                                       ││                                                                                                                          │

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -20,6 +20,7 @@ use crate::app::model::shared::viewport::{
     widths_fingerprint,
 };
 use crate::app::services::AppServices;
+use crate::domain::DatabaseType;
 use crate::primitives::atoms::{apply_yank_flash, panel_block};
 use crate::primitives::utils::text_utils::{
     MIN_COL_WIDTH, PADDING, calculate_header_min_widths, truncate_to_width,
@@ -188,6 +189,7 @@ impl Inspector {
                     frame,
                     inner,
                     rows,
+                    state.session.active_database_type_or_default(),
                     state.ui.inspector_scroll_offset(),
                     theme,
                 );
@@ -595,24 +597,62 @@ impl Inspector {
         frame: &mut Frame,
         area: Rect,
         rows: &[InspectorTriggerRow],
+        database_type: DatabaseType,
         scroll_offset: usize,
         theme: &ThemePalette,
     ) {
-        let headers = ["Name", "Timing", "Event", "Function", "SecDef"];
-        let widths = [
-            Constraint::Percentage(25),
-            Constraint::Percentage(15),
-            Constraint::Percentage(20),
-            Constraint::Percentage(25),
-            Constraint::Percentage(15),
-        ];
+        let (headers, widths): (&[&str], &[Constraint]) = match database_type {
+            DatabaseType::MySQL => (
+                &["Name", "Timing", "Event", "Action", "Definer"],
+                &[
+                    Constraint::Percentage(25),
+                    Constraint::Percentage(15),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(25),
+                    Constraint::Percentage(15),
+                ],
+            ),
+            DatabaseType::PostgreSQL => (
+                &["Name", "Timing", "Event", "Function", "Security"],
+                &[
+                    Constraint::Percentage(25),
+                    Constraint::Percentage(15),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(25),
+                    Constraint::Percentage(15),
+                ],
+            ),
+            DatabaseType::SQLite => (
+                &["Name", "Timing", "Event", "Definition"],
+                &[
+                    Constraint::Percentage(25),
+                    Constraint::Percentage(15),
+                    Constraint::Percentage(20),
+                    Constraint::Percentage(40),
+                ],
+            ),
+        };
+        let data_rows: Vec<Vec<String>> = rows
+            .iter()
+            .take(50)
+            .map(|row| trigger_row_cells(row, database_type))
+            .collect();
+        let col_widths = calculate_column_widths(headers, &data_rows);
+        let widths: Vec<Constraint> = widths
+            .iter()
+            .zip(col_widths)
+            .map(|(configured, calculated)| match configured {
+                Constraint::Percentage(_) => *configured,
+                _ => Constraint::Length(calculated),
+            })
+            .collect();
 
         use crate::primitives::molecules::{StripedTableConfig, render_striped_table};
         render_striped_table(
             frame,
             area,
             &StripedTableConfig {
-                headers: &headers,
+                headers,
                 widths: &widths,
                 total_items: rows.len(),
                 empty_message: "No triggers",
@@ -620,7 +660,7 @@ impl Inspector {
             scroll_offset,
             theme,
             |idx| {
-                trigger_row_cells(&rows[idx])
+                trigger_row_cells(&rows[idx], database_type)
                     .into_iter()
                     .map(Cell::from)
                     .collect()
@@ -711,14 +751,17 @@ fn foreign_key_row_cells(row: &InspectorForeignKeyRow) -> Vec<String> {
     ]
 }
 
-fn trigger_row_cells(row: &InspectorTriggerRow) -> Vec<String> {
-    vec![
+fn trigger_row_cells(row: &InspectorTriggerRow, database_type: DatabaseType) -> Vec<String> {
+    let mut cells = vec![
         row.name.clone(),
         row.timing.clone(),
         row.events.clone(),
-        row.function_name.clone(),
-        checkmark(row.security_definer),
-    ]
+        row.definition.clone(),
+    ];
+    if !matches!(database_type, DatabaseType::SQLite) {
+        cells.push(row.security_context.clone().unwrap_or_default());
+    }
+    cells
 }
 
 fn checkmark(value: bool) -> String {


### PR DESCRIPTION
## Problem
MySQL table inspection did not expose trigger action/definer metadata or server-generated table and view DDL.

## Background
The shared trigger model was PostgreSQL-specific, and MySQL DDL generation had no server source to display.

## Approach
Map PostgreSQL, SQLite, and MySQL trigger metadata into one domain shape, select database-specific Inspector columns, and make MySQL full table details retain SHOW CREATE output as the sole DDL source.

## Screenshots

## Linear Issue Link (optional)

- Implements https://linear.app/sabiql/issue/SAB-384