### PR TITLE
fix(mysql): ignore stale ER diagram completions

### DIFF
--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -134,6 +134,7 @@ pub enum Effect {
     TriggerCompletion,
 
     GenerateErDiagramFromCache {
+        run_id: u64,
         total_tables: usize,
         project_name: String,
         target_tables: Vec<String>,

--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -13,8 +13,16 @@ use crate::domain::er::{er_output_filename, fk_neighbors_of_seeds, fk_reachable_
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{ConfigWriter, ErDiagramExporter, ErLogWriter, MetadataProvider};
 use crate::update::action::{
-    Action, ErDiagramError, ErLogError, SmartErRefreshError, SmartErRefreshResult,
+    Action, ErDiagramError, ErDiagramFailure, ErLogError, SmartErRefreshError, SmartErRefreshResult,
 };
+
+struct GenerateErDiagramRequest {
+    run_id: u64,
+    total_tables: usize,
+    project_name: String,
+    target_tables: Vec<String>,
+    browser: Option<String>,
+}
 
 pub async fn run(
     effect: Effect,
@@ -28,6 +36,7 @@ pub async fn run(
 ) -> Result<()> {
     match effect {
         Effect::GenerateErDiagramFromCache {
+            run_id,
             total_tables,
             project_name,
             target_tables,
@@ -37,10 +46,13 @@ pub async fn run(
                 er_exporter,
                 config_writer,
                 completion_engine,
-                total_tables,
-                project_name,
-                target_tables,
-                state.settings.saved_er_browser().map(str::to_string),
+                GenerateErDiagramRequest {
+                    run_id,
+                    total_tables,
+                    project_name,
+                    target_tables,
+                    browser: state.settings.saved_er_browser().map(str::to_string),
+                },
             )
             .await
         }
@@ -78,17 +90,22 @@ async fn handle_generate_diagram(
     er_exporter: &Arc<dyn ErDiagramExporter>,
     config_writer: &Arc<dyn ConfigWriter>,
     completion_engine: &RefCell<CompletionEngine>,
-    total_tables: usize,
-    project_name: String,
-    target_tables: Vec<String>,
-    browser: Option<String>,
+    request: GenerateErDiagramRequest,
 ) -> Result<()> {
+    let GenerateErDiagramRequest {
+        run_id,
+        total_tables,
+        project_name,
+        target_tables,
+        browser,
+    } = request;
     let all_tables = collect_cached_er_tables(completion_engine);
     if all_tables.is_empty() {
         action_tx
-            .send(Action::ErDiagramFailed(ErDiagramError::NoData(
-                "No table data loaded yet".to_string(),
-            )))
+            .send(Action::ErDiagramFailed(ErDiagramFailure {
+                run_id,
+                error: ErDiagramError::NoData("No table data loaded yet".to_string()),
+            }))
             .await
             .ok();
         return Ok(());
@@ -104,9 +121,12 @@ async fn handle_generate_diagram(
 
     if tables.is_empty() {
         action_tx
-            .send(Action::ErDiagramFailed(ErDiagramError::NoData(
-                "Selected tables not found in cached data".to_string(),
-            )))
+            .send(Action::ErDiagramFailed(ErDiagramFailure {
+                run_id,
+                error: ErDiagramError::NoData(
+                    "Selected tables not found in cached data".to_string(),
+                ),
+            }))
             .await
             .ok();
         return Ok(());
@@ -116,6 +136,7 @@ async fn handle_generate_diagram(
     spawn_er_diagram_task(
         Arc::clone(er_exporter),
         tables,
+        run_id,
         total_tables,
         cache_dir,
         action_tx.clone(),

--- a/src/app/cmd/er/task.rs
+++ b/src/app/cmd/er/task.rs
@@ -5,11 +5,12 @@ use tokio::sync::mpsc;
 
 use crate::domain::ErTableInfo;
 use crate::ports::outbound::ErDiagramExporter;
-use crate::update::action::{Action, ErDiagramError, ErDiagramInfo};
+use crate::update::action::{Action, ErDiagramError, ErDiagramFailure, ErDiagramInfo};
 
 pub fn spawn_er_diagram_task(
     exporter: Arc<dyn ErDiagramExporter>,
     tables: Vec<ErTableInfo>,
+    run_id: u64,
     total_tables: usize,
     cache_dir: PathBuf,
     tx: mpsc::Sender<Action>,
@@ -27,6 +28,7 @@ pub fn spawn_er_diagram_task(
             Ok(Ok(path)) => {
                 let _ = tx
                     .send(Action::ErDiagramOpened(ErDiagramInfo {
+                        run_id,
                         path: path.display().to_string(),
                         table_count,
                         total_tables,
@@ -35,16 +37,18 @@ pub fn spawn_er_diagram_task(
             }
             Ok(Err(e)) => {
                 let _ = tx
-                    .send(Action::ErDiagramFailed(ErDiagramError::ExportFailed(
-                        e.to_string(),
-                    )))
+                    .send(Action::ErDiagramFailed(ErDiagramFailure {
+                        run_id,
+                        error: ErDiagramError::ExportFailed(e.to_string()),
+                    }))
                     .await;
             }
             Err(e) => {
                 let _ = tx
-                    .send(Action::ErDiagramFailed(ErDiagramError::TaskPanicked(
-                        e.to_string(),
-                    )))
+                    .send(Action::ErDiagramFailed(ErDiagramFailure {
+                        run_id,
+                        error: ErDiagramError::TaskPanicked(e.to_string()),
+                    }))
                     .await;
             }
         }
@@ -122,6 +126,7 @@ mod tests {
             spawn_er_diagram_task(
                 exporter,
                 vec![],
+                1,
                 5,
                 temp_dir.path().to_path_buf(),
                 tx,
@@ -132,6 +137,7 @@ mod tests {
             let action = receive_action(&mut rx).await;
             match action {
                 Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id,
                     path,
                     table_count,
                     total_tables,
@@ -139,6 +145,7 @@ mod tests {
                     assert!(path.contains("test.svg"));
                     assert_eq!(table_count, 0);
                     assert_eq!(total_tables, 5);
+                    assert_eq!(run_id, 1);
                 }
                 _ => panic!("expected ErDiagramOpened, got {action:?}"),
             }
@@ -153,6 +160,7 @@ mod tests {
             spawn_er_diagram_task(
                 exporter,
                 vec![],
+                1,
                 5,
                 temp_dir.path().to_path_buf(),
                 tx,
@@ -178,6 +186,7 @@ mod tests {
             spawn_er_diagram_task(
                 exporter,
                 vec![],
+                1,
                 5,
                 temp_dir.path().to_path_buf(),
                 tx,

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -52,6 +52,13 @@ pub enum ErDiagramError {
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
+#[error("{error}")]
+pub struct ErDiagramFailure {
+    pub run_id: u64,
+    pub error: ErDiagramError,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum ErLogError {
     #[error("{0}")]
     Io(String),
@@ -234,6 +241,7 @@ pub struct SmartErRefreshError {
 
 #[derive(Debug, Clone)]
 pub struct ErDiagramInfo {
+    pub run_id: u64,
     pub path: String,
     pub table_count: usize,
     pub total_tables: usize,
@@ -703,7 +711,7 @@ pub enum Action {
     SmartErRefreshCompleted(SmartErRefreshResult),
     SmartErRefreshFailed(SmartErRefreshError),
     ErDiagramOpened(ErDiagramInfo),
-    ErDiagramFailed(ErDiagramError),
+    ErDiagramFailed(ErDiagramFailure),
     ErLogWriteFailed(ErLogError),
 }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1559,6 +1559,7 @@ mod tests {
 
     mod mysql_database_tests {
         use super::*;
+        use crate::update::action::ErDiagramInfo;
 
         fn mysql_target(id: &ConnectionId, database: Option<&str>) -> ConnectionTarget {
             let database = database.map(str::to_string);
@@ -1627,6 +1628,8 @@ mod tests {
             ]);
             state.ui.set_database_picker(true);
             state.modal.set_mode(InputMode::TablePicker);
+            let stale_er_run_id = state.er_preparation.start_waiting_run();
+            state.er_preparation.mark_rendering();
             state
                 .query_history_picker
                 .replace_entries(&[QueryHistoryEntry::new(
@@ -1664,6 +1667,21 @@ mod tests {
                     .iter()
                     .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
             );
+
+            let effects = reduce_app(
+                &mut state,
+                Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id: stale_er_run_id,
+                    path: "stale.svg".to_string(),
+                    table_count: 1,
+                    total_tables: 1,
+                }),
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.is_empty());
+            assert!(state.messages.last_success().is_none());
         }
 
         #[test]

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -13,10 +13,14 @@ pub(super) fn reduce_diagram_lifecycle(
 ) -> DispatchResult {
     match action {
         Action::ErDiagramOpened(ErDiagramInfo {
+            run_id,
             path,
             table_count,
             total_tables,
         }) => {
+            if !state.er_preparation.is_current_run(*run_id) {
+                return DispatchResult::handled();
+            }
             state.er_preparation.mark_idle();
             // Reset so next ErOpenDiagram re-evaluates target_tables from scratch.
             state.sql_modal.invalidate_prefetch();
@@ -28,9 +32,12 @@ pub(super) fn reduce_diagram_lifecycle(
             );
             DispatchResult::handled()
         }
-        Action::ErDiagramFailed(error) => {
+        Action::ErDiagramFailed(failure) => {
+            if !state.er_preparation.is_current_run(failure.run_id) {
+                return DispatchResult::handled();
+            }
             state.er_preparation.mark_idle();
-            state.messages.set_error_at(error.to_string(), now);
+            state.messages.set_error_at(failure.error.to_string(), now);
             DispatchResult::handled()
         }
         Action::ErLogWriteFailed(error) => {
@@ -75,12 +82,14 @@ pub(super) fn reduce_diagram_lifecycle(
             }
 
             state.er_preparation.mark_rendering();
+            let run_id = state.er_preparation.run_id();
             let total_tables = state
                 .session
                 .metadata()
                 .map_or(0, |m| m.table_summaries.len());
 
             DispatchResult::handled_with(vec![Effect::GenerateErDiagramFromCache {
+                run_id,
                 total_tables,
                 project_name: state.runtime.project_name.clone(),
                 target_tables: state.er_preparation.target_tables().to_vec(),

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -24,7 +24,7 @@ mod tests {
     use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, TableSummary};
     use crate::model::app_state::AppState;
     use crate::model::er_state::ErStatus;
-    use crate::update::action::{SmartErRefreshError, SmartErRefreshResult};
+    use crate::update::action::{ErDiagramInfo, SmartErRefreshError, SmartErRefreshResult};
     use std::sync::Arc;
 
     fn reduce_er(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
@@ -254,6 +254,35 @@ mod tests {
                 state.messages.last_error.as_deref(),
                 Some("ER diagrams are not available for this connection")
             );
+        }
+    }
+
+    mod stale_diagram_completion {
+        use super::*;
+
+        #[test]
+        fn completion_after_reset_is_ignored() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = state.er_preparation.start_waiting_run();
+            state.er_preparation.mark_rendering();
+            state.er_preparation.reset();
+
+            let effects = reduce_er(
+                &mut state,
+                &Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id,
+                    path: "stale.svg".to_string(),
+                    table_count: 1,
+                    total_tables: 1,
+                }),
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("reducer should handle stale completion");
+
+            assert!(effects.is_empty());
+            assert!(state.messages.last_success().is_none());
+            assert!(state.messages.last_error().is_none());
         }
     }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -352,6 +352,7 @@ mod tests {
             assert_unsupported_action_is_a_noop(
                 &mut state,
                 Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id: 0,
                     path: "diagram.svg".to_string(),
                     table_count: 1,
                     total_tables: 1,


### PR DESCRIPTION
## Problem

ER rendering completion and failure actions did not carry the ER preparation run identity, so an in-flight diagram from the previous MySQL database could update the newly selected database.

## Background

MySQL ER metadata follows the existing Graphviz path, while database switches reset preparation state before old renderer tasks necessarily finish.

## Approach

Carry the preparation run ID through the ER generation effect and renderer task, and ignore completion and failure actions that no longer belong to the active run. Add regression coverage for reset and MySQL database switching.

## Screenshots

Not applicable; this change reuses the existing ER and Graphviz UI.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-395