### PR TITLE
feat(mysql): compare execution plans

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -141,6 +141,7 @@ pub async fn run(
         Effect::ExecuteExplain {
             dsn,
             database_type,
+            database_generation,
             run_id,
             query,
             source_query,
@@ -165,6 +166,7 @@ pub async fn run(
                         tx.send(Action::ExplainCompleted {
                             dsn,
                             database_type,
+                            database_generation,
                             run_id,
                             query: source_query,
                             plan_text,
@@ -177,6 +179,7 @@ pub async fn run(
                     Err(e) => {
                         tx.send(Action::ExplainFailed {
                             dsn,
+                            database_generation,
                             run_id,
                             error: e,
                             is_analyze,
@@ -873,6 +876,7 @@ mod tests {
                 Effect::ExecuteExplain {
                     dsn: "dsn://test".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database_generation: 0,
                     run_id: 2,
                     query: "EXPLAIN SELECT 1".to_string(),
                     source_query: "SELECT 1".to_string(),

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -84,6 +84,7 @@ pub enum Effect {
     ExecuteExplain {
         dsn: String,
         database_type: DatabaseType,
+        database_generation: u64,
         run_id: u64,
         query: String,
         source_query: String,

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -450,6 +450,11 @@ impl AppState {
     pub fn is_stale_query_run(&self, dsn: &str, run_id: u64) -> bool {
         !self.session.dsn_matches(dsn) || !self.query.is_current_run(run_id)
     }
+
+    pub fn is_stale_explain_run(&self, dsn: &str, database_generation: u64, run_id: u64) -> bool {
+        self.is_stale_query_run(dsn, run_id)
+            || self.session.database_generation() != database_generation
+    }
 }
 
 #[cfg(test)]

--- a/src/app/model/explain_context.rs
+++ b/src/app/model/explain_context.rs
@@ -22,6 +22,7 @@ impl SlotSource {
 #[derive(Debug, Clone)]
 pub struct CompareSlot {
     pub plan: ExplainPlan,
+    pub database_type: DatabaseType,
     pub query_snippet: String,
     pub full_query: String,
     pub source: SlotSource,
@@ -130,6 +131,7 @@ impl ExplainContext {
 
         let new_slot = CompareSlot {
             plan: parsed,
+            database_type,
             query_snippet: snippet,
             full_query: query.to_string(),
             source: SlotSource::AutoLatest,

--- a/src/app/model/shared/engine_feature_profile.rs
+++ b/src/app/model/shared/engine_feature_profile.rs
@@ -189,7 +189,7 @@ impl EngineFeatureProfile {
         Self::new(
             MYSQL_INSPECTOR,
             ExplainProfile::QueryPlanAndAnalyze {
-                comparison: ComparisonSupport::Unsupported,
+                comparison: ComparisonSupport::Supported,
             },
             MYSQL_FEATURES,
         )
@@ -446,12 +446,12 @@ mod tests {
     }
 
     #[test]
-    fn mysql_profile_exposes_browse_metadata_ddl_and_analyze_without_compare() {
+    fn mysql_profile_exposes_browse_metadata_ddl_analyze_and_compare() {
         let profile = EngineFeatureProfile::mysql_like();
 
         assert!(profile.supports_explain());
         assert!(profile.supports_explain_analyze());
-        assert!(!profile.supports_plan_comparison());
+        assert!(profile.supports_plan_comparison());
         assert!(profile.supports_er_diagram());
         assert!(!profile.supports_jsonb_detail());
         assert!(!profile.supports_sqlite_diagnostics());
@@ -478,7 +478,7 @@ mod tests {
         );
         assert_eq!(
             profile.supported_sql_modal_tabs(),
-            &[SqlModalTab::Sql, SqlModalTab::Plan]
+            &[SqlModalTab::Sql, SqlModalTab::Plan, SqlModalTab::Compare]
         );
     }
 

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -566,6 +566,7 @@ pub enum Action {
     ExplainCompleted {
         dsn: String,
         database_type: DatabaseType,
+        database_generation: u64,
         run_id: u64,
         query: String,
         plan_text: String,
@@ -574,6 +575,7 @@ pub enum Action {
     },
     ExplainFailed {
         dsn: String,
+        database_generation: u64,
         run_id: u64,
         error: DbOperationError,
         is_analyze: bool,
@@ -942,6 +944,7 @@ mod tests {
             Action::ExplainCompleted {
                 dsn: "dsn".to_string(),
                 database_type: DatabaseType::PostgreSQL,
+                database_generation: 0,
                 run_id: 1,
                 query: "SELECT 1".to_string(),
                 plan_text: "plan".to_string(),
@@ -954,6 +957,7 @@ mod tests {
         assert_eq!(
             Action::ExplainFailed {
                 dsn: "dsn".to_string(),
+                database_generation: 0,
                 run_id: 1,
                 error: DbOperationError::QueryFailed("error".to_string()),
                 is_analyze: false,

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1699,6 +1699,20 @@ mod tests {
             state.session.mark_probe_connected(true);
             state.modal.set_mode(InputMode::QueryHistoryPicker);
             state.sql_modal.completion_mut_for_test().visible = true;
+            state.explain.set_plan(
+                "-> Table scan on users  (cost=1 rows=10)".to_string(),
+                DatabaseType::MySQL,
+                false,
+                1,
+                "SELECT * FROM users",
+            );
+            state.explain.set_plan(
+                "-> Index lookup on users  (cost=0.5 rows=1)".to_string(),
+                DatabaseType::MySQL,
+                false,
+                1,
+                "SELECT * FROM users WHERE id = 1",
+            );
             state
                 .query_history_picker
                 .replace_entries(&[QueryHistoryEntry::new_with_database(
@@ -1723,6 +1737,9 @@ mod tests {
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(state.query_history_picker.entries().is_empty());
             assert!(!state.sql_modal.completion().visible);
+            assert!(state.explain.left().is_none());
+            assert!(state.explain.right().is_none());
+            assert!(state.explain.history().is_empty());
             assert!(
                 effects
                     .iter()

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -89,9 +89,11 @@ pub(super) fn reduce_analyze(
                         return DispatchResult::handled();
                     };
                     let run_id = begin_explain_running(state, now);
+                    let database_generation = state.session.database_generation();
                     return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                         dsn,
                         database_type,
+                        database_generation,
                         run_id,
                         query: explain_query,
                         source_query: content,
@@ -132,9 +134,11 @@ pub(super) fn reduce_analyze(
                     return DispatchResult::handled();
                 };
                 let run_id = begin_explain_running(state, now);
+                let database_generation = state.session.database_generation();
                 return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                     dsn,
                     database_type,
+                    database_generation,
                     run_id,
                     query: explain_query,
                     source_query: query,

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -181,7 +181,7 @@ mod tests {
         }
 
         #[test]
-        fn mysql_select_emits_tree_explain_effect_and_keeps_compare_disabled() {
+        fn mysql_select_emits_tree_explain_effect_and_enables_compare() {
             let mut state = sql_modal_state();
             state.sql_modal.editor.set_content("SELECT 1".to_string());
             test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
@@ -212,7 +212,7 @@ mod tests {
                     .supports_explain_analyze()
             );
             assert!(
-                !state
+                state
                     .session
                     .active_engine_feature_profile()
                     .supports_plan_comparison()
@@ -1038,12 +1038,14 @@ mod tests {
             activate_postgres_connection(&mut state);
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            let database_generation = state.session.database_generation();
 
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
                     dsn: "dsn://test".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database_generation,
                     run_id: 1,
                     query: "SELECT 1".to_string(),
                     plan_text: "Seq Scan".to_string(),
@@ -1065,12 +1067,14 @@ mod tests {
             test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            let database_generation = state.session.database_generation();
 
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
                     dsn: "mysql://test".to_string(),
                     database_type: DatabaseType::MySQL,
+                    database_generation,
                     run_id: 1,
                     query: "SELECT 1".to_string(),
                     plan_text: "-> Table scan on users  (cost=1.25 rows=2.5)".to_string(),
@@ -1095,6 +1099,7 @@ mod tests {
             test_fixtures::activate_postgres_connection(&mut state, "dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            let database_generation = state.session.database_generation();
             state.explain.set_plan(
                 "Original".to_string(),
                 DatabaseType::PostgreSQL,
@@ -1108,6 +1113,7 @@ mod tests {
                 &Action::ExplainCompleted {
                     dsn: "dsn://stale".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database_generation,
                     run_id: 1,
                     query: "SELECT stale".to_string(),
                     plan_text: "Stale".to_string(),
@@ -1124,6 +1130,50 @@ mod tests {
             );
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
         }
+
+        #[test]
+        fn mismatched_database_generation_does_not_replace_plan() {
+            let mut state = sql_modal_state();
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+            let database_generation = state.session.database_generation();
+            let run_id = state.query.begin_running(Instant::now());
+            state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            state.explain.set_plan(
+                "original".to_string(),
+                DatabaseType::MySQL,
+                false,
+                10,
+                "SELECT old",
+            );
+
+            let id = state.session.active_connection_id().cloned().unwrap();
+            let name = state.session.active_connection_name().unwrap().to_string();
+            state.session.activate_connection_with_target(
+                &id,
+                &name,
+                DatabaseType::MySQL,
+                "mysql://test",
+                Some("analytics"),
+            );
+
+            reduce_explain(
+                &mut state,
+                &Action::ExplainCompleted {
+                    dsn: "mysql://test".to_string(),
+                    database_type: DatabaseType::MySQL,
+                    database_generation,
+                    run_id,
+                    query: "SELECT stale".to_string(),
+                    plan_text: "stale".to_string(),
+                    is_analyze: false,
+                    execution_time_ms: 42,
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(state.explain.plan_text(), Some("original"));
+            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
+        }
     }
 
     mod explain_failed {
@@ -1136,11 +1186,13 @@ mod tests {
             activate_postgres_connection(&mut state);
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            let database_generation = state.session.database_generation();
 
             reduce_explain(
                 &mut state,
                 &Action::ExplainFailed {
                     dsn: "dsn://test".to_string(),
+                    database_generation,
                     run_id: 1,
                     error: DbOperationError::QueryFailed("syntax error".to_string()),
                     is_analyze: false,
@@ -1163,6 +1215,7 @@ mod tests {
             test_fixtures::activate_postgres_connection(&mut state, "dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            let database_generation = state.session.database_generation();
             state.explain.set_plan(
                 "Original".to_string(),
                 DatabaseType::PostgreSQL,
@@ -1175,6 +1228,7 @@ mod tests {
                 &mut state,
                 &Action::ExplainFailed {
                     dsn: "dsn://stale".to_string(),
+                    database_generation,
                     run_id: 1,
                     error: DbOperationError::QueryFailed("syntax error".to_string()),
                     is_analyze: false,
@@ -1230,6 +1284,7 @@ mod tests {
             state.sql_modal.editor.set_content("SELECT 1".to_string());
             activate_postgres_connection(&mut state);
             let now = Instant::now();
+            let database_generation = state.session.database_generation();
 
             // Step 1: First EXPLAIN
             reduce_explain(&mut state, &Action::ExplainRequest, now);
@@ -1238,6 +1293,7 @@ mod tests {
                 &Action::ExplainCompleted {
                     dsn: "dsn://test".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database_generation,
                     run_id: 1,
                     query: "SELECT 1".to_string(),
                     plan_text: "Seq Scan  (cost=0.00..100.00 rows=10 width=32)".to_string(),
@@ -1252,11 +1308,13 @@ mod tests {
             // Step 2: Second EXPLAIN — auto-advance moves right→left
             state.sql_modal.editor.set_content("SELECT 2".to_string());
             reduce_explain(&mut state, &Action::ExplainRequest, now);
+            let database_generation = state.session.database_generation();
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
                     dsn: "dsn://test".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database_generation,
                     run_id: 2,
                     query: "SELECT 2".to_string(),
                     plan_text: "Index Scan  (cost=0.00..5.00 rows=1 width=32)".to_string(),

--- a/src/app/update/explain/output.rs
+++ b/src/app/update/explain/output.rs
@@ -15,13 +15,14 @@ pub(super) fn reduce_output(
         Action::ExplainCompleted {
             dsn,
             database_type,
+            database_generation,
             run_id,
             query,
             plan_text,
             is_analyze,
             execution_time_ms,
         } => {
-            if state.is_stale_query_run(dsn, *run_id) {
+            if state.is_stale_explain_run(dsn, *database_generation, *run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_success(
@@ -36,9 +37,13 @@ pub(super) fn reduce_output(
         }
 
         Action::ExplainFailed {
-            dsn, run_id, error, ..
+            dsn,
+            database_generation,
+            run_id,
+            error,
+            ..
         } => {
-            if state.is_stale_query_run(dsn, *run_id) {
+            if state.is_stale_explain_run(dsn, *database_generation, *run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_error(state, error.user_message());

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -86,10 +86,12 @@ pub(super) fn reduce_request(
                 }
             };
             let run_id = begin_explain_running(state, now);
+            let database_generation = state.session.database_generation();
 
             DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                 dsn,
                 database_type,
+                database_generation,
                 run_id,
                 query,
                 source_query: content,

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -431,6 +431,7 @@ mod tests {
                 Action::ExplainCompleted {
                     dsn: "sqlite://test.db".to_string(),
                     database_type: DatabaseType::SQLite,
+                    database_generation: 0,
                     run_id: 1,
                     query: "SELECT 1".to_string(),
                     plan_text: "QUERY PLAN".to_string(),
@@ -443,6 +444,7 @@ mod tests {
                 &mut explain_state,
                 Action::ExplainFailed {
                     dsn: "sqlite://test.db".to_string(),
+                    database_generation: 0,
                     run_id: 1,
                     error: DbOperationError::QueryFailed("error".to_string()),
                     is_analyze: true,

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -25,6 +25,7 @@ pub fn dispatch_sql_modal(state: &mut AppState, action: &Action, now: Instant) -
 mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
+    use crate::domain::DatabaseType;
     use crate::model::shared::flash_timer::FlashId;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::text_input::{TextInputLike, TextInputState};
@@ -1056,6 +1057,7 @@ mod tests {
                     is_analyze,
                     execution_time_ms: ms,
                 },
+                database_type: DatabaseType::PostgreSQL,
                 query_snippet: "SELECT 1".to_string(),
                 full_query: "SELECT 1".to_string(),
                 source,
@@ -1248,6 +1250,7 @@ mod tests {
                     is_analyze: false,
                     execution_time_ms: 420,
                 },
+                database_type: DatabaseType::PostgreSQL,
                 query_snippet: "SELECT *".to_string(),
                 full_query: "SELECT * FROM users".to_string(),
                 source: SlotSource::AutoPrevious,
@@ -1266,6 +1269,7 @@ mod tests {
                     is_analyze: false,
                     execution_time_ms: 50,
                 },
+                database_type: DatabaseType::PostgreSQL,
                 query_snippet: "SELECT *".to_string(),
                 full_query: "SELECT * FROM users WHERE id=1".to_string(),
                 source: SlotSource::AutoLatest,

--- a/src/domain/explain_plan.rs
+++ b/src/domain/explain_plan.rs
@@ -162,21 +162,25 @@ fn parse_mysql_cost_fragment(line: &str) -> (Option<f64>, Option<f64>) {
         .find(|c: char| c.is_whitespace() || c == ')')
         .unwrap_or(after_cost.len());
     let cost_token = after_cost.get(..cost_end).unwrap_or_default();
-    let total_cost = cost_token
+    let total_cost_token = cost_token
         .rsplit_once("..")
-        .map_or(cost_token, |(_, total)| total)
-        .parse()
-        .ok();
+        .map_or(cost_token, |(_, total)| total);
+    let total_cost = parse_mysql_metric(total_cost_token);
 
     let estimated_rows = line.find("rows=").and_then(|rows_start| {
         let after_rows = line.get(rows_start + 5..)?;
         let rows_end = after_rows
             .find(|c: char| c.is_whitespace() || c == ')')
             .unwrap_or(after_rows.len());
-        after_rows.get(..rows_end)?.parse().ok()
+        parse_mysql_metric(after_rows.get(..rows_end)?)
     });
 
     (total_cost, estimated_rows)
+}
+
+fn parse_mysql_metric(token: &str) -> Option<f64> {
+    let value: f64 = token.parse().ok()?;
+    (value.is_finite() && value >= 0.0).then_some(value)
 }
 
 fn mysql_node_name(line: &str) -> Option<String> {
@@ -188,11 +192,6 @@ fn mysql_node_name(line: &str) -> Option<String> {
         .trim_start_matches("->")
         .trim();
     (!node_name.is_empty()).then(|| node_name.to_string())
-}
-
-fn parse_finite_f64(token: &str) -> Option<f64> {
-    let value: f64 = token.parse().ok()?;
-    value.is_finite().then_some(value)
 }
 
 fn parse_mysql_loops(token: &str) -> Option<u64> {
@@ -267,11 +266,11 @@ fn parse_mysql_actual_fragment(line: &str) -> (Option<f64>, Option<f64>, Option<
     for token in fragment.split_whitespace() {
         if let Some(time) = token.strip_prefix("time=") {
             if let Some((start, end)) = time.split_once("..") {
-                actual_start_ms = parse_finite_f64(start);
-                actual_end_ms = parse_finite_f64(end.trim_end_matches(')'));
+                actual_start_ms = parse_mysql_metric(start);
+                actual_end_ms = parse_mysql_metric(end.trim_end_matches(')'));
             }
         } else if let Some(rows) = token.strip_prefix("rows=") {
-            actual_rows = parse_finite_f64(rows.trim_end_matches(')'));
+            actual_rows = parse_mysql_metric(rows.trim_end_matches(')'));
         } else if let Some(value) = token.strip_prefix("loops=") {
             loops = parse_mysql_loops(value.trim_end_matches(')'));
         }
@@ -333,6 +332,10 @@ pub fn parse_mysql_tree_explain_text(
         loops,
     ) = first_cost_line.map_or((None, None, None, None, None, None, None), |line| {
         let (cost, rows) = parse_mysql_cost_fragment(line);
+        let (cost, rows) = match (cost, rows) {
+            (Some(cost), Some(rows)) => (Some(cost), Some(rows)),
+            _ => (None, None),
+        };
         let (actual_start_ms, actual_end_ms, actual_rows, loops) =
             parse_mysql_actual_fragment(line);
         (
@@ -538,6 +541,23 @@ Execution Time: 0.600 ms";
             assert_eq!(plan.top_node_type.as_deref(), Some("Filter: (id > 10)"));
             assert!(plan.total_cost.is_none());
             assert!(plan.estimated_rows.is_none());
+        }
+
+        #[test]
+        fn mysql_tree_rejects_non_finite_or_negative_comparison_metrics() {
+            for metrics in [
+                "cost=NaN rows=1",
+                "cost=1 rows=NaN",
+                "cost=-1 rows=1",
+                "cost=1 rows=-1",
+            ] {
+                let text = format!("-> Table scan on users  ({metrics})");
+                let plan = parse_mysql_tree_explain_text(&text, false, 0);
+
+                assert_eq!(plan.raw_text, text);
+                assert!(plan.total_cost.is_none(), "{metrics}");
+                assert!(plan.estimated_rows.is_none(), "{metrics}");
+            }
         }
 
         #[test]
@@ -794,6 +814,26 @@ Execution Time: 0.600 ms";
             let result = compare_plans(&baseline, &current);
 
             assert_eq!(result.verdict, ComparisonVerdict::Similar);
+        }
+
+        #[test]
+        fn actual_metrics_do_not_change_comparison_verdict() {
+            let mut baseline = make_plan(Some(100.0), Some(10.0), Some("Table scan"));
+            baseline.actual_start_ms = Some(1.0);
+            baseline.actual_end_ms = Some(2.0);
+            baseline.actual_rows = Some(10.0);
+            baseline.loops = Some(1);
+
+            let mut current = baseline.clone();
+            current.actual_start_ms = Some(100.0);
+            current.actual_end_ms = Some(200.0);
+            current.actual_rows = Some(1_000.0);
+            current.loops = Some(10);
+
+            assert_eq!(
+                compare_plans(&baseline, &current).verdict,
+                ComparisonVerdict::Similar
+            );
         }
     }
 }

--- a/src/ui/features/sql_modal/compare.rs
+++ b/src/ui/features/sql_modal/compare.rs
@@ -10,7 +10,8 @@ use crate::app::model::app_state::AppState;
 use crate::app::model::explain_context::CompareSlot;
 use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::update::input::keybindings::sql_modal_compare_explain;
-use crate::domain::explain_plan::{self, ComparisonVerdict};
+use crate::domain::DatabaseType;
+use crate::domain::explain_plan::{self, ComparisonVerdict, ExplainPlan};
 use crate::primitives::atoms::apply_yank_flash_masked;
 use crate::primitives::utils::text_utils::truncate_to_width_with;
 use crate::theme::ThemePalette;
@@ -339,14 +340,10 @@ fn render_stacked_slot(
             flash_mask,
             Line::from(Span::styled(format!(" {}", s.source.label()), active_style)),
         );
-        let time_secs = s.plan.execution_secs();
         push_chrome(
             lines,
             flash_mask,
-            Line::from(Span::styled(
-                format!("  {}  ({:.2}s)", mode_label(s.plan.is_analyze), time_secs),
-                badge_style,
-            )),
+            Line::from(Span::styled(slot_detail_text(Some(s)), badge_style)),
         );
         for line in s.plan.raw_text.lines() {
             push_content(
@@ -383,10 +380,28 @@ fn slot_detail_text(slot: Option<&CompareSlot>) -> String {
     match slot {
         Some(s) => {
             let time_secs = s.plan.execution_secs();
-            format!(" {}  ({:.2}s)", mode_label(s.plan.is_analyze), time_secs)
+            let summary = format!(" {}  ({:.2}s)", mode_label(s.plan.is_analyze), time_secs);
+            if s.database_type == DatabaseType::MySQL && s.plan.is_analyze {
+                format!("{summary}  {}", actual_metrics_text(&s.plan))
+            } else {
+                summary
+            }
         }
         None => " Run EXPLAIN again".to_string(),
     }
+}
+
+fn actual_metrics_text(plan: &ExplainPlan) -> String {
+    let (Some(start), Some(end), Some(rows), Some(loops)) = (
+        plan.actual_start_ms,
+        plan.actual_end_ms,
+        plan.actual_rows,
+        plan.loops,
+    ) else {
+        return "Actual: unavailable".to_string();
+    };
+
+    format!("Actual: time={start:.3}..{end:.3} ms rows={rows} loops={loops}")
 }
 
 fn mode_label(is_analyze: bool) -> &'static str {
@@ -407,7 +422,6 @@ pub(super) fn pad_or_truncate(s: &str, width: usize) -> String {
 mod tests {
     use super::*;
     use crate::app::model::explain_context::SlotSource;
-    use crate::domain::explain_plan::ExplainPlan;
     use crate::theme::DEFAULT_THEME;
 
     mod pad_or_truncate_tests {
@@ -446,6 +460,7 @@ mod tests {
                 is_analyze: false,
                 execution_time_ms: 250,
             },
+            database_type: DatabaseType::PostgreSQL,
             query_snippet: "SELECT 1".to_string(),
             full_query: "SELECT 1".to_string(),
             source: label,
@@ -506,5 +521,29 @@ mod tests {
 
         assert_eq!(lines.len(), flash_mask.len());
         assert!(flash_mask.iter().all(|&flash| !flash));
+    }
+
+    #[test]
+    fn mysql_analyze_slot_summary_shows_actual_metrics() {
+        let mut slot = sample_slot(SlotSource::AutoLatest, "plan");
+        slot.database_type = DatabaseType::MySQL;
+        slot.plan.is_analyze = true;
+        slot.plan.actual_start_ms = Some(0.01);
+        slot.plan.actual_end_ms = Some(0.5);
+        slot.plan.actual_rows = Some(95.0);
+        slot.plan.loops = Some(2);
+
+        let summary = slot_detail_text(Some(&slot));
+
+        assert!(summary.contains("Actual: time=0.010..0.500 ms rows=95 loops=2"));
+    }
+
+    #[test]
+    fn mysql_analyze_slot_summary_marks_missing_actual_metrics_unavailable() {
+        let mut slot = sample_slot(SlotSource::AutoLatest, "plan");
+        slot.database_type = DatabaseType::MySQL;
+        slot.plan.is_analyze = true;
+
+        assert!(slot_detail_text(Some(&slot)).contains("Actual: unavailable"));
     }
 }


### PR DESCRIPTION
## Problem
MySQL execution plans cannot be compared in the existing Compare tab, and a delayed EXPLAIN response can survive a database switch on the same connection.

## Background
MySQL database changes reuse the connection identity, so plans and responses must be scoped to the selected database.

## Approach
Enable MySQL plan comparison using cost and estimated rows, display ANALYZE metrics as per-plan details without using them in the verdict, and reject stale responses by database generation while clearing comparison state on database switches.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-399
