### PR TITLE
feat(mysql): preserve hidden row identities for grid writes

### DIFF
--- a/scripts/init-mysql.sql
+++ b/scripts/init-mysql.sql
@@ -55,6 +55,34 @@ CREATE TABLE mysql_preview_composite (
 INSERT INTO mysql_preview_composite (first_key, second_key, payload)
 VALUES (1, 20, 'first'), (2, 10, 'second');
 
+CREATE TABLE mysql_edit_invisible_pk (
+    id INT NOT NULL INVISIBLE,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_edit_invisible_pk (id, payload)
+VALUES (1, 'invisible single primary key');
+
+CREATE TABLE mysql_edit_invisible_composite (
+    first_key INT NOT NULL INVISIBLE,
+    second_key INT NOT NULL INVISIBLE,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (second_key, first_key)
+) ENGINE=InnoDB CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_edit_invisible_composite (first_key, second_key, payload)
+VALUES (1, 20, 'invisible composite primary key');
+
+SET SESSION sql_generate_invisible_primary_key = ON;
+
+CREATE TABLE mysql_edit_gipk (
+    payload TEXT NOT NULL
+) ENGINE=InnoDB CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_edit_gipk (payload)
+VALUES ('generated invisible primary key');
+
 CREATE TABLE mysql_metadata_parent (
     first_key INT NOT NULL,
     second_key INT NOT NULL,

--- a/scripts/init-mysql.sql
+++ b/scripts/init-mysql.sql
@@ -83,6 +83,8 @@ CREATE TABLE mysql_edit_gipk (
 INSERT INTO mysql_edit_gipk (payload)
 VALUES ('generated invisible primary key');
 
+SET SESSION sql_generate_invisible_primary_key = OFF;
+
 CREATE TABLE mysql_metadata_parent (
     first_key INT NOT NULL,
     second_key INT NOT NULL,

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -33,7 +33,9 @@ use crate::policy::preview_cell_text::CellPresentationPolicy;
 use crate::policy::sql::result_query::is_rerunnable_select;
 use crate::policy::table_kind::max_explorer_table_label_width;
 use crate::policy::write::inline_cell_edit::supports_inline_edit;
-use crate::policy::write::write_guardrails::{PreviewWriteability, preview_writeability};
+use crate::policy::write::write_guardrails::{
+    PreviewWriteability, preview_writeability_for_result,
+};
 use crate::ports::outbound::DdlGenerator;
 
 pub struct AppState {
@@ -385,7 +387,8 @@ impl AppState {
         if !self.query.pagination.matches_table(table_detail) {
             return None;
         }
-        match preview_writeability(table_detail) {
+        let result = self.query.visible_result()?;
+        match preview_writeability_for_result(table_detail, result) {
             PreviewWriteability::Writable => None,
             PreviewWriteability::ReadOnly(reason) => Some(reason),
             PreviewWriteability::MissingStableRowIdentity => Some("table without PRIMARY KEY"),

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use super::explain_context::ExplainContext;
 use super::runtime_state::RuntimeState;
 use crate::domain::connection::{ConnectionProfile, ServiceEntry};
-use crate::domain::{DatabaseType, TableSummary};
+use crate::domain::{Column, DatabaseType, TableSummary};
 use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::browse::inspector_view_model::InspectorViewModel;
 use crate::model::browse::jsonb_detail::JsonbDetailState;
@@ -400,6 +400,16 @@ impl AppState {
             && self.visible_preview_target_read_only_reason().is_none()
     }
 
+    pub fn visible_preview_column(&self, col_idx: usize) -> Option<&Column> {
+        let result = self.query.visible_result()?;
+        let column_name = result.columns.get(col_idx)?;
+        let table_detail = self.session.table_detail()?;
+        table_detail
+            .columns
+            .iter()
+            .find(|column| column.name == *column_name)
+    }
+
     pub fn can_edit_selected_cell(&self) -> bool {
         let Some(row_idx) = self.result_interaction.selection().row() else {
             return false;
@@ -421,28 +431,26 @@ impl AppState {
             return false;
         };
 
-        if let Some(table_detail) = self.session.table_detail()
-            && let Some(column) = table_detail.columns.get(col_idx)
-        {
-            if table_detail
-                .primary_key
-                .as_ref()
-                .is_some_and(|pk| pk.iter().any(|name| name == &column.name))
-            {
-                return false;
-            }
-            if column.is_read_only() {
-                return false;
-            }
+        let Some(column) = self.visible_preview_column(col_idx) else {
+            return false;
+        };
+        let is_primary_key = column.is_primary_key()
+            || self
+                .session
+                .table_detail()
+                .and_then(|table| table.primary_key.as_ref())
+                .is_some_and(|primary_key| primary_key.iter().any(|name| name == &column.name));
+        if is_primary_key || column.is_read_only() {
+            return false;
+        }
 
-            let policy = CellPresentationPolicy::new(
-                self.session.active_database_type_or_default(),
-                column.data_type.as_str(),
-                value.as_str().unwrap_or_default(),
-            );
-            if policy.uses_jsonb_detail_modal() {
-                return true;
-            }
+        let policy = CellPresentationPolicy::new(
+            self.session.active_database_type_or_default(),
+            column.data_type.as_str(),
+            value.as_str().unwrap_or_default(),
+        );
+        if policy.uses_jsonb_detail_modal() {
+            return true;
         }
 
         supports_inline_edit(self.session.active_database_type_or_default(), value)
@@ -469,8 +477,8 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        Column, ColumnAttributes, ConnectionId, DatabaseMetadata, DatabaseType, QueryResult,
-        QuerySource, QueryValue, Table, TableKind, TableKindInfo,
+        ColumnAttributes, ConnectionId, DatabaseMetadata, DatabaseType, QueryResult, QuerySource,
+        QueryValue, Table, TableKind, TableKindInfo,
     };
     use crate::model::browse::row_detail::RowDetailState;
     use crate::model::er_state::ErStatus;
@@ -611,6 +619,129 @@ mod tests {
         state.result_interaction.activate_cell(0, 1);
 
         assert!(!state.can_edit_selected_cell());
+    }
+
+    #[test]
+    fn can_edit_selected_cell_maps_visible_column_by_name_after_hidden_primary_key() {
+        let mut state = make_state();
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "mysql",
+            DatabaseType::MySQL,
+            "mysql://localhost/test",
+        );
+        state.query.set_current_result(Arc::new(
+            QueryResult::success_with_values(
+                "SELECT `payload` FROM `sabiql_test`.`users`".to_string(),
+                vec!["payload".to_string()],
+                vec![vec![QueryValue::text("before")]],
+                10,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["id".to_string()],
+                vec![vec![QueryValue::SqlLiteral("1".to_string())]],
+            ),
+        ));
+        state
+            .query
+            .pagination
+            .reset_for_table("sabiql_test", "users");
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "sabiql_test".to_string(),
+            name: "users".to_string(),
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "INT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::PRIMARY_KEY
+                        | ColumnAttributes::HIDDEN
+                        | ColumnAttributes::READ_ONLY,
+                    comment: None,
+                    ordinal_position: 1,
+                },
+                Column {
+                    name: "payload".to_string(),
+                    data_type: "TEXT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::empty(),
+                    comment: None,
+                    ordinal_position: 2,
+                },
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..test_support::table::minimal("", "")
+        }));
+        state.result_interaction.activate_cell(0, 0);
+
+        assert!(state.can_edit_selected_cell());
+    }
+
+    #[test]
+    fn can_edit_selected_cell_maps_visible_column_by_name_when_hidden_primary_key_is_between_columns()
+     {
+        let mut state = make_state();
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "mysql",
+            DatabaseType::MySQL,
+            "mysql://localhost/test",
+        );
+        state.query.set_current_result(Arc::new(
+            QueryResult::success_with_values(
+                "SELECT `name`, `payload` FROM `sabiql_test`.`users`".to_string(),
+                vec!["name".to_string(), "payload".to_string()],
+                vec![vec![QueryValue::text("Alice"), QueryValue::text("before")]],
+                10,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["id".to_string()],
+                vec![vec![QueryValue::SqlLiteral("1".to_string())]],
+            ),
+        ));
+        state
+            .query
+            .pagination
+            .reset_for_table("sabiql_test", "users");
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "sabiql_test".to_string(),
+            name: "users".to_string(),
+            columns: vec![
+                Column {
+                    name: "name".to_string(),
+                    data_type: "VARCHAR".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::empty(),
+                    comment: None,
+                    ordinal_position: 1,
+                },
+                Column {
+                    name: "id".to_string(),
+                    data_type: "INT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::PRIMARY_KEY
+                        | ColumnAttributes::HIDDEN
+                        | ColumnAttributes::READ_ONLY,
+                    comment: None,
+                    ordinal_position: 2,
+                },
+                Column {
+                    name: "payload".to_string(),
+                    data_type: "TEXT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::empty(),
+                    comment: None,
+                    ordinal_position: 3,
+                },
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..test_support::table::minimal("", "")
+        }));
+        state.result_interaction.activate_cell(0, 1);
+
+        assert!(state.can_edit_selected_cell());
     }
 
     mod pane_geometry {

--- a/src/app/policy/write/write_guardrails.rs
+++ b/src/app/policy/write/write_guardrails.rs
@@ -5,6 +5,7 @@ use crate::policy::write::write_update::build_pk_pairs;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StableRowIdentity {
     PrimaryKey(Vec<String>),
+    Explicit(Vec<String>),
 }
 
 impl StableRowIdentity {
@@ -13,9 +14,22 @@ impl StableRowIdentity {
         result: &QueryResult,
         row_idx: usize,
     ) -> Option<Vec<(String, QueryValue)>> {
-        let Self::PrimaryKey(columns) = self;
-        let row = result.values().get(row_idx)?;
-        build_pk_pairs(&result.columns, row, columns)
+        match self {
+            Self::PrimaryKey(columns) => {
+                let row = result.values().get(row_idx)?;
+                build_pk_pairs(&result.columns, row, columns)
+            }
+            Self::Explicit(columns) => {
+                let values = result.explicit_row_identity()?.values_for_row(row_idx)?;
+                (columns.len() == values.len()).then(|| {
+                    columns
+                        .iter()
+                        .cloned()
+                        .zip(values.iter().cloned())
+                        .collect()
+                })
+            }
+        }
     }
 
     pub fn predicate_pairs_for_row(
@@ -27,8 +41,11 @@ impl StableRowIdentity {
     }
 
     pub fn is_primary_key_column(&self, column_name: &str) -> bool {
-        let Self::PrimaryKey(columns) = self;
-        columns.iter().any(|pk| pk == column_name)
+        match self {
+            Self::PrimaryKey(columns) | Self::Explicit(columns) => {
+                columns.iter().any(|pk| pk == column_name)
+            }
+        }
     }
 }
 
@@ -42,6 +59,17 @@ pub fn stable_row_identity_for_table(table: &Table) -> Option<StableRowIdentity>
         return None;
     }
     table.primary_key.clone().map(StableRowIdentity::PrimaryKey)
+}
+
+pub fn stable_row_identity_for_preview(
+    table: &Table,
+    result: &QueryResult,
+) -> Option<StableRowIdentity> {
+    if let Some(explicit) = result.explicit_row_identity() {
+        return valid_explicit_row_identity(table, result)
+            .then(|| StableRowIdentity::Explicit(explicit.columns().to_vec()));
+    }
+    stable_row_identity_for_table(table)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,6 +90,32 @@ pub fn preview_writeability(table: &Table) -> PreviewWriteability {
         return PreviewWriteability::MissingStableRowIdentity;
     }
     PreviewWriteability::Writable
+}
+
+pub fn preview_writeability_for_result(table: &Table, result: &QueryResult) -> PreviewWriteability {
+    let writeability = preview_writeability(table);
+    if writeability == PreviewWriteability::Writable
+        && result.explicit_row_identity().is_some()
+        && !valid_explicit_row_identity(table, result)
+    {
+        return PreviewWriteability::ReadOnly("invalid row identity");
+    }
+    writeability
+}
+
+fn valid_explicit_row_identity(table: &Table, result: &QueryResult) -> bool {
+    let Some(primary_key) = table.primary_key.as_ref() else {
+        return false;
+    };
+    let Some(identity) = result.explicit_row_identity() else {
+        return false;
+    };
+    identity.columns() == primary_key
+        && identity.values().len() == result.data_row_count()
+        && identity
+            .values()
+            .iter()
+            .all(|values| values.len() == primary_key.len())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,7 +248,7 @@ pub fn evaluate_guardrails(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::TableKindInfo;
+    use crate::domain::{QueryResult, QuerySource, TableKindInfo};
     use crate::test_support;
 
     mod guardrail_evaluation {
@@ -255,6 +309,88 @@ mod tests {
             assert_eq!(
                 stable_row_identity_for_table(&table),
                 Some(StableRowIdentity::PrimaryKey(vec!["id".to_string()]))
+            );
+        }
+
+        #[test]
+        fn explicit_identity_uses_values_separate_from_display_columns() {
+            let table = primary_key_table();
+            let result = QueryResult::success_with_values(
+                "SELECT name".to_string(),
+                vec!["name".to_string()],
+                vec![vec![QueryValue::text("alice")]],
+                0,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(vec!["id".to_string()], vec![vec![QueryValue::text("42")]]);
+
+            let identity = stable_row_identity_for_preview(&table, &result).unwrap();
+
+            assert_eq!(
+                identity.identity_pairs_for_row(&result, 0),
+                Some(vec![("id".to_string(), QueryValue::text("42"))])
+            );
+        }
+
+        #[test]
+        fn malformed_explicit_identity_makes_preview_read_only() {
+            let table = primary_key_table();
+            let result = QueryResult::success_with_values(
+                "SELECT name".to_string(),
+                vec!["name".to_string()],
+                vec![vec![QueryValue::text("alice")]],
+                0,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["wrong_id".to_string()],
+                vec![vec![QueryValue::text("42")]],
+            );
+
+            assert_eq!(
+                preview_writeability_for_result(&table, &result),
+                PreviewWriteability::ReadOnly("invalid row identity")
+            );
+            assert!(stable_row_identity_for_preview(&table, &result).is_none());
+        }
+
+        #[test]
+        fn row_count_mismatch_in_explicit_identity_makes_preview_read_only() {
+            let table = primary_key_table();
+            let result = QueryResult::success_with_values(
+                "SELECT name".to_string(),
+                vec!["name".to_string()],
+                vec![vec![QueryValue::text("alice")]],
+                0,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(vec!["id".to_string()], Vec::new());
+
+            assert_eq!(
+                preview_writeability_for_result(&table, &result),
+                PreviewWriteability::ReadOnly("invalid row identity")
+            );
+        }
+
+        #[test]
+        fn value_count_mismatch_in_explicit_identity_makes_preview_read_only() {
+            let mut table = primary_key_table();
+            table.primary_key = Some(vec!["first_id".to_string(), "second_id".to_string()]);
+            let result = QueryResult::success_with_values(
+                "SELECT name".to_string(),
+                vec!["name".to_string()],
+                vec![vec![QueryValue::text("alice")]],
+                0,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["first_id".to_string(), "second_id".to_string()],
+                vec![vec![QueryValue::text("42")]],
+            );
+
+            assert_eq!(
+                preview_writeability_for_result(&table, &result),
+                PreviewWriteability::ReadOnly("invalid row identity")
             );
         }
 

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -103,9 +103,7 @@ fn build_update_preview(
         diff: {
             let database_type = state.session.active_database_type_or_default();
             let column_data_type = state
-                .session
-                .table_detail()
-                .and_then(|td| td.columns.get(col_idx))
+                .visible_preview_column(col_idx)
                 .map_or("", |c| c.data_type.as_str());
             let handling =
                 CellPresentationPolicy::new(database_type, column_data_type, "").diff_handling();
@@ -1040,6 +1038,53 @@ mod tests {
                 preview.diff[0].json_diff.is_some(),
                 "jsonb column should have structured diff"
             );
+        }
+
+        #[test]
+        fn jsonb_diff_uses_visible_column_name_after_hidden_primary_key() {
+            let mut state = editable_state_with_jsonb();
+            let mut detail = jsonb_table_detail();
+            detail.columns[0].attributes = detail.columns[0].attributes
+                | ColumnAttributes::HIDDEN
+                | ColumnAttributes::READ_ONLY;
+            state.session.set_table_detail_raw(Some(detail));
+            state.query.set_current_result(Arc::new(
+                QueryResult::success(
+                    "SELECT `name`, `metadata` FROM `public`.`users`".to_string(),
+                    vec!["name".to_string(), "metadata".to_string()],
+                    vec![vec!["Alice".to_string(), r#"{"role":"admin"}"#.to_string()]],
+                    10,
+                    QuerySource::Preview,
+                )
+                .with_explicit_row_identity(
+                    vec!["id".to_string()],
+                    vec![vec![QueryValue::text("1")]],
+                ),
+            ));
+            state.result_interaction.clear_cell_edit();
+            state.modal.set_mode(InputMode::CellEdit);
+            state
+                .result_interaction
+                .begin_cell_edit(0, 1, r#"{"role":"admin"}"#.to_string());
+            state
+                .result_interaction
+                .replace_cell_edit_draft(r#"{"role":"user"}"#.to_string());
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+            let preview = match &effects[0] {
+                Effect::DispatchActions(actions) => match actions.first().expect("action") {
+                    Action::OpenWritePreviewConfirm(preview) => preview,
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+            assert!(preview.diff[0].json_diff.is_some());
         }
 
         #[test]

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -174,12 +174,12 @@ fn selected_cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
 }
 
 fn selected_column_data_type(state: &AppState, col_idx: usize) -> Option<&str> {
-    let td = state.session.table_detail()?;
-    if !state.query.pagination.matches_table(td) {
+    let table_detail = state.session.table_detail()?;
+    if !state.query.pagination.matches_table(table_detail) {
         return None;
     }
-    td.columns
-        .get(col_idx)
+    state
+        .visible_preview_column(col_idx)
         .map(|column| column.data_type.as_str())
 }
 

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -16,13 +16,13 @@ fn cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
     let Some(col_idx) = state.result_interaction.selection().cell() else {
         return false;
     };
-    let Some(td) = state.session.table_detail() else {
+    let Some(table_detail) = state.session.table_detail() else {
         return false;
     };
-    if !state.query.pagination.matches_table(td) {
+    if !state.query.pagination.matches_table(table_detail) {
         return false;
     }
-    let Some(column) = td.columns.get(col_idx) else {
+    let Some(column) = state.visible_preview_column(col_idx) else {
         return false;
     };
     let policy = CellPresentationPolicy::new(
@@ -478,6 +478,47 @@ mod tests {
             state
         }
 
+        fn state_with_hidden_primary_key_jsonb_column() -> AppState {
+            let mut state = AppState::new("test".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "database",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
+            state.query.set_current_result(Arc::new(
+                QueryResult::success(
+                    String::new(),
+                    vec!["settings".to_string()],
+                    vec![vec![r#"{"theme":"dark"}"#.to_string()]],
+                    1,
+                    QuerySource::Preview,
+                )
+                .with_explicit_row_identity(
+                    vec!["id".to_string()],
+                    vec![vec![QueryValue::text("1")]],
+                ),
+            ));
+            state.query.pagination.reset_for_table("public", "users");
+            state.session.set_table_detail_raw(Some(Table {
+                schema: "public".to_string(),
+                name: "users".to_string(),
+                columns: vec![
+                    Column {
+                        attributes: ColumnAttributes::PRIMARY_KEY
+                            | ColumnAttributes::HIDDEN
+                            | ColumnAttributes::READ_ONLY,
+                        ..test_support::column::test_nullable_column("id", "integer", 1)
+                    },
+                    test_support::column::test_nullable_column("settings", "jsonb", 2),
+                ],
+                primary_key: Some(vec!["id".to_string()]),
+                ..test_support::table::minimal("", "")
+            }));
+            state.result_interaction.activate_cell(0, 0);
+            state
+        }
+
         #[test]
         fn jsonb_cell_returns_dispatch_to_open_jsonb_detail() {
             let mut state = state_with_jsonb_column();
@@ -487,6 +528,20 @@ mod tests {
                 .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
+            assert!(matches!(
+                &effects[0],
+                Effect::DispatchActions(actions) if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonbDetail)])
+            ));
+        }
+
+        #[test]
+        fn jsonb_cell_after_hidden_primary_key_dispatches_to_detail() {
+            let mut state = state_with_hidden_primary_key_jsonb_column();
+
+            let effects = reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
             assert!(matches!(
                 &effects[0],
                 Effect::DispatchActions(actions) if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonbDetail)])

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -26,15 +26,14 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 _ => return DispatchResult::handled(),
             };
 
-            let table_detail = match state.session.table_detail() {
-                Some(td)
-                    if td.schema == state.query.pagination.schema()
-                        && td.name == state.query.pagination.table() =>
-                {
-                    td
-                }
-                _ => return DispatchResult::handled(),
+            let Some(table_detail) = state.session.table_detail() else {
+                return DispatchResult::handled();
             };
+            if table_detail.schema != state.query.pagination.schema()
+                || table_detail.name != state.query.pagination.table()
+            {
+                return DispatchResult::handled();
+            }
 
             let Some(row_idx) = state.result_interaction.selection().row() else {
                 return DispatchResult::handled();
@@ -44,7 +43,7 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
             };
 
             let database_type = state.session.active_database_type_or_default();
-            let Some(column) = table_detail.columns.get(col_idx) else {
+            let Some(column) = state.visible_preview_column(col_idx) else {
                 return DispatchResult::handled();
             };
             let policy = CellPresentationPolicy::new(database_type, column.data_type.as_str(), "");
@@ -455,6 +454,38 @@ mod tests {
         state
     }
 
+    fn state_with_hidden_primary_key_jsonb_value() -> AppState {
+        let mut state = state_with_jsonb_value(r#"{"theme":"dark"}"#);
+        state.query.set_current_result(Arc::new(
+            QueryResult::success(
+                String::new(),
+                vec!["settings".to_string()],
+                vec![vec![r#"{"theme":"dark"}"#.to_string()]],
+                1,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(vec!["id".to_string()], vec![vec![QueryValue::text("1")]]),
+        ));
+        state.query.pagination.reset_for_table("public", "users");
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "public".to_string(),
+            name: "users".to_string(),
+            columns: vec![
+                Column {
+                    attributes: ColumnAttributes::PRIMARY_KEY
+                        | ColumnAttributes::HIDDEN
+                        | ColumnAttributes::READ_ONLY,
+                    ..test_support::column::test_nullable_column("id", "integer", 1)
+                },
+                test_support::column::test_nullable_column("settings", "jsonb", 2),
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..test_support::table::minimal("", "")
+        }));
+        state.result_interaction.activate_cell(0, 0);
+        state
+    }
+
     fn open_detail(state: &mut AppState) {
         reduce_jsonb(
             state,
@@ -720,6 +751,16 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::JsonbDetail);
             assert_eq!(state.jsonb_detail.mode(), JsonbDetailMode::Viewing);
+        }
+
+        #[test]
+        fn hidden_primary_key_does_not_shift_jsonb_detail_column() {
+            let mut state = state_with_hidden_primary_key_jsonb_value();
+
+            open_detail(&mut state);
+
+            assert!(state.jsonb_detail.is_active());
+            assert_eq!(state.jsonb_detail.column_name(), "settings");
         }
 
         #[test]

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -11,7 +11,7 @@ use crate::model::connection::setup::{ConnectionField, ConnectionSetupState};
 use crate::policy::write::inline_cell_edit::InlineCellEditError;
 use crate::policy::write::write_guardrails::{
     PreviewWriteability, StableRowIdentity, TargetSummary, WriteOperation, WritePreview,
-    evaluate_guardrails, preview_writeability, stable_row_identity_for_table,
+    evaluate_guardrails, preview_writeability_for_result, stable_row_identity_for_preview,
 };
 use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::services::AppServices;
@@ -135,7 +135,7 @@ pub fn editable_preview_base(
     if !state.query.pagination.matches_table(table_detail) {
         return Err(EditGuardrailError::StaleTableMetadata);
     }
-    match preview_writeability(table_detail) {
+    match preview_writeability_for_result(table_detail, result) {
         PreviewWriteability::Writable => {}
         PreviewWriteability::ReadOnly(reason) => {
             return Err(EditGuardrailError::ReadOnlyPreviewTarget(reason));
@@ -144,7 +144,7 @@ pub fn editable_preview_base(
             return Err(EditGuardrailError::EditingRequiresPrimaryKey);
         }
     }
-    let identity = stable_row_identity_for_table(table_detail)
+    let identity = stable_row_identity_for_preview(table_detail, result)
         .ok_or(EditGuardrailError::EditingRequiresPrimaryKey)?;
 
     Ok((result, identity))

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -30,7 +30,7 @@ pub use explain_plan::{
 pub use foreign_key::{FkAction, ForeignKey, UNRESOLVED_FK_COLUMN};
 pub use index::{Index, IndexAttributes, IndexType};
 pub use metadata::{DatabaseMetadata, MetadataState};
-pub use query_result::{QueryResult, QuerySource, QueryValue, RefreshScope};
+pub use query_result::{ExplicitRowIdentity, QueryResult, QuerySource, QueryValue, RefreshScope};
 pub use rls::{RlsCommand, RlsInfo, RlsPolicy};
 pub use schema::Schema;
 pub use sqlite_diagnostics::{DiagnosticField, SqliteDiagnosticsSnapshot};

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -222,6 +222,29 @@ pub enum QuerySource {
     Adhoc,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExplicitRowIdentity {
+    columns: Vec<String>,
+    values: Vec<Vec<QueryValue>>,
+}
+
+impl ExplicitRowIdentity {
+    #[must_use]
+    pub fn columns(&self) -> &[String] {
+        &self.columns
+    }
+
+    #[must_use]
+    pub fn values(&self) -> &[Vec<QueryValue>] {
+        &self.values
+    }
+
+    #[must_use]
+    pub fn values_for_row(&self, row: usize) -> Option<&[QueryValue]> {
+        self.values.get(row).map(Vec::as_slice)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum RefreshScope {
     None,
@@ -247,6 +270,7 @@ pub struct QueryResult {
     pub refresh_scope: RefreshScope,
     rows: Vec<Vec<String>>,
     values: Vec<Vec<QueryValue>>,
+    explicit_row_identity: Option<ExplicitRowIdentity>,
     row_count: usize,
     typed_values: bool,
 }
@@ -270,6 +294,7 @@ impl QueryResult {
             columns,
             rows,
             values,
+            explicit_row_identity: None,
             row_count,
             typed_values: false,
             execution_time_ms,
@@ -294,6 +319,7 @@ impl QueryResult {
             columns,
             rows: Vec::new(),
             values,
+            explicit_row_identity: None,
             row_count,
             typed_values: true,
             execution_time_ms,
@@ -316,6 +342,7 @@ impl QueryResult {
             columns: Vec::new(),
             rows: Vec::new(),
             values: Vec::new(),
+            explicit_row_identity: None,
             row_count: 0,
             typed_values: false,
             execution_time_ms,
@@ -342,6 +369,16 @@ impl QueryResult {
     #[must_use]
     pub fn with_row_count(mut self, row_count: usize) -> Self {
         self.row_count = row_count;
+        self
+    }
+
+    #[must_use]
+    pub fn with_explicit_row_identity(
+        mut self,
+        columns: Vec<String>,
+        values: Vec<Vec<QueryValue>>,
+    ) -> Self {
+        self.explicit_row_identity = Some(ExplicitRowIdentity { columns, values });
         self
     }
 
@@ -399,6 +436,11 @@ impl QueryResult {
     #[must_use]
     pub fn values(&self) -> &[Vec<QueryValue>] {
         &self.values
+    }
+
+    #[must_use]
+    pub fn explicit_row_identity(&self) -> Option<&ExplicitRowIdentity> {
+        self.explicit_row_identity.as_ref()
     }
 
     #[must_use]
@@ -601,6 +643,30 @@ mod tests {
             assert_eq!(result.columns, vec!["body"]);
             assert_eq!(result.values(), &[vec![QueryValue::text("body")]]);
             assert_eq!(result.display_row_at(0), Some(vec!["body".to_string()]));
+        }
+
+        #[test]
+        fn explicit_identity_is_not_part_of_display_rows_or_column_count() {
+            let result = QueryResult::success_with_values(
+                "SELECT payload".to_string(),
+                vec!["payload".to_string()],
+                vec![vec![QueryValue::text("visible")]],
+                0,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["id".to_string()],
+                vec![vec![QueryValue::SqlLiteral("42".to_string())]],
+            );
+
+            assert_eq!(result.column_count(), 1);
+            assert_eq!(result.display_row_at(0), Some(vec!["visible".to_string()]));
+            assert_eq!(
+                result
+                    .explicit_row_identity()
+                    .and_then(|identity| identity.values_for_row(0)),
+                Some([QueryValue::SqlLiteral("42".to_string())].as_slice())
+            );
         }
     }
 

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -96,6 +96,16 @@ impl QueryExecutor for MySqlAdapter {
             table,
             &preview.order_columns,
             &preview.visible_columns,
+            &preview.identity_columns,
+            limit,
+            offset,
+        );
+        let display_query = metadata::build_preview_query(
+            schema,
+            table,
+            &preview.order_columns,
+            &preview.visible_columns,
+            &[],
             limit,
             offset,
         );
@@ -118,20 +128,35 @@ impl QueryExecutor for MySqlAdapter {
                 "MySQL preview query returned no result set".to_string(),
             )
         })?;
-        let values = metadata::convert_preview_values(&result_set, &preview.visible_columns)?;
+        let values = metadata::convert_preview_values(
+            &result_set,
+            &preview.visible_columns,
+            &preview.identity_columns,
+        )?;
         let elapsed = start.elapsed().as_millis() as u64;
 
-        Ok(QueryResult::success_with_values(
-            query,
+        let mut query_result = QueryResult::success_with_values(
+            display_query,
             preview
                 .visible_columns
                 .iter()
                 .map(|column| column.name.clone())
                 .collect(),
-            values,
+            values.visible,
             elapsed,
             QuerySource::Preview,
-        ))
+        );
+        if let Some(identity_values) = values.identity {
+            query_result = query_result.with_explicit_row_identity(
+                preview
+                    .identity_columns
+                    .iter()
+                    .map(|column| column.name.clone())
+                    .collect(),
+                identity_values,
+            );
+        }
+        Ok(query_result)
     }
 
     async fn execute_adhoc(

--- a/src/infra/adapters/mysql/metadata.rs
+++ b/src/infra/adapters/mysql/metadata.rs
@@ -13,6 +13,7 @@ use super::{
 };
 
 const TABLES_QUERY: &str = "SELECT TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') UNION ALL SELECT NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')) ORDER BY TABLE_NAME";
+const PREVIEW_IDENTITY_ALIAS_PREFIX: &str = "__sabiql_row_identity_";
 
 #[derive(Debug, Clone)]
 struct MysqlColumnMetadata {
@@ -55,6 +56,13 @@ struct MysqlForeignKeyMetadata {
 pub(super) struct PreviewMetadata {
     pub visible_columns: Vec<Column>,
     pub order_columns: Vec<String>,
+    pub identity_columns: Vec<Column>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ConvertedPreviewValues {
+    pub visible: Vec<Vec<QueryValue>>,
+    pub identity: Option<Vec<Vec<QueryValue>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -156,7 +164,22 @@ pub(super) async fn fetch_preview_metadata(
             "MySQL object has no visible columns: {schema}.{table}"
         )));
     }
-    let order_columns = primary_key_names(&column_metadata);
+    let primary_key_names = primary_key_names(&column_metadata);
+    let identity_columns = if primary_key_names.iter().any(|name| {
+        columns
+            .iter()
+            .find(|column| &column.name == name)
+            .is_some_and(Column::is_hidden)
+    }) {
+        primary_key_names
+            .iter()
+            .filter_map(|name| columns.iter().find(|column| &column.name == name))
+            .cloned()
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let order_columns = primary_key_names;
     let order_columns = if order_columns.is_empty() {
         visible_columns
             .iter()
@@ -168,6 +191,7 @@ pub(super) async fn fetch_preview_metadata(
     Ok(PreviewMetadata {
         visible_columns,
         order_columns,
+        identity_columns,
     })
 }
 
@@ -176,12 +200,29 @@ pub(super) fn build_preview_query(
     table: &str,
     order_columns: &[String],
     visible_columns: &[Column],
+    identity_columns: &[Column],
     limit: usize,
     offset: usize,
 ) -> String {
-    let columns = visible_columns
+    let visible_select = visible_columns
         .iter()
         .map(|column| quote_identifier(&column.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let identity_select = identity_columns
+        .iter()
+        .enumerate()
+        .map(|(index, column)| {
+            format!(
+                "{} AS {}",
+                quote_identifier(&column.name),
+                quote_identifier(&preview_identity_alias(index)),
+            )
+        })
+        .collect::<Vec<_>>();
+    let columns = std::iter::once(visible_select)
+        .chain(identity_select)
+        .filter(|select| !select.is_empty())
         .collect::<Vec<_>>()
         .join(", ");
     let order_by = order_columns
@@ -199,35 +240,65 @@ pub(super) fn build_preview_query(
 pub(super) fn convert_preview_values(
     result: &MysqlResultSet,
     columns: &[Column],
-) -> Result<Vec<Vec<QueryValue>>, DbOperationError> {
+    identity_columns: &[Column],
+) -> Result<ConvertedPreviewValues, DbOperationError> {
+    let expected_columns = columns
+        .iter()
+        .map(|column| column.name.clone())
+        .chain(
+            identity_columns
+                .iter()
+                .enumerate()
+                .map(|(index, _)| preview_identity_alias(index)),
+        )
+        .collect::<Vec<_>>();
     if result.values.is_empty() {
-        if result.columns.is_empty() || result.columns.len() == columns.len() {
-            return Ok(Vec::new());
+        if result.columns.is_empty() || result.columns == expected_columns {
+            return Ok(ConvertedPreviewValues {
+                visible: Vec::new(),
+                identity: (!identity_columns.is_empty()).then(Vec::new),
+            });
         }
         return Err(DbOperationError::MetadataParseFailed(
             "MySQL preview returned an unexpected column count".to_string(),
         ));
     }
-    if result.columns.len() != columns.len() {
+    if result.columns != expected_columns {
         return Err(DbOperationError::MetadataParseFailed(
-            "MySQL preview returned an unexpected column count".to_string(),
+            "MySQL preview returned unexpected columns".to_string(),
         ));
     }
-    result
+    let rows = result
         .values
         .iter()
         .map(|row| {
-            if row.len() != columns.len() {
+            if row.len() != expected_columns.len() {
                 return Err(DbOperationError::MetadataParseFailed(
                     "MySQL preview returned an unexpected row width".to_string(),
                 ));
             }
             row.iter()
-                .zip(columns)
+                .zip(columns.iter().chain(identity_columns))
                 .map(|(value, column)| Ok(convert_preview_value(value, &column.data_type)))
-                .collect()
+                .collect::<Result<Vec<_>, _>>()
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    let (visible, identity) = rows.into_iter().fold(
+        (Vec::new(), (!identity_columns.is_empty()).then(Vec::new)),
+        |(mut visible, mut identity), row| {
+            let (visible_row, identity_row) = row.split_at(columns.len());
+            visible.push(visible_row.to_vec());
+            if let Some(identity) = identity.as_mut() {
+                identity.push(identity_row.to_vec());
+            }
+            (visible, identity)
+        },
+    );
+    Ok(ConvertedPreviewValues { visible, identity })
+}
+
+fn preview_identity_alias(index: usize) -> String {
+    format!("{PREVIEW_IDENTITY_ALIAS_PREFIX}{index}")
 }
 
 fn convert_preview_value(value: &QueryValue, data_type: &str) -> QueryValue {
@@ -1162,10 +1233,10 @@ mod tests {
             column("binary_value", "blob"),
         ];
 
-        let values = convert_preview_values(&result, &columns).expect("conversion succeeds");
+        let values = convert_preview_values(&result, &columns, &[]).expect("conversion succeeds");
 
-        assert_eq!(values[0][0], QueryValue::Text("0x41".to_string()));
-        assert_eq!(values[0][1], QueryValue::Blob(vec![0, 255]));
+        assert_eq!(values.visible[0][0], QueryValue::Text("0x41".to_string()));
+        assert_eq!(values.visible[0][1], QueryValue::Blob(vec![0, 255]));
     }
 
     #[test]
@@ -1184,12 +1255,12 @@ mod tests {
             column("float_value", "double"),
         ];
 
-        let values = convert_preview_values(&result, &columns).expect("conversion succeeds");
+        let values = convert_preview_values(&result, &columns, &[]).expect("conversion succeeds");
 
-        assert_eq!(values[0][0].as_str(), Some("18446744073709551615"));
-        assert!(matches!(values[0][0], QueryValue::SqlLiteral(_)));
-        assert!(matches!(values[0][1], QueryValue::SqlLiteral(_)));
-        assert!(matches!(values[0][2], QueryValue::SqlLiteral(_)));
+        assert_eq!(values.visible[0][0].as_str(), Some("18446744073709551615"));
+        assert!(matches!(values.visible[0][0], QueryValue::SqlLiteral(_)));
+        assert!(matches!(values.visible[0][1], QueryValue::SqlLiteral(_)));
+        assert!(matches!(values.visible[0][2], QueryValue::SqlLiteral(_)));
     }
 
     #[test]
@@ -1205,11 +1276,65 @@ mod tests {
     fn preview_query_lists_visible_columns_and_orders_by_primary_key() {
         let columns = vec![column("id", "int"), column("display", "text")];
 
-        let query = build_preview_query("app", "items", &["id".to_string()], &columns, 500, 1000);
+        let query = build_preview_query(
+            "app",
+            "items",
+            &["id".to_string()],
+            &columns,
+            &[],
+            500,
+            1000,
+        );
 
         assert_eq!(
             query,
             "SELECT `id`, `display` FROM `app`.`items` ORDER BY `id` LIMIT 500 OFFSET 1000"
+        );
+    }
+
+    #[test]
+    fn preview_query_appends_aliased_hidden_primary_key_columns() {
+        let visible_columns = vec![column("payload", "text")];
+        let identity_columns = vec![column("id", "int")];
+
+        let query = build_preview_query(
+            "app",
+            "items",
+            &["id".to_string()],
+            &visible_columns,
+            &identity_columns,
+            10,
+            0,
+        );
+
+        assert_eq!(
+            query,
+            "SELECT `payload`, `id` AS `__sabiql_row_identity_0` FROM `app`.`items` ORDER BY `id` LIMIT 10 OFFSET 0"
+        );
+    }
+
+    #[test]
+    fn preview_conversion_separates_aliased_primary_key_values() {
+        let result = result(
+            &["payload", "__sabiql_row_identity_0"],
+            vec![vec![
+                QueryValue::Text("visible".to_string()),
+                QueryValue::Text("42".to_string()),
+            ]],
+        );
+        let visible_columns = vec![column("payload", "text")];
+        let identity_columns = vec![column("id", "int")];
+
+        let values = convert_preview_values(&result, &visible_columns, &identity_columns)
+            .expect("conversion succeeds");
+
+        assert_eq!(
+            values.visible,
+            vec![vec![QueryValue::Text("visible".to_string())]]
+        );
+        assert_eq!(
+            values.identity,
+            Some(vec![vec![QueryValue::SqlLiteral("42".to_string())]])
         );
     }
 

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -29,6 +29,9 @@ fn mysql_tls_profile(name: &str, config: MySqlConnectionConfig) -> ConnectionPro
 }
 
 const MYSQL_COMPOSITE_TABLE: &str = "mysql_preview_composite";
+const MYSQL_INVISIBLE_PK_TABLE: &str = "mysql_edit_invisible_pk";
+const MYSQL_INVISIBLE_COMPOSITE_TABLE: &str = "mysql_edit_invisible_composite";
+const MYSQL_GIPK_TABLE: &str = "mysql_edit_gipk";
 const MYSQL_NO_PK_TABLE: &str = "mysql_preview_no_pk";
 const MYSQL_EMPTY_TABLE: &str = "mysql_preview_empty";
 const MYSQL_VIEW: &str = "mysql_preview_view";
@@ -496,6 +499,136 @@ async fn previews_empty_mysql_table_with_metadata_columns() {
                 .map_err(|error| format!("{error:?}"))?;
             if result.columns != ["id", "payload"] || !result.values().is_empty() {
                 return Err(format!("unexpected empty preview: {result:?}"));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn previews_and_writes_rows_using_hidden_mysql_primary_keys() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let invisible = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_INVISIBLE_PK_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("failed to preview invisible primary key: {error:?}"))?;
+            if invisible.columns != ["payload"]
+                || invisible.query.contains("__sabiql_row_identity_")
+                || invisible.values()
+                    != [[QueryValue::Text("invisible single primary key".to_string())]]
+            {
+                return Err(format!(
+                    "unexpected invisible primary key preview: {invisible:?}"
+                ));
+            }
+            let identity = invisible
+                .explicit_row_identity()
+                .ok_or_else(|| "invisible primary key identity was not returned".to_string())?;
+            if identity.columns() != ["id"]
+                || identity.values() != [[QueryValue::SqlLiteral("1".to_string())]]
+            {
+                return Err(format!(
+                    "unexpected invisible primary key identity: {identity:?}"
+                ));
+            }
+
+            let composite = db
+                .adapter()
+                .execute_preview(
+                    db.dsn(),
+                    "sabiql_test",
+                    MYSQL_INVISIBLE_COMPOSITE_TABLE,
+                    10,
+                    0,
+                )
+                .await
+                .map_err(|error| format!("failed to preview invisible composite key: {error:?}"))?;
+            let composite_identity = composite
+                .explicit_row_identity()
+                .ok_or_else(|| "invisible composite identity was not returned".to_string())?;
+            if composite.columns != ["payload"]
+                || composite.query.contains("__sabiql_row_identity_")
+                || composite_identity.columns() != ["second_key", "first_key"]
+                || composite_identity.values()
+                    != [[
+                        QueryValue::SqlLiteral("20".to_string()),
+                        QueryValue::SqlLiteral("1".to_string()),
+                    ]]
+            {
+                return Err(format!(
+                    "unexpected invisible composite preview: {composite:?}"
+                ));
+            }
+
+            let gipk_detail = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_GIPK_TABLE)
+                .await
+                .map_err(|error| format!("failed to fetch GIPK metadata: {error:?}"))?;
+            if gipk_detail.primary_key != Some(vec!["my_row_id".to_string()]) {
+                return Err(format!(
+                    "GIPK was not exposed by INFORMATION_SCHEMA: {:?}",
+                    gipk_detail.primary_key
+                ));
+            }
+            let gipk = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_GIPK_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("failed to preview GIPK: {error:?}"))?;
+            if gipk.columns != ["payload"]
+                || gipk.query.contains("__sabiql_row_identity_")
+                || gipk
+                    .explicit_row_identity()
+                    .is_none_or(|identity| identity.columns() != ["my_row_id"])
+            {
+                return Err(format!("unexpected GIPK preview: {gipk:?}"));
+            }
+
+            let update_sql = db.adapter().build_update_sql(
+                DatabaseType::MySQL,
+                "sabiql_test",
+                MYSQL_GIPK_TABLE,
+                "payload",
+                &QueryValue::text("updated through GIPK"),
+                &[(
+                    "my_row_id".to_string(),
+                    QueryValue::SqlLiteral("1".to_string()),
+                )],
+            );
+            let update = db
+                .adapter()
+                .execute_write(db.dsn(), &update_sql, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| format!("failed to update through GIPK: {error:?}"))?;
+            if update.affected_rows != 1 {
+                return Err(format!("unexpected GIPK update result: {update:?}"));
+            }
+
+            let delete_sql = db.adapter().build_bulk_delete_sql(
+                DatabaseType::MySQL,
+                "sabiql_test",
+                MYSQL_INVISIBLE_PK_TABLE,
+                &[vec![(
+                    "id".to_string(),
+                    QueryValue::SqlLiteral("1".to_string()),
+                )]],
+            );
+            let delete = db
+                .adapter()
+                .execute_write(db.dsn(), &delete_sql, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| {
+                    format!("failed to delete through invisible primary key: {error:?}")
+                })?;
+            if delete.affected_rows != 1 {
+                return Err(format!(
+                    "unexpected invisible primary key delete result: {delete:?}"
+                ));
             }
             Ok(())
         })


### PR DESCRIPTION
## Problem
MySQL invisible primary keys and generated invisible primary keys are omitted from `SELECT *`, so grid writes cannot target their rows without exposing key columns.

## Background
The existing write path derives row identity from displayed result columns. GIPK support must follow the primary-key metadata exposed by `INFORMATION_SCHEMA` and must not guess a key when metadata is unavailable.

## Approach
Preview results keep visible columns and values separate from an optional explicit row identity. MySQL appends internal aliases for hidden primary-key values, preserves parsed `QueryValue`s for writes, and the write guardrails reject stale or malformed identity shapes. The display query remains free of internal aliases so copy, CSV, row details, and query reuse stay visible-only.

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
- `./scripts/lint_all.sh`
- release builds with and without default features
- focused unit tests, snapshot checks, and MySQL integration test compilation
- Workspace nextest has one pre-existing SQLite CSV test failure; no-default nextest passes.
- Oracle MySQL 8.4 integration execution is blocked by a Docker containerd I/O error while pulling `mysql:8.4.10`.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-394
