### PR TITLE
feat(mysql): enable JSON document updates

### DIFF
--- a/src/app/model/browse/jsonb_detail.rs
+++ b/src/app/model/browse/jsonb_detail.rs
@@ -145,9 +145,6 @@ impl JsonbDetailState {
 
     pub fn has_pending_changes(&self) -> bool {
         let content = self.editor.content();
-        if content.is_empty() {
-            return false;
-        }
         let trimmed = content.trim();
         trimmed != self.original_json().trim() && trimmed != self.pretty_original().trim()
     }

--- a/src/app/model/shared/engine_feature_profile.rs
+++ b/src/app/model/shared/engine_feature_profile.rs
@@ -131,6 +131,7 @@ const SQLITE_FEATURES: &[ConnectionFeature] = &[ConnectionFeature::SqliteDiagnos
 const MYSQL_FEATURES: &[ConnectionFeature] = &[
     ConnectionFeature::ErDiagram,
     ConnectionFeature::JsonDocumentDetail,
+    ConnectionFeature::JsonDocumentEdit,
 ];
 
 impl EngineFeatureProfile {
@@ -467,7 +468,7 @@ mod tests {
         assert!(profile.supports_plan_comparison());
         assert!(profile.supports_er_diagram());
         assert!(profile.supports_json_document_detail());
-        assert!(!profile.supports_json_document_edit());
+        assert!(profile.supports_json_document_edit());
         assert!(!profile.supports_sqlite_diagnostics());
         assert_eq!(
             profile.supported_inspector_tabs(),

--- a/src/app/policy/preview_cell_text/diff.rs
+++ b/src/app/policy/preview_cell_text/diff.rs
@@ -1,9 +1,13 @@
 use super::handling::PreviewCellTextDiffHandling;
 
 fn normalize_jsonb_for_diff(value: &str) -> String {
-    serde_json::from_str::<serde_json::Value>(value)
-        .and_then(|v| serde_json::to_string(&v))
-        .unwrap_or_else(|_| value.to_string())
+    normalize_structured_json_for_write(value)
+        .ok()
+        .unwrap_or_else(|| value.to_string())
+}
+
+pub fn normalize_structured_json_for_write(value: &str) -> Result<String, serde_json::Error> {
+    serde_json::from_str::<serde_json::Value>(value).and_then(|value| serde_json::to_string(&value))
 }
 
 pub fn normalize_for_write_diff(value: &str, handling: PreviewCellTextDiffHandling) -> String {

--- a/src/app/policy/preview_cell_text/mod.rs
+++ b/src/app/policy/preview_cell_text/mod.rs
@@ -2,6 +2,8 @@ mod diff;
 mod display;
 mod handling;
 
-pub use diff::{normalize_for_write_diff, uses_structured_json_diff};
+pub use diff::{
+    normalize_for_write_diff, normalize_structured_json_for_write, uses_structured_json_diff,
+};
 pub use display::format_for_cell_detail;
 pub use handling::CellPresentationPolicy;

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -9,7 +9,8 @@ use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::json::json_diff::compute_json_diff;
 use crate::policy::preview_cell_text::{
-    CellPresentationPolicy, normalize_for_write_diff, uses_structured_json_diff,
+    CellPresentationPolicy, normalize_for_write_diff, normalize_structured_json_for_write,
+    uses_structured_json_diff,
 };
 use crate::policy::write::inline_cell_edit::build_inline_edited_value;
 use crate::policy::write::write_guardrails::{
@@ -66,6 +67,24 @@ fn build_update_preview(
         state.result_interaction.cell_edit().draft_value(),
     )?;
 
+    let database_type = state.session.active_database_type_or_default();
+    let column_data_type = state
+        .visible_preview_column(col_idx)
+        .map_or("", |c| c.data_type.as_str());
+    let handling = CellPresentationPolicy::new(database_type, column_data_type, "").diff_handling();
+    if uses_structured_json_diff(handling) {
+        let before = normalize_structured_json_for_write(
+            state.result_interaction.cell_edit().original_value(),
+        )
+        .map_err(|error| EditGuardrailError::InvalidJson(error.to_string()))?;
+        let after =
+            normalize_structured_json_for_write(state.result_interaction.cell_edit().draft_value())
+                .map_err(|error| EditGuardrailError::InvalidJson(error.to_string()))?;
+        if before == after {
+            return Err(EditGuardrailError::NoSemanticChanges);
+        }
+    }
+
     let identity_pairs = identity.identity_pairs_for_row(result, row_idx);
     if let Some(pairs) = identity_pairs.as_deref() {
         reject_sqlite_null_pk(state.session.active_database_type_or_default(), pairs)?;
@@ -101,12 +120,6 @@ fn build_update_preview(
         sql,
         target_summary: target,
         diff: {
-            let database_type = state.session.active_database_type_or_default();
-            let column_data_type = state
-                .visible_preview_column(col_idx)
-                .map_or("", |c| c.data_type.as_str());
-            let handling =
-                CellPresentationPolicy::new(database_type, column_data_type, "").diff_handling();
             let before = normalize_for_write_diff(
                 state.result_interaction.cell_edit().original_value(),
                 handling,

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -1572,6 +1572,39 @@ mod tests {
         }
 
         #[test]
+        fn empty_mysql_json_editor_is_rejected_before_write_preview() {
+            let mut state = state_with_mysql_json_value(r#"{"theme":"dark"}"#);
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state.jsonb_detail.editor_mut().set_content(String::new());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+
+            assert!(effects.is_empty());
+            assert!(
+                state
+                    .messages
+                    .last_error()
+                    .is_some_and(|error| error.starts_with("Invalid JSON:"))
+            );
+        }
+
+        #[test]
         fn semantically_unchanged_mysql_json_is_not_written() {
             let mut state = state_with_mysql_json_value(r#"{"a":1,"b":2}"#);
             let services = AppServices::stub();

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -376,23 +376,22 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
 
     let content = state.jsonb_detail.editor().content().to_string();
 
-    if let Ok(compact) = serde_json::from_str::<serde_json::Value>(&content) {
-        let compact_str = serde_json::to_string(&compact).unwrap_or_else(|_| content.clone());
-        let row = state.jsonb_detail.row();
-        let col = state.jsonb_detail.col();
-        let original_cell = state
-            .query
-            .visible_result()
-            .and_then(|result| result.display_value_at(row, col))
-            .unwrap_or_default();
-        state
-            .result_interaction
-            .begin_cell_edit(row, col, original_cell);
-        state.result_interaction.clear_write_preview();
-        state
-            .result_interaction
-            .replace_cell_edit_draft(compact_str);
-    }
+    let compact = serde_json::from_str::<serde_json::Value>(&content)
+        .ok()
+        .and_then(|value| serde_json::to_string(&value).ok())
+        .unwrap_or(content);
+    let row = state.jsonb_detail.row();
+    let col = state.jsonb_detail.col();
+    let original_cell = state
+        .query
+        .visible_result()
+        .and_then(|result| result.display_value_at(row, col))
+        .unwrap_or_default();
+    state
+        .result_interaction
+        .begin_cell_edit(row, col, original_cell);
+    state.result_interaction.clear_write_preview();
+    state.result_interaction.replace_cell_edit_draft(compact);
 }
 
 #[cfg(test)]
@@ -402,7 +401,8 @@ mod tests {
 
     use super::*;
     pub use crate::domain::Column;
-    use crate::domain::{QueryResult, QuerySource, Table};
+    use crate::domain::connection::ConnectionId;
+    use crate::domain::{DatabaseType, QueryResult, QuerySource, Table};
     use crate::services::AppServices;
     use crate::update::action::TextKillDirection;
     use std::sync::Arc;
@@ -515,8 +515,6 @@ mod tests {
 
     mod entry_guards {
         use super::*;
-        use crate::domain::DatabaseType;
-        use crate::domain::connection::ConnectionId;
         use rstest::rstest;
 
         #[test]
@@ -736,7 +734,7 @@ mod tests {
         }
 
         #[test]
-        fn mysql_json_detail_does_not_start_edit_mode() {
+        fn mysql_json_detail_starts_edit_mode() {
             let mut state = state_with_mysql_json_value(r#"{"key":"value"}"#);
             let services = AppServices::stub();
             let now = Instant::now();
@@ -749,8 +747,8 @@ mod tests {
             );
             reduce(&mut state, Action::JsonbEnterEdit, now, &services);
 
-            assert_eq!(state.input_mode(), InputMode::JsonbDetail);
-            assert_eq!(state.jsonb_detail.mode(), JsonbDetailMode::Viewing);
+            assert_eq!(state.input_mode(), InputMode::JsonbEdit);
+            assert_eq!(state.jsonb_detail.mode(), JsonbDetailMode::Editing);
         }
 
         #[test]
@@ -1449,6 +1447,202 @@ mod tests {
                 state.confirm_dialog.intent(),
                 Some(ConfirmIntent::ExecuteWrite { blocked: false, .. })
             ));
+        }
+
+        #[test]
+        fn mysql_json_edit_close_can_continue_to_write_preview() {
+            let mut state = state_with_mysql_json_value(r#"{"theme":"dark"}"#);
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content(r#"{"theme":"light"}"#.to_string());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+            let preview = match effects.first() {
+                Some(Effect::DispatchActions(actions)) => match actions.first() {
+                    Some(Action::OpenWritePreviewConfirm(preview)) => preview,
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+
+            assert_eq!(
+                preview.sql,
+                "UPDATE `public`.`users` SET `settings` = '{\"theme\":\"light\"}' WHERE `id` = '1'"
+            );
+        }
+
+        #[test]
+        fn mysql_json_edit_uses_explicit_hidden_row_identity() {
+            let mut state = state_with_hidden_primary_key_jsonb_value();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("mysql-test"),
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://localhost/test",
+            );
+            let mut detail = state.session.table_detail().cloned().expect("table detail");
+            detail.columns[1].data_type = "json".to_string();
+            state.session.set_table_detail_raw(Some(detail));
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content(r#"{"theme":"light"}"#.to_string());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+            let preview = match effects.first() {
+                Some(Effect::DispatchActions(actions)) => match actions.first() {
+                    Some(Action::OpenWritePreviewConfirm(preview)) => preview,
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+
+            assert!(preview.sql.contains("WHERE `id` = '1'"));
+        }
+
+        #[test]
+        fn invalid_mysql_json_is_rejected_before_write_preview() {
+            let mut state = state_with_mysql_json_value(r#"{"theme":"dark"}"#);
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content("{invalid}".to_string());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+
+            assert!(effects.is_empty());
+            assert!(
+                state
+                    .messages
+                    .last_error()
+                    .is_some_and(|error| error.starts_with("Invalid JSON:"))
+            );
+        }
+
+        #[test]
+        fn semantically_unchanged_mysql_json_is_not_written() {
+            let mut state = state_with_mysql_json_value(r#"{"a":1,"b":2}"#);
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content("{ \"b\": 2, \"a\": 1 }".to_string());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.messages.last_error(),
+                Some("No semantic changes to write")
+            );
+        }
+
+        #[test]
+        fn mysql_json_null_and_string_null_use_distinct_literals() {
+            let mut state = state_with_mysql_json_value("null");
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content(r#""null""#.to_string());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+            let preview = match effects.first() {
+                Some(Effect::DispatchActions(actions)) => match actions.first() {
+                    Some(Action::OpenWritePreviewConfirm(preview)) => preview,
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+
+            assert_eq!(
+                preview.sql,
+                "UPDATE `public`.`users` SET `settings` = '\"null\"' WHERE `id` = '1'"
+            );
         }
     }
 }

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -81,6 +81,10 @@ pub enum EditGuardrailError {
     NoActiveCell,
     #[error("Cell index out of bounds")]
     CellIndexOutOfBounds,
+    #[error("Invalid JSON: {0}")]
+    InvalidJson(String),
+    #[error("No semantic changes to write")]
+    NoSemanticChanges,
     #[error(transparent)]
     InlineCellEdit(#[from] InlineCellEditError),
     #[error("SQLite writes require non-NULL primary key values")]

--- a/src/app/update/input/handlers/jsonb.rs
+++ b/src/app/update/input/handlers/jsonb.rs
@@ -387,7 +387,7 @@ mod tests {
         }
 
         #[test]
-        fn mysql_json_detail_keeps_view_actions_and_hides_edit() {
+        fn mysql_json_detail_keeps_view_actions_and_enables_edit() {
             let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::mysql_like());
 
             assert!(matches!(
@@ -415,7 +415,7 @@ mod tests {
                     None,
                     &feature_policy,
                 ),
-                Action::None
+                Action::JsonbEnterEdit
             ));
         }
 
@@ -563,12 +563,15 @@ mod tests {
         }
 
         #[test]
-        fn mysql_json_edit_mode_rejects_editing_keys() {
+        fn mysql_json_edit_mode_accepts_editing_keys() {
             let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::mysql_like());
 
             assert!(matches!(
                 handle_jsonb_edit_keys_with_policy(combo(Key::Char('a')), &feature_policy),
-                Action::None
+                Action::TextInput {
+                    target: InputTarget::JsonbEdit,
+                    ch: 'a',
+                }
             ));
             assert!(matches!(
                 handle_jsonb_edit_keys_with_policy(combo(Key::Esc), &feature_policy),

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -489,6 +489,31 @@ mod write_sql_tests {
     }
 
     #[test]
+    fn json_document_update_keeps_json_null_distinct_from_string_null() {
+        let adapter = MySqlAdapter::new();
+        let json_null = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "documents",
+            "payload",
+            &QueryValue::text("null"),
+            &[("id".to_string(), QueryValue::SqlLiteral("1".into()))],
+        );
+        let string_null = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "documents",
+            "payload",
+            &QueryValue::text(r#""null""#),
+            &[("id".to_string(), QueryValue::SqlLiteral("1".into()))],
+        );
+
+        assert!(json_null.contains("SET `payload` = 'null'"));
+        assert!(string_null.contains("SET `payload` = '\"null\"'"));
+        assert_ne!(json_null, string_null);
+    }
+
+    #[test]
     fn bulk_delete_targets_each_composite_primary_key_row() {
         let adapter = MySqlAdapter::new();
         let sql = adapter.build_bulk_delete_sql(

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -755,6 +755,106 @@ async fn updates_and_bulk_deletes_mysql_rows_with_visible_composite_primary_keys
 }
 
 #[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn updates_mysql_json_documents_as_whole_values() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let suffix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|error| format!("system clock error: {error}"))?
+                .as_nanos();
+            let table = format!("mysql_sab396_{suffix}");
+            let create = format!(
+                "CREATE TABLE {table} (id INT NOT NULL PRIMARY KEY, payload JSON NOT NULL)"
+            );
+            db.adapter()
+                .execute_adhoc(db.dsn(), &create, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| format!("failed to create JSON fixture: {error:?}"))?;
+
+            let result = async {
+                db.adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!("INSERT INTO {table} VALUES (1, '{{\"a\":1}}')"),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to seed JSON fixture: {error:?}"))?;
+
+                let update_json = db.adapter().build_update_sql(
+                    DatabaseType::MySQL,
+                    "sabiql_test",
+                    &table,
+                    "payload",
+                    &QueryValue::text(r#"{"b":2,"a":1}"#),
+                    &[("id".to_string(), QueryValue::SqlLiteral("1".to_string()))],
+                );
+                if update_json.contains("JSON_SET") {
+                    return Err("JSON update unexpectedly used JSON_SET".to_string());
+                }
+                db.adapter()
+                    .execute_write(db.dsn(), &update_json, AccessMode::ReadWrite)
+                    .await
+                    .map_err(|error| format!("failed to update JSON document: {error:?}"))?;
+
+                let reordered = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!("SELECT JSON_EXTRACT(payload, '$.b'), JSON_EXTRACT(payload, '$.a') FROM {table} WHERE id = 1"),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to read JSON document: {error:?}"))?;
+                if reordered.values()
+                    != [[QueryValue::Text("2".to_string()), QueryValue::Text("1".to_string())]]
+                {
+                    return Err(format!("unexpected updated JSON document: {reordered:?}"));
+                }
+
+                for (json, expected_type) in [("null", "NULL"), (r#""null""#, "STRING")] {
+                    let update = db.adapter().build_update_sql(
+                        DatabaseType::MySQL,
+                        "sabiql_test",
+                        &table,
+                        "payload",
+                        &QueryValue::text(json),
+                        &[("id".to_string(), QueryValue::SqlLiteral("1".to_string()))],
+                    );
+                    db.adapter()
+                        .execute_write(db.dsn(), &update, AccessMode::ReadWrite)
+                        .await
+                        .map_err(|error| format!("failed to update JSON null value: {error:?}"))?;
+                    let value = db
+                        .adapter()
+                        .execute_adhoc(
+                            db.dsn(),
+                            &format!("SELECT JSON_TYPE(payload) FROM {table} WHERE id = 1"),
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .map_err(|error| format!("failed to read JSON type: {error:?}"))?;
+                    if value.values() != [[QueryValue::Text(expected_type.to_string())]] {
+                        return Err(format!("unexpected JSON type: {value:?}"));
+                    }
+                }
+                Ok(())
+            }
+            .await;
+
+            let drop = format!("DROP TABLE {table}");
+            let _ = db
+                .adapter()
+                .execute_adhoc(db.dsn(), &drop, AccessMode::ReadWrite)
+                .await;
+            result
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
 #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
 async fn executes_multiple_statements_and_returns_only_the_last_result() {
     with_mysql_test_db(|db| Box::pin(async move {

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -553,7 +553,7 @@ mod tests {
     }
 
     #[test]
-    fn mysql_json_detail_hides_edit_hint() {
+    fn mysql_json_detail_shows_edit_hint() {
         let mut state = AppState::new("test".to_string());
         state.session.activate_connection_with_dsn(
             &ConnectionId::new(),
@@ -565,7 +565,7 @@ mod tests {
 
         let hints = Footer::get_context_hints(&state);
 
-        assert!(!hints.contains(&jsonb_detail::INSERT.as_hint()));
+        assert!(hints.contains(&jsonb_detail::INSERT.as_hint()));
         assert!(hints.contains(&jsonb_detail::YANK.as_hint()));
         assert!(hints.contains(&jsonb_detail::SEARCH.as_hint()));
     }


### PR DESCRIPTION
## Problem
MySQL JSON columns could be viewed but could not use the existing document editor and write preview.

## Background
The MySQL JSON detail surface already shared structured JSON presentation with PostgreSQL jsonb, while MySQL editing remained disabled.

## Approach
Enable the shared JSON document editing path for MySQL, validate and semantically normalize JSON before write preview, and pass the complete document through the existing dialect-aware single-column UPDATE flow. Existing row identity, read-only, generated-column, view, and primary-key guardrails remain authoritative.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-396,--draft