### PR TITLE
chore: review MySQL SQL workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,6 +2149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
+ "tokio",
 ]
 
 [[package]]
@@ -2633,6 +2634,7 @@ dependencies = [
  "toml",
  "unicode-casefold",
  "unicode-width",
+ "url",
  "uuid",
 ]
 
@@ -2646,6 +2648,7 @@ dependencies = [
  "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-width",
+ "url",
  "uuid",
 ]
 
@@ -2657,6 +2660,8 @@ dependencies = [
  "async-trait",
  "csv",
  "dirs",
+ "libc",
+ "quick-xml",
  "rstest",
  "sabiql-app",
  "sabiql-domain",
@@ -2666,7 +2671,9 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "toml",
+ "url",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,10 @@ dotenvy = "0.15"
 futures = "0.3"
 insta = "1"
 lru = "0.18"
+libc = "0.2"
 mockall = "0.13"
 nucleo-matcher = "0.3"
+quick-xml = { version = "0.37", features = ["async-tokio"] }
 ratatui = "0.30"
 rstest = "0.19"
 serde = { version = "1", features = ["derive"] }
@@ -47,6 +49,7 @@ unicode-casefold = "0.2"
 unicode-segmentation = "1"
 unicode-width = "0.2"
 urlencoding = "2"
+url = "2"
 uuid = { version = "1", features = ["v4", "v5"] }
 
 [package]
@@ -54,12 +57,12 @@ name = "sabiql"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-description = "A fast, driver-less TUI for browsing and editing PostgreSQL and SQLite databases"
+description = "A fast, driver-less TUI for browsing and editing PostgreSQL, MySQL, and SQLite databases"
 license.workspace = true
 repository.workspace = true
 homepage = "https://github.com/riii111/sabiql"
 readme = "README.md"
-keywords = ["postgresql", "sqlite", "tui", "database", "sql"]
+keywords = ["postgresql", "mysql", "sqlite", "tui", "database"]
 categories = ["command-line-utilities", "database"]
 
 [dependencies]

--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -6,11 +6,13 @@ use tokio::sync::mpsc;
 
 use crate::cmd::effect::Effect;
 use crate::cmd::query_task::QueryTaskRegistry;
-use crate::domain::ConnectionId;
-use crate::domain::QuerySource;
 use crate::domain::command_tag::CommandTag;
-use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
-use crate::domain::sqlite_explain_query_plan_text_from_result;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope, QueryResultStatus};
+use crate::domain::{DatabaseType, QuerySource};
+use crate::domain::{
+    mysql_explain_plan_text_from_result, postgres_explain_plan_text_from_result,
+    sqlite_explain_query_plan_text_from_result,
+};
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{CachedResultExporter, QueryExecutor, QueryHistoryStore};
 use crate::update::action::Action;
@@ -48,24 +50,25 @@ fn save_query_history(
     query_history_store: &Arc<dyn QueryHistoryStore>,
     action_tx: &mpsc::Sender<Action>,
     project_name: &str,
-    connection_id: &ConnectionId,
+    scope: &QueryHistoryScope,
     query: &str,
     result_status: QueryResultStatus,
     affected_rows: Option<u64>,
 ) {
     let store = Arc::clone(query_history_store);
     let tx = action_tx.clone();
-    let entry = QueryHistoryEntry::new(
+    let entry = QueryHistoryEntry::new_with_database(
         query.to_string(),
         utc_now_iso8601(),
-        connection_id.clone(),
+        scope.connection_id.clone(),
+        scope.database.clone(),
         result_status,
         affected_rows,
     );
     let project = project_name.to_string();
-    let conn_id = connection_id.clone();
+    let scope = scope.clone();
     tokio::spawn(async move {
-        if let Err(e) = store.append(&project, &conn_id, &entry).await {
+        if let Err(e) = store.append(&project, &scope, &entry).await {
             let _ = tx.send(Action::QueryHistoryAppendFailed(e)).await;
         }
     });
@@ -137,6 +140,8 @@ pub async fn run(
 
         Effect::ExecuteExplain {
             dsn,
+            database_type,
+            database_generation,
             run_id,
             query,
             source_query,
@@ -149,9 +154,19 @@ pub async fn run(
             query_tasks.spawn(async move {
                 match executor.execute_adhoc(&dsn, &query, access_mode).await {
                     Ok(result) => {
-                        let plan_text = sqlite_explain_query_plan_text_from_result(&result);
+                        let plan_text = match database_type {
+                            DatabaseType::SQLite => {
+                                sqlite_explain_query_plan_text_from_result(&result)
+                            }
+                            DatabaseType::PostgreSQL => {
+                                postgres_explain_plan_text_from_result(&result)
+                            }
+                            DatabaseType::MySQL => mysql_explain_plan_text_from_result(&result),
+                        };
                         tx.send(Action::ExplainCompleted {
                             dsn,
+                            database_type,
+                            database_generation,
                             run_id,
                             query: source_query,
                             plan_text,
@@ -164,6 +179,7 @@ pub async fn run(
                     Err(e) => {
                         tx.send(Action::ExplainFailed {
                             dsn,
+                            database_generation,
                             run_id,
                             error: e,
                             is_analyze,
@@ -187,13 +203,13 @@ pub async fn run(
             let history_store = Arc::clone(query_history_store);
             let history_tx = action_tx.clone();
             let project = state.runtime.project_name().to_string();
-            let conn_id = state.session.active_connection_id().cloned();
+            let history_scope = state.session.query_history_scope();
             let query_for_history = query.clone();
 
             query_tasks.spawn(async move {
                 match executor.execute_adhoc(&dsn, &query, access_mode).await {
                     Ok(result) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             let rows = result
                                 .command_tag
                                 .as_ref()
@@ -202,7 +218,7 @@ pub async fn run(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Success,
                                 rows,
@@ -219,12 +235,12 @@ pub async fn run(
                         .ok();
                     }
                     Err(e) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             save_query_history(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Failed,
                                 None,
@@ -256,18 +272,18 @@ pub async fn run(
             let history_store = Arc::clone(query_history_store);
             let history_tx = action_tx.clone();
             let project = state.runtime.project_name().to_string();
-            let conn_id = state.session.active_connection_id().cloned();
+            let history_scope = state.session.query_history_scope();
             let query_for_history = query.clone();
 
             query_tasks.spawn(async move {
                 match executor.execute_write(&dsn, &query, access_mode).await {
                     Ok(result) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             save_query_history(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Success,
                                 Some(result.affected_rows as u64),
@@ -282,12 +298,12 @@ pub async fn run(
                         .ok();
                     }
                     Err(e) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             save_query_history(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Failed,
                                 None,
@@ -779,6 +795,7 @@ mod tests {
 
     mod execute_access_mode {
         use super::*;
+        use crate::domain::DatabaseType;
 
         struct NoopRenderer;
         impl Renderer for NoopRenderer {
@@ -858,6 +875,8 @@ mod tests {
             let action = run_effect(
                 Effect::ExecuteExplain {
                     dsn: "dsn://test".to_string(),
+                    database_type: DatabaseType::PostgreSQL,
+                    database_generation: 0,
                     run_id: 2,
                     query: "EXPLAIN SELECT 1".to_string(),
                     source_query: "SELECT 1".to_string(),

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -3,13 +3,124 @@ use std::collections::HashSet;
 use crate::cmd::cache::BoundedLruCache;
 #[cfg(test)]
 use crate::domain::ColumnAttributes;
-use crate::domain::{DatabaseMetadata, Table, TableSummary};
+use crate::domain::{DatabaseMetadata, DatabaseType, Table, TableSummary};
 use crate::model::sql_editor::completion::{CompletionCandidate, CompletionKind};
 use crate::policy::sql::lexer::{SqlContext, SqlLexer, TableReference, Token, TokenKind};
 use crate::update::helpers::char_to_byte_index;
 
 const COMPLETION_MAX_CANDIDATES: usize = 30;
 const TABLE_CACHE_CAPACITY: usize = 500;
+
+const MYSQL_COMPLETION_KEYWORDS: &[&str] = &[
+    "SELECT",
+    "FROM",
+    "WHERE",
+    "JOIN",
+    "LEFT",
+    "RIGHT",
+    "INNER",
+    "OUTER",
+    "CROSS",
+    "ON",
+    "AND",
+    "OR",
+    "NOT",
+    "IN",
+    "IS",
+    "NULL",
+    "TRUE",
+    "FALSE",
+    "LIKE",
+    "BETWEEN",
+    "EXISTS",
+    "CASE",
+    "WHEN",
+    "THEN",
+    "ELSE",
+    "END",
+    "AS",
+    "DISTINCT",
+    "ORDER",
+    "BY",
+    "ASC",
+    "DESC",
+    "GROUP",
+    "HAVING",
+    "LIMIT",
+    "OFFSET",
+    "UNION",
+    "INTERSECT",
+    "EXCEPT",
+    "ALL",
+    "INSERT",
+    "INTO",
+    "VALUES",
+    "UPDATE",
+    "SET",
+    "DELETE",
+    "CREATE",
+    "DROP",
+    "ALTER",
+    "TABLE",
+    "INDEX",
+    "VIEW",
+    "WITH",
+    "RECURSIVE",
+    "COALESCE",
+    "NULLIF",
+    "CAST",
+    "USING",
+    "FULL",
+    "NATURAL",
+    "WINDOW",
+    "OVER",
+    "PARTITION",
+    "ROWS",
+    "RANGE",
+    "UNBOUNDED",
+    "PRECEDING",
+    "FOLLOWING",
+    "CURRENT",
+    "ROW",
+    "EXPLAIN",
+    "ANALYZE",
+    "SHOW",
+    "DESCRIBE",
+    "DATABASE",
+    "DATABASES",
+    "PRIMARY",
+    "KEY",
+    "FOREIGN",
+    "REFERENCES",
+    "UNIQUE",
+    "DEFAULT",
+    "CONSTRAINT",
+    "CHECK",
+    "IF",
+    "CASCADE",
+    "RENAME",
+    "MODIFY",
+    "COLUMN",
+    "ENGINE",
+    "CHARACTER",
+    "CHARSET",
+    "COLLATE",
+    "AUTO_INCREMENT",
+    "FOR",
+    "LOCK",
+    "SHARE",
+    "START",
+    "TRANSACTION",
+    "COMMIT",
+    "ROLLBACK",
+];
+
+#[derive(Clone, Copy)]
+pub(crate) struct CompletionDatabaseScope<'a> {
+    pub(crate) database_type: DatabaseType,
+    pub(crate) active_database: Option<&'a str>,
+    pub(crate) available_databases: &'a [String],
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CompletionContext {
@@ -110,7 +221,7 @@ impl CompletionEngine {
                 "CAST",
                 "USING",
             ],
-            lexer: SqlLexer::new(),
+            lexer: SqlLexer::default(),
             table_detail_cache: BoundedLruCache::new(TABLE_CACHE_CAPACITY),
         }
     }
@@ -173,6 +284,33 @@ impl CompletionEngine {
             metadata,
             table_detail,
             recent_columns,
+            CompletionDatabaseScope {
+                database_type: DatabaseType::PostgreSQL,
+                active_database: None,
+                available_databases: &[],
+            },
+        )
+    }
+
+    #[cfg(test)]
+    fn get_candidates_for_database(
+        &self,
+        content: &str,
+        cursor_pos: usize,
+        metadata: Option<&DatabaseMetadata>,
+        table_detail: Option<&Table>,
+        recent_columns: &[String],
+        scope: CompletionDatabaseScope<'_>,
+    ) -> Vec<CompletionCandidate> {
+        let prep = self.prepare_for_database(content, cursor_pos, scope.database_type);
+        self.get_candidates_prepared_for_database(
+            content,
+            cursor_pos,
+            &prep,
+            metadata,
+            table_detail,
+            recent_columns,
+            scope,
         )
     }
 
@@ -182,8 +320,27 @@ impl CompletionEngine {
     }
 
     pub fn prepare(&self, content: &str, cursor_pos: usize) -> PreparedCompletion {
-        let tokens = self.lexer.tokenize(content, content.len());
-        let context = self.lexer.build_context(&tokens, cursor_pos);
+        self.prepare_with_lexer(content, cursor_pos, &self.lexer)
+    }
+
+    pub fn prepare_for_database(
+        &self,
+        content: &str,
+        cursor_pos: usize,
+        database_type: DatabaseType,
+    ) -> PreparedCompletion {
+        let lexer = SqlLexer::new(database_type);
+        self.prepare_with_lexer(content, cursor_pos, &lexer)
+    }
+
+    fn prepare_with_lexer(
+        &self,
+        content: &str,
+        cursor_pos: usize,
+        lexer: &SqlLexer,
+    ) -> PreparedCompletion {
+        let tokens = lexer.tokenize(content, content.len());
+        let context = lexer.build_context(&tokens, cursor_pos);
         let in_string_or_comment =
             SqlLexer::is_in_string_or_comment_from_tokens(&tokens, cursor_pos);
         let before_cursor: String = content.chars().take(cursor_pos).collect();
@@ -250,6 +407,32 @@ impl CompletionEngine {
             metadata,
             table_detail,
             recent_columns,
+            CompletionDatabaseScope {
+                database_type: DatabaseType::PostgreSQL,
+                active_database: None,
+                available_databases: &[],
+            },
+        )
+    }
+
+    pub(crate) fn get_candidates_prepared_for_database(
+        &self,
+        content: &str,
+        cursor_pos: usize,
+        prep: &PreparedCompletion,
+        metadata: Option<&DatabaseMetadata>,
+        table_detail: Option<&Table>,
+        recent_columns: &[String],
+        scope: CompletionDatabaseScope<'_>,
+    ) -> Vec<CompletionCandidate> {
+        self.get_candidates_inner(
+            content,
+            cursor_pos,
+            prep,
+            metadata,
+            table_detail,
+            recent_columns,
+            scope,
         )
     }
 
@@ -261,6 +444,7 @@ impl CompletionEngine {
         metadata: Option<&DatabaseMetadata>,
         table_detail: Option<&Table>,
         recent_columns: &[String],
+        scope: CompletionDatabaseScope<'_>,
     ) -> Vec<CompletionCandidate> {
         if prep.in_string_or_comment {
             return vec![];
@@ -280,8 +464,12 @@ impl CompletionEngine {
         );
 
         let mut candidates = match &context {
-            CompletionContext::Keyword => self.keyword_candidates(&current_token),
-            CompletionContext::Table => self.table_candidates(metadata, &current_token),
+            CompletionContext::Keyword => {
+                self.keyword_candidates_for_database(&current_token, scope.database_type)
+            }
+            CompletionContext::Table => {
+                self.table_candidates_for_database(metadata, &current_token, scope)
+            }
             CompletionContext::Column => {
                 let keywords = self.primary_clause_keywords(&current_token);
 
@@ -376,18 +564,21 @@ impl CompletionEngine {
                 mixed
             }
             CompletionContext::SchemaQualified(schema) => {
-                self.schema_qualified_candidates(metadata, schema, &current_token)
+                self.schema_qualified_candidates_for_database(metadata, schema, &current_token)
             }
             CompletionContext::AliasColumn(alias) => {
                 self.alias_column_candidates(alias, &prep.context, metadata, &current_token)
             }
-            CompletionContext::CteOrTable => {
-                self.cte_or_table_candidates(&prep.context, metadata, &current_token)
-            }
+            CompletionContext::CteOrTable => self.cte_or_table_candidates_for_database(
+                &prep.context,
+                metadata,
+                &current_token,
+                scope,
+            ),
         };
 
         if candidates.is_empty() && context != CompletionContext::Keyword {
-            return self.keyword_candidates(&current_token);
+            return self.keyword_candidates_for_database(&current_token, scope.database_type);
         }
 
         let mut seen = HashSet::new();
@@ -456,33 +647,24 @@ impl CompletionEngine {
         current_token: &str,
         sql_context: &SqlContext,
     ) -> Option<String> {
-        let prefix_end = before_cursor.len().saturating_sub(current_token.len());
-        let prefix = &before_cursor[..prefix_end];
+        let prefix = before_cursor
+            .strip_suffix(current_token)
+            .unwrap_or(before_cursor);
 
-        if prefix.ends_with('.') {
-            let potential_alias: String = prefix
-                .trim_end_matches('.')
-                .chars()
-                .rev()
-                .take_while(|c| c.is_alphanumeric() || *c == '_')
-                .collect::<String>()
-                .chars()
-                .rev()
-                .collect();
-
-            if !potential_alias.is_empty() {
-                // Check if it matches any table alias in the context
-                let alias_lower = potential_alias.to_lowercase();
-                for table_ref in &sql_context.tables {
-                    if let Some(ref alias) = table_ref.alias
-                        && alias.to_lowercase() == alias_lower
-                    {
-                        return Some(potential_alias);
-                    }
-                    // Also check if it matches the table name directly
-                    if table_ref.table.to_lowercase() == alias_lower {
-                        return Some(potential_alias);
-                    }
+        if prefix.ends_with('.')
+            && let Some(potential_alias) = Self::identifier_before_dot(prefix)
+        {
+            // Check if it matches any table alias in the context
+            let alias_lower = potential_alias.to_lowercase();
+            for table_ref in &sql_context.tables {
+                if let Some(ref alias) = table_ref.alias
+                    && alias.to_lowercase() == alias_lower
+                {
+                    return Some(potential_alias);
+                }
+                // Also check if it matches the table name directly
+                if table_ref.table.to_lowercase() == alias_lower {
+                    return Some(potential_alias);
                 }
             }
         }
@@ -500,26 +682,30 @@ impl CompletionEngine {
     }
 
     fn detect_schema_prefix(&self, before_cursor: &str, current_token: &str) -> Option<String> {
-        let prefix_end = before_cursor.len().saturating_sub(current_token.len());
-        let prefix = &before_cursor[..prefix_end];
+        let prefix = before_cursor
+            .strip_suffix(current_token)
+            .unwrap_or(before_cursor);
 
         if prefix.ends_with('.') {
-            // Extract schema name before the dot
-            let schema: String = prefix
-                .trim_end_matches('.')
-                .chars()
-                .rev()
-                .take_while(|c| c.is_alphanumeric() || *c == '_')
-                .collect::<String>()
-                .chars()
-                .rev()
-                .collect();
-
-            if !schema.is_empty() {
-                return Some(schema);
-            }
+            return Self::identifier_before_dot(prefix);
         }
         None
+    }
+
+    fn identifier_before_dot(prefix: &str) -> Option<String> {
+        let name = prefix.strip_suffix('.')?.trim_end();
+        if let Some(unquoted) = name.strip_suffix('`') {
+            let start = unquoted.rfind('`')?;
+            return Some(unquoted[start + 1..].replace("``", "`"));
+        }
+
+        let start = name
+            .char_indices()
+            .rev()
+            .take_while(|(_, c)| c.is_alphanumeric() || *c == '_')
+            .last()
+            .map_or(name.len(), |(index, _)| index);
+        (start < name.len()).then(|| name[start..].to_string())
     }
 
     fn detect_context_from_tokens(&self, tokens: &[Token], cursor_pos: usize) -> CompletionContext {
@@ -553,10 +739,23 @@ impl CompletionEngine {
         }
     }
 
+    #[cfg(test)]
     fn keyword_candidates(&self, prefix: &str) -> Vec<CompletionCandidate> {
+        self.keyword_candidates_for_database(prefix, DatabaseType::PostgreSQL)
+    }
+
+    fn keyword_candidates_for_database(
+        &self,
+        prefix: &str,
+        database_type: DatabaseType,
+    ) -> Vec<CompletionCandidate> {
         let prefix_upper = prefix.to_uppercase();
-        let mut candidates: Vec<_> = self
-            .keywords
+        let keywords = if database_type == DatabaseType::MySQL {
+            MYSQL_COMPLETION_KEYWORDS
+        } else {
+            &self.keywords
+        };
+        let mut candidates: Vec<_> = keywords
             .iter()
             .filter(|kw| prefix.is_empty() || kw.starts_with(&prefix_upper))
             .map(|kw| {
@@ -631,43 +830,75 @@ impl CompletionEngine {
             .collect()
     }
 
+    #[cfg(test)]
     fn table_candidates(
         &self,
         metadata: Option<&DatabaseMetadata>,
         prefix: &str,
     ) -> Vec<CompletionCandidate> {
+        self.table_candidates_for_database(
+            metadata,
+            prefix,
+            CompletionDatabaseScope {
+                database_type: DatabaseType::PostgreSQL,
+                active_database: None,
+                available_databases: &[],
+            },
+        )
+    }
+
+    fn table_candidates_for_database(
+        &self,
+        metadata: Option<&DatabaseMetadata>,
+        prefix: &str,
+        scope: CompletionDatabaseScope<'_>,
+    ) -> Vec<CompletionCandidate> {
+        let mut candidates = if scope.database_type == DatabaseType::MySQL {
+            self.database_candidates(scope.active_database, scope.available_databases, prefix)
+        } else {
+            Vec::new()
+        };
+
         let Some(metadata) = metadata else {
-            return vec![];
+            return candidates
+                .into_iter()
+                .take(COMPLETION_MAX_CANDIDATES)
+                .collect();
         };
 
         let prefix_lower = prefix.to_lowercase();
-        let mut candidates: Vec<_> = metadata
-            .table_summaries
-            .iter()
-            .filter(|t| {
-                prefix.is_empty()
-                    || t.name.to_lowercase().starts_with(&prefix_lower)
-                    || t.qualified_name().to_lowercase().starts_with(&prefix_lower)
-            })
-            .map(|t| {
-                let name_lower = t.name.to_lowercase();
-                let is_name_prefix = name_lower.starts_with(&prefix_lower);
-                let is_qualified_prefix =
-                    t.qualified_name().to_lowercase().starts_with(&prefix_lower);
-                let score = if is_name_prefix {
-                    100
-                } else if is_qualified_prefix {
-                    50
-                } else {
-                    10
-                };
-                CompletionCandidate {
-                    text: t.qualified_name(),
-                    kind: CompletionKind::Table,
-                    score,
-                }
-            })
-            .collect();
+        candidates.extend(
+            metadata
+                .table_summaries
+                .iter()
+                .filter(|t| {
+                    prefix.is_empty()
+                        || t.name.to_lowercase().starts_with(&prefix_lower)
+                        || t.qualified_name().to_lowercase().starts_with(&prefix_lower)
+                })
+                .map(|t| {
+                    let name_lower = t.name.to_lowercase();
+                    let is_name_prefix = name_lower.starts_with(&prefix_lower);
+                    let is_qualified_prefix =
+                        t.qualified_name().to_lowercase().starts_with(&prefix_lower);
+                    let score = if is_name_prefix {
+                        100
+                    } else if is_qualified_prefix {
+                        50
+                    } else {
+                        10
+                    };
+                    CompletionCandidate {
+                        text: if scope.database_type == DatabaseType::MySQL {
+                            t.name.clone()
+                        } else {
+                            t.qualified_name()
+                        },
+                        kind: CompletionKind::Table,
+                        score,
+                    }
+                }),
+        );
 
         // Sort by score (descending), then alphabetically
         candidates.sort_by(|a, b| match b.score.cmp(&a.score) {
@@ -679,6 +910,36 @@ impl CompletionEngine {
             .into_iter()
             .take(COMPLETION_MAX_CANDIDATES)
             .collect()
+    }
+
+    fn database_candidates(
+        &self,
+        active_database: Option<&str>,
+        available_databases: &[String],
+        prefix: &str,
+    ) -> Vec<CompletionCandidate> {
+        let prefix_lower = prefix.to_lowercase();
+        let mut names = Vec::with_capacity(available_databases.len() + 1);
+        if let Some(database) = active_database {
+            names.push(database.to_string());
+        }
+        names.extend(available_databases.iter().cloned());
+
+        let mut seen = HashSet::new();
+        let mut candidates: Vec<_> = names
+            .into_iter()
+            .filter(|name| {
+                seen.insert(name.to_lowercase())
+                    && (prefix.is_empty() || name.to_lowercase().starts_with(&prefix_lower))
+            })
+            .map(|name| CompletionCandidate {
+                text: name,
+                kind: CompletionKind::Database,
+                score: 120,
+            })
+            .collect();
+        candidates.sort_by(|a, b| a.text.cmp(&b.text));
+        candidates
     }
 
     fn column_candidates(
@@ -766,7 +1027,17 @@ impl CompletionEngine {
             .collect()
     }
 
+    #[cfg(test)]
     fn schema_qualified_candidates(
+        &self,
+        metadata: Option<&DatabaseMetadata>,
+        schema: &str,
+        prefix: &str,
+    ) -> Vec<CompletionCandidate> {
+        self.schema_qualified_candidates_for_database(metadata, schema, prefix)
+    }
+
+    fn schema_qualified_candidates_for_database(
         &self,
         metadata: Option<&DatabaseMetadata>,
         schema: &str,
@@ -840,14 +1111,38 @@ impl CompletionEngine {
         vec![]
     }
 
+    #[cfg(test)]
     fn cte_or_table_candidates(
         &self,
         sql_context: &SqlContext,
         metadata: Option<&DatabaseMetadata>,
         prefix: &str,
     ) -> Vec<CompletionCandidate> {
+        self.cte_or_table_candidates_for_database(
+            sql_context,
+            metadata,
+            prefix,
+            CompletionDatabaseScope {
+                database_type: DatabaseType::PostgreSQL,
+                active_database: None,
+                available_databases: &[],
+            },
+        )
+    }
+
+    fn cte_or_table_candidates_for_database(
+        &self,
+        sql_context: &SqlContext,
+        metadata: Option<&DatabaseMetadata>,
+        prefix: &str,
+        scope: CompletionDatabaseScope<'_>,
+    ) -> Vec<CompletionCandidate> {
         let prefix_lower = prefix.to_lowercase();
-        let mut candidates = Vec::new();
+        let mut candidates = if scope.database_type == DatabaseType::MySQL {
+            self.database_candidates(scope.active_database, scope.available_databases, prefix)
+        } else {
+            Vec::new()
+        };
 
         // Add CTE names first (higher priority)
         for cte in &sql_context.ctes {
@@ -869,7 +1164,11 @@ impl CompletionEngine {
                 {
                     let is_name_prefix = t.name.to_lowercase().starts_with(&prefix_lower);
                     candidates.push(CompletionCandidate {
-                        text: t.qualified_name(),
+                        text: if scope.database_type == DatabaseType::MySQL {
+                            t.name.clone()
+                        } else {
+                            t.qualified_name()
+                        },
                         kind: CompletionKind::Table,
                         score: if is_name_prefix { 100 } else { 50 },
                     });
@@ -1285,6 +1584,148 @@ mod tests {
 
             assert!(!candidates.is_empty());
             assert!(candidates.iter().any(|c| c.text == "SELECT"));
+        }
+    }
+
+    mod mysql_completion {
+        use super::*;
+
+        fn metadata() -> DatabaseMetadata {
+            let mut metadata = DatabaseMetadata::new("app".to_string());
+            metadata.table_summaries = vec![TableSummary::new(
+                "app".to_string(),
+                "users".to_string(),
+                None,
+                false,
+            )];
+            metadata
+        }
+
+        #[test]
+        fn database_and_table_candidates_use_mysql_scope() {
+            let e = engine();
+            let metadata = metadata();
+            let candidates = e.get_candidates_for_database(
+                "SELECT * FROM ",
+                14,
+                Some(&metadata),
+                None,
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app"),
+                    available_databases: &["analytics".to_string()],
+                },
+            );
+
+            assert!(candidates.iter().any(|candidate| {
+                candidate.text == "app" && candidate.kind == CompletionKind::Database
+            }));
+            assert!(candidates.iter().any(|candidate| {
+                candidate.text == "analytics" && candidate.kind == CompletionKind::Database
+            }));
+            assert!(candidates.iter().any(|candidate| {
+                candidate.text == "users" && candidate.kind == CompletionKind::Table
+            }));
+            assert!(
+                !candidates
+                    .iter()
+                    .any(|candidate| candidate.text == "app.users")
+            );
+        }
+
+        #[test]
+        fn mysql_keyword_candidates_include_describe() {
+            let e = engine();
+            let candidates = e.get_candidates_for_database(
+                "DES",
+                3,
+                None,
+                None,
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app"),
+                    available_databases: &[],
+                },
+            );
+
+            assert!(
+                candidates
+                    .iter()
+                    .any(|candidate| candidate.text == "DESCRIBE")
+            );
+            assert!(!candidates.iter().any(|candidate| candidate.text == "ILIKE"));
+        }
+
+        #[test]
+        fn mysql_comments_strings_and_backticks_return_no_candidates() {
+            let e = engine();
+            for sql in ["# SELECT", "SELECT 'FROM", "SELECT `FROM", "SELECT `a``"] {
+                let candidates = e.get_candidates_for_database(
+                    sql,
+                    sql.chars().count(),
+                    None,
+                    None,
+                    &[],
+                    CompletionDatabaseScope {
+                        database_type: DatabaseType::MySQL,
+                        active_database: Some("app"),
+                        available_databases: &[],
+                    },
+                );
+
+                assert!(candidates.is_empty(), "unexpected candidates for {sql}");
+            }
+        }
+
+        #[test]
+        fn mysql_backtick_table_alias_returns_cached_columns() {
+            let mut e = engine();
+            e.cache_table_detail(
+                "app.users".to_string(),
+                create_table("app", "users", &["id", "name"]),
+            );
+            let metadata = metadata();
+            let sql = "SELECT u.na FROM `app`.`users` AS `u`";
+            let cursor = "SELECT u.na".chars().count();
+            let candidates = e.get_candidates_for_database(
+                sql,
+                cursor,
+                Some(&metadata),
+                None,
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app"),
+                    available_databases: &[],
+                },
+            );
+
+            assert!(candidates.iter().any(|candidate| {
+                candidate.text == "name" && candidate.kind == CompletionKind::Column
+            }));
+        }
+
+        #[test]
+        fn mysql_backtick_database_prefix_returns_selected_tables() {
+            let e = engine();
+            let metadata = metadata();
+            let sql = "SELECT * FROM `app`.";
+            let candidates = e.get_candidates_for_database(
+                sql,
+                sql.chars().count(),
+                Some(&metadata),
+                None,
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app"),
+                    available_databases: &[],
+                },
+            );
+
+            assert!(candidates.iter().any(|candidate| candidate.text == "users"));
         }
     }
 
@@ -2658,7 +3099,7 @@ mod tests {
 
         #[test]
         fn is_in_string_or_comment_from_tokens_edges() {
-            let lexer = SqlLexer::new();
+            let lexer = SqlLexer::default();
 
             let cases = [
                 ("SELECT 'hello'", 10, true),     // inside string

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -1,7 +1,8 @@
-use crate::domain::connection::{ConnectionConfig, ConnectionId};
+use crate::domain::connection::{ConnectionConfig, ConnectionId, DatabaseType};
+use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{QueryValue, Table};
 use crate::ports::outbound::{AccessMode, AppSettings};
-use crate::update::action::Action;
+use crate::update::action::{Action, ConnectionTarget};
 
 #[derive(Debug, Clone)]
 pub enum Effect {
@@ -11,6 +12,16 @@ pub enum Effect {
         id: Option<ConnectionId>,
         name: String,
         config: ConnectionConfig,
+    },
+    ProbeConnection {
+        target: ConnectionTarget,
+        run_id: u64,
+    },
+    FetchMySqlDatabases {
+        connection_id: ConnectionId,
+        dsn: String,
+        connection_generation: u64,
+        database_generation: u64,
     },
     LoadConnectionForEdit {
         id: ConnectionId,
@@ -72,6 +83,8 @@ pub enum Effect {
     },
     ExecuteExplain {
         dsn: String,
+        database_type: DatabaseType,
+        database_generation: u64,
         run_id: u64,
         query: String,
         source_query: String,
@@ -122,6 +135,7 @@ pub enum Effect {
     TriggerCompletion,
 
     GenerateErDiagramFromCache {
+        run_id: u64,
         total_tables: usize,
         project_name: String,
         target_tables: Vec<String>,
@@ -148,7 +162,7 @@ pub enum Effect {
 
     LoadQueryHistory {
         project_name: String,
-        connection_id: ConnectionId,
+        scope: QueryHistoryScope,
     },
 
     SaveSettings {

--- a/src/app/cmd/sql_editor/completion.rs
+++ b/src/app/cmd/sql_editor/completion.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
 
-use crate::cmd::completion_engine::CompletionEngine;
+use crate::cmd::completion_engine::{CompletionDatabaseScope, CompletionEngine};
 use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
@@ -44,10 +44,13 @@ pub async fn run(
         Effect::TriggerCompletion => {
             let cursor = state.sql_modal.editor().cursor();
             let content = state.sql_modal.editor().content();
+            let database_type = state.session.active_database_type_or_default();
+            let active_database = state.session.active_database();
+            let available_databases = state.session.available_databases();
 
             let (prep, missing) = {
                 let engine = completion_engine.borrow();
-                let prep = engine.prepare(content, cursor);
+                let prep = engine.prepare_for_database(content, cursor, database_type);
                 let missing = engine
                     .missing_tables_prepared(&prep, state.session.metadata().map(AsRef::as_ref));
                 (prep, missing)
@@ -80,13 +83,18 @@ pub async fn run(
                 let engine = completion_engine.borrow();
                 let token_len = CompletionEngine::current_token_len_prepared(&prep);
                 let recent_cols = state.sql_modal.completion().recent_columns_vec();
-                let candidates = engine.get_candidates_prepared(
+                let candidates = engine.get_candidates_prepared_for_database(
                     content,
                     cursor,
                     &prep,
                     state.session.metadata().map(AsRef::as_ref),
                     state.session.table_detail(),
                     &recent_cols,
+                    CompletionDatabaseScope {
+                        database_type,
+                        active_database,
+                        available_databases,
+                    },
                 );
                 let visible = !candidates.is_empty() && !content.trim().is_empty();
                 (candidates, token_len, visible)
@@ -97,6 +105,10 @@ pub async fn run(
                     candidates,
                     trigger_position: cursor.saturating_sub(token_len),
                     visible,
+                    dsn: state.session.dsn().map(str::to_string),
+                    connection_generation: state.session.connection_generation(),
+                    database_generation: state.session.database_generation(),
+                    metadata_generation: state.session.metadata_generation(),
                 })
                 .await
                 .ok();

--- a/src/app/cmd/sql_editor/query_history.rs
+++ b/src/app/cmd/sql_editor/query_history.rs
@@ -14,21 +14,24 @@ pub fn run(
     match effect {
         Effect::LoadQueryHistory {
             project_name,
-            connection_id,
+            scope,
         } => {
             let store = Arc::clone(query_history_store);
             let tx = action_tx.clone();
 
-            let conn_id = connection_id.clone();
+            let scope_for_action = scope.clone();
             tokio::spawn(async move {
-                match store.load(&project_name, &connection_id).await {
+                match store.load(&project_name, &scope).await {
                     Ok(entries) => {
-                        tx.send(Action::QueryHistoryLoaded(conn_id, entries))
-                            .await
-                            .ok();
+                        tx.send(Action::QueryHistoryLoaded(
+                            scope_for_action.clone(),
+                            entries,
+                        ))
+                        .await
+                        .ok();
                     }
                     Err(e) => {
-                        tx.send(Action::QueryHistoryLoadFailed(conn_id, e))
+                        tx.send(Action::QueryHistoryLoadFailed(scope_for_action, e))
                             .await
                             .ok();
                     }

--- a/src/app/cmd/test_fixtures.rs
+++ b/src/app/cmd/test_fixtures.rs
@@ -9,18 +9,18 @@ use crate::cmd::runner::{
 };
 use crate::domain::SqliteDiagnosticsSnapshot;
 use crate::domain::connection::{ConnectionProfile, ServiceEntry};
-use crate::domain::query_history::QueryHistoryEntry;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 use crate::domain::{
-    ConnectionId, DatabaseMetadata, DiagnosticField, ErTableInfo, QueryResult, QuerySource,
-    QueryValue, SqlitePathError, classify_sqlite_metadata_error, classify_sqlite_read_error,
+    DatabaseMetadata, DiagnosticField, ErTableInfo, QueryResult, QuerySource, QueryValue,
+    SqlitePathError, classify_sqlite_metadata_error, classify_sqlite_read_error,
 };
 use crate::ports::outbound::DbOperationError;
 use crate::ports::outbound::{
     AppSettings, CachedResultExporter, ClipboardError, ClipboardWriter, ConfigWriter,
-    ConfigWriterError, ConnectionStore, DsnBuilder, ErDiagramExporter, ErExportResult, ErLogWriter,
-    FolderOpenError, FolderOpener, MetadataProvider, PgServiceEntryReader, QueryExecutor,
-    QueryHistoryError, QueryHistoryStore, ServiceFileError, SettingsStore, SettingsStoreError,
-    SqliteDiagnosticsProvider, SqlitePathValidator,
+    ConfigWriterError, ConnectionProbe, ConnectionStore, DsnBuilder, ErDiagramExporter,
+    ErExportResult, ErLogWriter, FolderOpenError, FolderOpener, MetadataProvider,
+    PgServiceEntryReader, QueryExecutor, QueryHistoryError, QueryHistoryStore, ServiceFileError,
+    SettingsStore, SettingsStoreError, SqliteDiagnosticsProvider, SqlitePathValidator,
 };
 use crate::update::action::Action;
 
@@ -123,6 +123,14 @@ impl DsnBuilder for NoopDsnBuilder {
     }
 }
 
+pub struct NoopConnectionProbe;
+#[async_trait::async_trait]
+impl ConnectionProbe for NoopConnectionProbe {
+    async fn probe(&self, _dsn: &str) -> Result<(), DbOperationError> {
+        Ok(())
+    }
+}
+
 pub struct NoopPgServiceEntryReader;
 impl PgServiceEntryReader for NoopPgServiceEntryReader {
     fn read_services(&self) -> Result<(Vec<ServiceEntry>, PathBuf), ServiceFileError> {
@@ -150,7 +158,7 @@ impl QueryHistoryStore for NoopQueryHistoryStore {
     async fn append(
         &self,
         _project_name: &str,
-        _connection_id: &ConnectionId,
+        _scope: &QueryHistoryScope,
         _entry: &QueryHistoryEntry,
     ) -> Result<(), QueryHistoryError> {
         Ok(())
@@ -159,7 +167,7 @@ impl QueryHistoryStore for NoopQueryHistoryStore {
     async fn load(
         &self,
         _project_name: &str,
-        _connection_id: &ConnectionId,
+        _scope: &QueryHistoryScope,
     ) -> Result<Vec<QueryHistoryEntry>, QueryHistoryError> {
         Ok(Vec::new())
     }
@@ -235,13 +243,34 @@ pub fn make_runner_with_dsn(
     action_tx: mpsc::Sender<Action>,
     dsn_builder: Arc<dyn DsnBuilder>,
 ) -> EffectRunner {
-    make_runner_with_dsn_and_cached_result_exporter(
+    make_runner_with_dsn_and_probe(
         metadata_provider,
         query_executor,
         connection_store,
         cache,
         action_tx,
         dsn_builder,
+        Arc::new(NoopConnectionProbe),
+    )
+}
+
+pub fn make_runner_with_dsn_and_probe(
+    metadata_provider: Arc<dyn MetadataProvider>,
+    query_executor: Arc<dyn QueryExecutor>,
+    connection_store: Arc<dyn ConnectionStore>,
+    cache: TtlCache<String, Arc<DatabaseMetadata>>,
+    action_tx: mpsc::Sender<Action>,
+    dsn_builder: Arc<dyn DsnBuilder>,
+    connection_probe: Arc<dyn ConnectionProbe>,
+) -> EffectRunner {
+    make_runner_with_dsn_and_cached_result_exporter_and_probe(
+        metadata_provider,
+        query_executor,
+        connection_store,
+        cache,
+        action_tx,
+        dsn_builder,
+        connection_probe,
         Arc::new(TestCachedResultExporter),
     )
 }
@@ -255,10 +284,33 @@ fn make_runner_with_dsn_and_cached_result_exporter(
     dsn_builder: Arc<dyn DsnBuilder>,
     cached_result_exporter: Arc<dyn CachedResultExporter>,
 ) -> EffectRunner {
+    make_runner_with_dsn_and_cached_result_exporter_and_probe(
+        metadata_provider,
+        query_executor,
+        connection_store,
+        cache,
+        action_tx,
+        dsn_builder,
+        Arc::new(NoopConnectionProbe),
+        cached_result_exporter,
+    )
+}
+
+fn make_runner_with_dsn_and_cached_result_exporter_and_probe(
+    metadata_provider: Arc<dyn MetadataProvider>,
+    query_executor: Arc<dyn QueryExecutor>,
+    connection_store: Arc<dyn ConnectionStore>,
+    cache: TtlCache<String, Arc<DatabaseMetadata>>,
+    action_tx: mpsc::Sender<Action>,
+    dsn_builder: Arc<dyn DsnBuilder>,
+    connection_probe: Arc<dyn ConnectionProbe>,
+    cached_result_exporter: Arc<dyn CachedResultExporter>,
+) -> EffectRunner {
     EffectRunner::new(
         metadata_provider,
         ConnectionDeps {
             dsn_builder,
+            connection_probe,
             connection_store,
             pg_service_entry_reader: Some(Arc::new(NoopPgServiceEntryReader)),
             sqlite_path_validator: Arc::new(TestFsSqlitePathValidator),

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -1,5 +1,7 @@
+use std::fmt;
 use std::sync::Arc;
 
+use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{
     ConnectionId, DatabaseMetadata, DatabaseType, MetadataState, QueryResult, Table, TableSummary,
 };
@@ -11,6 +13,7 @@ use crate::model::connection::state::ConnectionState;
 use crate::model::shared::async_run::AsyncRun;
 use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::model::shared::inspector_tab::InspectorTab;
+use crate::policy::mask_password;
 
 #[derive(Debug, Clone)]
 struct ActiveConnection {
@@ -18,6 +21,31 @@ struct ActiveConnection {
     name: String,
     database_type: DatabaseType,
     origin: ConnectionOrigin,
+    database: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct PendingConnectionProbe {
+    pub id: ConnectionId,
+    pub name: String,
+    pub database_type: DatabaseType,
+    pub dsn: String,
+    pub database: Option<String>,
+    pub run_id: u64,
+}
+
+impl fmt::Debug for PendingConnectionProbe {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PendingConnectionProbe")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("database_type", &self.database_type)
+            .field("dsn", &mask_password(&self.dsn))
+            .field("database", &self.database)
+            .field("run_id", &self.run_id)
+            .finish()
+    }
 }
 
 // # Invariants
@@ -56,6 +84,11 @@ pub struct BrowseSession {
     // -- co-dependent: connection identity / lifecycle --
     dsn: Option<String>,
     active_connection: Option<ActiveConnection>,
+    connection_probe_run: AsyncRun,
+    pending_connection_probe: Option<PendingConnectionProbe>,
+    connection_generation: u64,
+    database_generation: u64,
+    available_databases: Vec<String>,
     active_engine_feature_profile: EngineFeatureProfile,
     read_only: bool,
     is_reloading: bool,
@@ -76,6 +109,11 @@ impl Default for BrowseSession {
             table_detail_run: AsyncRun::default(),
             dsn: None,
             active_connection: None,
+            connection_probe_run: AsyncRun::default(),
+            pending_connection_probe: None,
+            connection_generation: 0,
+            database_generation: 0,
+            available_databases: Vec::new(),
             active_engine_feature_profile: EngineFeatureProfile::disconnected(),
             read_only: false,
             is_reloading: false,
@@ -136,7 +174,90 @@ impl BrowseSession {
     }
 
     #[must_use]
+    pub fn begin_connection_probe(
+        &mut self,
+        id: &ConnectionId,
+        name: &str,
+        database_type: DatabaseType,
+        dsn: &str,
+        database: Option<&str>,
+    ) -> u64 {
+        self.cancel_metadata_for_connection_probe();
+        self.connection_generation = self.connection_generation.wrapping_add(1);
+        let run_id = self.connection_probe_run.begin();
+        self.pending_connection_probe = Some(PendingConnectionProbe {
+            id: id.clone(),
+            name: name.to_string(),
+            database_type,
+            dsn: dsn.to_string(),
+            database: database.map(str::to_string),
+            run_id,
+        });
+        run_id
+    }
+
+    pub fn invalidate_connection_generation(&mut self) {
+        self.connection_generation = self.connection_generation.wrapping_add(1);
+    }
+
+    fn cancel_metadata_for_connection_probe(&mut self) {
+        self.metadata_run.clear_active();
+        self.effective_user_run.clear_active();
+        self.table_detail_run.clear_active();
+        self.is_reloading = false;
+        match self.connection_state {
+            ConnectionState::Connecting => {
+                self.connection_state = ConnectionState::NotConnected;
+                self.metadata_state = MetadataState::NotLoaded;
+            }
+            ConnectionState::Connected => {
+                self.metadata_state = if self.metadata.is_some() {
+                    MetadataState::Loaded
+                } else {
+                    MetadataState::NotLoaded
+                };
+            }
+            ConnectionState::AwaitingDatabase
+            | ConnectionState::Failed
+            | ConnectionState::NotConnected => {}
+        }
+    }
+
+    pub fn is_current_connection_probe(
+        &self,
+        id: &ConnectionId,
+        name: &str,
+        database_type: DatabaseType,
+        dsn: &str,
+        database: Option<&str>,
+        run_id: u64,
+    ) -> bool {
+        self.connection_probe_run.is_current(run_id)
+            && self
+                .pending_connection_probe
+                .as_ref()
+                .is_some_and(|pending| {
+                    pending.run_id == run_id
+                        && pending.id == *id
+                        && pending.name == name
+                        && pending.database_type == database_type
+                        && pending.dsn == dsn
+                        && pending.database.as_deref() == database
+                })
+    }
+
+    pub fn pending_connection_probe(&self) -> Option<&PendingConnectionProbe> {
+        self.pending_connection_probe.as_ref()
+    }
+
+    pub fn clear_connection_probe(&mut self) {
+        self.connection_probe_run.clear_active();
+        self.pending_connection_probe = None;
+    }
+
+    #[must_use]
     pub fn begin_connecting(&mut self, dsn: &str) -> u64 {
+        self.clear_connection_probe();
         self.dsn = Some(dsn.to_string());
         self.mark_connecting();
         self.begin_metadata_run()
@@ -149,15 +270,30 @@ impl BrowseSession {
         database_type: DatabaseType,
         dsn: &str,
     ) {
+        self.activate_connection_with_target(id, name, database_type, dsn, None);
+    }
+
+    pub fn activate_connection_with_target(
+        &mut self,
+        id: &ConnectionId,
+        name: &str,
+        database_type: DatabaseType,
+        dsn: &str,
+        database: Option<&str>,
+    ) {
+        self.database_generation = self.database_generation.wrapping_add(1);
+        self.available_databases.clear();
         self.active_connection = Some(ActiveConnection {
             id: id.clone(),
             name: name.to_string(),
             database_type,
             origin: ConnectionOrigin::Profile,
+            database: database.map(str::to_string),
         });
         self.active_engine_feature_profile = EngineFeatureProfile::for_database_type(database_type);
         self.dsn = Some(dsn.to_string());
         self.read_only = false;
+        self.clear_connection_probe();
     }
 
     pub fn activate_cli_ephemeral_connection(&mut self, id: &ConnectionId, name: &str, dsn: &str) {
@@ -166,11 +302,13 @@ impl BrowseSession {
             name: name.to_string(),
             database_type: DatabaseType::SQLite,
             origin: ConnectionOrigin::CliEphemeral,
+            database: None,
         });
         self.active_engine_feature_profile =
             EngineFeatureProfile::for_database_type(DatabaseType::SQLite);
         self.dsn = Some(dsn.to_string());
         self.read_only = false;
+        self.clear_connection_probe();
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -186,6 +324,7 @@ impl BrowseSession {
             name: name.to_string(),
             database_type,
             origin: ConnectionOrigin::Profile,
+            database: None,
         });
         self.active_engine_feature_profile = EngineFeatureProfile::for_database_type(database_type);
     }
@@ -199,6 +338,8 @@ impl BrowseSession {
     pub fn clear_connection(&mut self) {
         self.dsn = None;
         self.active_connection = None;
+        self.available_databases.clear();
+        self.clear_connection_probe();
         self.active_engine_feature_profile = EngineFeatureProfile::disconnected();
     }
 
@@ -206,6 +347,19 @@ impl BrowseSession {
         self.connection_state = ConnectionState::Connected;
         self.metadata_state = MetadataState::Loaded;
         self.metadata = Some(metadata);
+        self.metadata_run.clear_active();
+        self.effective_user = None;
+        self.effective_user_run.clear_active();
+    }
+
+    pub fn mark_probe_connected(&mut self, has_database: bool) {
+        self.connection_state = if has_database {
+            ConnectionState::Connected
+        } else {
+            ConnectionState::AwaitingDatabase
+        };
+        self.metadata_state = MetadataState::NotLoaded;
+        self.metadata = None;
         self.metadata_run.clear_active();
         self.effective_user = None;
         self.effective_user_run.clear_active();
@@ -226,6 +380,7 @@ impl BrowseSession {
 
     #[must_use]
     pub fn begin_metadata_refresh(&mut self) -> u64 {
+        self.clear_connection_probe();
         self.metadata_state = MetadataState::Loading;
         self.begin_metadata_run()
     }
@@ -238,10 +393,12 @@ impl BrowseSession {
         self.effective_user = None;
         self.effective_user_run.clear_active();
         self.table_detail_run.clear_active();
+        self.clear_connection_probe();
     }
 
     #[must_use]
     pub fn begin_reload(&mut self) -> u64 {
+        self.clear_connection_probe();
         self.is_reloading = true;
         self.begin_metadata_run()
     }
@@ -265,6 +422,23 @@ impl BrowseSession {
 
     pub fn is_current_metadata_run(&self, run_id: u64) -> bool {
         self.metadata_run.is_current(run_id)
+    }
+
+    pub fn metadata_generation(&self) -> u64 {
+        self.metadata_run.last_id()
+    }
+
+    pub fn is_current_completion_scope(
+        &self,
+        dsn: Option<&str>,
+        connection_generation: u64,
+        database_generation: u64,
+        metadata_generation: u64,
+    ) -> bool {
+        self.dsn() == dsn
+            && self.connection_generation == connection_generation
+            && self.database_generation == database_generation
+            && self.metadata_generation() == metadata_generation
     }
 
     #[must_use]
@@ -316,6 +490,7 @@ impl BrowseSession {
         self.metadata_run.clear_active();
         self.effective_user_run.clear_active();
         self.table_detail_run.clear_active();
+        self.clear_connection_probe();
         match &cache.query_result {
             Some(r) => query.set_current_result(r.clone()),
             None => query.clear_current_result(),
@@ -331,9 +506,10 @@ impl BrowseSession {
         name: &str,
         database_type: DatabaseType,
         dsn: &str,
+        database: Option<&str>,
     ) {
         self.restore_from_cache(cache, query);
-        self.activate_connection_with_dsn(id, name, database_type, dsn);
+        self.activate_connection_with_target(id, name, database_type, dsn, database);
     }
 
     // Caller must also call `result_interaction.reset_view()` and restore UI state.
@@ -372,7 +548,8 @@ impl BrowseSession {
     }
 
     pub fn database_name(&self) -> Option<&str> {
-        self.metadata.as_ref().map(|m| m.database_name.as_str())
+        self.active_database()
+            .or_else(|| self.metadata.as_ref().map(|m| m.database_name.as_str()))
     }
 
     pub fn effective_user(&self) -> Option<&str> {
@@ -401,6 +578,52 @@ impl BrowseSession {
         self.dsn() == Some(expected)
     }
 
+    pub fn connection_generation(&self) -> u64 {
+        self.connection_generation
+    }
+
+    pub fn database_generation(&self) -> u64 {
+        self.database_generation
+    }
+
+    pub fn is_current_database_fetch(
+        &self,
+        id: &ConnectionId,
+        dsn: &str,
+        connection_generation: u64,
+        database_generation: u64,
+    ) -> bool {
+        self.connection_generation == connection_generation
+            && self.database_generation == database_generation
+            && self.active_connection_id() == Some(id)
+            && self.active_database_type() == Some(DatabaseType::MySQL)
+            && self.dsn().is_some_and(|current| {
+                self.server_dsn().as_deref() == Some(dsn) && current.starts_with("mysql:")
+            })
+    }
+
+    pub fn server_dsn(&self) -> Option<String> {
+        let mut url = url::Url::parse(self.dsn()?).ok()?;
+        url.path_segments_mut().ok()?.clear();
+        Some(url.to_string())
+    }
+
+    pub fn set_available_databases(&mut self, databases: Vec<String>) {
+        self.available_databases = databases
+            .into_iter()
+            .filter(|database| {
+                !matches!(
+                    database.to_ascii_lowercase().as_str(),
+                    "information_schema" | "mysql" | "performance_schema" | "sys"
+                )
+            })
+            .collect();
+    }
+
+    pub fn available_databases(&self) -> &[String] {
+        &self.available_databases
+    }
+
     pub fn active_connection_id(&self) -> Option<&ConnectionId> {
         self.active_connection
             .as_ref()
@@ -421,6 +644,21 @@ impl BrowseSession {
 
     pub fn active_database_type_or_default(&self) -> DatabaseType {
         self.active_database_type().unwrap_or_default()
+    }
+
+    pub fn active_database(&self) -> Option<&str> {
+        self.active_connection
+            .as_ref()
+            .and_then(|connection| connection.database.as_deref())
+    }
+
+    pub fn query_history_scope(&self) -> Option<QueryHistoryScope> {
+        let connection_id = self.active_connection_id()?.clone();
+        let database = match self.active_database_type() {
+            Some(DatabaseType::MySQL) => self.active_database().map(str::to_owned),
+            Some(DatabaseType::PostgreSQL | DatabaseType::SQLite) | None => None,
+        };
+        Some(QueryHistoryScope::new(connection_id, database))
     }
 
     pub fn active_engine_feature_profile(&self) -> &EngineFeatureProfile {
@@ -1026,6 +1264,42 @@ mod tests {
         }
     }
 
+    mod query_history_scope_tests {
+        use super::*;
+
+        #[test]
+        fn mysql_scope_includes_selected_database() {
+            let mut session = BrowseSession::default();
+            session.activate_connection_with_target(
+                &ConnectionId::from_string("mysql"),
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://localhost/app",
+                Some("app"),
+            );
+
+            let scope = session.query_history_scope().unwrap();
+
+            assert_eq!(scope.database.as_deref(), Some("app"));
+        }
+
+        #[test]
+        fn postgres_and_sqlite_scopes_omit_database() {
+            for database_type in [DatabaseType::PostgreSQL, DatabaseType::SQLite] {
+                let mut session = BrowseSession::default();
+                session.activate_connection_with_target(
+                    &ConnectionId::from_string("connection"),
+                    "connection",
+                    database_type,
+                    "dsn://connection",
+                    Some("database"),
+                );
+
+                assert_eq!(session.query_history_scope().unwrap().database, None);
+            }
+        }
+    }
+
     // ── Getters ──────────────────────────────────────────────────────
 
     mod getter_tests {
@@ -1089,6 +1363,23 @@ mod tests {
 
             assert!(!session.is_ephemeral_connection());
             assert!(session.can_reenter_connection_setup());
+        }
+
+        #[test]
+        fn pending_probe_debug_masks_password() {
+            let mut session = BrowseSession::default();
+            let id = ConnectionId::new();
+            let _ = session.begin_connection_probe(
+                &id,
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://user:secret@localhost:3306/app",
+                Some("app"),
+            );
+
+            let debug = format!("{session:?}");
+            assert!(!debug.contains("secret"));
+            assert!(debug.contains("mysql://user:****@localhost:3306/app"));
         }
 
         #[test]

--- a/src/app/model/sql_editor/completion.rs
+++ b/src/app/model/sql_editor/completion.rs
@@ -3,6 +3,7 @@ use std::collections::VecDeque;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompletionKind {
     Keyword,
+    Database,
     Table,
     Column,
 }

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -1,7 +1,10 @@
+use crate::domain::DatabaseType;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TokenKind {
     Keyword(String),
     Identifier(String),
+    BacktickIdentifier(String),
     Operator(String),
     Punctuation(char),
     StringLiteral,
@@ -46,13 +49,14 @@ enum LexerState {
     Normal,
     InSingleQuote,
     InDoubleQuote,
+    InBacktickIdentifier,
     InDollarQuote,
     InLineComment,
     InBlockComment,
     InEscapeString,
 }
 
-const SQL_KEYWORDS: &[&str] = &[
+const POSTGRESQL_KEYWORDS: &[&str] = &[
     "SELECT",
     "FROM",
     "WHERE",
@@ -149,11 +153,130 @@ const SQL_KEYWORDS: &[&str] = &[
     "RELEASE",
 ];
 
-pub struct SqlLexer;
+const MYSQL_KEYWORDS: &[&str] = &[
+    "SELECT",
+    "FROM",
+    "WHERE",
+    "JOIN",
+    "LEFT",
+    "RIGHT",
+    "INNER",
+    "OUTER",
+    "CROSS",
+    "ON",
+    "AND",
+    "OR",
+    "NOT",
+    "IN",
+    "IS",
+    "NULL",
+    "TRUE",
+    "FALSE",
+    "LIKE",
+    "BETWEEN",
+    "EXISTS",
+    "CASE",
+    "WHEN",
+    "THEN",
+    "ELSE",
+    "END",
+    "AS",
+    "DISTINCT",
+    "ORDER",
+    "BY",
+    "ASC",
+    "DESC",
+    "GROUP",
+    "HAVING",
+    "LIMIT",
+    "OFFSET",
+    "UNION",
+    "INTERSECT",
+    "EXCEPT",
+    "ALL",
+    "INSERT",
+    "INTO",
+    "VALUES",
+    "UPDATE",
+    "SET",
+    "DELETE",
+    "CREATE",
+    "DROP",
+    "ALTER",
+    "TABLE",
+    "INDEX",
+    "VIEW",
+    "WITH",
+    "RECURSIVE",
+    "COALESCE",
+    "NULLIF",
+    "CAST",
+    "USING",
+    "FULL",
+    "NATURAL",
+    "WINDOW",
+    "OVER",
+    "PARTITION",
+    "ROWS",
+    "RANGE",
+    "UNBOUNDED",
+    "PRECEDING",
+    "FOLLOWING",
+    "CURRENT",
+    "ROW",
+    "EXPLAIN",
+    "ANALYZE",
+    "SHOW",
+    "DESCRIBE",
+    "DATABASE",
+    "DATABASES",
+    "PRIMARY",
+    "KEY",
+    "FOREIGN",
+    "REFERENCES",
+    "UNIQUE",
+    "DEFAULT",
+    "CONSTRAINT",
+    "CHECK",
+    "IF",
+    "CASCADE",
+    "RENAME",
+    "MODIFY",
+    "COLUMN",
+    "ENGINE",
+    "CHARACTER",
+    "CHARSET",
+    "COLLATE",
+    "AUTO_INCREMENT",
+    "FOR",
+    "LOCK",
+    "SHARE",
+    "START",
+    "TRANSACTION",
+    "COMMIT",
+    "ROLLBACK",
+];
+
+pub struct SqlLexer {
+    database_type: DatabaseType,
+}
 
 impl SqlLexer {
-    pub fn new() -> Self {
-        Self
+    pub fn new(database_type: DatabaseType) -> Self {
+        Self { database_type }
+    }
+
+    fn is_mysql(&self) -> bool {
+        self.database_type == DatabaseType::MySQL
+    }
+
+    fn is_keyword(&self, word: &str) -> bool {
+        let keywords = if self.is_mysql() {
+            MYSQL_KEYWORDS
+        } else {
+            POSTGRESQL_KEYWORDS
+        };
+        keywords.contains(&word)
     }
 
     pub fn tokenize(&self, text: &str, cursor_pos: usize) -> Vec<Token> {
@@ -197,6 +320,13 @@ impl SqlLexer {
                         token_start = pos;
                         state = LexerState::InBlockComment;
                         pos += 2;
+                        continue;
+                    }
+
+                    if self.is_mysql() && c == '#' {
+                        token_start = pos;
+                        state = LexerState::InLineComment;
+                        pos += 1;
                         continue;
                     }
 
@@ -248,6 +378,13 @@ impl SqlLexer {
                     if c == '"' {
                         token_start = pos;
                         state = LexerState::InDoubleQuote;
+                        pos += 1;
+                        continue;
+                    }
+
+                    if self.is_mysql() && c == '`' {
+                        token_start = pos;
+                        state = LexerState::InBacktickIdentifier;
                         pos += 1;
                         continue;
                     }
@@ -316,7 +453,7 @@ impl SqlLexer {
                         }
                         let text: String = chars[start..pos].iter().collect();
                         let upper = text.to_uppercase();
-                        let kind = if SQL_KEYWORDS.contains(&upper.as_str()) {
+                        let kind = if self.is_keyword(&upper) {
                             TokenKind::Keyword(upper)
                         } else {
                             TokenKind::Identifier(text.clone())
@@ -373,6 +510,29 @@ impl SqlLexer {
                         tokens.push(Token {
                             kind: TokenKind::Identifier(text.clone()),
                             text,
+                            start: token_start,
+                            end: pos + 1,
+                        });
+                        state = LexerState::Normal;
+                        pos += 1;
+                        continue;
+                    }
+                    pos += 1;
+                }
+
+                LexerState::InBacktickIdentifier => {
+                    if c == '`' {
+                        if pos + 1 < end_pos && chars[pos + 1] == '`' {
+                            pos += 2;
+                            continue;
+                        }
+                        let name: String = chars[token_start + 1..pos]
+                            .iter()
+                            .collect::<String>()
+                            .replace("``", "`");
+                        tokens.push(Token {
+                            kind: TokenKind::BacktickIdentifier(name),
+                            text: chars[token_start..=pos].iter().collect(),
                             start: token_start,
                             end: pos + 1,
                         });
@@ -472,6 +632,9 @@ impl SqlLexer {
                 | LexerState::InDollarQuote
                 | LexerState::InEscapeString => TokenKind::StringLiteral,
                 LexerState::InDoubleQuote => TokenKind::Identifier(text.clone()),
+                LexerState::InBacktickIdentifier => {
+                    TokenKind::BacktickIdentifier(text[1..].to_string())
+                }
                 LexerState::InLineComment | LexerState::InBlockComment => TokenKind::Comment,
                 LexerState::Normal => unreachable!(),
             };
@@ -487,29 +650,25 @@ impl SqlLexer {
     }
 
     pub fn is_in_string_or_comment(&self, text: &str, cursor_pos: usize) -> bool {
-        let tokens = self.tokenize(text, cursor_pos);
-
-        if let Some(last) = tokens.last() {
-            // If cursor is at the end of the last token
-            if last.end == cursor_pos {
-                matches!(last.kind, TokenKind::StringLiteral | TokenKind::Comment)
-            } else if last.start <= cursor_pos && cursor_pos < last.end {
-                // Cursor is inside a token
-                matches!(last.kind, TokenKind::StringLiteral | TokenKind::Comment)
-            } else {
-                false
-            }
-        } else {
-            false
-        }
+        let tokens = self.tokenize(text, text.chars().count());
+        Self::is_in_string_or_comment_from_tokens(&tokens, cursor_pos)
     }
 
     pub fn is_in_string_or_comment_from_tokens(tokens: &[Token], cursor_pos: usize) -> bool {
         tokens.iter().any(|t| {
-            t.start < cursor_pos
-                && cursor_pos <= t.end
-                && matches!(t.kind, TokenKind::StringLiteral | TokenKind::Comment)
+            if matches!(t.kind, TokenKind::StringLiteral | TokenKind::Comment) {
+                t.start < cursor_pos && cursor_pos <= t.end
+            } else if matches!(t.kind, TokenKind::BacktickIdentifier(_)) {
+                (t.start < cursor_pos && cursor_pos < t.end)
+                    || (cursor_pos == t.end && Self::is_unterminated_backtick(&t.text))
+            } else {
+                false
+            }
         })
+    }
+
+    fn is_unterminated_backtick(text: &str) -> bool {
+        text.starts_with('`') && text.chars().skip(1).filter(|&c| c == '`').count() % 2 == 0
     }
 
     fn is_operator_char(c: char) -> bool {
@@ -660,7 +819,9 @@ impl SqlLexer {
 
         // Get first identifier (could be schema or table)
         match &tokens[*i].kind {
-            TokenKind::Identifier(name) | TokenKind::Keyword(name) => {
+            TokenKind::Identifier(name)
+            | TokenKind::BacktickIdentifier(name)
+            | TokenKind::Keyword(name) => {
                 table = name.clone();
             }
             _ => return None,
@@ -679,12 +840,16 @@ impl SqlLexer {
             while *i < tokens.len() && tokens[*i].kind == TokenKind::Whitespace {
                 *i += 1;
             }
-            if *i < tokens.len()
-                && let TokenKind::Identifier(name) | TokenKind::Keyword(name) = &tokens[*i].kind
+            let token = tokens.get(*i)?;
+            if let TokenKind::Identifier(name)
+            | TokenKind::BacktickIdentifier(name)
+            | TokenKind::Keyword(name) = &token.kind
             {
                 schema = Some(table);
                 table = name.clone();
                 *i += 1;
+            } else {
+                return None;
             }
         }
 
@@ -708,7 +873,7 @@ impl SqlLexer {
         // Get alias if present (identifier that's not a keyword like ON, WHERE, etc.)
         if *i < tokens.len() {
             match &tokens[*i].kind {
-                TokenKind::Identifier(name) => {
+                TokenKind::Identifier(name) | TokenKind::BacktickIdentifier(name) => {
                     alias = Some(name.clone());
                     *i += 1;
                 }
@@ -793,7 +958,9 @@ impl SqlLexer {
 
                     // Get CTE name
                     let position = tokens[i].start;
-                    if let TokenKind::Identifier(name) | TokenKind::Keyword(name) = &tokens[i].kind
+                    if let TokenKind::Identifier(name)
+                    | TokenKind::BacktickIdentifier(name)
+                    | TokenKind::Keyword(name) = &tokens[i].kind
                     {
                         // Don't treat SELECT as a CTE name
                         if name != "SELECT" {
@@ -1006,7 +1173,7 @@ impl SqlLexer {
 
 impl Default for SqlLexer {
     fn default() -> Self {
-        Self::new()
+        Self::new(DatabaseType::PostgreSQL)
     }
 }
 
@@ -1015,7 +1182,7 @@ mod tests {
     use super::*;
 
     fn lexer() -> SqlLexer {
-        SqlLexer::new()
+        SqlLexer::default()
     }
 
     mod tokenization {
@@ -1267,6 +1434,93 @@ mod tests {
                 })
                 .collect();
             assert_eq!(keywords, vec!["FROM"]);
+        }
+    }
+
+    mod mysql_syntax {
+        use super::*;
+
+        fn mysql_lexer() -> SqlLexer {
+            SqlLexer::new(DatabaseType::MySQL)
+        }
+
+        #[test]
+        fn backtick_identifiers_are_normalized_and_preserve_escaped_ticks() {
+            let l = mysql_lexer();
+            let sql = "SELECT `select` FROM `app`.`order``items`";
+            let tokens = l.tokenize(sql, sql.chars().count());
+
+            assert!(tokens.iter().any(|token| {
+                matches!(
+                    &token.kind,
+                    TokenKind::BacktickIdentifier(name) if name == "select"
+                )
+            }));
+            assert!(tokens.iter().any(|token| {
+                matches!(
+                    &token.kind,
+                    TokenKind::BacktickIdentifier(name) if name == "order`items"
+                )
+            }));
+        }
+
+        #[test]
+        fn hash_comment_hides_keywords_from_context() {
+            let l = mysql_lexer();
+            let tokens = l.tokenize("SELECT # FROM\nFROM", 18);
+            let keywords: Vec<_> = tokens
+                .iter()
+                .filter_map(|token| match &token.kind {
+                    TokenKind::Keyword(keyword) => Some(keyword.as_str()),
+                    _ => None,
+                })
+                .collect();
+
+            assert_eq!(keywords, vec!["SELECT", "FROM"]);
+        }
+
+        #[test]
+        fn mysql_keywords_are_distinct_from_postgresql_keywords() {
+            let mysql = mysql_lexer();
+            let postgres = SqlLexer::default();
+
+            assert!(matches!(
+                mysql.tokenize("DESCRIBE users", 14)[0].kind,
+                TokenKind::Keyword(_)
+            ));
+            assert!(matches!(
+                postgres.tokenize("DESCRIBE users", 14)[0].kind,
+                TokenKind::Identifier(_)
+            ));
+        }
+
+        #[test]
+        fn backtick_identifier_is_not_a_completion_context() {
+            let l = mysql_lexer();
+            let sql = "SELECT `SEL";
+
+            assert!(l.is_in_string_or_comment(sql, sql.chars().count()));
+            assert!(l.is_in_string_or_comment("SELECT `a``", 11));
+            assert!(l.is_in_string_or_comment("SELECT `a``b`", 10));
+            assert!(!l.is_in_string_or_comment("SELECT `SEL`", 12));
+        }
+
+        #[test]
+        fn backtick_qualified_table_reference_supports_aliases() {
+            let l = mysql_lexer();
+            let sql = "SELECT * FROM `app`.`users` AS `u`";
+            let tokens = l.tokenize(sql, sql.chars().count());
+            let references = l.extract_table_references(&tokens);
+
+            assert_eq!(
+                references,
+                vec![TableReference {
+                    schema: Some("app".to_string()),
+                    table: "users".to_string(),
+                    alias: Some("u".to_string()),
+                    position: 14,
+                }]
+            );
         }
     }
 

--- a/src/app/policy/sql/mod.rs
+++ b/src/app/policy/sql/mod.rs
@@ -1,4 +1,5 @@
 pub mod lexer;
+pub mod mysql_statement;
 pub mod result_query;
 pub mod sqlite_explain;
 pub mod sqlite_export;

--- a/src/app/policy/sql/mysql_statement.rs
+++ b/src/app/policy/sql/mysql_statement.rs
@@ -1,0 +1,1182 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MysqlStatementKind {
+    Select,
+    Table,
+    Show,
+    Describe,
+    Insert,
+    Replace,
+    Update { has_where: bool },
+    Delete { has_where: bool },
+    CreateTable { temporary: bool },
+    AlterTable,
+    DropTable { temporary: bool },
+    TruncateTable,
+    CreateView,
+    DropView,
+    CreateIndex,
+    DropIndex,
+    Begin,
+    StartTransaction,
+    Commit,
+    Rollback,
+    Savepoint,
+    RollbackToSavepoint,
+    ReleaseSavepoint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MysqlStatement {
+    pub sql: String,
+    pub kind: MysqlStatementKind,
+    pub target: Option<String>,
+    pub target_database: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MysqlLexError(pub String);
+
+impl fmt::Display for MysqlLexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TokenKind {
+    Word(String),
+    Identifier(String),
+    StringLiteral,
+    Number,
+    Symbol(char),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Token {
+    kind: TokenKind,
+    depth: usize,
+}
+
+pub fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MysqlLexError> {
+    let mut statements = Vec::new();
+    let mut start = 0;
+    let mut index = 0;
+    let mut quote = None;
+    let bytes = sql.as_bytes();
+    let mut depth = 0usize;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if let Some(delimiter) = quote {
+            if byte == b'\\' && delimiter != b'`' {
+                index += 2;
+                continue;
+            }
+            if byte == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                } else {
+                    quote = None;
+                    index += 1;
+                }
+                continue;
+            }
+            index += 1;
+            continue;
+        }
+
+        if is_line_comment_start(bytes, index) {
+            index = skip_line_comment(bytes, index);
+            continue;
+        }
+        if bytes.get(index..index + 2) == Some(b"/*") {
+            index = skip_block_comment(bytes, index)?;
+            continue;
+        }
+        if matches!(byte, b'\'' | b'"' | b'`') {
+            quote = Some(byte);
+            index += 1;
+            continue;
+        }
+        match byte {
+            b'(' => depth += 1,
+            b')' => {
+                depth = depth
+                    .checked_sub(1)
+                    .ok_or_else(|| MysqlLexError("unbalanced MySQL parentheses".to_string()))?;
+            }
+            b';' if depth == 0 => {
+                push_mysql_statement(&mut statements, &sql[start..index]);
+                start = index + 1;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    if quote.is_some() {
+        return Err(MysqlLexError(
+            "unterminated MySQL quoted literal".to_string(),
+        ));
+    }
+    if depth != 0 {
+        return Err(MysqlLexError("unbalanced MySQL parentheses".to_string()));
+    }
+    push_mysql_statement(&mut statements, &sql[start..]);
+    Ok(statements)
+}
+
+fn push_mysql_statement(statements: &mut Vec<String>, fragment: &str) {
+    let trimmed = fragment.trim();
+    if !trimmed.is_empty() && !is_comment_only(trimmed) {
+        statements.push(trimmed.to_string());
+    }
+}
+
+fn is_line_comment_start(bytes: &[u8], index: usize) -> bool {
+    bytes[index] == b'#'
+        || (bytes.get(index..index + 2) == Some(b"--")
+            && bytes.get(index + 2).is_none_or(u8::is_ascii_whitespace))
+}
+
+fn skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() {
+        let byte = bytes[index];
+        index += 1;
+        if byte == b'\n' {
+            break;
+        }
+    }
+    index
+}
+
+fn skip_block_comment(bytes: &[u8], index: usize) -> Result<usize, MysqlLexError> {
+    let mut cursor = index + 2;
+    while cursor + 1 < bytes.len() {
+        if bytes[cursor] == b'*' && bytes[cursor + 1] == b'/' {
+            return Ok(cursor + 2);
+        }
+        cursor += 1;
+    }
+    Err(MysqlLexError(
+        "unterminated MySQL block comment".to_string(),
+    ))
+}
+
+fn is_comment_only(sql: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index].is_ascii_whitespace() {
+            index += 1;
+        } else if is_line_comment_start(bytes, index) {
+            index = skip_line_comment(bytes, index);
+        } else if bytes.get(index..index + 2) == Some(b"/*") {
+            if bytes.get(index + 2) == Some(&b'!') {
+                return false;
+            }
+            index = match skip_block_comment(bytes, index) {
+                Ok(next) => next,
+                Err(_) => return false,
+            };
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MysqlLexError> {
+    let bytes = sql.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    let mut depth = 0usize;
+    let mut leading_executable_version_comment = false;
+
+    while index < bytes.len() {
+        if bytes[index].is_ascii_whitespace() {
+            index += 1;
+            continue;
+        }
+        if is_line_comment_start(bytes, index) {
+            index = skip_line_comment(bytes, index);
+            continue;
+        }
+        if bytes.get(index..index + 2) == Some(b"/*") {
+            let end = skip_block_comment(bytes, index)?;
+            let body = &sql[index + 2..end - 2];
+            if let Some(body) = body.strip_prefix('!') {
+                let body = body.trim_start();
+                let version_len = body.bytes().take_while(u8::is_ascii_digit).count();
+                if version_len == 0 {
+                    return Err(MysqlLexError(
+                        "MySQL version comment has no verifiable version".to_string(),
+                    ));
+                }
+                let content = body[version_len..].trim_start();
+                if content.is_empty() {
+                    return Err(MysqlLexError(
+                        "MySQL version comment has no executable statement".to_string(),
+                    ));
+                }
+                let inner = lex_mysql_statement(content)?;
+                let executable_statement = inner.first().is_some_and(|token| {
+                    matches!(&token.kind, TokenKind::Word(word) if is_mysql_statement_keyword(word))
+                });
+                let contains_statement_separator = inner
+                    .iter()
+                    .any(|token| matches!(token.kind, TokenKind::Symbol(';')));
+                if tokens.is_empty() && executable_statement && !contains_statement_separator {
+                    tokens.extend(inner);
+                    leading_executable_version_comment = true;
+                } else if !inner.is_empty() {
+                    tokens.push(Token {
+                        kind: TokenKind::Word("UNSUPPORTED_VERSION_COMMENT".to_string()),
+                        depth,
+                    });
+                }
+            }
+            index = end;
+            continue;
+        }
+
+        if leading_executable_version_comment {
+            tokens.push(Token {
+                kind: TokenKind::Word("UNSUPPORTED_VERSION_COMMENT".to_string()),
+                depth,
+            });
+            leading_executable_version_comment = false;
+        }
+
+        let byte = bytes[index];
+        if matches!(byte, b'\'' | b'"' | b'`') {
+            let end = skip_quoted(bytes, index, byte)?;
+            let text = &sql[index + 1..end - 1];
+            let kind = if byte == b'`' {
+                TokenKind::Identifier(text.replace("``", "`"))
+            } else {
+                TokenKind::StringLiteral
+            };
+            tokens.push(Token { kind, depth });
+            index = end;
+            continue;
+        }
+        if byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$' {
+            let start = index;
+            index += 1;
+            while index < bytes.len()
+                && (bytes[index].is_ascii_alphanumeric() || matches!(bytes[index], b'_' | b'$'))
+            {
+                index += 1;
+            }
+            let word = sql[start..index].to_ascii_uppercase();
+            tokens.push(Token {
+                kind: TokenKind::Word(word),
+                depth,
+            });
+            continue;
+        }
+        if byte.is_ascii_digit() {
+            index += 1;
+            while index < bytes.len()
+                && (bytes[index].is_ascii_alphanumeric() || matches!(bytes[index], b'.' | b'_'))
+            {
+                index += 1;
+            }
+            tokens.push(Token {
+                kind: TokenKind::Number,
+                depth,
+            });
+            continue;
+        }
+        let kind = TokenKind::Symbol(byte as char);
+        tokens.push(Token { kind, depth });
+        match byte {
+            b'(' => depth += 1,
+            b')' => {
+                depth = depth
+                    .checked_sub(1)
+                    .ok_or_else(|| MysqlLexError("unbalanced MySQL parentheses".to_string()))?;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    Ok(tokens)
+}
+
+fn is_mysql_statement_keyword(word: &str) -> bool {
+    matches!(
+        word,
+        "SELECT"
+            | "TABLE"
+            | "SHOW"
+            | "DESCRIBE"
+            | "DESC"
+            | "WITH"
+            | "INSERT"
+            | "UPDATE"
+            | "DELETE"
+            | "CREATE"
+            | "ALTER"
+            | "DROP"
+            | "TRUNCATE"
+            | "BEGIN"
+            | "START"
+            | "COMMIT"
+            | "ROLLBACK"
+            | "SAVEPOINT"
+            | "RELEASE"
+            | "USE"
+            | "SET"
+            | "LOCK"
+            | "UNLOCK"
+            | "REPLACE"
+            | "CALL"
+            | "DO"
+            | "HANDLER"
+            | "LOAD"
+            | "PREPARE"
+            | "EXECUTE"
+            | "DEALLOCATE"
+            | "XA"
+    )
+}
+
+fn skip_quoted(bytes: &[u8], index: usize, quote: u8) -> Result<usize, MysqlLexError> {
+    let mut cursor = index + 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' && quote != b'`' {
+            cursor += 2;
+            continue;
+        }
+        if bytes[cursor] == quote {
+            if bytes.get(cursor + 1) == Some(&quote) {
+                cursor += 2;
+            } else {
+                return Ok(cursor + 1);
+            }
+        } else {
+            cursor += 1;
+        }
+    }
+    Err(MysqlLexError(
+        "unterminated MySQL quoted literal".to_string(),
+    ))
+}
+
+fn word(tokens: &[Token], index: usize) -> Option<&str> {
+    match tokens.get(index)?.kind {
+        TokenKind::Word(ref word) => Some(word),
+        _ => None,
+    }
+}
+
+fn top_level_word(tokens: &[Token], word_value: &str) -> bool {
+    tokens.iter().any(|token| {
+        token.depth == 0 && matches!(&token.kind, TokenKind::Word(word) if word == word_value)
+    })
+}
+
+fn identifier_at(tokens: &[Token], mut index: usize) -> Option<(String, Option<String>, usize)> {
+    while matches!(
+        tokens.get(index).map(|token| &token.kind),
+        Some(TokenKind::Symbol(','))
+    ) {
+        index += 1;
+    }
+    let first = match &tokens.get(index)?.kind {
+        TokenKind::Word(word) => word.clone(),
+        TokenKind::Identifier(identifier) => identifier.clone(),
+        _ => return None,
+    };
+    if matches!(
+        tokens.get(index + 1).map(|token| &token.kind),
+        Some(TokenKind::Symbol('.'))
+    ) {
+        let second = match &tokens.get(index + 2)?.kind {
+            TokenKind::Word(word) => word.clone(),
+            TokenKind::Identifier(identifier) => identifier.clone(),
+            _ => return None,
+        };
+        return Some((second, Some(first), index + 3));
+    }
+    Some((first, None, index + 1))
+}
+
+fn skip_mysql_modifiers(tokens: &[Token], mut index: usize, modifiers: &[&str]) -> usize {
+    while word(tokens, index).is_some_and(|value| modifiers.contains(&value)) {
+        index += 1;
+    }
+    index
+}
+
+fn find_word(tokens: &[Token], value: &str, start: usize) -> Option<usize> {
+    tokens
+        .iter()
+        .enumerate()
+        .skip(start)
+        .find_map(|(index, token)| {
+            (token.depth == 0 && matches!(&token.kind, TokenKind::Word(word) if word == value))
+                .then_some(index)
+        })
+}
+
+fn cte_body_start(tokens: &[Token]) -> Option<usize> {
+    if word(tokens, 0) != Some("WITH") {
+        return None;
+    }
+    let mut index = 1;
+    if word(tokens, index) == Some("RECURSIVE") {
+        index += 1;
+    }
+    loop {
+        if !matches!(
+            tokens.get(index).map(|token| &token.kind),
+            Some(TokenKind::Word(_) | TokenKind::Identifier(_))
+        ) {
+            return None;
+        }
+        index += 1;
+        if matches!(
+            tokens.get(index).map(|token| &token.kind),
+            Some(TokenKind::Symbol('('))
+        ) {
+            index = skip_parenthesized_tokens(tokens, index)?;
+        }
+        if word(tokens, index) != Some("AS") {
+            return None;
+        }
+        index += 1;
+        if !matches!(
+            tokens.get(index).map(|token| &token.kind),
+            Some(TokenKind::Symbol('('))
+        ) {
+            return None;
+        }
+        index = skip_parenthesized_tokens(tokens, index)?;
+        if matches!(
+            tokens.get(index).map(|token| &token.kind),
+            Some(TokenKind::Symbol(','))
+        ) {
+            index += 1;
+            continue;
+        }
+        return Some(index);
+    }
+}
+
+fn skip_parenthesized_tokens(tokens: &[Token], index: usize) -> Option<usize> {
+    if !matches!(
+        tokens.get(index).map(|token| &token.kind),
+        Some(TokenKind::Symbol('('))
+    ) {
+        return None;
+    }
+    let mut depth = 0usize;
+    for (cursor, token) in tokens.iter().enumerate().skip(index) {
+        match token.kind {
+            TokenKind::Symbol('(') => depth += 1,
+            TokenKind::Symbol(')') => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(cursor + 1);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn drop_target_after(
+    tokens: &[Token],
+    index: usize,
+) -> Result<(Option<String>, Option<String>), MysqlLexError> {
+    let (target, database, next) = identifier_at(tokens, index)
+        .ok_or_else(|| MysqlLexError("MySQL statement target is ambiguous".to_string()))?;
+    if tokens[next..]
+        .iter()
+        .any(|token| token.depth == 0 && matches!(token.kind, TokenKind::Symbol(',')))
+    {
+        return Err(MysqlLexError(
+            "MySQL DROP statements must have one target".to_string(),
+        ));
+    }
+    Ok((Some(target), database))
+}
+
+fn effective_start(tokens: &[Token]) -> usize {
+    cte_body_start(tokens).unwrap_or(0)
+}
+
+fn kind_and_target(
+    tokens: &[Token],
+) -> Result<(MysqlStatementKind, Option<String>, Option<String>), MysqlLexError> {
+    let start = effective_start(tokens);
+    let first =
+        word(tokens, start).ok_or_else(|| MysqlLexError("unknown MySQL statement".to_string()))?;
+    let target_after = |index: usize| {
+        identifier_at(tokens, index)
+            .map(|(target, database, _)| (Some(target), database))
+            .ok_or_else(|| MysqlLexError("MySQL statement target is ambiguous".to_string()))
+    };
+
+    let result = match first {
+        "SELECT" => (MysqlStatementKind::Select, None, None),
+        "TABLE" => (MysqlStatementKind::Table, None, None),
+        "SHOW" => (MysqlStatementKind::Show, None, None),
+        "DESCRIBE" | "DESC" => (MysqlStatementKind::Describe, None, None),
+        "INSERT" | "REPLACE" => {
+            let index = if first == "INSERT" {
+                skip_mysql_modifiers(
+                    tokens,
+                    start + 1,
+                    &["LOW_PRIORITY", "DELAYED", "HIGH_PRIORITY", "IGNORE"],
+                )
+            } else {
+                skip_mysql_modifiers(tokens, start + 1, &["LOW_PRIORITY", "DELAYED"])
+            };
+            let target_index = if word(tokens, index) == Some("INTO") {
+                index + 1
+            } else {
+                index
+            };
+            let (target, database) = target_after(target_index)?;
+            let kind = if first == "REPLACE" {
+                MysqlStatementKind::Replace
+            } else {
+                MysqlStatementKind::Insert
+            };
+            (kind, target, database)
+        }
+        "UPDATE" => {
+            let has_where = top_level_word(&tokens[start..], "WHERE");
+            let target_index = skip_mysql_modifiers(tokens, start + 1, &["LOW_PRIORITY", "IGNORE"]);
+            let (target, database) = target_after(target_index)?;
+            (MysqlStatementKind::Update { has_where }, target, database)
+        }
+        "DELETE" => {
+            let has_where = top_level_word(&tokens[start..], "WHERE");
+            let index =
+                skip_mysql_modifiers(tokens, start + 1, &["LOW_PRIORITY", "QUICK", "IGNORE"]);
+            let target_index = if word(tokens, index) == Some("FROM") {
+                index + 1
+            } else {
+                index
+            };
+            let (target, database) = target_after(target_index)?;
+            (MysqlStatementKind::Delete { has_where }, target, database)
+        }
+        "CREATE" => {
+            let mut index = start + 1;
+            let temporary = word(tokens, index) == Some("TEMPORARY");
+            if temporary {
+                index += 1;
+            }
+            match word(tokens, index) {
+                Some("TABLE") => {
+                    index += 1;
+                    if word(tokens, index) == Some("IF") {
+                        index += 3;
+                    }
+                    let (target, database) = target_after(index)?;
+                    (
+                        MysqlStatementKind::CreateTable { temporary },
+                        target,
+                        database,
+                    )
+                }
+                Some("VIEW") => {
+                    let (target, database) = target_after(index + 1)?;
+                    (MysqlStatementKind::CreateView, target, database)
+                }
+                Some("UNIQUE") if word(tokens, index + 1) == Some("INDEX") => {
+                    let on = find_word(tokens, "ON", index + 2).ok_or_else(|| {
+                        MysqlLexError("CREATE INDEX target is ambiguous".to_string())
+                    })?;
+                    let (_, database) = target_after(on + 1)?;
+                    let (index_name, _, _) = identifier_at(tokens, index + 2).ok_or_else(|| {
+                        MysqlLexError("CREATE INDEX name is ambiguous".to_string())
+                    })?;
+                    (MysqlStatementKind::CreateIndex, Some(index_name), database)
+                }
+                Some("INDEX" | "KEY") => {
+                    let on = find_word(tokens, "ON", index + 1).ok_or_else(|| {
+                        MysqlLexError("CREATE INDEX target is ambiguous".to_string())
+                    })?;
+                    let (_, database) = target_after(on + 1)?;
+                    let (index_name, _, _) = identifier_at(tokens, index + 1).ok_or_else(|| {
+                        MysqlLexError("CREATE INDEX name is ambiguous".to_string())
+                    })?;
+                    (MysqlStatementKind::CreateIndex, Some(index_name), database)
+                }
+                _ => {
+                    return Err(MysqlLexError(
+                        "unsupported MySQL CREATE statement".to_string(),
+                    ));
+                }
+            }
+        }
+        "ALTER" => {
+            if word(tokens, start + 1) != Some("TABLE") {
+                return Err(MysqlLexError(
+                    "unsupported MySQL ALTER statement".to_string(),
+                ));
+            }
+            let (target, database) = target_after(start + 2)?;
+            (MysqlStatementKind::AlterTable, target, database)
+        }
+        "DROP" => {
+            let mut index = start + 1;
+            let temporary = word(tokens, index) == Some("TEMPORARY");
+            if temporary {
+                index += 1;
+            }
+            match word(tokens, index) {
+                Some("TABLE") => {
+                    let target_index = if word(tokens, index + 1) == Some("IF") {
+                        index + 3
+                    } else {
+                        index + 1
+                    };
+                    let (target, database) = drop_target_after(tokens, target_index)?;
+                    (
+                        MysqlStatementKind::DropTable { temporary },
+                        target,
+                        database,
+                    )
+                }
+                Some("VIEW") => {
+                    let target_index = if word(tokens, index + 1) == Some("IF") {
+                        index + 3
+                    } else {
+                        index + 1
+                    };
+                    let (target, database) = drop_target_after(tokens, target_index)?;
+                    (MysqlStatementKind::DropView, target, database)
+                }
+                Some("INDEX" | "KEY") => {
+                    let on = find_word(tokens, "ON", index + 1).ok_or_else(|| {
+                        MysqlLexError("DROP INDEX target is ambiguous".to_string())
+                    })?;
+                    let (_, database) = target_after(on + 1)?;
+                    let index_name_index = if word(tokens, index + 1) == Some("IF") {
+                        index + 3
+                    } else {
+                        index + 1
+                    };
+                    let (index_name, _, _) = identifier_at(tokens, index_name_index)
+                        .ok_or_else(|| MysqlLexError("DROP INDEX name is ambiguous".to_string()))?;
+                    (MysqlStatementKind::DropIndex, Some(index_name), database)
+                }
+                _ => {
+                    return Err(MysqlLexError(
+                        "unsupported MySQL DROP statement".to_string(),
+                    ));
+                }
+            }
+        }
+        "TRUNCATE" => {
+            let target_index = if word(tokens, start + 1) == Some("TABLE") {
+                start + 2
+            } else {
+                start + 1
+            };
+            let (target, database) = target_after(target_index)?;
+            (MysqlStatementKind::TruncateTable, target, database)
+        }
+        "BEGIN" => {
+            if tokens.len() != start + 1 {
+                return Err(MysqlLexError(
+                    "BEGIN modifiers are not supported".to_string(),
+                ));
+            }
+            (MysqlStatementKind::Begin, None, None)
+        }
+        "START" if word(tokens, start + 1) == Some("TRANSACTION") => {
+            if tokens.len() != start + 2 {
+                return Err(MysqlLexError(
+                    "START TRANSACTION modifiers are not supported".to_string(),
+                ));
+            }
+            (MysqlStatementKind::StartTransaction, None, None)
+        }
+        "COMMIT" => {
+            if tokens.len() != start + 1 {
+                return Err(MysqlLexError(
+                    "COMMIT modifiers are not supported".to_string(),
+                ));
+            }
+            (MysqlStatementKind::Commit, None, None)
+        }
+        "ROLLBACK" => {
+            if word(tokens, start + 1).is_none() && tokens.len() == start + 1 {
+                (MysqlStatementKind::Rollback, None, None)
+            } else if word(tokens, start + 1) == Some("TO") {
+                let name_index = if word(tokens, start + 2) == Some("SAVEPOINT") {
+                    start + 3
+                } else {
+                    start + 2
+                };
+                if tokens.len() != name_index + 1 {
+                    return Err(MysqlLexError(
+                        "ROLLBACK modifiers are not supported".to_string(),
+                    ));
+                }
+                let (name, database, _) = identifier_at(tokens, name_index).ok_or_else(|| {
+                    MysqlLexError("ROLLBACK SAVEPOINT name is ambiguous".to_string())
+                })?;
+                (
+                    MysqlStatementKind::RollbackToSavepoint,
+                    Some(name),
+                    database,
+                )
+            } else {
+                return Err(MysqlLexError(
+                    "ROLLBACK modifiers are not supported".to_string(),
+                ));
+            }
+        }
+        "SAVEPOINT" if tokens.len() == start + 2 => {
+            let (name, database, _) = identifier_at(tokens, start + 1)
+                .ok_or_else(|| MysqlLexError("SAVEPOINT name is ambiguous".to_string()))?;
+            (MysqlStatementKind::Savepoint, Some(name), database)
+        }
+        "RELEASE" if word(tokens, start + 1) == Some("SAVEPOINT") && tokens.len() == start + 3 => {
+            let (name, database, _) = identifier_at(tokens, start + 2)
+                .ok_or_else(|| MysqlLexError("RELEASE SAVEPOINT name is ambiguous".to_string()))?;
+            (MysqlStatementKind::ReleaseSavepoint, Some(name), database)
+        }
+        _ => {
+            return Err(MysqlLexError(format!(
+                "unsupported MySQL statement: {first}"
+            )));
+        }
+    };
+    Ok(result)
+}
+
+pub fn classify_mysql_statement(sql: &str) -> Result<MysqlStatement, MysqlLexError> {
+    let tokens = lex_mysql_statement(sql)?;
+    if tokens.is_empty() {
+        return Err(MysqlLexError("empty MySQL statement".to_string()));
+    }
+    if tokens.iter().any(|token| {
+        matches!(
+            &token.kind,
+            TokenKind::Word(word) if word == "UNSUPPORTED_VERSION_COMMENT"
+        )
+    }) {
+        return Err(MysqlLexError(
+            "executable MySQL version comment contains another statement".to_string(),
+        ));
+    }
+    let (kind, target, target_database) = kind_and_target(&tokens)?;
+    Ok(MysqlStatement {
+        sql: sql.to_string(),
+        kind,
+        target,
+        target_database,
+    })
+}
+
+pub fn mysql_explain_rejection_message(sql: &str) -> Option<&'static str> {
+    let Ok(statements) = split_mysql_statements(sql) else {
+        return Some("MySQL EXPLAIN requires one valid statement");
+    };
+    if statements.len() != 1 {
+        return Some("MySQL EXPLAIN does not support multiple statements");
+    }
+    if statement_contains_unsupported_mysql_control(sql) {
+        return Some("MySQL EXPLAIN does not support MySQL client commands");
+    }
+
+    let Ok(statement) = classify_mysql_statement(&statements[0]) else {
+        return Some(
+            "MySQL EXPLAIN supports SELECT, TABLE, INSERT, REPLACE, UPDATE, or DELETE statements",
+        );
+    };
+    (!matches!(
+        statement.kind,
+        MysqlStatementKind::Select
+            | MysqlStatementKind::Table
+            | MysqlStatementKind::Insert
+            | MysqlStatementKind::Replace
+            | MysqlStatementKind::Update { .. }
+            | MysqlStatementKind::Delete { .. }
+    ))
+    .then_some(
+        "MySQL EXPLAIN supports SELECT, TABLE, INSERT, REPLACE, UPDATE, or DELETE statements",
+    )
+}
+
+pub fn mysql_tree_explain_query_kind(sql: &str) -> Option<bool> {
+    let trimmed = sql.trim();
+    let (is_analyze, target) = if let Some(target) =
+        strip_ascii_prefix_case_insensitive(trimmed, "EXPLAIN ANALYZE FORMAT=TREE")
+    {
+        (true, target)
+    } else if let Some(target) = strip_ascii_prefix_case_insensitive(trimmed, "EXPLAIN FORMAT=TREE")
+    {
+        (false, target)
+    } else {
+        return None;
+    };
+
+    if target.is_empty() || !target.chars().next().is_some_and(char::is_whitespace) {
+        return None;
+    }
+    let target = target.trim();
+
+    let valid = if is_analyze {
+        !statement_contains_unsupported_mysql_control(target)
+            && split_mysql_statements(target).is_ok_and(|statements| {
+                statements.len() == 1
+                    && classify_mysql_statement(&statements[0]).is_ok_and(|statement| {
+                        matches!(
+                            statement.kind,
+                            MysqlStatementKind::Select | MysqlStatementKind::Table
+                        ) && !has_mysql_read_only_side_effect(target).unwrap_or(true)
+                    })
+            })
+    } else {
+        mysql_explain_rejection_message(target).is_none()
+    };
+    valid.then_some(is_analyze)
+}
+
+fn strip_ascii_prefix_case_insensitive<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
+    text.get(..prefix.len())
+        .filter(|candidate| candidate.eq_ignore_ascii_case(prefix))
+        .map(|_| &text[prefix.len()..])
+}
+
+pub fn has_top_level_into_clause(sql: &str) -> Result<bool, MysqlLexError> {
+    let tokens = lex_mysql_statement(sql)?;
+    Ok(tokens.iter().any(|token| {
+        token.depth == 0 && matches!(&token.kind, TokenKind::Word(word) if word == "INTO")
+    }))
+}
+
+pub fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MysqlLexError> {
+    if has_mysql_version_comment(sql)? {
+        return Ok(true);
+    }
+
+    let tokens = lex_mysql_statement(sql)?;
+    for (index, token) in tokens.iter().enumerate() {
+        if matches!(&token.kind, TokenKind::Word(word) if word == "INTO") {
+            return Ok(true);
+        }
+        if matches!(&token.kind, TokenKind::Word(word) if matches!(
+            word.as_str(),
+            "GET_LOCK" | "RELEASE_LOCK" | "RELEASE_ALL_LOCKS"
+        )) {
+            return Ok(true);
+        }
+        if matches!(&token.kind, TokenKind::Symbol(':'))
+            && matches!(
+                tokens.get(index + 1).map(|token| &token.kind),
+                Some(TokenKind::Symbol('='))
+            )
+        {
+            return Ok(true);
+        }
+        if word_at(&tokens, index) == Some("FOR")
+            && matches!(word_at(&tokens, index + 1), Some("UPDATE" | "SHARE"))
+        {
+            return Ok(true);
+        }
+        if word_at(&tokens, index) == Some("LOCK")
+            && word_at(&tokens, index + 1) == Some("IN")
+            && word_at(&tokens, index + 2) == Some("SHARE")
+            && word_at(&tokens, index + 3) == Some("MODE")
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn word_at(tokens: &[Token], index: usize) -> Option<&str> {
+    match tokens.get(index)?.kind {
+        TokenKind::Word(ref word) => Some(word),
+        _ => None,
+    }
+}
+
+pub fn has_mysql_version_comment(sql: &str) -> Result<bool, MysqlLexError> {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    let mut quote = None;
+
+    while index < bytes.len() {
+        if let Some(delimiter) = quote {
+            if bytes[index] == b'\\' && delimiter != b'`' {
+                index = (index + 2).min(bytes.len());
+            } else if bytes[index] == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                } else {
+                    quote = None;
+                    index += 1;
+                }
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if is_line_comment_start(bytes, index) {
+            index = skip_line_comment(bytes, index);
+            continue;
+        }
+        if bytes.get(index..index + 2) == Some(b"/*") {
+            if bytes.get(index + 2) == Some(&b'!') {
+                return Ok(true);
+            }
+            index = skip_block_comment(bytes, index)?;
+            continue;
+        }
+        if matches!(bytes[index], b'\'' | b'"' | b'`') {
+            quote = Some(bytes[index]);
+        }
+        index += 1;
+    }
+
+    if quote.is_some() {
+        return Err(MysqlLexError(
+            "unterminated MySQL quoted literal".to_string(),
+        ));
+    }
+    Ok(false)
+}
+
+pub fn target_is_selected_database(
+    statement: &MysqlStatement,
+    selected_database: Option<&str>,
+) -> bool {
+    match (statement.target_database.as_deref(), selected_database) {
+        (Some(target_database), Some(selected)) => target_database.eq_ignore_ascii_case(selected),
+        (None, Some(_)) => true,
+        (Some(_) | None, None) => false,
+    }
+}
+
+pub fn statement_contains_unsupported_mysql_control(sql: &str) -> bool {
+    let lower = sql.trim_start().to_ascii_lowercase();
+    [
+        "use ",
+        "use\n",
+        "set ",
+        "set\n",
+        "lock tables",
+        "unlock tables",
+    ]
+    .iter()
+    .any(|prefix| lower.starts_with(prefix))
+        || contains_mysql_client_command(sql)
+}
+
+fn contains_mysql_client_command(sql: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    let mut line_start = true;
+    let mut quote = None;
+    let mut block_comment = false;
+
+    while index < bytes.len() {
+        if let Some(delimiter) = quote {
+            if bytes[index] == b'\\' && delimiter != b'`' {
+                index = (index + 2).min(bytes.len());
+            } else if bytes[index] == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                } else {
+                    quote = None;
+                    index += 1;
+                }
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if block_comment {
+            if bytes.get(index..index + 2) == Some(b"*/") {
+                block_comment = false;
+                index += 2;
+            } else {
+                line_start = bytes[index] == b'\n' || line_start;
+                index += 1;
+            }
+            continue;
+        }
+        if line_start {
+            if matches!(bytes[index], b' ' | b'\t' | b'\r') {
+                index += 1;
+                continue;
+            }
+            if bytes[index] == b'\n' {
+                index += 1;
+                continue;
+            }
+            if bytes[index] == b'\\' {
+                return true;
+            }
+            if bytes.get(index..index + 2) == Some(b"/*") {
+                block_comment = true;
+                index += 2;
+                continue;
+            }
+            if is_line_comment_start(bytes, index) {
+                index = skip_line_comment(bytes, index);
+                continue;
+            }
+            if bytes[index].is_ascii_alphabetic() {
+                let start = index;
+                index += 1;
+                while index < bytes.len()
+                    && (bytes[index].is_ascii_alphanumeric() || bytes[index] == b'_')
+                {
+                    index += 1;
+                }
+                let word = &sql[start..index];
+                if matches!(
+                    word.to_ascii_lowercase().as_str(),
+                    "delimiter" | "charset" | "source" | "system"
+                ) && (index == bytes.len() || bytes[index].is_ascii_whitespace())
+                {
+                    return true;
+                }
+                line_start = false;
+                continue;
+            }
+            line_start = false;
+        }
+
+        if bytes.get(index..index + 2) == Some(b"/*") {
+            block_comment = true;
+            index += 2;
+        } else if is_line_comment_start(bytes, index) {
+            index = skip_line_comment(bytes, index);
+            line_start = true;
+        } else if bytes[index] == b'\n' {
+            line_start = true;
+            index += 1;
+        } else if matches!(bytes[index], b'\'' | b'"' | b'`') {
+            quote = Some(bytes[index]);
+            line_start = false;
+            index += 1;
+        } else {
+            index += 1;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_mysql_comments_quotes_and_backticks() {
+        let sql = "SELECT 'a;\\'b'; # comment;\n SELECT `semi;colon` /* ; */";
+        assert_eq!(split_mysql_statements(sql).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn rejects_ambiguous_quotes() {
+        assert!(split_mysql_statements("SELECT 'unfinished").is_err());
+    }
+
+    #[test]
+    fn classifies_with_and_version_comment() {
+        let statement = classify_mysql_statement(
+            "WITH rows(id) AS (SELECT 1) UPDATE `app`.`items` SET value = 1",
+        )
+        .unwrap();
+        assert!(matches!(statement.kind, MysqlStatementKind::Update { .. }));
+        assert_eq!(statement.target, Some("items".to_string()));
+    }
+
+    #[test]
+    fn rejects_unverifiable_version_comment() {
+        assert!(classify_mysql_statement("/*! SET sql_mode='ANSI_QUOTES' */ SELECT 1").is_err());
+    }
+
+    #[test]
+    fn classifies_leading_version_comment_statement() {
+        assert!(matches!(
+            classify_mysql_statement("/*!80000 SELECT 1 */"),
+            Ok(MysqlStatement {
+                kind: MysqlStatementKind::Select,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_executable_version_comment_clause() {
+        assert!(classify_mysql_statement("SELECT 1 /*!80000 INTO OUTFILE '/tmp/x' */").is_err());
+        assert!(classify_mysql_statement("/*!80000 SELECT 1 */ SELECT 2").is_err());
+        assert!(classify_mysql_statement("/*!80000 SELECT 1; DROP TABLE items */").is_err());
+    }
+
+    #[test]
+    fn rejects_multiple_drop_targets_and_ambiguous_ddl_quotes() {
+        assert!(classify_mysql_statement("DROP TABLE app.keep, other.drop_me").is_err());
+        assert!(classify_mysql_statement("DROP VIEW app.keep, other.drop_me").is_err());
+        assert!(classify_mysql_statement("CREATE TABLE \"items\" (id INT)").is_err());
+    }
+
+    #[test]
+    fn rejects_executable_inline_control_statement() {
+        assert!(
+            classify_mysql_statement("SELECT 1 /*!80000 SET sql_mode='ANSI_QUOTES' */").is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_mysql_client_commands_at_line_start() {
+        for sql in [
+            "DELIMITER //\nSELECT 1//",
+            "charset utf8mb4\nSELECT 1",
+            "source ./script.sql",
+            "system echo unsafe",
+            "\\C /tmp/other.sock\nSELECT 1",
+            "SELECT 1\nsource ./script.sql",
+        ] {
+            assert!(statement_contains_unsupported_mysql_control(sql), "{sql}");
+        }
+        assert!(!statement_contains_unsupported_mysql_control(
+            "SELECT 'source ./script.sql\\n'"
+        ));
+    }
+
+    #[test]
+    fn keeps_index_confirmation_name_separate_from_ddl_database_target() {
+        let statement = classify_mysql_statement("DROP INDEX ix ON app.items").unwrap();
+        assert_eq!(statement.target, Some("IX".to_string()));
+        assert_eq!(statement.target_database, Some("APP".to_string()));
+        let statement = classify_mysql_statement("DROP INDEX IF EXISTS ix ON app.items").unwrap();
+        assert_eq!(statement.target, Some("IX".to_string()));
+    }
+
+    #[test]
+    fn recognizes_generated_tree_explain_queries() {
+        assert_eq!(
+            mysql_tree_explain_query_kind("EXPLAIN FORMAT=TREE UPDATE items SET value = 1"),
+            Some(false)
+        );
+        assert_eq!(
+            mysql_tree_explain_query_kind("EXPLAIN ANALYZE FORMAT=TREE TABLE items"),
+            Some(true)
+        );
+        assert_eq!(
+            mysql_tree_explain_query_kind("EXPLAIN ANALYZE FORMAT=TREE DELETE FROM items"),
+            None
+        );
+    }
+}

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1,5 +1,10 @@
 use super::write_guardrails::{self, RiskLevel};
 use crate::domain::DatabaseType;
+use crate::policy::sql::mysql_statement::{
+    MysqlStatement, MysqlStatementKind, classify_mysql_statement, has_mysql_read_only_side_effect,
+    has_top_level_into_clause, split_mysql_statements,
+    statement_contains_unsupported_mysql_control, target_is_selected_database,
+};
 use crate::policy::sql::sqlite_statement_splitter::split_sqlite_statements;
 use crate::policy::sql::sqlite_transaction::{
     SqliteStatementClassification, SqliteTransactionPolicy, parse_sqlite_pragma,
@@ -24,6 +29,208 @@ pub enum AcknowledgeReason {
     // SQLite cannot run this multi-statement script inside the automatic
     // transaction because one statement changes connection-level settings.
     NonAtomicTransaction,
+    // MySQL EXPLAIN ANALYZE executes an otherwise read-only target statement.
+    AnalyzeExecution,
+}
+
+#[cfg(test)]
+mod mysql_tests {
+    use super::*;
+
+    fn mysql(sql: &str) -> MultiStatementDecision {
+        evaluate_multi_statement_for_database_with_context(DatabaseType::MySQL, Some("app"), sql)
+    }
+
+    #[test]
+    fn max_risk_uses_destructive_confirmation() {
+        let decision = mysql("SELECT 'a;#'; UPDATE items SET value = 1");
+        match decision {
+            MultiStatementDecision::Allow { risk, statements } => {
+                assert_eq!(statements.len(), 2);
+                assert_eq!(risk.risk_level, RiskLevel::High);
+                assert_eq!(
+                    risk.confirmation,
+                    ConfirmationType::TableNameInput {
+                        target: "ITEMS".to_string()
+                    }
+                );
+                assert!(!risk.read_only_allowed);
+            }
+            MultiStatementDecision::Block { reason } => panic!("unexpected block: {reason}"),
+        }
+    }
+
+    #[test]
+    fn accepts_comments_hints_and_version_comments() {
+        assert!(matches!(
+            mysql("SELECT /*+ MAX_EXECUTION_TIME(1000) */ 1 # trailing\n"),
+            MultiStatementDecision::Allow { .. }
+        ));
+        assert!(matches!(
+            mysql("/*!80000 SELECT 1 */"),
+            MultiStatementDecision::Allow { .. }
+        ));
+    }
+
+    #[test]
+    fn read_only_allows_only_side_effect_free_mysql_reads() {
+        for sql in [
+            "SELECT 1",
+            "TABLE items",
+            "SHOW TABLES",
+            "DESCRIBE items",
+            "WITH rows AS (SELECT 1) SELECT * FROM rows",
+        ] {
+            let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
+                panic!("{sql}");
+            };
+            assert!(risk.read_only_allowed, "{sql}");
+        }
+
+        for sql in [
+            "SELECT * FROM items FOR UPDATE",
+            "SELECT * FROM items FOR SHARE",
+            "SELECT * FROM items LOCK IN SHARE MODE",
+            "SELECT @value := value FROM items",
+            "SELECT GET_LOCK('sabiql', 0)",
+            "SELECT RELEASE_LOCK('sabiql')",
+            "SELECT RELEASE_ALL_LOCKS()",
+            "/*!80000 SELECT 1 */",
+        ] {
+            let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
+                panic!("{sql}");
+            };
+            assert!(!risk.read_only_allowed, "{sql}");
+        }
+    }
+
+    #[test]
+    fn explain_targets_share_the_read_only_allowlist() {
+        for sql in ["SELECT 1", "TABLE items", "SHOW TABLES", "DESCRIBE items"] {
+            assert!(evaluate_mysql_explain_target(sql, false).is_some(), "{sql}");
+        }
+        for sql in [
+            "UPDATE items SET value = 1",
+            "SELECT * FROM items FOR UPDATE",
+            "SELECT * FROM items INTO OUTFILE '/tmp/items'",
+            "SELECT 1; SELECT 2",
+            "SELECT 1\nsystem echo unsafe",
+            "SELECT 1\n\\! echo unsafe",
+        ] {
+            assert!(evaluate_mysql_explain_target(sql, false).is_none(), "{sql}");
+            assert!(evaluate_mysql_explain_target(sql, true).is_none(), "{sql}");
+        }
+        for (sql, label) in [("SELECT 1", "SELECT"), ("TABLE items", "TABLE")] {
+            let risk = evaluate_mysql_explain_target(sql, true).expect(sql);
+            assert_eq!(risk.risk_level, RiskLevel::Low);
+            assert!(risk.read_only_allowed);
+            assert_eq!(
+                risk.confirmation,
+                ConfirmationType::Acknowledge {
+                    reason: AcknowledgeReason::AnalyzeExecution,
+                    label: label.to_string(),
+                }
+            );
+        }
+        assert!(evaluate_mysql_explain_target("SHOW TABLES", true).is_none());
+    }
+
+    #[test]
+    fn rejects_unsupported_controls_and_statements_before_execution() {
+        for sql in [
+            "USE app",
+            "SET sql_mode = 'ANSI_QUOTES'",
+            "LOCK TABLES items READ",
+            "UNLOCK TABLES",
+            "REPLACE INTO items VALUES (1)",
+            "CALL do_work()",
+            "LOAD DATA INFILE 'x' INTO TABLE items",
+            "/*! SET sql_mode='ANSI_QUOTES' */ SELECT 1",
+            "SELECT 1\n\\! echo unsafe",
+            "SELECT 1\nsystem echo unsafe",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Block { .. }),
+                "{sql}"
+            );
+        }
+        for sql in [
+            "SELECT 'source ./script.sql\\n'",
+            "SELECT /* source ./script.sql */ 1",
+            "SELECT `system echo unsafe`",
+            "UPDATE items\nSET value = 1 WHERE id = 1",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Allow { .. }),
+                "{sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn ddl_rejects_a_different_database() {
+        assert!(matches!(
+            evaluate_multi_statement_for_database_with_context(
+                DatabaseType::MySQL,
+                Some("app"),
+                "ALTER TABLE other.items ADD COLUMN value INT",
+            ),
+            MultiStatementDecision::Block { .. }
+        ));
+        assert!(matches!(
+            evaluate_multi_statement_for_database_with_context(
+                DatabaseType::MySQL,
+                Some("app"),
+                "ALTER TABLE app.items ADD COLUMN value INT",
+            ),
+            MultiStatementDecision::Allow { .. }
+        ));
+        assert!(matches!(
+            evaluate_multi_statement_for_database_with_context(
+                DatabaseType::MySQL,
+                None,
+                "CREATE TABLE items (id INT)",
+            ),
+            MultiStatementDecision::Block { .. }
+        ));
+        assert!(matches!(
+            mysql("DROP TABLE app.keep, other.drop_me"),
+            MultiStatementDecision::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn transaction_modifiers_are_rejected() {
+        for sql in [
+            "START TRANSACTION READ ONLY",
+            "COMMIT AND CHAIN",
+            "ROLLBACK AND NO CHAIN",
+            "ROLLBACK TO SAVEPOINT named extra",
+            "RELEASE SAVEPOINT named extra",
+            "BEGIN",
+            "BEGIN; UPDATE items SET value = 1",
+            "SAVEPOINT named",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Block { .. }),
+                "{sql}"
+            );
+        }
+        for sql in [
+            "COMMIT",
+            "ROLLBACK",
+            "BEGIN; COMMIT",
+            "START TRANSACTION; ROLLBACK",
+            "BEGIN; SAVEPOINT named; ROLLBACK TO named; RELEASE SAVEPOINT named; COMMIT",
+            "CREATE TEMPORARY TABLE temp_items (id INT); INSERT INTO temp_items VALUES (1); SELECT * FROM temp_items",
+            "CREATE TEMPORARY TABLE temp_items (id INT); DROP TEMPORARY TABLE app.temp_items",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Allow { .. }),
+                "{sql}"
+            );
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,6 +262,351 @@ pub enum MultiStatementDecision {
     Block {
         reason: String,
     },
+}
+
+fn mysql_low(read_only_allowed: bool) -> SqlRiskDecision {
+    SqlRiskDecision {
+        risk_level: RiskLevel::Low,
+        confirmation: ConfirmationType::Immediate,
+        read_only_allowed,
+    }
+}
+
+fn mysql_table_name_input(statement: &MysqlStatement) -> SqlRiskDecision {
+    match statement.target.as_deref() {
+        Some(target) => SqlRiskDecision {
+            risk_level: RiskLevel::High,
+            confirmation: ConfirmationType::TableNameInput {
+                target: target.to_string(),
+            },
+            read_only_allowed: false,
+        },
+        None => SqlRiskDecision {
+            risk_level: RiskLevel::High,
+            confirmation: ConfirmationType::Acknowledge {
+                reason: AcknowledgeReason::TargetNameUnavailable,
+                label: mysql_statement_label(&statement.kind).to_string(),
+            },
+            read_only_allowed: false,
+        },
+    }
+}
+
+fn mysql_statement_risk(statement: &MysqlStatement) -> SqlRiskDecision {
+    match statement.kind {
+        MysqlStatementKind::Select
+        | MysqlStatementKind::Table
+        | MysqlStatementKind::Show
+        | MysqlStatementKind::Describe => {
+            mysql_low(!has_mysql_read_only_side_effect(&statement.sql).unwrap_or(true))
+        }
+        MysqlStatementKind::Begin
+        | MysqlStatementKind::StartTransaction
+        | MysqlStatementKind::Commit
+        | MysqlStatementKind::Rollback
+        | MysqlStatementKind::Savepoint
+        | MysqlStatementKind::RollbackToSavepoint
+        | MysqlStatementKind::ReleaseSavepoint
+        | MysqlStatementKind::Insert
+        | MysqlStatementKind::CreateTable { .. }
+        | MysqlStatementKind::CreateView
+        | MysqlStatementKind::CreateIndex => mysql_low(false),
+        MysqlStatementKind::Replace
+        | MysqlStatementKind::Update { has_where: true }
+        | MysqlStatementKind::Delete { has_where: true }
+        | MysqlStatementKind::AlterTable => SqlRiskDecision {
+            risk_level: RiskLevel::Medium,
+            confirmation: ConfirmationType::Immediate,
+            read_only_allowed: false,
+        },
+        MysqlStatementKind::Update { has_where: false }
+        | MysqlStatementKind::Delete { has_where: false }
+        | MysqlStatementKind::DropTable { .. }
+        | MysqlStatementKind::DropView
+        | MysqlStatementKind::DropIndex
+        | MysqlStatementKind::TruncateTable => mysql_table_name_input(statement),
+    }
+}
+
+pub fn mysql_statement_label(kind: &MysqlStatementKind) -> &'static str {
+    match kind {
+        MysqlStatementKind::Select => "SELECT",
+        MysqlStatementKind::Table => "TABLE",
+        MysqlStatementKind::Show => "SHOW",
+        MysqlStatementKind::Describe => "DESCRIBE",
+        MysqlStatementKind::Insert => "INSERT",
+        MysqlStatementKind::Replace => "REPLACE",
+        MysqlStatementKind::Update { has_where: true } => "UPDATE",
+        MysqlStatementKind::Update { has_where: false } => "UPDATE (no WHERE)",
+        MysqlStatementKind::Delete { has_where: true } => "DELETE",
+        MysqlStatementKind::Delete { has_where: false } => "DELETE (no WHERE)",
+        MysqlStatementKind::CreateTable { temporary: true } => "CREATE TEMPORARY TABLE",
+        MysqlStatementKind::CreateTable { temporary: false } => "CREATE TABLE",
+        MysqlStatementKind::AlterTable => "ALTER TABLE",
+        MysqlStatementKind::DropTable { temporary: true } => "DROP TEMPORARY TABLE",
+        MysqlStatementKind::DropTable { temporary: false } => "DROP TABLE",
+        MysqlStatementKind::TruncateTable => "TRUNCATE TABLE",
+        MysqlStatementKind::CreateView => "CREATE VIEW",
+        MysqlStatementKind::DropView => "DROP VIEW",
+        MysqlStatementKind::CreateIndex => "CREATE INDEX",
+        MysqlStatementKind::DropIndex => "DROP INDEX",
+        MysqlStatementKind::Begin => "BEGIN",
+        MysqlStatementKind::StartTransaction => "START TRANSACTION",
+        MysqlStatementKind::Commit => "COMMIT",
+        MysqlStatementKind::Rollback => "ROLLBACK",
+        MysqlStatementKind::Savepoint => "SAVEPOINT",
+        MysqlStatementKind::RollbackToSavepoint => "ROLLBACK TO SAVEPOINT",
+        MysqlStatementKind::ReleaseSavepoint => "RELEASE SAVEPOINT",
+    }
+}
+
+pub fn mysql_statement_is_schema_modifying(kind: &MysqlStatementKind) -> bool {
+    matches!(
+        kind,
+        MysqlStatementKind::CreateTable { .. }
+            | MysqlStatementKind::AlterTable
+            | MysqlStatementKind::DropTable { .. }
+            | MysqlStatementKind::TruncateTable
+            | MysqlStatementKind::CreateView
+            | MysqlStatementKind::DropView
+            | MysqlStatementKind::CreateIndex
+            | MysqlStatementKind::DropIndex
+    )
+}
+
+pub fn mysql_statement_is_data_modifying(kind: &MysqlStatementKind) -> bool {
+    matches!(
+        kind,
+        MysqlStatementKind::Insert
+            | MysqlStatementKind::Replace
+            | MysqlStatementKind::Update { .. }
+            | MysqlStatementKind::Delete { .. }
+    )
+}
+
+fn mysql_statement_is_persistent_schema_change(kind: &MysqlStatementKind) -> bool {
+    mysql_statement_is_schema_modifying(kind)
+        && !matches!(
+            kind,
+            MysqlStatementKind::CreateTable { temporary: true }
+                | MysqlStatementKind::DropTable { temporary: true }
+        )
+}
+
+fn mysql_target_key(statement: &MysqlStatement, selected_database: Option<&str>) -> Option<String> {
+    Some(format!(
+        "{}:{}",
+        statement
+            .target_database
+            .as_deref()
+            .or(selected_database)
+            .unwrap_or_default()
+            .to_ascii_uppercase(),
+        statement.target.as_deref()?.to_ascii_uppercase()
+    ))
+}
+
+fn mysql_validate_submission_state(
+    planned: &[(MysqlStatement, SqlRiskDecision)],
+    selected_database: Option<&str>,
+) -> Result<(), String> {
+    let mut transaction_open = false;
+    let mut savepoints = Vec::<String>::new();
+    let mut temporary_tables = Vec::<String>::new();
+
+    for (statement, _) in planned {
+        match &statement.kind {
+            MysqlStatementKind::Begin | MysqlStatementKind::StartTransaction => {
+                if transaction_open {
+                    return Err("nested MySQL transactions are not supported".to_string());
+                }
+                transaction_open = true;
+                savepoints.clear();
+            }
+            MysqlStatementKind::Commit | MysqlStatementKind::Rollback => {
+                transaction_open = false;
+                savepoints.clear();
+            }
+            MysqlStatementKind::Savepoint => {
+                if !transaction_open {
+                    return Err("MySQL SAVEPOINT requires an explicit transaction".to_string());
+                }
+                let name = statement
+                    .target
+                    .as_deref()
+                    .ok_or_else(|| "MySQL SAVEPOINT name is ambiguous".to_string())?;
+                savepoints.retain(|current| !current.eq_ignore_ascii_case(name));
+                savepoints.push(name.to_string());
+            }
+            MysqlStatementKind::RollbackToSavepoint => {
+                if !transaction_open {
+                    return Err(
+                        "MySQL ROLLBACK TO SAVEPOINT requires an explicit transaction".to_string(),
+                    );
+                }
+                let name = statement
+                    .target
+                    .as_deref()
+                    .ok_or_else(|| "MySQL SAVEPOINT name is ambiguous".to_string())?;
+                let Some(index) = savepoints
+                    .iter()
+                    .position(|current| current.eq_ignore_ascii_case(name))
+                else {
+                    return Err("MySQL ROLLBACK TO SAVEPOINT name is unknown".to_string());
+                };
+                savepoints.truncate(index + 1);
+            }
+            MysqlStatementKind::ReleaseSavepoint => {
+                if !transaction_open {
+                    return Err(
+                        "MySQL RELEASE SAVEPOINT requires an explicit transaction".to_string()
+                    );
+                }
+                let name = statement
+                    .target
+                    .as_deref()
+                    .ok_or_else(|| "MySQL SAVEPOINT name is ambiguous".to_string())?;
+                let Some(index) = savepoints
+                    .iter()
+                    .position(|current| current.eq_ignore_ascii_case(name))
+                else {
+                    return Err("MySQL RELEASE SAVEPOINT name is unknown".to_string());
+                };
+                savepoints.remove(index);
+            }
+            MysqlStatementKind::CreateTable { temporary: true } => {
+                let key = mysql_target_key(statement, selected_database)
+                    .ok_or_else(|| "MySQL temporary table target is ambiguous".to_string())?;
+                if temporary_tables.iter().any(|current| current == &key) {
+                    return Err("MySQL temporary table is created more than once".to_string());
+                }
+                temporary_tables.push(key);
+            }
+            MysqlStatementKind::DropTable { temporary: true } => {
+                let key = mysql_target_key(statement, selected_database)
+                    .ok_or_else(|| "MySQL temporary table target is ambiguous".to_string())?;
+                let Some(index) = temporary_tables.iter().position(|current| current == &key)
+                else {
+                    return Err(
+                        "MySQL temporary tables must be created and dropped in one submission"
+                            .to_string(),
+                    );
+                };
+                temporary_tables.remove(index);
+            }
+            kind if mysql_statement_is_persistent_schema_change(kind) => {
+                transaction_open = false;
+                savepoints.clear();
+            }
+            _ => {}
+        }
+    }
+
+    if transaction_open {
+        return Err("MySQL explicit transaction must finish in one submission".to_string());
+    }
+    Ok(())
+}
+
+pub fn evaluate_mysql_multi_statement(
+    sql: &str,
+    selected_database: Option<&str>,
+) -> MultiStatementDecision {
+    if statement_contains_unsupported_mysql_control(sql) {
+        return MultiStatementDecision::Block {
+            reason: "unsupported MySQL session or table-lock statement".to_string(),
+        };
+    }
+    let statements = match split_mysql_statements(sql) {
+        Ok(statements) if !statements.is_empty() => statements,
+        Ok(_) => {
+            return MultiStatementDecision::Block {
+                reason: "Empty MySQL input".to_string(),
+            };
+        }
+        Err(error) => {
+            return MultiStatementDecision::Block {
+                reason: error.to_string(),
+            };
+        }
+    };
+
+    let mut planned = Vec::with_capacity(statements.len());
+    for statement_sql in statements {
+        let statement = match classify_mysql_statement(&statement_sql) {
+            Ok(statement) => statement,
+            Err(error) => {
+                return MultiStatementDecision::Block {
+                    reason: error.to_string(),
+                };
+            }
+        };
+        if matches!(statement.kind, MysqlStatementKind::Replace) {
+            return MultiStatementDecision::Block {
+                reason: "MySQL REPLACE execution is not supported".to_string(),
+            };
+        }
+        if matches!(
+            statement.kind,
+            MysqlStatementKind::Select | MysqlStatementKind::Table
+        ) && has_top_level_into_clause(&statement.sql).unwrap_or(true)
+        {
+            return MultiStatementDecision::Block {
+                reason: "MySQL SELECT INTO clauses are not supported".to_string(),
+            };
+        }
+        if mysql_statement_is_schema_modifying(&statement.kind)
+            && !target_is_selected_database(&statement, selected_database)
+        {
+            return MultiStatementDecision::Block {
+                reason: "MySQL DDL target must be in the selected database".to_string(),
+            };
+        }
+        let decision = mysql_statement_risk(&statement);
+        planned.push((statement, decision));
+    }
+
+    if let Err(reason) = mysql_validate_submission_state(&planned, selected_database) {
+        return MultiStatementDecision::Block { reason };
+    }
+
+    let max_risk = planned
+        .iter()
+        .map(|(_, decision)| decision.risk_level)
+        .max()
+        .unwrap_or(RiskLevel::Low);
+    let table_confirmations: Vec<String> = planned
+        .iter()
+        .filter_map(|(_, decision)| match &decision.confirmation {
+            ConfirmationType::TableNameInput { target } => Some(target.clone()),
+            _ => None,
+        })
+        .collect();
+    if table_confirmations.len() > 1 {
+        return MultiStatementDecision::Block {
+            reason: "MySQL statements require separate destructive confirmations".to_string(),
+        };
+    }
+    let confirmation = if let Some(target) = table_confirmations.into_iter().next() {
+        ConfirmationType::TableNameInput { target }
+    } else {
+        ConfirmationType::Immediate
+    };
+    let read_only_allowed = planned
+        .iter()
+        .all(|(_, decision)| decision.read_only_allowed);
+    let statements = planned
+        .iter()
+        .map(|(statement, _)| statement.sql.clone())
+        .collect();
+    MultiStatementDecision::Allow {
+        statements,
+        risk: SqlRiskDecision {
+            risk_level: max_risk,
+            confirmation,
+            read_only_allowed,
+        },
+    }
 }
 
 fn contains_cli_meta_command(database_type: DatabaseType, sql: &str) -> bool {
@@ -134,6 +686,9 @@ pub fn split_statements(sql: &str) -> Vec<String> {
 }
 
 pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> Vec<String> {
+    if database_type == DatabaseType::MySQL {
+        return split_mysql_statements(sql).unwrap_or_default();
+    }
     if database_type == DatabaseType::SQLite {
         return split_sqlite_statements(sql)
             .statements()
@@ -266,6 +821,9 @@ pub fn evaluate_sql_risk_for_database(
     kind: &StatementKind,
     sql: &str,
 ) -> SqlRiskDecision {
+    if database_type == DatabaseType::MySQL {
+        return evaluate_mysql_statement_risk(sql);
+    }
     if database_type == DatabaseType::SQLite
         && let Some(decision) = evaluate_sqlite_specific_risk(sql)
     {
@@ -333,6 +891,56 @@ pub fn evaluate_sql_risk_for_database(
     }
 }
 
+fn evaluate_mysql_statement_risk(sql: &str) -> SqlRiskDecision {
+    if let Ok(statement) = classify_mysql_statement(sql) {
+        return mysql_statement_risk(&statement);
+    }
+
+    SqlRiskDecision {
+        risk_level: RiskLevel::Low,
+        confirmation: ConfirmationType::Acknowledge {
+            reason: AcknowledgeReason::UnknownRisk,
+            label: first_keyword(sql).unwrap_or_else(|| "SQL".to_string()),
+        },
+        read_only_allowed: false,
+    }
+}
+
+pub fn evaluate_mysql_explain_target(sql: &str, analyze: bool) -> Option<SqlRiskDecision> {
+    if statement_contains_unsupported_mysql_control(sql) {
+        return None;
+    }
+    let statements = split_mysql_statements(sql).ok()?;
+    if statements.len() != 1 {
+        return None;
+    }
+    let statement = classify_mysql_statement(&statements[0]).ok()?;
+    let allowed_kind = if analyze {
+        matches!(
+            statement.kind,
+            MysqlStatementKind::Select | MysqlStatementKind::Table
+        )
+    } else {
+        matches!(
+            statement.kind,
+            MysqlStatementKind::Select
+                | MysqlStatementKind::Table
+                | MysqlStatementKind::Show
+                | MysqlStatementKind::Describe
+        )
+    };
+    let mut risk = mysql_statement_risk(&statement);
+    if analyze && risk.read_only_allowed {
+        risk.confirmation = ConfirmationType::Acknowledge {
+            reason: AcknowledgeReason::AnalyzeExecution,
+            label: mysql_statement_label(&statement.kind).to_string(),
+        };
+    }
+    allowed_kind
+        .then_some(risk)
+        .filter(|risk| risk.read_only_allowed)
+}
+
 pub fn evaluate_multi_statement(sql: &str) -> MultiStatementDecision {
     evaluate_multi_statement_for_database(DatabaseType::PostgreSQL, sql)
 }
@@ -341,6 +949,17 @@ pub fn evaluate_multi_statement_for_database(
     database_type: DatabaseType,
     sql: &str,
 ) -> MultiStatementDecision {
+    evaluate_multi_statement_for_database_with_context(database_type, None, sql)
+}
+
+pub fn evaluate_multi_statement_for_database_with_context(
+    database_type: DatabaseType,
+    selected_database: Option<&str>,
+    sql: &str,
+) -> MultiStatementDecision {
+    if database_type == DatabaseType::MySQL {
+        return evaluate_mysql_multi_statement(sql, selected_database);
+    }
     if contains_cli_meta_command(database_type, sql) {
         return MultiStatementDecision::Block {
             reason: "CLI meta-commands are not supported in SQL input".to_string(),
@@ -553,6 +1172,10 @@ pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
 }
 
 pub fn adhoc_label_for_statement(database_type: DatabaseType, sql: &str) -> &'static str {
+    if database_type == DatabaseType::MySQL {
+        return classify_mysql_statement(sql)
+            .map_or("SQL", |statement| mysql_statement_label(&statement.kind));
+    }
     let sqlite_label = (database_type == DatabaseType::SQLite)
         .then(|| sqlite_specific_label(sql))
         .flatten();
@@ -565,6 +1188,19 @@ pub fn adhoc_label_for_table_name_confirmation(
     database_type: DatabaseType,
     sql: &str,
 ) -> Option<&'static str> {
+    if database_type == DatabaseType::MySQL {
+        return split_mysql_statements(sql)
+            .ok()?
+            .into_iter()
+            .find_map(|statement| {
+                let statement = classify_mysql_statement(&statement).ok()?;
+                matches!(
+                    mysql_statement_risk(&statement).confirmation,
+                    ConfirmationType::TableNameInput { .. }
+                )
+                .then(|| mysql_statement_label(&statement.kind))
+            });
+    }
     for stmt in split_statements_for_database(database_type, sql) {
         let kind = classify(&stmt);
         let decision = evaluate_sql_risk_for_database(database_type, &kind, &stmt);

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -2,15 +2,20 @@ use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
 
+use crate::domain::RefreshScope;
 use crate::policy::password_masking::mask_password;
 
 pub const SQLITE_TABLE_LIST_REQUIRED_MARKER: &str = "SQLITE_TABLE_LIST_REQUIRED";
 pub const SQLITE_SAFE_MODE_REQUIRED_MARKER: &str = "SQLITE_SAFE_MODE_REQUIRED";
+pub const MYSQL_CLI_VERSION_REQUIRED_MARKER: &str = "MYSQL_CLI_VERSION_REQUIRED";
+pub const MYSQL_SERVER_VERSION_REQUIRED_MARKER: &str = "MYSQL_SERVER_VERSION_REQUIRED";
+pub const MYSQL_SQL_MODE_UNSUPPORTED_MARKER: &str = "MYSQL_SQL_MODE_UNSUPPORTED";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DatabaseCli {
     Psql,
     Sqlite3,
+    MySql,
 }
 
 impl DatabaseCli {
@@ -18,6 +23,7 @@ impl DatabaseCli {
         match self {
             Self::Psql => "Database CLI not found",
             Self::Sqlite3 => "sqlite3 not found",
+            Self::MySql => "mysql not found",
         }
     }
 
@@ -25,6 +31,7 @@ impl DatabaseCli {
         match self {
             Self::Psql => "Install the database client and add it to PATH",
             Self::Sqlite3 => "Install sqlite3 and add it to PATH",
+            Self::MySql => "Install the Oracle MySQL 8.4 client and add it to PATH",
         }
     }
 }
@@ -48,6 +55,11 @@ pub enum DbOperationError {
     ObjectMissing(String),
     #[error("Query failed")]
     QueryFailed(String),
+    #[error("Query failed after a change")]
+    QueryFailedAfterChange {
+        details: String,
+        refresh_scope: RefreshScope,
+    },
     #[error("Unsupported operation")]
     UnsupportedOperation(String),
     #[error("Metadata parse failed")]
@@ -82,6 +94,7 @@ impl DbOperationError {
             Self::LockTimeout(_) => "Operation blocked by lock or timeout",
             Self::ObjectMissing(_) => "Database object not found",
             Self::QueryFailed(_) => "Query failed",
+            Self::QueryFailedAfterChange { .. } => "Query failed after a change",
             Self::UnsupportedOperation(_) => "Unsupported operation",
             Self::MetadataParseFailed(_) => "Failed to parse database metadata output",
             Self::InvalidJson(_) => "Failed to parse database JSON output",
@@ -108,6 +121,9 @@ impl DbOperationError {
             }
             Self::ObjectMissing(_) => "Check the table, column, or connected database",
             Self::QueryFailed(_) => "Review the database error details and SQL",
+            Self::QueryFailedAfterChange { .. } => {
+                "Some changes may have been committed; refresh the database state before retrying"
+            }
             Self::UnsupportedOperation(_) => "Use a supported operation for this database",
             Self::MetadataParseFailed(_) => {
                 "Check whether the metadata output format changed unexpectedly"
@@ -132,6 +148,7 @@ impl DbOperationError {
             | Self::LockTimeout(details)
             | Self::ObjectMissing(details)
             | Self::QueryFailed(details)
+            | Self::QueryFailedAfterChange { details, .. }
             | Self::UnsupportedOperation(details)
             | Self::MetadataParseFailed(details)
             | Self::EmptyResponse(details)
@@ -305,6 +322,21 @@ mod tests {
             assert_eq!(
                 error.user_message(),
                 "Query failed: syntax error at or near SELECT. Review the database error details and SQL."
+            );
+        }
+
+        #[test]
+        fn change_failure_warns_about_possible_commits() {
+            let error = DbOperationError::QueryFailedAfterChange {
+                details: "syntax error".to_string(),
+                refresh_scope: RefreshScope::Metadata,
+            };
+
+            assert_eq!(error.summary(), "Query failed after a change");
+            assert!(
+                error
+                    .user_message()
+                    .contains("Some changes may have been committed")
             );
         }
 

--- a/src/app/ports/outbound/query_history.rs
+++ b/src/app/ports/outbound/query_history.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::domain::connection::ConnectionId;
-use crate::domain::query_history::QueryHistoryEntry;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum QueryHistoryError {
@@ -40,14 +39,14 @@ pub trait QueryHistoryStore: Send + Sync {
     async fn append(
         &self,
         project_name: &str,
-        connection_id: &ConnectionId,
+        scope: &QueryHistoryScope,
         entry: &QueryHistoryEntry,
     ) -> Result<(), QueryHistoryError>;
 
     async fn load(
         &self,
         project_name: &str,
-        connection_id: &ConnectionId,
+        scope: &QueryHistoryScope,
     ) -> Result<Vec<QueryHistoryEntry>, QueryHistoryError>;
 }
 

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -1,9 +1,10 @@
+use std::fmt;
 use std::sync::Arc;
 
 use crate::domain::connection::{
-    ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
+    ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
 };
-use crate::domain::query_history::QueryHistoryEntry;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 use crate::model::app_state::AppState;
 use crate::model::browse::jsonb_detail::JsonbDetailMode;
 use crate::model::connection::error::ConnectionErrorInfo;
@@ -11,8 +12,8 @@ use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::Prefix;
 use crate::model::sql_editor::completion::CompletionCandidate;
-use crate::policy::FeatureRequirement;
 use crate::policy::write::write_guardrails::WritePreview;
+use crate::policy::{FeatureRequirement, mask_password};
 use crate::ports::outbound::clipboard::ClipboardError;
 use crate::ports::outbound::connection_store::ConnectionStoreError;
 use crate::ports::outbound::folder_opener::FolderOpenError;
@@ -20,11 +21,10 @@ use crate::ports::outbound::query_history::QueryHistoryError;
 use crate::ports::outbound::settings_store::SettingsStoreError;
 use crate::ports::outbound::{AppSettings, DbOperationError};
 use std::collections::HashMap;
+use url::Url;
 
 use crate::domain::SqliteDiagnosticsSnapshot;
-use crate::domain::{
-    ConnectionId, DatabaseMetadata, DiagnosticField, QueryResult, QuerySource, Table,
-};
+use crate::domain::{DatabaseMetadata, DiagnosticField, QueryResult, QuerySource, Table};
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ConnectionSaveError {
@@ -34,6 +34,11 @@ pub enum ConnectionSaveError {
     Store(#[from] ConnectionStoreError),
     #[error("{0}")]
     Metadata(#[from] DbOperationError),
+    #[error("{error}")]
+    Probe {
+        error: DbOperationError,
+        dsn: String,
+    },
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -44,6 +49,13 @@ pub enum ErDiagramError {
     ExportFailed(String),
     #[error("Task panicked: {0}")]
     TaskPanicked(String),
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{error}")]
+pub struct ErDiagramFailure {
+    pub run_id: u64,
+    pub error: ErDiagramError,
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -192,6 +204,7 @@ pub enum ListMotion {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModalKind {
     TablePicker,
+    DatabasePicker,
     CommandPalette,
     Settings,
     Help,
@@ -228,6 +241,7 @@ pub struct SmartErRefreshError {
 
 #[derive(Debug, Clone)]
 pub struct ErDiagramInfo {
+    pub run_id: u64,
     pub path: String,
     pub table_count: usize,
     pub total_tables: usize,
@@ -249,12 +263,44 @@ pub struct TableTarget {
     pub generation: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ConnectionTarget {
     pub id: ConnectionId,
     pub dsn: String,
     pub name: String,
     pub database_type: DatabaseType,
+    pub database: Option<String>,
+}
+
+impl fmt::Debug for ConnectionTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ConnectionTarget")
+            .field("id", &self.id)
+            .field("dsn", &mask_password(&self.dsn))
+            .field("name", &self.name)
+            .field("database_type", &self.database_type)
+            .field("database", &self.database)
+            .finish()
+    }
+}
+
+impl ConnectionTarget {
+    pub fn with_database(&self, database: &str) -> Option<Self> {
+        let mut url = Url::parse(&self.dsn).ok()?;
+        url.path_segments_mut().ok()?.clear().push(database);
+        Some(Self {
+            dsn: url.to_string(),
+            database: Some(database.to_string()),
+            ..self.clone()
+        })
+    }
+
+    pub fn server_dsn(&self) -> Option<String> {
+        let mut url = Url::parse(&self.dsn).ok()?;
+        url.path_segments_mut().ok()?.clear();
+        Some(url.to_string())
+    }
 }
 
 // Full Action equality is intentionally unavailable: some payloads carry
@@ -347,6 +393,32 @@ pub enum Action {
     ConnectionSetupCancel,
     ConnectionSaveCompleted(ConnectionTarget),
     ConnectionSaveFailed(ConnectionSaveError),
+    ConnectionProbeCompleted {
+        target: ConnectionTarget,
+        run_id: u64,
+    },
+    ConnectionProbeFailed {
+        target: ConnectionTarget,
+        run_id: u64,
+        error: DbOperationError,
+    },
+    SwitchMySqlDatabase {
+        database: String,
+    },
+    MySqlDatabasesLoaded {
+        connection_id: ConnectionId,
+        dsn: String,
+        connection_generation: u64,
+        database_generation: u64,
+        databases: Vec<String>,
+    },
+    MySqlDatabasesFailed {
+        connection_id: ConnectionId,
+        dsn: String,
+        connection_generation: u64,
+        database_generation: u64,
+        error: DbOperationError,
+    },
     ConnectionEditLoaded(Box<ConnectionProfile>),
     ConnectionEditLoadFailed(ConnectionStoreError),
     ShowConnectionError(ConnectionErrorInfo),
@@ -476,6 +548,10 @@ pub enum Action {
         candidates: Vec<CompletionCandidate>,
         trigger_position: usize,
         visible: bool,
+        dsn: Option<String>,
+        connection_generation: u64,
+        database_generation: u64,
+        metadata_generation: u64,
     },
     CompletionAccept,
     CompletionDismiss,
@@ -489,6 +565,8 @@ pub enum Action {
     ExplainAnalyzeCancel,
     ExplainCompleted {
         dsn: String,
+        database_type: DatabaseType,
+        database_generation: u64,
         run_id: u64,
         query: String,
         plan_text: String,
@@ -497,6 +575,7 @@ pub enum Action {
     },
     ExplainFailed {
         dsn: String,
+        database_generation: u64,
         run_id: u64,
         error: DbOperationError,
         is_analyze: bool,
@@ -566,8 +645,8 @@ pub enum Action {
     ToggleReadOnly,
 
     // Query history
-    QueryHistoryLoaded(ConnectionId, Vec<QueryHistoryEntry>),
-    QueryHistoryLoadFailed(ConnectionId, QueryHistoryError),
+    QueryHistoryLoaded(QueryHistoryScope, Vec<QueryHistoryEntry>),
+    QueryHistoryLoadFailed(QueryHistoryScope, QueryHistoryError),
     QueryHistoryAppendFailed(QueryHistoryError),
     QueryHistoryConfirmSelection,
 
@@ -634,7 +713,7 @@ pub enum Action {
     SmartErRefreshCompleted(SmartErRefreshResult),
     SmartErRefreshFailed(SmartErRefreshError),
     ErDiagramOpened(ErDiagramInfo),
-    ErDiagramFailed(ErDiagramError),
+    ErDiagramFailed(ErDiagramFailure),
     ErLogWriteFailed(ErLogError),
 }
 
@@ -649,8 +728,8 @@ impl Action {
 
     pub fn feature_requirement(&self) -> FeatureRequirement {
         use FeatureRequirement::{
-            ErDiagram, Explain, ExplainAnalyze, JsonbDetail, None, PlanComparison,
-            SqliteDiagnostics,
+            ErDiagram, Explain, ExplainAnalyze, JsonDocumentDetail, JsonDocumentEdit, None,
+            PlanComparison, SqliteDiagnostics,
         };
 
         match self {
@@ -704,35 +783,52 @@ impl Action {
             | Self::ToggleModal(ModalKind::JsonbDetail)
             | Self::JsonbYankAll
             | Self::JsonbYankSuccess
-            | Self::JsonbEnterEdit
-            | Self::JsonbAppendInsert
-            | Self::JsonbExitEdit
             | Self::JsonbEnterSearch
             | Self::JsonbExitSearch
             | Self::JsonbSearchNext
             | Self::JsonbSearchPrev
             | Self::JsonbSearchSubmit
             | Self::TextInput {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
                 ..
             }
             | Self::TextBackspace {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
             }
             | Self::TextDelete {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
             }
             | Self::TextKill {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
                 ..
             }
             | Self::TextYank {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
             }
             | Self::TextMoveCursor {
                 target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
                 ..
-            } => JsonbDetail,
+            } => JsonDocumentDetail,
+            Self::JsonbEnterEdit
+            | Self::JsonbAppendInsert
+            | Self::JsonbExitEdit
+            | Self::TextInput {
+                target: InputTarget::JsonbEdit,
+                ..
+            }
+            | Self::TextBackspace {
+                target: InputTarget::JsonbEdit,
+            }
+            | Self::TextDelete {
+                target: InputTarget::JsonbEdit,
+            }
+            | Self::TextKill {
+                target: InputTarget::JsonbEdit,
+                ..
+            }
+            | Self::TextYank {
+                target: InputTarget::JsonbEdit,
+            } => JsonDocumentEdit,
             Self::ExplainRequest
             | Self::Scroll {
                 target: ScrollTarget::ExplainPlan,
@@ -800,7 +896,8 @@ impl Action {
             }
             Self::Paste(_) => match state.input_mode() {
                 InputMode::ErTablePicker => FeatureRequirement::ErDiagram,
-                InputMode::JsonbDetail | InputMode::JsonbEdit => FeatureRequirement::JsonbDetail,
+                InputMode::JsonbDetail => FeatureRequirement::JsonDocumentDetail,
+                InputMode::JsonbEdit => FeatureRequirement::JsonDocumentEdit,
                 _ => FeatureRequirement::None,
             },
             Self::BeginKeySequence(Prefix::G)
@@ -809,7 +906,7 @@ impl Action {
                     InputMode::JsonbDetail | InputMode::JsonbEdit
                 ) =>
             {
-                FeatureRequirement::JsonbDetail
+                FeatureRequirement::JsonDocumentDetail
             }
             _ => self.feature_requirement(),
         }
@@ -820,6 +917,22 @@ impl Action {
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    #[test]
+    fn connection_target_debug_masks_mysql_password() {
+        let target = ConnectionTarget {
+            id: ConnectionId::from_string("mysql"),
+            dsn: "mysql://user:secret@localhost:3306/app".to_string(),
+            name: "MySQL".to_string(),
+            database_type: DatabaseType::MySQL,
+            database: Some("app".to_string()),
+        };
+
+        let debug = format!("{target:?}");
+
+        assert!(!debug.contains("secret"));
+        assert!(debug.contains("mysql://user:****@localhost"));
+    }
 
     #[test]
     fn scroll_action_returns_true() {
@@ -848,6 +961,8 @@ mod tests {
         assert_eq!(
             Action::ExplainCompleted {
                 dsn: "dsn".to_string(),
+                database_type: DatabaseType::PostgreSQL,
+                database_generation: 0,
                 run_id: 1,
                 query: "SELECT 1".to_string(),
                 plan_text: "plan".to_string(),
@@ -860,6 +975,7 @@ mod tests {
         assert_eq!(
             Action::ExplainFailed {
                 dsn: "dsn".to_string(),
+                database_generation: 0,
                 run_id: 1,
                 error: DbOperationError::QueryFailed("error".to_string()),
                 is_analyze: false,
@@ -919,7 +1035,7 @@ mod tests {
         let normal_state = AppState::new("test".to_string());
         assert_eq!(
             Action::JsonbExitEdit.feature_requirement_for_state(&normal_state),
-            FeatureRequirement::JsonbDetail
+            FeatureRequirement::JsonDocumentEdit
         );
     }
 

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -2,27 +2,25 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::cmd::effect::Effect;
-use crate::domain::{QueryResult, QuerySource};
+use crate::domain::{QueryResult, QuerySource, RefreshScope};
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{PREVIEW_PAGE_SIZE, PostDeleteRowSelection};
 use crate::model::shared::help::HelpOrigin;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::AdhocSuccessSnapshot;
-use crate::ports::outbound::AccessMode;
+use crate::ports::outbound::{AccessMode, DbOperationError};
 use crate::services::AppServices;
 use crate::update::action::{Action, ModalKind, TableTarget};
 use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::input::command::{command_to_action, parse_command};
 
-fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -> Vec<Effect> {
-    if result.source != QuerySource::Adhoc || result.is_error() {
-        return vec![];
-    }
-    let Some(tag) = &result.command_tag else {
-        return vec![];
-    };
-    if !tag.needs_refresh() {
+fn refresh_effects_for_scope(
+    state: &mut AppState,
+    refresh_scope: RefreshScope,
+    now: Instant,
+) -> Vec<Effect> {
+    if refresh_scope == RefreshScope::None {
         return vec![];
     }
     let Some(dsn) = state.session.dsn().map(String::from) else {
@@ -31,7 +29,7 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -
 
     let mut effects = vec![];
 
-    if tag.is_schema_modifying() {
+    if refresh_scope == RefreshScope::Metadata {
         state.sql_modal.reset_prefetch();
         state.session.set_table_detail_raw(None);
         let run_id = state.session.begin_metadata_refresh();
@@ -48,6 +46,13 @@ fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -
     }
 
     effects
+}
+
+fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -> Vec<Effect> {
+    if result.source != QuerySource::Adhoc || result.is_error() {
+        return vec![];
+    }
+    refresh_effects_for_scope(state, result.refresh_scope, now)
 }
 
 fn reset_view_for_new_result(state: &mut AppState, now: Instant) {
@@ -182,7 +187,16 @@ pub fn reduce_execution(
                     state.sql_modal.finish_adhoc_error(user_message);
                 }
             }
-            DispatchResult::handled()
+            let refresh_scope = match error {
+                DbOperationError::QueryFailedAfterChange { refresh_scope, .. } => *refresh_scope,
+                _ => RefreshScope::None,
+            };
+            let effects = if *source == QuerySource::Adhoc {
+                refresh_effects_for_scope(state, refresh_scope, now)
+            } else {
+                vec![]
+            };
+            DispatchResult::handled_with(effects)
         }
 
         Action::CommandLineSubmit => {
@@ -266,6 +280,9 @@ pub fn reduce_execution(
         }
 
         Action::ExecuteAdhoc(query) => {
+            if state.session.connection_state().is_awaiting_database() {
+                return DispatchResult::handled();
+            }
             if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.query.begin_running(now);
                 DispatchResult::handled_with(vec![Effect::ExecuteAdhoc {
@@ -704,6 +721,67 @@ mod tests {
                     .is_some_and(|message| message.contains("Permission denied"))
             );
             assert!(state.messages.last_error.is_none());
+        }
+
+        #[test]
+        fn adhoc_failure_after_data_change_refreshes_preview() {
+            let mut state = state_with_table("public", "users");
+            let action = query_failed_action(
+                &mut state,
+                DbOperationError::QueryFailedAfterChange {
+                    details: "later statement failed".to_string(),
+                    refresh_scope: RefreshScope::Data,
+                },
+                0,
+                QuerySource::Adhoc,
+            );
+
+            let effects =
+                dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
+
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::ExecutePreview { table, .. } if table == "users"
+            )));
+            assert!(
+                state
+                    .sql_modal
+                    .last_adhoc_error()
+                    .is_some_and(|message| message.contains("later statement failed"))
+            );
+        }
+
+        #[test]
+        fn adhoc_failure_after_schema_change_refreshes_metadata() {
+            let mut state = state_with_table("public", "users");
+            let action = query_failed_action(
+                &mut state,
+                DbOperationError::QueryFailedAfterChange {
+                    details: "later DDL failed".to_string(),
+                    refresh_scope: RefreshScope::Metadata,
+                },
+                0,
+                QuerySource::Adhoc,
+            );
+
+            let effects =
+                dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
+
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::CacheInvalidate { .. }))
+            );
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
+            assert!(
+                !effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ExecutePreview { .. }))
+            );
         }
 
         #[test]

--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -7,6 +7,8 @@ use crate::update::action::ConnectionTarget;
 use crate::update::query_context::termination_effects;
 
 fn reset_connection_scoped_state(state: &mut AppState) {
+    state.query_history_picker.reset();
+    state.sql_modal.reset_completion();
     state.sql_modal.reset_prefetch();
     state.explain.reset_for_connection_change();
     state.er_preparation.reset();
@@ -31,6 +33,7 @@ pub(super) fn reset_for_new_connection(
     dsn: &str,
     name: &str,
     database_type: DatabaseType,
+    database: Option<&str>,
 ) {
     let inspector_tab = state.ui.inspector_tab();
     let sql_modal_tab = state.sql_modal.active_tab();
@@ -39,7 +42,7 @@ pub(super) fn reset_for_new_connection(
     state.sql_modal.set_active_tab(sql_modal_tab);
     state
         .session
-        .activate_connection_with_dsn(id, name, database_type, dsn);
+        .activate_connection_with_target(id, name, database_type, dsn, database);
     reconcile_connection_state(state, inspector_tab);
 }
 
@@ -87,6 +90,29 @@ pub(super) fn reset_active_connection_state(state: &mut AppState) {
     reconcile_connection_state(state, inspector_tab);
 }
 
+pub(super) fn reset_for_database_switch(state: &mut AppState, target: &ConnectionTarget) {
+    let inspector_tab = state.ui.inspector_tab();
+    let sql_modal_tab = state.sql_modal.active_tab();
+    let read_only = state.session.is_read_only();
+    let available_databases = state.session.available_databases().to_vec();
+    reset_active_connection_state_inner(state);
+    state.ui.set_inspector_tab(inspector_tab);
+    state.sql_modal.set_active_tab(sql_modal_tab);
+    state.session.activate_connection_with_target(
+        &target.id,
+        &target.name,
+        target.database_type,
+        &target.dsn,
+        target.database.as_deref(),
+    );
+    state.session.mark_probe_connected(true);
+    state.session.set_available_databases(available_databases);
+    if read_only {
+        state.session.enable_read_only();
+    }
+    reconcile_connection_state(state, inspector_tab);
+}
+
 fn reset_active_connection_state_inner(state: &mut AppState) {
     state.session.reset(&mut state.query);
     state.result_interaction.reset_view();
@@ -106,6 +132,7 @@ pub(super) fn restore_cache(
         &target.name,
         target.database_type,
         &target.dsn,
+        target.database.as_deref(),
     );
     reconcile_connection_state(state, cache.inspector_tab);
     state

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1,5 +1,8 @@
 use crate::cmd::effect::Effect;
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
+use crate::model::connection::error::ConnectionErrorInfo;
+use crate::model::connection::state::ConnectionState;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
 use crate::update::action::{Action, ConnectionTarget};
@@ -7,12 +10,14 @@ use crate::update::query_context::termination_effects;
 
 use crate::update::dispatch_result::DispatchResult;
 
-use super::helpers::{reset_for_new_connection, restore_cache, save_current_cache};
+use super::helpers::{
+    reset_for_database_switch, reset_for_new_connection, restore_cache, save_current_cache,
+};
 
 pub fn reduce_connection_lifecycle(
     state: &mut AppState,
     action: &Action,
-    _now: std::time::Instant,
+    now: std::time::Instant,
     _services: &AppServices,
 ) -> DispatchResult {
     match action {
@@ -21,6 +26,35 @@ pub fn reduce_connection_lifecycle(
                 && state.modal.active_mode() == InputMode::Normal
             {
                 if let Some(dsn) = state.session.dsn().map(str::to_string) {
+                    if state.session.active_database_type() == Some(DatabaseType::MySQL) {
+                        let target = ConnectionTarget {
+                            id: state
+                                .session
+                                .active_connection_id()
+                                .cloned()
+                                .expect("active MySQL connection"),
+                            dsn,
+                            name: state
+                                .session
+                                .active_connection_name()
+                                .unwrap_or_default()
+                                .to_string(),
+                            database_type: DatabaseType::MySQL,
+                            database: state.session.active_database().map(str::to_string),
+                        };
+                        let run_id = state.session.begin_connection_probe(
+                            &target.id,
+                            &target.name,
+                            target.database_type,
+                            &target.dsn,
+                            target.database.as_deref(),
+                        );
+                        state.session.mark_connecting();
+                        return DispatchResult::handled_with(vec![Effect::ProbeConnection {
+                            target,
+                            run_id,
+                        }]);
+                    }
                     let run_id = state.session.begin_connecting(&dsn);
                     DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
                 } else {
@@ -37,9 +71,34 @@ pub fn reduce_connection_lifecycle(
                 dsn,
                 name,
                 database_type,
+                database,
             } = target;
 
-            if let Some(current_id) = state.session.active_connection_id().cloned() {
+            if *database_type == DatabaseType::MySQL {
+                if state.session.active_database_type() != Some(DatabaseType::MySQL)
+                    && let Some(current_id) = state.session.active_connection_id().cloned()
+                {
+                    let cache = save_current_cache(state);
+                    state.connection_caches.save(&current_id, cache);
+                }
+                let run_id = state.session.begin_connection_probe(
+                    id,
+                    name,
+                    *database_type,
+                    dsn,
+                    database.as_deref(),
+                );
+                return DispatchResult::handled_with(vec![Effect::ProbeConnection {
+                    target: target.clone(),
+                    run_id,
+                }]);
+            }
+
+            state.session.clear_connection_probe();
+
+            if state.session.active_database_type() != Some(DatabaseType::MySQL)
+                && let Some(current_id) = state.session.active_connection_id().cloned()
+            {
                 let cache = save_current_cache(state);
                 state.connection_caches.save(&current_id, cache);
             }
@@ -57,7 +116,7 @@ pub fn reduce_connection_lifecycle(
                 DispatchResult::handled_with(termination_effects(&state.query, effects))
             } else {
                 // No cache: reset and fetch metadata
-                reset_for_new_connection(state, id, dsn, name, *database_type);
+                reset_for_new_connection(state, id, dsn, name, *database_type, database.as_deref());
                 let run_id = state.session.begin_connecting(dsn);
                 DispatchResult::handled_with(termination_effects(
                     &state.query,
@@ -72,23 +131,197 @@ pub fn reduce_connection_lifecycle(
             }
         }
 
+        Action::ConnectionProbeCompleted { target, run_id } => {
+            let ConnectionTarget {
+                id,
+                dsn,
+                name,
+                database_type,
+                database,
+            } = target;
+            if *database_type != DatabaseType::MySQL
+                || !state.session.is_current_connection_probe(
+                    id,
+                    name,
+                    *database_type,
+                    dsn,
+                    database.as_deref(),
+                    *run_id,
+                )
+            {
+                return DispatchResult::handled();
+            }
+            reset_for_new_connection(state, id, dsn, name, *database_type, database.as_deref());
+            state.session.mark_probe_connected(database.is_some());
+            state.session.clear_connection_probe();
+            let mut effects = vec![Effect::ClearCompletionEngineCache];
+            if database.is_none() {
+                state.ui.set_database_picker(true);
+                state.modal.set_mode(InputMode::TablePicker);
+                if let (Some(connection_id), Some(server_dsn)) = (
+                    state.session.active_connection_id().cloned(),
+                    state.session.server_dsn(),
+                ) {
+                    effects.push(Effect::FetchMySqlDatabases {
+                        connection_id,
+                        dsn: server_dsn,
+                        connection_generation: state.session.connection_generation(),
+                        database_generation: state.session.database_generation(),
+                    });
+                }
+            } else {
+                let metadata_run_id = state.session.begin_metadata_refresh();
+                effects.push(Effect::FetchMetadata {
+                    dsn: dsn.clone(),
+                    run_id: metadata_run_id,
+                });
+            }
+            DispatchResult::handled_with(termination_effects(&state.query, effects))
+        }
+
+        Action::SwitchMySqlDatabase { database } => {
+            if state.session.active_database_type() != Some(DatabaseType::MySQL)
+                || !matches!(
+                    state.session.connection_state(),
+                    ConnectionState::Connected | ConnectionState::AwaitingDatabase
+                )
+            {
+                return DispatchResult::handled();
+            }
+            let Some(target) = (|| {
+                let target = ConnectionTarget {
+                    id: state.session.active_connection_id()?.clone(),
+                    dsn: state.session.dsn()?.to_string(),
+                    name: state.session.active_connection_name()?.to_string(),
+                    database_type: DatabaseType::MySQL,
+                    database: state.session.active_database().map(str::to_string),
+                };
+                target.with_database(database)
+            })() else {
+                state.messages.set_error_at(
+                    "Unable to build the selected MySQL database target".to_string(),
+                    now,
+                );
+                return DispatchResult::handled();
+            };
+            reset_for_database_switch(state, &target);
+            state.ui.set_database_picker(false);
+            state.modal.set_mode(InputMode::Normal);
+            let metadata_run_id = state.session.begin_metadata_refresh();
+            DispatchResult::handled_with(termination_effects(
+                &state.query,
+                vec![
+                    Effect::ClearCompletionEngineCache,
+                    Effect::FetchMetadata {
+                        dsn: target.dsn,
+                        run_id: metadata_run_id,
+                    },
+                ],
+            ))
+        }
+
+        Action::MySqlDatabasesLoaded {
+            connection_id,
+            dsn,
+            connection_generation,
+            database_generation,
+            databases,
+        } => {
+            if !state.session.is_current_database_fetch(
+                connection_id,
+                dsn,
+                *connection_generation,
+                *database_generation,
+            ) {
+                return DispatchResult::handled();
+            }
+            state.session.set_available_databases(databases.clone());
+            if state.session.available_databases().is_empty() {
+                state
+                    .messages
+                    .set_error_at("No selectable MySQL databases are visible".to_string(), now);
+            }
+            DispatchResult::handled()
+        }
+
+        Action::MySqlDatabasesFailed {
+            connection_id,
+            dsn,
+            connection_generation,
+            database_generation,
+            error,
+        } => {
+            if !state.session.is_current_database_fetch(
+                connection_id,
+                dsn,
+                *connection_generation,
+                *database_generation,
+            ) {
+                return DispatchResult::handled();
+            }
+            state.messages.set_error_at(error.user_message(), now);
+            if state.session.active_database().is_none() {
+                state.ui.set_database_picker(false);
+                state.session.mark_connection_failed(error.user_message());
+                state
+                    .connection_error
+                    .set_error(ConnectionErrorInfo::from_db_operation_error(error));
+                state.modal.replace_mode(InputMode::ConnectionError);
+            }
+            DispatchResult::handled()
+        }
+
+        Action::ConnectionProbeFailed {
+            target,
+            run_id,
+            error,
+        } => {
+            if target.database_type != DatabaseType::MySQL
+                || !state.session.is_current_connection_probe(
+                    &target.id,
+                    &target.name,
+                    target.database_type,
+                    &target.dsn,
+                    target.database.as_deref(),
+                    *run_id,
+                )
+            {
+                return DispatchResult::handled();
+            }
+            if state.session.dsn_matches(&target.dsn) {
+                state.session.mark_connection_failed(error.user_message());
+            }
+            state.connection_error.set_error(
+                ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
+            );
+            state.modal.replace_mode(InputMode::ConnectionError);
+            DispatchResult::handled()
+        }
+
         _ => DispatchResult::pass(),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
-    use crate::domain::ConnectionId;
     use crate::domain::connection::DatabaseType;
+    use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
+    use crate::domain::{ConnectionId, DatabaseMetadata, MetadataState};
     use crate::model::connection::cache::ConnectionCache;
+    use crate::model::connection::error::ConnectionErrorKind;
     use crate::model::connection::state::ConnectionState;
     use crate::model::er_state::ErStatus;
+    use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::inspector_tab::InspectorTab;
     use crate::model::shared::ui_state::ResultNavMode;
+    use crate::ports::outbound::DbOperationError;
     use crate::test_support::connection::{
         assert_explain_state_cleared, assert_sqlite_diagnostics_cleared,
     };
+    use crate::update::reducer::reduce as reduce_app;
 
     fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
         reduce_connection_lifecycle(
@@ -106,6 +339,7 @@ mod tests {
             dsn: format!("postgres://localhost/{name}"),
             name: name.to_string(),
             database_type: DatabaseType::PostgreSQL,
+            database: None,
         })
     }
 
@@ -133,6 +367,76 @@ mod tests {
             let saved = state.connection_caches.get(&current_id).unwrap();
             assert_eq!(saved.explorer_selected, 5);
             assert_eq!(saved.inspector_tab, InspectorTab::Indexes);
+        }
+
+        fn assert_non_mysql_cache_survives_mysql_switch(
+            database_type: DatabaseType,
+            dsn: &str,
+            name: &str,
+        ) {
+            let mut state = AppState::new("test".to_string());
+            let source_id = ConnectionId::from_string("source");
+            let mysql_id = ConnectionId::from_string("mysql");
+            let source = ConnectionTarget {
+                id: source_id.clone(),
+                dsn: dsn.to_string(),
+                name: name.to_string(),
+                database_type,
+                database: None,
+            };
+
+            state
+                .session
+                .activate_connection_with_dsn(&source_id, name, database_type, dsn);
+            state.ui.set_explorer_selected_raw(5);
+            state.ui.set_inspector_tab(InspectorTab::Indexes);
+
+            let mysql = ConnectionTarget {
+                id: mysql_id,
+                dsn: "mysql://user@localhost:3306/app".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .expect("switching to MySQL should probe the connection");
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target: mysql,
+                    run_id,
+                },
+            );
+
+            reduce(&mut state, &Action::SwitchConnection(source));
+
+            assert_eq!(state.session.active_connection_id(), Some(&source_id));
+            assert_eq!(state.ui.explorer_selected(), 5);
+            assert_eq!(state.ui.inspector_tab(), InspectorTab::Indexes);
+        }
+
+        #[test]
+        fn restores_postgres_cache_after_switching_through_mysql() {
+            assert_non_mysql_cache_survives_mysql_switch(
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/current",
+                "postgres",
+            );
+        }
+
+        #[test]
+        fn restores_sqlite_cache_after_switching_through_mysql() {
+            assert_non_mysql_cache_survives_mysql_switch(
+                DatabaseType::SQLite,
+                "sqlite:///tmp/current.db",
+                "sqlite",
+            );
         }
 
         #[test]
@@ -190,6 +494,7 @@ mod tests {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 name: "app.db".to_string(),
                 database_type: DatabaseType::SQLite,
+                database: None,
             });
             reduce(&mut state, &action);
 
@@ -206,24 +511,28 @@ mod tests {
             let dsn = match database_type {
                 DatabaseType::PostgreSQL => format!("postgres://localhost/{name}"),
                 DatabaseType::SQLite => format!("sqlite:///tmp/{name}.db"),
+                DatabaseType::MySQL => format!("mysql://user@localhost/{name}"),
             };
             Action::SwitchConnection(ConnectionTarget {
                 id,
                 dsn,
                 name: name.to_string(),
                 database_type,
+                database: None,
             })
         }
 
         fn seed_explain_state(state: &mut AppState) {
             state.explain.set_plan(
                 "Seq Scan  (cost=0.00..100.00 rows=10 width=32)".to_string(),
+                DatabaseType::PostgreSQL,
                 false,
                 0,
                 "SELECT * FROM users",
             );
             state.explain.set_plan(
                 "Index Scan  (cost=0.00..5.00 rows=1 width=32)".to_string(),
+                DatabaseType::PostgreSQL,
                 false,
                 0,
                 "SELECT * FROM users WHERE id = 1",
@@ -437,6 +746,7 @@ mod tests {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 name: "app.db".to_string(),
                 database_type: DatabaseType::SQLite,
+                database: None,
             });
             let effects = reduce(&mut state, &action).unwrap();
 
@@ -478,6 +788,7 @@ mod tests {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 name: "app.db".to_string(),
                 database_type: DatabaseType::SQLite,
+                database: None,
             });
             let effects = reduce(&mut state, &action).unwrap();
 
@@ -541,6 +852,7 @@ mod tests {
 
     mod connection_state_tests {
         use super::*;
+        use crate::update::connection::error::reduce_connection_error;
 
         #[test]
         fn sqlite_try_connect_fetches_metadata() {
@@ -565,6 +877,545 @@ mod tests {
             assert_eq!(
                 state.session.connection_state(),
                 ConnectionState::Connecting
+            );
+        }
+
+        #[test]
+        fn mysql_switch_probes_without_fetching_metadata() {
+            let mut state = AppState::new("test".to_string());
+            let target = ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "mysql://user@localhost:3306/app?ssl-mode=PREFERRED".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            };
+
+            let effects = reduce(&mut state, &Action::SwitchConnection(target.clone())).unwrap();
+
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::ProbeConnection { target: actual, .. } if actual.dsn == target.dsn
+            )));
+            assert!(
+                !effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
+        }
+
+        #[test]
+        fn mysql_switch_invalidates_previous_metadata_failure() {
+            let mut state = AppState::new("test".to_string());
+            let postgres = ConnectionTarget {
+                id: ConnectionId::from_string("postgres-b"),
+                dsn: "postgres://localhost/b".to_string(),
+                name: "postgres-b".to_string(),
+                database_type: DatabaseType::PostgreSQL,
+                database: None,
+            };
+            let postgres_effects =
+                reduce(&mut state, &Action::SwitchConnection(postgres.clone())).unwrap();
+            let postgres_run_id = postgres_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::FetchMetadata { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-c"),
+                dsn: "mysql://user@localhost:3306/c?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-c".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("c".to_string()),
+            };
+            let mysql_effects =
+                reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = mysql_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::MetadataFailed {
+                    dsn: postgres.dsn,
+                    run_id: postgres_run_id,
+                    error: DbOperationError::ConnectionFailed("stale postgres".to_string()),
+                },
+            );
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                },
+            );
+
+            assert_eq!(
+                state.session.active_database_type(),
+                Some(DatabaseType::MySQL)
+            );
+            assert!(state.session.connection_state().is_connected());
+            assert_eq!(state.modal.active_mode(), InputMode::Normal);
+            assert!(state.connection_error.error_info().is_none());
+        }
+
+        #[test]
+        fn mysql_probe_failure_does_not_leave_previous_connecting_state() {
+            let mut state = AppState::new("test".to_string());
+            let postgres = ConnectionTarget {
+                id: ConnectionId::from_string("postgres-b"),
+                dsn: "postgres://localhost/b".to_string(),
+                name: "postgres-b".to_string(),
+                database_type: DatabaseType::PostgreSQL,
+                database: None,
+            };
+            let _ = reduce(&mut state, &Action::SwitchConnection(postgres)).unwrap();
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-c"),
+                dsn: "mysql://user@localhost:3306/c?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-c".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("c".to_string()),
+            };
+            let mysql_effects =
+                reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = mysql_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            assert!(state.session.connection_state().is_not_connected());
+            assert!(matches!(
+                state.session.metadata_state(),
+                MetadataState::NotLoaded
+            ));
+            assert!(!state.session.is_reloading());
+        }
+
+        #[test]
+        fn mysql_probe_failure_finishes_previous_reload() {
+            let mut state = AppState::new("test".to_string());
+            let postgres_id = ConnectionId::from_string("postgres-b");
+            state.session.activate_connection_with_dsn(
+                &postgres_id,
+                "postgres-b",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/b",
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            let _ = state.session.begin_reload();
+            assert!(state.session.is_reloading());
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-c"),
+                dsn: "mysql://user@localhost:3306/c?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-c".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("c".to_string()),
+            };
+            let mysql_effects =
+                reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = mysql_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            assert!(state.session.connection_state().is_connected());
+            assert!(!state.session.is_reloading());
+        }
+
+        #[test]
+        fn stale_mysql_probe_completion_is_ignored_after_switch() {
+            let mut state = AppState::new("test".to_string());
+            let first = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-a"),
+                dsn: "mysql://user@localhost:3306/a?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-a".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("a".to_string()),
+            };
+            let second = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+
+            let first_effects =
+                reduce(&mut state, &Action::SwitchConnection(first.clone())).unwrap();
+            let first_run_id = first_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(&mut state, &Action::SwitchConnection(second));
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target: first,
+                    run_id: first_run_id,
+                },
+            );
+
+            assert_eq!(state.session.active_connection_id(), None);
+            assert_eq!(state.session.dsn(), None);
+        }
+
+        #[test]
+        fn stale_mysql_probe_failure_is_ignored_after_switch() {
+            let mut state = AppState::new("test".to_string());
+            let first = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-a"),
+                dsn: "mysql://user@localhost:3306/a?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-a".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("a".to_string()),
+            };
+            let second = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+
+            let first_effects =
+                reduce(&mut state, &Action::SwitchConnection(first.clone())).unwrap();
+            let first_run_id = first_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(&mut state, &Action::SwitchConnection(second));
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: first,
+                    run_id: first_run_id,
+                    error: DbOperationError::ConnectionFailed("stale".to_string()),
+                },
+            );
+
+            assert_eq!(state.modal.active_mode(), InputMode::Normal);
+            assert!(state.connection_error.error_info().is_none());
+        }
+
+        #[test]
+        fn retry_after_mysql_switch_failure_reprobes_failed_target() {
+            let mut state = AppState::new("test".to_string());
+            let target = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(target.clone())).unwrap();
+            let first_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: target.clone(),
+                    run_id: first_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+
+            let (retry_target, retry_run_id) = retry_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { target, run_id } => Some((target, *run_id)),
+                    _ => None,
+                })
+                .unwrap();
+            assert_eq!(retry_target.dsn, target.dsn);
+            assert_eq!(retry_target.id, target.id);
+            assert_ne!(retry_run_id, first_run_id);
+        }
+
+        #[test]
+        fn retry_after_mysql_switch_failure_preserves_connected_previous_target() {
+            let mut state = AppState::new("test".to_string());
+            let postgres_id = ConnectionId::from_string("postgres-a");
+            let postgres_dsn = "postgres://localhost/a".to_string();
+            state.session.activate_connection_with_dsn(
+                &postgres_id,
+                "postgres-a",
+                DatabaseType::PostgreSQL,
+                &postgres_dsn,
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            state
+                .session
+                .set_metadata(Some(Arc::new(DatabaseMetadata::new("a".to_string()))));
+            state.session.set_metadata_state(MetadataState::Loaded);
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let first_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql.clone(),
+                    run_id: first_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+            assert!(state.session.connection_state().is_connected());
+            assert_eq!(state.session.metadata_state(), &MetadataState::Loaded);
+            let retry_run_id = retry_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: retry_run_id,
+                    error: DbOperationError::ConnectionFailed("refused again".to_string()),
+                },
+            );
+
+            assert_eq!(state.session.dsn(), Some(postgres_dsn.as_str()));
+            assert!(state.session.connection_state().is_connected());
+            assert_eq!(state.session.metadata_state(), &MetadataState::Loaded);
+            assert!(!state.session.is_reloading());
+        }
+
+        #[test]
+        fn postgres_reload_retry_does_not_use_old_mysql_probe_target() {
+            let mut state = AppState::new("test".to_string());
+            let postgres_id = ConnectionId::from_string("postgres-a");
+            let postgres_dsn = "postgres://localhost/a".to_string();
+            state.session.activate_connection_with_dsn(
+                &postgres_id,
+                "postgres-a",
+                DatabaseType::PostgreSQL,
+                &postgres_dsn,
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            let reload_run_id = state.session.begin_reload();
+            assert!(state.session.pending_connection_probe().is_none());
+            reduce_app(
+                &mut state,
+                Action::MetadataFailed {
+                    dsn: postgres_dsn.clone(),
+                    run_id: reload_run_id,
+                    error: DbOperationError::ConnectionFailed("reload refused".to_string()),
+                },
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+            assert!(retry_effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchMetadata { dsn, .. } if dsn == &postgres_dsn
+            )));
+            assert!(
+                !retry_effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ProbeConnection { .. }))
+            );
+        }
+
+        #[test]
+        fn mysql_probe_without_database_enters_awaiting_database() {
+            let mut state = AppState::new("test".to_string());
+            let target = ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "mysql://user@localhost:3306?ssl-mode=PREFERRED".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: None,
+            };
+
+            let run_id = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+            let effects = reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted { target, run_id },
+            )
+            .unwrap();
+
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ClearCompletionEngineCache))
+            );
+            assert!(state.session.connection_state().is_awaiting_database());
+            assert!(matches!(
+                state.session.metadata_state(),
+                MetadataState::NotLoaded
+            ));
+        }
+
+        #[test]
+        fn mysql_probe_failure_never_enters_connected_state() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::new();
+            let dsn = "mysql://user@localhost:3306/app?ssl-mode=PREFERRED".to_string();
+            state.session.activate_connection_with_target(
+                &id,
+                "mysql",
+                DatabaseType::MySQL,
+                &dsn,
+                Some("app"),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connecting);
+            let target = ConnectionTarget {
+                id,
+                dsn,
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            };
+            let run_id = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target,
+                    run_id,
+                    error: DbOperationError::ConnectionFailed(
+                        "ERROR 1045: Access denied for user 'user'".to_string(),
+                    ),
+                },
+            );
+
+            assert!(!state.session.connection_state().is_connected());
+            assert!(state.session.connection_state().is_failed());
+            assert_eq!(state.modal.active_mode(), InputMode::ConnectionError);
+            assert_eq!(
+                state.connection_error.error_info().unwrap().kind,
+                ConnectionErrorKind::AuthFailed
             );
         }
 
@@ -703,6 +1554,235 @@ mod tests {
                     .iter()
                     .any(|e| matches!(e, Effect::ClearCompletionEngineCache))
             );
+        }
+    }
+
+    mod mysql_database_tests {
+        use super::*;
+        use crate::update::action::ErDiagramInfo;
+
+        fn mysql_target(id: &ConnectionId, database: Option<&str>) -> ConnectionTarget {
+            let database = database.map(str::to_string);
+            let dsn = format!(
+                "mysql://user:secret@localhost:3306/{}?ssl-mode=PREFERRED",
+                database.as_deref().unwrap_or("")
+            );
+            ConnectionTarget {
+                id: id.clone(),
+                dsn,
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database,
+            }
+        }
+
+        #[test]
+        fn connection_without_database_opens_picker_and_fetches_server_databases() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, None);
+            let probe_run_id = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                None,
+            );
+
+            let effects = reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target,
+                    run_id: probe_run_id,
+                },
+            )
+            .unwrap();
+
+            assert!(state.session.connection_state().is_awaiting_database());
+            assert_eq!(state.session.active_database(), None);
+            assert!(state.ui.database_picker());
+            assert_eq!(state.input_mode(), InputMode::TablePicker);
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchMySqlDatabases { connection_id, .. } if connection_id == &id
+            )));
+        }
+
+        #[test]
+        fn database_selection_resets_context_and_preserves_read_only() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, Some("app"));
+            state.session.activate_connection_with_target(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+            state.session.mark_probe_connected(true);
+            state.session.enable_read_only();
+            state.session.set_available_databases(vec![
+                "information_schema".to_string(),
+                "analytics".to_string(),
+            ]);
+            state.ui.set_database_picker(true);
+            state.modal.set_mode(InputMode::TablePicker);
+            let stale_er_run_id = state.er_preparation.start_waiting_run();
+            state.er_preparation.mark_rendering();
+            state
+                .query_history_picker
+                .replace_entries(&[QueryHistoryEntry::new(
+                    "SELECT old_database".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    id,
+                    QueryResultStatus::Success,
+                    None,
+                )]);
+
+            let effects = reduce_app(
+                &mut state,
+                Action::ConfirmSelection,
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.session.active_database(), Some("analytics"));
+            assert!(
+                state
+                    .session
+                    .dsn()
+                    .is_some_and(|dsn| dsn.contains("/analytics"))
+            );
+            assert!(state.session.metadata().is_none());
+            assert!(state.session.is_read_only());
+            assert_eq!(
+                state.session.available_databases(),
+                ["analytics".to_string()]
+            );
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert!(state.query_history_picker.entries().is_empty());
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
+
+            let effects = reduce_app(
+                &mut state,
+                Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id: stale_er_run_id,
+                    path: "stale.svg".to_string(),
+                    table_count: 1,
+                    total_tables: 1,
+                }),
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.is_empty());
+            assert!(state.messages.last_success().is_none());
+        }
+
+        #[test]
+        fn database_switch_closes_query_history_picker_and_discards_entries() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, Some("app"));
+            state.session.activate_connection_with_target(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+            state.session.mark_probe_connected(true);
+            state.modal.set_mode(InputMode::QueryHistoryPicker);
+            state.sql_modal.completion_mut_for_test().visible = true;
+            state.explain.set_plan(
+                "-> Table scan on users  (cost=1 rows=10)".to_string(),
+                DatabaseType::MySQL,
+                false,
+                1,
+                "SELECT * FROM users",
+            );
+            state.explain.set_plan(
+                "-> Index lookup on users  (cost=0.5 rows=1)".to_string(),
+                DatabaseType::MySQL,
+                false,
+                1,
+                "SELECT * FROM users WHERE id = 1",
+            );
+            state
+                .query_history_picker
+                .replace_entries(&[QueryHistoryEntry::new_with_database(
+                    "SELECT from app".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    id,
+                    Some("app".to_string()),
+                    QueryResultStatus::Success,
+                    None,
+                )]);
+
+            let effects = reduce_app(
+                &mut state,
+                Action::SwitchMySqlDatabase {
+                    database: "analytics".to_string(),
+                },
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.session.active_database(), Some("analytics"));
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert!(state.query_history_picker.entries().is_empty());
+            assert!(!state.sql_modal.completion().visible);
+            assert!(state.explain.left().is_none());
+            assert!(state.explain.right().is_none());
+            assert!(state.explain.history().is_empty());
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ClearCompletionEngineCache))
+            );
+        }
+
+        #[test]
+        fn stale_database_list_from_previous_connection_generation_is_ignored() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, None);
+            state.session.activate_connection_with_target(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                None,
+            );
+            state.session.mark_probe_connected(false);
+            let stale_generation = state.session.connection_generation();
+            let _ = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                None,
+            );
+            let server_dsn = state.session.server_dsn().unwrap();
+            let database_generation = state.session.database_generation();
+
+            let _ = reduce(
+                &mut state,
+                &Action::MySqlDatabasesLoaded {
+                    connection_id: id,
+                    dsn: server_dsn,
+                    connection_generation: stale_generation,
+                    database_generation,
+                    databases: vec!["stale".to_string()],
+                },
+            );
+
+            assert!(state.session.available_databases().is_empty());
         }
     }
 }

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -1,11 +1,14 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
 use crate::policy::sql::statement_classifier;
-use crate::policy::write::sql_risk::{ConfirmationType, evaluate_sql_risk_for_database};
+use crate::policy::write::sql_risk::{
+    ConfirmationType, evaluate_mysql_explain_target, evaluate_sql_risk_for_database,
+};
 use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
@@ -42,8 +45,19 @@ pub(super) fn reduce_analyze(
                 );
                 return DispatchResult::handled();
             }
-            let kind = statement_classifier::classify(&content);
-            let risk = evaluate_sql_risk_for_database(database_type, &kind, &content);
+            let risk = if database_type == DatabaseType::MySQL {
+                let Some(risk) = evaluate_mysql_explain_target(&content, true) else {
+                    show_explain_error_on_plan(
+                        state,
+                        "MySQL EXPLAIN ANALYZE only supports side-effect-free SELECT or TABLE statements",
+                    );
+                    return DispatchResult::handled();
+                };
+                risk
+            } else {
+                let kind = statement_classifier::classify(&content);
+                evaluate_sql_risk_for_database(database_type, &kind, &content)
+            };
 
             if state.session.is_read_only() && !risk.read_only_allowed {
                 show_explain_error_on_plan(
@@ -75,8 +89,11 @@ pub(super) fn reduce_analyze(
                         return DispatchResult::handled();
                     };
                     let run_id = begin_explain_running(state, now);
+                    let database_generation = state.session.database_generation();
                     return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                         dsn,
+                        database_type,
+                        database_generation,
                         run_id,
                         query: explain_query,
                         source_query: content,
@@ -103,6 +120,12 @@ pub(super) fn reduce_analyze(
                 && let Some(dsn) = state.session.dsn().map(String::from)
             {
                 let database_type = state.session.active_database_type_or_default();
+                if database_type == DatabaseType::MySQL
+                    && evaluate_mysql_explain_target(&query, true).is_none()
+                {
+                    finish_explain_unsupported_analyze(state);
+                    return DispatchResult::handled();
+                }
                 let Some(explain_query) = services
                     .sql_dialect
                     .build_explain_analyze_sql(database_type, &query)
@@ -111,8 +134,11 @@ pub(super) fn reduce_analyze(
                     return DispatchResult::handled();
                 };
                 let run_id = begin_explain_running(state, now);
+                let database_generation = state.session.database_generation();
                 return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                     dsn,
+                    database_type,
+                    database_generation,
                     run_id,
                     query: explain_query,
                     source_query: query,

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -1,9 +1,14 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
+use crate::policy::sql::mysql_statement::{
+    MysqlStatementKind, classify_mysql_statement, mysql_explain_rejection_message,
+};
+use crate::policy::write::sql_risk::evaluate_mysql_explain_target;
 use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
@@ -34,8 +39,33 @@ pub(super) fn reduce_request(
                 return DispatchResult::handled();
             }
             let database_type = state.session.active_database_type_or_default();
-            if is_multi_statement(database_type, &content) {
+            if database_type == DatabaseType::MySQL {
+                if let Some(message) = mysql_explain_rejection_message(&content) {
+                    show_explain_error_on_plan(state, message);
+                    return DispatchResult::handled();
+                }
+            } else if is_multi_statement(database_type, &content) {
                 show_explain_error_on_plan(state, "EXPLAIN does not support multiple statements");
+                return DispatchResult::handled();
+            }
+            let mysql_explain_dml = database_type == DatabaseType::MySQL
+                && classify_mysql_statement(&content).is_ok_and(|statement| {
+                    matches!(
+                        statement.kind,
+                        MysqlStatementKind::Insert
+                            | MysqlStatementKind::Replace
+                            | MysqlStatementKind::Update { .. }
+                            | MysqlStatementKind::Delete { .. }
+                    )
+                });
+            if database_type == DatabaseType::MySQL
+                && !mysql_explain_dml
+                && evaluate_mysql_explain_target(&content, false).is_none()
+            {
+                show_explain_error_on_plan(
+                    state,
+                    "MySQL EXPLAIN only supports side-effect-free read statements",
+                );
                 return DispatchResult::handled();
             }
 
@@ -56,9 +86,12 @@ pub(super) fn reduce_request(
                 }
             };
             let run_id = begin_explain_running(state, now);
+            let database_generation = state.session.database_generation();
 
             DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                 dsn,
+                database_type,
+                database_generation,
                 run_id,
                 query,
                 source_query: content,

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -1066,7 +1066,9 @@ mod tests {
 
     mod query_history_picker {
         use super::*;
-        use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
+        use crate::domain::query_history::{
+            QueryHistoryEntry, QueryHistoryScope, QueryResultStatus,
+        };
         use crate::model::shared::text_input::TextInputLike;
         use crate::ports::outbound::query_history::QueryHistoryError;
 
@@ -1080,6 +1082,10 @@ mod tests {
             )
         }
 
+        fn scope(conn_id: &ConnectionId, database: Option<&str>) -> QueryHistoryScope {
+            QueryHistoryScope::new(conn_id.clone(), database.map(str::to_owned))
+        }
+
         fn connected_state() -> AppState {
             let mut state = create_test_state();
             state.session.activate_connection_with_dsn(
@@ -1088,6 +1094,20 @@ mod tests {
                 DatabaseType::PostgreSQL,
                 "postgres://localhost/test",
             );
+            state.runtime.project_name = "test-project".to_string();
+            state
+        }
+
+        fn mysql_connected_state(database: &str) -> AppState {
+            let mut state = create_test_state();
+            state.session.activate_connection_with_target(
+                &ConnectionId::from_string("mysql-conn"),
+                "mysql",
+                DatabaseType::MySQL,
+                &format!("mysql://localhost/{database}"),
+                Some(database),
+            );
+            state.session.mark_probe_connected(true);
             state.runtime.project_name = "test-project".to_string();
             state
         }
@@ -1171,6 +1191,24 @@ mod tests {
             }
 
             #[test]
+            fn open_for_mysql_captures_selected_database_in_scope() {
+                let mut state = mysql_connected_state("analytics");
+
+                let effects = super::dispatch_modal(
+                    &mut state,
+                    &Action::OpenModal(ModalKind::QueryHistoryPicker),
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert!(matches!(
+                    &effects[0],
+                    Effect::LoadQueryHistory { scope, .. }
+                        if scope.database.as_deref() == Some("analytics")
+                ));
+            }
+
+            #[test]
             fn close_restores_origin_mode() {
                 let mut state = connected_state();
                 state.modal.set_mode(InputMode::SqlModal);
@@ -1200,7 +1238,7 @@ mod tests {
 
                 let effects = super::dispatch_modal(
                     &mut state,
-                    &Action::QueryHistoryLoaded(conn_id, entries),
+                    &Action::QueryHistoryLoaded(scope(&conn_id, None), entries),
                     Instant::now(),
                 )
                 .unwrap();
@@ -1218,7 +1256,32 @@ mod tests {
 
                 super::dispatch_modal(
                     &mut state,
-                    &Action::QueryHistoryLoaded(stale_conn, entries),
+                    &Action::QueryHistoryLoaded(scope(&stale_conn, None), entries),
+                    Instant::now(),
+                )
+                .unwrap();
+
+                assert!(state.query_history_picker.entries().is_empty());
+            }
+
+            #[test]
+            fn loaded_ignores_stale_mysql_database_scope() {
+                let mut state = mysql_connected_state("analytics");
+                state.modal.set_mode(InputMode::QueryHistoryPicker);
+                let conn_id = ConnectionId::from_string("mysql-conn");
+                let stale_scope = scope(&conn_id, Some("app"));
+                let entries = vec![QueryHistoryEntry::new_with_database(
+                    "SELECT 1".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    conn_id,
+                    Some("app".to_string()),
+                    QueryResultStatus::Success,
+                    None,
+                )];
+
+                super::dispatch_modal(
+                    &mut state,
+                    &Action::QueryHistoryLoaded(stale_scope, entries),
                     Instant::now(),
                 )
                 .unwrap();
@@ -1234,7 +1297,7 @@ mod tests {
 
                 super::dispatch_modal(
                     &mut state,
-                    &Action::QueryHistoryLoaded(conn_id, entries),
+                    &Action::QueryHistoryLoaded(scope(&conn_id, None), entries),
                     Instant::now(),
                 )
                 .unwrap();
@@ -1251,7 +1314,7 @@ mod tests {
                 super::dispatch_modal(
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
-                        ConnectionId::from_string("test-conn"),
+                        scope(&ConnectionId::from_string("test-conn"), None),
                         QueryHistoryError::Io(Arc::new(std::io::Error::other("disk error"))),
                     ),
                     now,
@@ -1273,7 +1336,7 @@ mod tests {
                 super::dispatch_modal(
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
-                        ConnectionId::from_string("test-conn"),
+                        scope(&ConnectionId::from_string("test-conn"), None),
                         QueryHistoryError::Io(Arc::new(std::io::Error::other("stale error"))),
                     ),
                     now,
@@ -1292,7 +1355,7 @@ mod tests {
                 super::dispatch_modal(
                     &mut state,
                     &Action::QueryHistoryLoadFailed(
-                        ConnectionId::from_string("old-conn"),
+                        scope(&ConnectionId::from_string("old-conn"), None),
                         QueryHistoryError::Io(Arc::new(std::io::Error::other("stale error"))),
                     ),
                     now,

--- a/src/app/update/modal/query_history.rs
+++ b/src/app/update/modal/query_history.rs
@@ -35,10 +35,13 @@ pub(super) fn reduce_query_history_picker(
             state.query_history_picker.reset();
             state.modal.push_mode(InputMode::QueryHistoryPicker);
 
-            let conn_id = state.session.active_connection_id().unwrap();
+            let scope = state
+                .session
+                .query_history_scope()
+                .expect("active connection checked above");
             DispatchResult::handled_with(vec![Effect::LoadQueryHistory {
                 project_name: state.runtime.project_name.clone(),
-                connection_id: conn_id.clone(),
+                scope,
             }])
         }
         Action::CloseModal(ModalKind::QueryHistoryPicker) => {
@@ -46,21 +49,21 @@ pub(super) fn reduce_query_history_picker(
             state.query_history_picker.reset();
             DispatchResult::handled()
         }
-        Action::QueryHistoryLoaded(conn_id, entries) => {
+        Action::QueryHistoryLoaded(scope, entries) => {
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
                 return DispatchResult::handled();
             }
-            if state.session.active_connection_id() != Some(conn_id) {
+            if state.session.query_history_scope().as_ref() != Some(scope) {
                 return DispatchResult::handled();
             }
             state.query_history_picker.replace_entries(entries);
             DispatchResult::handled()
         }
-        Action::QueryHistoryLoadFailed(conn_id, e) => {
+        Action::QueryHistoryLoadFailed(scope, e) => {
             if state.modal.active_mode() != InputMode::QueryHistoryPicker {
                 return DispatchResult::handled();
             }
-            if state.session.active_connection_id() != Some(conn_id) {
+            if state.session.query_history_scope().as_ref() != Some(scope) {
                 return DispatchResult::handled();
             }
             state.messages.set_error_at(e.to_string(), now);

--- a/src/app/update/sql_editor/completion.rs
+++ b/src/app/update/sql_editor/completion.rs
@@ -39,12 +39,79 @@ pub(super) fn reduce_completion(
             candidates,
             trigger_position,
             visible,
+            dsn,
+            connection_generation,
+            database_generation,
+            metadata_generation,
         } => {
+            if !state.session.is_current_completion_scope(
+                dsn.as_deref(),
+                *connection_generation,
+                *database_generation,
+                *metadata_generation,
+            ) {
+                return DispatchResult::handled();
+            }
             state
                 .sql_modal
                 .apply_completion_update(candidates, *trigger_position, *visible);
             DispatchResult::handled()
         }
         _ => DispatchResult::pass(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType};
+
+    #[test]
+    fn stale_completion_update_from_previous_database_is_ignored() {
+        let mut state = AppState::new("test".to_string());
+        let id = ConnectionId::new();
+        state.session.activate_connection_with_target(
+            &id,
+            "mysql",
+            DatabaseType::MySQL,
+            "mysql://user@localhost:3306/app",
+            Some("app"),
+        );
+        let metadata_run = state.session.begin_metadata_refresh();
+        state
+            .session
+            .mark_connected(Arc::new(DatabaseMetadata::new("app".to_string())));
+
+        let old_scope = (
+            state.session.dsn().map(str::to_string),
+            state.session.connection_generation(),
+            state.session.database_generation(),
+            metadata_run,
+        );
+        state.session.activate_connection_with_target(
+            &id,
+            "mysql",
+            DatabaseType::MySQL,
+            "mysql://user@localhost:3306/analytics",
+            Some("analytics"),
+        );
+
+        reduce_completion(
+            &mut state,
+            &Action::CompletionUpdated {
+                candidates: vec![],
+                trigger_position: 0,
+                visible: true,
+                dsn: old_scope.0,
+                connection_generation: old_scope.1,
+                database_generation: old_scope.2,
+                metadata_generation: old_scope.3,
+            },
+            Instant::now(),
+        );
+
+        assert!(!state.sql_modal.completion().visible);
     }
 }

--- a/src/app/update/sql_editor/submit.rs
+++ b/src/app/update/sql_editor/submit.rs
@@ -4,7 +4,7 @@ use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::policy::write::sql_risk::{
     ConfirmationType, MultiStatementDecision, adhoc_label_for_table_name_confirmation,
-    evaluate_multi_statement_for_database,
+    evaluate_multi_statement_for_database_with_context,
 };
 use crate::policy::write::write_guardrails::AdhocRiskDecision;
 use crate::update::action::Action;
@@ -23,7 +23,11 @@ pub(super) fn reduce_submit(state: &mut AppState, action: &Action, now: Instant)
 
             let database_type = state.session.active_database_type_or_default();
 
-            match evaluate_multi_statement_for_database(database_type, &query) {
+            match evaluate_multi_statement_for_database_with_context(
+                database_type,
+                state.session.active_database(),
+                &query,
+            ) {
                 MultiStatementDecision::Block { reason } => {
                     state.sql_modal.finish_adhoc_error(reason);
                     DispatchResult::handled()

--- a/src/domain/command_tag.rs
+++ b/src/domain/command_tag.rs
@@ -1,3 +1,5 @@
+use super::query_result::RefreshScope;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CommandTag {
     Select(u64),
@@ -42,6 +44,16 @@ impl CommandTag {
                     "ANALYZE" | "ATTACH" | "DETACH" | "REINDEX" | "VACUUM"
                 )
         )
+    }
+
+    pub fn refresh_scope(&self) -> RefreshScope {
+        if self.is_schema_modifying() {
+            RefreshScope::Metadata
+        } else if self.needs_refresh() {
+            RefreshScope::Data
+        } else {
+            RefreshScope::None
+        }
     }
 
     pub fn affected_rows(&self) -> Option<u64> {

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -23,11 +23,14 @@ pub use command_tag::CommandTag;
 #[cfg(test)]
 pub use er::ErFkInfo;
 pub use er::ErTableInfo;
-pub use explain_plan::sqlite_explain_query_plan_text_from_result;
+pub use explain_plan::{
+    mysql_explain_plan_text_from_result, postgres_explain_plan_text_from_result,
+    sqlite_explain_query_plan_text_from_result,
+};
 pub use foreign_key::{FkAction, ForeignKey, UNRESOLVED_FK_COLUMN};
 pub use index::{Index, IndexAttributes, IndexType};
 pub use metadata::{DatabaseMetadata, MetadataState};
-pub use query_result::{QueryResult, QuerySource, QueryValue};
+pub use query_result::{ExplicitRowIdentity, QueryResult, QuerySource, QueryValue, RefreshScope};
 pub use rls::{RlsCommand, RlsInfo, RlsPolicy};
 pub use schema::Schema;
 pub use sqlite_diagnostics::{DiagnosticField, SqliteDiagnosticsSnapshot};
@@ -38,6 +41,7 @@ pub use write_result::WriteExecutionResult;
 
 pub use connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
-    PostgresConnectionConfig, SqliteConnectionConfig, SqliteConnectionConfigError, SqlitePathError,
-    SslMode, classify_sqlite_metadata_error, classify_sqlite_read_error, sqlite_path_from_dsn,
+    MySqlConnectionConfig, MySqlSslMode, PostgresConnectionConfig, SqliteConnectionConfig,
+    SqliteConnectionConfigError, SqlitePathError, SslMode, classify_sqlite_metadata_error,
+    classify_sqlite_read_error, sqlite_path_from_dsn,
 };

--- a/src/domain/query_history.rs
+++ b/src/domain/query_history.rs
@@ -2,6 +2,21 @@ use serde::{Deserialize, Serialize};
 
 use super::connection::ConnectionId;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryHistoryScope {
+    pub connection_id: ConnectionId,
+    pub database: Option<String>,
+}
+
+impl QueryHistoryScope {
+    pub fn new(connection_id: ConnectionId, database: Option<String>) -> Self {
+        Self {
+            connection_id,
+            database,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Iso8601Timestamp(String);
@@ -39,6 +54,8 @@ pub struct QueryHistoryEntry {
     pub query: String,
     pub executed_at: Iso8601Timestamp,
     pub connection_id: ConnectionId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
     pub result_status: QueryResultStatus,
     pub affected_rows: Option<u64>,
 }
@@ -51,10 +68,29 @@ impl QueryHistoryEntry {
         result_status: QueryResultStatus,
         affected_rows: Option<u64>,
     ) -> Self {
+        Self::new_with_database(
+            query,
+            executed_at,
+            connection_id,
+            None,
+            result_status,
+            affected_rows,
+        )
+    }
+
+    pub fn new_with_database(
+        query: String,
+        executed_at: String,
+        connection_id: ConnectionId,
+        database: Option<String>,
+        result_status: QueryResultStatus,
+        affected_rows: Option<u64>,
+    ) -> Self {
         Self {
             query,
             executed_at: Iso8601Timestamp::new(executed_at),
             connection_id,
+            database,
             result_status,
             affected_rows,
         }
@@ -115,5 +151,37 @@ mod tests {
         assert!(json.contains("\"executed_at\":\"2026-03-13T12:00:00Z\""));
         assert!(json.contains("\"connection_id\":\"abc-123\""));
         assert!(json.contains("\"result_status\":\"Success\""));
+    }
+
+    #[test]
+    fn serde_reads_entries_without_database() {
+        let json = r#"{
+            "query":"SELECT 1",
+            "executed_at":"2026-03-13T12:00:00Z",
+            "connection_id":"abc-123",
+            "result_status":"Success",
+            "affected_rows":null
+        }"#;
+
+        let entry: QueryHistoryEntry = serde_json::from_str(json).unwrap();
+
+        assert_eq!(entry.database, None);
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_database() {
+        let entry = QueryHistoryEntry::new_with_database(
+            "SELECT 1".to_string(),
+            "2026-03-13T12:00:00Z".to_string(),
+            ConnectionId::from_string("abc-123"),
+            Some("analytics".to_string()),
+            QueryResultStatus::Success,
+            None,
+        );
+
+        let json = serde_json::to_string(&entry).unwrap();
+        let deserialized: QueryHistoryEntry = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.database.as_deref(), Some("analytics"));
     }
 }

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -222,6 +222,43 @@ pub enum QuerySource {
     Adhoc,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExplicitRowIdentity {
+    columns: Vec<String>,
+    values: Vec<Vec<QueryValue>>,
+}
+
+impl ExplicitRowIdentity {
+    #[must_use]
+    pub fn columns(&self) -> &[String] {
+        &self.columns
+    }
+
+    #[must_use]
+    pub fn values(&self) -> &[Vec<QueryValue>] {
+        &self.values
+    }
+
+    #[must_use]
+    pub fn values_for_row(&self, row: usize) -> Option<&[QueryValue]> {
+        self.values.get(row).map(Vec::as_slice)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RefreshScope {
+    None,
+    Data,
+    Metadata,
+}
+
+impl RefreshScope {
+    #[must_use]
+    pub fn merge(self, other: Self) -> Self {
+        self.max(other)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct QueryResult {
     pub query: String,
@@ -230,8 +267,10 @@ pub struct QueryResult {
     pub source: QuerySource,
     pub error: Option<String>,
     pub command_tag: Option<CommandTag>,
+    pub refresh_scope: RefreshScope,
     rows: Vec<Vec<String>>,
     values: Vec<Vec<QueryValue>>,
+    explicit_row_identity: Option<ExplicitRowIdentity>,
     row_count: usize,
     typed_values: bool,
 }
@@ -255,12 +294,14 @@ impl QueryResult {
             columns,
             rows,
             values,
+            explicit_row_identity: None,
             row_count,
             typed_values: false,
             execution_time_ms,
             source,
             error: None,
             command_tag: None,
+            refresh_scope: RefreshScope::None,
         }
     }
 
@@ -278,12 +319,14 @@ impl QueryResult {
             columns,
             rows: Vec::new(),
             values,
+            explicit_row_identity: None,
             row_count,
             typed_values: true,
             execution_time_ms,
             source,
             error: None,
             command_tag: None,
+            refresh_scope: RefreshScope::None,
         }
     }
 
@@ -299,24 +342,43 @@ impl QueryResult {
             columns: Vec::new(),
             rows: Vec::new(),
             values: Vec::new(),
+            explicit_row_identity: None,
             row_count: 0,
             typed_values: false,
             execution_time_ms,
             source,
             error: Some(error),
             command_tag: None,
+            refresh_scope: RefreshScope::None,
         }
     }
 
     #[must_use]
     pub fn with_command_tag(mut self, tag: CommandTag) -> Self {
+        self.refresh_scope = tag.refresh_scope();
         self.command_tag = Some(tag);
+        self
+    }
+
+    #[must_use]
+    pub fn with_refresh_scope(mut self, refresh_scope: RefreshScope) -> Self {
+        self.refresh_scope = refresh_scope;
         self
     }
 
     #[must_use]
     pub fn with_row_count(mut self, row_count: usize) -> Self {
         self.row_count = row_count;
+        self
+    }
+
+    #[must_use]
+    pub fn with_explicit_row_identity(
+        mut self,
+        columns: Vec<String>,
+        values: Vec<Vec<QueryValue>>,
+    ) -> Self {
+        self.explicit_row_identity = Some(ExplicitRowIdentity { columns, values });
         self
     }
 
@@ -374,6 +436,11 @@ impl QueryResult {
     #[must_use]
     pub fn values(&self) -> &[Vec<QueryValue>] {
         &self.values
+    }
+
+    #[must_use]
+    pub fn explicit_row_identity(&self) -> Option<&ExplicitRowIdentity> {
+        self.explicit_row_identity.as_ref()
     }
 
     #[must_use]
@@ -576,6 +643,30 @@ mod tests {
             assert_eq!(result.columns, vec!["body"]);
             assert_eq!(result.values(), &[vec![QueryValue::text("body")]]);
             assert_eq!(result.display_row_at(0), Some(vec!["body".to_string()]));
+        }
+
+        #[test]
+        fn explicit_identity_is_not_part_of_display_rows_or_column_count() {
+            let result = QueryResult::success_with_values(
+                "SELECT payload".to_string(),
+                vec!["payload".to_string()],
+                vec![vec![QueryValue::text("visible")]],
+                0,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["id".to_string()],
+                vec![vec![QueryValue::SqlLiteral("42".to_string())]],
+            );
+
+            assert_eq!(result.column_count(), 1);
+            assert_eq!(result.display_row_at(0), Some(vec!["visible".to_string()]));
+            assert_eq!(
+                result
+                    .explicit_row_identity()
+                    .and_then(|identity| identity.values_for_row(0)),
+                Some([QueryValue::SqlLiteral("42".to_string())].as_slice())
+            );
         }
     }
 

--- a/src/infra/adapters/cached_result_exporter.rs
+++ b/src/infra/adapters/cached_result_exporter.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
 use sabiql_app::domain::QueryValue;
 use sabiql_app::ports::outbound::{CachedResultExporter, DbOperationError};
-use tokio::io::{AsyncWriteExt, BufWriter};
 
-use crate::adapters::csv_export::export_to_downloads;
+use crate::adapters::csv_export::{CsvFileWriter, export_to_downloads};
 
-const CSV_FLUSH_THRESHOLD: usize = 64 * 1024;
+#[cfg(test)]
+use crate::adapters::csv_export::CSV_FLUSH_THRESHOLD;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct CsvCachedResultExporter;
@@ -45,73 +45,12 @@ async fn write_cached_result_csv(
     columns: Vec<String>,
     values: Vec<Vec<QueryValue>>,
 ) -> Result<(), DbOperationError> {
-    let file = tokio::fs::File::create(path)
-        .await
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    let mut file = BufWriter::new(file);
-    let mut csv_writer =
-        csv::WriterBuilder::new().from_writer(Vec::with_capacity(CSV_FLUSH_THRESHOLD));
-    let mut bytes_since_flush = 0;
-
-    csv_writer = write_csv_record(
-        csv_writer,
-        &mut file,
-        columns.iter(),
-        &mut bytes_since_flush,
-    )
-    .await?;
+    let mut file = CsvFileWriter::create(path).await?;
+    file.write_record(columns.iter()).await?;
     for row in &values {
-        csv_writer = write_csv_record(
-            csv_writer,
-            &mut file,
-            row.iter().map(cached_csv_cell),
-            &mut bytes_since_flush,
-        )
-        .await?;
+        file.write_record(row.iter().map(cached_csv_cell)).await?;
     }
-    let encoded = csv_writer
-        .into_inner()
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    file.write_all(&encoded)
-        .await
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    file.flush()
-        .await
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-    Ok(())
-}
-
-async fn write_csv_record<I>(
-    mut csv_writer: csv::Writer<Vec<u8>>,
-    file: &mut BufWriter<tokio::fs::File>,
-    record: I,
-    bytes_since_flush: &mut usize,
-) -> Result<csv::Writer<Vec<u8>>, DbOperationError>
-where
-    I: IntoIterator,
-    I::Item: AsRef<[u8]>,
-{
-    csv_writer.write_record(record)?;
-    csv_writer
-        .flush()
-        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-
-    *bytes_since_flush = csv_writer.get_ref().len();
-    if *bytes_since_flush >= CSV_FLUSH_THRESHOLD {
-        let mut encoded = csv_writer
-            .into_inner()
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-        file.write_all(&encoded)
-            .await
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-        file.flush()
-            .await
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-        *bytes_since_flush = 0;
-        encoded.clear();
-        csv_writer = csv::WriterBuilder::new().from_writer(encoded);
-    }
-    Ok(csv_writer)
+    file.finish().await
 }
 
 #[cfg(test)]

--- a/src/infra/adapters/csv_export.rs
+++ b/src/infra/adapters/csv_export.rs
@@ -3,6 +3,9 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::SystemTime;
 
 use sabiql_app::ports::outbound::DbOperationError;
+use tokio::io::{AsyncWriteExt, BufWriter};
+
+pub const CSV_FLUSH_THRESHOLD: usize = 64 * 1024;
 
 fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
     let z = days + 719_468;
@@ -101,6 +104,73 @@ where
     Fut: Future<Output = Result<(), DbOperationError>>,
 {
     export_to_path_with_cleanup(final_path, write, |path| std::fs::remove_file(path)).await
+}
+
+pub struct CsvFileWriter {
+    file: BufWriter<tokio::fs::File>,
+    csv_writer: csv::Writer<Vec<u8>>,
+    bytes_since_flush: usize,
+}
+
+impl CsvFileWriter {
+    pub(crate) async fn create(path: PathBuf) -> Result<Self, DbOperationError> {
+        let file = tokio::fs::File::create(path)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        Ok(Self {
+            file: BufWriter::new(file),
+            csv_writer: csv::WriterBuilder::new()
+                .from_writer(Vec::with_capacity(CSV_FLUSH_THRESHOLD)),
+            bytes_since_flush: 0,
+        })
+    }
+
+    pub(crate) async fn write_record<I>(&mut self, record: I) -> Result<(), DbOperationError>
+    where
+        I: IntoIterator,
+        I::Item: AsRef<[u8]>,
+    {
+        self.csv_writer.write_record(record)?;
+        self.csv_writer
+            .flush()
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        self.bytes_since_flush = self.csv_writer.get_ref().len();
+        if self.bytes_since_flush >= CSV_FLUSH_THRESHOLD {
+            self.flush_buffer().await?;
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn finish(mut self) -> Result<(), DbOperationError> {
+        let encoded = self
+            .csv_writer
+            .into_inner()
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        self.file
+            .write_all(&encoded)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        self.file
+            .flush()
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
+    }
+
+    async fn flush_buffer(&mut self) -> Result<(), DbOperationError> {
+        let encoded = self.csv_writer.get_ref().as_slice().to_vec();
+        self.file
+            .write_all(&encoded)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        self.file
+            .flush()
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        self.csv_writer =
+            csv::WriterBuilder::new().from_writer(Vec::with_capacity(CSV_FLUSH_THRESHOLD));
+        self.bytes_since_flush = 0;
+        Ok(())
+    }
 }
 
 async fn export_to_path_with_cleanup<F, Fut, C>(

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -1,15 +1,67 @@
-use async_trait::async_trait;
+use std::ffi::OsStr;
+use std::fmt::Write as _;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
 
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+
+use async_trait::async_trait;
+use quick_xml::Reader;
+use quick_xml::events::Event;
+use serde::Deserialize;
+#[cfg(unix)]
+use tokio::fs::File as TokioFile;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, ReadBuf};
+use tokio::process::Child;
+use tokio::process::Command;
+#[cfg(not(unix))]
+use tokio::process::{ChildStderr, ChildStdin, ChildStdout};
+use tokio::time::timeout;
+use url::Url;
+use uuid::Uuid;
+
+#[cfg(test)]
+use crate::adapters::csv_export::export_to_path;
+use crate::adapters::csv_export::{CsvFileWriter, export_to_downloads};
+#[cfg(test)]
+use crate::app::policy::sql::mysql_statement::split_mysql_statements;
+use crate::app::policy::sql::mysql_statement::{
+    MysqlStatement, MysqlStatementKind, classify_mysql_statement, mysql_explain_rejection_message,
+    mysql_tree_explain_query_kind,
+};
+use crate::app::policy::write::sql_risk::{
+    MultiStatementDecision, evaluate_mysql_multi_statement, mysql_statement_is_data_modifying,
+    mysql_statement_is_schema_modifying,
+};
 use crate::app::ports::outbound::{
-    AccessMode, DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor,
-    SqlDialect,
+    AccessMode, ConnectionProbe, DatabaseCli, DbOperationError, DdlGenerator, DsnBuilder,
+    MYSQL_CLI_VERSION_REQUIRED_MARKER, MYSQL_SERVER_VERSION_REQUIRED_MARKER,
+    MYSQL_SQL_MODE_UNSUPPORTED_MARKER, QueryExecutor, SqlDialect,
 };
-use crate::domain::connection::{ConnectionProfile, DatabaseType};
+use crate::domain::connection::{
+    ConnectionProfile, DatabaseType, MySqlConnectionConfig, MySqlSslMode,
+};
 use crate::domain::{
-    DatabaseMetadata, QueryResult, QueryValue, Table, TableSignature, WriteExecutionResult,
+    CommandTag, QueryResult, QuerySource, QueryValue, RefreshScope, Table, WriteExecutionResult,
 };
+
+mod metadata;
 
 pub struct MySqlAdapter;
+
+const MYSQL_PROBE_TIMEOUT: Duration = Duration::from_secs(11);
+const MYSQL_QUERY_TIMEOUT: Duration = Duration::from_secs(31);
+const MYSQL_PROBE_QUERY: &str = "SELECT JSON_OBJECT('database', DATABASE(), 'user', CURRENT_USER(), 'version', VERSION(), 'sql_mode', @@SESSION.sql_mode)";
+const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
+const MYSQL_SESSION_MARKER_COLUMN: &str = "__sabiql_session_marker";
+static OPTION_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 impl MySqlAdapter {
     pub fn new() -> Self {
@@ -24,144 +76,4493 @@ impl Default for MySqlAdapter {
 }
 
 #[async_trait]
-impl MetadataProvider for MySqlAdapter {
-    async fn fetch_metadata(&self, _dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_detail(
-        &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-    ) -> Result<Table, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_columns_and_fks(
-        &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-    ) -> Result<Table, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_signatures(
-        &self,
-        _dsn: &str,
-    ) -> Result<Vec<TableSignature>, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-}
-
-#[async_trait]
 impl QueryExecutor for MySqlAdapter {
     async fn execute_preview(
         &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-        _limit: usize,
-        _offset: usize,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+        limit: usize,
+        offset: usize,
     ) -> Result<QueryResult, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures mysql execution time at the I/O boundary"
+        )]
+        let start = Instant::now();
+        let preview = metadata::fetch_preview_metadata(dsn, schema, table).await?;
+        let query = metadata::build_preview_query(
+            schema,
+            table,
+            &preview.order_columns,
+            &preview.visible_columns,
+            &preview.identity_columns,
+            limit,
+            offset,
+        );
+        let display_query = metadata::build_preview_query(
+            schema,
+            table,
+            &preview.order_columns,
+            &preview.visible_columns,
+            &[],
+            limit,
+            offset,
+        );
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        let statements =
+            validate_mysql_multi_query(&query, target.database.as_deref(), AccessMode::ReadWrite)?;
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc(
+            &option_file.path,
+            &query,
+            &statements,
+            AccessMode::ReadWrite,
+        )
+        .await;
+        drop(option_file);
+        let result_set = result?.result_set.ok_or_else(|| {
+            DbOperationError::MetadataParseFailed(
+                "MySQL preview query returned no result set".to_string(),
+            )
+        })?;
+        let values = metadata::convert_preview_values(
+            &result_set,
+            &preview.visible_columns,
+            &preview.identity_columns,
+        )?;
+        let elapsed = start.elapsed().as_millis() as u64;
+
+        let mut query_result = QueryResult::success_with_values(
+            display_query,
+            preview
+                .visible_columns
+                .iter()
+                .map(|column| column.name.clone())
+                .collect(),
+            values.visible,
+            elapsed,
+            QuerySource::Preview,
+        );
+        if let Some(identity_values) = values.identity {
+            query_result = query_result.with_explicit_row_identity(
+                preview
+                    .identity_columns
+                    .iter()
+                    .map(|column| column.name.clone())
+                    .collect(),
+                identity_values,
+            );
+        }
+        Ok(query_result)
     }
 
     async fn execute_adhoc(
         &self,
-        _dsn: &str,
-        _query: &str,
-        _access_mode: AccessMode,
+        dsn: &str,
+        query: &str,
+        access_mode: AccessMode,
     ) -> Result<QueryResult, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+
+        if mysql_tree_explain_query_kind(query).is_some() {
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "infra measures mysql execution time at the I/O boundary"
+            )]
+            let start = Instant::now();
+            let option_file = MySqlOptionFile::create(&target)?;
+            let result = run_mysql_single_statement(&option_file.path, query, access_mode).await;
+            drop(option_file);
+            let result_set = result?;
+            return Ok(QueryResult::success_with_values(
+                query.to_string(),
+                result_set.columns,
+                result_set.values,
+                start.elapsed().as_millis() as u64,
+                QuerySource::Adhoc,
+            ));
+        }
+
+        let statements =
+            validate_mysql_multi_query(query, target.database.as_deref(), access_mode)?;
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures mysql execution time at the I/O boundary"
+        )]
+        let start = Instant::now();
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc(&option_file.path, query, &statements, access_mode).await;
+        drop(option_file);
+        let execution = result?;
+        let elapsed = start.elapsed().as_millis() as u64;
+        let mut result = match execution.result_set {
+            Some(result_set) => QueryResult::success_with_values(
+                query.to_string(),
+                result_set.columns,
+                result_set.values,
+                elapsed,
+                QuerySource::Adhoc,
+            ),
+            None => QueryResult::success(
+                query.to_string(),
+                Vec::new(),
+                Vec::new(),
+                elapsed,
+                QuerySource::Adhoc,
+            ),
+        };
+        if let Some(tag) = execution.command_tag {
+            result = result.with_command_tag(tag);
+        }
+        Ok(result.with_refresh_scope(execution.refresh_scope))
     }
 
     async fn execute_write(
         &self,
-        _dsn: &str,
-        _query: &str,
-        _access_mode: AccessMode,
+        dsn: &str,
+        query: &str,
+        access_mode: AccessMode,
     ) -> Result<WriteExecutionResult, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        let statements =
+            validate_mysql_multi_query(query, target.database.as_deref(), access_mode)?;
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures mysql execution time at the I/O boundary"
+        )]
+        let start = Instant::now();
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc(&option_file.path, query, &statements, access_mode).await;
+        drop(option_file);
+        let execution = result?;
+        let affected_rows = execution
+            .command_tag
+            .and_then(|tag| tag.affected_rows())
+            .ok_or_else(|| {
+                DbOperationError::CommandTagParseFailed(
+                    "MySQL write did not return an affected row count".to_string(),
+                )
+            })?;
+        let affected_rows = usize::try_from(affected_rows).map_err(|_| {
+            DbOperationError::CommandTagParseFailed(
+                "MySQL affected row count does not fit in usize".to_string(),
+            )
+        })?;
+
+        Ok(WriteExecutionResult {
+            affected_rows,
+            execution_time_ms: start.elapsed().as_millis() as u64,
+        })
     }
 
-    async fn count_query_rows(&self, _dsn: &str, _query: &str) -> Result<usize, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        validate_mysql_export_query(query, target.database.as_deref())?;
+
+        let result = self.execute_adhoc(dsn, query, AccessMode::ReadOnly).await?;
+        let value = result
+            .values()
+            .first()
+            .and_then(|row| row.first())
+            .and_then(QueryValue::as_str)
+            .ok_or_else(|| {
+                DbOperationError::QueryFailed(
+                    "MySQL row count query returned an invalid result".to_string(),
+                )
+            })?;
+        value.parse::<usize>().map_err(|_| {
+            DbOperationError::QueryFailed("MySQL row count was not an integer".to_string())
+        })
     }
 
     async fn export_to_csv(
         &self,
-        _dsn: &str,
-        _query: &str,
-        _file_name: &str,
+        dsn: &str,
+        query: &str,
+        file_name: &str,
     ) -> Result<std::path::PathBuf, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        validate_mysql_export_query(query, target.database.as_deref())?;
+
+        let query = query.to_string();
+        export_to_downloads(file_name, move |path| async move {
+            export_mysql_csv_to_file(target, &query, path).await
+        })
+        .await
     }
 }
 
 impl DdlGenerator for MySqlAdapter {
-    fn generate_ddl(&self, _database_type: DatabaseType, _table: &Table) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+    fn generate_ddl(&self, _database_type: DatabaseType, table: &Table) -> String {
+        table.source_ddl().unwrap_or_default().to_string()
     }
 }
 
 impl SqlDialect for MySqlAdapter {
-    fn build_explain_sql(&self, _database_type: DatabaseType, _query: &str) -> Option<String> {
-        None
+    fn build_explain_sql(&self, _database_type: DatabaseType, query: &str) -> Option<String> {
+        if mysql_explain_rejection_message(query).is_some() {
+            return None;
+        }
+        Some(format!("EXPLAIN FORMAT=TREE {query}"))
     }
 
     fn build_explain_analyze_sql(
         &self,
         _database_type: DatabaseType,
-        _query: &str,
+        query: &str,
     ) -> Option<String> {
-        None
+        mysql_tree_explain_query_kind(&format!("EXPLAIN ANALYZE FORMAT=TREE {query}"))?;
+        Some(format!("EXPLAIN ANALYZE FORMAT=TREE {query}"))
     }
 
     fn build_update_sql(
         &self,
         _database_type: DatabaseType,
-        _schema: &str,
-        _table: &str,
-        _column: &str,
-        _new_value: &QueryValue,
-        _pk_pairs: &[(String, QueryValue)],
+        schema: &str,
+        table: &str,
+        column: &str,
+        new_value: &QueryValue,
+        pk_pairs: &[(String, QueryValue)],
     ) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+        let where_clause = pk_pairs
+            .iter()
+            .map(|(column, value)| mysql_equality_predicate(column, value))
+            .collect::<Vec<_>>()
+            .join(" AND ");
+
+        format!(
+            "UPDATE {}.{}\nSET {} = {}\nWHERE {};",
+            mysql_quote_identifier(schema),
+            mysql_quote_identifier(table),
+            mysql_quote_identifier(column),
+            mysql_sql_literal(new_value),
+            where_clause
+        )
     }
 
     fn build_bulk_delete_sql(
         &self,
         _database_type: DatabaseType,
-        _schema: &str,
-        _table: &str,
-        _pk_pairs_per_row: &[Vec<(String, QueryValue)>],
+        schema: &str,
+        table: &str,
+        pk_pairs_per_row: &[Vec<(String, QueryValue)>],
     ) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+        assert!(
+            !pk_pairs_per_row.is_empty(),
+            "pk_pairs_per_row must not be empty"
+        );
+
+        let predicates = pk_pairs_per_row
+            .iter()
+            .map(|pairs| {
+                pairs
+                    .iter()
+                    .map(|(column, value)| mysql_equality_predicate(column, value))
+                    .collect::<Vec<_>>()
+                    .join(" AND ")
+            })
+            .collect::<Vec<_>>();
+        let where_clause = if predicates.len() == 1 {
+            predicates[0].clone()
+        } else {
+            predicates
+                .into_iter()
+                .map(|predicate| format!("({predicate})"))
+                .collect::<Vec<_>>()
+                .join(" OR ")
+        };
+
+        format!(
+            "DELETE FROM {}.{}\nWHERE {};",
+            mysql_quote_identifier(schema),
+            mysql_quote_identifier(table),
+            where_clause
+        )
+    }
+}
+
+fn mysql_quote_identifier(value: &str) -> String {
+    format!("`{}`", value.replace('`', "``"))
+}
+
+fn mysql_sql_literal(value: &QueryValue) -> String {
+    match value {
+        QueryValue::Null => "NULL".to_string(),
+        QueryValue::Text(value) => mysql_quote_string(value),
+        QueryValue::SqlLiteral(value) => value.clone(),
+        QueryValue::Blob(bytes) => {
+            let mut hex = String::with_capacity(bytes.len() * 2);
+            for byte in bytes {
+                let _ = write!(hex, "{byte:02X}");
+            }
+            format!("X'{hex}'")
+        }
+    }
+}
+
+fn mysql_quote_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\0' => escaped.push_str("\\0"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\u{0008}' => escaped.push_str("\\b"),
+            '\u{001a}' => escaped.push_str("\\Z"),
+            '\\' => escaped.push_str("\\\\"),
+            '\'' => escaped.push_str("\\'"),
+            _ => escaped.push(character),
+        }
+    }
+    format!("'{escaped}'")
+}
+
+fn mysql_equality_predicate(column: &str, value: &QueryValue) -> String {
+    let column = mysql_quote_identifier(column);
+    match value {
+        QueryValue::Null => format!("{column} IS NULL"),
+        _ => format!("{column} = {}", mysql_sql_literal(value)),
+    }
+}
+
+#[cfg(test)]
+mod write_sql_tests {
+    use super::*;
+
+    #[test]
+    fn update_quotes_identifiers_and_mysql_string_escapes() {
+        let adapter = MySqlAdapter::new();
+        let sql = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "db`name",
+            "table`name",
+            "value`name",
+            &QueryValue::text("O'Reilly\\path\n\t\0"),
+            &[
+                (
+                    "id`part".to_string(),
+                    QueryValue::SqlLiteral("18446744073709551615".into()),
+                ),
+                ("tenant".to_string(), QueryValue::Null),
+            ],
+        );
+
+        assert_eq!(
+            sql,
+            "UPDATE \x60db\x60\x60name\x60.\x60table\x60\x60name\x60\nSET \x60value\x60\x60name\x60 = 'O\\'Reilly\\\\path\\n\\t\\0'\nWHERE \x60id\x60\x60part\x60 = 18446744073709551615 AND \x60tenant\x60 IS NULL;"
+        );
+    }
+
+    #[test]
+    fn update_uses_text_datetime_and_blob_literals_without_coercion() {
+        let adapter = MySqlAdapter::new();
+        let sql = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "events",
+            "payload",
+            &QueryValue::Blob(vec![0, 255, 16]),
+            &[(
+                "created_at".to_string(),
+                QueryValue::text("2026-08-13 12:34:56"),
+            )],
+        );
+
+        assert_eq!(
+            sql,
+            "UPDATE `sabiql_test`.`events`\nSET `payload` = X'00FF10'\nWHERE `created_at` = '2026-08-13 12:34:56';"
+        );
+    }
+
+    #[test]
+    fn json_document_update_keeps_json_null_distinct_from_string_null() {
+        let adapter = MySqlAdapter::new();
+        let json_null = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "documents",
+            "payload",
+            &QueryValue::text("null"),
+            &[("id".to_string(), QueryValue::SqlLiteral("1".into()))],
+        );
+        let string_null = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "documents",
+            "payload",
+            &QueryValue::text(r#""null""#),
+            &[("id".to_string(), QueryValue::SqlLiteral("1".into()))],
+        );
+
+        assert!(json_null.contains("SET `payload` = 'null'"));
+        assert!(string_null.contains("SET `payload` = '\"null\"'"));
+        assert_ne!(json_null, string_null);
+    }
+
+    #[test]
+    fn bulk_delete_targets_each_composite_primary_key_row() {
+        let adapter = MySqlAdapter::new();
+        let sql = adapter.build_bulk_delete_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "items",
+            &[
+                vec![
+                    ("first".to_string(), QueryValue::SqlLiteral("1".into())),
+                    ("second".to_string(), QueryValue::SqlLiteral("20".into())),
+                ],
+                vec![
+                    ("first".to_string(), QueryValue::SqlLiteral("2".into())),
+                    ("second".to_string(), QueryValue::SqlLiteral("10".into())),
+                ],
+            ],
+        );
+
+        assert_eq!(
+            sql,
+            "DELETE FROM `sabiql_test`.`items`\nWHERE (`first` = 1 AND `second` = 20) OR (`first` = 2 AND `second` = 10);"
+        );
     }
 }
 
 impl DsnBuilder for MySqlAdapter {
-    fn build_dsn(&self, _profile: &ConnectionProfile) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+    fn build_dsn(&self, profile: &ConnectionProfile) -> String {
+        let config = profile
+            .mysql_config()
+            .expect("MySQL profile requires MySQL config");
+        build_mysql_dsn(config)
+    }
+}
+
+#[cfg(test)]
+mod explain_tests {
+    use super::*;
+
+    #[test]
+    fn builds_tree_explain_for_select_table_and_dml() {
+        let adapter = MySqlAdapter::new();
+
+        for query in [
+            "SELECT * FROM users",
+            "TABLE users",
+            "INSERT INTO users VALUES (1)",
+            "REPLACE INTO users VALUES (1)",
+            "REPLACE users VALUES (1)",
+            "REPLACE LOW_PRIORITY INTO users VALUES (1)",
+            "REPLACE DELAYED users VALUES (1)",
+            "UPDATE users SET name = 'Ada' WHERE id = 1",
+            "DELETE FROM users WHERE id = 1",
+        ] {
+            assert_eq!(
+                adapter.build_explain_sql(DatabaseType::MySQL, query),
+                Some(format!("EXPLAIN FORMAT=TREE {query}")),
+                "{query}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_mysql_explain_for_unsupported_input() {
+        let adapter = MySqlAdapter::new();
+
+        for query in [
+            "CREATE TABLE users(id INT)",
+            "DROP TABLE users",
+            "\\C /tmp/other.sock",
+            "SELECT 1; SELECT 2",
+        ] {
+            assert_eq!(
+                adapter.build_explain_sql(DatabaseType::MySQL, query),
+                None,
+                "{query}"
+            );
+        }
+    }
+
+    #[test]
+    fn builds_tree_explain_analyze_only_for_side_effect_free_reads() {
+        let adapter = MySqlAdapter::new();
+
+        for query in ["SELECT * FROM users", "TABLE users"] {
+            assert_eq!(
+                adapter.build_explain_analyze_sql(DatabaseType::MySQL, query),
+                Some(format!("EXPLAIN ANALYZE FORMAT=TREE {query}")),
+                "{query}"
+            );
+        }
+
+        for query in [
+            "UPDATE users SET name = 'Ada' WHERE id = 1",
+            "DELETE FROM users WHERE id = 1",
+            "INSERT INTO users VALUES (1)",
+            "REPLACE INTO users VALUES (1)",
+            "SELECT * FROM users FOR UPDATE",
+            "SELECT 1; SELECT 2",
+        ] {
+            assert_eq!(
+                adapter.build_explain_analyze_sql(DatabaseType::MySQL, query),
+                None,
+                "{query}"
+            );
+        }
+    }
+}
+
+#[async_trait]
+impl ConnectionProbe for MySqlAdapter {
+    async fn probe(&self, dsn: &str) -> Result<(), DbOperationError> {
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        self.check_cli_version().await?;
+
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = self.run_probe(&option_file.path).await;
+        drop(option_file);
+        let output = result?;
+
+        if !output.status.success() {
+            return Err(classify_mysql_probe_failure(clean_stderr(&output.stderr)));
+        }
+
+        let response: MySqlProbeResponse = serde_json::from_slice(&output.stdout)?;
+        let _ = (&response.database, &response.user);
+        validate_server_version(&response.version)?;
+        validate_sql_mode(&response.sql_mode)?;
+        Ok(())
+    }
+
+    async fn fetch_databases(&self, dsn: &str) -> Result<Vec<String>, DbOperationError> {
+        let mut target = parse_mysql_dsn(dsn)?;
+        target.database = None;
+        validate_mysql_values(&target)?;
+        self.check_cli_version().await?;
+
+        let option_file = MySqlOptionFile::create(&target)?;
+        let statements = validate_mysql_multi_query("SHOW DATABASES", None, AccessMode::ReadWrite)?;
+        let result = run_mysql_adhoc(
+            &option_file.path,
+            "SHOW DATABASES",
+            &statements,
+            AccessMode::ReadWrite,
+        )
+        .await;
+        drop(option_file);
+        result.map(|execution| {
+            execution
+                .result_set
+                .unwrap_or(MysqlResultSet {
+                    columns: Vec::new(),
+                    values: Vec::new(),
+                })
+                .values
+                .into_iter()
+                .filter_map(|mut row| row.drain(..).next())
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect()
+        })
+    }
+}
+
+impl MySqlAdapter {
+    async fn check_cli_version(&self) -> Result<(), DbOperationError> {
+        let output = run_mysql_command(["--version"], None).await?;
+        let version_output = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if !output.status.success() || !is_oracle_mysql_cli_84_version(&version_output) {
+            return Err(DbOperationError::UnsupportedOperation(format!(
+                "{MYSQL_CLI_VERSION_REQUIRED_MARKER}: {}",
+                version_output.trim()
+            )));
+        }
+        Ok(())
+    }
+
+    async fn run_probe(
+        &self,
+        option_file: &PathBuf,
+    ) -> Result<std::process::Output, DbOperationError> {
+        let args = mysql_probe_args(option_file);
+        run_mysql_command(args, Some(option_file)).await
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct MySqlProbeResponse {
+    database: Option<String>,
+    user: String,
+    version: String,
+    sql_mode: String,
+}
+
+#[derive(Debug)]
+struct MySqlDsn {
+    host: String,
+    port: u16,
+    database: Option<String>,
+    username: String,
+    password: String,
+    ssl_mode: MySqlSslMode,
+    ssl_ca: Option<String>,
+    ssl_cert: Option<String>,
+    ssl_key: Option<String>,
+}
+
+fn build_mysql_dsn(config: &MySqlConnectionConfig) -> String {
+    let mut url = Url::parse("mysql://localhost").expect("static MySQL URL is valid");
+    url.set_username(&config.username)
+        .expect("MySQL username is valid URL data");
+    url.set_password(Some(&config.password))
+        .expect("MySQL password is valid URL data");
+    let host = normalize_mysql_host(&config.host);
+    let host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]")
+    } else {
+        host
+    };
+    url.set_host(Some(&host))
+        .expect("validated MySQL host is valid URL data");
+    url.set_port(Some(config.port))
+        .expect("MySQL port is valid URL data");
+    if let Some(database) = config.database.as_deref() {
+        url.path_segments_mut()
+            .expect("MySQL URL supports path segments")
+            .push(database);
+    }
+    url.query_pairs_mut()
+        .append_pair("ssl-mode", &config.ssl_mode.to_string());
+    if let Some(path) = config.ssl_ca.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-ca", path);
+    }
+    if let Some(path) = config.ssl_cert.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-cert", path);
+    }
+    if let Some(path) = config.ssl_key.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-key", path);
+    }
+    url.to_string()
+}
+
+fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
+    let url = Url::parse(dsn).map_err(|error| {
+        DbOperationError::ConnectionFailed(format!("Invalid MySQL DSN: {error}"))
+    })?;
+    if url.scheme() != "mysql" {
+        return Err(DbOperationError::ConnectionFailed(
+            "Invalid MySQL DSN scheme".to_string(),
+        ));
+    }
+    let host = url.host_str().ok_or_else(|| {
+        DbOperationError::ConnectionFailed("MySQL DSN is missing a host".to_string())
+    })?;
+    let host = normalize_mysql_host(host);
+    let username = decode_url_component(url.username())?;
+    let password = decode_url_component(url.password().unwrap_or_default())?;
+    let database = url
+        .path_segments()
+        .and_then(|mut segments| segments.next())
+        .filter(|segment| !segment.is_empty())
+        .map(decode_url_component)
+        .transpose()?;
+    let ssl_mode = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-mode").then(|| parse_ssl_mode(&value)))
+        .transpose()?
+        .unwrap_or_default();
+    let ssl_ca = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-ca").then(|| value.into_owned()));
+    let ssl_cert = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-cert").then(|| value.into_owned()));
+    let ssl_key = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-key").then(|| value.into_owned()));
+
+    Ok(MySqlDsn {
+        host,
+        port: url.port().unwrap_or(3306),
+        database,
+        username,
+        password,
+        ssl_mode,
+        ssl_ca,
+        ssl_cert,
+        ssl_key,
+    })
+}
+
+fn normalize_mysql_host(host: &str) -> String {
+    host.strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host)
+        .to_string()
+}
+
+fn parse_ssl_mode(value: &str) -> Result<MySqlSslMode, DbOperationError> {
+    match value {
+        "DISABLED" => Ok(MySqlSslMode::Disabled),
+        "PREFERRED" => Ok(MySqlSslMode::Preferred),
+        "REQUIRED" => Ok(MySqlSslMode::Required),
+        "VERIFY_CA" => Ok(MySqlSslMode::VerifyCa),
+        "VERIFY_IDENTITY" => Ok(MySqlSslMode::VerifyIdentity),
+        _ => Err(DbOperationError::ConnectionFailed(
+            "Invalid MySQL TLS mode".to_string(),
+        )),
+    }
+}
+
+fn decode_url_component(value: &str) -> Result<String, DbOperationError> {
+    urlencoding::decode(value)
+        .map(std::borrow::Cow::into_owned)
+        .map_err(|error| DbOperationError::ConnectionFailed(format!("Invalid MySQL DSN: {error}")))
+}
+
+fn validate_mysql_values(target: &MySqlDsn) -> Result<(), DbOperationError> {
+    let values = [
+        target.host.as_str(),
+        target.username.as_str(),
+        target.password.as_str(),
+    ];
+    if target
+        .database
+        .as_deref()
+        .into_iter()
+        .chain(values)
+        .any(|value| value.chars().any(char::is_control))
+    {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL connection settings contain a control character".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_mysql_tls_files(target: &MySqlDsn) -> Result<(), DbOperationError> {
+    let has_tls_path =
+        target.ssl_ca.is_some() || target.ssl_cert.is_some() || target.ssl_key.is_some();
+    if target.ssl_mode == MySqlSslMode::Disabled && has_tls_path {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL TLS paths require an enabled TLS mode".to_string(),
+        ));
+    }
+    if matches!(
+        target.ssl_mode,
+        MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity
+    ) && target.ssl_ca.is_none()
+    {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL CA path is required for certificate verification".to_string(),
+        ));
+    }
+    if target.ssl_cert.is_some() != target.ssl_key.is_some() {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL client certificate and key must be specified together".to_string(),
+        ));
+    }
+
+    for (kind, path) in [
+        ("CA", target.ssl_ca.as_deref()),
+        ("client certificate", target.ssl_cert.as_deref()),
+        ("client key", target.ssl_key.as_deref()),
+    ] {
+        let Some(path) = path else { continue };
+        let metadata = fs::metadata(path).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} path cannot be accessed: {error}"
+            ))
+        })?;
+        if !metadata.is_file() {
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} path is not a regular file"
+            )));
+        }
+        let contents = fs::read(path).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!("MySQL {kind} cannot be read: {error}"))
+        })?;
+        let text = String::from_utf8_lossy(&contents);
+        if matches!(kind, "CA" | "client certificate") && !text.contains("BEGIN CERTIFICATE") {
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} is not a PEM certificate"
+            )));
+        }
+        if kind == "client key" {
+            if text.contains("BEGIN ENCRYPTED PRIVATE KEY")
+                || text
+                    .lines()
+                    .any(|line| line.trim().eq_ignore_ascii_case("Proc-Type: 4,ENCRYPTED"))
+            {
+                return Err(DbOperationError::ConnectionFailed(
+                    "Encrypted MySQL client keys are not supported".to_string(),
+                ));
+            }
+            if ![
+                "BEGIN PRIVATE KEY",
+                "BEGIN RSA PRIVATE KEY",
+                "BEGIN EC PRIVATE KEY",
+            ]
+            .iter()
+            .any(|marker| text.contains(marker))
+            {
+                return Err(DbOperationError::ConnectionFailed(
+                    "MySQL client key is not a PEM private key".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn contains_unsupported_mysql_product(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    ["mariadb", "percona", "tidb", "vitess", "aurora"]
+        .iter()
+        .any(|product| lower.contains(product))
+}
+
+fn is_oracle_mysql_cli_84_version(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("mysql")
+        && !contains_unsupported_mysql_product(value)
+        && version_major_minor(value) == Some((8, 4))
+}
+
+fn is_oracle_mysql_server_84_version(value: &str) -> bool {
+    !contains_unsupported_mysql_product(value) && version_major_minor(value) == Some((8, 4))
+}
+
+fn validate_server_version(version: &str) -> Result<(), DbOperationError> {
+    if is_oracle_mysql_server_84_version(version) {
+        Ok(())
+    } else {
+        Err(DbOperationError::UnsupportedOperation(format!(
+            "{MYSQL_SERVER_VERSION_REQUIRED_MARKER}: {version}"
+        )))
+    }
+}
+
+fn validate_sql_mode(sql_mode: &str) -> Result<(), DbOperationError> {
+    let unsupported = sql_mode.split(',').map(str::trim).any(|mode| {
+        mode.eq_ignore_ascii_case("NO_BACKSLASH_ESCAPES")
+            || mode.eq_ignore_ascii_case("ANSI_QUOTES")
+    });
+    if unsupported {
+        Err(DbOperationError::UnsupportedOperation(format!(
+            "{MYSQL_SQL_MODE_UNSUPPORTED_MARKER}: {sql_mode}"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn version_major_minor(value: &str) -> Option<(u32, u32)> {
+    let mut numbers = value
+        .split(|character: char| !character.is_ascii_digit())
+        .filter(|part| !part.is_empty())
+        .filter_map(|part| part.parse::<u32>().ok());
+    Some((numbers.next()?, numbers.next()?))
+}
+
+fn mysql_probe_args(option_file: &std::path::Path) -> Vec<String> {
+    vec![
+        format!("--defaults-file={}", option_file.display()),
+        "--no-login-paths".to_string(),
+        "--protocol=TCP".to_string(),
+        "--connect-timeout=10".to_string(),
+        "--batch".to_string(),
+        "--raw".to_string(),
+        "--skip-column-names".to_string(),
+        "--binary-mode".to_string(),
+        "--skip-reconnect".to_string(),
+        format!("--execute={MYSQL_PROBE_QUERY}"),
+    ]
+}
+
+async fn run_mysql_command<I, S>(
+    args: I,
+    option_file: Option<&PathBuf>,
+) -> Result<std::process::Output, DbOperationError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new("mysql");
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .env_remove("MYSQL_PWD")
+        .env_remove("MYSQL_PASSWORD")
+        .kill_on_drop(true);
+    if option_file.is_some() {
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    }
+
+    match timeout(MYSQL_PROBE_TIMEOUT, command.output()).await {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(error)) if error.kind() == io::ErrorKind::NotFound => {
+            Err(DbOperationError::CommandNotFound {
+                command: DatabaseCli::MySql,
+                details: error.to_string(),
+            })
+        }
+        Ok(Err(error)) => Err(DbOperationError::ConnectionFailed(error.to_string())),
+        Err(_) => Err(DbOperationError::Timeout(
+            "mysql probe exceeded the connection timeout".to_string(),
+        )),
+    }
+}
+
+fn clean_stderr(stderr: &[u8]) -> String {
+    let text = String::from_utf8_lossy(stderr).trim().to_string();
+    if text.is_empty() {
+        "mysql probe failed".to_string()
+    } else {
+        text
+    }
+}
+
+fn classify_mysql_probe_failure(stderr: String) -> DbOperationError {
+    if is_mysql_connect_timeout_message(&stderr) {
+        DbOperationError::Timeout(stderr)
+    } else {
+        DbOperationError::ConnectionFailed(stderr)
+    }
+}
+
+fn is_mysql_connect_timeout_message(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("can't connect to mysql server")
+        && (lower.contains("(110)") || lower.contains("(10060)"))
+}
+
+struct MySqlOptionFile {
+    path: PathBuf,
+}
+
+impl MySqlOptionFile {
+    fn create(target: &MySqlDsn) -> Result<Self, DbOperationError> {
+        validate_mysql_tls_files(target)?;
+        let sequence = OPTION_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "sabiql-mysql-{}-{sequence}.cnf",
+            std::process::id()
+        ));
+        if !path.is_absolute() {
+            path = std::env::current_dir()
+                .map_err(|error| DbOperationError::ConnectionFailed(error.to_string()))?
+                .join(path);
+        }
+
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        std::os::unix::fs::OpenOptionsExt::mode(&mut options, 0o600);
+        let mut file = options.open(&path).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!(
+                "Unable to create MySQL option file: {error}"
+            ))
+        })?;
+        let contents = serialize_option_file(target);
+        if let Err(error) = file.write_all(contents.as_bytes()) {
+            let _ = fs::remove_file(&path);
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "Unable to write MySQL option file: {error}"
+            )));
+        }
+        Ok(Self { path })
+    }
+}
+
+impl Drop for MySqlOptionFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn serialize_option_file(target: &MySqlDsn) -> String {
+    let mut contents = String::from("[client]\n");
+    push_option(&mut contents, "host", &target.host);
+    push_option(&mut contents, "port", &target.port.to_string());
+    push_option(&mut contents, "user", &target.username);
+    push_option(&mut contents, "password", &target.password);
+    if let Some(database) = target.database.as_deref() {
+        push_option(&mut contents, "database", database);
+    }
+    push_option(&mut contents, "ssl-mode", &target.ssl_mode.to_string());
+    if let Some(path) = target.ssl_ca.as_deref() {
+        push_option(&mut contents, "ssl-ca", path);
+    }
+    if let Some(path) = target.ssl_cert.as_deref() {
+        push_option(&mut contents, "ssl-cert", path);
+    }
+    if let Some(path) = target.ssl_key.as_deref() {
+        push_option(&mut contents, "ssl-key", path);
+    }
+    contents
+}
+
+fn push_option(contents: &mut String, key: &str, value: &str) {
+    contents.push_str(key);
+    contents.push_str(" = ");
+    contents.push_str(&quote_option_value(value));
+    contents.push('\n');
+}
+
+fn quote_option_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            _ => escaped.push(character),
+        }
+    }
+    format!("\"{escaped}\"")
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MysqlResultSet {
+    columns: Vec<String>,
+    values: Vec<Vec<QueryValue>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MysqlExecutionResult {
+    result_set: Option<MysqlResultSet>,
+    command_tag: Option<CommandTag>,
+    refresh_scope: RefreshScope,
+}
+
+struct MysqlCommandEvent {
+    kind: MysqlStatementKind,
+    target: Option<String>,
+    tag: CommandTag,
+}
+
+fn validate_mysql_multi_query(
+    query: &str,
+    selected_database: Option<&str>,
+    access_mode: AccessMode,
+) -> Result<Vec<MysqlStatement>, DbOperationError> {
+    let decision = evaluate_mysql_multi_statement(query, selected_database);
+    let (statements, risk) = match decision {
+        MultiStatementDecision::Allow { statements, risk } => (statements, risk),
+        MultiStatementDecision::Block { reason } => {
+            return Err(DbOperationError::UnsupportedOperation(reason));
+        }
+    };
+    if access_mode.is_read_only() && !risk.read_only_allowed {
+        return Err(DbOperationError::PermissionDenied(
+            "read-only mode blocks MySQL write statements".to_string(),
+        ));
+    }
+    statements
+        .iter()
+        .map(|statement| {
+            classify_mysql_statement(statement)
+                .map_err(|error| DbOperationError::UnsupportedOperation(error.to_string()))
+        })
+        .collect()
+}
+
+fn validate_mysql_export_query(
+    query: &str,
+    selected_database: Option<&str>,
+) -> Result<(), DbOperationError> {
+    let statements = validate_mysql_multi_query(query, selected_database, AccessMode::ReadOnly)?;
+    if statements.len() != 1
+        || !matches!(
+            statements[0].kind,
+            MysqlStatementKind::Select
+                | MysqlStatementKind::Table
+                | MysqlStatementKind::Show
+                | MysqlStatementKind::Describe
+        )
+    {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL CSV export supports a single read-only result query".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+struct MysqlProcess {
+    child: Child,
+    #[cfg(unix)]
+    pty: MysqlPty,
+    #[cfg(not(unix))]
+    stdin: ChildStdin,
+    #[cfg(not(unix))]
+    stdout: ChildStdout,
+    #[cfg(not(unix))]
+    stderr: ChildStderr,
+    #[cfg(not(unix))]
+    pending: Vec<u8>,
+    #[cfg(not(unix))]
+    pending_stderr: Vec<u8>,
+}
+
+#[cfg(unix)]
+struct MysqlPty {
+    input: TokioFile,
+    output: TokioFile,
+    pending: Vec<u8>,
+}
+
+impl MysqlProcess {
+    fn spawn_with_program(
+        program: &OsStr,
+        option_file: &std::path::Path,
+    ) -> Result<Self, DbOperationError> {
+        #[cfg(unix)]
+        {
+            Self::spawn_with_pty(program, option_file)
+        }
+
+        #[cfg(not(unix))]
+        {
+            let mut command = Command::new(program);
+            command
+                .args(mysql_query_args(option_file))
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .env_remove("MYSQL_PWD")
+                .env_remove("MYSQL_PASSWORD")
+                .kill_on_drop(true);
+            let mut child = command.spawn().map_err(|error| {
+                if error.kind() == io::ErrorKind::NotFound {
+                    DbOperationError::CommandNotFound {
+                        command: DatabaseCli::MySql,
+                        details: error.to_string(),
+                    }
+                } else {
+                    DbOperationError::ConnectionFailed(error.to_string())
+                }
+            })?;
+            let stdin = child.stdin.take().ok_or_else(|| {
+                DbOperationError::QueryFailed("mysql stdin was not piped".to_string())
+            })?;
+            let stdout = child.stdout.take().ok_or_else(|| {
+                DbOperationError::QueryFailed("mysql stdout was not piped".to_string())
+            })?;
+            let stderr = child.stderr.take().ok_or_else(|| {
+                DbOperationError::QueryFailed("mysql stderr was not piped".to_string())
+            })?;
+            return Ok(Self {
+                child,
+                stdin,
+                stdout,
+                stderr,
+                pending: Vec::new(),
+                pending_stderr: Vec::new(),
+            });
+        }
+    }
+
+    #[cfg(unix)]
+    fn spawn_with_pty(
+        program: &OsStr,
+        option_file: &std::path::Path,
+    ) -> Result<Self, DbOperationError> {
+        let (master, slave) = create_mysql_pty().map_err(|error| {
+            DbOperationError::ConnectionFailed(format!("Unable to create MySQL PTY: {error}"))
+        })?;
+        let mut command = Command::new(program);
+        command
+            .args(mysql_query_args(option_file))
+            .stdin(Stdio::from(slave.try_clone().map_err(|error| {
+                DbOperationError::ConnectionFailed(error.to_string())
+            })?))
+            .stdout(Stdio::from(slave.try_clone().map_err(|error| {
+                DbOperationError::ConnectionFailed(error.to_string())
+            })?))
+            .stderr(Stdio::from(slave))
+            .env_remove("MYSQL_PWD")
+            .env_remove("MYSQL_PASSWORD")
+            .kill_on_drop(true);
+        let child = command.spawn().map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                DbOperationError::CommandNotFound {
+                    command: DatabaseCli::MySql,
+                    details: error.to_string(),
+                }
+            } else {
+                DbOperationError::ConnectionFailed(error.to_string())
+            }
+        })?;
+        let output = TokioFile::from_std(
+            master
+                .try_clone()
+                .map_err(|error| DbOperationError::ConnectionFailed(error.to_string()))?,
+        );
+        let input = TokioFile::from_std(master);
+        Ok(Self {
+            child,
+            pty: MysqlPty {
+                input,
+                output,
+                pending: Vec::new(),
+            },
+        })
+    }
+}
+
+#[cfg(unix)]
+fn create_mysql_pty() -> io::Result<(std::fs::File, std::fs::File)> {
+    let mut master = -1;
+    let mut slave = -1;
+    let result = unsafe {
+        libc::openpty(
+            &raw mut master,
+            &raw mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let slave_file = unsafe { std::fs::File::from_raw_fd(slave) };
+    let master_file = unsafe { std::fs::File::from_raw_fd(master) };
+    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+    if unsafe { libc::tcgetattr(slave_file.as_raw_fd(), termios.as_mut_ptr()) } == 0 {
+        let mut termios = unsafe { termios.assume_init() };
+        termios.c_lflag &= !(libc::ECHO | libc::ECHONL);
+        termios.c_oflag &= !libc::OPOST;
+        let _ =
+            unsafe { libc::tcsetattr(slave_file.as_raw_fd(), libc::TCSANOW, &raw const termios) };
+    }
+    Ok((master_file, slave_file))
+}
+
+async fn run_mysql_adhoc(
+    option_file: &std::path::Path,
+    query: &str,
+    statements: &[MysqlStatement],
+    access_mode: AccessMode,
+) -> Result<MysqlExecutionResult, DbOperationError> {
+    run_mysql_adhoc_with_program_and_statements(
+        OsStr::new("mysql"),
+        option_file,
+        query,
+        statements,
+        access_mode,
+        MYSQL_QUERY_TIMEOUT,
+    )
+    .await
+}
+
+async fn export_mysql_csv_to_file(
+    target: MySqlDsn,
+    query: &str,
+    path: PathBuf,
+) -> Result<(), DbOperationError> {
+    let option_file = MySqlOptionFile::create(&target)?;
+    let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
+    let result = timeout(
+        MYSQL_QUERY_TIMEOUT,
+        run_mysql_export_process(&mut process, query, path),
+    )
+    .await;
+    match result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_export_process(
+    process: &mut MysqlProcess,
+    query: &str,
+    path: PathBuf,
+) -> Result<(), DbOperationError> {
+    let marker = Uuid::new_v4().simple().to_string();
+    let probe_query =
+        format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");
+    write_mysql_statement(process, &probe_query).await?;
+    let probe_xml = read_one_mysql_resultset(process).await?;
+    let probe = parse_mysql_xml(&probe_xml)?;
+    validate_mode_probe(&probe, &marker)?;
+
+    write_mysql_statement(process, query).await?;
+    let mut csv_writer = CsvFileWriter::create(path).await?;
+    stream_mysql_resultset_to_csv(process, &mut csv_writer).await?;
+
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .shutdown()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let tail = {
+        write_mysql_input(process, b"\\q\n").await?;
+        read_pty_all(&mut process.pty)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?
+    };
+
+    #[cfg(not(unix))]
+    let (_stdout, stderr) =
+        tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    #[cfg(not(unix))]
+    let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+
+    let status = process
+        .child
+        .wait()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(unix)]
+    let error_bytes = tail.as_slice();
+    #[cfg(not(unix))]
+    let error_bytes = stderr.as_slice();
+    if !status.success() {
+        return Err(classify_mysql_query_failure(error_bytes));
+    }
+
+    csv_writer.finish().await
+}
+
+async fn stream_mysql_resultset_to_csv(
+    process: &mut MysqlProcess,
+    csv_writer: &mut CsvFileWriter,
+) -> Result<(), DbOperationError> {
+    #[cfg(unix)]
+    {
+        let source = MysqlExportPtySource {
+            pty: &mut process.pty,
+            error_output: Vec::new(),
+        };
+        let mut reader = Reader::from_reader(BufReader::new(source));
+        reader.config_mut().trim_text(false);
+        let result = stream_mysql_xml_to_csv(&mut reader, csv_writer).await;
+        let buffered = reader.into_inner();
+        let unread = buffered.buffer().to_vec();
+        let source = buffered.into_inner();
+        source.pty.pending.extend(unread);
+        if !source.error_output.is_empty() {
+            return Err(classify_mysql_query_failure(&source.error_output));
+        }
+        result
+    }
+
+    #[cfg(not(unix))]
+    {
+        let source = MysqlExportPipeSource {
+            stdout: &mut process.stdout,
+            stderr: &mut process.stderr,
+            pending: &mut process.pending,
+            error_output: Vec::new(),
+            stderr_buffer: [0; 4096],
+            stderr_closed: false,
+            stdout_closed: false,
+        };
+        let mut reader = Reader::from_reader(BufReader::new(source));
+        reader.config_mut().trim_text(false);
+        let result = stream_mysql_xml_to_csv(&mut reader, csv_writer).await;
+        let buffered = reader.into_inner();
+        let unread = buffered.buffer().to_vec();
+        let source = buffered.into_inner();
+        source.pending.extend(unread);
+        if has_mysql_cli_error(&source.error_output) {
+            return Err(classify_mysql_query_failure(&source.error_output));
+        }
+        return result;
+    }
+}
+
+async fn stream_mysql_xml_to_csv<R>(
+    reader: &mut Reader<BufReader<R>>,
+    csv_writer: &mut CsvFileWriter,
+) -> Result<(), DbOperationError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = Vec::new();
+    let mut resultset_count = 0;
+    let mut in_resultset = false;
+    let mut current_row: Option<Vec<(String, String)>> = None;
+    let mut current_field: Option<MysqlField> = None;
+    let mut columns: Option<Vec<String>> = None;
+
+    loop {
+        let event = reader
+            .read_event_into_async(&mut buffer)
+            .await
+            .map_err(|error| {
+                DbOperationError::QueryFailed(format!("invalid MySQL XML result: {error}"))
+            })?;
+        match event {
+            Event::Start(element) => match element.name().as_ref() {
+                b"resultset" => {
+                    if in_resultset || resultset_count > 0 {
+                        return Err(DbOperationError::QueryFailed(
+                            "mysql returned more than one resultset".to_string(),
+                        ));
+                    }
+                    resultset_count += 1;
+                    in_resultset = true;
+                }
+                b"row" if in_resultset && current_row.is_none() => {
+                    current_row = Some(Vec::new());
+                }
+                b"field" if current_row.is_some() && current_field.is_none() => {
+                    current_field = Some(parse_mysql_field(&element)?);
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected element in MySQL XML result".to_string(),
+                    ));
+                }
+            },
+            Event::Empty(element) if element.name().as_ref() == b"field" => {
+                let row = current_row.as_mut().ok_or_else(|| {
+                    DbOperationError::QueryFailed("MySQL XML field is outside a row".to_string())
+                })?;
+                if current_field.is_some() {
+                    return Err(DbOperationError::QueryFailed(
+                        "nested MySQL XML fields are not supported".to_string(),
+                    ));
+                }
+                row.push(parse_mysql_field(&element)?.finish_raw());
+            }
+            Event::Text(text) => {
+                let text = text.unescape().map_err(|error| {
+                    DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
+                })?;
+                if let Some(field) = current_field.as_mut() {
+                    field.value.push_str(&text);
+                } else if !text.chars().all(char::is_whitespace) {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected text in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::CData(data) => {
+                if let Some(field) = current_field.as_mut() {
+                    field
+                        .value
+                        .push_str(std::str::from_utf8(data.as_ref()).map_err(|error| {
+                            DbOperationError::QueryFailed(format!(
+                                "invalid MySQL XML text: {error}"
+                            ))
+                        })?);
+                } else {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected CDATA in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::End(element) => match element.name().as_ref() {
+                b"field" => {
+                    let row = current_row.as_mut().ok_or_else(|| {
+                        DbOperationError::QueryFailed(
+                            "MySQL XML field is outside a row".to_string(),
+                        )
+                    })?;
+                    let field = current_field.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML field end".to_string())
+                    })?;
+                    row.push(field.finish_raw());
+                }
+                b"row" => {
+                    let row = current_row.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML row end".to_string())
+                    })?;
+                    let row_columns = row.iter().map(|(name, _)| name.clone()).collect::<Vec<_>>();
+                    if let Some(columns) = columns.as_ref() {
+                        if row_columns != *columns {
+                            return Err(DbOperationError::QueryFailed(
+                                "MySQL XML rows have inconsistent fields".to_string(),
+                            ));
+                        }
+                    } else {
+                        csv_writer.write_record(row_columns.iter()).await?;
+                        columns = Some(row_columns);
+                    }
+                    csv_writer
+                        .write_record(row.iter().map(|(_, value)| value))
+                        .await?;
+                }
+                b"resultset" => {
+                    if !in_resultset || current_row.is_some() || current_field.is_some() {
+                        return Err(DbOperationError::QueryFailed(
+                            "malformed MySQL XML resultset".to_string(),
+                        ));
+                    }
+                    return Ok(());
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected MySQL XML closing element".to_string(),
+                    ));
+                }
+            },
+            Event::Decl(_) | Event::Comment(_) => {}
+            Event::Eof => break,
+            _ => {
+                return Err(DbOperationError::QueryFailed(
+                    "unexpected event in MySQL XML result".to_string(),
+                ));
+            }
+        }
+        buffer.clear();
+    }
+
+    if resultset_count != 1 || in_resultset || current_row.is_some() || current_field.is_some() {
+        return Err(DbOperationError::QueryFailed(
+            "MySQL XML result did not contain one complete resultset".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+struct MysqlExportPtySource<'a> {
+    pty: &'a mut MysqlPty,
+    error_output: Vec<u8>,
+}
+
+#[cfg(unix)]
+impl MysqlExportPtySource<'_> {
+    fn capture_error(&mut self, bytes: &[u8]) {
+        if self.error_output.is_empty() && has_mysql_cli_error(bytes) {
+            self.error_output
+                .extend_from_slice(&bytes[..bytes.len().min(32 * 1024)]);
+        }
+    }
+}
+
+#[cfg(unix)]
+impl AsyncRead for MysqlExportPtySource<'_> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if !this.pty.pending.is_empty() {
+            let count = buffer.remaining().min(this.pty.pending.len());
+            let bytes = this.pty.pending.drain(..count).collect::<Vec<_>>();
+            this.capture_error(&bytes);
+            buffer.put_slice(&bytes);
+            return Poll::Ready(Ok(()));
+        }
+
+        let filled_before = buffer.filled().len();
+        let result = Pin::new(&mut this.pty.output).poll_read(cx, buffer);
+        if matches!(&result, Poll::Ready(Ok(()))) {
+            this.capture_error(&buffer.filled()[filled_before..]);
+        }
+        result
+    }
+}
+
+#[cfg(not(unix))]
+struct MysqlExportPipeSource<'a, O, E> {
+    stdout: &'a mut O,
+    stderr: &'a mut E,
+    pending: &'a mut Vec<u8>,
+    error_output: Vec<u8>,
+    stderr_buffer: [u8; 4096],
+    stderr_closed: bool,
+    stdout_closed: bool,
+}
+
+#[cfg(not(unix))]
+impl<O, E> MysqlExportPipeSource<'_, O, E>
+where
+    O: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
+    fn capture_error(&mut self, bytes: &[u8]) {
+        let remaining = (32usize * 1024).saturating_sub(self.error_output.len());
+        if remaining > 0 {
+            self.error_output
+                .extend_from_slice(&bytes[..bytes.len().min(remaining)]);
+        }
+    }
+
+    fn poll_stderr(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+        if self.stderr_closed {
+            return Poll::Ready(Ok(0));
+        }
+        let result = {
+            let mut read_buffer = ReadBuf::new(&mut self.stderr_buffer);
+            match Pin::new(&mut *self.stderr).poll_read(cx, &mut read_buffer) {
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(read_buffer.filled().to_vec())),
+                Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+                Poll::Pending => Poll::Pending,
+            }
+        };
+        match result {
+            Poll::Ready(Ok(bytes)) => {
+                if bytes.is_empty() {
+                    self.stderr_closed = true;
+                } else {
+                    self.capture_error(&bytes);
+                }
+                Poll::Ready(Ok(bytes.len()))
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(not(unix))]
+impl<O, E> AsyncRead for MysqlExportPipeSource<'_, O, E>
+where
+    O: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        let stderr_count = match this.poll_stderr(cx) {
+            Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+            Poll::Pending => 0,
+            Poll::Ready(Ok(count)) => count,
+        };
+        if !this.pending.is_empty() {
+            let count = buffer.remaining().min(this.pending.len());
+            let bytes = this.pending.drain(..count).collect::<Vec<_>>();
+            buffer.put_slice(&bytes);
+            return Poll::Ready(Ok(()));
+        }
+
+        if this.stdout_closed {
+            if this.stderr_closed {
+                return Poll::Ready(Ok(()));
+            }
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        }
+
+        let filled_before = buffer.filled().len();
+        let result = Pin::new(&mut *this.stdout).poll_read(cx, buffer);
+        if let Poll::Ready(Ok(())) = &result {
+            let count = buffer.filled().len() - filled_before;
+            if count == 0 {
+                this.stdout_closed = true;
+                if !this.stderr_closed {
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+            }
+        } else if matches!(&result, Poll::Pending) && stderr_count > 0 {
+            cx.waker().wake_by_ref();
+        }
+        result
+    }
+}
+
+#[cfg(all(test, not(unix)))]
+mod export_pipe_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn consumes_stderr_while_streaming_stdout() {
+        let (mut stdout_writer, mut stdout_reader) = tokio::io::duplex(64);
+        let (mut stderr_writer, mut stderr_reader) = tokio::io::duplex(64);
+        let stdout = b"<resultset><row><field name=\"value\">ok</field></row></resultset>".to_vec();
+        let stderr = format!(
+            "ERROR 1146 (42S02): Table 'app.missing' doesn't exist\n{}",
+            "warning\n".repeat(16 * 1024)
+        )
+        .into_bytes();
+
+        let stdout_task = tokio::spawn(async move {
+            stdout_writer.write_all(&stdout).await.unwrap();
+        });
+        let stderr_task = tokio::spawn(async move {
+            stderr_writer.write_all(&stderr).await.unwrap();
+        });
+
+        let mut source = MysqlExportPipeSource {
+            stdout: &mut stdout_reader,
+            stderr: &mut stderr_reader,
+            pending: &mut Vec::new(),
+            error_output: Vec::new(),
+            stderr_buffer: [0; 4096],
+            stderr_closed: false,
+            stdout_closed: false,
+        };
+        let mut output = Vec::new();
+        source.read_to_end(&mut output).await.unwrap();
+        stdout_task.await.unwrap();
+        stderr_task.await.unwrap();
+
+        assert!(output.starts_with(b"<resultset>"));
+        assert!(has_mysql_cli_error(&source.error_output));
+        assert!(matches!(
+            classify_mysql_query_failure(&source.error_output),
+            DbOperationError::ObjectMissing(_)
+        ));
+    }
+}
+
+#[cfg(test)]
+async fn export_mysql_csv_with_program(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+    path: PathBuf,
+    execution_timeout: Duration,
+) -> Result<(), DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+    let result = timeout(
+        execution_timeout,
+        run_mysql_export_process(&mut process, query, path),
+    )
+    .await;
+    match result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+async fn run_mysql_adhoc_with_program(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+    access_mode: AccessMode,
+    execution_timeout: Duration,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+    let result = timeout(
+        execution_timeout,
+        run_mysql_single_statement_process(&mut process, query, access_mode),
+    )
+    .await;
+    match result {
+        Ok(Ok(result_set)) => Ok(result_set),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_single_statement(
+    option_file: &std::path::Path,
+    query: &str,
+    access_mode: AccessMode,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), option_file)?;
+    let result = timeout(
+        MYSQL_QUERY_TIMEOUT,
+        run_mysql_single_statement_process(&mut process, query, access_mode),
+    )
+    .await;
+    match result {
+        Ok(Ok(result_set)) => Ok(result_set),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_single_statement_process(
+    process: &mut MysqlProcess,
+    query: &str,
+    access_mode: AccessMode,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let marker = Uuid::new_v4().simple().to_string();
+    let probe_query =
+        format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");
+    write_mysql_statement(process, &probe_query).await?;
+    let probe_xml = read_one_mysql_resultset(process).await?;
+    let probe = parse_mysql_xml(&probe_xml)?;
+    validate_mode_probe(&probe, &marker)?;
+    configure_mysql_session(process, access_mode).await?;
+
+    write_mysql_statement(process, query).await?;
+
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .shutdown()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let (stdout, tail) = {
+        let stdout = read_one_mysql_resultset(process).await?;
+        write_mysql_input(process, b"\\q\n").await?;
+        let tail = read_pty_all(&mut process.pty)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        (stdout, tail)
+    };
+
+    #[cfg(not(unix))]
+    let (stdout, stderr) =
+        tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    #[cfg(not(unix))]
+    let stdout = stdout.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    #[cfg(not(unix))]
+    let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+
+    let status = process
+        .child
+        .wait()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(unix)]
+    let error_bytes = tail.as_slice();
+    #[cfg(not(unix))]
+    let error_bytes = stderr.as_slice();
+    if !status.success() {
+        return Err(classify_mysql_query_failure(error_bytes));
+    }
+    parse_mysql_xml(&stdout)
+}
+
+async fn run_mysql_adhoc_with_program_and_statements(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+    statements: &[MysqlStatement],
+    access_mode: AccessMode,
+    execution_timeout: Duration,
+) -> Result<MysqlExecutionResult, DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+    let result = timeout(
+        execution_timeout,
+        run_mysql_adhoc_process(&mut process, query, statements, access_mode),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(result_set)) => Ok(result_set),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_adhoc_process(
+    process: &mut MysqlProcess,
+    _query: &str,
+    statements: &[MysqlStatement],
+    access_mode: AccessMode,
+) -> Result<MysqlExecutionResult, DbOperationError> {
+    let probe_marker = Uuid::new_v4().simple().to_string();
+    let probe_query = format!(
+        "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
+    );
+    write_mysql_statement(process, &probe_query).await?;
+    let probe_xml = read_one_mysql_resultset(process).await?;
+    let probe = parse_mysql_xml(&probe_xml)?;
+    validate_mode_probe(&probe, &probe_marker)?;
+    configure_mysql_session(process, access_mode).await?;
+
+    let mut last_result_set = None;
+    let mut command_tags = Vec::with_capacity(statements.len());
+    let mut refresh_scope = RefreshScope::None;
+
+    for statement in statements {
+        let marker = Uuid::new_v4().simple().to_string();
+        let statement_scope = mysql_refresh_scope(&statement.kind);
+        refresh_scope = refresh_scope.merge(statement_scope);
+        if let Err(error) = write_mysql_statement(process, &statement.sql).await {
+            return Err(query_failed_after_change(error, refresh_scope));
+        }
+        let marker_query =
+            format!("SELECT '{marker}' AS __sabiql_marker, ROW_COUNT() AS affected_rows");
+        if let Err(error) = write_mysql_statement(process, &marker_query).await {
+            return Err(query_failed_after_change(error, refresh_scope));
+        }
+        let first_xml = match read_one_mysql_resultset(process).await {
+            Ok(xml) => xml,
+            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+        };
+        let first_result = match parse_mysql_xml(&first_xml) {
+            Ok(result) => result,
+            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+        };
+        let (user_result, marker_result) = if is_mysql_row_count_marker(&first_result, &marker) {
+            (None, first_result)
+        } else {
+            let xml = match read_one_mysql_resultset(process).await {
+                Ok(xml) => xml,
+                Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+            };
+            let marker_result = match parse_mysql_xml(&xml) {
+                Ok(result) => result,
+                Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+            };
+            (Some(first_result), marker_result)
+        };
+        let affected_rows = match mysql_row_count_marker(&marker_result, &marker) {
+            Ok(rows) => rows,
+            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+        };
+        if let Some(result) = user_result {
+            last_result_set = Some(result);
+        }
+        let tag = mysql_command_tag(&statement.kind, affected_rows, last_result_set.as_ref());
+        command_tags.push(MysqlCommandEvent {
+            kind: statement.kind.clone(),
+            target: statement.target.clone(),
+            tag,
+        });
+    }
+
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .shutdown()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let tail = {
+        write_mysql_input(process, b"\\q\n").await?;
+        let tail = read_pty_all(&mut process.pty)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        trace_mysql_frame("discard tail", tail.len());
+        trace_mysql_error(&tail);
+        tail
+    };
+
+    #[cfg(not(unix))]
+    let (_stdout, stderr) =
+        tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    #[cfg(not(unix))]
+    let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+
+    let status = process
+        .child
+        .wait()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let error_bytes = tail.as_slice();
+    #[cfg(not(unix))]
+    let error_bytes = stderr.as_slice();
+    if has_mysql_cli_error(error_bytes) {
+        return Err(query_failed_after_change(
+            classify_mysql_query_failure(error_bytes),
+            refresh_scope,
+        ));
+    }
+    if !status.success() {
+        return Err(query_failed_after_change(
+            classify_mysql_query_failure(error_bytes),
+            refresh_scope,
+        ));
+    }
+
+    Ok(MysqlExecutionResult {
+        result_set: last_result_set,
+        command_tag: aggregate_mysql_command_tag(&command_tags),
+        refresh_scope,
+    })
+}
+
+async fn configure_mysql_session(
+    process: &mut MysqlProcess,
+    access_mode: AccessMode,
+) -> Result<(), DbOperationError> {
+    if !access_mode.is_read_only() {
+        return Ok(());
+    }
+
+    let marker = Uuid::new_v4().simple().to_string();
+    write_mysql_statement(process, MYSQL_READ_ONLY_STATEMENT).await?;
+    write_mysql_statement(
+        process,
+        &format!("SELECT '{marker}' AS {MYSQL_SESSION_MARKER_COLUMN}"),
+    )
+    .await?;
+    loop {
+        let result = read_one_mysql_resultset(process).await?;
+        let result = parse_mysql_xml(&result)?;
+        if result.columns.is_empty() && result.values.is_empty() {
+            continue;
+        }
+        return validate_mysql_session_marker(&result, &marker);
+    }
+}
+
+fn validate_mysql_session_marker(
+    result: &MysqlResultSet,
+    marker: &str,
+) -> Result<(), DbOperationError> {
+    if result.columns != [MYSQL_SESSION_MARKER_COLUMN]
+        || result.values.len() != 1
+        || result.values[0].len() != 1
+        || result.values[0][0].as_str() != Some(marker)
+    {
+        return Err(DbOperationError::QueryFailed(
+            "mysql read-only session marker did not match".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn query_failed_after_change(
+    error: DbOperationError,
+    refresh_scope: RefreshScope,
+) -> DbOperationError {
+    if refresh_scope == RefreshScope::None {
+        error
+    } else {
+        DbOperationError::QueryFailedAfterChange {
+            details: error.masked_details(),
+            refresh_scope,
+        }
+    }
+}
+
+fn is_mysql_row_count_marker(result: &MysqlResultSet, marker: &str) -> bool {
+    result.columns == ["__sabiql_marker", "affected_rows"]
+        && result.values.len() == 1
+        && result.values[0].first().and_then(QueryValue::as_str) == Some(marker)
+}
+
+fn mysql_row_count_marker(result: &MysqlResultSet, marker: &str) -> Result<i64, DbOperationError> {
+    if !is_mysql_row_count_marker(result, marker) || result.values[0].len() != 2 {
+        return Err(DbOperationError::QueryFailed(
+            "mysql ROW_COUNT marker did not match the executed statement".to_string(),
+        ));
+    }
+    let value = result.values[0][1].as_str().ok_or_else(|| {
+        DbOperationError::QueryFailed("mysql ROW_COUNT marker was NULL".to_string())
+    })?;
+    value.parse::<i64>().map_err(|_| {
+        DbOperationError::QueryFailed("mysql ROW_COUNT marker was not an integer".to_string())
+    })
+}
+
+fn mysql_command_tag(
+    kind: &MysqlStatementKind,
+    affected_rows: i64,
+    user_result: Option<&MysqlResultSet>,
+) -> CommandTag {
+    let rows = || u64::try_from(affected_rows.max(0)).unwrap_or(0);
+    match kind {
+        MysqlStatementKind::Select
+        | MysqlStatementKind::Table
+        | MysqlStatementKind::Show
+        | MysqlStatementKind::Describe => {
+            CommandTag::Select(user_result.map_or(0, |result| result.values.len() as u64))
+        }
+        MysqlStatementKind::Insert | MysqlStatementKind::Replace => CommandTag::Insert(rows()),
+        MysqlStatementKind::Update { .. } => CommandTag::Update(rows()),
+        MysqlStatementKind::Delete { .. } => CommandTag::Delete(rows()),
+        MysqlStatementKind::CreateTable { temporary: true } => {
+            CommandTag::Other("CREATE TEMPORARY TABLE".to_string())
+        }
+        MysqlStatementKind::CreateTable { temporary: false } => {
+            CommandTag::Create("TABLE".to_string())
+        }
+        MysqlStatementKind::AlterTable => CommandTag::Alter("TABLE".to_string()),
+        MysqlStatementKind::DropTable { temporary: true } => {
+            CommandTag::Other("DROP TEMPORARY TABLE".to_string())
+        }
+        MysqlStatementKind::DropTable { temporary: false } => CommandTag::Drop("TABLE".to_string()),
+        MysqlStatementKind::TruncateTable => CommandTag::Truncate,
+        MysqlStatementKind::CreateView => CommandTag::Create("VIEW".to_string()),
+        MysqlStatementKind::DropView => CommandTag::Drop("VIEW".to_string()),
+        MysqlStatementKind::CreateIndex => CommandTag::Create("INDEX".to_string()),
+        MysqlStatementKind::DropIndex => CommandTag::Drop("INDEX".to_string()),
+        MysqlStatementKind::Begin | MysqlStatementKind::StartTransaction => CommandTag::Begin,
+        MysqlStatementKind::Commit => CommandTag::Commit,
+        MysqlStatementKind::Rollback | MysqlStatementKind::RollbackToSavepoint => {
+            CommandTag::Rollback
+        }
+        MysqlStatementKind::Savepoint => CommandTag::Other("SAVEPOINT".to_string()),
+        MysqlStatementKind::ReleaseSavepoint => CommandTag::Other("RELEASE SAVEPOINT".to_string()),
+    }
+}
+
+fn mysql_refresh_scope(kind: &MysqlStatementKind) -> RefreshScope {
+    if mysql_statement_is_schema_modifying(kind) {
+        RefreshScope::Metadata
+    } else if mysql_statement_is_data_modifying(kind) {
+        RefreshScope::Data
+    } else {
+        RefreshScope::None
+    }
+}
+
+fn mysql_statement_is_persistent_schema_change(kind: &MysqlStatementKind) -> bool {
+    mysql_statement_is_schema_modifying(kind)
+        && !matches!(
+            kind,
+            MysqlStatementKind::CreateTable { temporary: true }
+                | MysqlStatementKind::DropTable { temporary: true }
+        )
+}
+
+#[derive(Default)]
+struct MysqlPendingTransactionTags {
+    data: Vec<CommandTag>,
+    savepoints: Vec<(String, usize)>,
+}
+
+fn apply_pending_mysql_data(
+    pending: MysqlPendingTransactionTags,
+    committed_data: &mut Option<CommandTag>,
+) {
+    if let Some(tag) = pending.data.last() {
+        *committed_data = Some(tag.clone());
+    }
+}
+
+fn aggregate_mysql_command_tag(events: &[MysqlCommandEvent]) -> Option<CommandTag> {
+    let mut committed_schema = None;
+    let mut committed_data = None;
+    let mut pending = None;
+    let mut last_tag = None;
+
+    for event in events {
+        last_tag = Some(event.tag.clone());
+        match &event.kind {
+            MysqlStatementKind::Begin | MysqlStatementKind::StartTransaction => {
+                pending = Some(MysqlPendingTransactionTags::default());
+            }
+            MysqlStatementKind::Commit => {
+                if let Some(transaction) = pending.take() {
+                    apply_pending_mysql_data(transaction, &mut committed_data);
+                }
+            }
+            MysqlStatementKind::Rollback => {
+                pending = None;
+            }
+            MysqlStatementKind::Savepoint => {
+                if let Some(transaction) = pending.as_mut()
+                    && let Some(name) = event.target.as_deref()
+                {
+                    transaction
+                        .savepoints
+                        .retain(|(current, _)| !current.eq_ignore_ascii_case(name));
+                    transaction
+                        .savepoints
+                        .push((name.to_string(), transaction.data.len()));
+                }
+            }
+            MysqlStatementKind::RollbackToSavepoint => {
+                if let Some(transaction) = pending.as_mut()
+                    && let Some(name) = event.target.as_deref()
+                    && let Some(index) = transaction
+                        .savepoints
+                        .iter()
+                        .position(|(current, _)| current.eq_ignore_ascii_case(name))
+                {
+                    transaction.data.truncate(transaction.savepoints[index].1);
+                    transaction.savepoints.truncate(index + 1);
+                }
+            }
+            MysqlStatementKind::ReleaseSavepoint => {
+                if let Some(transaction) = pending.as_mut()
+                    && let Some(name) = event.target.as_deref()
+                    && let Some(index) = transaction
+                        .savepoints
+                        .iter()
+                        .position(|(current, _)| current.eq_ignore_ascii_case(name))
+                {
+                    transaction.savepoints.remove(index);
+                }
+            }
+            MysqlStatementKind::CreateTable { temporary: true }
+            | MysqlStatementKind::DropTable { temporary: true } => {}
+            kind if mysql_statement_is_persistent_schema_change(kind) => {
+                if let Some(transaction) = pending.take() {
+                    apply_pending_mysql_data(transaction, &mut committed_data);
+                }
+                committed_schema = Some(event.tag.clone());
+            }
+            kind if mysql_statement_is_data_modifying(kind) => {
+                if let Some(transaction) = pending.as_mut() {
+                    transaction.data.push(event.tag.clone());
+                } else {
+                    committed_data = Some(event.tag.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    committed_schema.or(committed_data).or(last_tag)
+}
+
+async fn write_mysql_statement(
+    process: &mut MysqlProcess,
+    query: &str,
+) -> Result<(), DbOperationError> {
+    let query = query.trim_end();
+    write_mysql_input(process, query.as_bytes()).await?;
+    if query.ends_with(';') {
+        write_mysql_input(process, b"\n").await
+    } else if mysql_statement_has_trailing_line_comment(query) {
+        write_mysql_input(process, b"\n;\n").await
+    } else {
+        write_mysql_input(process, b";\n").await
+    }
+}
+
+fn mysql_statement_has_trailing_line_comment(sql: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    let mut quote = None;
+    let mut line_comment = false;
+    while index < bytes.len() {
+        if let Some(delimiter) = quote {
+            if bytes[index] == b'\\' && delimiter != b'`' {
+                index += 2;
+            } else if bytes[index] == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                } else {
+                    quote = None;
+                    index += 1;
+                }
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if line_comment {
+            if bytes[index] == b'\n' {
+                line_comment = false;
+            }
+            index += 1;
+            continue;
+        }
+        if matches!(bytes[index], b'\'' | b'"' | b'`') {
+            quote = Some(bytes[index]);
+            index += 1;
+        } else if mysql_is_line_comment_start(bytes, index) {
+            let comment_start = index;
+            index = mysql_skip_line_comment(bytes, index);
+            line_comment = !bytes[comment_start..index].contains(&b'\n');
+        } else if bytes.get(index..index + 2) == Some(b"/*") {
+            index = mysql_skip_block_comment(bytes, index);
+        } else {
+            index += 1;
+        }
+    }
+    line_comment
+}
+
+fn mysql_is_line_comment_start(bytes: &[u8], index: usize) -> bool {
+    bytes[index] == b'#'
+        || (bytes.get(index..index + 2) == Some(b"--")
+            && bytes.get(index + 2).is_none_or(u8::is_ascii_whitespace))
+}
+
+fn mysql_skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() {
+        let byte = bytes[index];
+        index += 1;
+        if byte == b'\n' {
+            break;
+        }
+    }
+    index
+}
+
+fn mysql_skip_block_comment(bytes: &[u8], index: usize) -> usize {
+    let mut cursor = index + 2;
+    while cursor + 1 < bytes.len() {
+        if bytes[cursor] == b'*' && bytes[cursor + 1] == b'/' {
+            return cursor + 2;
+        }
+        cursor += 1;
+    }
+    bytes.len()
+}
+
+async fn write_mysql_input(
+    process: &mut MysqlProcess,
+    input: &[u8],
+) -> Result<(), DbOperationError> {
+    #[cfg(unix)]
+    process
+        .pty
+        .input
+        .write_all(input)
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .write_all(input)
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(unix)]
+    process
+        .pty
+        .input
+        .flush()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .flush()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    Ok(())
+}
+
+async fn cleanup_mysql_process(process: &mut MysqlProcess) {
+    let _ = process.child.kill().await;
+    #[cfg(unix)]
+    let _ = read_pty_all(&mut process.pty).await;
+    #[cfg(not(unix))]
+    let _ = tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    let _ = process.child.wait().await;
+}
+
+async fn read_one_mysql_resultset(process: &mut MysqlProcess) -> Result<Vec<u8>, DbOperationError> {
+    #[cfg(unix)]
+    {
+        return read_one_pty_resultset(&mut process.pty).await;
+    }
+    #[cfg(not(unix))]
+    read_one_mysql_resultset_from_pipes(
+        &mut process.stdout,
+        &mut process.stderr,
+        &mut process.pending,
+        &mut process.pending_stderr,
+    )
+    .await
+}
+
+#[cfg(unix)]
+async fn read_one_pty_resultset(pty: &mut MysqlPty) -> Result<Vec<u8>, DbOperationError> {
+    let mut chunk = [0; 4096];
+    loop {
+        if has_mysql_cli_error(&pty.pending) {
+            trace_mysql_error(&pty.pending);
+            return Err(classify_mysql_query_failure(&pty.pending));
+        }
+        if let Some(frame) = take_mysql_resultset_frame(&mut pty.pending) {
+            trace_mysql_frame("receive resultset", frame.len());
+            return Ok(frame);
+        }
+        let count = match pty.output.read(&mut chunk).await {
+            Ok(count) => count,
+            Err(error) if error.raw_os_error() == Some(libc::EIO) => 0,
+            Err(error) => return Err(DbOperationError::ConnectionLost(error.to_string())),
+        };
+        if count == 0 {
+            return Err(DbOperationError::EmptyResponse(
+                "mysql query returned no resultset".to_string(),
+            ));
+        }
+        pty.pending.extend_from_slice(&chunk[..count]);
+    }
+}
+
+#[cfg(unix)]
+async fn read_pty_all(pty: &mut MysqlPty) -> io::Result<Vec<u8>> {
+    let mut output = std::mem::take(&mut pty.pending);
+    let mut chunk = [0; 4096];
+    loop {
+        match pty.output.read(&mut chunk).await {
+            Ok(0) => return Ok(output),
+            Ok(count) => output.extend_from_slice(&chunk[..count]),
+            Err(error) if error.raw_os_error() == Some(libc::EIO) => return Ok(output),
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn has_mysql_cli_error(output: &[u8]) -> bool {
+    output
+        .split(|byte| *byte == b'\n' || *byte == b'\r')
+        .any(|line| {
+            let mut line = line;
+            while line
+                .first()
+                .is_some_and(|byte| byte.is_ascii_whitespace() || byte.is_ascii_control())
+            {
+                line = &line[1..];
+            }
+            line.starts_with(b"ERROR ") || line == b"ERROR"
+        })
+}
+
+fn take_mysql_resultset_frame(buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
+    let (start, end) = mysql_resultset_frame_bounds(buffer)?;
+    let frame = buffer[start..end].to_vec();
+    buffer.drain(..end);
+    Some(frame)
+}
+
+fn mysql_resultset_frame_bounds(buffer: &[u8]) -> Option<(usize, usize)> {
+    let start = find_bytes(buffer, b"<resultset")?;
+    let end = buffer[start..]
+        .windows(b"</resultset>".len())
+        .position(|window| window == b"</resultset>")?
+        + start
+        + b"</resultset>".len();
+    Some((start, end))
+}
+
+#[cfg(any(not(unix), test))]
+fn take_mysql_resultset_frame_after_error_check(
+    buffer: &mut Vec<u8>,
+    error_output: &[u8],
+) -> Result<Option<Vec<u8>>, DbOperationError> {
+    if has_mysql_cli_error(error_output) {
+        trace_mysql_error(error_output);
+        return Err(classify_mysql_query_failure(error_output));
+    }
+    Ok(take_mysql_resultset_frame(buffer))
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn trace_mysql_frame(kind: &str, bytes: usize) {
+    if std::env::var_os("SABIQL_MYSQL_TRANSCRIPT").is_some() {
+        write_mysql_transcript_line(&format!("sabiql mysql frame: {kind}, bytes={bytes}"));
+    }
+}
+
+fn trace_mysql_error(output: &[u8]) {
+    if std::env::var_os("SABIQL_MYSQL_TRANSCRIPT").is_some() && has_mysql_cli_error(output) {
+        write_mysql_transcript_line("sabiql mysql frame: ERROR line observed");
+    }
+}
+
+fn write_mysql_transcript_line(line: &str) {
+    let mut stderr = io::stderr();
+    let _ = stderr.write_all(line.as_bytes());
+    let _ = stderr.write_all(b"\n");
+}
+
+#[cfg(not(unix))]
+async fn read_all<R>(reader: &mut R) -> io::Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).await?;
+    Ok(output)
+}
+
+#[cfg(not(unix))]
+async fn read_one_mysql_resultset_from_pipes<R, E>(
+    reader: &mut R,
+    stderr: &mut E,
+    pending: &mut Vec<u8>,
+    pending_stderr: &mut Vec<u8>,
+) -> Result<Vec<u8>, DbOperationError>
+where
+    R: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
+    let mut chunk = [0; 4096];
+    let mut stderr_chunk = [0; 4096];
+    let mut stderr_closed = false;
+    loop {
+        if mysql_resultset_frame_bounds(pending).is_some() && !stderr_closed {
+            tokio::select! {
+                biased;
+                result = stderr.read(&mut stderr_chunk) => {
+                    let count = result.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+                    if count == 0 {
+                        stderr_closed = true;
+                    } else {
+                        pending_stderr.extend_from_slice(&stderr_chunk[..count]);
+                    }
+                }
+                _ = tokio::task::yield_now() => {}
+            }
+        }
+        if let Some(frame) = take_mysql_resultset_frame_after_error_check(pending, pending_stderr)?
+        {
+            trace_mysql_frame("receive resultset", frame.len());
+            return Ok(frame);
+        }
+        if stderr_closed {
+            let count = reader
+                .read(&mut chunk)
+                .await
+                .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+            if count == 0 {
+                return Err(DbOperationError::EmptyResponse(
+                    "mysql mode probe returned no resultset".to_string(),
+                ));
+            }
+            pending.extend_from_slice(&chunk[..count]);
+        } else {
+            tokio::select! {
+                result = reader.read(&mut chunk) => {
+                    let count = result.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+                    if count == 0 {
+                        return Err(DbOperationError::EmptyResponse(
+                            "mysql mode probe returned no resultset".to_string(),
+                        ));
+                    }
+                    pending.extend_from_slice(&chunk[..count]);
+                }
+                result = stderr.read(&mut stderr_chunk) => {
+                    let count = result.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+                    if count == 0 {
+                        stderr_closed = true;
+                    } else {
+                        pending_stderr.extend_from_slice(&stderr_chunk[..count]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn mysql_query_args(option_file: &std::path::Path) -> Vec<String> {
+    let args = vec![
+        format!("--defaults-file={}", option_file.display()),
+        "--no-login-paths".to_string(),
+        "--protocol=TCP".to_string(),
+        "--connect-timeout=10".to_string(),
+        "--xml".to_string(),
+        "--binary-as-hex".to_string(),
+        "--binary-mode".to_string(),
+        "--unbuffered".to_string(),
+        "--skip-reconnect".to_string(),
+        "--default-character-set=utf8mb4".to_string(),
+        "--silent".to_string(),
+        "--prompt=".to_string(),
+    ];
+    #[cfg(not(unix))]
+    return args
+        .into_iter()
+        .chain(std::iter::once("--batch".to_string()))
+        .collect();
+    #[cfg(unix)]
+    args
+}
+
+fn validate_mode_probe(result: &MysqlResultSet, marker: &str) -> Result<(), DbOperationError> {
+    if result.values.len() != 1 || result.columns != ["__sabiql_probe", "__sabiql_sql_mode"] {
+        return Err(DbOperationError::QueryFailed(
+            "mysql sql_mode probe returned an unexpected result".to_string(),
+        ));
+    }
+    let values = &result.values[0];
+    if values.len() != 2 {
+        return Err(DbOperationError::QueryFailed(
+            "mysql sql_mode probe returned an unexpected result".to_string(),
+        ));
+    }
+    if values[0].as_str() != Some(marker) {
+        return Err(DbOperationError::QueryFailed(
+            "mysql sql_mode probe marker did not match".to_string(),
+        ));
+    }
+    let mode = values[1].as_str().ok_or_else(|| {
+        DbOperationError::QueryFailed("mysql sql_mode probe returned no mode".to_string())
+    })?;
+    validate_sql_mode(mode)
+}
+
+fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {
+    let details = clean_mysql_stderr(stderr, "mysql query failed");
+    let lower = details.to_ascii_lowercase();
+    let error_code = mysql_server_error_code(&lower);
+    if is_mysql_tls_error(&lower) {
+        DbOperationError::ConnectionFailed(details)
+    } else if is_mysql_connect_timeout_message(&details)
+        || lower.contains("connect timeout")
+        || lower.contains("connection timed out")
+    {
+        DbOperationError::Timeout(details)
+    } else if matches!(error_code, Some(1044 | 1142 | 1143 | 1227))
+        || lower.contains("command denied")
+    {
+        DbOperationError::PermissionDenied(details)
+    } else if error_code == Some(1045)
+        || lower.contains("access denied")
+        || lower.contains("authentication")
+    {
+        DbOperationError::ConnectionFailed(details)
+    } else if lower.contains("lost connection") || lower.contains("server has gone away") {
+        DbOperationError::ConnectionLost(details)
+    } else if lower.contains("lock wait timeout") || lower.contains("deadlock found") {
+        DbOperationError::LockTimeout(details)
+    } else if lower.contains("doesn't exist") || lower.contains("does not exist") {
+        DbOperationError::ObjectMissing(details)
+    } else if lower.contains("duplicate entry") {
+        DbOperationError::UniqueViolation(details)
+    } else if lower.contains("query execution was interrupted")
+        || lower.contains("query was interrupted")
+    {
+        DbOperationError::Canceled(details)
+    } else {
+        DbOperationError::QueryFailed(details)
+    }
+}
+
+fn is_mysql_tls_error(lowercase_details: &str) -> bool {
+    [
+        "error 2026",
+        "tls/ssl error",
+        "ssl connection error",
+        "ssl handshake",
+        "tls handshake",
+        "handshake failure",
+        "tlsv1 alert",
+        "certificate verify failed",
+        "certificate verification failure",
+        "certificate validation failure",
+        "unable to get local issuer",
+        "self-signed certificate",
+        "unknown ca",
+        "certificate required",
+        "peer did not return a certificate",
+    ]
+    .iter()
+    .any(|marker| lowercase_details.contains(marker))
+}
+
+fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
+    let marker = "error ";
+    let start = lowercase_details.find(marker)? + marker.len();
+    let digits = &lowercase_details[start..];
+    let end = digits
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(digits.len());
+    digits[..end].parse().ok()
+}
+
+fn clean_mysql_stderr(stderr: &[u8], fallback: &str) -> String {
+    let text = String::from_utf8_lossy(stderr).trim().to_string();
+    if text.is_empty() {
+        fallback.to_string()
+    } else {
+        text
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
+enum MysqlToken {
+    Word(String),
+    OpenParen,
+    CloseParen,
+    Comma,
+    Other,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MysqlReadStatement {
+    Select,
+    Table,
+    Show,
+    Describe,
+}
+
+#[cfg(test)]
+fn validate_mysql_adhoc_query(query: &str) -> Result<(), DbOperationError> {
+    let tokens = scan_mysql_sql(query)?;
+    let first = tokens.first().ok_or_else(|| {
+        DbOperationError::UnsupportedOperation("empty MySQL statement".to_string())
+    })?;
+    let kind = match first {
+        MysqlToken::Word(word) => match word.as_str() {
+            "SELECT" => Some(MysqlReadStatement::Select),
+            "TABLE" => Some(MysqlReadStatement::Table),
+            "SHOW" => Some(MysqlReadStatement::Show),
+            "DESCRIBE" => Some(MysqlReadStatement::Describe),
+            "WITH" => classify_with_statement(&tokens),
+            _ => None,
+        },
+        _ => None,
+    };
+    if kind.is_some() && has_top_level_into_clause(&tokens) {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL SELECT INTO clauses are not supported".to_string(),
+        ));
+    }
+    kind.map(|_| ()).ok_or_else(|| {
+        DbOperationError::UnsupportedOperation(
+            "only a single SELECT, TABLE, SHOW, DESCRIBE, or SELECT CTE is supported".to_string(),
+        )
+    })
+}
+
+#[cfg(test)]
+fn has_top_level_into_clause(tokens: &[MysqlToken]) -> bool {
+    let mut depth = 0usize;
+    for token in tokens {
+        match token {
+            MysqlToken::OpenParen => depth += 1,
+            MysqlToken::CloseParen => depth = depth.saturating_sub(1),
+            MysqlToken::Word(word) if depth == 0 && word == "INTO" => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+fn scan_mysql_sql(query: &str) -> Result<Vec<MysqlToken>, DbOperationError> {
+    let chars: Vec<char> = query.chars().collect();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    let mut line_start = true;
+    let mut semicolons = 0;
+    let mut statement_ended = false;
+    while index < chars.len() {
+        let character = chars[index];
+        if line_start && matches!(character, ' ' | '\t' | '\r') {
+            index += 1;
+            continue;
+        }
+        if line_start && character == '\\' {
+            return Err(unsupported_client_command("backslash command"));
+        }
+        if line_start && character.is_ascii_alphabetic() {
+            let start = index;
+            while index < chars.len()
+                && (chars[index].is_ascii_alphanumeric() || chars[index] == '_')
+            {
+                index += 1;
+            }
+            let word: String = chars[start..index].iter().collect();
+            if matches!(
+                word.to_ascii_lowercase().as_str(),
+                "delimiter" | "charset" | "source" | "system"
+            ) && (index == chars.len() || chars[index].is_whitespace())
+            {
+                return Err(unsupported_client_command(&word));
+            }
+            if statement_ended {
+                return Err(unsupported_client_command("multiple SQL statements"));
+            }
+            tokens.push(MysqlToken::Word(word.to_ascii_uppercase()));
+            line_start = false;
+            continue;
+        }
+        if character == '\n' {
+            line_start = true;
+            index += 1;
+            continue;
+        }
+        if character.is_whitespace() {
+            index += 1;
+            continue;
+        }
+        if character == '#' {
+            skip_line_comment(&chars, &mut index, &mut line_start);
+            continue;
+        }
+        if character == '-'
+            && chars.get(index + 1) == Some(&'-')
+            && chars.get(index + 2).is_none_or(|next| next.is_whitespace())
+        {
+            skip_line_comment(&chars, &mut index, &mut line_start);
+            continue;
+        }
+        if character == '/' && chars.get(index + 1) == Some(&'*') {
+            if chars.get(index + 2) == Some(&'!') {
+                return Err(unsupported_client_command("MySQL version comment"));
+            }
+            skip_block_comment(&chars, &mut index, &mut line_start)?;
+            continue;
+        }
+        if matches!(character, '\'' | '"' | '`') {
+            if statement_ended {
+                return Err(unsupported_client_command("multiple SQL statements"));
+            }
+            skip_quoted_literal(&chars, &mut index, character)?;
+            line_start = false;
+            tokens.push(MysqlToken::Other);
+            continue;
+        }
+        match character {
+            ';' => {
+                semicolons += 1;
+                if semicolons > 1 {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                if tokens.is_empty() {
+                    return Err(unsupported_client_command("empty MySQL statement"));
+                }
+                statement_ended = true;
+                index += 1;
+            }
+            '(' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::OpenParen);
+                line_start = false;
+                index += 1;
+            }
+            ')' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::CloseParen);
+                line_start = false;
+                index += 1;
+            }
+            ',' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::Comma);
+                line_start = false;
+                index += 1;
+            }
+            character if character.is_ascii_alphabetic() || character == '_' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                let start = index;
+                while index < chars.len()
+                    && (chars[index].is_ascii_alphanumeric() || matches!(chars[index], '_' | '$'))
+                {
+                    index += 1;
+                }
+                let word: String = chars[start..index].iter().collect();
+                tokens.push(MysqlToken::Word(word.to_ascii_uppercase()));
+                line_start = false;
+            }
+            _ => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::Other);
+                line_start = false;
+                index += 1;
+            }
+        }
+    }
+    if tokens.is_empty() || query.trim_start().starts_with(';') {
+        return Err(unsupported_client_command("empty MySQL statement"));
+    }
+    Ok(tokens)
+}
+
+#[cfg(test)]
+fn skip_line_comment(chars: &[char], index: &mut usize, line_start: &mut bool) {
+    while *index < chars.len() {
+        let character = chars[*index];
+        *index += 1;
+        if character == '\n' {
+            *line_start = true;
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+fn skip_block_comment(
+    chars: &[char],
+    index: &mut usize,
+    line_start: &mut bool,
+) -> Result<(), DbOperationError> {
+    *index += 2;
+    while *index < chars.len() {
+        if chars[*index] == '\n' {
+            *line_start = true;
+        }
+        if chars[*index] == '*' && chars.get(*index + 1) == Some(&'/') {
+            *index += 2;
+            return Ok(());
+        }
+        *index += 1;
+    }
+    Err(unsupported_client_command("unterminated block comment"))
+}
+
+#[cfg(test)]
+fn skip_quoted_literal(
+    chars: &[char],
+    index: &mut usize,
+    quote: char,
+) -> Result<(), DbOperationError> {
+    *index += 1;
+    while *index < chars.len() {
+        if chars[*index] == '\\' {
+            *index += 2;
+            continue;
+        }
+        if chars[*index] == quote {
+            if chars.get(*index + 1) == Some(&quote) {
+                *index += 2;
+            } else {
+                *index += 1;
+                return Ok(());
+            }
+        } else {
+            *index += 1;
+        }
+    }
+    Err(unsupported_client_command("unterminated quoted literal"))
+}
+
+#[cfg(test)]
+fn classify_with_statement(tokens: &[MysqlToken]) -> Option<MysqlReadStatement> {
+    let mut index = 1;
+    if matches!(tokens.get(index), Some(MysqlToken::Word(word)) if word == "RECURSIVE") {
+        index += 1;
+    }
+    loop {
+        if !matches!(
+            tokens.get(index),
+            Some(MysqlToken::Word(_) | MysqlToken::Other)
+        ) {
+            return None;
+        }
+        index += 1;
+        if matches!(tokens.get(index), Some(MysqlToken::OpenParen)) {
+            index = skip_parenthesized(tokens, index)?;
+        }
+        if !matches!(tokens.get(index), Some(MysqlToken::Word(word)) if word == "AS") {
+            return None;
+        }
+        index += 1;
+        if !matches!(tokens.get(index), Some(MysqlToken::OpenParen)) {
+            return None;
+        }
+        index = skip_parenthesized(tokens, index)?;
+        if matches!(tokens.get(index), Some(MysqlToken::Comma)) {
+            index += 1;
+            continue;
+        }
+        return match tokens.get(index) {
+            Some(MysqlToken::Word(word)) if word == "SELECT" => Some(MysqlReadStatement::Select),
+            _ => None,
+        };
+    }
+}
+
+#[cfg(test)]
+fn skip_parenthesized(tokens: &[MysqlToken], mut index: usize) -> Option<usize> {
+    let mut depth = 0;
+    while let Some(token) = tokens.get(index) {
+        match token {
+            MysqlToken::OpenParen => depth += 1,
+            MysqlToken::CloseParen => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(index + 1);
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+fn unsupported_client_command(command: &str) -> DbOperationError {
+    DbOperationError::UnsupportedOperation(format!("unsupported MySQL {command}"))
+}
+
+fn parse_mysql_xml(xml: &[u8]) -> Result<MysqlResultSet, DbOperationError> {
+    let mut reader = Reader::from_reader(xml);
+    reader.config_mut().trim_text(false);
+    let mut buffer = Vec::new();
+    let mut resultset_count = 0;
+    let mut in_resultset = false;
+    let mut current_row: Option<Vec<(String, QueryValue)>> = None;
+    let mut current_field: Option<MysqlField> = None;
+    let mut rows = Vec::new();
+    let mut columns = Vec::new();
+
+    loop {
+        let event = reader.read_event_into(&mut buffer).map_err(|error| {
+            DbOperationError::QueryFailed(format!("invalid MySQL XML result: {error}"))
+        })?;
+        match event {
+            Event::Start(element) => match element.name().as_ref() {
+                b"resultset" => {
+                    if in_resultset || resultset_count > 0 {
+                        return Err(DbOperationError::QueryFailed(
+                            "mysql returned more than one resultset".to_string(),
+                        ));
+                    }
+                    resultset_count += 1;
+                    in_resultset = true;
+                }
+                b"row" if in_resultset && current_row.is_none() => {
+                    current_row = Some(Vec::new());
+                }
+                b"field" if current_row.is_some() && current_field.is_none() => {
+                    current_field = Some(parse_mysql_field(&element)?);
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected element in MySQL XML result".to_string(),
+                    ));
+                }
+            },
+            Event::Empty(element) if element.name().as_ref() == b"field" => {
+                let row = current_row.as_mut().ok_or_else(|| {
+                    DbOperationError::QueryFailed("MySQL XML field is outside a row".to_string())
+                })?;
+                if current_field.is_some() {
+                    return Err(DbOperationError::QueryFailed(
+                        "nested MySQL XML fields are not supported".to_string(),
+                    ));
+                }
+                let field = parse_mysql_field(&element)?;
+                row.push(field.finish());
+            }
+            Event::Text(text) => {
+                let text = text.unescape().map_err(|error| {
+                    DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
+                })?;
+                if let Some(field) = current_field.as_mut() {
+                    field.value.push_str(&text);
+                } else if !text.chars().all(char::is_whitespace) {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected text in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::CData(data) => {
+                if let Some(field) = current_field.as_mut() {
+                    field
+                        .value
+                        .push_str(std::str::from_utf8(data.as_ref()).map_err(|error| {
+                            DbOperationError::QueryFailed(format!(
+                                "invalid MySQL XML text: {error}"
+                            ))
+                        })?);
+                } else {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected CDATA in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::End(element) => match element.name().as_ref() {
+                b"field" => {
+                    let row = current_row.as_mut().ok_or_else(|| {
+                        DbOperationError::QueryFailed(
+                            "MySQL XML field is outside a row".to_string(),
+                        )
+                    })?;
+                    let field = current_field.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML field end".to_string())
+                    })?;
+                    row.push(field.finish());
+                }
+                b"row" => {
+                    let row = current_row.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML row end".to_string())
+                    })?;
+                    if columns.is_empty() {
+                        columns = row.iter().map(|(name, _)| name.clone()).collect();
+                    } else if row.len() != columns.len()
+                        || row
+                            .iter()
+                            .zip(&columns)
+                            .any(|((name, _), column)| name != column)
+                    {
+                        return Err(DbOperationError::QueryFailed(
+                            "MySQL XML rows have inconsistent fields".to_string(),
+                        ));
+                    }
+                    rows.push(row.into_iter().map(|(_, value)| value).collect());
+                }
+                b"resultset" => {
+                    if !in_resultset || current_row.is_some() || current_field.is_some() {
+                        return Err(DbOperationError::QueryFailed(
+                            "malformed MySQL XML resultset".to_string(),
+                        ));
+                    }
+                    in_resultset = false;
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected MySQL XML closing element".to_string(),
+                    ));
+                }
+            },
+            Event::Decl(_) | Event::Comment(_) => {}
+            Event::Eof => break,
+            _ => {
+                return Err(DbOperationError::QueryFailed(
+                    "unexpected event in MySQL XML result".to_string(),
+                ));
+            }
+        }
+        buffer.clear();
+    }
+
+    if resultset_count != 1 || in_resultset || current_row.is_some() || current_field.is_some() {
+        return Err(DbOperationError::QueryFailed(
+            "MySQL XML result did not contain one complete resultset".to_string(),
+        ));
+    }
+    Ok(MysqlResultSet {
+        columns,
+        values: rows,
+    })
+}
+
+struct MysqlField {
+    name: String,
+    value: String,
+    is_null: bool,
+}
+
+impl MysqlField {
+    fn finish(self) -> (String, QueryValue) {
+        let value = if self.is_null {
+            QueryValue::Null
+        } else {
+            QueryValue::Text(self.value)
+        };
+        (self.name, value)
+    }
+
+    fn finish_raw(self) -> (String, String) {
+        let value = if self.is_null {
+            String::new()
+        } else {
+            self.value
+        };
+        (self.name, value)
+    }
+}
+
+fn parse_mysql_field(
+    element: &quick_xml::events::BytesStart<'_>,
+) -> Result<MysqlField, DbOperationError> {
+    let mut name = None;
+    let mut is_null = false;
+    for attribute in element.attributes() {
+        let attribute = attribute.map_err(|error| {
+            DbOperationError::QueryFailed(format!("invalid MySQL XML field: {error}"))
+        })?;
+        let value = attribute.unescape_value().map_err(|error| {
+            DbOperationError::QueryFailed(format!("invalid MySQL XML field: {error}"))
+        })?;
+        match attribute.key.as_ref() {
+            b"name" => name = Some(value.into_owned()),
+            b"xsi:nil" | b"nil" => is_null = matches!(value.as_ref(), "true" | "1"),
+            _ => {}
+        }
+    }
+    let name = name
+        .ok_or_else(|| DbOperationError::QueryFailed("MySQL XML field has no name".to_string()))?;
+    Ok(MysqlField {
+        name,
+        value: String::new(),
+        is_null,
+    })
+}
+
+#[cfg(test)]
+mod probe_tests {
+    use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+
+    use super::*;
+
+    #[test]
+    fn builds_and_parses_mysql_dsn_with_encoded_components() {
+        let config = MySqlConnectionConfig::new(
+            "db.example",
+            3307,
+            Some("app/schema".to_string()),
+            "user name",
+            "p@ss#word",
+            MySqlSslMode::Required,
+        );
+        let dsn = build_mysql_dsn(&config);
+        let parsed = parse_mysql_dsn(&dsn).unwrap();
+
+        assert_eq!(parsed.host, "db.example");
+        assert_eq!(parsed.port, 3307);
+        assert_eq!(parsed.database.as_deref(), Some("app/schema"));
+        assert_eq!(parsed.username, "user name");
+        assert_eq!(parsed.password, "p@ss#word");
+        assert_eq!(parsed.ssl_mode, MySqlSslMode::Required);
+    }
+
+    #[test]
+    fn builds_and_parses_mysql_dsn_with_tls_paths() {
+        let config = MySqlConnectionConfig::new(
+            "db.example",
+            3307,
+            Some("app".to_string()),
+            "user",
+            "password",
+            MySqlSslMode::VerifyIdentity,
+        )
+        .with_tls_paths(
+            Some(r"C:\certs\ca #1.pem".to_string()),
+            Some(r"C:\certs\client.pem".to_string()),
+            Some(r"C:\certs\client-key.pem".to_string()),
+        );
+        let parsed = parse_mysql_dsn(&build_mysql_dsn(&config)).unwrap();
+
+        assert_eq!(parsed.ssl_mode, MySqlSslMode::VerifyIdentity);
+        assert_eq!(parsed.ssl_ca.as_deref(), Some(r"C:\certs\ca #1.pem"));
+        assert_eq!(parsed.ssl_cert.as_deref(), Some(r"C:\certs\client.pem"));
+        assert_eq!(parsed.ssl_key.as_deref(), Some(r"C:\certs\client-key.pem"));
+    }
+
+    #[test]
+    fn ipv6_host_round_trip_serializes_without_url_brackets() {
+        let config = MySqlConnectionConfig::new(
+            "::1",
+            3306,
+            None,
+            "user",
+            "password",
+            MySqlSslMode::Disabled,
+        );
+        let parsed = parse_mysql_dsn(&build_mysql_dsn(&config)).unwrap();
+
+        assert_eq!(parsed.host, "::1");
+        assert!(serialize_option_file(&parsed).contains("host = \"::1\"\n"));
+    }
+
+    #[test]
+    fn option_file_quotes_syntax_characters_and_windows_paths() {
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: Some("app".to_string()),
+            username: "user".to_string(),
+            password: "p a#ss;=\"\\word".to_string(),
+            ssl_mode: MySqlSslMode::Preferred,
+            ssl_ca: None,
+            ssl_cert: None,
+            ssl_key: None,
+        };
+        let contents = serialize_option_file(&target);
+
+        assert!(contents.contains("password = \"p a#ss;=\\\"\\\\word\""));
+        let mut certificate = String::new();
+        push_option(&mut certificate, "ssl-ca", r"C:\certs\server.pem");
+        assert_eq!(certificate, "ssl-ca = \"C:\\\\certs\\\\server.pem\"\n");
+        assert_eq!(
+            quote_option_value(r"C:\certs\server.pem"),
+            r#""C:\\certs\\server.pem""#
+        );
+    }
+
+    #[test]
+    fn server_database_listing_option_file_omits_selected_database() {
+        let mut target = parse_mysql_dsn("mysql://user:password@localhost:3306/app").unwrap();
+        target.database = None;
+
+        let contents = serialize_option_file(&target);
+
+        assert!(!contents.contains("database ="));
+    }
+
+    #[test]
+    fn option_file_serializes_tls_paths_without_option_syntax_confusion() {
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(r"C:\certs\ca #1.pem".to_string()),
+            ssl_cert: Some(r"C:\certs\client.pem".to_string()),
+            ssl_key: Some(r"C:\certs\client-key.pem".to_string()),
+        };
+
+        let contents = serialize_option_file(&target);
+
+        assert!(contents.contains("ssl-mode = \"VERIFY_CA\"\n"));
+        assert!(contents.contains("ssl-ca = \"C:\\\\certs\\\\ca #1.pem\"\n"));
+        assert!(contents.contains("ssl-cert = \"C:\\\\certs\\\\client.pem\"\n"));
+        assert!(contents.contains("ssl-key = \"C:\\\\certs\\\\client-key.pem\"\n"));
+    }
+
+    #[test]
+    fn rejects_encrypted_client_keys_before_process_start() {
+        let directory = tempfile::tempdir().unwrap();
+        let ca = directory.path().join("ca.pem");
+        let cert = directory.path().join("client.pem");
+        let key = directory.path().join("client-key.pem");
+        fs::write(&ca, "-----BEGIN CERTIFICATE-----\nca\n").unwrap();
+        fs::write(&cert, "-----BEGIN CERTIFICATE-----\ncert\n").unwrap();
+        fs::write(&key, "-----BEGIN ENCRYPTED PRIVATE KEY-----\nsecret\n").unwrap();
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(ca.display().to_string()),
+            ssl_cert: Some(cert.display().to_string()),
+            ssl_key: Some(key.display().to_string()),
+        };
+
+        let result = validate_mysql_tls_files(&target);
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::ConnectionFailed(details))
+                if details == "Encrypted MySQL client keys are not supported"
+        ));
+    }
+
+    #[test]
+    fn rejects_traditional_encrypted_client_keys_before_process_start() {
+        let directory = tempfile::tempdir().unwrap();
+        let ca = directory.path().join("ca.pem");
+        let cert = directory.path().join("client.pem");
+        let key = directory.path().join("client-key.pem");
+        fs::write(&ca, "-----BEGIN CERTIFICATE-----\nca\n").unwrap();
+        fs::write(&cert, "-----BEGIN CERTIFICATE-----\ncert\n").unwrap();
+        fs::write(&key, "Proc-Type: 4,ENCRYPTED\nDEK-Info: AES-256-CBC,x\n").unwrap();
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(ca.display().to_string()),
+            ssl_cert: Some(cert.display().to_string()),
+            ssl_key: Some(key.display().to_string()),
+        };
+
+        assert!(validate_mysql_tls_files(&target).is_err());
+    }
+
+    #[test]
+    fn option_file_is_owner_only_and_removed_on_drop() {
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "secret".to_string(),
+            ssl_mode: MySqlSslMode::Disabled,
+            ssl_ca: None,
+            ssl_cert: None,
+            ssl_key: None,
+        };
+        let option_file = MySqlOptionFile::create(&target).unwrap();
+        assert!(option_file.path.is_absolute());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&option_file.path)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+        let path = option_file.path.clone();
+        drop(option_file);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn validates_supported_versions_and_sql_modes() {
+        assert!(is_oracle_mysql_cli_84_version("mysql  Ver 8.4.3 for macos"));
+        assert!(!is_oracle_mysql_cli_84_version(
+            "mysql  Ver 8.0.36 for macos"
+        ));
+        assert!(!is_oracle_mysql_cli_84_version(
+            "mysql  Ver 15.1 Distrib 10.11.8-MariaDB"
+        ));
+        assert!(!is_oracle_mysql_cli_84_version(
+            "mysql  Ver 8.4.3-3 for Linux (Percona Server)"
+        ));
+        assert!(is_oracle_mysql_server_84_version("8.4.3"));
+        assert!(!is_oracle_mysql_server_84_version("8.4.3-TiDB"));
+        assert!(!is_oracle_mysql_server_84_version("8.4.3-Percona"));
+        assert!(validate_sql_mode("STRICT_TRANS_TABLES").is_ok());
+        assert!(validate_sql_mode("STRICT_TRANS_TABLES,ANSI_QUOTES").is_err());
+    }
+
+    #[test]
+    fn uses_tcp_and_keeps_defaults_file_first() {
+        let args = mysql_probe_args(std::path::Path::new("/tmp/sabiql-mysql.cnf"));
+
+        assert_eq!(args[0], "--defaults-file=/tmp/sabiql-mysql.cnf");
+        assert_eq!(args[1], "--no-login-paths");
+        assert_eq!(args[2], "--protocol=TCP");
+        assert!(args.contains(&"--batch".to_string()));
+        assert!(args.contains(&"--raw".to_string()));
+        assert!(args.contains(&"--skip-column-names".to_string()));
+        assert!(args.contains(&"--binary-mode".to_string()));
+        assert!(args.contains(&"--skip-reconnect".to_string()));
+        assert!(
+            args.last()
+                .unwrap()
+                .starts_with("--execute=SELECT JSON_OBJECT")
+        );
+    }
+
+    #[test]
+    fn arguments_do_not_contain_credentials() {
+        let args = mysql_probe_args(std::path::Path::new("/tmp/sabiql-mysql.cnf"));
+
+        assert!(
+            args.iter()
+                .all(|argument| { !argument.contains("password") && !argument.contains("secret") })
+        );
+    }
+
+    #[test]
+    fn classifies_mysql_cli_timeout_errno_before_connection_refusal() {
+        assert!(matches!(
+            classify_mysql_probe_failure(
+                "ERROR 2003 (HY000): Can't connect to MySQL server on 'host:3306' (110)"
+                    .to_string()
+            ),
+            DbOperationError::Timeout(_)
+        ));
+        assert!(matches!(
+            classify_mysql_probe_failure(
+                "ERROR 2003 (HY000): Can't connect to MySQL server on 'host:3306' (111)"
+                    .to_string()
+            ),
+            DbOperationError::ConnectionFailed(_)
+        ));
+    }
+
+    #[test]
+    fn classifies_mysql_tls_probe_failure_for_connection_error() {
+        let error = classify_mysql_probe_failure(
+            "ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed"
+                .to_string(),
+        );
+
+        assert_eq!(
+            ConnectionErrorInfo::from_db_operation_error(&error).kind,
+            ConnectionErrorKind::MySqlTlsHandshakeFailed
+        );
+    }
+}
+
+#[cfg(test)]
+mod query_tests {
+    use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn parses_mysql_xml_without_collapsing_value_boundaries() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<row>
+  <field name="null" xsi:nil="true"/>
+  <field name="empty"></field>
+  <field name="text-null">NULL</field>
+  <field name="special">tab&#9;line&#10;slash\unicode 日本語</field>
+  <field name="json">{"a":[1,true]}</field>
+  <field name="binary-looking">0x41</field>
+</row>
+</resultset>"#;
+
+        let result = parse_mysql_xml(xml.as_bytes()).unwrap();
+
+        assert_eq!(
+            result.columns,
+            vec![
+                "null",
+                "empty",
+                "text-null",
+                "special",
+                "json",
+                "binary-looking"
+            ]
+        );
+        assert_eq!(
+            result.values,
+            vec![vec![
+                QueryValue::Null,
+                QueryValue::Text(String::new()),
+                QueryValue::Text("NULL".to_string()),
+                QueryValue::Text("tab\tline\nslash\\unicode 日本語".to_string()),
+                QueryValue::Text("{\"a\":[1,true]}".to_string()),
+                QueryValue::Text("0x41".to_string()),
+            ]]
+        );
+    }
+
+    #[test]
+    fn parses_numeric_and_binary_values_as_text() {
+        let xml = br#"<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row>
+<field name="integer">18446744073709551615</field>
+<field name="decimal">12345678901234567890.123456789</field>
+<field name="float">1.25e+100</field>
+<field name="binary">0x00FF10</field>
+</row></resultset>"#;
+
+        let result = parse_mysql_xml(xml).unwrap();
+        assert!(
+            result.values[0]
+                .iter()
+                .all(|value| matches!(value, QueryValue::Text(_)))
+        );
+        assert_eq!(result.values[0][0].as_str(), Some("18446744073709551615"));
+        assert_eq!(result.values[0][3].as_str(), Some("0x00FF10"));
+    }
+
+    #[test]
+    fn rejects_multiple_resultsets_instead_of_guessing_the_last_one() {
+        let xml = br#"<resultset><row><field name="value">1</field></row></resultset>
+<resultset><row><field name="value">2</field></row></resultset>"#;
+
+        assert!(matches!(
+            parse_mysql_xml(xml),
+            Err(DbOperationError::QueryFailed(details))
+                if details.contains("more than one resultset")
+        ));
+    }
+
+    #[test]
+    fn accepts_xml_declaration_after_probe_separator_and_empty_resultsets() {
+        let xml = br#"
+<?xml version="1.0" encoding="utf-8"?>
+<resultset></resultset>
+"#;
+
+        let result = parse_mysql_xml(xml).unwrap();
+        assert!(result.columns.is_empty());
+        assert!(result.values.is_empty());
+    }
+
+    #[tokio::test]
+    async fn streams_mysql_xml_rows_into_csv_without_binary_type_inference() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row>
+<field name="comma">a,b</field>
+<field name="quote">a&quot;b</field>
+<field name="newline"><![CDATA[line1
+line2]]></field>
+<field name="tab">a	b</field>
+<field name="unicode">日本語</field>
+<field name="null" xsi:nil="true"/>
+<field name="empty"></field>
+<field name="binary">0x00FF</field>
+</row></resultset>"#;
+        let (mut input, output) = tokio::io::duplex(32);
+        let producer = tokio::spawn(async move {
+            input.write_all(xml.as_bytes()).await.unwrap();
+        });
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("stream.csv");
+        let mut csv_writer = CsvFileWriter::create(path.clone()).await.unwrap();
+        let mut reader = Reader::from_reader(BufReader::new(output));
+        reader.config_mut().trim_text(false);
+
+        stream_mysql_xml_to_csv(&mut reader, &mut csv_writer)
+            .await
+            .unwrap();
+        csv_writer.finish().await.unwrap();
+        producer.await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(path).unwrap(),
+            "comma,quote,newline,tab,unicode,null,empty,binary\n\
+             \"a,b\",\"a\"\"b\",\"line1\n\
+             line2\",a\tb,日本語,,,0x00FF\n"
+                .replace("             ", "")
+        );
+    }
+
+    #[test]
+    fn csv_export_accepts_one_read_only_result_query() {
+        assert!(validate_mysql_export_query("SELECT 1", Some("app")).is_ok());
+        for query in ["TABLE users", "SHOW TABLES", "DESCRIBE users"] {
+            assert!(
+                validate_mysql_export_query(query, Some("app")).is_ok(),
+                "{query}"
+            );
+        }
+        assert!(matches!(
+            validate_mysql_export_query("INSERT INTO users VALUES (1)", Some("app")),
+            Err(DbOperationError::PermissionDenied(_))
+        ));
+        assert!(matches!(
+            validate_mysql_export_query("SELECT 1; SELECT 2", Some("app")),
+            Err(DbOperationError::UnsupportedOperation(details))
+                if details.contains("single read-only result")
+        ));
+    }
+
+    #[test]
+    fn scanner_ignores_semicolons_in_quotes_and_comments() {
+        let query = r#"
+            SELECT 'a; b', "quoted; identifier", `back;tick`
+            /* block ; comment */
+            FROM `table` -- line ; comment
+            WHERE value = 'backslash\\;'
+        "#;
+
+        assert!(validate_mysql_adhoc_query(query).is_ok());
+    }
+
+    #[test]
+    fn scanner_rejects_multiple_statements_before_starting_a_process() {
+        for query in ["SELECT 1; SELECT 2", "SELECT 1;\nSHOW TABLES"] {
+            assert!(matches!(
+                validate_mysql_adhoc_query(query),
+                Err(DbOperationError::UnsupportedOperation(details))
+                    if details.contains("multiple SQL statements")
+            ));
+        }
+    }
+
+    #[test]
+    fn scanner_accepts_read_statements_and_select_ctes_only() {
+        for query in [
+            "SELECT 1",
+            "TABLE users",
+            "SHOW TABLES",
+            "DESCRIBE users",
+            "WITH rows AS (SELECT 1) SELECT * FROM rows",
+            "WITH RECURSIVE rows AS (SELECT 1) SELECT * FROM rows",
+        ] {
+            assert!(validate_mysql_adhoc_query(query).is_ok(), "{query}");
+        }
+        for query in [
+            "INSERT INTO users VALUES (1)",
+            "WITH rows AS (SELECT 1) UPDATE users SET id = 2",
+            "WITH rows AS (SELECT 1) SHOW TABLES",
+        ] {
+            assert!(validate_mysql_adhoc_query(query).is_err(), "{query}");
+        }
+    }
+
+    #[test]
+    fn scanner_rejects_top_level_into_clauses_before_starting_a_process() {
+        for query in [
+            "SELECT id INTO OUTFILE '/tmp/result' FROM users",
+            "SELECT id INTO DUMPFILE '/tmp/result' FROM users",
+            "SELECT id INTO @value FROM users",
+            "TABLE users INTO OUTFILE '/tmp/result'",
+            "WITH rows AS (SELECT 1) SELECT * INTO OUTFILE '/tmp/result' FROM rows",
+        ] {
+            assert!(matches!(
+                validate_mysql_adhoc_query(query),
+                Err(DbOperationError::UnsupportedOperation(details))
+                    if details.contains("SELECT INTO clauses")
+            ));
+        }
+        assert!(
+            validate_mysql_adhoc_query("WITH rows AS (SELECT 'INTO OUTFILE') SELECT * FROM rows")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn scanner_rejects_client_commands_and_version_comments() {
+        for query in [
+            "DELIMITER //\nSELECT 1//",
+            "  charset utf8mb4\nSELECT 1",
+            "source ./script.sql",
+            "system echo unsafe",
+            "\\C /tmp/other.sock\nSELECT 1",
+            "SELECT 1 /*!40101 + 1 */",
+        ] {
+            assert!(matches!(
+                validate_mysql_adhoc_query(query),
+                Err(DbOperationError::UnsupportedOperation(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn mode_probe_requires_marker_and_allowed_mode_before_user_sql() {
+        let probe = MysqlResultSet {
+            columns: vec![
+                "__sabiql_probe".to_string(),
+                "__sabiql_sql_mode".to_string(),
+            ],
+            values: vec![vec![
+                QueryValue::Text("marker".to_string()),
+                QueryValue::Text("STRICT_TRANS_TABLES".to_string()),
+            ]],
+        };
+        assert!(validate_mode_probe(&probe, "marker").is_ok());
+
+        let mut unsupported = probe;
+        unsupported.values[0][1] = QueryValue::Text("ANSI_QUOTES".to_string());
+        assert!(matches!(
+            validate_mode_probe(&unsupported, "marker"),
+            Err(DbOperationError::UnsupportedOperation(details))
+                if details.contains(MYSQL_SQL_MODE_UNSUPPORTED_MARKER)
+        ));
+    }
+
+    #[test]
+    fn arguments_keep_credentials_out_of_argv() {
+        let args = mysql_query_args(std::path::Path::new("/tmp/sabiql-mysql.cnf"));
+
+        assert_eq!(args[0], "--defaults-file=/tmp/sabiql-mysql.cnf");
+        assert_eq!(args[1], "--no-login-paths");
+        for expected in [
+            "--xml",
+            "--binary-as-hex",
+            "--binary-mode",
+            "--unbuffered",
+            "--skip-reconnect",
+            "--default-character-set=utf8mb4",
+        ] {
+            assert!(args.contains(&expected.to_string()), "{expected}");
+        }
+        #[cfg(unix)]
+        {
+            assert!(args.contains(&"--silent".to_string()));
+            assert!(args.contains(&"--prompt=".to_string()));
+            assert!(!args.contains(&"--batch".to_string()));
+        }
+        #[cfg(not(unix))]
+        assert!(args.contains(&"--batch".to_string()));
+        assert!(args.iter().all(|argument| !argument.contains("password")));
+    }
+
+    #[test]
+    fn classifies_mysql_query_failures_by_server_error() {
+        assert!(matches!(
+            classify_mysql_query_failure(
+                b"ERROR 1045 (28000): Access denied for user 'app'@'localhost' (using password: YES)"
+            ),
+            DbOperationError::ConnectionFailed(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1142 (42000): command denied to user"),
+            DbOperationError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(
+                b"ERROR 1044 (42000): Access denied for user 'app' to database 'app'"
+            ),
+            DbOperationError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1146 (42S02): Table does not exist"),
+            DbOperationError::ObjectMissing(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1205 (HY000): Lock wait timeout exceeded"),
+            DbOperationError::LockTimeout(_)
+        ));
+        let masked = classify_mysql_query_failure(b"ERROR password=secret");
+        assert!(!masked.masked_details().contains("secret"));
+    }
+
+    #[test]
+    fn classifies_mysql_tls_query_failures_as_connection_errors() {
+        let error = classify_mysql_query_failure(
+            b"ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed",
+        );
+
+        assert_eq!(
+            ConnectionErrorInfo::from_db_operation_error(&error).kind,
+            ConnectionErrorKind::MySqlTlsHandshakeFailed
+        );
+        assert!(matches!(error, DbOperationError::ConnectionFailed(_)));
+    }
+}
+
+#[cfg(all(test, unix))]
+mod executor_tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn fake_mysql(mode: &str) -> (TempDir, PathBuf, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let option_file = directory.path().join("option.cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let program = directory.path().join("mysql");
+        let probe_response = match mode {
+            "missing" => "exit 0".to_string(),
+            "invalid" => {
+                "printf '%s\\n' '<resultset><row><field name=\"wrong\">x</field></row></resultset>'"
+                    .to_string()
+            }
+            "unsupported" => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_probe\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">ANSI_QUOTES</field></row></resultset>'".to_string(),
+            "timeout" => "while :; do :; done".to_string(),
+            _ => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_probe\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">STRICT_TRANS_TABLES</field></row></resultset>'".to_string(),
+        };
+        let user_response = if mode == "failure" {
+            "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2\n    exit 1"
+        } else {
+            "printf '%s\\n' '<resultset><row><field name=\"value\">ok</field></row></resultset>'"
+        };
+        let session_failure = if mode == "read_only_failure" {
+            "printf '%s\\n' 'ERROR 1227 (42000): access denied to set transaction read only' >&2\n      exit 1"
+        } else {
+            ""
+        };
+        let script = format!(
+            r#"#!/bin/sh
+option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
+log="$option.log"
+phase=probe
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$log"
+  [ "$line" = ";" ] && continue
+  if [ "$phase" = probe ]; then
+    marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)'.*/\\1/")
+    {probe_response}
+    phase=user
+  else
+    case "$line" in
+      "SET SESSION TRANSACTION READ ONLY")
+        {session_failure}
+        ;;
+      *__sabiql_session_marker*)
+        marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
+        printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+        ;;
+      *)
+        {user_response}
+        exit 0
+        ;;
+    esac
+  fi
+done
+"#,
+        );
+        fs::write(&program, script).unwrap();
+        let mut permissions = fs::metadata(&program).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).unwrap();
+        (directory, program, log_file)
+    }
+
+    fn fake_mysql_multi() -> (TempDir, PathBuf, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let option_file = directory.path().join("option.cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let program = directory.path().join("mysql");
+        let script = r#"#!/bin/sh
+option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
+log="$option.log"
+pending_error=0
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$log"
+  case "$line" in
+    *\\q*)
+      exit 0
+      ;;
+    *__sabiql_probe*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_probe.*/\\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
+      ;;
+    "SET SESSION TRANSACTION READ ONLY")
+      ;;
+    *__sabiql_session_marker*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      ;;
+    *__sabiql_marker*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_marker.*/\\1/")
+      rows=0
+      case "$line" in *ROW_COUNT\(\)* ) rows=3 ;; esac
+      printf '%s\n' '<resultset><row><field name="__sabiql_marker">'"$marker"'</field><field name="affected_rows">'"$rows"'</field></row></resultset>'
+      if [ "$pending_error" = 1 ]; then
+        sleep 0.05
+        printf '%s\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2
+        pending_error=0
+      fi
+      ;;
+    *missing_column*)
+      pending_error=1
+      ;;
+    *SELECT*)
+      value=one
+      case "$line" in *SELECT\ 2*) value=two ;; esac
+      printf '%s\n' '<resultset><row><field name="value">'"$value"'</field></row></resultset>'
+      ;;
+    *UPDATE*)
+      printf '%s\n' '<resultset><row><field name="affected">ok</field></row></resultset>'
+      ;;
+    *)
+      printf '%s\n' '<resultset></resultset>'
+      ;;
+  esac
+done
+"#;
+        fs::write(&program, script).unwrap();
+        let mut permissions = fs::metadata(&program).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).unwrap();
+        (directory, program, option_file)
+    }
+
+    #[tokio::test]
+    async fn sends_user_sql_only_after_a_valid_mode_probe() {
+        let (_directory, program, log_file) = fake_mysql("success");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.columns, vec!["value"]);
+        assert_eq!(result.values[0][0].as_str(), Some("ok"));
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+        assert!(log.contains("__sabiql_probe"));
+        assert!(log.contains("SELECT 123"));
+        assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT));
+    }
+
+    #[tokio::test]
+    async fn configures_read_only_session_before_user_sql() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let statements = split_mysql_statements("SELECT 2")
+            .unwrap()
+            .into_iter()
+            .map(|sql| classify_mysql_statement(&sql).unwrap())
+            .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 2",
+            &statements,
+            AccessMode::ReadOnly,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_or_else(|error| {
+            let log = fs::read_to_string(&log_file).unwrap_or_default();
+            panic!("read-only execution failed: {error:?}; log: {log}");
+        });
+
+        assert_eq!(
+            result.result_set.unwrap().values[0][0].as_str(),
+            Some("two")
+        );
+        let log = fs::read_to_string(log_file).unwrap();
+        let session_index = log
+            .find(MYSQL_READ_ONLY_STATEMENT)
+            .expect("read-only session statement");
+        let user_index = log.find("SELECT 2").expect("user statement");
+        assert!(session_index < user_index, "{log}");
+        assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN));
+    }
+
+    #[tokio::test]
+    async fn read_only_session_failure_never_writes_user_sql() {
+        let (_directory, program, log_file) = fake_mysql("read_only_failure");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadOnly,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+        assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
+        assert!(!log.contains("SELECT 123"), "{log}");
+    }
+
+    #[tokio::test]
+    async fn generated_preview_and_metadata_queries_skip_read_only_session_setup() {
+        for query in [
+            "SELECT id FROM app.items ORDER BY id LIMIT 10 OFFSET 0",
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES",
+        ] {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let statements = split_mysql_statements(query)
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
+
+            run_mysql_adhoc_with_program_and_statements(
+                OsStr::new(&program),
+                &option_file,
+                query,
+                &statements,
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT), "{query}: {log}");
+        }
+    }
+
+    #[test]
+    fn read_only_rejects_temporary_table_dml_before_starting_mysql() {
+        let (_directory, _program, option_file) = fake_mysql_multi();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let query = "CREATE TEMPORARY TABLE temp_items (id INT); INSERT INTO temp_items VALUES (1); DROP TEMPORARY TABLE temp_items";
+
+        let result = validate_mysql_multi_query(query, Some("app"), AccessMode::ReadOnly);
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::PermissionDenied(details))
+                if details.contains("read-only mode blocks MySQL write statements")
+        ));
+        assert!(!log_file.exists());
+    }
+
+    #[test]
+    fn read_only_rejects_read_write_overrides_before_starting_mysql() {
+        for query in [
+            "SET SESSION TRANSACTION READ WRITE",
+            "START TRANSACTION READ WRITE",
+        ] {
+            let (_directory, _program, option_file) = fake_mysql_multi();
+            let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+
+            let result = validate_mysql_multi_query(query, Some("app"), AccessMode::ReadOnly);
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::UnsupportedOperation(_))
+            ));
+            assert!(!log_file.exists(), "{query}");
+        }
+    }
+
+    #[tokio::test]
+    async fn exports_mysql_xml_rows_through_the_shared_csv_writer() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let path = option_file.with_file_name("export.csv");
+
+        export_mysql_csv_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 1",
+            path.clone(),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(fs::read_to_string(path).unwrap(), "value\none\n");
+    }
+
+    #[tokio::test]
+    async fn export_failure_removes_the_partial_file() {
+        let (_directory, program, option_file) = fake_mysql("failure");
+        let output_directory = tempfile::tempdir().unwrap();
+        let final_path = output_directory.path().join("export.csv");
+
+        let result = export_to_path(final_path.clone(), |path| {
+            export_mysql_csv_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 1",
+                path,
+                Duration::from_secs(5),
+            )
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert!(!final_path.exists());
+        assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn export_timeout_kills_the_process_and_removes_the_partial_file() {
+        let (_directory, program, option_file) = fake_mysql("timeout");
+        let output_directory = tempfile::tempdir().unwrap();
+        let final_path = output_directory.path().join("export.csv");
+
+        let result = export_to_path(final_path.clone(), |path| {
+            export_mysql_csv_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 1",
+                path,
+                Duration::from_millis(50),
+            )
+        })
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::Timeout(_))));
+        assert!(!final_path.exists());
+        assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
+    }
+
+    #[test]
+    fn frames_one_xml_resultset_and_preserves_following_output() {
+        let mut buffer = b"    -> <?xml version=\"1.0\"?>\n<resultset></resultset>\r\n    -> <?xml version=\"1.0\"?>\n<resultset>"
+            .to_vec();
+
+        assert_eq!(
+            take_mysql_resultset_frame(&mut buffer),
+            Some(b"<resultset></resultset>".to_vec())
+        );
+        assert_eq!(
+            take_mysql_resultset_frame(&mut buffer),
+            None,
+            "an incomplete following frame must remain buffered"
+        );
+        assert!(buffer.starts_with(b"\r\n    -> <?xml"));
+    }
+
+    #[test]
+    fn frames_resultset_after_mysql_cli_text() {
+        let mut buffer =
+            b"SELECT 1;\n<?xml version=\"1.0\"?>\nquery text\n<resultset></resultset>".to_vec();
+
+        assert_eq!(
+            take_mysql_resultset_frame(&mut buffer),
+            Some(b"<resultset></resultset>".to_vec())
+        );
+        assert!(buffer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn probe_failure_never_writes_user_sql() {
+        for mode in ["unsupported", "invalid", "missing"] {
+            let (_directory, program, log_file) = fake_mysql(mode);
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_adhoc_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await;
+            assert!(result.is_err(), "{mode}");
+            let log =
+                fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
+            assert!(!log.contains("SELECT 123"), "{mode}: {log}");
+        }
+    }
+
+    #[tokio::test]
+    async fn probe_timeout_kills_the_process_and_discards_output() {
+        let (_directory, program, log_file) = fake_mysql("timeout");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadWrite,
+            Duration::from_millis(50),
+        )
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::Timeout(_))));
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
+        assert!(!log.contains("SELECT 123"));
+    }
+
+    #[tokio::test]
+    async fn nonzero_cli_exit_discards_any_collected_stdout() {
+        let (_directory, program, log_file) = fake_mysql("failure");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn executes_each_statement_and_returns_the_last_user_result() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let statements = split_mysql_statements("UPDATE items SET value = 1; SELECT 2")
+            .unwrap()
+            .into_iter()
+            .map(|sql| classify_mysql_statement(&sql).unwrap())
+            .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "UPDATE items SET value = 1; SELECT 2",
+            &statements,
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("multi execution failed: {error:?}"));
+
+        assert_eq!(
+            result.result_set,
+            Some(MysqlResultSet {
+                columns: vec!["value".to_string()],
+                values: vec![vec![QueryValue::Text("two".to_string())]],
+            })
+        );
+        assert_eq!(result.command_tag, Some(CommandTag::Update(3)));
+        assert_eq!(result.refresh_scope, RefreshScope::Data);
+        let log = fs::read_to_string(log_file).unwrap();
+        assert!(log.contains("UPDATE items SET value = 1"));
+        assert!(log.matches("__sabiql_marker").count() >= 2);
+    }
+
+    #[tokio::test]
+    async fn marks_a_later_failure_after_a_confirmed_change_for_refresh() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let statements =
+            split_mysql_statements("UPDATE items SET value = 1; SELECT missing_column FROM items")
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "UPDATE items SET value = 1; SELECT missing_column FROM items",
+            &statements,
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::QueryFailedAfterChange {
+                refresh_scope: RefreshScope::Data,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_error_reported_after_row_count_marker() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let statements = split_mysql_statements("SELECT missing_column FROM items")
+            .unwrap()
+            .into_iter()
+            .map(|sql| classify_mysql_statement(&sql).unwrap())
+            .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT missing_column FROM items",
+            &statements,
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::QueryFailed(details))
+                if details.contains("missing_column")
+        ));
+    }
+
+    #[test]
+    fn transaction_rollback_removes_pending_data_tag() {
+        let events = vec![
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Begin,
+                target: None,
+                tag: CommandTag::Begin,
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Update { has_where: true },
+                target: Some("items".to_string()),
+                tag: CommandTag::Update(1),
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Rollback,
+                target: None,
+                tag: CommandTag::Rollback,
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Select,
+                target: None,
+                tag: CommandTag::Select(1),
+            },
+        ];
+
+        assert_eq!(
+            aggregate_mysql_command_tag(&events),
+            Some(CommandTag::Select(1))
+        );
+    }
+
+    #[test]
+    fn ddl_implicit_commit_keeps_prior_data_change() {
+        let events = vec![
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Begin,
+                target: None,
+                tag: CommandTag::Begin,
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Insert,
+                target: Some("items".to_string()),
+                tag: CommandTag::Insert(1),
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::CreateTable { temporary: false },
+                target: Some("created".to_string()),
+                tag: CommandTag::Create("TABLE".to_string()),
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Rollback,
+                target: None,
+                tag: CommandTag::Rollback,
+            },
+        ];
+
+        assert_eq!(
+            aggregate_mysql_command_tag(&events),
+            Some(CommandTag::Create("TABLE".to_string()))
+        );
+    }
+}
+
+#[cfg(test)]
+mod resultset_frame_tests {
+    use super::*;
+
+    #[test]
+    fn error_before_resultset_frame_is_not_accepted() {
+        let mut buffer = b"<resultset><row></row></resultset>".to_vec();
+        let error = b"ERROR 1054 (42S22): Unknown column missing_column\n";
+
+        assert!(matches!(
+            take_mysql_resultset_frame_after_error_check(&mut buffer, error),
+            Err(DbOperationError::QueryFailed(_))
+        ));
+        assert_eq!(buffer, b"<resultset><row></row></resultset>");
+    }
+}
+
+#[cfg(all(test, not(unix)))]
+mod pipe_executor_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn pipe_errors_are_checked_before_resultset_frames() {
+        let (mut stdout_writer, mut stdout_reader) = tokio::io::duplex(1024);
+        let (mut stderr_writer, mut stderr_reader) = tokio::io::duplex(1024);
+        stdout_writer
+            .write_all(b"<resultset><row></row></resultset>")
+            .await
+            .unwrap();
+        stderr_writer
+            .write_all(b"ERROR 1054 (42S22): Unknown column missing_column\n")
+            .await
+            .unwrap();
+        drop(stdout_writer);
+        drop(stderr_writer);
+
+        let result = read_one_mysql_resultset_from_pipes(
+            &mut stdout_reader,
+            &mut stderr_reader,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
     }
 }

--- a/src/infra/adapters/mysql/metadata.rs
+++ b/src/infra/adapters/mysql/metadata.rs
@@ -1,0 +1,1536 @@
+use async_trait::async_trait;
+
+use crate::app::ports::outbound::{AccessMode, DbOperationError, MetadataProvider};
+use crate::domain::{
+    Column, ColumnAttributes, DatabaseMetadata, FkAction, ForeignKey, Index, IndexAttributes,
+    IndexType, QueryValue, Schema, Table, TableKind, TableKindInfo, TableSignature, TableSummary,
+    Trigger, TriggerEvent, TriggerTiming,
+};
+
+use super::{
+    MySqlAdapter, MySqlOptionFile, MysqlResultSet, parse_mysql_dsn, run_mysql_adhoc,
+    validate_mysql_values,
+};
+
+const TABLES_QUERY: &str = "SELECT TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') UNION ALL SELECT NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')) ORDER BY TABLE_NAME";
+const PREVIEW_IDENTITY_ALIAS_PREFIX: &str = "__sabiql_row_identity_";
+
+#[derive(Debug, Clone)]
+struct MysqlColumnMetadata {
+    name: String,
+    data_type: String,
+    nullable: bool,
+    default: Option<String>,
+    comment: Option<String>,
+    ordinal_position: i32,
+    primary_key_position: Option<i32>,
+    invisible: bool,
+    generated: bool,
+}
+
+#[derive(Debug, Clone)]
+struct MysqlIndexMetadata {
+    name: String,
+    non_unique: bool,
+    index_type: String,
+    ordinal_position: i32,
+    column_name: String,
+    primary: bool,
+}
+
+#[derive(Debug, Clone)]
+struct MysqlForeignKeyMetadata {
+    name: String,
+    from_schema: String,
+    from_table: String,
+    from_column: String,
+    to_schema: String,
+    to_table: String,
+    to_column: String,
+    ordinal_position: i32,
+    on_update: FkAction,
+    on_delete: FkAction,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PreviewMetadata {
+    pub visible_columns: Vec<Column>,
+    pub order_columns: Vec<String>,
+    pub identity_columns: Vec<Column>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ConvertedPreviewValues {
+    pub visible: Vec<Vec<QueryValue>>,
+    pub identity: Option<Vec<Vec<QueryValue>>>,
+}
+
+#[derive(Debug, Clone)]
+struct MysqlTableMetadata {
+    name: String,
+    kind: TableKind,
+    row_count_estimate: Option<i64>,
+    comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct MysqlTriggerMetadata {
+    name: String,
+    timing: TriggerTiming,
+    event: TriggerEvent,
+    definition: String,
+    security_context: Option<String>,
+}
+
+#[async_trait]
+impl MetadataProvider for MySqlAdapter {
+    async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
+        let database = selected_database(dsn)?;
+        let result = execute_metadata_query(dsn, TABLES_QUERY).await?;
+        let tables = parse_table_metadata(&result)?;
+        let mut metadata = DatabaseMetadata::new(database.clone());
+        metadata.schemas = vec![Schema::new(database.clone())];
+        metadata.table_summaries = tables
+            .into_iter()
+            .map(|table| table_summary(&database, table))
+            .collect();
+        Ok(metadata)
+    }
+
+    async fn fetch_table_detail(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Table, DbOperationError> {
+        let metadata = self.fetch_metadata(dsn).await?;
+        fetch_table(dsn, schema, table, &metadata.table_summaries).await
+    }
+
+    async fn fetch_table_columns_and_fks(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Table, DbOperationError> {
+        let metadata = self.fetch_metadata(dsn).await?;
+        fetch_table_columns_and_fks_with_summaries(dsn, schema, table, &metadata.table_summaries)
+            .await
+    }
+
+    async fn fetch_table_signatures(
+        &self,
+        dsn: &str,
+    ) -> Result<Vec<TableSignature>, DbOperationError> {
+        let metadata = self.fetch_metadata(dsn).await?;
+        let mut signatures = Vec::with_capacity(metadata.table_summaries.len());
+        let summaries = metadata.table_summaries;
+        for summary in &summaries {
+            let detail = fetch_table_columns_and_fks_with_summaries(
+                dsn,
+                &summary.schema,
+                &summary.name,
+                &summaries,
+            )
+            .await?;
+            signatures.push(TableSignature {
+                schema: summary.schema.clone(),
+                name: summary.name.clone(),
+                signature: table_signature(&detail),
+            });
+        }
+        Ok(signatures)
+    }
+}
+
+pub(super) async fn fetch_preview_metadata(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<PreviewMetadata, DbOperationError> {
+    find_table(dsn, schema, table).await?;
+    let column_metadata = fetch_columns(dsn, schema, table).await?;
+    let columns = column_metadata
+        .iter()
+        .map(column_from_metadata)
+        .collect::<Vec<_>>();
+    let visible_columns = columns
+        .iter()
+        .filter(|column| !column.is_hidden())
+        .cloned()
+        .collect::<Vec<_>>();
+    if visible_columns.is_empty() {
+        return Err(DbOperationError::MetadataParseFailed(format!(
+            "MySQL object has no visible columns: {schema}.{table}"
+        )));
+    }
+    let primary_key_names = primary_key_names(&column_metadata);
+    let identity_columns = if primary_key_names.iter().any(|name| {
+        columns
+            .iter()
+            .find(|column| &column.name == name)
+            .is_some_and(Column::is_hidden)
+    }) {
+        primary_key_names
+            .iter()
+            .filter_map(|name| columns.iter().find(|column| &column.name == name))
+            .cloned()
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let order_columns = primary_key_names;
+    let order_columns = if order_columns.is_empty() {
+        visible_columns
+            .iter()
+            .map(|column| column.name.clone())
+            .collect()
+    } else {
+        order_columns
+    };
+    Ok(PreviewMetadata {
+        visible_columns,
+        order_columns,
+        identity_columns,
+    })
+}
+
+pub(super) fn build_preview_query(
+    schema: &str,
+    table: &str,
+    order_columns: &[String],
+    visible_columns: &[Column],
+    identity_columns: &[Column],
+    limit: usize,
+    offset: usize,
+) -> String {
+    let visible_select = visible_columns
+        .iter()
+        .map(|column| quote_identifier(&column.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let identity_select = identity_columns
+        .iter()
+        .enumerate()
+        .map(|(index, column)| {
+            format!(
+                "{} AS {}",
+                quote_identifier(&column.name),
+                quote_identifier(&preview_identity_alias(index)),
+            )
+        })
+        .collect::<Vec<_>>();
+    let columns = std::iter::once(visible_select)
+        .chain(identity_select)
+        .filter(|select| !select.is_empty())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let order_by = order_columns
+        .iter()
+        .map(|column| quote_identifier(column))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "SELECT {columns} FROM {}.{} ORDER BY {order_by} LIMIT {limit} OFFSET {offset}",
+        quote_identifier(schema),
+        quote_identifier(table),
+    )
+}
+
+pub(super) fn convert_preview_values(
+    result: &MysqlResultSet,
+    columns: &[Column],
+    identity_columns: &[Column],
+) -> Result<ConvertedPreviewValues, DbOperationError> {
+    let expected_columns = columns
+        .iter()
+        .map(|column| column.name.clone())
+        .chain(
+            identity_columns
+                .iter()
+                .enumerate()
+                .map(|(index, _)| preview_identity_alias(index)),
+        )
+        .collect::<Vec<_>>();
+    if result.values.is_empty() {
+        if result.columns.is_empty() || result.columns == expected_columns {
+            return Ok(ConvertedPreviewValues {
+                visible: Vec::new(),
+                identity: (!identity_columns.is_empty()).then(Vec::new),
+            });
+        }
+        return Err(DbOperationError::MetadataParseFailed(
+            "MySQL preview returned an unexpected column count".to_string(),
+        ));
+    }
+    if result.columns != expected_columns {
+        return Err(DbOperationError::MetadataParseFailed(
+            "MySQL preview returned unexpected columns".to_string(),
+        ));
+    }
+    let rows = result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != expected_columns.len() {
+                return Err(DbOperationError::MetadataParseFailed(
+                    "MySQL preview returned an unexpected row width".to_string(),
+                ));
+            }
+            row.iter()
+                .zip(columns.iter().chain(identity_columns))
+                .map(|(value, column)| Ok(convert_preview_value(value, &column.data_type)))
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let (visible, identity) = rows.into_iter().fold(
+        (Vec::new(), (!identity_columns.is_empty()).then(Vec::new)),
+        |(mut visible, mut identity), row| {
+            let (visible_row, identity_row) = row.split_at(columns.len());
+            visible.push(visible_row.to_vec());
+            if let Some(identity) = identity.as_mut() {
+                identity.push(identity_row.to_vec());
+            }
+            (visible, identity)
+        },
+    );
+    Ok(ConvertedPreviewValues { visible, identity })
+}
+
+fn preview_identity_alias(index: usize) -> String {
+    format!("{PREVIEW_IDENTITY_ALIAS_PREFIX}{index}")
+}
+
+fn convert_preview_value(value: &QueryValue, data_type: &str) -> QueryValue {
+    let QueryValue::Text(value) = value else {
+        return value.clone();
+    };
+    if is_binary_type(data_type)
+        && let Some(bytes) = decode_hex(value)
+    {
+        return QueryValue::Blob(bytes);
+    }
+    if is_numeric_type(data_type) && is_sql_numeric_literal(value) {
+        return QueryValue::SqlLiteral(value.clone());
+    }
+    QueryValue::Text(value.clone())
+}
+
+async fn fetch_table(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+    summaries: &[TableSummary],
+) -> Result<Table, DbOperationError> {
+    let table_metadata = find_table(dsn, schema, table).await?;
+    let columns = fetch_columns(dsn, schema, table).await?;
+    let indexes = fetch_indexes(dsn, schema, table).await?;
+    let foreign_keys = fetch_foreign_keys(dsn, schema, table, summaries).await?;
+    let triggers = fetch_triggers(dsn, schema, table).await?;
+    let source_ddl = fetch_source_ddl(dsn, table, table_metadata.kind).await?;
+    let primary_key = primary_key_names(&columns);
+    let columns = columns.iter().map(column_from_metadata).collect::<Vec<_>>();
+    Ok(Table {
+        schema: schema.to_string(),
+        name: table_metadata.name,
+        owner: None,
+        columns,
+        primary_key: (!primary_key.is_empty()).then_some(primary_key),
+        foreign_keys,
+        indexes,
+        rls: None,
+        triggers,
+        row_count_estimate: table_metadata.row_count_estimate,
+        comment: table_metadata.comment,
+        source_ddl: Some(source_ddl),
+        kind_info: TableKindInfo {
+            kind: table_metadata.kind,
+            ..TableKindInfo::default()
+        },
+    })
+}
+
+async fn fetch_table_columns_and_fks_with_summaries(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+    summaries: &[TableSummary],
+) -> Result<Table, DbOperationError> {
+    let table_metadata = find_table(dsn, schema, table).await?;
+    let columns = fetch_columns(dsn, schema, table).await?;
+    let foreign_keys = fetch_foreign_keys(dsn, schema, table, summaries).await?;
+    let primary_key = primary_key_names(&columns);
+    Ok(Table {
+        schema: schema.to_string(),
+        name: table_metadata.name,
+        owner: None,
+        columns: columns.iter().map(column_from_metadata).collect(),
+        primary_key: (!primary_key.is_empty()).then_some(primary_key),
+        foreign_keys,
+        indexes: Vec::new(),
+        rls: None,
+        triggers: Vec::new(),
+        row_count_estimate: table_metadata.row_count_estimate,
+        comment: table_metadata.comment,
+        source_ddl: None,
+        kind_info: TableKindInfo {
+            kind: table_metadata.kind,
+            ..TableKindInfo::default()
+        },
+    })
+}
+
+async fn find_table(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<MysqlTableMetadata, DbOperationError> {
+    let database = selected_database(dsn)?;
+    if schema != database {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    let result = execute_metadata_query(dsn, TABLES_QUERY).await?;
+    parse_table_metadata(&result)?
+        .into_iter()
+        .find(|candidate| candidate.name == table)
+        .ok_or_else(|| {
+            DbOperationError::ObjectMissing(format!("MySQL table not found: {schema}.{table}"))
+        })
+}
+
+async fn fetch_columns(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
+    let query = format!(
+        "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = {} ORDER BY c.ORDINAL_POSITION",
+        quote_string(table)
+    );
+    let result = execute_metadata_query(dsn, &query).await?;
+    let database = selected_database(dsn)?;
+    if schema != database {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    let columns = parse_column_metadata(&result)?;
+    if columns.is_empty() {
+        return Err(DbOperationError::MetadataParseFailed(format!(
+            "MySQL object has no column metadata: {schema}.{table}"
+        )));
+    }
+    Ok(columns)
+}
+
+async fn execute_metadata_query(
+    dsn: &str,
+    query: &str,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let target = parse_mysql_dsn(dsn)?;
+    validate_mysql_values(&target)?;
+    super::validate_mysql_tls_files(&target)?;
+    let statements = super::validate_mysql_multi_query(
+        query,
+        target.database.as_deref(),
+        AccessMode::ReadWrite,
+    )?;
+    let option_file = MySqlOptionFile::create(&target)?;
+    let result =
+        run_mysql_adhoc(&option_file.path, query, &statements, AccessMode::ReadWrite).await;
+    drop(option_file);
+    result?.result_set.ok_or_else(|| {
+        DbOperationError::MetadataParseFailed(
+            "MySQL metadata query returned no result set".to_string(),
+        )
+    })
+}
+
+fn selected_database(dsn: &str) -> Result<String, DbOperationError> {
+    parse_mysql_dsn(dsn)?.database.ok_or_else(|| {
+        DbOperationError::UnsupportedOperation(
+            "MySQL metadata requires a selected database".to_string(),
+        )
+    })
+}
+
+fn parse_table_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlTableMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &["TABLE_NAME", "TABLE_TYPE", "TABLE_ROWS", "TABLE_COMMENT"],
+    )?;
+    let tables = result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != 4 {
+                return Err(metadata_shape_error("TABLES row"));
+            }
+            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
+                return Ok(None);
+            }
+            let name = required_text(&row[0], "TABLE_NAME")?.to_string();
+            let kind = match required_text(&row[1], "TABLE_TYPE")? {
+                "BASE TABLE" => TableKind::Table,
+                "VIEW" => TableKind::View,
+                value => {
+                    return Err(DbOperationError::MetadataParseFailed(format!(
+                        "unexpected MySQL table type: {value}"
+                    )));
+                }
+            };
+            let row_count_estimate = optional_text(&row[2], "TABLE_ROWS")?
+                .map(|value| {
+                    value.parse::<i64>().map_err(|_| {
+                        DbOperationError::MetadataParseFailed(
+                            "invalid MySQL TABLE_ROWS value".to_string(),
+                        )
+                    })
+                })
+                .transpose()?;
+            let comment = optional_text(&row[3], "TABLE_COMMENT")?
+                .filter(|value| !value.is_empty())
+                .map(str::to_string);
+            Ok(Some(MysqlTableMetadata {
+                name,
+                kind,
+                row_count_estimate,
+                comment,
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(tables.into_iter().flatten().collect())
+}
+
+async fn fetch_indexes(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<Index>, DbOperationError> {
+    let query = format!(
+        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = DATABASE() AND s.TABLE_NAME = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = {}) ORDER BY INDEX_NAME, SEQ_IN_INDEX",
+        quote_string(table),
+        quote_string(table),
+    );
+    let result = execute_metadata_query(dsn, &query).await?;
+    let raw = parse_index_metadata(&result)?;
+    if schema != selected_database(dsn)? {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    Ok(indexes_from_metadata(raw))
+}
+
+async fn fetch_foreign_keys(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+    summaries: &[TableSummary],
+) -> Result<Vec<ForeignKey>, DbOperationError> {
+    let query = format!(
+        "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = DATABASE() AND tc.TABLE_NAME = {} AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_SCHEMA = DATABASE() AND TABLE_NAME = {} AND CONSTRAINT_TYPE = 'FOREIGN KEY') ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
+        quote_string(table),
+        quote_string(table),
+    );
+    let result = execute_metadata_query(dsn, &query).await?;
+    let raw = parse_foreign_key_metadata(&result)?;
+    if schema != selected_database(dsn)? {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    foreign_keys_from_metadata(raw, summaries)
+}
+
+async fn fetch_triggers(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<Trigger>, DbOperationError> {
+    if schema != selected_database(dsn)? {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    let result = execute_metadata_query(dsn, &triggers_query(table)).await?;
+    triggers_from_metadata(parse_trigger_metadata(&result)?)
+}
+
+async fn fetch_source_ddl(
+    dsn: &str,
+    table: &str,
+    kind: TableKind,
+) -> Result<String, DbOperationError> {
+    let result = execute_metadata_query(dsn, &show_create_query(table, kind)).await?;
+    parse_source_ddl(&result, kind)
+}
+
+fn triggers_query(table: &str) -> String {
+    format!(
+        "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {}) ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION",
+        quote_string(table),
+        quote_string(table),
+    )
+}
+
+fn show_create_query(table: &str, kind: TableKind) -> String {
+    let object_type = if kind == TableKind::View {
+        "VIEW"
+    } else {
+        "TABLE"
+    };
+    format!("SHOW CREATE {object_type} {}", quote_identifier(table))
+}
+
+fn parse_trigger_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlTriggerMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &[
+            "TRIGGER_NAME",
+            "ACTION_TIMING",
+            "EVENT_MANIPULATION",
+            "ACTION_STATEMENT",
+            "DEFINER",
+        ],
+    )?;
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != 5 {
+                return Err(metadata_shape_error("TRIGGERS row"));
+            }
+            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
+                return Ok(None);
+            }
+            let timing = required_text(&row[1], "ACTION_TIMING")?
+                .parse::<TriggerTiming>()
+                .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
+            let event = required_text(&row[2], "EVENT_MANIPULATION")?
+                .parse::<TriggerEvent>()
+                .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
+            Ok(Some(MysqlTriggerMetadata {
+                name: required_text(&row[0], "TRIGGER_NAME")?.to_string(),
+                timing,
+                event,
+                definition: required_text(&row[3], "ACTION_STATEMENT")?.to_string(),
+                security_context: optional_text(&row[4], "DEFINER")?.map(str::to_string),
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|rows| rows.into_iter().flatten().collect())
+}
+
+fn triggers_from_metadata(
+    raw: Vec<MysqlTriggerMetadata>,
+) -> Result<Vec<Trigger>, DbOperationError> {
+    let mut triggers = Vec::new();
+    for metadata in raw {
+        if let Some(trigger) = triggers
+            .iter_mut()
+            .find(|trigger: &&mut Trigger| trigger.name == metadata.name)
+        {
+            if trigger.timing != metadata.timing
+                || trigger.definition != metadata.definition
+                || trigger.security_context != metadata.security_context
+            {
+                return Err(metadata_shape_error("TRIGGERS definition"));
+            }
+            trigger.events.push(metadata.event);
+        } else {
+            triggers.push(Trigger {
+                name: metadata.name,
+                timing: metadata.timing,
+                events: vec![metadata.event],
+                definition: metadata.definition,
+                security_context: metadata.security_context,
+            });
+        }
+    }
+    Ok(triggers)
+}
+
+fn parse_source_ddl(result: &MysqlResultSet, kind: TableKind) -> Result<String, DbOperationError> {
+    let expected_columns = if kind == TableKind::View {
+        ["View", "Create View"]
+    } else {
+        ["Table", "Create Table"]
+    };
+    if result.columns.len() < 2
+        || result.columns[0] != expected_columns[0]
+        || result.columns[1] != expected_columns[1]
+        || result.values.len() != 1
+    {
+        return Err(metadata_shape_error("SHOW CREATE result"));
+    }
+    let row = &result.values[0];
+    if row.len() != result.columns.len() {
+        return Err(metadata_shape_error("SHOW CREATE row"));
+    }
+    let ddl = required_text(&row[1], expected_columns[1])?;
+    if ddl.is_empty() {
+        return Err(DbOperationError::MetadataParseFailed(
+            "MySQL SHOW CREATE returned empty DDL".to_string(),
+        ));
+    }
+    Ok(ddl.to_string())
+}
+
+fn parse_column_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &[
+            "COLUMN_NAME",
+            "COLUMN_TYPE",
+            "IS_NULLABLE",
+            "COLUMN_DEFAULT",
+            "EXTRA",
+            "COLUMN_COMMENT",
+            "ORDINAL_POSITION",
+            "PRIMARY_KEY_POSITION",
+        ],
+    )?;
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != 8 {
+                return Err(metadata_shape_error("COLUMNS row"));
+            }
+            let extra = required_text(&row[4], "EXTRA")?;
+            Ok(MysqlColumnMetadata {
+                name: required_text(&row[0], "COLUMN_NAME")?.to_string(),
+                data_type: required_text(&row[1], "COLUMN_TYPE")?.to_string(),
+                nullable: required_text(&row[2], "IS_NULLABLE")? == "YES",
+                default: optional_text(&row[3], "COLUMN_DEFAULT")?.map(str::to_string),
+                comment: optional_text(&row[5], "COLUMN_COMMENT")?
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string),
+                ordinal_position: parse_positive_i32(&row[6], "ORDINAL_POSITION")?,
+                primary_key_position: optional_text(&row[7], "PRIMARY_KEY_POSITION")?
+                    .map(|value| parse_positive_i32_text(value, "PRIMARY_KEY_POSITION"))
+                    .transpose()?,
+                invisible: extra
+                    .split_ascii_whitespace()
+                    .any(|word| word.eq_ignore_ascii_case("INVISIBLE")),
+                generated: extra
+                    .split_ascii_whitespace()
+                    .any(|word| word.eq_ignore_ascii_case("GENERATED")),
+            })
+        })
+        .collect()
+}
+
+fn parse_index_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlIndexMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &[
+            "INDEX_NAME",
+            "NON_UNIQUE",
+            "INDEX_TYPE",
+            "SEQ_IN_INDEX",
+            "COLUMN_NAME",
+            "IS_PRIMARY",
+        ],
+    )?;
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
+                return Ok(None);
+            }
+            if row.len() != 6 {
+                return Err(metadata_shape_error("STATISTICS row"));
+            }
+            Ok(Some(MysqlIndexMetadata {
+                name: required_text(&row[0], "INDEX_NAME")?.to_string(),
+                non_unique: parse_boolean_flag(&row[1], "NON_UNIQUE")?,
+                index_type: required_text(&row[2], "INDEX_TYPE")?.to_string(),
+                ordinal_position: parse_positive_i32(&row[3], "SEQ_IN_INDEX")?,
+                column_name: required_text(&row[4], "COLUMN_NAME")?.to_string(),
+                primary: parse_boolean_flag(&row[5], "IS_PRIMARY")?,
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|rows| rows.into_iter().flatten().collect())
+}
+
+fn parse_foreign_key_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlForeignKeyMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &[
+            "CONSTRAINT_NAME",
+            "TABLE_SCHEMA",
+            "TABLE_NAME",
+            "COLUMN_NAME",
+            "REFERENCED_TABLE_SCHEMA",
+            "REFERENCED_TABLE_NAME",
+            "REFERENCED_COLUMN_NAME",
+            "ORDINAL_POSITION",
+            "UPDATE_RULE",
+            "DELETE_RULE",
+        ],
+    )?;
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
+                return Ok(None);
+            }
+            if row.len() != 10 {
+                return Err(metadata_shape_error("foreign key row"));
+            }
+            Ok(Some(MysqlForeignKeyMetadata {
+                name: required_text(&row[0], "CONSTRAINT_NAME")?.to_string(),
+                from_schema: required_text(&row[1], "TABLE_SCHEMA")?.to_string(),
+                from_table: required_text(&row[2], "TABLE_NAME")?.to_string(),
+                from_column: required_text(&row[3], "COLUMN_NAME")?.to_string(),
+                to_schema: required_text(&row[4], "REFERENCED_TABLE_SCHEMA")?.to_string(),
+                to_table: required_text(&row[5], "REFERENCED_TABLE_NAME")?.to_string(),
+                to_column: required_text(&row[6], "REFERENCED_COLUMN_NAME")?.to_string(),
+                ordinal_position: parse_positive_i32(&row[7], "ORDINAL_POSITION")?,
+                on_update: parse_fk_action(&row[8], "UPDATE_RULE")?,
+                on_delete: parse_fk_action(&row[9], "DELETE_RULE")?,
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|rows| rows.into_iter().flatten().collect())
+}
+
+fn indexes_from_metadata(mut raw: Vec<MysqlIndexMetadata>) -> Vec<Index> {
+    raw.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then(left.ordinal_position.cmp(&right.ordinal_position))
+    });
+    let mut indexes = Vec::new();
+    for column in raw {
+        if let Some(index) = indexes
+            .iter_mut()
+            .find(|index: &&mut Index| index.name == column.name)
+        {
+            index.columns.push(column.column_name);
+            continue;
+        }
+        indexes.push(Index {
+            name: column.name,
+            columns: vec![column.column_name],
+            attributes: IndexAttributes::from_parts(!column.non_unique, column.primary),
+            index_type: column
+                .index_type
+                .to_ascii_lowercase()
+                .parse::<IndexType>()
+                .unwrap_or_else(|never| match never {}),
+            definition: None,
+        });
+    }
+    indexes
+}
+
+fn foreign_keys_from_metadata(
+    mut raw: Vec<MysqlForeignKeyMetadata>,
+    summaries: &[TableSummary],
+) -> Result<Vec<ForeignKey>, DbOperationError> {
+    raw.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then(left.ordinal_position.cmp(&right.ordinal_position))
+    });
+    let mut foreign_keys = Vec::new();
+    for column in raw {
+        let reference_resolved = summaries
+            .iter()
+            .any(|summary| summary.schema == column.to_schema && summary.name == column.to_table);
+        if let Some(foreign_key) = foreign_keys
+            .iter_mut()
+            .find(|foreign_key: &&mut ForeignKey| foreign_key.name == column.name)
+        {
+            if foreign_key.from_schema != column.from_schema
+                || foreign_key.from_table != column.from_table
+                || foreign_key.to_schema != column.to_schema
+                || foreign_key.to_table != column.to_table
+                || foreign_key.on_update != column.on_update
+                || foreign_key.on_delete != column.on_delete
+            {
+                return Err(metadata_shape_error("foreign key constraint columns"));
+            }
+            foreign_key.from_columns.push(column.from_column);
+            foreign_key.to_columns.push(column.to_column);
+            foreign_key.reference_resolved &= reference_resolved;
+            continue;
+        }
+        foreign_keys.push(ForeignKey {
+            name: column.name,
+            from_schema: column.from_schema,
+            from_table: column.from_table,
+            from_columns: vec![column.from_column],
+            to_schema: column.to_schema,
+            to_table: column.to_table,
+            to_columns: vec![column.to_column],
+            on_delete: column.on_delete,
+            on_update: column.on_update,
+            reference_resolved,
+        });
+    }
+    Ok(foreign_keys)
+}
+
+fn column_from_metadata(metadata: &MysqlColumnMetadata) -> Column {
+    let primary_key = metadata.primary_key_position.is_some();
+    let attributes = ColumnAttributes::from_parts(metadata.nullable, primary_key, false)
+        | if metadata.invisible {
+            ColumnAttributes::HIDDEN | ColumnAttributes::READ_ONLY
+        } else {
+            ColumnAttributes::empty()
+        }
+        | if metadata.generated {
+            ColumnAttributes::GENERATED | ColumnAttributes::READ_ONLY
+        } else {
+            ColumnAttributes::empty()
+        };
+    Column {
+        name: metadata.name.clone(),
+        data_type: metadata.data_type.clone(),
+        default: metadata.default.clone(),
+        attributes,
+        comment: metadata.comment.clone(),
+        ordinal_position: metadata.ordinal_position,
+    }
+}
+
+fn primary_key_names(columns: &[MysqlColumnMetadata]) -> Vec<String> {
+    let mut columns = columns
+        .iter()
+        .filter_map(|column| {
+            column
+                .primary_key_position
+                .map(|position| (position, column.name.clone()))
+        })
+        .collect::<Vec<_>>();
+    columns.sort_by_key(|(position, _)| *position);
+    columns.into_iter().map(|(_, name)| name).collect()
+}
+
+fn parse_boolean_flag(value: &QueryValue, field: &str) -> Result<bool, DbOperationError> {
+    match required_text(value, field)? {
+        "0" | "NO" => Ok(false),
+        "1" | "YES" => Ok(true),
+        _ => Err(DbOperationError::MetadataParseFailed(format!(
+            "invalid MySQL metadata boolean: {field}"
+        ))),
+    }
+}
+
+fn parse_fk_action(value: &QueryValue, field: &str) -> Result<FkAction, DbOperationError> {
+    required_text(value, field)?.parse().map_err(|error| {
+        DbOperationError::MetadataParseFailed(format!("invalid MySQL foreign key action: {error}"))
+    })
+}
+
+fn table_signature(table: &Table) -> String {
+    format!(
+        "{:?}|{:?}|{:?}",
+        table.kind_info.kind, table.columns, table.foreign_keys
+    )
+}
+
+fn table_summary(database: &str, table: MysqlTableMetadata) -> TableSummary {
+    TableSummary::new(
+        database.to_string(),
+        table.name,
+        table.row_count_estimate,
+        false,
+    )
+    .with_kind_info(TableKindInfo {
+        kind: table.kind,
+        ..TableKindInfo::default()
+    })
+}
+
+fn expect_columns(result: &MysqlResultSet, expected: &[&str]) -> Result<(), DbOperationError> {
+    if result.columns == expected {
+        Ok(())
+    } else {
+        Err(metadata_shape_error("MySQL metadata columns"))
+    }
+}
+
+fn required_text<'a>(value: &'a QueryValue, field: &str) -> Result<&'a str, DbOperationError> {
+    optional_text(value, field)?.ok_or_else(|| {
+        DbOperationError::MetadataParseFailed(format!("MySQL metadata field is NULL: {field}"))
+    })
+}
+
+fn optional_text<'a>(
+    value: &'a QueryValue,
+    field: &str,
+) -> Result<Option<&'a str>, DbOperationError> {
+    match value {
+        QueryValue::Null => Ok(None),
+        QueryValue::Text(value) | QueryValue::SqlLiteral(value) => Ok(Some(value)),
+        QueryValue::Blob(_) => Err(DbOperationError::MetadataParseFailed(format!(
+            "MySQL metadata field is binary: {field}"
+        ))),
+    }
+}
+
+fn parse_positive_i32(value: &QueryValue, field: &str) -> Result<i32, DbOperationError> {
+    parse_positive_i32_text(required_text(value, field)?, field)
+}
+
+fn parse_positive_i32_text(value: &str, field: &str) -> Result<i32, DbOperationError> {
+    let value = value.parse::<i32>().map_err(|_| {
+        DbOperationError::MetadataParseFailed(format!("invalid MySQL metadata integer: {field}"))
+    })?;
+    if value > 0 {
+        Ok(value)
+    } else {
+        Err(DbOperationError::MetadataParseFailed(format!(
+            "invalid MySQL metadata ordinal: {field}"
+        )))
+    }
+}
+
+fn metadata_shape_error(field: &str) -> DbOperationError {
+    DbOperationError::MetadataParseFailed(format!("unexpected MySQL metadata shape: {field}"))
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("`{}`", value.replace('`', "``"))
+}
+
+fn quote_string(value: &str) -> String {
+    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "''"))
+}
+
+fn is_binary_type(data_type: &str) -> bool {
+    let name = data_type
+        .split(['(', ' '])
+        .next()
+        .unwrap_or(data_type)
+        .to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        "binary" | "varbinary" | "tinyblob" | "blob" | "mediumblob" | "longblob" | "bit"
+    )
+}
+
+fn is_numeric_type(data_type: &str) -> bool {
+    let name = data_type
+        .split(['(', ' '])
+        .next()
+        .unwrap_or(data_type)
+        .to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        "tinyint"
+            | "smallint"
+            | "mediumint"
+            | "int"
+            | "integer"
+            | "bigint"
+            | "decimal"
+            | "dec"
+            | "numeric"
+            | "fixed"
+            | "float"
+            | "double"
+            | "real"
+    )
+}
+
+fn decode_hex(value: &str) -> Option<Vec<u8>> {
+    let hex = value.strip_prefix("0x")?;
+    if hex.len() % 2 != 0 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    (0..hex.len())
+        .step_by(2)
+        .map(|index| u8::from_str_radix(&hex[index..index + 2], 16).ok())
+        .collect()
+}
+
+fn is_sql_numeric_literal(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+    let mut index = usize::from(matches!(bytes[0], b'+' | b'-'));
+    let integer_start = index;
+    while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+        index += 1;
+    }
+    let has_integer = index > integer_start;
+    let mut has_fraction = false;
+    if bytes.get(index) == Some(&b'.') {
+        has_fraction = true;
+        index += 1;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+    }
+    if !has_integer && !has_fraction {
+        return false;
+    }
+    if matches!(bytes.get(index), Some(b'e' | b'E')) {
+        index += 1;
+        if matches!(bytes.get(index), Some(b'+' | b'-')) {
+            index += 1;
+        }
+        let exponent_start = index;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+        if exponent_start == index {
+            return false;
+        }
+    }
+    index == bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
+        MysqlResultSet {
+            columns: columns.iter().map(|value| (*value).to_string()).collect(),
+            values,
+        }
+    }
+
+    fn column(name: &str, data_type: &str) -> Column {
+        Column {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            default: None,
+            attributes: ColumnAttributes::empty(),
+            comment: None,
+            ordinal_position: 1,
+        }
+    }
+
+    #[test]
+    fn trigger_metadata_preserves_action_definer_and_event_order() {
+        let result = result(
+            &[
+                "TRIGGER_NAME",
+                "ACTION_TIMING",
+                "EVENT_MANIPULATION",
+                "ACTION_STATEMENT",
+                "DEFINER",
+            ],
+            vec![
+                vec![
+                    QueryValue::Text("audit_changes".to_string()),
+                    QueryValue::Text("BEFORE".to_string()),
+                    QueryValue::Text("INSERT".to_string()),
+                    QueryValue::Text("BEGIN\n  SET @seen = 1;\nEND".to_string()),
+                    QueryValue::Text("sabiql@%".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("audit_changes".to_string()),
+                    QueryValue::Text("BEFORE".to_string()),
+                    QueryValue::Text("UPDATE".to_string()),
+                    QueryValue::Text("BEGIN\n  SET @seen = 1;\nEND".to_string()),
+                    QueryValue::Text("sabiql@%".to_string()),
+                ],
+            ],
+        );
+
+        let triggers = triggers_from_metadata(parse_trigger_metadata(&result).unwrap()).unwrap();
+
+        assert_eq!(triggers.len(), 1);
+        assert_eq!(
+            triggers[0].events,
+            [TriggerEvent::Insert, TriggerEvent::Update]
+        );
+        assert_eq!(triggers[0].definition, "BEGIN\n  SET @seen = 1;\nEND");
+        assert_eq!(triggers[0].security_context.as_deref(), Some("sabiql@%"));
+    }
+
+    #[test]
+    fn empty_trigger_sentinel_returns_no_triggers() {
+        let result = result(
+            &[
+                "TRIGGER_NAME",
+                "ACTION_TIMING",
+                "EVENT_MANIPULATION",
+                "ACTION_STATEMENT",
+                "DEFINER",
+            ],
+            vec![vec![
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+            ]],
+        );
+
+        assert!(parse_trigger_metadata(&result).unwrap().is_empty());
+    }
+
+    #[test]
+    fn show_create_query_uses_object_kind_and_identifier_quoting() {
+        assert_eq!(
+            show_create_query("table`name", TableKind::Table),
+            "SHOW CREATE TABLE `table``name`"
+        );
+        assert_eq!(
+            show_create_query("view_name", TableKind::View),
+            "SHOW CREATE VIEW `view_name`"
+        );
+    }
+
+    #[test]
+    fn show_create_parser_preserves_view_ddl_and_extra_server_columns() {
+        let ddl = "CREATE ALGORITHM=UNDEFINED VIEW `v` AS select 1";
+        let result = result(
+            &[
+                "View",
+                "Create View",
+                "character_set_client",
+                "collation_connection",
+            ],
+            vec![vec![
+                QueryValue::Text("v".to_string()),
+                QueryValue::Text(ddl.to_string()),
+                QueryValue::Text("utf8mb4".to_string()),
+                QueryValue::Text("utf8mb4_0900_ai_ci".to_string()),
+            ]],
+        );
+
+        assert_eq!(parse_source_ddl(&result, TableKind::View).unwrap(), ddl);
+    }
+
+    #[test]
+    fn preview_conversion_keeps_text_hex_and_decodes_binary_hex() {
+        let result = result(
+            &["text_value", "binary_value"],
+            vec![vec![
+                QueryValue::Text("0x41".to_string()),
+                QueryValue::Text("0x00FF".to_string()),
+            ]],
+        );
+        let columns = vec![
+            column("text_value", "varchar(20)"),
+            column("binary_value", "blob"),
+        ];
+
+        let values = convert_preview_values(&result, &columns, &[]).expect("conversion succeeds");
+
+        assert_eq!(values.visible[0][0], QueryValue::Text("0x41".to_string()));
+        assert_eq!(values.visible[0][1], QueryValue::Blob(vec![0, 255]));
+    }
+
+    #[test]
+    fn preview_conversion_keeps_numeric_server_literals_without_rounding() {
+        let result = result(
+            &["unsigned_value", "decimal_value", "float_value"],
+            vec![vec![
+                QueryValue::Text("18446744073709551615".to_string()),
+                QueryValue::Text("12345678901234567890.12345678901234567890".to_string()),
+                QueryValue::Text("1.23e+100".to_string()),
+            ]],
+        );
+        let columns = vec![
+            column("unsigned_value", "bigint unsigned"),
+            column("decimal_value", "decimal(65,30)"),
+            column("float_value", "double"),
+        ];
+
+        let values = convert_preview_values(&result, &columns, &[]).expect("conversion succeeds");
+
+        assert_eq!(values.visible[0][0].as_str(), Some("18446744073709551615"));
+        assert!(matches!(values.visible[0][0], QueryValue::SqlLiteral(_)));
+        assert!(matches!(values.visible[0][1], QueryValue::SqlLiteral(_)));
+        assert!(matches!(values.visible[0][2], QueryValue::SqlLiteral(_)));
+    }
+
+    #[test]
+    fn numeric_literal_validation_rejects_partial_values() {
+        assert!(is_sql_numeric_literal("1."));
+        assert!(is_sql_numeric_literal(".5"));
+        assert!(is_sql_numeric_literal("-1.2e-3"));
+        assert!(!is_sql_numeric_literal("1e"));
+        assert!(!is_sql_numeric_literal("nan"));
+    }
+
+    #[test]
+    fn preview_query_lists_visible_columns_and_orders_by_primary_key() {
+        let columns = vec![column("id", "int"), column("display", "text")];
+
+        let query = build_preview_query(
+            "app",
+            "items",
+            &["id".to_string()],
+            &columns,
+            &[],
+            500,
+            1000,
+        );
+
+        assert_eq!(
+            query,
+            "SELECT `id`, `display` FROM `app`.`items` ORDER BY `id` LIMIT 500 OFFSET 1000"
+        );
+    }
+
+    #[test]
+    fn preview_query_appends_aliased_hidden_primary_key_columns() {
+        let visible_columns = vec![column("payload", "text")];
+        let identity_columns = vec![column("id", "int")];
+
+        let query = build_preview_query(
+            "app",
+            "items",
+            &["id".to_string()],
+            &visible_columns,
+            &identity_columns,
+            10,
+            0,
+        );
+
+        assert_eq!(
+            query,
+            "SELECT `payload`, `id` AS `__sabiql_row_identity_0` FROM `app`.`items` ORDER BY `id` LIMIT 10 OFFSET 0"
+        );
+    }
+
+    #[test]
+    fn preview_conversion_separates_aliased_primary_key_values() {
+        let result = result(
+            &["payload", "__sabiql_row_identity_0"],
+            vec![vec![
+                QueryValue::Text("visible".to_string()),
+                QueryValue::Text("42".to_string()),
+            ]],
+        );
+        let visible_columns = vec![column("payload", "text")];
+        let identity_columns = vec![column("id", "int")];
+
+        let values = convert_preview_values(&result, &visible_columns, &identity_columns)
+            .expect("conversion succeeds");
+
+        assert_eq!(
+            values.visible,
+            vec![vec![QueryValue::Text("visible".to_string())]]
+        );
+        assert_eq!(
+            values.identity,
+            Some(vec![vec![QueryValue::SqlLiteral("42".to_string())]])
+        );
+    }
+
+    #[test]
+    fn metadata_parser_preserves_column_and_composite_key_order() {
+        let result = result(
+            &[
+                "COLUMN_NAME",
+                "COLUMN_TYPE",
+                "IS_NULLABLE",
+                "COLUMN_DEFAULT",
+                "EXTRA",
+                "COLUMN_COMMENT",
+                "ORDINAL_POSITION",
+                "PRIMARY_KEY_POSITION",
+            ],
+            vec![
+                vec![
+                    QueryValue::Text("first_key".to_string()),
+                    QueryValue::Text("int".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("2".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("second_key".to_string()),
+                    QueryValue::Text("int".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Text("1".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("generated_value".to_string()),
+                    QueryValue::Text("int".to_string()),
+                    QueryValue::Text("YES".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("STORED GENERATED".to_string()),
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text("3".to_string()),
+                    QueryValue::Null,
+                ],
+            ],
+        );
+
+        let parsed = parse_column_metadata(&result).expect("metadata parses");
+        assert_eq!(primary_key_names(&parsed), ["second_key", "first_key"]);
+        assert_eq!(
+            parsed
+                .iter()
+                .map(|column| column.ordinal_position)
+                .collect::<Vec<_>>(),
+            [1, 2, 3]
+        );
+        assert!(column_from_metadata(&parsed[2]).is_generated());
+    }
+
+    #[test]
+    fn empty_table_list_sentinel_parses_as_no_tables() {
+        let result = result(
+            &["TABLE_NAME", "TABLE_TYPE", "TABLE_ROWS", "TABLE_COMMENT"],
+            vec![vec![
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+            ]],
+        );
+
+        assert!(
+            parse_table_metadata(&result)
+                .expect("empty table metadata parses")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn groups_indexes_by_name_and_orders_columns_by_sequence() {
+        let result = result(
+            &[
+                "INDEX_NAME",
+                "NON_UNIQUE",
+                "INDEX_TYPE",
+                "SEQ_IN_INDEX",
+                "COLUMN_NAME",
+                "IS_PRIMARY",
+            ],
+            vec![
+                vec![
+                    QueryValue::Text("PRIMARY".to_string()),
+                    QueryValue::Text("0".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Text("second_key".to_string()),
+                    QueryValue::Text("YES".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("PRIMARY".to_string()),
+                    QueryValue::Text("0".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("first_key".to_string()),
+                    QueryValue::Text("YES".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("search_index".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("FULLTEXT".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("body".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                ],
+            ],
+        );
+
+        let indexes = indexes_from_metadata(parse_index_metadata(&result).unwrap());
+
+        assert_eq!(indexes[0].name, "PRIMARY");
+        assert_eq!(indexes[0].columns, ["first_key", "second_key"]);
+        assert!(indexes[0].is_primary());
+        assert_eq!(
+            indexes[1].index_type,
+            IndexType::Other("fulltext".to_string())
+        );
+        assert!(!indexes[1].is_unique());
+    }
+
+    #[test]
+    fn groups_foreign_keys_by_name_and_orders_columns_by_sequence() {
+        let result = result(
+            &[
+                "CONSTRAINT_NAME",
+                "TABLE_SCHEMA",
+                "TABLE_NAME",
+                "COLUMN_NAME",
+                "REFERENCED_TABLE_SCHEMA",
+                "REFERENCED_TABLE_NAME",
+                "REFERENCED_COLUMN_NAME",
+                "ORDINAL_POSITION",
+                "UPDATE_RULE",
+                "DELETE_RULE",
+            ],
+            vec![
+                vec![
+                    QueryValue::Text("fk_child_parent".to_string()),
+                    QueryValue::Text("sabiql_test".to_string()),
+                    QueryValue::Text("child".to_string()),
+                    QueryValue::Text("parent_second".to_string()),
+                    QueryValue::Text("sabiql_test".to_string()),
+                    QueryValue::Text("parent".to_string()),
+                    QueryValue::Text("second_key".to_string()),
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Text("CASCADE".to_string()),
+                    QueryValue::Text("SET NULL".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("fk_child_parent".to_string()),
+                    QueryValue::Text("sabiql_test".to_string()),
+                    QueryValue::Text("child".to_string()),
+                    QueryValue::Text("parent_first".to_string()),
+                    QueryValue::Text("sabiql_test".to_string()),
+                    QueryValue::Text("parent".to_string()),
+                    QueryValue::Text("first_key".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("CASCADE".to_string()),
+                    QueryValue::Text("SET NULL".to_string()),
+                ],
+            ],
+        );
+
+        let summaries = [TableSummary::new(
+            "sabiql_test".to_string(),
+            "parent".to_string(),
+            None,
+            false,
+        )];
+        let foreign_keys =
+            foreign_keys_from_metadata(parse_foreign_key_metadata(&result).unwrap(), &summaries)
+                .unwrap();
+
+        assert_eq!(foreign_keys.len(), 1);
+        assert_eq!(
+            foreign_keys[0].from_columns,
+            ["parent_first", "parent_second"]
+        );
+        assert_eq!(foreign_keys[0].to_columns, ["first_key", "second_key"]);
+        assert_eq!(foreign_keys[0].on_update, FkAction::Cascade);
+        assert_eq!(foreign_keys[0].on_delete, FkAction::SetNull);
+
+        let unresolved =
+            foreign_keys_from_metadata(parse_foreign_key_metadata(&result).unwrap(), &[]).unwrap();
+        assert!(!unresolved[0].is_reference_resolved());
+    }
+}

--- a/src/infra/adapters/query_history.rs
+++ b/src/infra/adapters/query_history.rs
@@ -4,8 +4,7 @@ use async_trait::async_trait;
 
 use crate::app::ports::outbound::{QueryHistoryError, QueryHistoryStore};
 use crate::config::cache::{CacheDirError, get_cache_dir};
-use crate::domain::connection::ConnectionId;
-use crate::domain::query_history::QueryHistoryEntry;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 
 const MAX_HISTORY_ENTRIES: usize = 1000;
 
@@ -80,11 +79,11 @@ impl QueryHistoryStore for FileQueryHistoryStore {
     async fn append(
         &self,
         project_name: &str,
-        connection_id: &ConnectionId,
+        scope: &QueryHistoryScope,
         entry: &QueryHistoryEntry,
     ) -> Result<(), QueryHistoryError> {
         let history_dir = self.resolve_history_dir(project_name)?;
-        let path = history_dir.join(format!("{connection_id}.jsonl"));
+        let path = history_dir.join(format!("{}.jsonl", scope.connection_id));
         let line = serde_json::to_string(entry)?;
 
         tokio::task::spawn_blocking(move || {
@@ -99,10 +98,11 @@ impl QueryHistoryStore for FileQueryHistoryStore {
     async fn load(
         &self,
         project_name: &str,
-        connection_id: &ConnectionId,
+        scope: &QueryHistoryScope,
     ) -> Result<Vec<QueryHistoryEntry>, QueryHistoryError> {
         let history_dir = self.resolve_history_dir(project_name)?;
-        let path = history_dir.join(format!("{connection_id}.jsonl"));
+        let path = history_dir.join(format!("{}.jsonl", scope.connection_id));
+        let database = scope.database.clone();
 
         tokio::task::spawn_blocking(move || {
             if !path.exists() {
@@ -114,6 +114,7 @@ impl QueryHistoryStore for FileQueryHistoryStore {
                 .lines()
                 .filter(|line| !line.trim().is_empty())
                 .filter_map(|line| serde_json::from_str(line).ok())
+                .filter(|entry: &QueryHistoryEntry| entry.database == database)
                 .collect();
 
             Ok(entries)
@@ -125,6 +126,7 @@ impl QueryHistoryStore for FileQueryHistoryStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::connection::ConnectionId;
     use crate::domain::query_history::QueryResultStatus;
     use tempfile::TempDir;
 
@@ -138,6 +140,14 @@ mod tests {
         )
     }
 
+    fn scope(connection_id: &ConnectionId) -> QueryHistoryScope {
+        QueryHistoryScope::new(connection_id.clone(), None)
+    }
+
+    fn database_scope(connection_id: &ConnectionId, database: &str) -> QueryHistoryScope {
+        QueryHistoryScope::new(connection_id.clone(), Some(database.to_string()))
+    }
+
     #[tokio::test]
     async fn append_and_load_succeed_for_cli_sqlite_connection_id() {
         use sabiql_app::cmd::cli_sqlite::connection_id_for_path;
@@ -149,7 +159,7 @@ mod tests {
         assert!(!conn_id.as_str().contains('/'));
 
         store
-            .append("test", &conn_id, &make_entry("SELECT 1"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 1"))
             .await
             .unwrap();
 
@@ -157,7 +167,7 @@ mod tests {
         let path = history_dir.join(format!("{conn_id}.jsonl"));
         assert!(path.is_file());
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].query, "SELECT 1");
     }
@@ -169,7 +179,10 @@ mod tests {
         let conn_id = ConnectionId::from_string("test-conn");
 
         let entry = make_entry("SELECT 1");
-        store.append("test", &conn_id, &entry).await.unwrap();
+        store
+            .append("test", &scope(&conn_id), &entry)
+            .await
+            .unwrap();
 
         let history_dir = tmp.path().join("history");
         let path = history_dir.join(format!("{conn_id}.jsonl"));
@@ -186,24 +199,82 @@ mod tests {
         let conn_id = ConnectionId::from_string("test-conn");
 
         store
-            .append("test", &conn_id, &make_entry("SELECT 1"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 1"))
             .await
             .unwrap();
         store
-            .append("test", &conn_id, &make_entry("SELECT 2"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 2"))
             .await
             .unwrap();
         store
-            .append("test", &conn_id, &make_entry("SELECT 3"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 3"))
             .await
             .unwrap();
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
 
         assert_eq!(entries.len(), 3);
         assert_eq!(entries[0].query, "SELECT 1");
         assert_eq!(entries[1].query, "SELECT 2");
         assert_eq!(entries[2].query, "SELECT 3");
+    }
+
+    #[tokio::test]
+    async fn load_filters_entries_by_database_scope() {
+        let tmp = TempDir::new().unwrap();
+        let store = FileQueryHistoryStore::with_base_dir(tmp.path().to_path_buf());
+        let conn_id = ConnectionId::from_string("test-conn");
+        let app_scope = database_scope(&conn_id, "app");
+        let analytics_scope = database_scope(&conn_id, "analytics");
+
+        store
+            .append(
+                "test",
+                &app_scope,
+                &QueryHistoryEntry::new_with_database(
+                    "SELECT app".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    conn_id.clone(),
+                    Some("app".to_string()),
+                    QueryResultStatus::Success,
+                    None,
+                ),
+            )
+            .await
+            .unwrap();
+        store
+            .append(
+                "test",
+                &analytics_scope,
+                &QueryHistoryEntry::new_with_database(
+                    "SELECT analytics".to_string(),
+                    "2026-03-13T12:01:00Z".to_string(),
+                    conn_id.clone(),
+                    Some("analytics".to_string()),
+                    QueryResultStatus::Success,
+                    None,
+                ),
+            )
+            .await
+            .unwrap();
+
+        let app_entries = store.load("test", &app_scope).await.unwrap();
+        let analytics_entries = store.load("test", &analytics_scope).await.unwrap();
+
+        assert_eq!(
+            app_entries
+                .iter()
+                .map(|entry| entry.query.as_str())
+                .collect::<Vec<_>>(),
+            ["SELECT app"]
+        );
+        assert_eq!(
+            analytics_entries
+                .iter()
+                .map(|entry| entry.query.as_str())
+                .collect::<Vec<_>>(),
+            ["SELECT analytics"]
+        );
     }
 
     #[tokio::test]
@@ -215,12 +286,16 @@ mod tests {
         // Write 1001 entries
         for i in 0..1001 {
             store
-                .append("test", &conn_id, &make_entry(&format!("SELECT {i}")))
+                .append(
+                    "test",
+                    &scope(&conn_id),
+                    &make_entry(&format!("SELECT {i}")),
+                )
                 .await
                 .unwrap();
         }
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
 
         assert_eq!(entries.len(), MAX_HISTORY_ENTRIES);
         // Oldest entry (SELECT 0) should be trimmed, newest (SELECT 1000) should remain
@@ -234,7 +309,7 @@ mod tests {
         let store = FileQueryHistoryStore::with_base_dir(tmp.path().to_path_buf());
         let conn_id = ConnectionId::from_string("nonexistent");
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
 
         assert!(entries.is_empty());
     }
@@ -247,7 +322,7 @@ mod tests {
 
         // Write a valid entry
         store
-            .append("test", &conn_id, &make_entry("SELECT 1"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 1"))
             .await
             .unwrap();
 
@@ -261,11 +336,11 @@ mod tests {
 
         // Write another valid entry
         store
-            .append("test", &conn_id, &make_entry("SELECT 2"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT 2"))
             .await
             .unwrap();
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
 
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].query, "SELECT 1");
@@ -280,12 +355,16 @@ mod tests {
 
         for i in 0..5 {
             store
-                .append("test", &conn_id, &make_entry(&format!("SELECT {i}")))
+                .append(
+                    "test",
+                    &scope(&conn_id),
+                    &make_entry(&format!("SELECT {i}")),
+                )
                 .await
                 .unwrap();
         }
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
         assert_eq!(entries.len(), 5);
         assert_eq!(entries[0].query, "SELECT 0");
         assert_eq!(entries[4].query, "SELECT 4");
@@ -299,12 +378,16 @@ mod tests {
 
         for i in 0..MAX_HISTORY_ENTRIES {
             store
-                .append("test", &conn_id, &make_entry(&format!("SELECT {i}")))
+                .append(
+                    "test",
+                    &scope(&conn_id),
+                    &make_entry(&format!("SELECT {i}")),
+                )
                 .await
                 .unwrap();
         }
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
         assert_eq!(entries.len(), MAX_HISTORY_ENTRIES);
         assert_eq!(entries[0].query, "SELECT 0");
         assert_eq!(
@@ -322,12 +405,16 @@ mod tests {
         let total = MAX_HISTORY_ENTRIES + 5;
         for i in 0..total {
             store
-                .append("test", &conn_id, &make_entry(&format!("SELECT {i}")))
+                .append(
+                    "test",
+                    &scope(&conn_id),
+                    &make_entry(&format!("SELECT {i}")),
+                )
                 .await
                 .unwrap();
         }
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
         assert_eq!(entries.len(), MAX_HISTORY_ENTRIES);
         // Oldest 5 entries (0..5) should be trimmed
         assert_eq!(entries[0].query, "SELECT 5");
@@ -346,7 +433,11 @@ mod tests {
         // Fill to just above the limit so trim fires on next append
         for i in 0..MAX_HISTORY_ENTRIES {
             store
-                .append("test", &conn_id, &make_entry(&format!("SELECT {i}")))
+                .append(
+                    "test",
+                    &scope(&conn_id),
+                    &make_entry(&format!("SELECT {i}")),
+                )
                 .await
                 .unwrap();
         }
@@ -358,12 +449,12 @@ mod tests {
 
         // append should still succeed (trim failure is best-effort)
         let result = store
-            .append("test", &conn_id, &make_entry("SELECT final"))
+            .append("test", &scope(&conn_id), &make_entry("SELECT final"))
             .await;
         assert!(result.is_ok());
 
         // The entry was written even though trim failed
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
         assert!(entries.len() > MAX_HISTORY_ENTRIES);
         assert_eq!(entries.last().unwrap().query, "SELECT final");
     }
@@ -385,7 +476,7 @@ mod tests {
         // Malformed line should be skipped
         writeln!(file, "not valid json").unwrap();
 
-        let entries = store.load("test", &conn_id).await.unwrap();
+        let entries = store.load("test", &scope(&conn_id)).await.unwrap();
 
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].query, "SELECT 1");

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1,0 +1,1102 @@
+//! Integration tests for the Oracle MySQL 8.4 server and mysql CLI.
+//!
+//! Start the exact fixture and CLI wrapper with:
+//! bash scripts/mysql_integration.sh test
+
+use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+use sabiql_app::ports::outbound::{
+    AccessMode, ConnectionProbe, DbOperationError, DdlGenerator, DsnBuilder,
+    MYSQL_SQL_MODE_UNSUPPORTED_MARKER, MetadataProvider, QueryExecutor, SqlDialect,
+};
+use sabiql_domain::{
+    CommandTag, DatabaseType, FkAction, IndexType, QueryValue, RefreshScope, TableKind,
+    TriggerEvent, TriggerTiming,
+};
+
+use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, mysql_tls_config, with_mysql_test_db};
+use sabiql_domain::connection::{
+    ConnectionConfig, ConnectionId, ConnectionProfile, MySqlConnectionConfig, MySqlSslMode,
+};
+use sabiql_infra::adapters::mysql::MySqlAdapter;
+
+fn mysql_tls_profile(name: &str, config: MySqlConnectionConfig) -> ConnectionProfile {
+    ConnectionProfile::with_id_and_config(
+        ConnectionId::new(),
+        name,
+        ConnectionConfig::MySQL(config),
+    )
+    .unwrap()
+}
+
+const MYSQL_COMPOSITE_TABLE: &str = "mysql_preview_composite";
+const MYSQL_INVISIBLE_PK_TABLE: &str = "mysql_edit_invisible_pk";
+const MYSQL_INVISIBLE_COMPOSITE_TABLE: &str = "mysql_edit_invisible_composite";
+const MYSQL_GIPK_TABLE: &str = "mysql_edit_gipk";
+const MYSQL_NO_PK_TABLE: &str = "mysql_preview_no_pk";
+const MYSQL_EMPTY_TABLE: &str = "mysql_preview_empty";
+const MYSQL_VIEW: &str = "mysql_preview_view";
+const MYSQL_FK_PARENT: &str = "mysql_metadata_parent";
+const MYSQL_FK_CHILD: &str = "mysql_metadata_child";
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn connects_to_oracle_mysql_84_fixture() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if result.columns != ["id"] || result.values() != [[QueryValue::Text("1".to_string())]]
+            {
+                return Err(format!("unexpected MySQL connection result: {result:?}"));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn connects_to_oracle_mysql_84_fixture_with_ca_and_client_certificate() {
+    let config = mysql_tls_config();
+    let profile = mysql_tls_profile("mysql-tls-integration", config);
+    let adapter = MySqlAdapter::new();
+    let dsn = adapter.build_dsn(&profile);
+
+    adapter.probe(&dsn).await.unwrap();
+    let result = adapter
+        .execute_adhoc(
+            &dsn,
+            &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
+            AccessMode::ReadWrite,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.values(), [[QueryValue::Text("1".to_string())]]);
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn rejects_oracle_mysql_84_fixture_with_wrong_ca() {
+    let mut config = mysql_tls_config();
+    config.ssl_ca = config.ssl_cert.clone();
+    let profile = mysql_tls_profile("mysql-tls-wrong-ca", config);
+    let adapter = MySqlAdapter::new();
+    let dsn = adapter.build_dsn(&profile);
+    let error = adapter.probe(&dsn).await.unwrap_err();
+    assert_eq!(
+        ConnectionErrorInfo::from_db_operation_error_with_dsn(&error, &dsn).kind,
+        ConnectionErrorKind::MySqlCaVerificationFailed
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn rejects_oracle_mysql_84_fixture_with_wrong_hostname() {
+    let mut config = mysql_tls_config();
+    config.host = "host.docker.internal".to_string();
+    config.ssl_mode = MySqlSslMode::VerifyIdentity;
+    let profile = mysql_tls_profile("mysql-tls-wrong-host", config);
+    let adapter = MySqlAdapter::new();
+    let dsn = adapter.build_dsn(&profile);
+    let error = adapter.probe(&dsn).await.unwrap_err();
+    let error_info = ConnectionErrorInfo::from_db_operation_error_with_dsn(&error, &dsn);
+    assert_eq!(
+        error_info.kind,
+        ConnectionErrorKind::MySqlHostnameVerificationFailed,
+        "masked connection error details: {}",
+        error_info.masked_details()
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn preserves_xml_value_boundaries_for_real_mysql_results() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!(
+                    "SELECT nullable_text, empty_text, unicode_text, JSON_EXTRACT(json_value, '$.array'), JSON_EXTRACT(json_value, '$.text'), blob_value FROM {MYSQL_FIXTURE_TABLE}"
+                ),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("{error:?}"))?;
+        let expected = vec![
+            QueryValue::Null,
+            QueryValue::Text(String::new()),
+            QueryValue::Text("日本語の値 🐬".to_string()),
+            QueryValue::Text("[1, true]".to_string()),
+            QueryValue::Text("\"空文字ではない\"".to_string()),
+            QueryValue::Text("0x00FF10".to_string()),
+        ];
+        if result.values() != [expected] {
+            return Err(format!("unexpected XML values: {:?}", result.values()));
+        }
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn loads_mysql_tables_views_and_column_attributes() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let metadata = db
+                .adapter()
+                .fetch_metadata(db.dsn())
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if metadata
+                .schemas
+                .iter()
+                .map(|schema| schema.name.as_str())
+                .collect::<Vec<_>>()
+                != ["sabiql_test"]
+            {
+                return Err(format!("unexpected MySQL schemas: {:?}", metadata.schemas));
+            }
+            let view = metadata
+                .table_summaries
+                .iter()
+                .find(|summary| summary.name == MYSQL_VIEW)
+                .ok_or_else(|| "MySQL view was not listed".to_string())?;
+            if view.kind_info.kind != TableKind::View {
+                return Err(format!("unexpected MySQL view kind: {:?}", view.kind_info));
+            }
+
+            let detail = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_FIXTURE_TABLE)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            let names = detail
+                .columns
+                .iter()
+                .map(|column| column.name.as_str())
+                .collect::<Vec<_>>();
+            if names
+                != [
+                    "id",
+                    "nullable_text",
+                    "empty_text",
+                    "unicode_text",
+                    "json_value",
+                    "blob_value",
+                    "invisible_value",
+                    "generated_value",
+                    "unsigned_value",
+                    "precise_decimal",
+                    "scientific_value",
+                ]
+            {
+                return Err(format!("unexpected MySQL column order: {names:?}"));
+            }
+            let invisible = detail
+                .columns
+                .iter()
+                .find(|column| column.name == "invisible_value")
+                .ok_or_else(|| "invisible MySQL column was not returned".to_string())?;
+            if !invisible.is_hidden() || !invisible.is_read_only() {
+                return Err(format!(
+                    "unexpected invisible column attributes: {invisible:?}"
+                ));
+            }
+            let generated = detail
+                .columns
+                .iter()
+                .find(|column| column.name == "generated_value")
+                .ok_or_else(|| "generated MySQL column was not returned".to_string())?;
+            if !generated.is_generated() || !generated.is_read_only() {
+                return Err(format!(
+                    "unexpected generated column attributes: {generated:?}"
+                ));
+            }
+            if detail.primary_key != Some(vec!["id".to_string()]) {
+                return Err(format!(
+                    "unexpected MySQL primary key: {:?}",
+                    detail.primary_key
+                ));
+            }
+            if detail.comment.as_deref() != Some("MySQL fixture table")
+                || detail.row_count_estimate.is_none()
+            {
+                return Err(format!(
+                    "unexpected MySQL table info: comment={:?}, rows={:?}",
+                    detail.comment, detail.row_count_estimate
+                ));
+            }
+            if detail.source_ddl().is_none()
+                || db
+                    .adapter()
+                    .generate_ddl(sabiql_domain::DatabaseType::MySQL, &detail)
+                    != detail.source_ddl().unwrap()
+            {
+                return Err(format!(
+                    "unexpected MySQL table DDL: {:?}",
+                    detail.source_ddl()
+                ));
+            }
+            if detail.triggers.len() != 1 {
+                return Err(format!("unexpected MySQL triggers: {:?}", detail.triggers));
+            }
+            let trigger = &detail.triggers[0];
+            if trigger.name != "mysql_cli_fixture_audit"
+                || trigger.timing != TriggerTiming::Before
+                || trigger.events != [TriggerEvent::Update]
+                || trigger.definition != "SET NEW.empty_text = NEW.empty_text"
+                || trigger.security_context.as_deref() != Some("sabiql@%")
+            {
+                return Err(format!("unexpected MySQL trigger: {trigger:?}"));
+            }
+
+            let view_detail = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_VIEW)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if view_detail.source_ddl().is_none()
+                || !view_detail
+                    .source_ddl()
+                    .is_some_and(|ddl| ddl.contains("CREATE") && ddl.contains(MYSQL_VIEW))
+                || db
+                    .adapter()
+                    .generate_ddl(sabiql_domain::DatabaseType::MySQL, &view_detail)
+                    != view_detail.source_ddl().unwrap()
+            {
+                return Err(format!(
+                    "unexpected MySQL view DDL: {:?}",
+                    view_detail.source_ddl()
+                ));
+            }
+
+            let composite = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_COMPOSITE_TABLE)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if composite.primary_key
+                != Some(vec!["second_key".to_string(), "first_key".to_string()])
+            {
+                return Err(format!(
+                    "unexpected composite primary key: {:?}",
+                    composite.primary_key
+                ));
+            }
+            let unique_index = composite
+                .indexes
+                .iter()
+                .find(|index| index.name == "uq_mysql_preview_composite_payload")
+                .ok_or_else(|| "MySQL unique index was not returned".to_string())?;
+            if !unique_index.is_unique() || unique_index.columns != ["payload"] {
+                return Err(format!("unexpected MySQL unique index: {unique_index:?}"));
+            }
+            let fulltext_index = composite
+                .indexes
+                .iter()
+                .find(|index| index.name == "ft_mysql_preview_composite_payload")
+                .ok_or_else(|| "MySQL fulltext index was not returned".to_string())?;
+            if fulltext_index.index_type != IndexType::Other("fulltext".to_string())
+                || fulltext_index.columns != ["payload"]
+            {
+                return Err(format!(
+                    "unexpected MySQL fulltext index: {fulltext_index:?}"
+                ));
+            }
+
+            let parent = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_FK_PARENT)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            let parent_unique_index = parent
+                .indexes
+                .iter()
+                .find(|index| index.name == "uq_mysql_metadata_parent_code")
+                .ok_or_else(|| "MySQL parent unique index was not returned".to_string())?;
+            if !parent_unique_index.is_unique() || parent_unique_index.columns != ["unique_code"] {
+                return Err(format!(
+                    "unexpected MySQL parent unique index: {parent_unique_index:?}"
+                ));
+            }
+
+            let child = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_FK_CHILD)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if child.foreign_keys.len() != 1 {
+                return Err(format!(
+                    "unexpected MySQL foreign keys: {:?}",
+                    child.foreign_keys
+                ));
+            }
+            let foreign_key = &child.foreign_keys[0];
+            if foreign_key.from_columns != ["parent_first", "parent_second"]
+                || foreign_key.to_schema != "sabiql_test"
+                || foreign_key.to_table != MYSQL_FK_PARENT
+                || foreign_key.to_columns != ["first_key", "second_key"]
+                || foreign_key.on_update != FkAction::Cascade
+                || foreign_key.on_delete != FkAction::SetNull
+                || !foreign_key.is_reference_resolved()
+            {
+                return Err(format!("unexpected MySQL foreign key: {foreign_key:?}"));
+            }
+
+            let columns_and_fks = db
+                .adapter()
+                .fetch_table_columns_and_fks(db.dsn(), "sabiql_test", MYSQL_FK_CHILD)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if columns_and_fks.foreign_keys != child.foreign_keys
+                || !columns_and_fks.indexes.is_empty()
+            {
+                return Err(format!(
+                    "unexpected columns-and-fks metadata: {columns_and_fks:?}"
+                ));
+            }
+
+            let signatures = db
+                .adapter()
+                .fetch_table_signatures(db.dsn())
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            let child_signature = signatures
+                .iter()
+                .find(|signature| signature.name == MYSQL_FK_CHILD)
+                .ok_or_else(|| "MySQL child signature was not returned".to_string())?;
+            if !child_signature
+                .signature
+                .contains("fk_mysql_metadata_child_parent")
+            {
+                return Err(format!(
+                    "unexpected MySQL table signature: {child_signature:?}"
+                ));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn previews_mysql_rows_with_visible_columns_types_and_pagination() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_FIXTURE_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if result
+                .columns
+                .iter()
+                .any(|column| column == "invisible_value")
+            {
+                return Err(format!(
+                    "invisible column reached preview: {:?}",
+                    result.columns
+                ));
+            }
+            if result.columns
+                != [
+                    "id",
+                    "nullable_text",
+                    "empty_text",
+                    "unicode_text",
+                    "json_value",
+                    "blob_value",
+                    "generated_value",
+                    "unsigned_value",
+                    "precise_decimal",
+                    "scientific_value",
+                ]
+            {
+                return Err(format!("unexpected preview columns: {:?}", result.columns));
+            }
+            let values = result.values();
+            if values.len() != 1
+                || values[0][5] != QueryValue::Blob(vec![0, 255, 16])
+                || values[0][7] != QueryValue::SqlLiteral("18446744073709551615".to_string())
+                || values[0][8]
+                    != QueryValue::SqlLiteral(
+                        "12345678901234567890123456789012345.123456789012345678901234567890"
+                            .to_string(),
+                    )
+            {
+                return Err(format!("unexpected typed preview values: {values:?}"));
+            }
+            if !result.query.contains("ORDER BY `id`")
+                || !result.query.contains("LIMIT 10 OFFSET 0")
+            {
+                return Err(format!("unexpected preview SQL: {}", result.query));
+            }
+
+            let page = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_NO_PK_TABLE, 1, 1)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if !page
+                .query
+                .contains("ORDER BY `duplicate_value`, `payload` LIMIT 1 OFFSET 1")
+            {
+                return Err(format!("unexpected no-PK preview SQL: {}", page.query));
+            }
+
+            let composite = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_COMPOSITE_TABLE, 1, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if !composite
+                .query
+                .contains("ORDER BY `second_key`, `first_key` LIMIT 1 OFFSET 0")
+            {
+                return Err(format!(
+                    "unexpected composite preview SQL: {}",
+                    composite.query
+                ));
+            }
+
+            let view = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_VIEW, 10, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if view.columns != ["id", "unicode_text"] {
+                return Err(format!(
+                    "unexpected view preview columns: {:?}",
+                    view.columns
+                ));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn previews_empty_mysql_table_with_metadata_columns() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_EMPTY_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if result.columns != ["id", "payload"] || !result.values().is_empty() {
+                return Err(format!("unexpected empty preview: {result:?}"));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn previews_and_writes_rows_using_hidden_mysql_primary_keys() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let invisible = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_INVISIBLE_PK_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("failed to preview invisible primary key: {error:?}"))?;
+            if invisible.columns != ["payload"]
+                || invisible.query.contains("__sabiql_row_identity_")
+                || invisible.values()
+                    != [[QueryValue::Text("invisible single primary key".to_string())]]
+            {
+                return Err(format!(
+                    "unexpected invisible primary key preview: {invisible:?}"
+                ));
+            }
+            let identity = invisible
+                .explicit_row_identity()
+                .ok_or_else(|| "invisible primary key identity was not returned".to_string())?;
+            if identity.columns() != ["id"]
+                || identity.values() != [[QueryValue::SqlLiteral("1".to_string())]]
+            {
+                return Err(format!(
+                    "unexpected invisible primary key identity: {identity:?}"
+                ));
+            }
+
+            let composite = db
+                .adapter()
+                .execute_preview(
+                    db.dsn(),
+                    "sabiql_test",
+                    MYSQL_INVISIBLE_COMPOSITE_TABLE,
+                    10,
+                    0,
+                )
+                .await
+                .map_err(|error| format!("failed to preview invisible composite key: {error:?}"))?;
+            let composite_identity = composite
+                .explicit_row_identity()
+                .ok_or_else(|| "invisible composite identity was not returned".to_string())?;
+            if composite.columns != ["payload"]
+                || composite.query.contains("__sabiql_row_identity_")
+                || composite_identity.columns() != ["second_key", "first_key"]
+                || composite_identity.values()
+                    != [[
+                        QueryValue::SqlLiteral("20".to_string()),
+                        QueryValue::SqlLiteral("1".to_string()),
+                    ]]
+            {
+                return Err(format!(
+                    "unexpected invisible composite preview: {composite:?}"
+                ));
+            }
+
+            let gipk_detail = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_GIPK_TABLE)
+                .await
+                .map_err(|error| format!("failed to fetch GIPK metadata: {error:?}"))?;
+            if gipk_detail.primary_key != Some(vec!["my_row_id".to_string()]) {
+                return Err(format!(
+                    "GIPK was not exposed by INFORMATION_SCHEMA: {:?}",
+                    gipk_detail.primary_key
+                ));
+            }
+            let gipk = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_GIPK_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("failed to preview GIPK: {error:?}"))?;
+            if gipk.columns != ["payload"]
+                || gipk.query.contains("__sabiql_row_identity_")
+                || gipk
+                    .explicit_row_identity()
+                    .is_none_or(|identity| identity.columns() != ["my_row_id"])
+            {
+                return Err(format!("unexpected GIPK preview: {gipk:?}"));
+            }
+
+            let update_sql = db.adapter().build_update_sql(
+                DatabaseType::MySQL,
+                "sabiql_test",
+                MYSQL_GIPK_TABLE,
+                "payload",
+                &QueryValue::text("updated through GIPK"),
+                &[(
+                    "my_row_id".to_string(),
+                    QueryValue::SqlLiteral("1".to_string()),
+                )],
+            );
+            let update = db
+                .adapter()
+                .execute_write(db.dsn(), &update_sql, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| format!("failed to update through GIPK: {error:?}"))?;
+            if update.affected_rows != 1 {
+                return Err(format!("unexpected GIPK update result: {update:?}"));
+            }
+
+            let delete_sql = db.adapter().build_bulk_delete_sql(
+                DatabaseType::MySQL,
+                "sabiql_test",
+                MYSQL_INVISIBLE_PK_TABLE,
+                &[vec![(
+                    "id".to_string(),
+                    QueryValue::SqlLiteral("1".to_string()),
+                )]],
+            );
+            let delete = db
+                .adapter()
+                .execute_write(db.dsn(), &delete_sql, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| {
+                    format!("failed to delete through invisible primary key: {error:?}")
+                })?;
+            if delete.affected_rows != 1 {
+                return Err(format!(
+                    "unexpected invisible primary key delete result: {delete:?}"
+                ));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn updates_and_bulk_deletes_mysql_rows_with_visible_composite_primary_keys() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let suffix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|error| format!("system clock error: {error}"))?
+                .as_nanos();
+            let table = format!("mysql_sab392_{suffix}");
+            let create = format!(
+                "CREATE TABLE {table} (first_key BIGINT UNSIGNED NOT NULL, second_key INT NOT NULL, payload TEXT NOT NULL, PRIMARY KEY (first_key, second_key))"
+            );
+            db.adapter()
+                .execute_adhoc(db.dsn(), &create, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| format!("failed to create write fixture: {error:?}"))?;
+
+            let result = async {
+                let insert = format!(
+                    "INSERT INTO {table} (first_key, second_key, payload) VALUES (18446744073709551615, 7, 'before'), (42, 8, 'second')"
+                );
+                db.adapter()
+                    .execute_adhoc(db.dsn(), &insert, AccessMode::ReadWrite)
+                    .await
+                    .map_err(|error| format!("failed to seed write fixture: {error:?}"))?;
+
+                let update_sql = db.adapter().build_update_sql(
+                    DatabaseType::MySQL,
+                    "sabiql_test",
+                    &table,
+                    "payload",
+                    &QueryValue::text("O'Reilly\\path"),
+                    &[
+                        (
+                            "first_key".to_string(),
+                            QueryValue::SqlLiteral("18446744073709551615".to_string()),
+                        ),
+                        (
+                            "second_key".to_string(),
+                            QueryValue::SqlLiteral("7".to_string()),
+                        ),
+                    ],
+                );
+                let update = db
+                    .adapter()
+                    .execute_write(db.dsn(), &update_sql, AccessMode::ReadWrite)
+                    .await
+                    .map_err(|error| format!("failed to update MySQL row: {error:?}"))?;
+                if update.affected_rows != 1 {
+                    return Err(format!("unexpected update result: {update:?}"));
+                }
+
+                let changed = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!(
+                            "SELECT payload FROM {table} WHERE first_key = 18446744073709551615 AND second_key = 7"
+                        ),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to read updated row: {error:?}"))?;
+                if changed.values() != [[QueryValue::Text("O'Reilly\\path".to_string())]] {
+                    return Err(format!("unexpected updated row: {changed:?}"));
+                }
+
+                let delete_sql = db.adapter().build_bulk_delete_sql(
+                    DatabaseType::MySQL,
+                    "sabiql_test",
+                    &table,
+                    &[
+                        vec![
+                            (
+                                "first_key".to_string(),
+                                QueryValue::SqlLiteral("18446744073709551615".to_string()),
+                            ),
+                            (
+                                "second_key".to_string(),
+                                QueryValue::SqlLiteral("7".to_string()),
+                            ),
+                        ],
+                        vec![
+                            (
+                                "first_key".to_string(),
+                                QueryValue::SqlLiteral("42".to_string()),
+                            ),
+                            (
+                                "second_key".to_string(),
+                                QueryValue::SqlLiteral("8".to_string()),
+                            ),
+                        ],
+                    ],
+                );
+                let delete = db
+                    .adapter()
+                    .execute_write(db.dsn(), &delete_sql, AccessMode::ReadWrite)
+                    .await
+                    .map_err(|error| format!("failed to delete MySQL rows: {error:?}"))?;
+                if delete.affected_rows != 2 {
+                    return Err(format!("unexpected delete result: {delete:?}"));
+                }
+                Ok(())
+            }
+            .await;
+
+            let drop = format!("DROP TABLE {table}");
+            let _ = db
+                .adapter()
+                .execute_adhoc(db.dsn(), &drop, AccessMode::ReadWrite)
+                .await;
+            result
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn updates_mysql_json_documents_as_whole_values() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let suffix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|error| format!("system clock error: {error}"))?
+                .as_nanos();
+            let table = format!("mysql_sab396_{suffix}");
+            let create = format!(
+                "CREATE TABLE {table} (id INT NOT NULL PRIMARY KEY, payload JSON NOT NULL)"
+            );
+            db.adapter()
+                .execute_adhoc(db.dsn(), &create, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| format!("failed to create JSON fixture: {error:?}"))?;
+
+            let result = async {
+                db.adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!("INSERT INTO {table} VALUES (1, '{{\"a\":1}}')"),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to seed JSON fixture: {error:?}"))?;
+
+                let update_json = db.adapter().build_update_sql(
+                    DatabaseType::MySQL,
+                    "sabiql_test",
+                    &table,
+                    "payload",
+                    &QueryValue::text(r#"{"b":2,"a":1}"#),
+                    &[("id".to_string(), QueryValue::SqlLiteral("1".to_string()))],
+                );
+                if update_json.contains("JSON_SET") {
+                    return Err("JSON update unexpectedly used JSON_SET".to_string());
+                }
+                db.adapter()
+                    .execute_write(db.dsn(), &update_json, AccessMode::ReadWrite)
+                    .await
+                    .map_err(|error| format!("failed to update JSON document: {error:?}"))?;
+
+                let reordered = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!("SELECT JSON_EXTRACT(payload, '$.b'), JSON_EXTRACT(payload, '$.a') FROM {table} WHERE id = 1"),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to read JSON document: {error:?}"))?;
+                if reordered.values()
+                    != [[QueryValue::Text("2".to_string()), QueryValue::Text("1".to_string())]]
+                {
+                    return Err(format!("unexpected updated JSON document: {reordered:?}"));
+                }
+
+                for (json, expected_type) in [("null", "NULL"), (r#""null""#, "STRING")] {
+                    let update = db.adapter().build_update_sql(
+                        DatabaseType::MySQL,
+                        "sabiql_test",
+                        &table,
+                        "payload",
+                        &QueryValue::text(json),
+                        &[("id".to_string(), QueryValue::SqlLiteral("1".to_string()))],
+                    );
+                    db.adapter()
+                        .execute_write(db.dsn(), &update, AccessMode::ReadWrite)
+                        .await
+                        .map_err(|error| format!("failed to update JSON null value: {error:?}"))?;
+                    let value = db
+                        .adapter()
+                        .execute_adhoc(
+                            db.dsn(),
+                            &format!("SELECT JSON_TYPE(payload) FROM {table} WHERE id = 1"),
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .map_err(|error| format!("failed to read JSON type: {error:?}"))?;
+                    if value.values() != [[QueryValue::Text(expected_type.to_string())]] {
+                        return Err(format!("unexpected JSON type: {value:?}"));
+                    }
+                }
+                Ok(())
+            }
+            .await;
+
+            let drop = format!("DROP TABLE {table}");
+            let _ = db
+                .adapter()
+                .execute_adhoc(db.dsn(), &drop, AccessMode::ReadWrite)
+                .await;
+            result
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn executes_multiple_statements_and_returns_only_the_last_result() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!(
+                    "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'multi statement' WHERE id = 1; SELECT empty_text FROM {MYSQL_FIXTURE_TABLE} WHERE id = 1"
+                ),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("{error:?}"))?;
+        if result.columns != ["empty_text"]
+            || result.values() != [[QueryValue::Text("multi statement".to_string())]]
+            || result.command_tag != Some(CommandTag::Update(1))
+            || result.refresh_scope != RefreshScope::Data
+        {
+            return Err(format!("unexpected multi-statement result: {result:?}"));
+        }
+        db.adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!("UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = '' WHERE id = 1"),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("failed to restore fixture: {error:?}"))?;
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn keeps_refresh_scope_and_discards_partial_result_after_a_later_failure() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!(
+                    "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'changed before failure' WHERE id = 1; SELECT missing_column FROM {MYSQL_FIXTURE_TABLE}"
+                ),
+                AccessMode::ReadWrite,
+            )
+            .await;
+        if !matches!(
+            result,
+            Err(DbOperationError::QueryFailedAfterChange {
+                refresh_scope: RefreshScope::Data,
+                ..
+            })
+        ) {
+            return Err(format!("expected partial-change failure: {result:?}"));
+        }
+        db.adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!("UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = '' WHERE id = 1"),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("failed to restore fixture: {error:?}"))?;
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn preserves_explicit_transaction_order_and_scope() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!(
+                    "BEGIN; UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'rolled back' WHERE id = 1; ROLLBACK; SELECT empty_text FROM {MYSQL_FIXTURE_TABLE} WHERE id = 1"
+                ),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("{error:?}"))?;
+        if result.columns != ["empty_text"]
+            || result.values() != [[QueryValue::Text(String::new())]]
+            || result.command_tag != Some(CommandTag::Select(1))
+            || result.refresh_scope != RefreshScope::Data
+        {
+            return Err(format!("unexpected transaction result: {result:?}"));
+        }
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn keeps_temporary_table_state_inside_one_submission() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|error| format!("system clock error: {error}"))?
+            .as_nanos();
+        let table = format!("sabiql_sab386_tmp_{suffix}");
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!(
+                    "CREATE TEMPORARY TABLE {table} (id INT); INSERT INTO {table} VALUES (1), (2); SELECT id FROM {table} ORDER BY id; DROP TEMPORARY TABLE {table}"
+                ),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("{error:?}"))?;
+        if result.columns != ["id"]
+            || result.values() != [[QueryValue::Text("1".to_string())], [QueryValue::Text("2".to_string())]]
+            || result.command_tag != Some(CommandTag::Insert(2))
+            || result.refresh_scope != RefreshScope::Metadata
+        {
+            return Err(format!("unexpected temporary-table result: {result:?}"));
+        }
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn reports_metadata_scope_when_a_later_ddl_statement_fails() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let suffix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|error| format!("system clock error: {error}"))?
+                .as_nanos();
+            let table = format!("sabiql_sab386_{suffix}");
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("CREATE TABLE {table} (id INT); CREATE TABLE {table} (id INT)"),
+                    AccessMode::ReadWrite,
+                )
+                .await;
+            if !matches!(
+                result,
+                Err(DbOperationError::QueryFailedAfterChange {
+                    refresh_scope: RefreshScope::Metadata,
+                    ..
+                })
+            ) {
+                return Err(format!("expected metadata-scope failure: {result:?}"));
+            }
+            db.adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("DROP TABLE IF EXISTS {table}"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to clean up DDL fixture: {error:?}"))?;
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn discards_real_cli_results_when_query_fails() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!("SELECT missing_column FROM {MYSQL_FIXTURE_TABLE}"),
+                AccessMode::ReadWrite,
+            )
+            .await;
+        if !matches!(result, Err(DbOperationError::QueryFailed(ref details)) if details.contains("missing_column")) {
+            return Err(format!("expected a query failure without a result: {result:?}"));
+        }
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn times_out_real_cli_query_and_discards_output() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_adhoc(db.dsn(), "SELECT SLEEP(32)", AccessMode::ReadWrite)
+                .await;
+            if !matches!(result, Err(DbOperationError::Timeout(_))) {
+                return Err(format!("expected a query timeout: {result:?}"));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn rejects_next_process_when_global_sql_mode_is_unsupported() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let original = db.global_sql_mode().await?;
+        let unsupported = if original.is_empty() {
+            "ANSI_QUOTES".to_string()
+        } else {
+            format!("{original},ANSI_QUOTES")
+        };
+        let test_result = async {
+            db.set_global_sql_mode(&unsupported).await?;
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    "SELECT SLEEP(32)",
+                    AccessMode::ReadWrite,
+                )
+                .await;
+            if !matches!(result, Err(DbOperationError::UnsupportedOperation(ref details)) if details.contains(MYSQL_SQL_MODE_UNSUPPORTED_MARKER)) {
+                return Err(format!("expected unsupported sql_mode rejection: {result:?}"));
+            }
+            Ok::<(), String>(())
+        }
+        .await;
+        let restore_result = db.set_global_sql_mode(&original).await;
+        if let Err(error) = restore_result {
+            return Err(format!("failed to restore MySQL global sql_mode: {error}"));
+        }
+        if db.global_sql_mode().await? != original {
+            return Err("MySQL global sql_mode was not restored".to_string());
+        }
+        test_result
+    }))
+    .await;
+}

--- a/src/ui/features/sql_modal/completion.rs
+++ b/src/ui/features/sql_modal/completion.rs
@@ -76,6 +76,7 @@ pub(super) fn render_completion_popup(
 
             let kind_label = match candidate.kind {
                 CompletionKind::Keyword => "keyword",
+                CompletionKind::Database => "database",
                 CompletionKind::Table => "table",
                 CompletionKind::Column => "column",
             };

--- a/src/ui/primitives/atoms/sql_highlight.rs
+++ b/src/ui/primitives/atoms/sql_highlight.rs
@@ -16,7 +16,7 @@ pub fn highlight_sql_spans(text: &str, theme: &ThemePalette) -> Vec<Vec<Span<'st
         return vec![];
     }
 
-    let lexer = SqlLexer::new();
+    let lexer = SqlLexer::default();
     let tokens = lexer.tokenize(text, text.chars().count());
     let mut lines: Vec<Vec<Span<'static>>> = vec![Vec::new()];
 
@@ -65,6 +65,7 @@ fn token_style(kind: &TokenKind, theme: &ThemePalette) -> Style {
         TokenKind::Comment => Style::default().fg(theme.component.syntax.sql_comment),
         TokenKind::Operator(_) => Style::default().fg(theme.component.syntax.sql_operator),
         TokenKind::Identifier(_)
+        | TokenKind::BacktickIdentifier(_)
         | TokenKind::Punctuation(_)
         | TokenKind::Whitespace
         | TokenKind::Unknown => Style::default().fg(theme.component.syntax.sql_text),


### PR DESCRIPTION
## Problem

MySQL SQL execution spans statement splitting, risk classification, result semantics, query history, completion, CSV export, and read-only enforcement. The final integrated behavior needs a coherent review without exceeding CodeRabbit's file limit.

## Approach

Review the SQL workflow files from final MySQL snapshot `e96e8f7d567a014e9650901532bb123cb95131ea` against main snapshot `6c91adfb7dadbb6616b706faadf2ba5a78f39e38`.

This is a synthetic review-only pull request and must not be merged. It intentionally excludes connection and TLS setup, browsing and structural metadata UI, grid and JSON editing, ER rendering, execution-plan presentation, and final documentation. Shared files are included only where they are needed to understand SQL execution, history, completion, export, or read-only behavior.

The slice is not a release candidate and is not expected to build independently because adjacent MySQL modules are intentionally absent. The source of truth remains the final `mysql` snapshot above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broad MySQL support, including connections, database selection, metadata browsing, previews, and schema information.
  * Added MySQL-aware SQL completion with database suggestions, keywords, comments, and quoted identifiers.
  * Added MySQL statement analysis, risk checks, transaction validation, and safer EXPLAIN ANALYZE support.
  * Query history is now separated by selected database.
  * CSV exports now use buffered asynchronous writing.
* **Bug Fixes**
  * Prevented stale completion, metadata, query-history, and connection results from updating the active session.
  * Added targeted refreshes after changes and improved failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->