### PR TITLE
chore: review MySQL structured data workflows

### DIFF
--- a/scripts/init-mysql.sql
+++ b/scripts/init-mysql.sql
@@ -1,0 +1,131 @@
+SET NAMES utf8mb4;
+
+USE sabiql_test;
+
+CREATE TABLE mysql_cli_fixture (
+    id INT PRIMARY KEY,
+    nullable_text TEXT NULL,
+    empty_text TEXT NOT NULL,
+    unicode_text TEXT NOT NULL,
+    json_value JSON NOT NULL,
+    blob_value BLOB NOT NULL,
+    invisible_value INT INVISIBLE,
+    generated_value INT GENERATED ALWAYS AS (id * 2) STORED,
+    unsigned_value BIGINT UNSIGNED NOT NULL,
+    precise_decimal DECIMAL(65, 30) NOT NULL,
+    scientific_value DOUBLE NOT NULL
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci COMMENT = 'MySQL fixture table';
+
+INSERT INTO mysql_cli_fixture (
+    id,
+    nullable_text,
+    empty_text,
+    unicode_text,
+    json_value,
+    blob_value,
+    unsigned_value,
+    precise_decimal,
+    scientific_value
+) VALUES (
+    1,
+    NULL,
+    '',
+    '日本語の値 🐬',
+    '{"array":[1,true],"text":"空文字ではない"}',
+    X'00FF10',
+    18446744073709551615,
+    12345678901234567890123456789012345.123456789012345678901234567890,
+    1.23e100
+);
+
+CREATE DEFINER='sabiql'@'%' TRIGGER mysql_cli_fixture_audit
+BEFORE UPDATE ON mysql_cli_fixture
+FOR EACH ROW
+SET NEW.empty_text = NEW.empty_text;
+
+CREATE TABLE mysql_preview_composite (
+    first_key INT NOT NULL,
+    second_key INT NOT NULL,
+    payload VARCHAR(255) NOT NULL,
+    PRIMARY KEY (second_key, first_key),
+    UNIQUE KEY uq_mysql_preview_composite_payload (payload),
+    FULLTEXT KEY ft_mysql_preview_composite_payload (payload)
+) CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_preview_composite (first_key, second_key, payload)
+VALUES (1, 20, 'first'), (2, 10, 'second');
+
+CREATE TABLE mysql_edit_invisible_pk (
+    id INT NOT NULL INVISIBLE,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_edit_invisible_pk (id, payload)
+VALUES (1, 'invisible single primary key');
+
+CREATE TABLE mysql_edit_invisible_composite (
+    first_key INT NOT NULL INVISIBLE,
+    second_key INT NOT NULL INVISIBLE,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (second_key, first_key)
+) ENGINE=InnoDB CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_edit_invisible_composite (first_key, second_key, payload)
+VALUES (1, 20, 'invisible composite primary key');
+
+SET SESSION sql_generate_invisible_primary_key = ON;
+
+CREATE TABLE mysql_edit_gipk (
+    payload TEXT NOT NULL
+) ENGINE=InnoDB CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_edit_gipk (payload)
+VALUES ('generated invisible primary key');
+
+SET SESSION sql_generate_invisible_primary_key = OFF;
+
+CREATE TABLE mysql_metadata_parent (
+    first_key INT NOT NULL,
+    second_key INT NOT NULL,
+    unique_code VARCHAR(32) NOT NULL,
+    label TEXT NOT NULL,
+    PRIMARY KEY (first_key, second_key),
+    UNIQUE KEY uq_mysql_metadata_parent_code (unique_code),
+    FULLTEXT KEY ft_mysql_metadata_parent_label (label)
+) CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_metadata_parent (first_key, second_key, unique_code, label)
+VALUES (1, 2, 'parent-1-2', 'parent row');
+
+CREATE TABLE mysql_metadata_child (
+    parent_first INT NULL,
+    parent_second INT NULL,
+    payload TEXT NOT NULL,
+    CONSTRAINT fk_mysql_metadata_child_parent
+        FOREIGN KEY (parent_first, parent_second)
+        REFERENCES mysql_metadata_parent (first_key, second_key)
+        ON UPDATE CASCADE
+        ON DELETE SET NULL
+) CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_metadata_child (parent_first, parent_second, payload)
+VALUES (1, 2, 'child row');
+
+CREATE TABLE mysql_preview_no_pk (
+    duplicate_value VARCHAR(20) NOT NULL,
+    payload TEXT NOT NULL
+) CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_preview_no_pk (duplicate_value, payload)
+VALUES ('same', 'first'), ('same', 'second');
+
+CREATE TABLE mysql_preview_empty (
+    id INT PRIMARY KEY,
+    payload TEXT
+) CHARACTER SET utf8mb4;
+
+CREATE VIEW mysql_preview_view AS
+SELECT id, unicode_text FROM mysql_cli_fixture;
+
+GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO 'sabiql'@'%';

--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -35,10 +35,14 @@ impl HelpDocument {
             filter.cursor(),
             state.settings.saved_keymap_preset(),
             state.session.active_engine_feature_profile(),
-            state
-                .session
-                .active_database_type()
-                .map(|database_type| CellPresentationPolicy::new(database_type, "jsonb", "")),
+            state.session.active_database_type().map(|database_type| {
+                let data_type = if database_type == DatabaseType::MySQL {
+                    "json"
+                } else {
+                    "jsonb"
+                };
+                CellPresentationPolicy::new(database_type, data_type, "")
+            }),
         )
     }
 
@@ -400,7 +404,7 @@ fn reference_sections(
         rows_from_bindings(CELL_EDIT_KEYS),
         rows_from_bindings_if_visible(SQL_MODAL_CONFIRMING_KEYS, feature_policy),
     ]);
-    if feature_policy.is_visible(jsonb_edit::ESC_NORMAL.feature_requirement())
+    if feature_policy.is_visible(FeatureRequirement::JsonDocumentEdit)
         && cell_presentation_policy.is_some_and(CellPresentationPolicy::uses_jsonb_detail_modal)
     {
         editing_rows.extend(rows_from_mode_rows_if_visible(
@@ -430,7 +434,7 @@ fn reference_sections(
             feature_policy,
         ));
     }
-    if feature_policy.is_visible(FeatureRequirement::JsonbDetail)
+    if feature_policy.is_visible(FeatureRequirement::JsonDocumentDetail)
         && cell_presentation_policy.is_some_and(CellPresentationPolicy::uses_jsonb_detail_modal)
     {
         advanced_rows.extend(rows_from_mode_rows_if_visible(

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -1,7 +1,8 @@
-use crate::domain::connection::{ConnectionConfig, ConnectionId};
+use crate::domain::connection::{ConnectionConfig, ConnectionId, DatabaseType};
+use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{QueryValue, Table};
 use crate::ports::outbound::{AccessMode, AppSettings};
-use crate::update::action::Action;
+use crate::update::action::{Action, ConnectionTarget};
 
 #[derive(Debug, Clone)]
 pub enum Effect {
@@ -11,6 +12,16 @@ pub enum Effect {
         id: Option<ConnectionId>,
         name: String,
         config: ConnectionConfig,
+    },
+    ProbeConnection {
+        target: ConnectionTarget,
+        run_id: u64,
+    },
+    FetchMySqlDatabases {
+        connection_id: ConnectionId,
+        dsn: String,
+        connection_generation: u64,
+        database_generation: u64,
     },
     LoadConnectionForEdit {
         id: ConnectionId,
@@ -72,6 +83,8 @@ pub enum Effect {
     },
     ExecuteExplain {
         dsn: String,
+        database_type: DatabaseType,
+        database_generation: u64,
         run_id: u64,
         query: String,
         source_query: String,
@@ -122,6 +135,7 @@ pub enum Effect {
     TriggerCompletion,
 
     GenerateErDiagramFromCache {
+        run_id: u64,
         total_tables: usize,
         project_name: String,
         target_tables: Vec<String>,
@@ -148,7 +162,7 @@ pub enum Effect {
 
     LoadQueryHistory {
         project_name: String,
-        connection_id: ConnectionId,
+        scope: QueryHistoryScope,
     },
 
     SaveSettings {

--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -13,8 +13,16 @@ use crate::domain::er::{er_output_filename, fk_neighbors_of_seeds, fk_reachable_
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{ConfigWriter, ErDiagramExporter, ErLogWriter, MetadataProvider};
 use crate::update::action::{
-    Action, ErDiagramError, ErLogError, SmartErRefreshError, SmartErRefreshResult,
+    Action, ErDiagramError, ErDiagramFailure, ErLogError, SmartErRefreshError, SmartErRefreshResult,
 };
+
+struct GenerateErDiagramRequest {
+    run_id: u64,
+    total_tables: usize,
+    project_name: String,
+    target_tables: Vec<String>,
+    browser: Option<String>,
+}
 
 pub async fn run(
     effect: Effect,
@@ -28,6 +36,7 @@ pub async fn run(
 ) -> Result<()> {
     match effect {
         Effect::GenerateErDiagramFromCache {
+            run_id,
             total_tables,
             project_name,
             target_tables,
@@ -37,10 +46,13 @@ pub async fn run(
                 er_exporter,
                 config_writer,
                 completion_engine,
-                total_tables,
-                project_name,
-                target_tables,
-                state.settings.saved_er_browser().map(str::to_string),
+                GenerateErDiagramRequest {
+                    run_id,
+                    total_tables,
+                    project_name,
+                    target_tables,
+                    browser: state.settings.saved_er_browser().map(str::to_string),
+                },
             )
             .await
         }
@@ -78,17 +90,22 @@ async fn handle_generate_diagram(
     er_exporter: &Arc<dyn ErDiagramExporter>,
     config_writer: &Arc<dyn ConfigWriter>,
     completion_engine: &RefCell<CompletionEngine>,
-    total_tables: usize,
-    project_name: String,
-    target_tables: Vec<String>,
-    browser: Option<String>,
+    request: GenerateErDiagramRequest,
 ) -> Result<()> {
+    let GenerateErDiagramRequest {
+        run_id,
+        total_tables,
+        project_name,
+        target_tables,
+        browser,
+    } = request;
     let all_tables = collect_cached_er_tables(completion_engine);
     if all_tables.is_empty() {
         action_tx
-            .send(Action::ErDiagramFailed(ErDiagramError::NoData(
-                "No table data loaded yet".to_string(),
-            )))
+            .send(Action::ErDiagramFailed(ErDiagramFailure {
+                run_id,
+                error: ErDiagramError::NoData("No table data loaded yet".to_string()),
+            }))
             .await
             .ok();
         return Ok(());
@@ -104,9 +121,12 @@ async fn handle_generate_diagram(
 
     if tables.is_empty() {
         action_tx
-            .send(Action::ErDiagramFailed(ErDiagramError::NoData(
-                "Selected tables not found in cached data".to_string(),
-            )))
+            .send(Action::ErDiagramFailed(ErDiagramFailure {
+                run_id,
+                error: ErDiagramError::NoData(
+                    "Selected tables not found in cached data".to_string(),
+                ),
+            }))
             .await
             .ok();
         return Ok(());
@@ -116,6 +136,7 @@ async fn handle_generate_diagram(
     spawn_er_diagram_task(
         Arc::clone(er_exporter),
         tables,
+        run_id,
         total_tables,
         cache_dir,
         action_tx.clone(),

--- a/src/app/cmd/er/task.rs
+++ b/src/app/cmd/er/task.rs
@@ -5,11 +5,12 @@ use tokio::sync::mpsc;
 
 use crate::domain::ErTableInfo;
 use crate::ports::outbound::ErDiagramExporter;
-use crate::update::action::{Action, ErDiagramError, ErDiagramInfo};
+use crate::update::action::{Action, ErDiagramError, ErDiagramFailure, ErDiagramInfo};
 
 pub fn spawn_er_diagram_task(
     exporter: Arc<dyn ErDiagramExporter>,
     tables: Vec<ErTableInfo>,
+    run_id: u64,
     total_tables: usize,
     cache_dir: PathBuf,
     tx: mpsc::Sender<Action>,
@@ -27,6 +28,7 @@ pub fn spawn_er_diagram_task(
             Ok(Ok(path)) => {
                 let _ = tx
                     .send(Action::ErDiagramOpened(ErDiagramInfo {
+                        run_id,
                         path: path.display().to_string(),
                         table_count,
                         total_tables,
@@ -35,16 +37,18 @@ pub fn spawn_er_diagram_task(
             }
             Ok(Err(e)) => {
                 let _ = tx
-                    .send(Action::ErDiagramFailed(ErDiagramError::ExportFailed(
-                        e.to_string(),
-                    )))
+                    .send(Action::ErDiagramFailed(ErDiagramFailure {
+                        run_id,
+                        error: ErDiagramError::ExportFailed(e.to_string()),
+                    }))
                     .await;
             }
             Err(e) => {
                 let _ = tx
-                    .send(Action::ErDiagramFailed(ErDiagramError::TaskPanicked(
-                        e.to_string(),
-                    )))
+                    .send(Action::ErDiagramFailed(ErDiagramFailure {
+                        run_id,
+                        error: ErDiagramError::TaskPanicked(e.to_string()),
+                    }))
                     .await;
             }
         }
@@ -122,6 +126,7 @@ mod tests {
             spawn_er_diagram_task(
                 exporter,
                 vec![],
+                1,
                 5,
                 temp_dir.path().to_path_buf(),
                 tx,
@@ -132,6 +137,7 @@ mod tests {
             let action = receive_action(&mut rx).await;
             match action {
                 Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id,
                     path,
                     table_count,
                     total_tables,
@@ -139,6 +145,7 @@ mod tests {
                     assert!(path.contains("test.svg"));
                     assert_eq!(table_count, 0);
                     assert_eq!(total_tables, 5);
+                    assert_eq!(run_id, 1);
                 }
                 _ => panic!("expected ErDiagramOpened, got {action:?}"),
             }
@@ -153,6 +160,7 @@ mod tests {
             spawn_er_diagram_task(
                 exporter,
                 vec![],
+                1,
                 5,
                 temp_dir.path().to_path_buf(),
                 tx,
@@ -178,6 +186,7 @@ mod tests {
             spawn_er_diagram_task(
                 exporter,
                 vec![],
+                1,
                 5,
                 temp_dir.path().to_path_buf(),
                 tx,

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use super::explain_context::ExplainContext;
 use super::runtime_state::RuntimeState;
 use crate::domain::connection::{ConnectionProfile, ServiceEntry};
-use crate::domain::{DatabaseType, TableSummary};
+use crate::domain::{Column, DatabaseType, TableSummary};
 use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::browse::inspector_view_model::InspectorViewModel;
 use crate::model::browse::jsonb_detail::JsonbDetailState;
@@ -33,7 +33,9 @@ use crate::policy::preview_cell_text::CellPresentationPolicy;
 use crate::policy::sql::result_query::is_rerunnable_select;
 use crate::policy::table_kind::max_explorer_table_label_width;
 use crate::policy::write::inline_cell_edit::supports_inline_edit;
-use crate::policy::write::write_guardrails::{PreviewWriteability, preview_writeability};
+use crate::policy::write::write_guardrails::{
+    PreviewWriteability, preview_writeability_for_result,
+};
 use crate::ports::outbound::DdlGenerator;
 
 pub struct AppState {
@@ -287,6 +289,20 @@ impl AppState {
             .unwrap_or_default()
     }
 
+    pub fn filtered_databases(&self) -> Vec<&String> {
+        let filter_lower = self
+            .ui
+            .table_picker()
+            .filter_input()
+            .content()
+            .to_lowercase();
+        self.session
+            .available_databases()
+            .iter()
+            .filter(|database| database.to_lowercase().contains(&filter_lower))
+            .collect()
+    }
+
     pub fn er_filtered_tables(&self) -> Vec<&TableSummary> {
         let filter_lower = self.ui.er_picker().filter_input().content().to_lowercase();
         self.session
@@ -371,7 +387,8 @@ impl AppState {
         if !self.query.pagination.matches_table(table_detail) {
             return None;
         }
-        match preview_writeability(table_detail) {
+        let result = self.query.visible_result()?;
+        match preview_writeability_for_result(table_detail, result) {
             PreviewWriteability::Writable => None,
             PreviewWriteability::ReadOnly(reason) => Some(reason),
             PreviewWriteability::MissingStableRowIdentity => Some("table without PRIMARY KEY"),
@@ -381,6 +398,16 @@ impl AppState {
     pub fn can_write_visible_preview(&self) -> bool {
         self.query.can_edit_visible_result()
             && self.visible_preview_target_read_only_reason().is_none()
+    }
+
+    pub fn visible_preview_column(&self, col_idx: usize) -> Option<&Column> {
+        let result = self.query.visible_result()?;
+        let column_name = result.columns.get(col_idx)?;
+        let table_detail = self.session.table_detail()?;
+        table_detail
+            .columns
+            .iter()
+            .find(|column| column.name == *column_name)
     }
 
     pub fn can_edit_selected_cell(&self) -> bool {
@@ -404,28 +431,26 @@ impl AppState {
             return false;
         };
 
-        if let Some(table_detail) = self.session.table_detail()
-            && let Some(column) = table_detail.columns.get(col_idx)
-        {
-            if table_detail
-                .primary_key
-                .as_ref()
-                .is_some_and(|pk| pk.iter().any(|name| name == &column.name))
-            {
-                return false;
-            }
-            if column.is_read_only() {
-                return false;
-            }
+        let Some(column) = self.visible_preview_column(col_idx) else {
+            return false;
+        };
+        let is_primary_key = column.is_primary_key()
+            || self
+                .session
+                .table_detail()
+                .and_then(|table| table.primary_key.as_ref())
+                .is_some_and(|primary_key| primary_key.iter().any(|name| name == &column.name));
+        if is_primary_key || column.is_read_only() {
+            return false;
+        }
 
-            let policy = CellPresentationPolicy::new(
-                self.session.active_database_type_or_default(),
-                column.data_type.as_str(),
-                value.as_str().unwrap_or_default(),
-            );
-            if policy.uses_jsonb_detail_modal() {
-                return true;
-            }
+        let policy = CellPresentationPolicy::new(
+            self.session.active_database_type_or_default(),
+            column.data_type.as_str(),
+            value.as_str().unwrap_or_default(),
+        );
+        if policy.uses_jsonb_detail_modal() {
+            return true;
         }
 
         supports_inline_edit(self.session.active_database_type_or_default(), value)
@@ -435,6 +460,11 @@ impl AppState {
     /// connection and query run, and must be dropped without touching state.
     pub fn is_stale_query_run(&self, dsn: &str, run_id: u64) -> bool {
         !self.session.dsn_matches(dsn) || !self.query.is_current_run(run_id)
+    }
+
+    pub fn is_stale_explain_run(&self, dsn: &str, database_generation: u64, run_id: u64) -> bool {
+        self.is_stale_query_run(dsn, run_id)
+            || self.session.database_generation() != database_generation
     }
 }
 
@@ -447,8 +477,8 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        Column, ColumnAttributes, ConnectionId, DatabaseMetadata, DatabaseType, QueryResult,
-        QuerySource, QueryValue, Table, TableKind, TableKindInfo,
+        ColumnAttributes, ConnectionId, DatabaseMetadata, DatabaseType, QueryResult, QuerySource,
+        QueryValue, Table, TableKind, TableKindInfo,
     };
     use crate::model::browse::row_detail::RowDetailState;
     use crate::model::er_state::ErStatus;
@@ -589,6 +619,129 @@ mod tests {
         state.result_interaction.activate_cell(0, 1);
 
         assert!(!state.can_edit_selected_cell());
+    }
+
+    #[test]
+    fn can_edit_selected_cell_maps_visible_column_by_name_after_hidden_primary_key() {
+        let mut state = make_state();
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "mysql",
+            DatabaseType::MySQL,
+            "mysql://localhost/test",
+        );
+        state.query.set_current_result(Arc::new(
+            QueryResult::success_with_values(
+                "SELECT `payload` FROM `sabiql_test`.`users`".to_string(),
+                vec!["payload".to_string()],
+                vec![vec![QueryValue::text("before")]],
+                10,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["id".to_string()],
+                vec![vec![QueryValue::SqlLiteral("1".to_string())]],
+            ),
+        ));
+        state
+            .query
+            .pagination
+            .reset_for_table("sabiql_test", "users");
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "sabiql_test".to_string(),
+            name: "users".to_string(),
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "INT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::PRIMARY_KEY
+                        | ColumnAttributes::HIDDEN
+                        | ColumnAttributes::READ_ONLY,
+                    comment: None,
+                    ordinal_position: 1,
+                },
+                Column {
+                    name: "payload".to_string(),
+                    data_type: "TEXT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::empty(),
+                    comment: None,
+                    ordinal_position: 2,
+                },
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..test_support::table::minimal("", "")
+        }));
+        state.result_interaction.activate_cell(0, 0);
+
+        assert!(state.can_edit_selected_cell());
+    }
+
+    #[test]
+    fn can_edit_selected_cell_maps_visible_column_by_name_when_hidden_primary_key_is_between_columns()
+     {
+        let mut state = make_state();
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "mysql",
+            DatabaseType::MySQL,
+            "mysql://localhost/test",
+        );
+        state.query.set_current_result(Arc::new(
+            QueryResult::success_with_values(
+                "SELECT `name`, `payload` FROM `sabiql_test`.`users`".to_string(),
+                vec!["name".to_string(), "payload".to_string()],
+                vec![vec![QueryValue::text("Alice"), QueryValue::text("before")]],
+                10,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["id".to_string()],
+                vec![vec![QueryValue::SqlLiteral("1".to_string())]],
+            ),
+        ));
+        state
+            .query
+            .pagination
+            .reset_for_table("sabiql_test", "users");
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "sabiql_test".to_string(),
+            name: "users".to_string(),
+            columns: vec![
+                Column {
+                    name: "name".to_string(),
+                    data_type: "VARCHAR".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::empty(),
+                    comment: None,
+                    ordinal_position: 1,
+                },
+                Column {
+                    name: "id".to_string(),
+                    data_type: "INT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::PRIMARY_KEY
+                        | ColumnAttributes::HIDDEN
+                        | ColumnAttributes::READ_ONLY,
+                    comment: None,
+                    ordinal_position: 2,
+                },
+                Column {
+                    name: "payload".to_string(),
+                    data_type: "TEXT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::empty(),
+                    comment: None,
+                    ordinal_position: 3,
+                },
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..test_support::table::minimal("", "")
+        }));
+        state.result_interaction.activate_cell(0, 1);
+
+        assert!(state.can_edit_selected_cell());
     }
 
     mod pane_geometry {

--- a/src/app/model/browse/jsonb_detail.rs
+++ b/src/app/model/browse/jsonb_detail.rs
@@ -145,9 +145,6 @@ impl JsonbDetailState {
 
     pub fn has_pending_changes(&self) -> bool {
         let content = self.editor.content();
-        if content.is_empty() {
-            return false;
-        }
         let trimmed = content.trim();
         trimmed != self.original_json().trim() && trimmed != self.pretty_original().trim()
     }

--- a/src/app/model/shared/engine_feature_profile.rs
+++ b/src/app/model/shared/engine_feature_profile.rs
@@ -16,7 +16,8 @@ pub enum InspectorInfoField {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConnectionFeature {
     ErDiagram,
-    JsonbDetail,
+    JsonDocumentDetail,
+    JsonDocumentEdit,
     SqliteDiagnostics,
 }
 
@@ -102,11 +103,36 @@ const SQLITE_INSPECTOR: InspectorProfile = InspectorProfile::new(
         InspectorInfoField::TableFlags,
     ],
 );
+const MYSQL_INSPECTOR: InspectorProfile = InspectorProfile::new(
+    &[
+        InspectorTab::Info,
+        InspectorTab::Columns,
+        InspectorTab::Indexes,
+        InspectorTab::ForeignKeys,
+        InspectorTab::Triggers,
+        InspectorTab::Ddl,
+    ],
+    &[
+        InspectorInfoField::Comment,
+        InspectorInfoField::RowCount,
+        InspectorInfoField::Schema,
+        InspectorInfoField::TableName,
+        InspectorInfoField::TableKind,
+    ],
+);
 
 const NO_CONNECTION_FEATURES: &[ConnectionFeature] = &[];
-const POSTGRESQL_FEATURES: &[ConnectionFeature] =
-    &[ConnectionFeature::ErDiagram, ConnectionFeature::JsonbDetail];
+const POSTGRESQL_FEATURES: &[ConnectionFeature] = &[
+    ConnectionFeature::ErDiagram,
+    ConnectionFeature::JsonDocumentDetail,
+    ConnectionFeature::JsonDocumentEdit,
+];
 const SQLITE_FEATURES: &[ConnectionFeature] = &[ConnectionFeature::SqliteDiagnostics];
+const MYSQL_FEATURES: &[ConnectionFeature] = &[
+    ConnectionFeature::ErDiagram,
+    ConnectionFeature::JsonDocumentDetail,
+    ConnectionFeature::JsonDocumentEdit,
+];
 
 impl EngineFeatureProfile {
     fn new(
@@ -167,10 +193,21 @@ impl EngineFeatureProfile {
         )
     }
 
+    pub fn mysql_like() -> Self {
+        Self::new(
+            MYSQL_INSPECTOR,
+            ExplainProfile::QueryPlanAndAnalyze {
+                comparison: ComparisonSupport::Supported,
+            },
+            MYSQL_FEATURES,
+        )
+    }
+
     pub fn for_database_type(database_type: DatabaseType) -> Self {
         match database_type {
             DatabaseType::PostgreSQL => Self::postgres_like(),
             DatabaseType::SQLite => Self::sqlite_like(),
+            DatabaseType::MySQL => Self::mysql_like(),
         }
     }
 
@@ -207,8 +244,12 @@ impl EngineFeatureProfile {
         )
     }
 
-    pub fn supports_jsonb_detail(&self) -> bool {
-        self.supports_connection_feature(ConnectionFeature::JsonbDetail)
+    pub fn supports_json_document_detail(&self) -> bool {
+        self.supports_connection_feature(ConnectionFeature::JsonDocumentDetail)
+    }
+
+    pub fn supports_json_document_edit(&self) -> bool {
+        self.supports_connection_feature(ConnectionFeature::JsonDocumentEdit)
     }
 
     pub fn supports_sqlite_diagnostics(&self) -> bool {
@@ -336,7 +377,8 @@ mod tests {
         assert!(profile.supports_explain_analyze());
         assert!(profile.supports_plan_comparison());
         assert!(profile.supports_er_diagram());
-        assert!(profile.supports_jsonb_detail());
+        assert!(profile.supports_json_document_detail());
+        assert!(profile.supports_json_document_edit());
         assert!(!profile.supports_sqlite_diagnostics());
         assert!(profile.supports_inspector_tab(InspectorTab::Ddl));
         assert_eq!(
@@ -371,7 +413,8 @@ mod tests {
         assert!(!profile.supports_explain_analyze());
         assert!(!profile.supports_plan_comparison());
         assert!(!profile.supports_er_diagram());
-        assert!(!profile.supports_jsonb_detail());
+        assert!(!profile.supports_json_document_detail());
+        assert!(!profile.supports_json_document_edit());
         assert!(profile.supports_sqlite_diagnostics());
         assert_eq!(
             profile.supported_inspector_tabs(),
@@ -410,6 +453,48 @@ mod tests {
             EngineFeatureProfile::for_database_type(DatabaseType::SQLite),
             EngineFeatureProfile::sqlite_like()
         );
+        assert_eq!(
+            EngineFeatureProfile::for_database_type(DatabaseType::MySQL),
+            EngineFeatureProfile::mysql_like()
+        );
+    }
+
+    #[test]
+    fn mysql_profile_exposes_browse_metadata_ddl_analyze_and_compare() {
+        let profile = EngineFeatureProfile::mysql_like();
+
+        assert!(profile.supports_explain());
+        assert!(profile.supports_explain_analyze());
+        assert!(profile.supports_plan_comparison());
+        assert!(profile.supports_er_diagram());
+        assert!(profile.supports_json_document_detail());
+        assert!(profile.supports_json_document_edit());
+        assert!(!profile.supports_sqlite_diagnostics());
+        assert_eq!(
+            profile.supported_inspector_tabs(),
+            &[
+                InspectorTab::Info,
+                InspectorTab::Columns,
+                InspectorTab::Indexes,
+                InspectorTab::ForeignKeys,
+                InspectorTab::Triggers,
+                InspectorTab::Ddl,
+            ]
+        );
+        assert_eq!(
+            profile.supported_inspector_info_fields(),
+            &[
+                InspectorInfoField::Comment,
+                InspectorInfoField::RowCount,
+                InspectorInfoField::Schema,
+                InspectorInfoField::TableName,
+                InspectorInfoField::TableKind,
+            ]
+        );
+        assert_eq!(
+            profile.supported_sql_modal_tabs(),
+            &[SqlModalTab::Sql, SqlModalTab::Plan, SqlModalTab::Compare]
+        );
     }
 
     #[test]
@@ -420,7 +505,8 @@ mod tests {
         assert!(!profile.supports_explain_analyze());
         assert!(!profile.supports_plan_comparison());
         assert!(!profile.supports_er_diagram());
-        assert!(!profile.supports_jsonb_detail());
+        assert!(!profile.supports_json_document_detail());
+        assert!(!profile.supports_json_document_edit());
         assert!(!profile.supports_sqlite_diagnostics());
         assert_eq!(profile.supported_inspector_tabs(), &[InspectorTab::Info]);
         assert_eq!(

--- a/src/app/policy/feature_policy.rs
+++ b/src/app/policy/feature_policy.rs
@@ -4,7 +4,8 @@ use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 pub enum FeatureRequirement {
     None,
     ErDiagram,
-    JsonbDetail,
+    JsonDocumentDetail,
+    JsonDocumentEdit,
     SqliteDiagnostics,
     Explain,
     ExplainAnalyze,
@@ -31,7 +32,8 @@ impl FeaturePolicy {
         let supported = match requirement {
             FeatureRequirement::None => true,
             FeatureRequirement::ErDiagram => self.profile.supports_er_diagram(),
-            FeatureRequirement::JsonbDetail => self.profile.supports_jsonb_detail(),
+            FeatureRequirement::JsonDocumentDetail => self.profile.supports_json_document_detail(),
+            FeatureRequirement::JsonDocumentEdit => self.profile.supports_json_document_edit(),
             FeatureRequirement::SqliteDiagnostics => self.profile.supports_sqlite_diagnostics(),
             FeatureRequirement::Explain => self.profile.supports_explain(),
             FeatureRequirement::ExplainAnalyze => self.profile.supports_explain_analyze(),
@@ -67,7 +69,11 @@ mod tests {
             FeatureAvailability::Enabled
         );
         assert_eq!(
-            policy.availability(FeatureRequirement::JsonbDetail),
+            policy.availability(FeatureRequirement::JsonDocumentDetail),
+            FeatureAvailability::Enabled
+        );
+        assert_eq!(
+            policy.availability(FeatureRequirement::JsonDocumentEdit),
             FeatureAvailability::Enabled
         );
         assert_eq!(
@@ -93,7 +99,11 @@ mod tests {
             FeatureAvailability::Hidden
         );
         assert_eq!(
-            policy.availability(FeatureRequirement::JsonbDetail),
+            policy.availability(FeatureRequirement::JsonDocumentDetail),
+            FeatureAvailability::Hidden
+        );
+        assert_eq!(
+            policy.availability(FeatureRequirement::JsonDocumentEdit),
             FeatureAvailability::Hidden
         );
         assert_eq!(

--- a/src/app/policy/preview_cell_text/diff.rs
+++ b/src/app/policy/preview_cell_text/diff.rs
@@ -1,20 +1,24 @@
 use super::handling::PreviewCellTextDiffHandling;
 
 fn normalize_jsonb_for_diff(value: &str) -> String {
-    serde_json::from_str::<serde_json::Value>(value)
-        .and_then(|v| serde_json::to_string(&v))
-        .unwrap_or_else(|_| value.to_string())
+    normalize_structured_json_for_write(value)
+        .ok()
+        .unwrap_or_else(|| value.to_string())
+}
+
+pub fn normalize_structured_json_for_write(value: &str) -> Result<String, serde_json::Error> {
+    serde_json::from_str::<serde_json::Value>(value).and_then(|value| serde_json::to_string(&value))
 }
 
 pub fn normalize_for_write_diff(value: &str, handling: PreviewCellTextDiffHandling) -> String {
     match handling {
-        PreviewCellTextDiffHandling::PostgreSqlJsonb => normalize_jsonb_for_diff(value),
+        PreviewCellTextDiffHandling::StructuredJson => normalize_jsonb_for_diff(value),
         PreviewCellTextDiffHandling::RawText => value.to_string(),
     }
 }
 
 pub fn uses_structured_json_diff(handling: PreviewCellTextDiffHandling) -> bool {
-    handling == PreviewCellTextDiffHandling::PostgreSqlJsonb
+    handling == PreviewCellTextDiffHandling::StructuredJson
 }
 
 #[cfg(test)]
@@ -34,6 +38,19 @@ mod tests {
             normalize_for_write_diff(pg_style, handling),
             normalize_for_write_diff(serde_style, handling)
         );
+    }
+
+    #[test]
+    fn mysql_json_column_normalizes_key_order() {
+        let handling = CellPresentationPolicy::new(DatabaseType::MySQL, "json", "").diff_handling();
+        let spaced = r#"{"a": 1, "b": 2}"#;
+        let compact = r#"{"b":2,"a":1}"#;
+
+        assert_eq!(
+            normalize_for_write_diff(spaced, handling),
+            normalize_for_write_diff(compact, handling)
+        );
+        assert!(uses_structured_json_diff(handling));
     }
 
     #[test]

--- a/src/app/policy/preview_cell_text/display.rs
+++ b/src/app/policy/preview_cell_text/display.rs
@@ -15,6 +15,7 @@ pub fn format_for_cell_detail(
         PreviewCellTextDisplayHandling::SqliteText
             | PreviewCellTextDisplayHandling::PostgreSqlJson
             | PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
+            | PreviewCellTextDisplayHandling::StructuredJson
     );
     if !should_pretty_print {
         return CellDetailDisplay {
@@ -54,6 +55,20 @@ mod tests {
         let formatted = format_for_cell_detail(r#"{"b":2,"a":1}"#, handling);
         assert_eq!(formatted.content, "{\n  \"a\": 1,\n  \"b\": 2\n}");
         assert!(formatted.formatted_json);
+    }
+
+    #[test]
+    fn mysql_json_scalar_pretty_prints() {
+        let handling =
+            CellPresentationPolicy::new(DatabaseType::MySQL, "json", "42").display_handling();
+
+        assert_eq!(
+            format_for_cell_detail("42", handling),
+            CellDetailDisplay {
+                content: "42".to_string(),
+                formatted_json: true,
+            }
+        );
     }
 
     #[test]

--- a/src/app/policy/preview_cell_text/handling.rs
+++ b/src/app/policy/preview_cell_text/handling.rs
@@ -3,7 +3,7 @@ use crate::domain::DatabaseType;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PreviewCellTextDiffHandling {
     RawText,
-    PostgreSqlJsonb,
+    StructuredJson,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -12,7 +12,7 @@ pub enum PreviewCellTextDisplayHandling {
     SqliteText,
     PostgreSqlJsonLikeText,
     PostgreSqlJson,
-    PostgreSqlJsonb,
+    StructuredJson,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24,16 +24,21 @@ pub struct CellPresentationPolicy {
 impl CellPresentationPolicy {
     pub fn new(database_type: DatabaseType, column_data_type: &str, value: &str) -> Self {
         let diff_handling = match (database_type, column_data_type) {
-            (DatabaseType::PostgreSQL, "jsonb") => PreviewCellTextDiffHandling::PostgreSqlJsonb,
+            (DatabaseType::PostgreSQL, "jsonb") | (DatabaseType::MySQL, "json") => {
+                PreviewCellTextDiffHandling::StructuredJson
+            }
             _ => PreviewCellTextDiffHandling::RawText,
         };
         let display_handling = match database_type {
             DatabaseType::SQLite if has_sqlite_text_affinity(column_data_type) => {
                 PreviewCellTextDisplayHandling::SqliteText
             }
-            DatabaseType::SQLite => PreviewCellTextDisplayHandling::RawText,
+            DatabaseType::MySQL if column_data_type == "json" => {
+                PreviewCellTextDisplayHandling::StructuredJson
+            }
+            DatabaseType::SQLite | DatabaseType::MySQL => PreviewCellTextDisplayHandling::RawText,
             DatabaseType::PostgreSQL => match column_data_type {
-                "jsonb" => PreviewCellTextDisplayHandling::PostgreSqlJsonb,
+                "jsonb" => PreviewCellTextDisplayHandling::StructuredJson,
                 "json" => PreviewCellTextDisplayHandling::PostgreSqlJson,
                 _ if looks_like_json_container(value) => {
                     PreviewCellTextDisplayHandling::PostgreSqlJsonLikeText
@@ -57,7 +62,7 @@ impl CellPresentationPolicy {
     }
 
     pub fn uses_jsonb_detail_modal(self) -> bool {
-        self.diff_handling == PreviewCellTextDiffHandling::PostgreSqlJsonb
+        self.display_handling == PreviewCellTextDisplayHandling::StructuredJson
     }
 }
 
@@ -99,12 +104,39 @@ mod tests {
     fn postgresql_jsonb_uses_semantic_handling() {
         assert_eq!(
             CellPresentationPolicy::new(DatabaseType::PostgreSQL, "jsonb", "").diff_handling(),
-            PreviewCellTextDiffHandling::PostgreSqlJsonb
+            PreviewCellTextDiffHandling::StructuredJson
         );
         assert!(
             CellPresentationPolicy::new(DatabaseType::PostgreSQL, "jsonb", "")
                 .uses_jsonb_detail_modal()
         );
+    }
+
+    #[test]
+    fn mysql_json_uses_structured_handling_without_edit_capability() {
+        let policy = CellPresentationPolicy::new(DatabaseType::MySQL, "json", "");
+
+        assert_eq!(
+            policy.diff_handling(),
+            PreviewCellTextDiffHandling::StructuredJson
+        );
+        assert_eq!(
+            policy.display_handling(),
+            PreviewCellTextDisplayHandling::StructuredJson
+        );
+        assert!(policy.uses_jsonb_detail_modal());
+    }
+
+    #[test]
+    fn mysql_non_json_columns_stay_raw() {
+        let policy = CellPresentationPolicy::new(DatabaseType::MySQL, "text", r#"{"a":1}"#);
+
+        assert_eq!(policy.diff_handling(), PreviewCellTextDiffHandling::RawText);
+        assert_eq!(
+            policy.display_handling(),
+            PreviewCellTextDisplayHandling::RawText
+        );
+        assert!(!policy.uses_jsonb_detail_modal());
     }
 
     #[test]

--- a/src/app/policy/preview_cell_text/mod.rs
+++ b/src/app/policy/preview_cell_text/mod.rs
@@ -2,6 +2,8 @@ mod diff;
 mod display;
 mod handling;
 
-pub use diff::{normalize_for_write_diff, uses_structured_json_diff};
+pub use diff::{
+    normalize_for_write_diff, normalize_structured_json_for_write, uses_structured_json_diff,
+};
 pub use display::format_for_cell_detail;
 pub use handling::CellPresentationPolicy;

--- a/src/app/policy/write/inline_cell_edit.rs
+++ b/src/app/policy/write/inline_cell_edit.rs
@@ -19,6 +19,8 @@ pub enum InlineCellEditError {
     InvalidReal,
     #[error("REAL value must be finite")]
     NonFiniteReal,
+    #[error("Invalid NUMERIC value")]
+    InvalidNumeric,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -26,6 +28,7 @@ enum InlineCellEditKind {
     Text,
     SqliteInteger,
     SqliteReal,
+    MysqlNumeric,
 }
 
 pub fn supports_inline_edit(database_type: DatabaseType, value: &QueryValue) -> bool {
@@ -41,9 +44,9 @@ pub fn text_for_inline_edit(
             QueryValue::Text(value) => Ok(value.clone()),
             _ => unreachable!("text edit kind must carry text value"),
         },
-        InlineCellEditKind::SqliteInteger | InlineCellEditKind::SqliteReal => {
-            Ok(value.display_value())
-        }
+        InlineCellEditKind::SqliteInteger
+        | InlineCellEditKind::SqliteReal
+        | InlineCellEditKind::MysqlNumeric => Ok(value.display_value()),
     }
 }
 
@@ -56,6 +59,9 @@ pub fn build_inline_edited_value(
         InlineCellEditKind::Text => Ok(QueryValue::text(edited_text)),
         InlineCellEditKind::SqliteInteger => parse_sqlite_integer_text(edited_text),
         InlineCellEditKind::SqliteReal => parse_sqlite_real_text(edited_text),
+        InlineCellEditKind::MysqlNumeric => matches_mysql_numeric_lexeme(edited_text)
+            .then(|| QueryValue::SqlLiteral(edited_text.to_string()))
+            .ok_or(InlineCellEditError::InvalidNumeric),
     }
 }
 
@@ -65,7 +71,22 @@ fn classify_inline_cell_edit(
 ) -> Result<InlineCellEditKind, InlineCellEditError> {
     match database_type {
         DatabaseType::PostgreSQL => classify_postgres_inline_cell_edit(value),
+        DatabaseType::MySQL => classify_mysql_inline_cell_edit(value),
         DatabaseType::SQLite => classify_sqlite_inline_cell_edit(value),
+    }
+}
+
+fn classify_mysql_inline_cell_edit(
+    value: &QueryValue,
+) -> Result<InlineCellEditKind, InlineCellEditError> {
+    match value {
+        QueryValue::Text(_) => Ok(InlineCellEditKind::Text),
+        QueryValue::Null => Err(InlineCellEditError::NullUnsupported),
+        QueryValue::Blob(_) => Err(InlineCellEditError::BlobUnsupported),
+        QueryValue::SqlLiteral(value) if matches_mysql_numeric_lexeme(value) => {
+            Ok(InlineCellEditKind::MysqlNumeric)
+        }
+        QueryValue::SqlLiteral(_) => Err(InlineCellEditError::UnsupportedCellType),
     }
 }
 
@@ -206,6 +227,51 @@ fn matches_sqlite_numeric_lexeme(value: &str) -> bool {
     index == bytes.len()
 }
 
+fn matches_mysql_numeric_lexeme(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+
+    let mut index = usize::from(matches!(bytes[0], b'+' | b'-'));
+    let integer_start = index;
+    while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+        index += 1;
+    }
+    let has_integer = index > integer_start;
+
+    let has_fraction = if bytes.get(index) == Some(&b'.') {
+        index += 1;
+        let fraction_start = index;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+        index > fraction_start
+    } else {
+        false
+    };
+
+    if !has_integer && !has_fraction {
+        return false;
+    }
+
+    if matches!(bytes.get(index), Some(b'e' | b'E')) {
+        index += 1;
+        if matches!(bytes.get(index), Some(b'+' | b'-')) {
+            index += 1;
+        }
+        let exponent_start = index;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+        if exponent_start == index {
+            return false;
+        }
+    }
+
+    index == bytes.len()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -299,5 +365,47 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error, InlineCellEditError::UnsupportedCellType);
+    }
+
+    #[test]
+    fn mysql_numeric_literal_preserves_large_integer_without_f64_conversion() {
+        let original = QueryValue::SqlLiteral("18446744073709551615".to_string());
+        let value =
+            build_inline_edited_value(DatabaseType::MySQL, &original, "18446744073709551615")
+                .unwrap();
+
+        assert_eq!(value, original);
+    }
+
+    #[test]
+    fn mysql_numeric_literal_preserves_decimal_and_exponent_lexemes() {
+        for draft in [
+            "12345678901234567890123456789012345.12345678901234567890",
+            "1.23e100",
+            ".5",
+            "1.",
+        ] {
+            assert_eq!(
+                build_inline_edited_value(
+                    DatabaseType::MySQL,
+                    &QueryValue::SqlLiteral("1".to_string()),
+                    draft,
+                )
+                .unwrap(),
+                QueryValue::SqlLiteral(draft.to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn mysql_numeric_literal_rejects_invalid_lexeme() {
+        let error = build_inline_edited_value(
+            DatabaseType::MySQL,
+            &QueryValue::SqlLiteral("1".to_string()),
+            "1e",
+        )
+        .unwrap_err();
+
+        assert_eq!(error, InlineCellEditError::InvalidNumeric);
     }
 }

--- a/src/app/policy/write/write_guardrails.rs
+++ b/src/app/policy/write/write_guardrails.rs
@@ -5,6 +5,7 @@ use crate::policy::write::write_update::build_pk_pairs;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StableRowIdentity {
     PrimaryKey(Vec<String>),
+    Explicit(Vec<String>),
 }
 
 impl StableRowIdentity {
@@ -13,9 +14,22 @@ impl StableRowIdentity {
         result: &QueryResult,
         row_idx: usize,
     ) -> Option<Vec<(String, QueryValue)>> {
-        let Self::PrimaryKey(columns) = self;
-        let row = result.values().get(row_idx)?;
-        build_pk_pairs(&result.columns, row, columns)
+        match self {
+            Self::PrimaryKey(columns) => {
+                let row = result.values().get(row_idx)?;
+                build_pk_pairs(&result.columns, row, columns)
+            }
+            Self::Explicit(columns) => {
+                let values = result.explicit_row_identity()?.values_for_row(row_idx)?;
+                (columns.len() == values.len()).then(|| {
+                    columns
+                        .iter()
+                        .cloned()
+                        .zip(values.iter().cloned())
+                        .collect()
+                })
+            }
+        }
     }
 
     pub fn predicate_pairs_for_row(
@@ -27,8 +41,11 @@ impl StableRowIdentity {
     }
 
     pub fn is_primary_key_column(&self, column_name: &str) -> bool {
-        let Self::PrimaryKey(columns) = self;
-        columns.iter().any(|pk| pk == column_name)
+        match self {
+            Self::PrimaryKey(columns) | Self::Explicit(columns) => {
+                columns.iter().any(|pk| pk == column_name)
+            }
+        }
     }
 }
 
@@ -42,6 +59,17 @@ pub fn stable_row_identity_for_table(table: &Table) -> Option<StableRowIdentity>
         return None;
     }
     table.primary_key.clone().map(StableRowIdentity::PrimaryKey)
+}
+
+pub fn stable_row_identity_for_preview(
+    table: &Table,
+    result: &QueryResult,
+) -> Option<StableRowIdentity> {
+    if let Some(explicit) = result.explicit_row_identity() {
+        return valid_explicit_row_identity(table, result)
+            .then(|| StableRowIdentity::Explicit(explicit.columns().to_vec()));
+    }
+    stable_row_identity_for_table(table)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,6 +90,32 @@ pub fn preview_writeability(table: &Table) -> PreviewWriteability {
         return PreviewWriteability::MissingStableRowIdentity;
     }
     PreviewWriteability::Writable
+}
+
+pub fn preview_writeability_for_result(table: &Table, result: &QueryResult) -> PreviewWriteability {
+    let writeability = preview_writeability(table);
+    if writeability == PreviewWriteability::Writable
+        && result.explicit_row_identity().is_some()
+        && !valid_explicit_row_identity(table, result)
+    {
+        return PreviewWriteability::ReadOnly("invalid row identity");
+    }
+    writeability
+}
+
+fn valid_explicit_row_identity(table: &Table, result: &QueryResult) -> bool {
+    let Some(primary_key) = table.primary_key.as_ref() else {
+        return false;
+    };
+    let Some(identity) = result.explicit_row_identity() else {
+        return false;
+    };
+    identity.columns() == primary_key
+        && identity.values().len() == result.data_row_count()
+        && identity
+            .values()
+            .iter()
+            .all(|values| values.len() == primary_key.len())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -194,7 +248,7 @@ pub fn evaluate_guardrails(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::TableKindInfo;
+    use crate::domain::{QueryResult, QuerySource, TableKindInfo};
     use crate::test_support;
 
     mod guardrail_evaluation {
@@ -255,6 +309,88 @@ mod tests {
             assert_eq!(
                 stable_row_identity_for_table(&table),
                 Some(StableRowIdentity::PrimaryKey(vec!["id".to_string()]))
+            );
+        }
+
+        #[test]
+        fn explicit_identity_uses_values_separate_from_display_columns() {
+            let table = primary_key_table();
+            let result = QueryResult::success_with_values(
+                "SELECT name".to_string(),
+                vec!["name".to_string()],
+                vec![vec![QueryValue::text("alice")]],
+                0,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(vec!["id".to_string()], vec![vec![QueryValue::text("42")]]);
+
+            let identity = stable_row_identity_for_preview(&table, &result).unwrap();
+
+            assert_eq!(
+                identity.identity_pairs_for_row(&result, 0),
+                Some(vec![("id".to_string(), QueryValue::text("42"))])
+            );
+        }
+
+        #[test]
+        fn malformed_explicit_identity_makes_preview_read_only() {
+            let table = primary_key_table();
+            let result = QueryResult::success_with_values(
+                "SELECT name".to_string(),
+                vec!["name".to_string()],
+                vec![vec![QueryValue::text("alice")]],
+                0,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["wrong_id".to_string()],
+                vec![vec![QueryValue::text("42")]],
+            );
+
+            assert_eq!(
+                preview_writeability_for_result(&table, &result),
+                PreviewWriteability::ReadOnly("invalid row identity")
+            );
+            assert!(stable_row_identity_for_preview(&table, &result).is_none());
+        }
+
+        #[test]
+        fn row_count_mismatch_in_explicit_identity_makes_preview_read_only() {
+            let table = primary_key_table();
+            let result = QueryResult::success_with_values(
+                "SELECT name".to_string(),
+                vec!["name".to_string()],
+                vec![vec![QueryValue::text("alice")]],
+                0,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(vec!["id".to_string()], Vec::new());
+
+            assert_eq!(
+                preview_writeability_for_result(&table, &result),
+                PreviewWriteability::ReadOnly("invalid row identity")
+            );
+        }
+
+        #[test]
+        fn value_count_mismatch_in_explicit_identity_makes_preview_read_only() {
+            let mut table = primary_key_table();
+            table.primary_key = Some(vec!["first_id".to_string(), "second_id".to_string()]);
+            let result = QueryResult::success_with_values(
+                "SELECT name".to_string(),
+                vec!["name".to_string()],
+                vec![vec![QueryValue::text("alice")]],
+                0,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["first_id".to_string(), "second_id".to_string()],
+                vec![vec![QueryValue::text("42")]],
+            );
+
+            assert_eq!(
+                preview_writeability_for_result(&table, &result),
+                PreviewWriteability::ReadOnly("invalid row identity")
             );
         }
 

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -15,16 +15,48 @@ impl AppServices {
     #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn stub() -> Self {
+        use crate::policy::sql::mysql_statement::{
+            mysql_explain_rejection_message, mysql_tree_explain_query_kind,
+        };
         use crate::policy::sql::sqlite_explain::build_sqlite_explain_query_plan_sql;
 
-        fn quote_literal(value: &str) -> String {
-            format!("'{}'", value.replace('\'', "''"))
+        fn quote_identifier(database_type: DatabaseType, value: &str) -> String {
+            match database_type {
+                DatabaseType::MySQL => {
+                    format!("`{}`", value.replace('`', "``"))
+                }
+                DatabaseType::PostgreSQL | DatabaseType::SQLite => {
+                    format!("\"{}\"", value.replace('"', "\"\""))
+                }
+            }
+        }
+
+        fn quote_literal(database_type: DatabaseType, value: &str) -> String {
+            if database_type != DatabaseType::MySQL {
+                return format!("'{}'", value.replace('\'', "''"));
+            }
+
+            let mut escaped = String::with_capacity(value.len());
+            for character in value.chars() {
+                match character {
+                    '\0' => escaped.push_str("\\0"),
+                    '\n' => escaped.push_str("\\n"),
+                    '\r' => escaped.push_str("\\r"),
+                    '\t' => escaped.push_str("\\t"),
+                    '\u{0008}' => escaped.push_str("\\b"),
+                    '\u{001a}' => escaped.push_str("\\Z"),
+                    '\\' => escaped.push_str("\\\\"),
+                    '\'' => escaped.push_str("\\'"),
+                    _ => escaped.push(character),
+                }
+            }
+            format!("'{escaped}'")
         }
 
         fn sql_literal(database_type: DatabaseType, value: &QueryValue) -> String {
             match value {
                 QueryValue::Null => "NULL".to_string(),
-                QueryValue::Text(value) => quote_literal(value),
+                QueryValue::Text(value) => quote_literal(database_type, value),
                 QueryValue::SqlLiteral(value) => value.clone(),
                 QueryValue::Blob(bytes) => {
                     let mut hex = String::with_capacity(bytes.len() * 2);
@@ -33,7 +65,9 @@ impl AppServices {
                     }
                     match database_type {
                         DatabaseType::PostgreSQL => format!("'\\x{hex}'"),
-                        DatabaseType::SQLite => format!("X'{}'", hex.to_uppercase()),
+                        DatabaseType::SQLite | DatabaseType::MySQL => {
+                            format!("X'{}'", hex.to_uppercase())
+                        }
                     }
                 }
             }
@@ -45,8 +79,14 @@ impl AppServices {
             value: &QueryValue,
         ) -> String {
             match value {
-                QueryValue::Null => format!("\"{key}\" IS NULL"),
-                _ => format!("\"{key}\" = {}", sql_literal(database_type, value)),
+                QueryValue::Null => {
+                    format!("{} IS NULL", quote_identifier(database_type, key))
+                }
+                _ => format!(
+                    "{} = {}",
+                    quote_identifier(database_type, key),
+                    sql_literal(database_type, value)
+                ),
             }
         }
 
@@ -67,6 +107,9 @@ impl AppServices {
                 match database_type {
                     DatabaseType::PostgreSQL => Some(format!("EXPLAIN {query}")),
                     DatabaseType::SQLite => build_sqlite_explain_query_plan_sql(query),
+                    DatabaseType::MySQL => mysql_explain_rejection_message(query)
+                        .is_none()
+                        .then(|| format!("EXPLAIN FORMAT=TREE {query}")),
                 }
             }
 
@@ -78,6 +121,12 @@ impl AppServices {
                 match database_type {
                     DatabaseType::PostgreSQL => Some(format!("EXPLAIN ANALYZE {query}")),
                     DatabaseType::SQLite => None,
+                    DatabaseType::MySQL => {
+                        let explain = format!("EXPLAIN ANALYZE FORMAT=TREE {query}");
+                        mysql_tree_explain_query_kind(&explain)
+                            .is_some()
+                            .then_some(explain)
+                    }
                 }
             }
 
@@ -90,21 +139,29 @@ impl AppServices {
                 new_value: &QueryValue,
                 pk_pairs: &[(String, QueryValue)],
             ) -> String {
-                let set_clause =
-                    format!("\"{column}\" = {}", sql_literal(database_type, new_value));
+                let set_clause = format!(
+                    "{} = {}",
+                    quote_identifier(database_type, column),
+                    sql_literal(database_type, new_value)
+                );
                 let where_clause = pk_pairs
                     .iter()
                     .map(|(key, value)| equality_predicate(database_type, key, value))
                     .collect::<Vec<_>>()
                     .join(" AND ");
                 match database_type {
-                    DatabaseType::PostgreSQL => {
+                    DatabaseType::PostgreSQL | DatabaseType::MySQL => {
                         format!(
-                            "UPDATE \"{schema}\".\"{table}\" SET {set_clause} WHERE {where_clause}"
+                            "UPDATE {}.{} SET {set_clause} WHERE {where_clause}",
+                            quote_identifier(database_type, schema),
+                            quote_identifier(database_type, table)
                         )
                     }
                     DatabaseType::SQLite => {
-                        format!("UPDATE \"{table}\" SET {set_clause} WHERE {where_clause}")
+                        format!(
+                            "UPDATE {} SET {set_clause} WHERE {where_clause}",
+                            quote_identifier(database_type, table)
+                        )
                     }
                 }
             }
@@ -127,10 +184,19 @@ impl AppServices {
                     .collect::<Vec<_>>()
                     .join(" OR ");
                 match database_type {
-                    DatabaseType::PostgreSQL => {
-                        format!("DELETE FROM \"{schema}\".\"{table}\" WHERE {where_clause}")
+                    DatabaseType::PostgreSQL | DatabaseType::MySQL => {
+                        format!(
+                            "DELETE FROM {}.{} WHERE {where_clause}",
+                            quote_identifier(database_type, schema),
+                            quote_identifier(database_type, table)
+                        )
                     }
-                    DatabaseType::SQLite => format!("DELETE FROM \"{table}\" WHERE {where_clause}"),
+                    DatabaseType::SQLite => {
+                        format!(
+                            "DELETE FROM {} WHERE {where_clause}",
+                            quote_identifier(database_type, table)
+                        )
+                    }
                 }
             }
         }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -1,9 +1,10 @@
+use std::fmt;
 use std::sync::Arc;
 
 use crate::domain::connection::{
-    ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
+    ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
 };
-use crate::domain::query_history::QueryHistoryEntry;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 use crate::model::app_state::AppState;
 use crate::model::browse::jsonb_detail::JsonbDetailMode;
 use crate::model::connection::error::ConnectionErrorInfo;
@@ -11,8 +12,8 @@ use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::Prefix;
 use crate::model::sql_editor::completion::CompletionCandidate;
-use crate::policy::FeatureRequirement;
 use crate::policy::write::write_guardrails::WritePreview;
+use crate::policy::{FeatureRequirement, mask_password};
 use crate::ports::outbound::clipboard::ClipboardError;
 use crate::ports::outbound::connection_store::ConnectionStoreError;
 use crate::ports::outbound::folder_opener::FolderOpenError;
@@ -20,11 +21,10 @@ use crate::ports::outbound::query_history::QueryHistoryError;
 use crate::ports::outbound::settings_store::SettingsStoreError;
 use crate::ports::outbound::{AppSettings, DbOperationError};
 use std::collections::HashMap;
+use url::Url;
 
 use crate::domain::SqliteDiagnosticsSnapshot;
-use crate::domain::{
-    ConnectionId, DatabaseMetadata, DiagnosticField, QueryResult, QuerySource, Table,
-};
+use crate::domain::{DatabaseMetadata, DiagnosticField, QueryResult, QuerySource, Table};
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ConnectionSaveError {
@@ -34,6 +34,11 @@ pub enum ConnectionSaveError {
     Store(#[from] ConnectionStoreError),
     #[error("{0}")]
     Metadata(#[from] DbOperationError),
+    #[error("{error}")]
+    Probe {
+        error: DbOperationError,
+        dsn: String,
+    },
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -44,6 +49,13 @@ pub enum ErDiagramError {
     ExportFailed(String),
     #[error("Task panicked: {0}")]
     TaskPanicked(String),
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{error}")]
+pub struct ErDiagramFailure {
+    pub run_id: u64,
+    pub error: ErDiagramError,
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -192,6 +204,7 @@ pub enum ListMotion {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModalKind {
     TablePicker,
+    DatabasePicker,
     CommandPalette,
     Settings,
     Help,
@@ -228,6 +241,7 @@ pub struct SmartErRefreshError {
 
 #[derive(Debug, Clone)]
 pub struct ErDiagramInfo {
+    pub run_id: u64,
     pub path: String,
     pub table_count: usize,
     pub total_tables: usize,
@@ -249,12 +263,44 @@ pub struct TableTarget {
     pub generation: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ConnectionTarget {
     pub id: ConnectionId,
     pub dsn: String,
     pub name: String,
     pub database_type: DatabaseType,
+    pub database: Option<String>,
+}
+
+impl fmt::Debug for ConnectionTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ConnectionTarget")
+            .field("id", &self.id)
+            .field("dsn", &mask_password(&self.dsn))
+            .field("name", &self.name)
+            .field("database_type", &self.database_type)
+            .field("database", &self.database)
+            .finish()
+    }
+}
+
+impl ConnectionTarget {
+    pub fn with_database(&self, database: &str) -> Option<Self> {
+        let mut url = Url::parse(&self.dsn).ok()?;
+        url.path_segments_mut().ok()?.clear().push(database);
+        Some(Self {
+            dsn: url.to_string(),
+            database: Some(database.to_string()),
+            ..self.clone()
+        })
+    }
+
+    pub fn server_dsn(&self) -> Option<String> {
+        let mut url = Url::parse(&self.dsn).ok()?;
+        url.path_segments_mut().ok()?.clear();
+        Some(url.to_string())
+    }
 }
 
 // Full Action equality is intentionally unavailable: some payloads carry
@@ -347,6 +393,32 @@ pub enum Action {
     ConnectionSetupCancel,
     ConnectionSaveCompleted(ConnectionTarget),
     ConnectionSaveFailed(ConnectionSaveError),
+    ConnectionProbeCompleted {
+        target: ConnectionTarget,
+        run_id: u64,
+    },
+    ConnectionProbeFailed {
+        target: ConnectionTarget,
+        run_id: u64,
+        error: DbOperationError,
+    },
+    SwitchMySqlDatabase {
+        database: String,
+    },
+    MySqlDatabasesLoaded {
+        connection_id: ConnectionId,
+        dsn: String,
+        connection_generation: u64,
+        database_generation: u64,
+        databases: Vec<String>,
+    },
+    MySqlDatabasesFailed {
+        connection_id: ConnectionId,
+        dsn: String,
+        connection_generation: u64,
+        database_generation: u64,
+        error: DbOperationError,
+    },
     ConnectionEditLoaded(Box<ConnectionProfile>),
     ConnectionEditLoadFailed(ConnectionStoreError),
     ShowConnectionError(ConnectionErrorInfo),
@@ -476,6 +548,10 @@ pub enum Action {
         candidates: Vec<CompletionCandidate>,
         trigger_position: usize,
         visible: bool,
+        dsn: Option<String>,
+        connection_generation: u64,
+        database_generation: u64,
+        metadata_generation: u64,
     },
     CompletionAccept,
     CompletionDismiss,
@@ -489,6 +565,8 @@ pub enum Action {
     ExplainAnalyzeCancel,
     ExplainCompleted {
         dsn: String,
+        database_type: DatabaseType,
+        database_generation: u64,
         run_id: u64,
         query: String,
         plan_text: String,
@@ -497,6 +575,7 @@ pub enum Action {
     },
     ExplainFailed {
         dsn: String,
+        database_generation: u64,
         run_id: u64,
         error: DbOperationError,
         is_analyze: bool,
@@ -566,8 +645,8 @@ pub enum Action {
     ToggleReadOnly,
 
     // Query history
-    QueryHistoryLoaded(ConnectionId, Vec<QueryHistoryEntry>),
-    QueryHistoryLoadFailed(ConnectionId, QueryHistoryError),
+    QueryHistoryLoaded(QueryHistoryScope, Vec<QueryHistoryEntry>),
+    QueryHistoryLoadFailed(QueryHistoryScope, QueryHistoryError),
     QueryHistoryAppendFailed(QueryHistoryError),
     QueryHistoryConfirmSelection,
 
@@ -634,7 +713,7 @@ pub enum Action {
     SmartErRefreshCompleted(SmartErRefreshResult),
     SmartErRefreshFailed(SmartErRefreshError),
     ErDiagramOpened(ErDiagramInfo),
-    ErDiagramFailed(ErDiagramError),
+    ErDiagramFailed(ErDiagramFailure),
     ErLogWriteFailed(ErLogError),
 }
 
@@ -649,8 +728,8 @@ impl Action {
 
     pub fn feature_requirement(&self) -> FeatureRequirement {
         use FeatureRequirement::{
-            ErDiagram, Explain, ExplainAnalyze, JsonbDetail, None, PlanComparison,
-            SqliteDiagnostics,
+            ErDiagram, Explain, ExplainAnalyze, JsonDocumentDetail, JsonDocumentEdit, None,
+            PlanComparison, SqliteDiagnostics,
         };
 
         match self {
@@ -704,35 +783,52 @@ impl Action {
             | Self::ToggleModal(ModalKind::JsonbDetail)
             | Self::JsonbYankAll
             | Self::JsonbYankSuccess
-            | Self::JsonbEnterEdit
-            | Self::JsonbAppendInsert
-            | Self::JsonbExitEdit
             | Self::JsonbEnterSearch
             | Self::JsonbExitSearch
             | Self::JsonbSearchNext
             | Self::JsonbSearchPrev
             | Self::JsonbSearchSubmit
             | Self::TextInput {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
                 ..
             }
             | Self::TextBackspace {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
             }
             | Self::TextDelete {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
             }
             | Self::TextKill {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
                 ..
             }
             | Self::TextYank {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
             }
             | Self::TextMoveCursor {
                 target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
                 ..
-            } => JsonbDetail,
+            } => JsonDocumentDetail,
+            Self::JsonbEnterEdit
+            | Self::JsonbAppendInsert
+            | Self::JsonbExitEdit
+            | Self::TextInput {
+                target: InputTarget::JsonbEdit,
+                ..
+            }
+            | Self::TextBackspace {
+                target: InputTarget::JsonbEdit,
+            }
+            | Self::TextDelete {
+                target: InputTarget::JsonbEdit,
+            }
+            | Self::TextKill {
+                target: InputTarget::JsonbEdit,
+                ..
+            }
+            | Self::TextYank {
+                target: InputTarget::JsonbEdit,
+            } => JsonDocumentEdit,
             Self::ExplainRequest
             | Self::Scroll {
                 target: ScrollTarget::ExplainPlan,
@@ -800,7 +896,8 @@ impl Action {
             }
             Self::Paste(_) => match state.input_mode() {
                 InputMode::ErTablePicker => FeatureRequirement::ErDiagram,
-                InputMode::JsonbDetail | InputMode::JsonbEdit => FeatureRequirement::JsonbDetail,
+                InputMode::JsonbDetail => FeatureRequirement::JsonDocumentDetail,
+                InputMode::JsonbEdit => FeatureRequirement::JsonDocumentEdit,
                 _ => FeatureRequirement::None,
             },
             Self::BeginKeySequence(Prefix::G)
@@ -809,7 +906,7 @@ impl Action {
                     InputMode::JsonbDetail | InputMode::JsonbEdit
                 ) =>
             {
-                FeatureRequirement::JsonbDetail
+                FeatureRequirement::JsonDocumentDetail
             }
             _ => self.feature_requirement(),
         }
@@ -820,6 +917,22 @@ impl Action {
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    #[test]
+    fn connection_target_debug_masks_mysql_password() {
+        let target = ConnectionTarget {
+            id: ConnectionId::from_string("mysql"),
+            dsn: "mysql://user:secret@localhost:3306/app".to_string(),
+            name: "MySQL".to_string(),
+            database_type: DatabaseType::MySQL,
+            database: Some("app".to_string()),
+        };
+
+        let debug = format!("{target:?}");
+
+        assert!(!debug.contains("secret"));
+        assert!(debug.contains("mysql://user:****@localhost"));
+    }
 
     #[test]
     fn scroll_action_returns_true() {
@@ -848,6 +961,8 @@ mod tests {
         assert_eq!(
             Action::ExplainCompleted {
                 dsn: "dsn".to_string(),
+                database_type: DatabaseType::PostgreSQL,
+                database_generation: 0,
                 run_id: 1,
                 query: "SELECT 1".to_string(),
                 plan_text: "plan".to_string(),
@@ -860,6 +975,7 @@ mod tests {
         assert_eq!(
             Action::ExplainFailed {
                 dsn: "dsn".to_string(),
+                database_generation: 0,
                 run_id: 1,
                 error: DbOperationError::QueryFailed("error".to_string()),
                 is_analyze: false,
@@ -919,7 +1035,7 @@ mod tests {
         let normal_state = AppState::new("test".to_string());
         assert_eq!(
             Action::JsonbExitEdit.feature_requirement_for_state(&normal_state),
-            FeatureRequirement::JsonbDetail
+            FeatureRequirement::JsonDocumentEdit
         );
     }
 

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -9,7 +9,8 @@ use crate::model::shared::confirm_dialog::ConfirmIntent;
 use crate::model::shared::input_mode::InputMode;
 use crate::policy::json::json_diff::compute_json_diff;
 use crate::policy::preview_cell_text::{
-    CellPresentationPolicy, normalize_for_write_diff, uses_structured_json_diff,
+    CellPresentationPolicy, normalize_for_write_diff, normalize_structured_json_for_write,
+    uses_structured_json_diff,
 };
 use crate::policy::write::inline_cell_edit::build_inline_edited_value;
 use crate::policy::write::write_guardrails::{
@@ -66,6 +67,24 @@ fn build_update_preview(
         state.result_interaction.cell_edit().draft_value(),
     )?;
 
+    let database_type = state.session.active_database_type_or_default();
+    let column_data_type = state
+        .visible_preview_column(col_idx)
+        .map_or("", |c| c.data_type.as_str());
+    let handling = CellPresentationPolicy::new(database_type, column_data_type, "").diff_handling();
+    if uses_structured_json_diff(handling) {
+        let before = normalize_structured_json_for_write(
+            state.result_interaction.cell_edit().original_value(),
+        )
+        .map_err(|error| EditGuardrailError::InvalidJson(error.to_string()))?;
+        let after =
+            normalize_structured_json_for_write(state.result_interaction.cell_edit().draft_value())
+                .map_err(|error| EditGuardrailError::InvalidJson(error.to_string()))?;
+        if before == after {
+            return Err(EditGuardrailError::NoSemanticChanges);
+        }
+    }
+
     let identity_pairs = identity.identity_pairs_for_row(result, row_idx);
     if let Some(pairs) = identity_pairs.as_deref() {
         reject_sqlite_null_pk(state.session.active_database_type_or_default(), pairs)?;
@@ -101,14 +120,6 @@ fn build_update_preview(
         sql,
         target_summary: target,
         diff: {
-            let database_type = state.session.active_database_type_or_default();
-            let column_data_type = state
-                .session
-                .table_detail()
-                .and_then(|td| td.columns.get(col_idx))
-                .map_or("", |c| c.data_type.as_str());
-            let handling =
-                CellPresentationPolicy::new(database_type, column_data_type, "").diff_handling();
             let before = normalize_for_write_diff(
                 state.result_interaction.cell_edit().original_value(),
                 handling,
@@ -254,6 +265,12 @@ pub fn reduce_write(
         }
 
         Action::ExecuteWrite(query) => {
+            if state.session.connection_state().is_awaiting_database() {
+                state
+                    .messages
+                    .set_error_at("Select a MySQL database first".to_string(), now);
+                return DispatchResult::handled();
+            }
             if state.session.is_read_only() {
                 state.messages.set_error_at(
                     "Read-only mode: write operations are disabled".to_string(),
@@ -299,8 +316,16 @@ pub fn reduce_write(
                             format!("UPDATE expected 1 row, but affected {affected_rows} rows"),
                             now,
                         );
-                        state.modal.set_mode(InputMode::CellEdit);
-                        return DispatchResult::handled();
+                        state.result_interaction.clear_cell_edit();
+                        state.modal.set_mode(InputMode::Normal);
+
+                        let page = state.query.pagination.current_page();
+                        let generation = state.session.selection_generation();
+                        return match preview_effect_for_current_table(state, now, page, generation)
+                        {
+                            Some(effect) => DispatchResult::handled_with(vec![effect]),
+                            None => DispatchResult::handled(),
+                        };
                     }
 
                     state
@@ -1029,6 +1054,53 @@ mod tests {
         }
 
         #[test]
+        fn jsonb_diff_uses_visible_column_name_after_hidden_primary_key() {
+            let mut state = editable_state_with_jsonb();
+            let mut detail = jsonb_table_detail();
+            detail.columns[0].attributes = detail.columns[0].attributes
+                | ColumnAttributes::HIDDEN
+                | ColumnAttributes::READ_ONLY;
+            state.session.set_table_detail_raw(Some(detail));
+            state.query.set_current_result(Arc::new(
+                QueryResult::success(
+                    "SELECT `name`, `metadata` FROM `public`.`users`".to_string(),
+                    vec!["name".to_string(), "metadata".to_string()],
+                    vec![vec!["Alice".to_string(), r#"{"role":"admin"}"#.to_string()]],
+                    10,
+                    QuerySource::Preview,
+                )
+                .with_explicit_row_identity(
+                    vec!["id".to_string()],
+                    vec![vec![QueryValue::text("1")]],
+                ),
+            ));
+            state.result_interaction.clear_cell_edit();
+            state.modal.set_mode(InputMode::CellEdit);
+            state
+                .result_interaction
+                .begin_cell_edit(0, 1, r#"{"role":"admin"}"#.to_string());
+            state
+                .result_interaction
+                .replace_cell_edit_draft(r#"{"role":"user"}"#.to_string());
+
+            let effects = dispatch_query(
+                &mut state,
+                &Action::SubmitCellEditWrite,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+            let preview = match &effects[0] {
+                Effect::DispatchActions(actions) => match actions.first().expect("action") {
+                    Action::OpenWritePreviewConfirm(preview) => preview,
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+            assert!(preview.diff[0].json_diff.is_some());
+        }
+
+        #[test]
         fn sqlite_jsonb_declared_type_preserves_string_diff_in_write_preview() {
             let mut state = editable_state_with_jsonb();
             state.session.activate_connection_with_dsn(
@@ -1225,12 +1297,17 @@ mod tests {
             let effects =
                 dispatch_query(&mut state, &action, Instant::now(), &AppServices::stub()).unwrap();
 
-            assert!(effects.is_empty());
-            assert_eq!(state.input_mode(), InputMode::CellEdit);
+            assert_eq!(effects.len(), 1);
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert_eq!(state.query.status(), QueryStatus::Running);
             assert_eq!(
                 state.messages.last_error.as_deref(),
                 Some("UPDATE expected 1 row, but affected 0 rows")
             );
+            assert!(matches!(
+                effects.first(),
+                Some(Effect::ExecutePreview { .. })
+            ));
         }
 
         #[test]

--- a/src/app/update/browse/result/cell_detail.rs
+++ b/src/app/update/browse/result/cell_detail.rs
@@ -174,12 +174,12 @@ fn selected_cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
 }
 
 fn selected_column_data_type(state: &AppState, col_idx: usize) -> Option<&str> {
-    let td = state.session.table_detail()?;
-    if !state.query.pagination.matches_table(td) {
+    let table_detail = state.session.table_detail()?;
+    if !state.query.pagination.matches_table(table_detail) {
         return None;
     }
-    td.columns
-        .get(col_idx)
+    state
+        .visible_preview_column(col_idx)
         .map(|column| column.data_type.as_str())
 }
 

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -16,13 +16,13 @@ fn cell_uses_jsonb_detail_modal(state: &AppState) -> bool {
     let Some(col_idx) = state.result_interaction.selection().cell() else {
         return false;
     };
-    let Some(td) = state.session.table_detail() else {
+    let Some(table_detail) = state.session.table_detail() else {
         return false;
     };
-    if !state.query.pagination.matches_table(td) {
+    if !state.query.pagination.matches_table(table_detail) {
         return false;
     }
-    let Some(column) = td.columns.get(col_idx) else {
+    let Some(column) = state.visible_preview_column(col_idx) else {
         return false;
     };
     let policy = CellPresentationPolicy::new(
@@ -478,6 +478,47 @@ mod tests {
             state
         }
 
+        fn state_with_hidden_primary_key_jsonb_column() -> AppState {
+            let mut state = AppState::new("test".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "database",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
+            state.query.set_current_result(Arc::new(
+                QueryResult::success(
+                    String::new(),
+                    vec!["settings".to_string()],
+                    vec![vec![r#"{"theme":"dark"}"#.to_string()]],
+                    1,
+                    QuerySource::Preview,
+                )
+                .with_explicit_row_identity(
+                    vec!["id".to_string()],
+                    vec![vec![QueryValue::text("1")]],
+                ),
+            ));
+            state.query.pagination.reset_for_table("public", "users");
+            state.session.set_table_detail_raw(Some(Table {
+                schema: "public".to_string(),
+                name: "users".to_string(),
+                columns: vec![
+                    Column {
+                        attributes: ColumnAttributes::PRIMARY_KEY
+                            | ColumnAttributes::HIDDEN
+                            | ColumnAttributes::READ_ONLY,
+                        ..test_support::column::test_nullable_column("id", "integer", 1)
+                    },
+                    test_support::column::test_nullable_column("settings", "jsonb", 2),
+                ],
+                primary_key: Some(vec!["id".to_string()]),
+                ..test_support::table::minimal("", "")
+            }));
+            state.result_interaction.activate_cell(0, 0);
+            state
+        }
+
         #[test]
         fn jsonb_cell_returns_dispatch_to_open_jsonb_detail() {
             let mut state = state_with_jsonb_column();
@@ -487,6 +528,20 @@ mod tests {
                 .expect("reducer should handle action");
 
             assert_eq!(effects.len(), 1);
+            assert!(matches!(
+                &effects[0],
+                Effect::DispatchActions(actions) if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonbDetail)])
+            ));
+        }
+
+        #[test]
+        fn jsonb_cell_after_hidden_primary_key_dispatches_to_detail() {
+            let mut state = state_with_hidden_primary_key_jsonb_column();
+
+            let effects = reduce_edit(&mut state, &Action::ResultEnterCellEdit, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
             assert!(matches!(
                 &effects[0],
                 Effect::DispatchActions(actions) if matches!(actions.as_slice(), [Action::OpenModal(ModalKind::JsonbDetail)])

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -26,15 +26,14 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
                 _ => return DispatchResult::handled(),
             };
 
-            let table_detail = match state.session.table_detail() {
-                Some(td)
-                    if td.schema == state.query.pagination.schema()
-                        && td.name == state.query.pagination.table() =>
-                {
-                    td
-                }
-                _ => return DispatchResult::handled(),
+            let Some(table_detail) = state.session.table_detail() else {
+                return DispatchResult::handled();
             };
+            if table_detail.schema != state.query.pagination.schema()
+                || table_detail.name != state.query.pagination.table()
+            {
+                return DispatchResult::handled();
+            }
 
             let Some(row_idx) = state.result_interaction.selection().row() else {
                 return DispatchResult::handled();
@@ -44,7 +43,7 @@ pub fn reduce_jsonb(state: &mut AppState, action: &Action, now: Instant) -> Disp
             };
 
             let database_type = state.session.active_database_type_or_default();
-            let Some(column) = table_detail.columns.get(col_idx) else {
+            let Some(column) = state.visible_preview_column(col_idx) else {
                 return DispatchResult::handled();
             };
             let policy = CellPresentationPolicy::new(database_type, column.data_type.as_str(), "");
@@ -377,23 +376,22 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
 
     let content = state.jsonb_detail.editor().content().to_string();
 
-    if let Ok(compact) = serde_json::from_str::<serde_json::Value>(&content) {
-        let compact_str = serde_json::to_string(&compact).unwrap_or_else(|_| content.clone());
-        let row = state.jsonb_detail.row();
-        let col = state.jsonb_detail.col();
-        let original_cell = state
-            .query
-            .visible_result()
-            .and_then(|result| result.display_value_at(row, col))
-            .unwrap_or_default();
-        state
-            .result_interaction
-            .begin_cell_edit(row, col, original_cell);
-        state.result_interaction.clear_write_preview();
-        state
-            .result_interaction
-            .replace_cell_edit_draft(compact_str);
-    }
+    let compact = serde_json::from_str::<serde_json::Value>(&content)
+        .ok()
+        .and_then(|value| serde_json::to_string(&value).ok())
+        .unwrap_or(content);
+    let row = state.jsonb_detail.row();
+    let col = state.jsonb_detail.col();
+    let original_cell = state
+        .query
+        .visible_result()
+        .and_then(|result| result.display_value_at(row, col))
+        .unwrap_or_default();
+    state
+        .result_interaction
+        .begin_cell_edit(row, col, original_cell);
+    state.result_interaction.clear_write_preview();
+    state.result_interaction.replace_cell_edit_draft(compact);
 }
 
 #[cfg(test)]
@@ -403,7 +401,8 @@ mod tests {
 
     use super::*;
     pub use crate::domain::Column;
-    use crate::domain::{QueryResult, QuerySource, Table};
+    use crate::domain::connection::ConnectionId;
+    use crate::domain::{DatabaseType, QueryResult, QuerySource, Table};
     use crate::services::AppServices;
     use crate::update::action::TextKillDirection;
     use std::sync::Arc;
@@ -446,6 +445,47 @@ mod tests {
         state
     }
 
+    fn state_with_mysql_json_value(cell_value: &str) -> AppState {
+        let mut state = state_with_jsonb_value(cell_value);
+        test_fixtures::activate_mysql_connection(&mut state, "mysql://localhost/test");
+        let mut table = jsonb_table();
+        table.columns[1].data_type = "json".to_string();
+        state.session.set_table_detail_raw(Some(table));
+        state
+    }
+
+    fn state_with_hidden_primary_key_jsonb_value() -> AppState {
+        let mut state = state_with_jsonb_value(r#"{"theme":"dark"}"#);
+        state.query.set_current_result(Arc::new(
+            QueryResult::success(
+                String::new(),
+                vec!["settings".to_string()],
+                vec![vec![r#"{"theme":"dark"}"#.to_string()]],
+                1,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(vec!["id".to_string()], vec![vec![QueryValue::text("1")]]),
+        ));
+        state.query.pagination.reset_for_table("public", "users");
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "public".to_string(),
+            name: "users".to_string(),
+            columns: vec![
+                Column {
+                    attributes: ColumnAttributes::PRIMARY_KEY
+                        | ColumnAttributes::HIDDEN
+                        | ColumnAttributes::READ_ONLY,
+                    ..test_support::column::test_nullable_column("id", "integer", 1)
+                },
+                test_support::column::test_nullable_column("settings", "jsonb", 2),
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..test_support::table::minimal("", "")
+        }));
+        state.result_interaction.activate_cell(0, 0);
+        state
+    }
+
     fn open_detail(state: &mut AppState) {
         reduce_jsonb(
             state,
@@ -475,8 +515,7 @@ mod tests {
 
     mod entry_guards {
         use super::*;
-        use crate::domain::DatabaseType;
-        use crate::domain::connection::ConnectionId;
+        use rstest::rstest;
 
         #[test]
         fn opens_on_valid_jsonb_cell() {
@@ -490,6 +529,49 @@ mod tests {
 
             assert!(state.jsonb_detail.is_active());
             assert_eq!(state.input_mode(), InputMode::JsonbDetail);
+        }
+
+        #[rstest]
+        #[case(r#"{"key":"value"}"#)]
+        #[case(r"[1,2,3]")]
+        #[case("42")]
+        #[case("null")]
+        #[case(r#""null""#)]
+        fn opens_on_mysql_json_documents(#[case] cell_value: &str) {
+            let mut state = state_with_mysql_json_value(cell_value);
+
+            reduce_jsonb(
+                &mut state,
+                &Action::OpenModal(ModalKind::JsonbDetail),
+                Instant::now(),
+            );
+
+            assert!(state.jsonb_detail.is_active());
+            assert_eq!(state.input_mode(), InputMode::JsonbDetail);
+            assert_eq!(state.jsonb_detail.original_json(), cell_value);
+        }
+
+        #[test]
+        fn mysql_json_sql_null_does_not_open_detail() {
+            let mut state = state_with_mysql_json_value("");
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success_with_values(
+                    String::new(),
+                    vec!["id".to_string(), "settings".to_string()],
+                    vec![vec![QueryValue::text("1"), QueryValue::Null]],
+                    1,
+                    QuerySource::Preview,
+                )));
+
+            reduce_jsonb(
+                &mut state,
+                &Action::OpenModal(ModalKind::JsonbDetail),
+                Instant::now(),
+            );
+
+            assert!(!state.jsonb_detail.is_active());
+            assert_eq!(state.messages.last_error(), None);
         }
 
         #[test]
@@ -637,6 +719,7 @@ mod tests {
         use super::*;
         use crate::model::shared::key_sequence::Prefix;
         use crate::update::action::CursorMove;
+        use crate::update::reducer::reduce;
         use rstest::rstest;
 
         #[test]
@@ -648,6 +731,34 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::JsonbEdit);
             assert_eq!(state.jsonb_detail.mode(), JsonbDetailMode::Editing);
+        }
+
+        #[test]
+        fn mysql_json_detail_starts_edit_mode() {
+            let mut state = state_with_mysql_json_value(r#"{"key":"value"}"#);
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce(&mut state, Action::JsonbEnterEdit, now, &services);
+
+            assert_eq!(state.input_mode(), InputMode::JsonbEdit);
+            assert_eq!(state.jsonb_detail.mode(), JsonbDetailMode::Editing);
+        }
+
+        #[test]
+        fn hidden_primary_key_does_not_shift_jsonb_detail_column() {
+            let mut state = state_with_hidden_primary_key_jsonb_value();
+
+            open_detail(&mut state);
+
+            assert!(state.jsonb_detail.is_active());
+            assert_eq!(state.jsonb_detail.column_name(), "settings");
         }
 
         #[test]
@@ -1336,6 +1447,235 @@ mod tests {
                 state.confirm_dialog.intent(),
                 Some(ConfirmIntent::ExecuteWrite { blocked: false, .. })
             ));
+        }
+
+        #[test]
+        fn mysql_json_edit_close_can_continue_to_write_preview() {
+            let mut state = state_with_mysql_json_value(r#"{"theme":"dark"}"#);
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content(r#"{"theme":"light"}"#.to_string());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+            let preview = match effects.first() {
+                Some(Effect::DispatchActions(actions)) => match actions.first() {
+                    Some(Action::OpenWritePreviewConfirm(preview)) => preview,
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+
+            assert_eq!(
+                preview.sql,
+                "UPDATE `public`.`users` SET `settings` = '{\"theme\":\"light\"}' WHERE `id` = '1'"
+            );
+        }
+
+        #[test]
+        fn mysql_json_edit_uses_explicit_hidden_row_identity() {
+            let mut state = state_with_hidden_primary_key_jsonb_value();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("mysql-test"),
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://localhost/test",
+            );
+            let mut detail = state.session.table_detail().cloned().expect("table detail");
+            detail.columns[1].data_type = "json".to_string();
+            state.session.set_table_detail_raw(Some(detail));
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content(r#"{"theme":"light"}"#.to_string());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+            let preview = match effects.first() {
+                Some(Effect::DispatchActions(actions)) => match actions.first() {
+                    Some(Action::OpenWritePreviewConfirm(preview)) => preview,
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+
+            assert!(preview.sql.contains("WHERE `id` = '1'"));
+        }
+
+        #[test]
+        fn invalid_mysql_json_is_rejected_before_write_preview() {
+            let mut state = state_with_mysql_json_value(r#"{"theme":"dark"}"#);
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content("{invalid}".to_string());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+
+            assert!(effects.is_empty());
+            assert!(
+                state
+                    .messages
+                    .last_error()
+                    .is_some_and(|error| error.starts_with("Invalid JSON:"))
+            );
+        }
+
+        #[test]
+        fn empty_mysql_json_editor_is_rejected_before_write_preview() {
+            let mut state = state_with_mysql_json_value(r#"{"theme":"dark"}"#);
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state.jsonb_detail.editor_mut().set_content(String::new());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+
+            assert!(effects.is_empty());
+            assert!(
+                state
+                    .messages
+                    .last_error()
+                    .is_some_and(|error| error.starts_with("Invalid JSON:"))
+            );
+        }
+
+        #[test]
+        fn semantically_unchanged_mysql_json_is_not_written() {
+            let mut state = state_with_mysql_json_value(r#"{"a":1,"b":2}"#);
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content("{ \"b\": 2, \"a\": 1 }".to_string());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.messages.last_error(),
+                Some("No semantic changes to write")
+            );
+        }
+
+        #[test]
+        fn mysql_json_null_and_string_null_use_distinct_literals() {
+            let mut state = state_with_mysql_json_value("null");
+            let services = AppServices::stub();
+            let now = Instant::now();
+
+            reduce_app(
+                &mut state,
+                Action::OpenModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+            reduce_app(&mut state, Action::JsonbEnterEdit, now, &services);
+            state
+                .jsonb_detail
+                .editor_mut()
+                .set_content(r#""null""#.to_string());
+            reduce_app(&mut state, Action::JsonbExitEdit, now, &services);
+            reduce_app(
+                &mut state,
+                Action::CloseModal(ModalKind::JsonbDetail),
+                now,
+                &services,
+            );
+
+            let effects = reduce_app(&mut state, Action::SubmitCellEditWrite, now, &services);
+            let preview = match effects.first() {
+                Some(Effect::DispatchActions(actions)) => match actions.first() {
+                    Some(Action::OpenWritePreviewConfirm(preview)) => preview,
+                    other => panic!("expected OpenWritePreviewConfirm, got {other:?}"),
+                },
+                other => panic!("expected DispatchActions, got {other:?}"),
+            };
+
+            assert_eq!(
+                preview.sql,
+                "UPDATE `public`.`users` SET `settings` = '\"null\"' WHERE `id` = '1'"
+            );
         }
     }
 }

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1,5 +1,8 @@
 use crate::cmd::effect::Effect;
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
+use crate::model::connection::error::ConnectionErrorInfo;
+use crate::model::connection::state::ConnectionState;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
 use crate::update::action::{Action, ConnectionTarget};
@@ -7,12 +10,14 @@ use crate::update::query_context::termination_effects;
 
 use crate::update::dispatch_result::DispatchResult;
 
-use super::helpers::{reset_for_new_connection, restore_cache, save_current_cache};
+use super::helpers::{
+    reset_for_database_switch, reset_for_new_connection, restore_cache, save_current_cache,
+};
 
 pub fn reduce_connection_lifecycle(
     state: &mut AppState,
     action: &Action,
-    _now: std::time::Instant,
+    now: std::time::Instant,
     _services: &AppServices,
 ) -> DispatchResult {
     match action {
@@ -21,6 +26,35 @@ pub fn reduce_connection_lifecycle(
                 && state.modal.active_mode() == InputMode::Normal
             {
                 if let Some(dsn) = state.session.dsn().map(str::to_string) {
+                    if state.session.active_database_type() == Some(DatabaseType::MySQL) {
+                        let target = ConnectionTarget {
+                            id: state
+                                .session
+                                .active_connection_id()
+                                .cloned()
+                                .expect("active MySQL connection"),
+                            dsn,
+                            name: state
+                                .session
+                                .active_connection_name()
+                                .unwrap_or_default()
+                                .to_string(),
+                            database_type: DatabaseType::MySQL,
+                            database: state.session.active_database().map(str::to_string),
+                        };
+                        let run_id = state.session.begin_connection_probe(
+                            &target.id,
+                            &target.name,
+                            target.database_type,
+                            &target.dsn,
+                            target.database.as_deref(),
+                        );
+                        state.session.mark_connecting();
+                        return DispatchResult::handled_with(vec![Effect::ProbeConnection {
+                            target,
+                            run_id,
+                        }]);
+                    }
                     let run_id = state.session.begin_connecting(&dsn);
                     DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
                 } else {
@@ -37,9 +71,34 @@ pub fn reduce_connection_lifecycle(
                 dsn,
                 name,
                 database_type,
+                database,
             } = target;
 
-            if let Some(current_id) = state.session.active_connection_id().cloned() {
+            if *database_type == DatabaseType::MySQL {
+                if state.session.active_database_type() != Some(DatabaseType::MySQL)
+                    && let Some(current_id) = state.session.active_connection_id().cloned()
+                {
+                    let cache = save_current_cache(state);
+                    state.connection_caches.save(&current_id, cache);
+                }
+                let run_id = state.session.begin_connection_probe(
+                    id,
+                    name,
+                    *database_type,
+                    dsn,
+                    database.as_deref(),
+                );
+                return DispatchResult::handled_with(vec![Effect::ProbeConnection {
+                    target: target.clone(),
+                    run_id,
+                }]);
+            }
+
+            state.session.clear_connection_probe();
+
+            if state.session.active_database_type() != Some(DatabaseType::MySQL)
+                && let Some(current_id) = state.session.active_connection_id().cloned()
+            {
                 let cache = save_current_cache(state);
                 state.connection_caches.save(&current_id, cache);
             }
@@ -57,7 +116,7 @@ pub fn reduce_connection_lifecycle(
                 DispatchResult::handled_with(termination_effects(&state.query, effects))
             } else {
                 // No cache: reset and fetch metadata
-                reset_for_new_connection(state, id, dsn, name, *database_type);
+                reset_for_new_connection(state, id, dsn, name, *database_type, database.as_deref());
                 let run_id = state.session.begin_connecting(dsn);
                 DispatchResult::handled_with(termination_effects(
                     &state.query,
@@ -72,23 +131,197 @@ pub fn reduce_connection_lifecycle(
             }
         }
 
+        Action::ConnectionProbeCompleted { target, run_id } => {
+            let ConnectionTarget {
+                id,
+                dsn,
+                name,
+                database_type,
+                database,
+            } = target;
+            if *database_type != DatabaseType::MySQL
+                || !state.session.is_current_connection_probe(
+                    id,
+                    name,
+                    *database_type,
+                    dsn,
+                    database.as_deref(),
+                    *run_id,
+                )
+            {
+                return DispatchResult::handled();
+            }
+            reset_for_new_connection(state, id, dsn, name, *database_type, database.as_deref());
+            state.session.mark_probe_connected(database.is_some());
+            state.session.clear_connection_probe();
+            let mut effects = vec![Effect::ClearCompletionEngineCache];
+            if database.is_none() {
+                state.ui.set_database_picker(true);
+                state.modal.set_mode(InputMode::TablePicker);
+                if let (Some(connection_id), Some(server_dsn)) = (
+                    state.session.active_connection_id().cloned(),
+                    state.session.server_dsn(),
+                ) {
+                    effects.push(Effect::FetchMySqlDatabases {
+                        connection_id,
+                        dsn: server_dsn,
+                        connection_generation: state.session.connection_generation(),
+                        database_generation: state.session.database_generation(),
+                    });
+                }
+            } else {
+                let metadata_run_id = state.session.begin_metadata_refresh();
+                effects.push(Effect::FetchMetadata {
+                    dsn: dsn.clone(),
+                    run_id: metadata_run_id,
+                });
+            }
+            DispatchResult::handled_with(termination_effects(&state.query, effects))
+        }
+
+        Action::SwitchMySqlDatabase { database } => {
+            if state.session.active_database_type() != Some(DatabaseType::MySQL)
+                || !matches!(
+                    state.session.connection_state(),
+                    ConnectionState::Connected | ConnectionState::AwaitingDatabase
+                )
+            {
+                return DispatchResult::handled();
+            }
+            let Some(target) = (|| {
+                let target = ConnectionTarget {
+                    id: state.session.active_connection_id()?.clone(),
+                    dsn: state.session.dsn()?.to_string(),
+                    name: state.session.active_connection_name()?.to_string(),
+                    database_type: DatabaseType::MySQL,
+                    database: state.session.active_database().map(str::to_string),
+                };
+                target.with_database(database)
+            })() else {
+                state.messages.set_error_at(
+                    "Unable to build the selected MySQL database target".to_string(),
+                    now,
+                );
+                return DispatchResult::handled();
+            };
+            reset_for_database_switch(state, &target);
+            state.ui.set_database_picker(false);
+            state.modal.set_mode(InputMode::Normal);
+            let metadata_run_id = state.session.begin_metadata_refresh();
+            DispatchResult::handled_with(termination_effects(
+                &state.query,
+                vec![
+                    Effect::ClearCompletionEngineCache,
+                    Effect::FetchMetadata {
+                        dsn: target.dsn,
+                        run_id: metadata_run_id,
+                    },
+                ],
+            ))
+        }
+
+        Action::MySqlDatabasesLoaded {
+            connection_id,
+            dsn,
+            connection_generation,
+            database_generation,
+            databases,
+        } => {
+            if !state.session.is_current_database_fetch(
+                connection_id,
+                dsn,
+                *connection_generation,
+                *database_generation,
+            ) {
+                return DispatchResult::handled();
+            }
+            state.session.set_available_databases(databases.clone());
+            if state.session.available_databases().is_empty() {
+                state
+                    .messages
+                    .set_error_at("No selectable MySQL databases are visible".to_string(), now);
+            }
+            DispatchResult::handled()
+        }
+
+        Action::MySqlDatabasesFailed {
+            connection_id,
+            dsn,
+            connection_generation,
+            database_generation,
+            error,
+        } => {
+            if !state.session.is_current_database_fetch(
+                connection_id,
+                dsn,
+                *connection_generation,
+                *database_generation,
+            ) {
+                return DispatchResult::handled();
+            }
+            state.messages.set_error_at(error.user_message(), now);
+            if state.session.active_database().is_none() {
+                state.ui.set_database_picker(false);
+                state.session.mark_connection_failed(error.user_message());
+                state
+                    .connection_error
+                    .set_error(ConnectionErrorInfo::from_db_operation_error(error));
+                state.modal.replace_mode(InputMode::ConnectionError);
+            }
+            DispatchResult::handled()
+        }
+
+        Action::ConnectionProbeFailed {
+            target,
+            run_id,
+            error,
+        } => {
+            if target.database_type != DatabaseType::MySQL
+                || !state.session.is_current_connection_probe(
+                    &target.id,
+                    &target.name,
+                    target.database_type,
+                    &target.dsn,
+                    target.database.as_deref(),
+                    *run_id,
+                )
+            {
+                return DispatchResult::handled();
+            }
+            if state.session.dsn_matches(&target.dsn) {
+                state.session.mark_connection_failed(error.user_message());
+            }
+            state.connection_error.set_error(
+                ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
+            );
+            state.modal.replace_mode(InputMode::ConnectionError);
+            DispatchResult::handled()
+        }
+
         _ => DispatchResult::pass(),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
-    use crate::domain::ConnectionId;
     use crate::domain::connection::DatabaseType;
+    use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
+    use crate::domain::{ConnectionId, DatabaseMetadata, MetadataState};
     use crate::model::connection::cache::ConnectionCache;
+    use crate::model::connection::error::ConnectionErrorKind;
     use crate::model::connection::state::ConnectionState;
     use crate::model::er_state::ErStatus;
+    use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::inspector_tab::InspectorTab;
     use crate::model::shared::ui_state::ResultNavMode;
+    use crate::ports::outbound::DbOperationError;
     use crate::test_support::connection::{
         assert_explain_state_cleared, assert_sqlite_diagnostics_cleared,
     };
+    use crate::update::reducer::reduce as reduce_app;
 
     fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
         reduce_connection_lifecycle(
@@ -106,6 +339,7 @@ mod tests {
             dsn: format!("postgres://localhost/{name}"),
             name: name.to_string(),
             database_type: DatabaseType::PostgreSQL,
+            database: None,
         })
     }
 
@@ -133,6 +367,76 @@ mod tests {
             let saved = state.connection_caches.get(&current_id).unwrap();
             assert_eq!(saved.explorer_selected, 5);
             assert_eq!(saved.inspector_tab, InspectorTab::Indexes);
+        }
+
+        fn assert_non_mysql_cache_survives_mysql_switch(
+            database_type: DatabaseType,
+            dsn: &str,
+            name: &str,
+        ) {
+            let mut state = AppState::new("test".to_string());
+            let source_id = ConnectionId::from_string("source");
+            let mysql_id = ConnectionId::from_string("mysql");
+            let source = ConnectionTarget {
+                id: source_id.clone(),
+                dsn: dsn.to_string(),
+                name: name.to_string(),
+                database_type,
+                database: None,
+            };
+
+            state
+                .session
+                .activate_connection_with_dsn(&source_id, name, database_type, dsn);
+            state.ui.set_explorer_selected_raw(5);
+            state.ui.set_inspector_tab(InspectorTab::Indexes);
+
+            let mysql = ConnectionTarget {
+                id: mysql_id,
+                dsn: "mysql://user@localhost:3306/app".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .expect("switching to MySQL should probe the connection");
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target: mysql,
+                    run_id,
+                },
+            );
+
+            reduce(&mut state, &Action::SwitchConnection(source));
+
+            assert_eq!(state.session.active_connection_id(), Some(&source_id));
+            assert_eq!(state.ui.explorer_selected(), 5);
+            assert_eq!(state.ui.inspector_tab(), InspectorTab::Indexes);
+        }
+
+        #[test]
+        fn restores_postgres_cache_after_switching_through_mysql() {
+            assert_non_mysql_cache_survives_mysql_switch(
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/current",
+                "postgres",
+            );
+        }
+
+        #[test]
+        fn restores_sqlite_cache_after_switching_through_mysql() {
+            assert_non_mysql_cache_survives_mysql_switch(
+                DatabaseType::SQLite,
+                "sqlite:///tmp/current.db",
+                "sqlite",
+            );
         }
 
         #[test]
@@ -190,6 +494,7 @@ mod tests {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 name: "app.db".to_string(),
                 database_type: DatabaseType::SQLite,
+                database: None,
             });
             reduce(&mut state, &action);
 
@@ -206,24 +511,28 @@ mod tests {
             let dsn = match database_type {
                 DatabaseType::PostgreSQL => format!("postgres://localhost/{name}"),
                 DatabaseType::SQLite => format!("sqlite:///tmp/{name}.db"),
+                DatabaseType::MySQL => format!("mysql://user@localhost/{name}"),
             };
             Action::SwitchConnection(ConnectionTarget {
                 id,
                 dsn,
                 name: name.to_string(),
                 database_type,
+                database: None,
             })
         }
 
         fn seed_explain_state(state: &mut AppState) {
             state.explain.set_plan(
                 "Seq Scan  (cost=0.00..100.00 rows=10 width=32)".to_string(),
+                DatabaseType::PostgreSQL,
                 false,
                 0,
                 "SELECT * FROM users",
             );
             state.explain.set_plan(
                 "Index Scan  (cost=0.00..5.00 rows=1 width=32)".to_string(),
+                DatabaseType::PostgreSQL,
                 false,
                 0,
                 "SELECT * FROM users WHERE id = 1",
@@ -437,6 +746,7 @@ mod tests {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 name: "app.db".to_string(),
                 database_type: DatabaseType::SQLite,
+                database: None,
             });
             let effects = reduce(&mut state, &action).unwrap();
 
@@ -478,6 +788,7 @@ mod tests {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 name: "app.db".to_string(),
                 database_type: DatabaseType::SQLite,
+                database: None,
             });
             let effects = reduce(&mut state, &action).unwrap();
 
@@ -541,6 +852,7 @@ mod tests {
 
     mod connection_state_tests {
         use super::*;
+        use crate::update::connection::error::reduce_connection_error;
 
         #[test]
         fn sqlite_try_connect_fetches_metadata() {
@@ -565,6 +877,545 @@ mod tests {
             assert_eq!(
                 state.session.connection_state(),
                 ConnectionState::Connecting
+            );
+        }
+
+        #[test]
+        fn mysql_switch_probes_without_fetching_metadata() {
+            let mut state = AppState::new("test".to_string());
+            let target = ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "mysql://user@localhost:3306/app?ssl-mode=PREFERRED".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            };
+
+            let effects = reduce(&mut state, &Action::SwitchConnection(target.clone())).unwrap();
+
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::ProbeConnection { target: actual, .. } if actual.dsn == target.dsn
+            )));
+            assert!(
+                !effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
+        }
+
+        #[test]
+        fn mysql_switch_invalidates_previous_metadata_failure() {
+            let mut state = AppState::new("test".to_string());
+            let postgres = ConnectionTarget {
+                id: ConnectionId::from_string("postgres-b"),
+                dsn: "postgres://localhost/b".to_string(),
+                name: "postgres-b".to_string(),
+                database_type: DatabaseType::PostgreSQL,
+                database: None,
+            };
+            let postgres_effects =
+                reduce(&mut state, &Action::SwitchConnection(postgres.clone())).unwrap();
+            let postgres_run_id = postgres_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::FetchMetadata { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-c"),
+                dsn: "mysql://user@localhost:3306/c?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-c".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("c".to_string()),
+            };
+            let mysql_effects =
+                reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = mysql_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::MetadataFailed {
+                    dsn: postgres.dsn,
+                    run_id: postgres_run_id,
+                    error: DbOperationError::ConnectionFailed("stale postgres".to_string()),
+                },
+            );
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                },
+            );
+
+            assert_eq!(
+                state.session.active_database_type(),
+                Some(DatabaseType::MySQL)
+            );
+            assert!(state.session.connection_state().is_connected());
+            assert_eq!(state.modal.active_mode(), InputMode::Normal);
+            assert!(state.connection_error.error_info().is_none());
+        }
+
+        #[test]
+        fn mysql_probe_failure_does_not_leave_previous_connecting_state() {
+            let mut state = AppState::new("test".to_string());
+            let postgres = ConnectionTarget {
+                id: ConnectionId::from_string("postgres-b"),
+                dsn: "postgres://localhost/b".to_string(),
+                name: "postgres-b".to_string(),
+                database_type: DatabaseType::PostgreSQL,
+                database: None,
+            };
+            let _ = reduce(&mut state, &Action::SwitchConnection(postgres)).unwrap();
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-c"),
+                dsn: "mysql://user@localhost:3306/c?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-c".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("c".to_string()),
+            };
+            let mysql_effects =
+                reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = mysql_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            assert!(state.session.connection_state().is_not_connected());
+            assert!(matches!(
+                state.session.metadata_state(),
+                MetadataState::NotLoaded
+            ));
+            assert!(!state.session.is_reloading());
+        }
+
+        #[test]
+        fn mysql_probe_failure_finishes_previous_reload() {
+            let mut state = AppState::new("test".to_string());
+            let postgres_id = ConnectionId::from_string("postgres-b");
+            state.session.activate_connection_with_dsn(
+                &postgres_id,
+                "postgres-b",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/b",
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            let _ = state.session.begin_reload();
+            assert!(state.session.is_reloading());
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-c"),
+                dsn: "mysql://user@localhost:3306/c?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-c".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("c".to_string()),
+            };
+            let mysql_effects =
+                reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = mysql_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            assert!(state.session.connection_state().is_connected());
+            assert!(!state.session.is_reloading());
+        }
+
+        #[test]
+        fn stale_mysql_probe_completion_is_ignored_after_switch() {
+            let mut state = AppState::new("test".to_string());
+            let first = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-a"),
+                dsn: "mysql://user@localhost:3306/a?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-a".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("a".to_string()),
+            };
+            let second = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+
+            let first_effects =
+                reduce(&mut state, &Action::SwitchConnection(first.clone())).unwrap();
+            let first_run_id = first_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(&mut state, &Action::SwitchConnection(second));
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target: first,
+                    run_id: first_run_id,
+                },
+            );
+
+            assert_eq!(state.session.active_connection_id(), None);
+            assert_eq!(state.session.dsn(), None);
+        }
+
+        #[test]
+        fn stale_mysql_probe_failure_is_ignored_after_switch() {
+            let mut state = AppState::new("test".to_string());
+            let first = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-a"),
+                dsn: "mysql://user@localhost:3306/a?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-a".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("a".to_string()),
+            };
+            let second = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+
+            let first_effects =
+                reduce(&mut state, &Action::SwitchConnection(first.clone())).unwrap();
+            let first_run_id = first_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(&mut state, &Action::SwitchConnection(second));
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: first,
+                    run_id: first_run_id,
+                    error: DbOperationError::ConnectionFailed("stale".to_string()),
+                },
+            );
+
+            assert_eq!(state.modal.active_mode(), InputMode::Normal);
+            assert!(state.connection_error.error_info().is_none());
+        }
+
+        #[test]
+        fn retry_after_mysql_switch_failure_reprobes_failed_target() {
+            let mut state = AppState::new("test".to_string());
+            let target = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(target.clone())).unwrap();
+            let first_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: target.clone(),
+                    run_id: first_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+
+            let (retry_target, retry_run_id) = retry_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { target, run_id } => Some((target, *run_id)),
+                    _ => None,
+                })
+                .unwrap();
+            assert_eq!(retry_target.dsn, target.dsn);
+            assert_eq!(retry_target.id, target.id);
+            assert_ne!(retry_run_id, first_run_id);
+        }
+
+        #[test]
+        fn retry_after_mysql_switch_failure_preserves_connected_previous_target() {
+            let mut state = AppState::new("test".to_string());
+            let postgres_id = ConnectionId::from_string("postgres-a");
+            let postgres_dsn = "postgres://localhost/a".to_string();
+            state.session.activate_connection_with_dsn(
+                &postgres_id,
+                "postgres-a",
+                DatabaseType::PostgreSQL,
+                &postgres_dsn,
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            state
+                .session
+                .set_metadata(Some(Arc::new(DatabaseMetadata::new("a".to_string()))));
+            state.session.set_metadata_state(MetadataState::Loaded);
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let first_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql.clone(),
+                    run_id: first_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+            assert!(state.session.connection_state().is_connected());
+            assert_eq!(state.session.metadata_state(), &MetadataState::Loaded);
+            let retry_run_id = retry_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: retry_run_id,
+                    error: DbOperationError::ConnectionFailed("refused again".to_string()),
+                },
+            );
+
+            assert_eq!(state.session.dsn(), Some(postgres_dsn.as_str()));
+            assert!(state.session.connection_state().is_connected());
+            assert_eq!(state.session.metadata_state(), &MetadataState::Loaded);
+            assert!(!state.session.is_reloading());
+        }
+
+        #[test]
+        fn postgres_reload_retry_does_not_use_old_mysql_probe_target() {
+            let mut state = AppState::new("test".to_string());
+            let postgres_id = ConnectionId::from_string("postgres-a");
+            let postgres_dsn = "postgres://localhost/a".to_string();
+            state.session.activate_connection_with_dsn(
+                &postgres_id,
+                "postgres-a",
+                DatabaseType::PostgreSQL,
+                &postgres_dsn,
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            let reload_run_id = state.session.begin_reload();
+            assert!(state.session.pending_connection_probe().is_none());
+            reduce_app(
+                &mut state,
+                Action::MetadataFailed {
+                    dsn: postgres_dsn.clone(),
+                    run_id: reload_run_id,
+                    error: DbOperationError::ConnectionFailed("reload refused".to_string()),
+                },
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+            assert!(retry_effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchMetadata { dsn, .. } if dsn == &postgres_dsn
+            )));
+            assert!(
+                !retry_effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ProbeConnection { .. }))
+            );
+        }
+
+        #[test]
+        fn mysql_probe_without_database_enters_awaiting_database() {
+            let mut state = AppState::new("test".to_string());
+            let target = ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "mysql://user@localhost:3306?ssl-mode=PREFERRED".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: None,
+            };
+
+            let run_id = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+            let effects = reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted { target, run_id },
+            )
+            .unwrap();
+
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ClearCompletionEngineCache))
+            );
+            assert!(state.session.connection_state().is_awaiting_database());
+            assert!(matches!(
+                state.session.metadata_state(),
+                MetadataState::NotLoaded
+            ));
+        }
+
+        #[test]
+        fn mysql_probe_failure_never_enters_connected_state() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::new();
+            let dsn = "mysql://user@localhost:3306/app?ssl-mode=PREFERRED".to_string();
+            state.session.activate_connection_with_target(
+                &id,
+                "mysql",
+                DatabaseType::MySQL,
+                &dsn,
+                Some("app"),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connecting);
+            let target = ConnectionTarget {
+                id,
+                dsn,
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            };
+            let run_id = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target,
+                    run_id,
+                    error: DbOperationError::ConnectionFailed(
+                        "ERROR 1045: Access denied for user 'user'".to_string(),
+                    ),
+                },
+            );
+
+            assert!(!state.session.connection_state().is_connected());
+            assert!(state.session.connection_state().is_failed());
+            assert_eq!(state.modal.active_mode(), InputMode::ConnectionError);
+            assert_eq!(
+                state.connection_error.error_info().unwrap().kind,
+                ConnectionErrorKind::AuthFailed
             );
         }
 
@@ -703,6 +1554,235 @@ mod tests {
                     .iter()
                     .any(|e| matches!(e, Effect::ClearCompletionEngineCache))
             );
+        }
+    }
+
+    mod mysql_database_tests {
+        use super::*;
+        use crate::update::action::ErDiagramInfo;
+
+        fn mysql_target(id: &ConnectionId, database: Option<&str>) -> ConnectionTarget {
+            let database = database.map(str::to_string);
+            let dsn = format!(
+                "mysql://user:secret@localhost:3306/{}?ssl-mode=PREFERRED",
+                database.as_deref().unwrap_or("")
+            );
+            ConnectionTarget {
+                id: id.clone(),
+                dsn,
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database,
+            }
+        }
+
+        #[test]
+        fn connection_without_database_opens_picker_and_fetches_server_databases() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, None);
+            let probe_run_id = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                None,
+            );
+
+            let effects = reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target,
+                    run_id: probe_run_id,
+                },
+            )
+            .unwrap();
+
+            assert!(state.session.connection_state().is_awaiting_database());
+            assert_eq!(state.session.active_database(), None);
+            assert!(state.ui.database_picker());
+            assert_eq!(state.input_mode(), InputMode::TablePicker);
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchMySqlDatabases { connection_id, .. } if connection_id == &id
+            )));
+        }
+
+        #[test]
+        fn database_selection_resets_context_and_preserves_read_only() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, Some("app"));
+            state.session.activate_connection_with_target(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+            state.session.mark_probe_connected(true);
+            state.session.enable_read_only();
+            state.session.set_available_databases(vec![
+                "information_schema".to_string(),
+                "analytics".to_string(),
+            ]);
+            state.ui.set_database_picker(true);
+            state.modal.set_mode(InputMode::TablePicker);
+            let stale_er_run_id = state.er_preparation.start_waiting_run();
+            state.er_preparation.mark_rendering();
+            state
+                .query_history_picker
+                .replace_entries(&[QueryHistoryEntry::new(
+                    "SELECT old_database".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    id,
+                    QueryResultStatus::Success,
+                    None,
+                )]);
+
+            let effects = reduce_app(
+                &mut state,
+                Action::ConfirmSelection,
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.session.active_database(), Some("analytics"));
+            assert!(
+                state
+                    .session
+                    .dsn()
+                    .is_some_and(|dsn| dsn.contains("/analytics"))
+            );
+            assert!(state.session.metadata().is_none());
+            assert!(state.session.is_read_only());
+            assert_eq!(
+                state.session.available_databases(),
+                ["analytics".to_string()]
+            );
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert!(state.query_history_picker.entries().is_empty());
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
+
+            let effects = reduce_app(
+                &mut state,
+                Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id: stale_er_run_id,
+                    path: "stale.svg".to_string(),
+                    table_count: 1,
+                    total_tables: 1,
+                }),
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.is_empty());
+            assert!(state.messages.last_success().is_none());
+        }
+
+        #[test]
+        fn database_switch_closes_query_history_picker_and_discards_entries() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, Some("app"));
+            state.session.activate_connection_with_target(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+            state.session.mark_probe_connected(true);
+            state.modal.set_mode(InputMode::QueryHistoryPicker);
+            state.sql_modal.completion_mut_for_test().visible = true;
+            state.explain.set_plan(
+                "-> Table scan on users  (cost=1 rows=10)".to_string(),
+                DatabaseType::MySQL,
+                false,
+                1,
+                "SELECT * FROM users",
+            );
+            state.explain.set_plan(
+                "-> Index lookup on users  (cost=0.5 rows=1)".to_string(),
+                DatabaseType::MySQL,
+                false,
+                1,
+                "SELECT * FROM users WHERE id = 1",
+            );
+            state
+                .query_history_picker
+                .replace_entries(&[QueryHistoryEntry::new_with_database(
+                    "SELECT from app".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    id,
+                    Some("app".to_string()),
+                    QueryResultStatus::Success,
+                    None,
+                )]);
+
+            let effects = reduce_app(
+                &mut state,
+                Action::SwitchMySqlDatabase {
+                    database: "analytics".to_string(),
+                },
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.session.active_database(), Some("analytics"));
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert!(state.query_history_picker.entries().is_empty());
+            assert!(!state.sql_modal.completion().visible);
+            assert!(state.explain.left().is_none());
+            assert!(state.explain.right().is_none());
+            assert!(state.explain.history().is_empty());
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ClearCompletionEngineCache))
+            );
+        }
+
+        #[test]
+        fn stale_database_list_from_previous_connection_generation_is_ignored() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, None);
+            state.session.activate_connection_with_target(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                None,
+            );
+            state.session.mark_probe_connected(false);
+            let stale_generation = state.session.connection_generation();
+            let _ = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                None,
+            );
+            let server_dsn = state.session.server_dsn().unwrap();
+            let database_generation = state.session.database_generation();
+
+            let _ = reduce(
+                &mut state,
+                &Action::MySqlDatabasesLoaded {
+                    connection_id: id,
+                    dsn: server_dsn,
+                    connection_generation: stale_generation,
+                    database_generation,
+                    databases: vec!["stale".to_string()],
+                },
+            );
+
+            assert!(state.session.available_databases().is_empty());
         }
     }
 }

--- a/src/app/update/er/diagram.rs
+++ b/src/app/update/er/diagram.rs
@@ -13,10 +13,14 @@ pub(super) fn reduce_diagram_lifecycle(
 ) -> DispatchResult {
     match action {
         Action::ErDiagramOpened(ErDiagramInfo {
+            run_id,
             path,
             table_count,
             total_tables,
         }) => {
+            if !state.er_preparation.is_current_run(*run_id) {
+                return DispatchResult::handled();
+            }
             state.er_preparation.mark_idle();
             // Reset so next ErOpenDiagram re-evaluates target_tables from scratch.
             state.sql_modal.invalidate_prefetch();
@@ -28,9 +32,12 @@ pub(super) fn reduce_diagram_lifecycle(
             );
             DispatchResult::handled()
         }
-        Action::ErDiagramFailed(error) => {
+        Action::ErDiagramFailed(failure) => {
+            if !state.er_preparation.is_current_run(failure.run_id) {
+                return DispatchResult::handled();
+            }
             state.er_preparation.mark_idle();
-            state.messages.set_error_at(error.to_string(), now);
+            state.messages.set_error_at(failure.error.to_string(), now);
             DispatchResult::handled()
         }
         Action::ErLogWriteFailed(error) => {
@@ -75,12 +82,14 @@ pub(super) fn reduce_diagram_lifecycle(
             }
 
             state.er_preparation.mark_rendering();
+            let run_id = state.er_preparation.run_id();
             let total_tables = state
                 .session
                 .metadata()
                 .map_or(0, |m| m.table_summaries.len());
 
             DispatchResult::handled_with(vec![Effect::GenerateErDiagramFromCache {
+                run_id,
                 total_tables,
                 project_name: state.runtime.project_name.clone(),
                 target_tables: state.er_preparation.target_tables().to_vec(),

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -24,7 +24,7 @@ mod tests {
     use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, TableSummary};
     use crate::model::app_state::AppState;
     use crate::model::er_state::ErStatus;
-    use crate::update::action::{SmartErRefreshError, SmartErRefreshResult};
+    use crate::update::action::{ErDiagramInfo, SmartErRefreshError, SmartErRefreshResult};
     use std::sync::Arc;
 
     fn reduce_er(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
@@ -254,6 +254,35 @@ mod tests {
                 state.messages.last_error.as_deref(),
                 Some("ER diagrams are not available for this connection")
             );
+        }
+    }
+
+    mod stale_diagram_completion {
+        use super::*;
+
+        #[test]
+        fn completion_after_reset_is_ignored() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = state.er_preparation.start_waiting_run();
+            state.er_preparation.mark_rendering();
+            state.er_preparation.reset();
+
+            let effects = reduce_er(
+                &mut state,
+                &Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id,
+                    path: "stale.svg".to_string(),
+                    table_count: 1,
+                    total_tables: 1,
+                }),
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("reducer should handle stale completion");
+
+            assert!(effects.is_empty());
+            assert!(state.messages.last_success().is_none());
+            assert!(state.messages.last_error().is_none());
         }
     }
 

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use unicode_casefold::UnicodeCaseFold;
 
 use crate::domain::DatabaseType;
-use crate::domain::connection::SqliteConnectionConfig;
+use crate::domain::connection::{MySqlConnectionConfig, MySqlSslMode, SqliteConnectionConfig};
 use crate::domain::{QueryResult, QueryValue};
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::QueryStatus;
@@ -11,7 +11,7 @@ use crate::model::connection::setup::{ConnectionField, ConnectionSetupState};
 use crate::policy::write::inline_cell_edit::InlineCellEditError;
 use crate::policy::write::write_guardrails::{
     PreviewWriteability, StableRowIdentity, TargetSummary, WriteOperation, WritePreview,
-    evaluate_guardrails, preview_writeability, stable_row_identity_for_table,
+    evaluate_guardrails, preview_writeability_for_result, stable_row_identity_for_preview,
 };
 use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::services::AppServices;
@@ -81,6 +81,10 @@ pub enum EditGuardrailError {
     NoActiveCell,
     #[error("Cell index out of bounds")]
     CellIndexOutOfBounds,
+    #[error("Invalid JSON: {0}")]
+    InvalidJson(String),
+    #[error("No semantic changes to write")]
+    NoSemanticChanges,
     #[error(transparent)]
     InlineCellEdit(#[from] InlineCellEditError),
     #[error("SQLite writes require non-NULL primary key values")]
@@ -135,7 +139,7 @@ pub fn editable_preview_base(
     if !state.query.pagination.matches_table(table_detail) {
         return Err(EditGuardrailError::StaleTableMetadata);
     }
-    match preview_writeability(table_detail) {
+    match preview_writeability_for_result(table_detail, result) {
         PreviewWriteability::Writable => {}
         PreviewWriteability::ReadOnly(reason) => {
             return Err(EditGuardrailError::ReadOnlyPreviewTarget(reason));
@@ -144,7 +148,7 @@ pub fn editable_preview_base(
             return Err(EditGuardrailError::EditingRequiresPrimaryKey);
         }
     }
-    let identity = stable_row_identity_for_table(table_detail)
+    let identity = stable_row_identity_for_preview(table_detail, result)
         .ok_or(EditGuardrailError::EditingRequiresPrimaryKey)?;
 
     Ok((result, identity))
@@ -456,7 +460,52 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
                 }
             }
         }
-        ConnectionField::Database => require_non_empty(state, field, "Required"),
+        ConnectionField::Database => {
+            if state.database_type() == DatabaseType::PostgreSQL {
+                require_non_empty(state, field, "Required");
+            }
+        }
+        ConnectionField::Host if state.database_type() == DatabaseType::MySQL => {
+            let host = text_input_content(state, field).trim();
+            if host.is_empty() {
+                state.set_validation_error(field, "Required");
+            } else if !MySqlConnectionConfig::is_valid_host(host) {
+                state.set_validation_error(field, "Invalid host");
+            }
+        }
+        ConnectionField::User if state.database_type() == DatabaseType::MySQL => {
+            require_non_empty(state, field, "Required");
+        }
+        ConnectionField::SslCa if state.database_type() == DatabaseType::MySQL => {
+            let path = text_input_content(state, field).to_string();
+            if matches!(
+                state.mysql_ssl_mode(),
+                MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity
+            ) && path.trim().is_empty()
+            {
+                state.set_validation_error(field, "Required for this TLS mode");
+            } else if path.chars().any(char::is_control) {
+                state.set_validation_error(field, "Invalid path");
+            }
+        }
+        ConnectionField::SslCert | ConnectionField::SslKey
+            if state.database_type() == DatabaseType::MySQL =>
+        {
+            let path = text_input_content(state, field).to_string();
+            if path.chars().any(char::is_control) {
+                state.set_validation_error(field, "Invalid path");
+            }
+            let other_field = match field {
+                ConnectionField::SslCert => ConnectionField::SslKey,
+                ConnectionField::SslKey => ConnectionField::SslCert,
+                _ => unreachable!(),
+            };
+            let other_path = text_input_content(state, other_field).to_string();
+            if path.trim().is_empty() != other_path.trim().is_empty() {
+                state.set_validation_error(field, "Both client paths are required");
+                state.set_validation_error(other_field, "Both client paths are required");
+            }
+        }
         ConnectionField::Name => {
             let name = text_input_content(state, field).trim().to_string();
             if name.is_empty() {
@@ -467,12 +516,15 @@ pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) 
         | ConnectionField::Host
         | ConnectionField::User
         | ConnectionField::Password
-        | ConnectionField::SslMode => {}
+        | ConnectionField::SslMode
+        | ConnectionField::SslCa
+        | ConnectionField::SslCert
+        | ConnectionField::SslKey => {}
     }
 }
 
 pub fn validate_all(state: &mut ConnectionSetupState) {
-    let active_fields = ConnectionField::fields_for(state.database_type());
+    let active_fields = ConnectionField::fields_for(state.database_type(), state.mysql_ssl_mode());
     state.retain_validation_errors_for_visible_fields();
     for field in active_fields {
         validate_field(state, *field);
@@ -690,6 +742,84 @@ mod tests {
         }
     }
 
+    #[test]
+    fn mysql_validation_requires_host_and_user_but_not_database() {
+        let mut state = ConnectionSetupState::default();
+        state.set_database_type(DatabaseType::MySQL);
+        state
+            .input_mut(ConnectionField::Host)
+            .unwrap()
+            .set_content(" ".to_string());
+        state
+            .input_mut(ConnectionField::User)
+            .unwrap()
+            .set_content(" ".to_string());
+
+        validate_all(&mut state);
+
+        assert_eq!(
+            state.validation_error(ConnectionField::Host),
+            Some("Required")
+        );
+        assert_eq!(
+            state.validation_error(ConnectionField::User),
+            Some("Required")
+        );
+        assert_eq!(state.validation_error(ConnectionField::Database), None);
+    }
+
+    #[test]
+    fn mysql_validation_rejects_url_syntax_in_host() {
+        let mut state = ConnectionSetupState::default();
+        state.set_database_type(DatabaseType::MySQL);
+        state
+            .input_mut(ConnectionField::Host)
+            .unwrap()
+            .set_content("db example".to_string());
+
+        validate_field(&mut state, ConnectionField::Host);
+
+        assert_eq!(
+            state.validation_error(ConnectionField::Host),
+            Some("Invalid host")
+        );
+    }
+
+    #[test]
+    fn mysql_verification_requires_ca_path() {
+        let mut state = ConnectionSetupState::default();
+        state.set_database_type(DatabaseType::MySQL);
+        state.mysql_ssl_mode = MySqlSslMode::VerifyCa;
+
+        validate_all(&mut state);
+
+        assert_eq!(
+            state.validation_error(ConnectionField::SslCa),
+            Some("Required for this TLS mode")
+        );
+    }
+
+    #[test]
+    fn mysql_client_certificate_and_key_are_a_pair() {
+        let mut state = ConnectionSetupState::default();
+        state.set_database_type(DatabaseType::MySQL);
+        state
+            .input_mut(ConnectionField::SslCert)
+            .unwrap()
+            .set_content("client.pem".to_string());
+
+        validate_all(&mut state);
+
+        assert_eq!(
+            state.validation_error(ConnectionField::SslCert),
+            Some("Both client paths are required")
+        );
+        assert_eq!(
+            state.validation_error(ConnectionField::SslKey),
+            Some("Both client paths are required")
+        );
+    }
+
     mod delete_refresh_target_bulk {
         use super::*;
 
@@ -739,6 +869,7 @@ mod tests {
             let dsn = match database_type {
                 DatabaseType::PostgreSQL => "postgres://localhost/test",
                 DatabaseType::SQLite => "sqlite:///tmp/app.db",
+                DatabaseType::MySQL => "mysql://user@localhost/test",
             };
             state.session.activate_connection_with_dsn(
                 &ConnectionId::from_string("test-connection"),

--- a/src/app/update/input/handlers/jsonb.rs
+++ b/src/app/update/input/handlers/jsonb.rs
@@ -17,7 +17,7 @@ pub fn handle_jsonb_detail_keys_with_policy(
     pending_prefix: Option<Prefix>,
     feature_policy: &FeaturePolicy,
 ) -> Action {
-    if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
+    if !feature_policy.is_enabled(FeatureRequirement::JsonDocumentDetail) {
         return disabled_jsonb_detail_exit_action(combo, interaction);
     }
 
@@ -69,7 +69,11 @@ pub fn handle_jsonb_detail_keys_with_policy(
         &combo,
         VimSurfaceContext::JsonbDetail(JsonbDetailVimContext::Viewing),
     ) {
-        return action;
+        return if feature_policy.is_enabled(action.feature_requirement()) {
+            action
+        } else {
+            Action::None
+        };
     }
 
     if let Some(action) = JSONB_DETAIL.resolve_with_policy(&combo, feature_policy) {
@@ -119,7 +123,7 @@ pub fn handle_jsonb_edit_keys_with_policy(
     combo: KeyCombo,
     feature_policy: &FeaturePolicy,
 ) -> Action {
-    if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
+    if !feature_policy.is_enabled(FeatureRequirement::JsonDocumentEdit) {
         return if combo.modifiers.is_empty() && combo.key == Key::Esc {
             Action::JsonbExitEdit
         } else {
@@ -383,6 +387,39 @@ mod tests {
         }
 
         #[test]
+        fn mysql_json_detail_keeps_view_actions_and_enables_edit() {
+            let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::mysql_like());
+
+            assert!(matches!(
+                handle_jsonb_detail_keys_with_policy(
+                    combo(Key::Char('y')),
+                    InputInteraction::Viewing,
+                    None,
+                    &feature_policy,
+                ),
+                Action::JsonbYankAll
+            ));
+            assert!(matches!(
+                handle_jsonb_detail_keys_with_policy(
+                    combo(Key::Char('/')),
+                    InputInteraction::Viewing,
+                    None,
+                    &feature_policy,
+                ),
+                Action::JsonbEnterSearch
+            ));
+            assert!(matches!(
+                handle_jsonb_detail_keys_with_policy(
+                    combo(Key::Char('i')),
+                    InputInteraction::Viewing,
+                    None,
+                    &feature_policy,
+                ),
+                Action::JsonbEnterEdit
+            ));
+        }
+
+        #[test]
         fn gg_moves_to_first_line() {
             let result = handle_jsonb_detail_keys(
                 combo(Key::Char('g')),
@@ -523,6 +560,23 @@ mod tests {
             let result = handle_jsonb_edit_keys_with_policy(combo(Key::Esc), &feature_policy);
 
             assert!(matches!(result, Action::JsonbExitEdit));
+        }
+
+        #[test]
+        fn mysql_json_edit_mode_accepts_editing_keys() {
+            let feature_policy = FeaturePolicy::new(&EngineFeatureProfile::mysql_like());
+
+            assert!(matches!(
+                handle_jsonb_edit_keys_with_policy(combo(Key::Char('a')), &feature_policy),
+                Action::TextInput {
+                    target: InputTarget::JsonbEdit,
+                    ch: 'a',
+                }
+            ));
+            assert!(matches!(
+                handle_jsonb_edit_keys_with_policy(combo(Key::Esc), &feature_policy),
+                Action::JsonbExitEdit
+            ));
         }
     }
 }

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -193,6 +193,7 @@ mod tests {
             #[case(global::QUIT, Action::Quit)]
             #[case(global::HELP, Action::ToggleModal(ModalKind::Help))]
             #[case(global::TABLE_PICKER, Action::OpenModal(ModalKind::TablePicker))]
+            #[case(global::DATABASE_PICKER, Action::OpenModal(ModalKind::DatabasePicker))]
             #[case(global::SETTINGS, Action::OpenModal(ModalKind::Settings))]
             #[case(global::COMMAND_LINE, Action::EnterCommandLine)]
             #[case(global::COMMAND_PALETTE, Action::OpenModal(ModalKind::CommandPalette))]
@@ -637,7 +638,7 @@ mod tests {
         );
         assert_eq!(
             JSONB_DETAIL_ROWS[0].feature_requirement(),
-            FeatureRequirement::JsonbDetail
+            FeatureRequirement::JsonDocumentDetail
         );
     }
 }

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -99,6 +99,23 @@ fn reduce_inner(
 
         Action::ConfirmSelection => {
             if state.modal.active_mode() == InputMode::TablePicker {
+                if state.ui.database_picker() {
+                    let database = state
+                        .filtered_databases()
+                        .get(state.ui.table_picker().selected())
+                        .map(|database| (*database).clone());
+                    if let Some(database) = database {
+                        state.modal.set_mode(InputMode::Normal);
+                        state.ui.set_database_picker(false);
+                        return reduce(
+                            state,
+                            Action::SwitchMySqlDatabase { database },
+                            now,
+                            services,
+                        );
+                    }
+                    return vec![];
+                }
                 let table = state
                     .filtered_tables()
                     .get(state.ui.table_picker().selected())
@@ -335,6 +352,7 @@ mod tests {
             assert_unsupported_action_is_a_noop(
                 &mut state,
                 Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id: 0,
                     path: "diagram.svg".to_string(),
                     table_count: 1,
                     total_tables: 1,
@@ -412,6 +430,8 @@ mod tests {
                 &mut explain_state,
                 Action::ExplainCompleted {
                     dsn: "sqlite://test.db".to_string(),
+                    database_type: DatabaseType::SQLite,
+                    database_generation: 0,
                     run_id: 1,
                     query: "SELECT 1".to_string(),
                     plan_text: "QUERY PLAN".to_string(),
@@ -424,6 +444,7 @@ mod tests {
                 &mut explain_state,
                 Action::ExplainFailed {
                     dsn: "sqlite://test.db".to_string(),
+                    database_generation: 0,
                     run_id: 1,
                     error: DbOperationError::QueryFailed("error".to_string()),
                     is_analyze: true,
@@ -1560,6 +1581,7 @@ mod tests {
     mod effect_producing_actions {
         use super::*;
         use crate::domain::{DatabaseMetadata, MetadataState};
+        use crate::model::connection::state::ConnectionState;
 
         #[test]
         fn load_metadata_with_dsn_returns_fetch_effect() {
@@ -1677,6 +1699,74 @@ mod tests {
 
             assert_eq!(effects.len(), 1);
             assert!(matches!(effects[0], Effect::ExecuteAdhoc { .. }));
+        }
+
+        #[test]
+        fn awaiting_mysql_database_blocks_adhoc_execution() {
+            let mut state = create_test_state();
+            let id = ConnectionId::from_string("mysql-awaiting");
+            state.session.activate_connection_with_target(
+                &id,
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://user@localhost:3306",
+                None,
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::AwaitingDatabase);
+            state.modal.set_mode(InputMode::TablePicker);
+            state.ui.set_database_picker(true);
+            reduce(
+                &mut state,
+                Action::CloseModal(ModalKind::DatabasePicker),
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let effects = reduce(
+                &mut state,
+                Action::ExecuteAdhoc("SELECT 1".to_string()),
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.is_empty());
+            assert!(!state.query.is_running());
+        }
+
+        #[test]
+        fn awaiting_mysql_database_blocks_write_execution() {
+            let mut state = create_test_state();
+            let id = ConnectionId::from_string("mysql-awaiting");
+            state.session.activate_connection_with_target(
+                &id,
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://user@localhost:3306",
+                None,
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::AwaitingDatabase);
+            state.modal.set_mode(InputMode::TablePicker);
+            state.ui.set_database_picker(true);
+            reduce(
+                &mut state,
+                Action::CloseModal(ModalKind::DatabasePicker),
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let effects = reduce(
+                &mut state,
+                Action::ExecuteWrite("UPDATE t SET v = 1".to_string()),
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.is_empty());
+            assert!(!state.query.is_running());
         }
     }
 
@@ -2025,6 +2115,7 @@ mod tests {
                     dsn: "postgres://db.example.com/mydb".to_string(),
                     name: "Test Connection".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2541,6 +2632,7 @@ mod tests {
                     dsn: "postgres://localhost/test".to_string(),
                     name: "Test".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2579,6 +2671,7 @@ mod tests {
                     dsn: "postgres://localhost/other".to_string(),
                     name: "Other".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2631,6 +2724,7 @@ mod tests {
                     dsn: "postgres://localhost/cached".to_string(),
                     name: "Cached".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2682,6 +2776,7 @@ mod tests {
                     dsn: "postgres://localhost/b".to_string(),
                     name: "B".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 Instant::now(),
                 &AppServices::stub(),
@@ -2694,6 +2789,7 @@ mod tests {
                     dsn: dsn_a.clone(),
                     name: "A".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 Instant::now(),
                 &AppServices::stub(),

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -23,11 +23,14 @@ pub use command_tag::CommandTag;
 #[cfg(test)]
 pub use er::ErFkInfo;
 pub use er::ErTableInfo;
-pub use explain_plan::sqlite_explain_query_plan_text_from_result;
+pub use explain_plan::{
+    mysql_explain_plan_text_from_result, postgres_explain_plan_text_from_result,
+    sqlite_explain_query_plan_text_from_result,
+};
 pub use foreign_key::{FkAction, ForeignKey, UNRESOLVED_FK_COLUMN};
 pub use index::{Index, IndexAttributes, IndexType};
 pub use metadata::{DatabaseMetadata, MetadataState};
-pub use query_result::{QueryResult, QuerySource, QueryValue};
+pub use query_result::{ExplicitRowIdentity, QueryResult, QuerySource, QueryValue, RefreshScope};
 pub use rls::{RlsCommand, RlsInfo, RlsPolicy};
 pub use schema::Schema;
 pub use sqlite_diagnostics::{DiagnosticField, SqliteDiagnosticsSnapshot};
@@ -38,6 +41,7 @@ pub use write_result::WriteExecutionResult;
 
 pub use connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
-    PostgresConnectionConfig, SqliteConnectionConfig, SqliteConnectionConfigError, SqlitePathError,
-    SslMode, classify_sqlite_metadata_error, classify_sqlite_read_error, sqlite_path_from_dsn,
+    MySqlConnectionConfig, MySqlSslMode, PostgresConnectionConfig, SqliteConnectionConfig,
+    SqliteConnectionConfigError, SqlitePathError, SslMode, classify_sqlite_metadata_error,
+    classify_sqlite_read_error, sqlite_path_from_dsn,
 };

--- a/src/domain/query_result.rs
+++ b/src/domain/query_result.rs
@@ -222,6 +222,43 @@ pub enum QuerySource {
     Adhoc,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExplicitRowIdentity {
+    columns: Vec<String>,
+    values: Vec<Vec<QueryValue>>,
+}
+
+impl ExplicitRowIdentity {
+    #[must_use]
+    pub fn columns(&self) -> &[String] {
+        &self.columns
+    }
+
+    #[must_use]
+    pub fn values(&self) -> &[Vec<QueryValue>] {
+        &self.values
+    }
+
+    #[must_use]
+    pub fn values_for_row(&self, row: usize) -> Option<&[QueryValue]> {
+        self.values.get(row).map(Vec::as_slice)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum RefreshScope {
+    None,
+    Data,
+    Metadata,
+}
+
+impl RefreshScope {
+    #[must_use]
+    pub fn merge(self, other: Self) -> Self {
+        self.max(other)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct QueryResult {
     pub query: String,
@@ -230,8 +267,10 @@ pub struct QueryResult {
     pub source: QuerySource,
     pub error: Option<String>,
     pub command_tag: Option<CommandTag>,
+    pub refresh_scope: RefreshScope,
     rows: Vec<Vec<String>>,
     values: Vec<Vec<QueryValue>>,
+    explicit_row_identity: Option<ExplicitRowIdentity>,
     row_count: usize,
     typed_values: bool,
 }
@@ -255,12 +294,14 @@ impl QueryResult {
             columns,
             rows,
             values,
+            explicit_row_identity: None,
             row_count,
             typed_values: false,
             execution_time_ms,
             source,
             error: None,
             command_tag: None,
+            refresh_scope: RefreshScope::None,
         }
     }
 
@@ -278,12 +319,14 @@ impl QueryResult {
             columns,
             rows: Vec::new(),
             values,
+            explicit_row_identity: None,
             row_count,
             typed_values: true,
             execution_time_ms,
             source,
             error: None,
             command_tag: None,
+            refresh_scope: RefreshScope::None,
         }
     }
 
@@ -299,24 +342,43 @@ impl QueryResult {
             columns: Vec::new(),
             rows: Vec::new(),
             values: Vec::new(),
+            explicit_row_identity: None,
             row_count: 0,
             typed_values: false,
             execution_time_ms,
             source,
             error: Some(error),
             command_tag: None,
+            refresh_scope: RefreshScope::None,
         }
     }
 
     #[must_use]
     pub fn with_command_tag(mut self, tag: CommandTag) -> Self {
+        self.refresh_scope = tag.refresh_scope();
         self.command_tag = Some(tag);
+        self
+    }
+
+    #[must_use]
+    pub fn with_refresh_scope(mut self, refresh_scope: RefreshScope) -> Self {
+        self.refresh_scope = refresh_scope;
         self
     }
 
     #[must_use]
     pub fn with_row_count(mut self, row_count: usize) -> Self {
         self.row_count = row_count;
+        self
+    }
+
+    #[must_use]
+    pub fn with_explicit_row_identity(
+        mut self,
+        columns: Vec<String>,
+        values: Vec<Vec<QueryValue>>,
+    ) -> Self {
+        self.explicit_row_identity = Some(ExplicitRowIdentity { columns, values });
         self
     }
 
@@ -374,6 +436,11 @@ impl QueryResult {
     #[must_use]
     pub fn values(&self) -> &[Vec<QueryValue>] {
         &self.values
+    }
+
+    #[must_use]
+    pub fn explicit_row_identity(&self) -> Option<&ExplicitRowIdentity> {
+        self.explicit_row_identity.as_ref()
     }
 
     #[must_use]
@@ -576,6 +643,30 @@ mod tests {
             assert_eq!(result.columns, vec!["body"]);
             assert_eq!(result.values(), &[vec![QueryValue::text("body")]]);
             assert_eq!(result.display_row_at(0), Some(vec!["body".to_string()]));
+        }
+
+        #[test]
+        fn explicit_identity_is_not_part_of_display_rows_or_column_count() {
+            let result = QueryResult::success_with_values(
+                "SELECT payload".to_string(),
+                vec!["payload".to_string()],
+                vec![vec![QueryValue::text("visible")]],
+                0,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["id".to_string()],
+                vec![vec![QueryValue::SqlLiteral("42".to_string())]],
+            );
+
+            assert_eq!(result.column_count(), 1);
+            assert_eq!(result.display_row_at(0), Some(vec!["visible".to_string()]));
+            assert_eq!(
+                result
+                    .explicit_row_identity()
+                    .and_then(|identity| identity.values_for_row(0)),
+                Some([QueryValue::SqlLiteral("42".to_string())].as_slice())
+            );
         }
     }
 

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -1,15 +1,67 @@
-use async_trait::async_trait;
+use std::ffi::OsStr;
+use std::fmt::Write as _;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
 
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+
+use async_trait::async_trait;
+use quick_xml::Reader;
+use quick_xml::events::Event;
+use serde::Deserialize;
+#[cfg(unix)]
+use tokio::fs::File as TokioFile;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, ReadBuf};
+use tokio::process::Child;
+use tokio::process::Command;
+#[cfg(not(unix))]
+use tokio::process::{ChildStderr, ChildStdin, ChildStdout};
+use tokio::time::timeout;
+use url::Url;
+use uuid::Uuid;
+
+#[cfg(test)]
+use crate::adapters::csv_export::export_to_path;
+use crate::adapters::csv_export::{CsvFileWriter, export_to_downloads};
+#[cfg(test)]
+use crate::app::policy::sql::mysql_statement::split_mysql_statements;
+use crate::app::policy::sql::mysql_statement::{
+    MysqlStatement, MysqlStatementKind, classify_mysql_statement, mysql_explain_rejection_message,
+    mysql_tree_explain_query_kind,
+};
+use crate::app::policy::write::sql_risk::{
+    MultiStatementDecision, evaluate_mysql_multi_statement, mysql_statement_is_data_modifying,
+    mysql_statement_is_schema_modifying,
+};
 use crate::app::ports::outbound::{
-    AccessMode, DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor,
-    SqlDialect,
+    AccessMode, ConnectionProbe, DatabaseCli, DbOperationError, DdlGenerator, DsnBuilder,
+    MYSQL_CLI_VERSION_REQUIRED_MARKER, MYSQL_SERVER_VERSION_REQUIRED_MARKER,
+    MYSQL_SQL_MODE_UNSUPPORTED_MARKER, QueryExecutor, SqlDialect,
 };
-use crate::domain::connection::{ConnectionProfile, DatabaseType};
+use crate::domain::connection::{
+    ConnectionProfile, DatabaseType, MySqlConnectionConfig, MySqlSslMode,
+};
 use crate::domain::{
-    DatabaseMetadata, QueryResult, QueryValue, Table, TableSignature, WriteExecutionResult,
+    CommandTag, QueryResult, QuerySource, QueryValue, RefreshScope, Table, WriteExecutionResult,
 };
+
+mod metadata;
 
 pub struct MySqlAdapter;
+
+const MYSQL_PROBE_TIMEOUT: Duration = Duration::from_secs(11);
+const MYSQL_QUERY_TIMEOUT: Duration = Duration::from_secs(31);
+const MYSQL_PROBE_QUERY: &str = "SELECT JSON_OBJECT('database', DATABASE(), 'user', CURRENT_USER(), 'version', VERSION(), 'sql_mode', @@SESSION.sql_mode)";
+const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
+const MYSQL_SESSION_MARKER_COLUMN: &str = "__sabiql_session_marker";
+static OPTION_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 impl MySqlAdapter {
     pub fn new() -> Self {
@@ -24,144 +76,4493 @@ impl Default for MySqlAdapter {
 }
 
 #[async_trait]
-impl MetadataProvider for MySqlAdapter {
-    async fn fetch_metadata(&self, _dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_detail(
-        &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-    ) -> Result<Table, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_columns_and_fks(
-        &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-    ) -> Result<Table, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_signatures(
-        &self,
-        _dsn: &str,
-    ) -> Result<Vec<TableSignature>, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-}
-
-#[async_trait]
 impl QueryExecutor for MySqlAdapter {
     async fn execute_preview(
         &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-        _limit: usize,
-        _offset: usize,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+        limit: usize,
+        offset: usize,
     ) -> Result<QueryResult, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures mysql execution time at the I/O boundary"
+        )]
+        let start = Instant::now();
+        let preview = metadata::fetch_preview_metadata(dsn, schema, table).await?;
+        let query = metadata::build_preview_query(
+            schema,
+            table,
+            &preview.order_columns,
+            &preview.visible_columns,
+            &preview.identity_columns,
+            limit,
+            offset,
+        );
+        let display_query = metadata::build_preview_query(
+            schema,
+            table,
+            &preview.order_columns,
+            &preview.visible_columns,
+            &[],
+            limit,
+            offset,
+        );
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        let statements =
+            validate_mysql_multi_query(&query, target.database.as_deref(), AccessMode::ReadWrite)?;
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc(
+            &option_file.path,
+            &query,
+            &statements,
+            AccessMode::ReadWrite,
+        )
+        .await;
+        drop(option_file);
+        let result_set = result?.result_set.ok_or_else(|| {
+            DbOperationError::MetadataParseFailed(
+                "MySQL preview query returned no result set".to_string(),
+            )
+        })?;
+        let values = metadata::convert_preview_values(
+            &result_set,
+            &preview.visible_columns,
+            &preview.identity_columns,
+        )?;
+        let elapsed = start.elapsed().as_millis() as u64;
+
+        let mut query_result = QueryResult::success_with_values(
+            display_query,
+            preview
+                .visible_columns
+                .iter()
+                .map(|column| column.name.clone())
+                .collect(),
+            values.visible,
+            elapsed,
+            QuerySource::Preview,
+        );
+        if let Some(identity_values) = values.identity {
+            query_result = query_result.with_explicit_row_identity(
+                preview
+                    .identity_columns
+                    .iter()
+                    .map(|column| column.name.clone())
+                    .collect(),
+                identity_values,
+            );
+        }
+        Ok(query_result)
     }
 
     async fn execute_adhoc(
         &self,
-        _dsn: &str,
-        _query: &str,
-        _access_mode: AccessMode,
+        dsn: &str,
+        query: &str,
+        access_mode: AccessMode,
     ) -> Result<QueryResult, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+
+        if mysql_tree_explain_query_kind(query).is_some() {
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "infra measures mysql execution time at the I/O boundary"
+            )]
+            let start = Instant::now();
+            let option_file = MySqlOptionFile::create(&target)?;
+            let result = run_mysql_single_statement(&option_file.path, query, access_mode).await;
+            drop(option_file);
+            let result_set = result?;
+            return Ok(QueryResult::success_with_values(
+                query.to_string(),
+                result_set.columns,
+                result_set.values,
+                start.elapsed().as_millis() as u64,
+                QuerySource::Adhoc,
+            ));
+        }
+
+        let statements =
+            validate_mysql_multi_query(query, target.database.as_deref(), access_mode)?;
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures mysql execution time at the I/O boundary"
+        )]
+        let start = Instant::now();
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc(&option_file.path, query, &statements, access_mode).await;
+        drop(option_file);
+        let execution = result?;
+        let elapsed = start.elapsed().as_millis() as u64;
+        let mut result = match execution.result_set {
+            Some(result_set) => QueryResult::success_with_values(
+                query.to_string(),
+                result_set.columns,
+                result_set.values,
+                elapsed,
+                QuerySource::Adhoc,
+            ),
+            None => QueryResult::success(
+                query.to_string(),
+                Vec::new(),
+                Vec::new(),
+                elapsed,
+                QuerySource::Adhoc,
+            ),
+        };
+        if let Some(tag) = execution.command_tag {
+            result = result.with_command_tag(tag);
+        }
+        Ok(result.with_refresh_scope(execution.refresh_scope))
     }
 
     async fn execute_write(
         &self,
-        _dsn: &str,
-        _query: &str,
-        _access_mode: AccessMode,
+        dsn: &str,
+        query: &str,
+        access_mode: AccessMode,
     ) -> Result<WriteExecutionResult, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        let statements =
+            validate_mysql_multi_query(query, target.database.as_deref(), access_mode)?;
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures mysql execution time at the I/O boundary"
+        )]
+        let start = Instant::now();
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc(&option_file.path, query, &statements, access_mode).await;
+        drop(option_file);
+        let execution = result?;
+        let affected_rows = execution
+            .command_tag
+            .and_then(|tag| tag.affected_rows())
+            .ok_or_else(|| {
+                DbOperationError::CommandTagParseFailed(
+                    "MySQL write did not return an affected row count".to_string(),
+                )
+            })?;
+        let affected_rows = usize::try_from(affected_rows).map_err(|_| {
+            DbOperationError::CommandTagParseFailed(
+                "MySQL affected row count does not fit in usize".to_string(),
+            )
+        })?;
+
+        Ok(WriteExecutionResult {
+            affected_rows,
+            execution_time_ms: start.elapsed().as_millis() as u64,
+        })
     }
 
-    async fn count_query_rows(&self, _dsn: &str, _query: &str) -> Result<usize, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        validate_mysql_export_query(query, target.database.as_deref())?;
+
+        let result = self.execute_adhoc(dsn, query, AccessMode::ReadOnly).await?;
+        let value = result
+            .values()
+            .first()
+            .and_then(|row| row.first())
+            .and_then(QueryValue::as_str)
+            .ok_or_else(|| {
+                DbOperationError::QueryFailed(
+                    "MySQL row count query returned an invalid result".to_string(),
+                )
+            })?;
+        value.parse::<usize>().map_err(|_| {
+            DbOperationError::QueryFailed("MySQL row count was not an integer".to_string())
+        })
     }
 
     async fn export_to_csv(
         &self,
-        _dsn: &str,
-        _query: &str,
-        _file_name: &str,
+        dsn: &str,
+        query: &str,
+        file_name: &str,
     ) -> Result<std::path::PathBuf, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        validate_mysql_export_query(query, target.database.as_deref())?;
+
+        let query = query.to_string();
+        export_to_downloads(file_name, move |path| async move {
+            export_mysql_csv_to_file(target, &query, path).await
+        })
+        .await
     }
 }
 
 impl DdlGenerator for MySqlAdapter {
-    fn generate_ddl(&self, _database_type: DatabaseType, _table: &Table) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+    fn generate_ddl(&self, _database_type: DatabaseType, table: &Table) -> String {
+        table.source_ddl().unwrap_or_default().to_string()
     }
 }
 
 impl SqlDialect for MySqlAdapter {
-    fn build_explain_sql(&self, _database_type: DatabaseType, _query: &str) -> Option<String> {
-        None
+    fn build_explain_sql(&self, _database_type: DatabaseType, query: &str) -> Option<String> {
+        if mysql_explain_rejection_message(query).is_some() {
+            return None;
+        }
+        Some(format!("EXPLAIN FORMAT=TREE {query}"))
     }
 
     fn build_explain_analyze_sql(
         &self,
         _database_type: DatabaseType,
-        _query: &str,
+        query: &str,
     ) -> Option<String> {
-        None
+        mysql_tree_explain_query_kind(&format!("EXPLAIN ANALYZE FORMAT=TREE {query}"))?;
+        Some(format!("EXPLAIN ANALYZE FORMAT=TREE {query}"))
     }
 
     fn build_update_sql(
         &self,
         _database_type: DatabaseType,
-        _schema: &str,
-        _table: &str,
-        _column: &str,
-        _new_value: &QueryValue,
-        _pk_pairs: &[(String, QueryValue)],
+        schema: &str,
+        table: &str,
+        column: &str,
+        new_value: &QueryValue,
+        pk_pairs: &[(String, QueryValue)],
     ) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+        let where_clause = pk_pairs
+            .iter()
+            .map(|(column, value)| mysql_equality_predicate(column, value))
+            .collect::<Vec<_>>()
+            .join(" AND ");
+
+        format!(
+            "UPDATE {}.{}\nSET {} = {}\nWHERE {};",
+            mysql_quote_identifier(schema),
+            mysql_quote_identifier(table),
+            mysql_quote_identifier(column),
+            mysql_sql_literal(new_value),
+            where_clause
+        )
     }
 
     fn build_bulk_delete_sql(
         &self,
         _database_type: DatabaseType,
-        _schema: &str,
-        _table: &str,
-        _pk_pairs_per_row: &[Vec<(String, QueryValue)>],
+        schema: &str,
+        table: &str,
+        pk_pairs_per_row: &[Vec<(String, QueryValue)>],
     ) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+        assert!(
+            !pk_pairs_per_row.is_empty(),
+            "pk_pairs_per_row must not be empty"
+        );
+
+        let predicates = pk_pairs_per_row
+            .iter()
+            .map(|pairs| {
+                pairs
+                    .iter()
+                    .map(|(column, value)| mysql_equality_predicate(column, value))
+                    .collect::<Vec<_>>()
+                    .join(" AND ")
+            })
+            .collect::<Vec<_>>();
+        let where_clause = if predicates.len() == 1 {
+            predicates[0].clone()
+        } else {
+            predicates
+                .into_iter()
+                .map(|predicate| format!("({predicate})"))
+                .collect::<Vec<_>>()
+                .join(" OR ")
+        };
+
+        format!(
+            "DELETE FROM {}.{}\nWHERE {};",
+            mysql_quote_identifier(schema),
+            mysql_quote_identifier(table),
+            where_clause
+        )
+    }
+}
+
+fn mysql_quote_identifier(value: &str) -> String {
+    format!("`{}`", value.replace('`', "``"))
+}
+
+fn mysql_sql_literal(value: &QueryValue) -> String {
+    match value {
+        QueryValue::Null => "NULL".to_string(),
+        QueryValue::Text(value) => mysql_quote_string(value),
+        QueryValue::SqlLiteral(value) => value.clone(),
+        QueryValue::Blob(bytes) => {
+            let mut hex = String::with_capacity(bytes.len() * 2);
+            for byte in bytes {
+                let _ = write!(hex, "{byte:02X}");
+            }
+            format!("X'{hex}'")
+        }
+    }
+}
+
+fn mysql_quote_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\0' => escaped.push_str("\\0"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\u{0008}' => escaped.push_str("\\b"),
+            '\u{001a}' => escaped.push_str("\\Z"),
+            '\\' => escaped.push_str("\\\\"),
+            '\'' => escaped.push_str("\\'"),
+            _ => escaped.push(character),
+        }
+    }
+    format!("'{escaped}'")
+}
+
+fn mysql_equality_predicate(column: &str, value: &QueryValue) -> String {
+    let column = mysql_quote_identifier(column);
+    match value {
+        QueryValue::Null => format!("{column} IS NULL"),
+        _ => format!("{column} = {}", mysql_sql_literal(value)),
+    }
+}
+
+#[cfg(test)]
+mod write_sql_tests {
+    use super::*;
+
+    #[test]
+    fn update_quotes_identifiers_and_mysql_string_escapes() {
+        let adapter = MySqlAdapter::new();
+        let sql = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "db`name",
+            "table`name",
+            "value`name",
+            &QueryValue::text("O'Reilly\\path\n\t\0"),
+            &[
+                (
+                    "id`part".to_string(),
+                    QueryValue::SqlLiteral("18446744073709551615".into()),
+                ),
+                ("tenant".to_string(), QueryValue::Null),
+            ],
+        );
+
+        assert_eq!(
+            sql,
+            "UPDATE \x60db\x60\x60name\x60.\x60table\x60\x60name\x60\nSET \x60value\x60\x60name\x60 = 'O\\'Reilly\\\\path\\n\\t\\0'\nWHERE \x60id\x60\x60part\x60 = 18446744073709551615 AND \x60tenant\x60 IS NULL;"
+        );
+    }
+
+    #[test]
+    fn update_uses_text_datetime_and_blob_literals_without_coercion() {
+        let adapter = MySqlAdapter::new();
+        let sql = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "events",
+            "payload",
+            &QueryValue::Blob(vec![0, 255, 16]),
+            &[(
+                "created_at".to_string(),
+                QueryValue::text("2026-08-13 12:34:56"),
+            )],
+        );
+
+        assert_eq!(
+            sql,
+            "UPDATE `sabiql_test`.`events`\nSET `payload` = X'00FF10'\nWHERE `created_at` = '2026-08-13 12:34:56';"
+        );
+    }
+
+    #[test]
+    fn json_document_update_keeps_json_null_distinct_from_string_null() {
+        let adapter = MySqlAdapter::new();
+        let json_null = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "documents",
+            "payload",
+            &QueryValue::text("null"),
+            &[("id".to_string(), QueryValue::SqlLiteral("1".into()))],
+        );
+        let string_null = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "documents",
+            "payload",
+            &QueryValue::text(r#""null""#),
+            &[("id".to_string(), QueryValue::SqlLiteral("1".into()))],
+        );
+
+        assert!(json_null.contains("SET `payload` = 'null'"));
+        assert!(string_null.contains("SET `payload` = '\"null\"'"));
+        assert_ne!(json_null, string_null);
+    }
+
+    #[test]
+    fn bulk_delete_targets_each_composite_primary_key_row() {
+        let adapter = MySqlAdapter::new();
+        let sql = adapter.build_bulk_delete_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "items",
+            &[
+                vec![
+                    ("first".to_string(), QueryValue::SqlLiteral("1".into())),
+                    ("second".to_string(), QueryValue::SqlLiteral("20".into())),
+                ],
+                vec![
+                    ("first".to_string(), QueryValue::SqlLiteral("2".into())),
+                    ("second".to_string(), QueryValue::SqlLiteral("10".into())),
+                ],
+            ],
+        );
+
+        assert_eq!(
+            sql,
+            "DELETE FROM `sabiql_test`.`items`\nWHERE (`first` = 1 AND `second` = 20) OR (`first` = 2 AND `second` = 10);"
+        );
     }
 }
 
 impl DsnBuilder for MySqlAdapter {
-    fn build_dsn(&self, _profile: &ConnectionProfile) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+    fn build_dsn(&self, profile: &ConnectionProfile) -> String {
+        let config = profile
+            .mysql_config()
+            .expect("MySQL profile requires MySQL config");
+        build_mysql_dsn(config)
+    }
+}
+
+#[cfg(test)]
+mod explain_tests {
+    use super::*;
+
+    #[test]
+    fn builds_tree_explain_for_select_table_and_dml() {
+        let adapter = MySqlAdapter::new();
+
+        for query in [
+            "SELECT * FROM users",
+            "TABLE users",
+            "INSERT INTO users VALUES (1)",
+            "REPLACE INTO users VALUES (1)",
+            "REPLACE users VALUES (1)",
+            "REPLACE LOW_PRIORITY INTO users VALUES (1)",
+            "REPLACE DELAYED users VALUES (1)",
+            "UPDATE users SET name = 'Ada' WHERE id = 1",
+            "DELETE FROM users WHERE id = 1",
+        ] {
+            assert_eq!(
+                adapter.build_explain_sql(DatabaseType::MySQL, query),
+                Some(format!("EXPLAIN FORMAT=TREE {query}")),
+                "{query}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_mysql_explain_for_unsupported_input() {
+        let adapter = MySqlAdapter::new();
+
+        for query in [
+            "CREATE TABLE users(id INT)",
+            "DROP TABLE users",
+            "\\C /tmp/other.sock",
+            "SELECT 1; SELECT 2",
+        ] {
+            assert_eq!(
+                adapter.build_explain_sql(DatabaseType::MySQL, query),
+                None,
+                "{query}"
+            );
+        }
+    }
+
+    #[test]
+    fn builds_tree_explain_analyze_only_for_side_effect_free_reads() {
+        let adapter = MySqlAdapter::new();
+
+        for query in ["SELECT * FROM users", "TABLE users"] {
+            assert_eq!(
+                adapter.build_explain_analyze_sql(DatabaseType::MySQL, query),
+                Some(format!("EXPLAIN ANALYZE FORMAT=TREE {query}")),
+                "{query}"
+            );
+        }
+
+        for query in [
+            "UPDATE users SET name = 'Ada' WHERE id = 1",
+            "DELETE FROM users WHERE id = 1",
+            "INSERT INTO users VALUES (1)",
+            "REPLACE INTO users VALUES (1)",
+            "SELECT * FROM users FOR UPDATE",
+            "SELECT 1; SELECT 2",
+        ] {
+            assert_eq!(
+                adapter.build_explain_analyze_sql(DatabaseType::MySQL, query),
+                None,
+                "{query}"
+            );
+        }
+    }
+}
+
+#[async_trait]
+impl ConnectionProbe for MySqlAdapter {
+    async fn probe(&self, dsn: &str) -> Result<(), DbOperationError> {
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        self.check_cli_version().await?;
+
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = self.run_probe(&option_file.path).await;
+        drop(option_file);
+        let output = result?;
+
+        if !output.status.success() {
+            return Err(classify_mysql_probe_failure(clean_stderr(&output.stderr)));
+        }
+
+        let response: MySqlProbeResponse = serde_json::from_slice(&output.stdout)?;
+        let _ = (&response.database, &response.user);
+        validate_server_version(&response.version)?;
+        validate_sql_mode(&response.sql_mode)?;
+        Ok(())
+    }
+
+    async fn fetch_databases(&self, dsn: &str) -> Result<Vec<String>, DbOperationError> {
+        let mut target = parse_mysql_dsn(dsn)?;
+        target.database = None;
+        validate_mysql_values(&target)?;
+        self.check_cli_version().await?;
+
+        let option_file = MySqlOptionFile::create(&target)?;
+        let statements = validate_mysql_multi_query("SHOW DATABASES", None, AccessMode::ReadWrite)?;
+        let result = run_mysql_adhoc(
+            &option_file.path,
+            "SHOW DATABASES",
+            &statements,
+            AccessMode::ReadWrite,
+        )
+        .await;
+        drop(option_file);
+        result.map(|execution| {
+            execution
+                .result_set
+                .unwrap_or(MysqlResultSet {
+                    columns: Vec::new(),
+                    values: Vec::new(),
+                })
+                .values
+                .into_iter()
+                .filter_map(|mut row| row.drain(..).next())
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect()
+        })
+    }
+}
+
+impl MySqlAdapter {
+    async fn check_cli_version(&self) -> Result<(), DbOperationError> {
+        let output = run_mysql_command(["--version"], None).await?;
+        let version_output = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if !output.status.success() || !is_oracle_mysql_cli_84_version(&version_output) {
+            return Err(DbOperationError::UnsupportedOperation(format!(
+                "{MYSQL_CLI_VERSION_REQUIRED_MARKER}: {}",
+                version_output.trim()
+            )));
+        }
+        Ok(())
+    }
+
+    async fn run_probe(
+        &self,
+        option_file: &PathBuf,
+    ) -> Result<std::process::Output, DbOperationError> {
+        let args = mysql_probe_args(option_file);
+        run_mysql_command(args, Some(option_file)).await
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct MySqlProbeResponse {
+    database: Option<String>,
+    user: String,
+    version: String,
+    sql_mode: String,
+}
+
+#[derive(Debug)]
+struct MySqlDsn {
+    host: String,
+    port: u16,
+    database: Option<String>,
+    username: String,
+    password: String,
+    ssl_mode: MySqlSslMode,
+    ssl_ca: Option<String>,
+    ssl_cert: Option<String>,
+    ssl_key: Option<String>,
+}
+
+fn build_mysql_dsn(config: &MySqlConnectionConfig) -> String {
+    let mut url = Url::parse("mysql://localhost").expect("static MySQL URL is valid");
+    url.set_username(&config.username)
+        .expect("MySQL username is valid URL data");
+    url.set_password(Some(&config.password))
+        .expect("MySQL password is valid URL data");
+    let host = normalize_mysql_host(&config.host);
+    let host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]")
+    } else {
+        host
+    };
+    url.set_host(Some(&host))
+        .expect("validated MySQL host is valid URL data");
+    url.set_port(Some(config.port))
+        .expect("MySQL port is valid URL data");
+    if let Some(database) = config.database.as_deref() {
+        url.path_segments_mut()
+            .expect("MySQL URL supports path segments")
+            .push(database);
+    }
+    url.query_pairs_mut()
+        .append_pair("ssl-mode", &config.ssl_mode.to_string());
+    if let Some(path) = config.ssl_ca.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-ca", path);
+    }
+    if let Some(path) = config.ssl_cert.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-cert", path);
+    }
+    if let Some(path) = config.ssl_key.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-key", path);
+    }
+    url.to_string()
+}
+
+fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
+    let url = Url::parse(dsn).map_err(|error| {
+        DbOperationError::ConnectionFailed(format!("Invalid MySQL DSN: {error}"))
+    })?;
+    if url.scheme() != "mysql" {
+        return Err(DbOperationError::ConnectionFailed(
+            "Invalid MySQL DSN scheme".to_string(),
+        ));
+    }
+    let host = url.host_str().ok_or_else(|| {
+        DbOperationError::ConnectionFailed("MySQL DSN is missing a host".to_string())
+    })?;
+    let host = normalize_mysql_host(host);
+    let username = decode_url_component(url.username())?;
+    let password = decode_url_component(url.password().unwrap_or_default())?;
+    let database = url
+        .path_segments()
+        .and_then(|mut segments| segments.next())
+        .filter(|segment| !segment.is_empty())
+        .map(decode_url_component)
+        .transpose()?;
+    let ssl_mode = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-mode").then(|| parse_ssl_mode(&value)))
+        .transpose()?
+        .unwrap_or_default();
+    let ssl_ca = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-ca").then(|| value.into_owned()));
+    let ssl_cert = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-cert").then(|| value.into_owned()));
+    let ssl_key = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-key").then(|| value.into_owned()));
+
+    Ok(MySqlDsn {
+        host,
+        port: url.port().unwrap_or(3306),
+        database,
+        username,
+        password,
+        ssl_mode,
+        ssl_ca,
+        ssl_cert,
+        ssl_key,
+    })
+}
+
+fn normalize_mysql_host(host: &str) -> String {
+    host.strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host)
+        .to_string()
+}
+
+fn parse_ssl_mode(value: &str) -> Result<MySqlSslMode, DbOperationError> {
+    match value {
+        "DISABLED" => Ok(MySqlSslMode::Disabled),
+        "PREFERRED" => Ok(MySqlSslMode::Preferred),
+        "REQUIRED" => Ok(MySqlSslMode::Required),
+        "VERIFY_CA" => Ok(MySqlSslMode::VerifyCa),
+        "VERIFY_IDENTITY" => Ok(MySqlSslMode::VerifyIdentity),
+        _ => Err(DbOperationError::ConnectionFailed(
+            "Invalid MySQL TLS mode".to_string(),
+        )),
+    }
+}
+
+fn decode_url_component(value: &str) -> Result<String, DbOperationError> {
+    urlencoding::decode(value)
+        .map(std::borrow::Cow::into_owned)
+        .map_err(|error| DbOperationError::ConnectionFailed(format!("Invalid MySQL DSN: {error}")))
+}
+
+fn validate_mysql_values(target: &MySqlDsn) -> Result<(), DbOperationError> {
+    let values = [
+        target.host.as_str(),
+        target.username.as_str(),
+        target.password.as_str(),
+    ];
+    if target
+        .database
+        .as_deref()
+        .into_iter()
+        .chain(values)
+        .any(|value| value.chars().any(char::is_control))
+    {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL connection settings contain a control character".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_mysql_tls_files(target: &MySqlDsn) -> Result<(), DbOperationError> {
+    let has_tls_path =
+        target.ssl_ca.is_some() || target.ssl_cert.is_some() || target.ssl_key.is_some();
+    if target.ssl_mode == MySqlSslMode::Disabled && has_tls_path {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL TLS paths require an enabled TLS mode".to_string(),
+        ));
+    }
+    if matches!(
+        target.ssl_mode,
+        MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity
+    ) && target.ssl_ca.is_none()
+    {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL CA path is required for certificate verification".to_string(),
+        ));
+    }
+    if target.ssl_cert.is_some() != target.ssl_key.is_some() {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL client certificate and key must be specified together".to_string(),
+        ));
+    }
+
+    for (kind, path) in [
+        ("CA", target.ssl_ca.as_deref()),
+        ("client certificate", target.ssl_cert.as_deref()),
+        ("client key", target.ssl_key.as_deref()),
+    ] {
+        let Some(path) = path else { continue };
+        let metadata = fs::metadata(path).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} path cannot be accessed: {error}"
+            ))
+        })?;
+        if !metadata.is_file() {
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} path is not a regular file"
+            )));
+        }
+        let contents = fs::read(path).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!("MySQL {kind} cannot be read: {error}"))
+        })?;
+        let text = String::from_utf8_lossy(&contents);
+        if matches!(kind, "CA" | "client certificate") && !text.contains("BEGIN CERTIFICATE") {
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} is not a PEM certificate"
+            )));
+        }
+        if kind == "client key" {
+            if text.contains("BEGIN ENCRYPTED PRIVATE KEY")
+                || text
+                    .lines()
+                    .any(|line| line.trim().eq_ignore_ascii_case("Proc-Type: 4,ENCRYPTED"))
+            {
+                return Err(DbOperationError::ConnectionFailed(
+                    "Encrypted MySQL client keys are not supported".to_string(),
+                ));
+            }
+            if ![
+                "BEGIN PRIVATE KEY",
+                "BEGIN RSA PRIVATE KEY",
+                "BEGIN EC PRIVATE KEY",
+            ]
+            .iter()
+            .any(|marker| text.contains(marker))
+            {
+                return Err(DbOperationError::ConnectionFailed(
+                    "MySQL client key is not a PEM private key".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn contains_unsupported_mysql_product(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    ["mariadb", "percona", "tidb", "vitess", "aurora"]
+        .iter()
+        .any(|product| lower.contains(product))
+}
+
+fn is_oracle_mysql_cli_84_version(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("mysql")
+        && !contains_unsupported_mysql_product(value)
+        && version_major_minor(value) == Some((8, 4))
+}
+
+fn is_oracle_mysql_server_84_version(value: &str) -> bool {
+    !contains_unsupported_mysql_product(value) && version_major_minor(value) == Some((8, 4))
+}
+
+fn validate_server_version(version: &str) -> Result<(), DbOperationError> {
+    if is_oracle_mysql_server_84_version(version) {
+        Ok(())
+    } else {
+        Err(DbOperationError::UnsupportedOperation(format!(
+            "{MYSQL_SERVER_VERSION_REQUIRED_MARKER}: {version}"
+        )))
+    }
+}
+
+fn validate_sql_mode(sql_mode: &str) -> Result<(), DbOperationError> {
+    let unsupported = sql_mode.split(',').map(str::trim).any(|mode| {
+        mode.eq_ignore_ascii_case("NO_BACKSLASH_ESCAPES")
+            || mode.eq_ignore_ascii_case("ANSI_QUOTES")
+    });
+    if unsupported {
+        Err(DbOperationError::UnsupportedOperation(format!(
+            "{MYSQL_SQL_MODE_UNSUPPORTED_MARKER}: {sql_mode}"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn version_major_minor(value: &str) -> Option<(u32, u32)> {
+    let mut numbers = value
+        .split(|character: char| !character.is_ascii_digit())
+        .filter(|part| !part.is_empty())
+        .filter_map(|part| part.parse::<u32>().ok());
+    Some((numbers.next()?, numbers.next()?))
+}
+
+fn mysql_probe_args(option_file: &std::path::Path) -> Vec<String> {
+    vec![
+        format!("--defaults-file={}", option_file.display()),
+        "--no-login-paths".to_string(),
+        "--protocol=TCP".to_string(),
+        "--connect-timeout=10".to_string(),
+        "--batch".to_string(),
+        "--raw".to_string(),
+        "--skip-column-names".to_string(),
+        "--binary-mode".to_string(),
+        "--skip-reconnect".to_string(),
+        format!("--execute={MYSQL_PROBE_QUERY}"),
+    ]
+}
+
+async fn run_mysql_command<I, S>(
+    args: I,
+    option_file: Option<&PathBuf>,
+) -> Result<std::process::Output, DbOperationError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new("mysql");
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .env_remove("MYSQL_PWD")
+        .env_remove("MYSQL_PASSWORD")
+        .kill_on_drop(true);
+    if option_file.is_some() {
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    }
+
+    match timeout(MYSQL_PROBE_TIMEOUT, command.output()).await {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(error)) if error.kind() == io::ErrorKind::NotFound => {
+            Err(DbOperationError::CommandNotFound {
+                command: DatabaseCli::MySql,
+                details: error.to_string(),
+            })
+        }
+        Ok(Err(error)) => Err(DbOperationError::ConnectionFailed(error.to_string())),
+        Err(_) => Err(DbOperationError::Timeout(
+            "mysql probe exceeded the connection timeout".to_string(),
+        )),
+    }
+}
+
+fn clean_stderr(stderr: &[u8]) -> String {
+    let text = String::from_utf8_lossy(stderr).trim().to_string();
+    if text.is_empty() {
+        "mysql probe failed".to_string()
+    } else {
+        text
+    }
+}
+
+fn classify_mysql_probe_failure(stderr: String) -> DbOperationError {
+    if is_mysql_connect_timeout_message(&stderr) {
+        DbOperationError::Timeout(stderr)
+    } else {
+        DbOperationError::ConnectionFailed(stderr)
+    }
+}
+
+fn is_mysql_connect_timeout_message(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("can't connect to mysql server")
+        && (lower.contains("(110)") || lower.contains("(10060)"))
+}
+
+struct MySqlOptionFile {
+    path: PathBuf,
+}
+
+impl MySqlOptionFile {
+    fn create(target: &MySqlDsn) -> Result<Self, DbOperationError> {
+        validate_mysql_tls_files(target)?;
+        let sequence = OPTION_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "sabiql-mysql-{}-{sequence}.cnf",
+            std::process::id()
+        ));
+        if !path.is_absolute() {
+            path = std::env::current_dir()
+                .map_err(|error| DbOperationError::ConnectionFailed(error.to_string()))?
+                .join(path);
+        }
+
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        std::os::unix::fs::OpenOptionsExt::mode(&mut options, 0o600);
+        let mut file = options.open(&path).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!(
+                "Unable to create MySQL option file: {error}"
+            ))
+        })?;
+        let contents = serialize_option_file(target);
+        if let Err(error) = file.write_all(contents.as_bytes()) {
+            let _ = fs::remove_file(&path);
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "Unable to write MySQL option file: {error}"
+            )));
+        }
+        Ok(Self { path })
+    }
+}
+
+impl Drop for MySqlOptionFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn serialize_option_file(target: &MySqlDsn) -> String {
+    let mut contents = String::from("[client]\n");
+    push_option(&mut contents, "host", &target.host);
+    push_option(&mut contents, "port", &target.port.to_string());
+    push_option(&mut contents, "user", &target.username);
+    push_option(&mut contents, "password", &target.password);
+    if let Some(database) = target.database.as_deref() {
+        push_option(&mut contents, "database", database);
+    }
+    push_option(&mut contents, "ssl-mode", &target.ssl_mode.to_string());
+    if let Some(path) = target.ssl_ca.as_deref() {
+        push_option(&mut contents, "ssl-ca", path);
+    }
+    if let Some(path) = target.ssl_cert.as_deref() {
+        push_option(&mut contents, "ssl-cert", path);
+    }
+    if let Some(path) = target.ssl_key.as_deref() {
+        push_option(&mut contents, "ssl-key", path);
+    }
+    contents
+}
+
+fn push_option(contents: &mut String, key: &str, value: &str) {
+    contents.push_str(key);
+    contents.push_str(" = ");
+    contents.push_str(&quote_option_value(value));
+    contents.push('\n');
+}
+
+fn quote_option_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            _ => escaped.push(character),
+        }
+    }
+    format!("\"{escaped}\"")
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MysqlResultSet {
+    columns: Vec<String>,
+    values: Vec<Vec<QueryValue>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MysqlExecutionResult {
+    result_set: Option<MysqlResultSet>,
+    command_tag: Option<CommandTag>,
+    refresh_scope: RefreshScope,
+}
+
+struct MysqlCommandEvent {
+    kind: MysqlStatementKind,
+    target: Option<String>,
+    tag: CommandTag,
+}
+
+fn validate_mysql_multi_query(
+    query: &str,
+    selected_database: Option<&str>,
+    access_mode: AccessMode,
+) -> Result<Vec<MysqlStatement>, DbOperationError> {
+    let decision = evaluate_mysql_multi_statement(query, selected_database);
+    let (statements, risk) = match decision {
+        MultiStatementDecision::Allow { statements, risk } => (statements, risk),
+        MultiStatementDecision::Block { reason } => {
+            return Err(DbOperationError::UnsupportedOperation(reason));
+        }
+    };
+    if access_mode.is_read_only() && !risk.read_only_allowed {
+        return Err(DbOperationError::PermissionDenied(
+            "read-only mode blocks MySQL write statements".to_string(),
+        ));
+    }
+    statements
+        .iter()
+        .map(|statement| {
+            classify_mysql_statement(statement)
+                .map_err(|error| DbOperationError::UnsupportedOperation(error.to_string()))
+        })
+        .collect()
+}
+
+fn validate_mysql_export_query(
+    query: &str,
+    selected_database: Option<&str>,
+) -> Result<(), DbOperationError> {
+    let statements = validate_mysql_multi_query(query, selected_database, AccessMode::ReadOnly)?;
+    if statements.len() != 1
+        || !matches!(
+            statements[0].kind,
+            MysqlStatementKind::Select
+                | MysqlStatementKind::Table
+                | MysqlStatementKind::Show
+                | MysqlStatementKind::Describe
+        )
+    {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL CSV export supports a single read-only result query".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+struct MysqlProcess {
+    child: Child,
+    #[cfg(unix)]
+    pty: MysqlPty,
+    #[cfg(not(unix))]
+    stdin: ChildStdin,
+    #[cfg(not(unix))]
+    stdout: ChildStdout,
+    #[cfg(not(unix))]
+    stderr: ChildStderr,
+    #[cfg(not(unix))]
+    pending: Vec<u8>,
+    #[cfg(not(unix))]
+    pending_stderr: Vec<u8>,
+}
+
+#[cfg(unix)]
+struct MysqlPty {
+    input: TokioFile,
+    output: TokioFile,
+    pending: Vec<u8>,
+}
+
+impl MysqlProcess {
+    fn spawn_with_program(
+        program: &OsStr,
+        option_file: &std::path::Path,
+    ) -> Result<Self, DbOperationError> {
+        #[cfg(unix)]
+        {
+            Self::spawn_with_pty(program, option_file)
+        }
+
+        #[cfg(not(unix))]
+        {
+            let mut command = Command::new(program);
+            command
+                .args(mysql_query_args(option_file))
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .env_remove("MYSQL_PWD")
+                .env_remove("MYSQL_PASSWORD")
+                .kill_on_drop(true);
+            let mut child = command.spawn().map_err(|error| {
+                if error.kind() == io::ErrorKind::NotFound {
+                    DbOperationError::CommandNotFound {
+                        command: DatabaseCli::MySql,
+                        details: error.to_string(),
+                    }
+                } else {
+                    DbOperationError::ConnectionFailed(error.to_string())
+                }
+            })?;
+            let stdin = child.stdin.take().ok_or_else(|| {
+                DbOperationError::QueryFailed("mysql stdin was not piped".to_string())
+            })?;
+            let stdout = child.stdout.take().ok_or_else(|| {
+                DbOperationError::QueryFailed("mysql stdout was not piped".to_string())
+            })?;
+            let stderr = child.stderr.take().ok_or_else(|| {
+                DbOperationError::QueryFailed("mysql stderr was not piped".to_string())
+            })?;
+            return Ok(Self {
+                child,
+                stdin,
+                stdout,
+                stderr,
+                pending: Vec::new(),
+                pending_stderr: Vec::new(),
+            });
+        }
+    }
+
+    #[cfg(unix)]
+    fn spawn_with_pty(
+        program: &OsStr,
+        option_file: &std::path::Path,
+    ) -> Result<Self, DbOperationError> {
+        let (master, slave) = create_mysql_pty().map_err(|error| {
+            DbOperationError::ConnectionFailed(format!("Unable to create MySQL PTY: {error}"))
+        })?;
+        let mut command = Command::new(program);
+        command
+            .args(mysql_query_args(option_file))
+            .stdin(Stdio::from(slave.try_clone().map_err(|error| {
+                DbOperationError::ConnectionFailed(error.to_string())
+            })?))
+            .stdout(Stdio::from(slave.try_clone().map_err(|error| {
+                DbOperationError::ConnectionFailed(error.to_string())
+            })?))
+            .stderr(Stdio::from(slave))
+            .env_remove("MYSQL_PWD")
+            .env_remove("MYSQL_PASSWORD")
+            .kill_on_drop(true);
+        let child = command.spawn().map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                DbOperationError::CommandNotFound {
+                    command: DatabaseCli::MySql,
+                    details: error.to_string(),
+                }
+            } else {
+                DbOperationError::ConnectionFailed(error.to_string())
+            }
+        })?;
+        let output = TokioFile::from_std(
+            master
+                .try_clone()
+                .map_err(|error| DbOperationError::ConnectionFailed(error.to_string()))?,
+        );
+        let input = TokioFile::from_std(master);
+        Ok(Self {
+            child,
+            pty: MysqlPty {
+                input,
+                output,
+                pending: Vec::new(),
+            },
+        })
+    }
+}
+
+#[cfg(unix)]
+fn create_mysql_pty() -> io::Result<(std::fs::File, std::fs::File)> {
+    let mut master = -1;
+    let mut slave = -1;
+    let result = unsafe {
+        libc::openpty(
+            &raw mut master,
+            &raw mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let slave_file = unsafe { std::fs::File::from_raw_fd(slave) };
+    let master_file = unsafe { std::fs::File::from_raw_fd(master) };
+    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+    if unsafe { libc::tcgetattr(slave_file.as_raw_fd(), termios.as_mut_ptr()) } == 0 {
+        let mut termios = unsafe { termios.assume_init() };
+        termios.c_lflag &= !(libc::ECHO | libc::ECHONL);
+        termios.c_oflag &= !libc::OPOST;
+        let _ =
+            unsafe { libc::tcsetattr(slave_file.as_raw_fd(), libc::TCSANOW, &raw const termios) };
+    }
+    Ok((master_file, slave_file))
+}
+
+async fn run_mysql_adhoc(
+    option_file: &std::path::Path,
+    query: &str,
+    statements: &[MysqlStatement],
+    access_mode: AccessMode,
+) -> Result<MysqlExecutionResult, DbOperationError> {
+    run_mysql_adhoc_with_program_and_statements(
+        OsStr::new("mysql"),
+        option_file,
+        query,
+        statements,
+        access_mode,
+        MYSQL_QUERY_TIMEOUT,
+    )
+    .await
+}
+
+async fn export_mysql_csv_to_file(
+    target: MySqlDsn,
+    query: &str,
+    path: PathBuf,
+) -> Result<(), DbOperationError> {
+    let option_file = MySqlOptionFile::create(&target)?;
+    let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
+    let result = timeout(
+        MYSQL_QUERY_TIMEOUT,
+        run_mysql_export_process(&mut process, query, path),
+    )
+    .await;
+    match result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_export_process(
+    process: &mut MysqlProcess,
+    query: &str,
+    path: PathBuf,
+) -> Result<(), DbOperationError> {
+    let marker = Uuid::new_v4().simple().to_string();
+    let probe_query =
+        format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");
+    write_mysql_statement(process, &probe_query).await?;
+    let probe_xml = read_one_mysql_resultset(process).await?;
+    let probe = parse_mysql_xml(&probe_xml)?;
+    validate_mode_probe(&probe, &marker)?;
+
+    write_mysql_statement(process, query).await?;
+    let mut csv_writer = CsvFileWriter::create(path).await?;
+    stream_mysql_resultset_to_csv(process, &mut csv_writer).await?;
+
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .shutdown()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let tail = {
+        write_mysql_input(process, b"\\q\n").await?;
+        read_pty_all(&mut process.pty)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?
+    };
+
+    #[cfg(not(unix))]
+    let (_stdout, stderr) =
+        tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    #[cfg(not(unix))]
+    let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+
+    let status = process
+        .child
+        .wait()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(unix)]
+    let error_bytes = tail.as_slice();
+    #[cfg(not(unix))]
+    let error_bytes = stderr.as_slice();
+    if !status.success() {
+        return Err(classify_mysql_query_failure(error_bytes));
+    }
+
+    csv_writer.finish().await
+}
+
+async fn stream_mysql_resultset_to_csv(
+    process: &mut MysqlProcess,
+    csv_writer: &mut CsvFileWriter,
+) -> Result<(), DbOperationError> {
+    #[cfg(unix)]
+    {
+        let source = MysqlExportPtySource {
+            pty: &mut process.pty,
+            error_output: Vec::new(),
+        };
+        let mut reader = Reader::from_reader(BufReader::new(source));
+        reader.config_mut().trim_text(false);
+        let result = stream_mysql_xml_to_csv(&mut reader, csv_writer).await;
+        let buffered = reader.into_inner();
+        let unread = buffered.buffer().to_vec();
+        let source = buffered.into_inner();
+        source.pty.pending.extend(unread);
+        if !source.error_output.is_empty() {
+            return Err(classify_mysql_query_failure(&source.error_output));
+        }
+        result
+    }
+
+    #[cfg(not(unix))]
+    {
+        let source = MysqlExportPipeSource {
+            stdout: &mut process.stdout,
+            stderr: &mut process.stderr,
+            pending: &mut process.pending,
+            error_output: Vec::new(),
+            stderr_buffer: [0; 4096],
+            stderr_closed: false,
+            stdout_closed: false,
+        };
+        let mut reader = Reader::from_reader(BufReader::new(source));
+        reader.config_mut().trim_text(false);
+        let result = stream_mysql_xml_to_csv(&mut reader, csv_writer).await;
+        let buffered = reader.into_inner();
+        let unread = buffered.buffer().to_vec();
+        let source = buffered.into_inner();
+        source.pending.extend(unread);
+        if has_mysql_cli_error(&source.error_output) {
+            return Err(classify_mysql_query_failure(&source.error_output));
+        }
+        return result;
+    }
+}
+
+async fn stream_mysql_xml_to_csv<R>(
+    reader: &mut Reader<BufReader<R>>,
+    csv_writer: &mut CsvFileWriter,
+) -> Result<(), DbOperationError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = Vec::new();
+    let mut resultset_count = 0;
+    let mut in_resultset = false;
+    let mut current_row: Option<Vec<(String, String)>> = None;
+    let mut current_field: Option<MysqlField> = None;
+    let mut columns: Option<Vec<String>> = None;
+
+    loop {
+        let event = reader
+            .read_event_into_async(&mut buffer)
+            .await
+            .map_err(|error| {
+                DbOperationError::QueryFailed(format!("invalid MySQL XML result: {error}"))
+            })?;
+        match event {
+            Event::Start(element) => match element.name().as_ref() {
+                b"resultset" => {
+                    if in_resultset || resultset_count > 0 {
+                        return Err(DbOperationError::QueryFailed(
+                            "mysql returned more than one resultset".to_string(),
+                        ));
+                    }
+                    resultset_count += 1;
+                    in_resultset = true;
+                }
+                b"row" if in_resultset && current_row.is_none() => {
+                    current_row = Some(Vec::new());
+                }
+                b"field" if current_row.is_some() && current_field.is_none() => {
+                    current_field = Some(parse_mysql_field(&element)?);
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected element in MySQL XML result".to_string(),
+                    ));
+                }
+            },
+            Event::Empty(element) if element.name().as_ref() == b"field" => {
+                let row = current_row.as_mut().ok_or_else(|| {
+                    DbOperationError::QueryFailed("MySQL XML field is outside a row".to_string())
+                })?;
+                if current_field.is_some() {
+                    return Err(DbOperationError::QueryFailed(
+                        "nested MySQL XML fields are not supported".to_string(),
+                    ));
+                }
+                row.push(parse_mysql_field(&element)?.finish_raw());
+            }
+            Event::Text(text) => {
+                let text = text.unescape().map_err(|error| {
+                    DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
+                })?;
+                if let Some(field) = current_field.as_mut() {
+                    field.value.push_str(&text);
+                } else if !text.chars().all(char::is_whitespace) {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected text in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::CData(data) => {
+                if let Some(field) = current_field.as_mut() {
+                    field
+                        .value
+                        .push_str(std::str::from_utf8(data.as_ref()).map_err(|error| {
+                            DbOperationError::QueryFailed(format!(
+                                "invalid MySQL XML text: {error}"
+                            ))
+                        })?);
+                } else {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected CDATA in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::End(element) => match element.name().as_ref() {
+                b"field" => {
+                    let row = current_row.as_mut().ok_or_else(|| {
+                        DbOperationError::QueryFailed(
+                            "MySQL XML field is outside a row".to_string(),
+                        )
+                    })?;
+                    let field = current_field.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML field end".to_string())
+                    })?;
+                    row.push(field.finish_raw());
+                }
+                b"row" => {
+                    let row = current_row.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML row end".to_string())
+                    })?;
+                    let row_columns = row.iter().map(|(name, _)| name.clone()).collect::<Vec<_>>();
+                    if let Some(columns) = columns.as_ref() {
+                        if row_columns != *columns {
+                            return Err(DbOperationError::QueryFailed(
+                                "MySQL XML rows have inconsistent fields".to_string(),
+                            ));
+                        }
+                    } else {
+                        csv_writer.write_record(row_columns.iter()).await?;
+                        columns = Some(row_columns);
+                    }
+                    csv_writer
+                        .write_record(row.iter().map(|(_, value)| value))
+                        .await?;
+                }
+                b"resultset" => {
+                    if !in_resultset || current_row.is_some() || current_field.is_some() {
+                        return Err(DbOperationError::QueryFailed(
+                            "malformed MySQL XML resultset".to_string(),
+                        ));
+                    }
+                    return Ok(());
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected MySQL XML closing element".to_string(),
+                    ));
+                }
+            },
+            Event::Decl(_) | Event::Comment(_) => {}
+            Event::Eof => break,
+            _ => {
+                return Err(DbOperationError::QueryFailed(
+                    "unexpected event in MySQL XML result".to_string(),
+                ));
+            }
+        }
+        buffer.clear();
+    }
+
+    if resultset_count != 1 || in_resultset || current_row.is_some() || current_field.is_some() {
+        return Err(DbOperationError::QueryFailed(
+            "MySQL XML result did not contain one complete resultset".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+struct MysqlExportPtySource<'a> {
+    pty: &'a mut MysqlPty,
+    error_output: Vec<u8>,
+}
+
+#[cfg(unix)]
+impl MysqlExportPtySource<'_> {
+    fn capture_error(&mut self, bytes: &[u8]) {
+        if self.error_output.is_empty() && has_mysql_cli_error(bytes) {
+            self.error_output
+                .extend_from_slice(&bytes[..bytes.len().min(32 * 1024)]);
+        }
+    }
+}
+
+#[cfg(unix)]
+impl AsyncRead for MysqlExportPtySource<'_> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if !this.pty.pending.is_empty() {
+            let count = buffer.remaining().min(this.pty.pending.len());
+            let bytes = this.pty.pending.drain(..count).collect::<Vec<_>>();
+            this.capture_error(&bytes);
+            buffer.put_slice(&bytes);
+            return Poll::Ready(Ok(()));
+        }
+
+        let filled_before = buffer.filled().len();
+        let result = Pin::new(&mut this.pty.output).poll_read(cx, buffer);
+        if matches!(&result, Poll::Ready(Ok(()))) {
+            this.capture_error(&buffer.filled()[filled_before..]);
+        }
+        result
+    }
+}
+
+#[cfg(not(unix))]
+struct MysqlExportPipeSource<'a, O, E> {
+    stdout: &'a mut O,
+    stderr: &'a mut E,
+    pending: &'a mut Vec<u8>,
+    error_output: Vec<u8>,
+    stderr_buffer: [u8; 4096],
+    stderr_closed: bool,
+    stdout_closed: bool,
+}
+
+#[cfg(not(unix))]
+impl<O, E> MysqlExportPipeSource<'_, O, E>
+where
+    O: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
+    fn capture_error(&mut self, bytes: &[u8]) {
+        let remaining = (32usize * 1024).saturating_sub(self.error_output.len());
+        if remaining > 0 {
+            self.error_output
+                .extend_from_slice(&bytes[..bytes.len().min(remaining)]);
+        }
+    }
+
+    fn poll_stderr(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+        if self.stderr_closed {
+            return Poll::Ready(Ok(0));
+        }
+        let result = {
+            let mut read_buffer = ReadBuf::new(&mut self.stderr_buffer);
+            match Pin::new(&mut *self.stderr).poll_read(cx, &mut read_buffer) {
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(read_buffer.filled().to_vec())),
+                Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+                Poll::Pending => Poll::Pending,
+            }
+        };
+        match result {
+            Poll::Ready(Ok(bytes)) => {
+                if bytes.is_empty() {
+                    self.stderr_closed = true;
+                } else {
+                    self.capture_error(&bytes);
+                }
+                Poll::Ready(Ok(bytes.len()))
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(not(unix))]
+impl<O, E> AsyncRead for MysqlExportPipeSource<'_, O, E>
+where
+    O: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        let stderr_count = match this.poll_stderr(cx) {
+            Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+            Poll::Pending => 0,
+            Poll::Ready(Ok(count)) => count,
+        };
+        if !this.pending.is_empty() {
+            let count = buffer.remaining().min(this.pending.len());
+            let bytes = this.pending.drain(..count).collect::<Vec<_>>();
+            buffer.put_slice(&bytes);
+            return Poll::Ready(Ok(()));
+        }
+
+        if this.stdout_closed {
+            if this.stderr_closed {
+                return Poll::Ready(Ok(()));
+            }
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        }
+
+        let filled_before = buffer.filled().len();
+        let result = Pin::new(&mut *this.stdout).poll_read(cx, buffer);
+        if let Poll::Ready(Ok(())) = &result {
+            let count = buffer.filled().len() - filled_before;
+            if count == 0 {
+                this.stdout_closed = true;
+                if !this.stderr_closed {
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+            }
+        } else if matches!(&result, Poll::Pending) && stderr_count > 0 {
+            cx.waker().wake_by_ref();
+        }
+        result
+    }
+}
+
+#[cfg(all(test, not(unix)))]
+mod export_pipe_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn consumes_stderr_while_streaming_stdout() {
+        let (mut stdout_writer, mut stdout_reader) = tokio::io::duplex(64);
+        let (mut stderr_writer, mut stderr_reader) = tokio::io::duplex(64);
+        let stdout = b"<resultset><row><field name=\"value\">ok</field></row></resultset>".to_vec();
+        let stderr = format!(
+            "ERROR 1146 (42S02): Table 'app.missing' doesn't exist\n{}",
+            "warning\n".repeat(16 * 1024)
+        )
+        .into_bytes();
+
+        let stdout_task = tokio::spawn(async move {
+            stdout_writer.write_all(&stdout).await.unwrap();
+        });
+        let stderr_task = tokio::spawn(async move {
+            stderr_writer.write_all(&stderr).await.unwrap();
+        });
+
+        let mut source = MysqlExportPipeSource {
+            stdout: &mut stdout_reader,
+            stderr: &mut stderr_reader,
+            pending: &mut Vec::new(),
+            error_output: Vec::new(),
+            stderr_buffer: [0; 4096],
+            stderr_closed: false,
+            stdout_closed: false,
+        };
+        let mut output = Vec::new();
+        source.read_to_end(&mut output).await.unwrap();
+        stdout_task.await.unwrap();
+        stderr_task.await.unwrap();
+
+        assert!(output.starts_with(b"<resultset>"));
+        assert!(has_mysql_cli_error(&source.error_output));
+        assert!(matches!(
+            classify_mysql_query_failure(&source.error_output),
+            DbOperationError::ObjectMissing(_)
+        ));
+    }
+}
+
+#[cfg(test)]
+async fn export_mysql_csv_with_program(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+    path: PathBuf,
+    execution_timeout: Duration,
+) -> Result<(), DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+    let result = timeout(
+        execution_timeout,
+        run_mysql_export_process(&mut process, query, path),
+    )
+    .await;
+    match result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+async fn run_mysql_adhoc_with_program(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+    access_mode: AccessMode,
+    execution_timeout: Duration,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+    let result = timeout(
+        execution_timeout,
+        run_mysql_single_statement_process(&mut process, query, access_mode),
+    )
+    .await;
+    match result {
+        Ok(Ok(result_set)) => Ok(result_set),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_single_statement(
+    option_file: &std::path::Path,
+    query: &str,
+    access_mode: AccessMode,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), option_file)?;
+    let result = timeout(
+        MYSQL_QUERY_TIMEOUT,
+        run_mysql_single_statement_process(&mut process, query, access_mode),
+    )
+    .await;
+    match result {
+        Ok(Ok(result_set)) => Ok(result_set),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_single_statement_process(
+    process: &mut MysqlProcess,
+    query: &str,
+    access_mode: AccessMode,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let marker = Uuid::new_v4().simple().to_string();
+    let probe_query =
+        format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");
+    write_mysql_statement(process, &probe_query).await?;
+    let probe_xml = read_one_mysql_resultset(process).await?;
+    let probe = parse_mysql_xml(&probe_xml)?;
+    validate_mode_probe(&probe, &marker)?;
+    configure_mysql_session(process, access_mode).await?;
+
+    write_mysql_statement(process, query).await?;
+
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .shutdown()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let (stdout, tail) = {
+        let stdout = read_one_mysql_resultset(process).await?;
+        write_mysql_input(process, b"\\q\n").await?;
+        let tail = read_pty_all(&mut process.pty)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        (stdout, tail)
+    };
+
+    #[cfg(not(unix))]
+    let (stdout, stderr) =
+        tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    #[cfg(not(unix))]
+    let stdout = stdout.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    #[cfg(not(unix))]
+    let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+
+    let status = process
+        .child
+        .wait()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(unix)]
+    let error_bytes = tail.as_slice();
+    #[cfg(not(unix))]
+    let error_bytes = stderr.as_slice();
+    if !status.success() {
+        return Err(classify_mysql_query_failure(error_bytes));
+    }
+    parse_mysql_xml(&stdout)
+}
+
+async fn run_mysql_adhoc_with_program_and_statements(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+    statements: &[MysqlStatement],
+    access_mode: AccessMode,
+    execution_timeout: Duration,
+) -> Result<MysqlExecutionResult, DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+    let result = timeout(
+        execution_timeout,
+        run_mysql_adhoc_process(&mut process, query, statements, access_mode),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(result_set)) => Ok(result_set),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_adhoc_process(
+    process: &mut MysqlProcess,
+    _query: &str,
+    statements: &[MysqlStatement],
+    access_mode: AccessMode,
+) -> Result<MysqlExecutionResult, DbOperationError> {
+    let probe_marker = Uuid::new_v4().simple().to_string();
+    let probe_query = format!(
+        "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
+    );
+    write_mysql_statement(process, &probe_query).await?;
+    let probe_xml = read_one_mysql_resultset(process).await?;
+    let probe = parse_mysql_xml(&probe_xml)?;
+    validate_mode_probe(&probe, &probe_marker)?;
+    configure_mysql_session(process, access_mode).await?;
+
+    let mut last_result_set = None;
+    let mut command_tags = Vec::with_capacity(statements.len());
+    let mut refresh_scope = RefreshScope::None;
+
+    for statement in statements {
+        let marker = Uuid::new_v4().simple().to_string();
+        let statement_scope = mysql_refresh_scope(&statement.kind);
+        refresh_scope = refresh_scope.merge(statement_scope);
+        if let Err(error) = write_mysql_statement(process, &statement.sql).await {
+            return Err(query_failed_after_change(error, refresh_scope));
+        }
+        let marker_query =
+            format!("SELECT '{marker}' AS __sabiql_marker, ROW_COUNT() AS affected_rows");
+        if let Err(error) = write_mysql_statement(process, &marker_query).await {
+            return Err(query_failed_after_change(error, refresh_scope));
+        }
+        let first_xml = match read_one_mysql_resultset(process).await {
+            Ok(xml) => xml,
+            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+        };
+        let first_result = match parse_mysql_xml(&first_xml) {
+            Ok(result) => result,
+            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+        };
+        let (user_result, marker_result) = if is_mysql_row_count_marker(&first_result, &marker) {
+            (None, first_result)
+        } else {
+            let xml = match read_one_mysql_resultset(process).await {
+                Ok(xml) => xml,
+                Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+            };
+            let marker_result = match parse_mysql_xml(&xml) {
+                Ok(result) => result,
+                Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+            };
+            (Some(first_result), marker_result)
+        };
+        let affected_rows = match mysql_row_count_marker(&marker_result, &marker) {
+            Ok(rows) => rows,
+            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+        };
+        if let Some(result) = user_result {
+            last_result_set = Some(result);
+        }
+        let tag = mysql_command_tag(&statement.kind, affected_rows, last_result_set.as_ref());
+        command_tags.push(MysqlCommandEvent {
+            kind: statement.kind.clone(),
+            target: statement.target.clone(),
+            tag,
+        });
+    }
+
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .shutdown()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let tail = {
+        write_mysql_input(process, b"\\q\n").await?;
+        let tail = read_pty_all(&mut process.pty)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        trace_mysql_frame("discard tail", tail.len());
+        trace_mysql_error(&tail);
+        tail
+    };
+
+    #[cfg(not(unix))]
+    let (_stdout, stderr) =
+        tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    #[cfg(not(unix))]
+    let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+
+    let status = process
+        .child
+        .wait()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let error_bytes = tail.as_slice();
+    #[cfg(not(unix))]
+    let error_bytes = stderr.as_slice();
+    if has_mysql_cli_error(error_bytes) {
+        return Err(query_failed_after_change(
+            classify_mysql_query_failure(error_bytes),
+            refresh_scope,
+        ));
+    }
+    if !status.success() {
+        return Err(query_failed_after_change(
+            classify_mysql_query_failure(error_bytes),
+            refresh_scope,
+        ));
+    }
+
+    Ok(MysqlExecutionResult {
+        result_set: last_result_set,
+        command_tag: aggregate_mysql_command_tag(&command_tags),
+        refresh_scope,
+    })
+}
+
+async fn configure_mysql_session(
+    process: &mut MysqlProcess,
+    access_mode: AccessMode,
+) -> Result<(), DbOperationError> {
+    if !access_mode.is_read_only() {
+        return Ok(());
+    }
+
+    let marker = Uuid::new_v4().simple().to_string();
+    write_mysql_statement(process, MYSQL_READ_ONLY_STATEMENT).await?;
+    write_mysql_statement(
+        process,
+        &format!("SELECT '{marker}' AS {MYSQL_SESSION_MARKER_COLUMN}"),
+    )
+    .await?;
+    loop {
+        let result = read_one_mysql_resultset(process).await?;
+        let result = parse_mysql_xml(&result)?;
+        if result.columns.is_empty() && result.values.is_empty() {
+            continue;
+        }
+        return validate_mysql_session_marker(&result, &marker);
+    }
+}
+
+fn validate_mysql_session_marker(
+    result: &MysqlResultSet,
+    marker: &str,
+) -> Result<(), DbOperationError> {
+    if result.columns != [MYSQL_SESSION_MARKER_COLUMN]
+        || result.values.len() != 1
+        || result.values[0].len() != 1
+        || result.values[0][0].as_str() != Some(marker)
+    {
+        return Err(DbOperationError::QueryFailed(
+            "mysql read-only session marker did not match".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn query_failed_after_change(
+    error: DbOperationError,
+    refresh_scope: RefreshScope,
+) -> DbOperationError {
+    if refresh_scope == RefreshScope::None {
+        error
+    } else {
+        DbOperationError::QueryFailedAfterChange {
+            details: error.masked_details(),
+            refresh_scope,
+        }
+    }
+}
+
+fn is_mysql_row_count_marker(result: &MysqlResultSet, marker: &str) -> bool {
+    result.columns == ["__sabiql_marker", "affected_rows"]
+        && result.values.len() == 1
+        && result.values[0].first().and_then(QueryValue::as_str) == Some(marker)
+}
+
+fn mysql_row_count_marker(result: &MysqlResultSet, marker: &str) -> Result<i64, DbOperationError> {
+    if !is_mysql_row_count_marker(result, marker) || result.values[0].len() != 2 {
+        return Err(DbOperationError::QueryFailed(
+            "mysql ROW_COUNT marker did not match the executed statement".to_string(),
+        ));
+    }
+    let value = result.values[0][1].as_str().ok_or_else(|| {
+        DbOperationError::QueryFailed("mysql ROW_COUNT marker was NULL".to_string())
+    })?;
+    value.parse::<i64>().map_err(|_| {
+        DbOperationError::QueryFailed("mysql ROW_COUNT marker was not an integer".to_string())
+    })
+}
+
+fn mysql_command_tag(
+    kind: &MysqlStatementKind,
+    affected_rows: i64,
+    user_result: Option<&MysqlResultSet>,
+) -> CommandTag {
+    let rows = || u64::try_from(affected_rows.max(0)).unwrap_or(0);
+    match kind {
+        MysqlStatementKind::Select
+        | MysqlStatementKind::Table
+        | MysqlStatementKind::Show
+        | MysqlStatementKind::Describe => {
+            CommandTag::Select(user_result.map_or(0, |result| result.values.len() as u64))
+        }
+        MysqlStatementKind::Insert | MysqlStatementKind::Replace => CommandTag::Insert(rows()),
+        MysqlStatementKind::Update { .. } => CommandTag::Update(rows()),
+        MysqlStatementKind::Delete { .. } => CommandTag::Delete(rows()),
+        MysqlStatementKind::CreateTable { temporary: true } => {
+            CommandTag::Other("CREATE TEMPORARY TABLE".to_string())
+        }
+        MysqlStatementKind::CreateTable { temporary: false } => {
+            CommandTag::Create("TABLE".to_string())
+        }
+        MysqlStatementKind::AlterTable => CommandTag::Alter("TABLE".to_string()),
+        MysqlStatementKind::DropTable { temporary: true } => {
+            CommandTag::Other("DROP TEMPORARY TABLE".to_string())
+        }
+        MysqlStatementKind::DropTable { temporary: false } => CommandTag::Drop("TABLE".to_string()),
+        MysqlStatementKind::TruncateTable => CommandTag::Truncate,
+        MysqlStatementKind::CreateView => CommandTag::Create("VIEW".to_string()),
+        MysqlStatementKind::DropView => CommandTag::Drop("VIEW".to_string()),
+        MysqlStatementKind::CreateIndex => CommandTag::Create("INDEX".to_string()),
+        MysqlStatementKind::DropIndex => CommandTag::Drop("INDEX".to_string()),
+        MysqlStatementKind::Begin | MysqlStatementKind::StartTransaction => CommandTag::Begin,
+        MysqlStatementKind::Commit => CommandTag::Commit,
+        MysqlStatementKind::Rollback | MysqlStatementKind::RollbackToSavepoint => {
+            CommandTag::Rollback
+        }
+        MysqlStatementKind::Savepoint => CommandTag::Other("SAVEPOINT".to_string()),
+        MysqlStatementKind::ReleaseSavepoint => CommandTag::Other("RELEASE SAVEPOINT".to_string()),
+    }
+}
+
+fn mysql_refresh_scope(kind: &MysqlStatementKind) -> RefreshScope {
+    if mysql_statement_is_schema_modifying(kind) {
+        RefreshScope::Metadata
+    } else if mysql_statement_is_data_modifying(kind) {
+        RefreshScope::Data
+    } else {
+        RefreshScope::None
+    }
+}
+
+fn mysql_statement_is_persistent_schema_change(kind: &MysqlStatementKind) -> bool {
+    mysql_statement_is_schema_modifying(kind)
+        && !matches!(
+            kind,
+            MysqlStatementKind::CreateTable { temporary: true }
+                | MysqlStatementKind::DropTable { temporary: true }
+        )
+}
+
+#[derive(Default)]
+struct MysqlPendingTransactionTags {
+    data: Vec<CommandTag>,
+    savepoints: Vec<(String, usize)>,
+}
+
+fn apply_pending_mysql_data(
+    pending: MysqlPendingTransactionTags,
+    committed_data: &mut Option<CommandTag>,
+) {
+    if let Some(tag) = pending.data.last() {
+        *committed_data = Some(tag.clone());
+    }
+}
+
+fn aggregate_mysql_command_tag(events: &[MysqlCommandEvent]) -> Option<CommandTag> {
+    let mut committed_schema = None;
+    let mut committed_data = None;
+    let mut pending = None;
+    let mut last_tag = None;
+
+    for event in events {
+        last_tag = Some(event.tag.clone());
+        match &event.kind {
+            MysqlStatementKind::Begin | MysqlStatementKind::StartTransaction => {
+                pending = Some(MysqlPendingTransactionTags::default());
+            }
+            MysqlStatementKind::Commit => {
+                if let Some(transaction) = pending.take() {
+                    apply_pending_mysql_data(transaction, &mut committed_data);
+                }
+            }
+            MysqlStatementKind::Rollback => {
+                pending = None;
+            }
+            MysqlStatementKind::Savepoint => {
+                if let Some(transaction) = pending.as_mut()
+                    && let Some(name) = event.target.as_deref()
+                {
+                    transaction
+                        .savepoints
+                        .retain(|(current, _)| !current.eq_ignore_ascii_case(name));
+                    transaction
+                        .savepoints
+                        .push((name.to_string(), transaction.data.len()));
+                }
+            }
+            MysqlStatementKind::RollbackToSavepoint => {
+                if let Some(transaction) = pending.as_mut()
+                    && let Some(name) = event.target.as_deref()
+                    && let Some(index) = transaction
+                        .savepoints
+                        .iter()
+                        .position(|(current, _)| current.eq_ignore_ascii_case(name))
+                {
+                    transaction.data.truncate(transaction.savepoints[index].1);
+                    transaction.savepoints.truncate(index + 1);
+                }
+            }
+            MysqlStatementKind::ReleaseSavepoint => {
+                if let Some(transaction) = pending.as_mut()
+                    && let Some(name) = event.target.as_deref()
+                    && let Some(index) = transaction
+                        .savepoints
+                        .iter()
+                        .position(|(current, _)| current.eq_ignore_ascii_case(name))
+                {
+                    transaction.savepoints.remove(index);
+                }
+            }
+            MysqlStatementKind::CreateTable { temporary: true }
+            | MysqlStatementKind::DropTable { temporary: true } => {}
+            kind if mysql_statement_is_persistent_schema_change(kind) => {
+                if let Some(transaction) = pending.take() {
+                    apply_pending_mysql_data(transaction, &mut committed_data);
+                }
+                committed_schema = Some(event.tag.clone());
+            }
+            kind if mysql_statement_is_data_modifying(kind) => {
+                if let Some(transaction) = pending.as_mut() {
+                    transaction.data.push(event.tag.clone());
+                } else {
+                    committed_data = Some(event.tag.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    committed_schema.or(committed_data).or(last_tag)
+}
+
+async fn write_mysql_statement(
+    process: &mut MysqlProcess,
+    query: &str,
+) -> Result<(), DbOperationError> {
+    let query = query.trim_end();
+    write_mysql_input(process, query.as_bytes()).await?;
+    if query.ends_with(';') {
+        write_mysql_input(process, b"\n").await
+    } else if mysql_statement_has_trailing_line_comment(query) {
+        write_mysql_input(process, b"\n;\n").await
+    } else {
+        write_mysql_input(process, b";\n").await
+    }
+}
+
+fn mysql_statement_has_trailing_line_comment(sql: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    let mut quote = None;
+    let mut line_comment = false;
+    while index < bytes.len() {
+        if let Some(delimiter) = quote {
+            if bytes[index] == b'\\' && delimiter != b'`' {
+                index += 2;
+            } else if bytes[index] == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                } else {
+                    quote = None;
+                    index += 1;
+                }
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if line_comment {
+            if bytes[index] == b'\n' {
+                line_comment = false;
+            }
+            index += 1;
+            continue;
+        }
+        if matches!(bytes[index], b'\'' | b'"' | b'`') {
+            quote = Some(bytes[index]);
+            index += 1;
+        } else if mysql_is_line_comment_start(bytes, index) {
+            let comment_start = index;
+            index = mysql_skip_line_comment(bytes, index);
+            line_comment = !bytes[comment_start..index].contains(&b'\n');
+        } else if bytes.get(index..index + 2) == Some(b"/*") {
+            index = mysql_skip_block_comment(bytes, index);
+        } else {
+            index += 1;
+        }
+    }
+    line_comment
+}
+
+fn mysql_is_line_comment_start(bytes: &[u8], index: usize) -> bool {
+    bytes[index] == b'#'
+        || (bytes.get(index..index + 2) == Some(b"--")
+            && bytes.get(index + 2).is_none_or(u8::is_ascii_whitespace))
+}
+
+fn mysql_skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() {
+        let byte = bytes[index];
+        index += 1;
+        if byte == b'\n' {
+            break;
+        }
+    }
+    index
+}
+
+fn mysql_skip_block_comment(bytes: &[u8], index: usize) -> usize {
+    let mut cursor = index + 2;
+    while cursor + 1 < bytes.len() {
+        if bytes[cursor] == b'*' && bytes[cursor + 1] == b'/' {
+            return cursor + 2;
+        }
+        cursor += 1;
+    }
+    bytes.len()
+}
+
+async fn write_mysql_input(
+    process: &mut MysqlProcess,
+    input: &[u8],
+) -> Result<(), DbOperationError> {
+    #[cfg(unix)]
+    process
+        .pty
+        .input
+        .write_all(input)
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .write_all(input)
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(unix)]
+    process
+        .pty
+        .input
+        .flush()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .flush()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    Ok(())
+}
+
+async fn cleanup_mysql_process(process: &mut MysqlProcess) {
+    let _ = process.child.kill().await;
+    #[cfg(unix)]
+    let _ = read_pty_all(&mut process.pty).await;
+    #[cfg(not(unix))]
+    let _ = tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    let _ = process.child.wait().await;
+}
+
+async fn read_one_mysql_resultset(process: &mut MysqlProcess) -> Result<Vec<u8>, DbOperationError> {
+    #[cfg(unix)]
+    {
+        return read_one_pty_resultset(&mut process.pty).await;
+    }
+    #[cfg(not(unix))]
+    read_one_mysql_resultset_from_pipes(
+        &mut process.stdout,
+        &mut process.stderr,
+        &mut process.pending,
+        &mut process.pending_stderr,
+    )
+    .await
+}
+
+#[cfg(unix)]
+async fn read_one_pty_resultset(pty: &mut MysqlPty) -> Result<Vec<u8>, DbOperationError> {
+    let mut chunk = [0; 4096];
+    loop {
+        if has_mysql_cli_error(&pty.pending) {
+            trace_mysql_error(&pty.pending);
+            return Err(classify_mysql_query_failure(&pty.pending));
+        }
+        if let Some(frame) = take_mysql_resultset_frame(&mut pty.pending) {
+            trace_mysql_frame("receive resultset", frame.len());
+            return Ok(frame);
+        }
+        let count = match pty.output.read(&mut chunk).await {
+            Ok(count) => count,
+            Err(error) if error.raw_os_error() == Some(libc::EIO) => 0,
+            Err(error) => return Err(DbOperationError::ConnectionLost(error.to_string())),
+        };
+        if count == 0 {
+            return Err(DbOperationError::EmptyResponse(
+                "mysql query returned no resultset".to_string(),
+            ));
+        }
+        pty.pending.extend_from_slice(&chunk[..count]);
+    }
+}
+
+#[cfg(unix)]
+async fn read_pty_all(pty: &mut MysqlPty) -> io::Result<Vec<u8>> {
+    let mut output = std::mem::take(&mut pty.pending);
+    let mut chunk = [0; 4096];
+    loop {
+        match pty.output.read(&mut chunk).await {
+            Ok(0) => return Ok(output),
+            Ok(count) => output.extend_from_slice(&chunk[..count]),
+            Err(error) if error.raw_os_error() == Some(libc::EIO) => return Ok(output),
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn has_mysql_cli_error(output: &[u8]) -> bool {
+    output
+        .split(|byte| *byte == b'\n' || *byte == b'\r')
+        .any(|line| {
+            let mut line = line;
+            while line
+                .first()
+                .is_some_and(|byte| byte.is_ascii_whitespace() || byte.is_ascii_control())
+            {
+                line = &line[1..];
+            }
+            line.starts_with(b"ERROR ") || line == b"ERROR"
+        })
+}
+
+fn take_mysql_resultset_frame(buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
+    let (start, end) = mysql_resultset_frame_bounds(buffer)?;
+    let frame = buffer[start..end].to_vec();
+    buffer.drain(..end);
+    Some(frame)
+}
+
+fn mysql_resultset_frame_bounds(buffer: &[u8]) -> Option<(usize, usize)> {
+    let start = find_bytes(buffer, b"<resultset")?;
+    let end = buffer[start..]
+        .windows(b"</resultset>".len())
+        .position(|window| window == b"</resultset>")?
+        + start
+        + b"</resultset>".len();
+    Some((start, end))
+}
+
+#[cfg(any(not(unix), test))]
+fn take_mysql_resultset_frame_after_error_check(
+    buffer: &mut Vec<u8>,
+    error_output: &[u8],
+) -> Result<Option<Vec<u8>>, DbOperationError> {
+    if has_mysql_cli_error(error_output) {
+        trace_mysql_error(error_output);
+        return Err(classify_mysql_query_failure(error_output));
+    }
+    Ok(take_mysql_resultset_frame(buffer))
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn trace_mysql_frame(kind: &str, bytes: usize) {
+    if std::env::var_os("SABIQL_MYSQL_TRANSCRIPT").is_some() {
+        write_mysql_transcript_line(&format!("sabiql mysql frame: {kind}, bytes={bytes}"));
+    }
+}
+
+fn trace_mysql_error(output: &[u8]) {
+    if std::env::var_os("SABIQL_MYSQL_TRANSCRIPT").is_some() && has_mysql_cli_error(output) {
+        write_mysql_transcript_line("sabiql mysql frame: ERROR line observed");
+    }
+}
+
+fn write_mysql_transcript_line(line: &str) {
+    let mut stderr = io::stderr();
+    let _ = stderr.write_all(line.as_bytes());
+    let _ = stderr.write_all(b"\n");
+}
+
+#[cfg(not(unix))]
+async fn read_all<R>(reader: &mut R) -> io::Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).await?;
+    Ok(output)
+}
+
+#[cfg(not(unix))]
+async fn read_one_mysql_resultset_from_pipes<R, E>(
+    reader: &mut R,
+    stderr: &mut E,
+    pending: &mut Vec<u8>,
+    pending_stderr: &mut Vec<u8>,
+) -> Result<Vec<u8>, DbOperationError>
+where
+    R: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
+    let mut chunk = [0; 4096];
+    let mut stderr_chunk = [0; 4096];
+    let mut stderr_closed = false;
+    loop {
+        if mysql_resultset_frame_bounds(pending).is_some() && !stderr_closed {
+            tokio::select! {
+                biased;
+                result = stderr.read(&mut stderr_chunk) => {
+                    let count = result.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+                    if count == 0 {
+                        stderr_closed = true;
+                    } else {
+                        pending_stderr.extend_from_slice(&stderr_chunk[..count]);
+                    }
+                }
+                _ = tokio::task::yield_now() => {}
+            }
+        }
+        if let Some(frame) = take_mysql_resultset_frame_after_error_check(pending, pending_stderr)?
+        {
+            trace_mysql_frame("receive resultset", frame.len());
+            return Ok(frame);
+        }
+        if stderr_closed {
+            let count = reader
+                .read(&mut chunk)
+                .await
+                .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+            if count == 0 {
+                return Err(DbOperationError::EmptyResponse(
+                    "mysql mode probe returned no resultset".to_string(),
+                ));
+            }
+            pending.extend_from_slice(&chunk[..count]);
+        } else {
+            tokio::select! {
+                result = reader.read(&mut chunk) => {
+                    let count = result.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+                    if count == 0 {
+                        return Err(DbOperationError::EmptyResponse(
+                            "mysql mode probe returned no resultset".to_string(),
+                        ));
+                    }
+                    pending.extend_from_slice(&chunk[..count]);
+                }
+                result = stderr.read(&mut stderr_chunk) => {
+                    let count = result.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+                    if count == 0 {
+                        stderr_closed = true;
+                    } else {
+                        pending_stderr.extend_from_slice(&stderr_chunk[..count]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn mysql_query_args(option_file: &std::path::Path) -> Vec<String> {
+    let args = vec![
+        format!("--defaults-file={}", option_file.display()),
+        "--no-login-paths".to_string(),
+        "--protocol=TCP".to_string(),
+        "--connect-timeout=10".to_string(),
+        "--xml".to_string(),
+        "--binary-as-hex".to_string(),
+        "--binary-mode".to_string(),
+        "--unbuffered".to_string(),
+        "--skip-reconnect".to_string(),
+        "--default-character-set=utf8mb4".to_string(),
+        "--silent".to_string(),
+        "--prompt=".to_string(),
+    ];
+    #[cfg(not(unix))]
+    return args
+        .into_iter()
+        .chain(std::iter::once("--batch".to_string()))
+        .collect();
+    #[cfg(unix)]
+    args
+}
+
+fn validate_mode_probe(result: &MysqlResultSet, marker: &str) -> Result<(), DbOperationError> {
+    if result.values.len() != 1 || result.columns != ["__sabiql_probe", "__sabiql_sql_mode"] {
+        return Err(DbOperationError::QueryFailed(
+            "mysql sql_mode probe returned an unexpected result".to_string(),
+        ));
+    }
+    let values = &result.values[0];
+    if values.len() != 2 {
+        return Err(DbOperationError::QueryFailed(
+            "mysql sql_mode probe returned an unexpected result".to_string(),
+        ));
+    }
+    if values[0].as_str() != Some(marker) {
+        return Err(DbOperationError::QueryFailed(
+            "mysql sql_mode probe marker did not match".to_string(),
+        ));
+    }
+    let mode = values[1].as_str().ok_or_else(|| {
+        DbOperationError::QueryFailed("mysql sql_mode probe returned no mode".to_string())
+    })?;
+    validate_sql_mode(mode)
+}
+
+fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {
+    let details = clean_mysql_stderr(stderr, "mysql query failed");
+    let lower = details.to_ascii_lowercase();
+    let error_code = mysql_server_error_code(&lower);
+    if is_mysql_tls_error(&lower) {
+        DbOperationError::ConnectionFailed(details)
+    } else if is_mysql_connect_timeout_message(&details)
+        || lower.contains("connect timeout")
+        || lower.contains("connection timed out")
+    {
+        DbOperationError::Timeout(details)
+    } else if matches!(error_code, Some(1044 | 1142 | 1143 | 1227))
+        || lower.contains("command denied")
+    {
+        DbOperationError::PermissionDenied(details)
+    } else if error_code == Some(1045)
+        || lower.contains("access denied")
+        || lower.contains("authentication")
+    {
+        DbOperationError::ConnectionFailed(details)
+    } else if lower.contains("lost connection") || lower.contains("server has gone away") {
+        DbOperationError::ConnectionLost(details)
+    } else if lower.contains("lock wait timeout") || lower.contains("deadlock found") {
+        DbOperationError::LockTimeout(details)
+    } else if lower.contains("doesn't exist") || lower.contains("does not exist") {
+        DbOperationError::ObjectMissing(details)
+    } else if lower.contains("duplicate entry") {
+        DbOperationError::UniqueViolation(details)
+    } else if lower.contains("query execution was interrupted")
+        || lower.contains("query was interrupted")
+    {
+        DbOperationError::Canceled(details)
+    } else {
+        DbOperationError::QueryFailed(details)
+    }
+}
+
+fn is_mysql_tls_error(lowercase_details: &str) -> bool {
+    [
+        "error 2026",
+        "tls/ssl error",
+        "ssl connection error",
+        "ssl handshake",
+        "tls handshake",
+        "handshake failure",
+        "tlsv1 alert",
+        "certificate verify failed",
+        "certificate verification failure",
+        "certificate validation failure",
+        "unable to get local issuer",
+        "self-signed certificate",
+        "unknown ca",
+        "certificate required",
+        "peer did not return a certificate",
+    ]
+    .iter()
+    .any(|marker| lowercase_details.contains(marker))
+}
+
+fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
+    let marker = "error ";
+    let start = lowercase_details.find(marker)? + marker.len();
+    let digits = &lowercase_details[start..];
+    let end = digits
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(digits.len());
+    digits[..end].parse().ok()
+}
+
+fn clean_mysql_stderr(stderr: &[u8], fallback: &str) -> String {
+    let text = String::from_utf8_lossy(stderr).trim().to_string();
+    if text.is_empty() {
+        fallback.to_string()
+    } else {
+        text
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
+enum MysqlToken {
+    Word(String),
+    OpenParen,
+    CloseParen,
+    Comma,
+    Other,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MysqlReadStatement {
+    Select,
+    Table,
+    Show,
+    Describe,
+}
+
+#[cfg(test)]
+fn validate_mysql_adhoc_query(query: &str) -> Result<(), DbOperationError> {
+    let tokens = scan_mysql_sql(query)?;
+    let first = tokens.first().ok_or_else(|| {
+        DbOperationError::UnsupportedOperation("empty MySQL statement".to_string())
+    })?;
+    let kind = match first {
+        MysqlToken::Word(word) => match word.as_str() {
+            "SELECT" => Some(MysqlReadStatement::Select),
+            "TABLE" => Some(MysqlReadStatement::Table),
+            "SHOW" => Some(MysqlReadStatement::Show),
+            "DESCRIBE" => Some(MysqlReadStatement::Describe),
+            "WITH" => classify_with_statement(&tokens),
+            _ => None,
+        },
+        _ => None,
+    };
+    if kind.is_some() && has_top_level_into_clause(&tokens) {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL SELECT INTO clauses are not supported".to_string(),
+        ));
+    }
+    kind.map(|_| ()).ok_or_else(|| {
+        DbOperationError::UnsupportedOperation(
+            "only a single SELECT, TABLE, SHOW, DESCRIBE, or SELECT CTE is supported".to_string(),
+        )
+    })
+}
+
+#[cfg(test)]
+fn has_top_level_into_clause(tokens: &[MysqlToken]) -> bool {
+    let mut depth = 0usize;
+    for token in tokens {
+        match token {
+            MysqlToken::OpenParen => depth += 1,
+            MysqlToken::CloseParen => depth = depth.saturating_sub(1),
+            MysqlToken::Word(word) if depth == 0 && word == "INTO" => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+fn scan_mysql_sql(query: &str) -> Result<Vec<MysqlToken>, DbOperationError> {
+    let chars: Vec<char> = query.chars().collect();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    let mut line_start = true;
+    let mut semicolons = 0;
+    let mut statement_ended = false;
+    while index < chars.len() {
+        let character = chars[index];
+        if line_start && matches!(character, ' ' | '\t' | '\r') {
+            index += 1;
+            continue;
+        }
+        if line_start && character == '\\' {
+            return Err(unsupported_client_command("backslash command"));
+        }
+        if line_start && character.is_ascii_alphabetic() {
+            let start = index;
+            while index < chars.len()
+                && (chars[index].is_ascii_alphanumeric() || chars[index] == '_')
+            {
+                index += 1;
+            }
+            let word: String = chars[start..index].iter().collect();
+            if matches!(
+                word.to_ascii_lowercase().as_str(),
+                "delimiter" | "charset" | "source" | "system"
+            ) && (index == chars.len() || chars[index].is_whitespace())
+            {
+                return Err(unsupported_client_command(&word));
+            }
+            if statement_ended {
+                return Err(unsupported_client_command("multiple SQL statements"));
+            }
+            tokens.push(MysqlToken::Word(word.to_ascii_uppercase()));
+            line_start = false;
+            continue;
+        }
+        if character == '\n' {
+            line_start = true;
+            index += 1;
+            continue;
+        }
+        if character.is_whitespace() {
+            index += 1;
+            continue;
+        }
+        if character == '#' {
+            skip_line_comment(&chars, &mut index, &mut line_start);
+            continue;
+        }
+        if character == '-'
+            && chars.get(index + 1) == Some(&'-')
+            && chars.get(index + 2).is_none_or(|next| next.is_whitespace())
+        {
+            skip_line_comment(&chars, &mut index, &mut line_start);
+            continue;
+        }
+        if character == '/' && chars.get(index + 1) == Some(&'*') {
+            if chars.get(index + 2) == Some(&'!') {
+                return Err(unsupported_client_command("MySQL version comment"));
+            }
+            skip_block_comment(&chars, &mut index, &mut line_start)?;
+            continue;
+        }
+        if matches!(character, '\'' | '"' | '`') {
+            if statement_ended {
+                return Err(unsupported_client_command("multiple SQL statements"));
+            }
+            skip_quoted_literal(&chars, &mut index, character)?;
+            line_start = false;
+            tokens.push(MysqlToken::Other);
+            continue;
+        }
+        match character {
+            ';' => {
+                semicolons += 1;
+                if semicolons > 1 {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                if tokens.is_empty() {
+                    return Err(unsupported_client_command("empty MySQL statement"));
+                }
+                statement_ended = true;
+                index += 1;
+            }
+            '(' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::OpenParen);
+                line_start = false;
+                index += 1;
+            }
+            ')' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::CloseParen);
+                line_start = false;
+                index += 1;
+            }
+            ',' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::Comma);
+                line_start = false;
+                index += 1;
+            }
+            character if character.is_ascii_alphabetic() || character == '_' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                let start = index;
+                while index < chars.len()
+                    && (chars[index].is_ascii_alphanumeric() || matches!(chars[index], '_' | '$'))
+                {
+                    index += 1;
+                }
+                let word: String = chars[start..index].iter().collect();
+                tokens.push(MysqlToken::Word(word.to_ascii_uppercase()));
+                line_start = false;
+            }
+            _ => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::Other);
+                line_start = false;
+                index += 1;
+            }
+        }
+    }
+    if tokens.is_empty() || query.trim_start().starts_with(';') {
+        return Err(unsupported_client_command("empty MySQL statement"));
+    }
+    Ok(tokens)
+}
+
+#[cfg(test)]
+fn skip_line_comment(chars: &[char], index: &mut usize, line_start: &mut bool) {
+    while *index < chars.len() {
+        let character = chars[*index];
+        *index += 1;
+        if character == '\n' {
+            *line_start = true;
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+fn skip_block_comment(
+    chars: &[char],
+    index: &mut usize,
+    line_start: &mut bool,
+) -> Result<(), DbOperationError> {
+    *index += 2;
+    while *index < chars.len() {
+        if chars[*index] == '\n' {
+            *line_start = true;
+        }
+        if chars[*index] == '*' && chars.get(*index + 1) == Some(&'/') {
+            *index += 2;
+            return Ok(());
+        }
+        *index += 1;
+    }
+    Err(unsupported_client_command("unterminated block comment"))
+}
+
+#[cfg(test)]
+fn skip_quoted_literal(
+    chars: &[char],
+    index: &mut usize,
+    quote: char,
+) -> Result<(), DbOperationError> {
+    *index += 1;
+    while *index < chars.len() {
+        if chars[*index] == '\\' {
+            *index += 2;
+            continue;
+        }
+        if chars[*index] == quote {
+            if chars.get(*index + 1) == Some(&quote) {
+                *index += 2;
+            } else {
+                *index += 1;
+                return Ok(());
+            }
+        } else {
+            *index += 1;
+        }
+    }
+    Err(unsupported_client_command("unterminated quoted literal"))
+}
+
+#[cfg(test)]
+fn classify_with_statement(tokens: &[MysqlToken]) -> Option<MysqlReadStatement> {
+    let mut index = 1;
+    if matches!(tokens.get(index), Some(MysqlToken::Word(word)) if word == "RECURSIVE") {
+        index += 1;
+    }
+    loop {
+        if !matches!(
+            tokens.get(index),
+            Some(MysqlToken::Word(_) | MysqlToken::Other)
+        ) {
+            return None;
+        }
+        index += 1;
+        if matches!(tokens.get(index), Some(MysqlToken::OpenParen)) {
+            index = skip_parenthesized(tokens, index)?;
+        }
+        if !matches!(tokens.get(index), Some(MysqlToken::Word(word)) if word == "AS") {
+            return None;
+        }
+        index += 1;
+        if !matches!(tokens.get(index), Some(MysqlToken::OpenParen)) {
+            return None;
+        }
+        index = skip_parenthesized(tokens, index)?;
+        if matches!(tokens.get(index), Some(MysqlToken::Comma)) {
+            index += 1;
+            continue;
+        }
+        return match tokens.get(index) {
+            Some(MysqlToken::Word(word)) if word == "SELECT" => Some(MysqlReadStatement::Select),
+            _ => None,
+        };
+    }
+}
+
+#[cfg(test)]
+fn skip_parenthesized(tokens: &[MysqlToken], mut index: usize) -> Option<usize> {
+    let mut depth = 0;
+    while let Some(token) = tokens.get(index) {
+        match token {
+            MysqlToken::OpenParen => depth += 1,
+            MysqlToken::CloseParen => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(index + 1);
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+fn unsupported_client_command(command: &str) -> DbOperationError {
+    DbOperationError::UnsupportedOperation(format!("unsupported MySQL {command}"))
+}
+
+fn parse_mysql_xml(xml: &[u8]) -> Result<MysqlResultSet, DbOperationError> {
+    let mut reader = Reader::from_reader(xml);
+    reader.config_mut().trim_text(false);
+    let mut buffer = Vec::new();
+    let mut resultset_count = 0;
+    let mut in_resultset = false;
+    let mut current_row: Option<Vec<(String, QueryValue)>> = None;
+    let mut current_field: Option<MysqlField> = None;
+    let mut rows = Vec::new();
+    let mut columns = Vec::new();
+
+    loop {
+        let event = reader.read_event_into(&mut buffer).map_err(|error| {
+            DbOperationError::QueryFailed(format!("invalid MySQL XML result: {error}"))
+        })?;
+        match event {
+            Event::Start(element) => match element.name().as_ref() {
+                b"resultset" => {
+                    if in_resultset || resultset_count > 0 {
+                        return Err(DbOperationError::QueryFailed(
+                            "mysql returned more than one resultset".to_string(),
+                        ));
+                    }
+                    resultset_count += 1;
+                    in_resultset = true;
+                }
+                b"row" if in_resultset && current_row.is_none() => {
+                    current_row = Some(Vec::new());
+                }
+                b"field" if current_row.is_some() && current_field.is_none() => {
+                    current_field = Some(parse_mysql_field(&element)?);
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected element in MySQL XML result".to_string(),
+                    ));
+                }
+            },
+            Event::Empty(element) if element.name().as_ref() == b"field" => {
+                let row = current_row.as_mut().ok_or_else(|| {
+                    DbOperationError::QueryFailed("MySQL XML field is outside a row".to_string())
+                })?;
+                if current_field.is_some() {
+                    return Err(DbOperationError::QueryFailed(
+                        "nested MySQL XML fields are not supported".to_string(),
+                    ));
+                }
+                let field = parse_mysql_field(&element)?;
+                row.push(field.finish());
+            }
+            Event::Text(text) => {
+                let text = text.unescape().map_err(|error| {
+                    DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
+                })?;
+                if let Some(field) = current_field.as_mut() {
+                    field.value.push_str(&text);
+                } else if !text.chars().all(char::is_whitespace) {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected text in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::CData(data) => {
+                if let Some(field) = current_field.as_mut() {
+                    field
+                        .value
+                        .push_str(std::str::from_utf8(data.as_ref()).map_err(|error| {
+                            DbOperationError::QueryFailed(format!(
+                                "invalid MySQL XML text: {error}"
+                            ))
+                        })?);
+                } else {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected CDATA in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::End(element) => match element.name().as_ref() {
+                b"field" => {
+                    let row = current_row.as_mut().ok_or_else(|| {
+                        DbOperationError::QueryFailed(
+                            "MySQL XML field is outside a row".to_string(),
+                        )
+                    })?;
+                    let field = current_field.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML field end".to_string())
+                    })?;
+                    row.push(field.finish());
+                }
+                b"row" => {
+                    let row = current_row.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML row end".to_string())
+                    })?;
+                    if columns.is_empty() {
+                        columns = row.iter().map(|(name, _)| name.clone()).collect();
+                    } else if row.len() != columns.len()
+                        || row
+                            .iter()
+                            .zip(&columns)
+                            .any(|((name, _), column)| name != column)
+                    {
+                        return Err(DbOperationError::QueryFailed(
+                            "MySQL XML rows have inconsistent fields".to_string(),
+                        ));
+                    }
+                    rows.push(row.into_iter().map(|(_, value)| value).collect());
+                }
+                b"resultset" => {
+                    if !in_resultset || current_row.is_some() || current_field.is_some() {
+                        return Err(DbOperationError::QueryFailed(
+                            "malformed MySQL XML resultset".to_string(),
+                        ));
+                    }
+                    in_resultset = false;
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected MySQL XML closing element".to_string(),
+                    ));
+                }
+            },
+            Event::Decl(_) | Event::Comment(_) => {}
+            Event::Eof => break,
+            _ => {
+                return Err(DbOperationError::QueryFailed(
+                    "unexpected event in MySQL XML result".to_string(),
+                ));
+            }
+        }
+        buffer.clear();
+    }
+
+    if resultset_count != 1 || in_resultset || current_row.is_some() || current_field.is_some() {
+        return Err(DbOperationError::QueryFailed(
+            "MySQL XML result did not contain one complete resultset".to_string(),
+        ));
+    }
+    Ok(MysqlResultSet {
+        columns,
+        values: rows,
+    })
+}
+
+struct MysqlField {
+    name: String,
+    value: String,
+    is_null: bool,
+}
+
+impl MysqlField {
+    fn finish(self) -> (String, QueryValue) {
+        let value = if self.is_null {
+            QueryValue::Null
+        } else {
+            QueryValue::Text(self.value)
+        };
+        (self.name, value)
+    }
+
+    fn finish_raw(self) -> (String, String) {
+        let value = if self.is_null {
+            String::new()
+        } else {
+            self.value
+        };
+        (self.name, value)
+    }
+}
+
+fn parse_mysql_field(
+    element: &quick_xml::events::BytesStart<'_>,
+) -> Result<MysqlField, DbOperationError> {
+    let mut name = None;
+    let mut is_null = false;
+    for attribute in element.attributes() {
+        let attribute = attribute.map_err(|error| {
+            DbOperationError::QueryFailed(format!("invalid MySQL XML field: {error}"))
+        })?;
+        let value = attribute.unescape_value().map_err(|error| {
+            DbOperationError::QueryFailed(format!("invalid MySQL XML field: {error}"))
+        })?;
+        match attribute.key.as_ref() {
+            b"name" => name = Some(value.into_owned()),
+            b"xsi:nil" | b"nil" => is_null = matches!(value.as_ref(), "true" | "1"),
+            _ => {}
+        }
+    }
+    let name = name
+        .ok_or_else(|| DbOperationError::QueryFailed("MySQL XML field has no name".to_string()))?;
+    Ok(MysqlField {
+        name,
+        value: String::new(),
+        is_null,
+    })
+}
+
+#[cfg(test)]
+mod probe_tests {
+    use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+
+    use super::*;
+
+    #[test]
+    fn builds_and_parses_mysql_dsn_with_encoded_components() {
+        let config = MySqlConnectionConfig::new(
+            "db.example",
+            3307,
+            Some("app/schema".to_string()),
+            "user name",
+            "p@ss#word",
+            MySqlSslMode::Required,
+        );
+        let dsn = build_mysql_dsn(&config);
+        let parsed = parse_mysql_dsn(&dsn).unwrap();
+
+        assert_eq!(parsed.host, "db.example");
+        assert_eq!(parsed.port, 3307);
+        assert_eq!(parsed.database.as_deref(), Some("app/schema"));
+        assert_eq!(parsed.username, "user name");
+        assert_eq!(parsed.password, "p@ss#word");
+        assert_eq!(parsed.ssl_mode, MySqlSslMode::Required);
+    }
+
+    #[test]
+    fn builds_and_parses_mysql_dsn_with_tls_paths() {
+        let config = MySqlConnectionConfig::new(
+            "db.example",
+            3307,
+            Some("app".to_string()),
+            "user",
+            "password",
+            MySqlSslMode::VerifyIdentity,
+        )
+        .with_tls_paths(
+            Some(r"C:\certs\ca #1.pem".to_string()),
+            Some(r"C:\certs\client.pem".to_string()),
+            Some(r"C:\certs\client-key.pem".to_string()),
+        );
+        let parsed = parse_mysql_dsn(&build_mysql_dsn(&config)).unwrap();
+
+        assert_eq!(parsed.ssl_mode, MySqlSslMode::VerifyIdentity);
+        assert_eq!(parsed.ssl_ca.as_deref(), Some(r"C:\certs\ca #1.pem"));
+        assert_eq!(parsed.ssl_cert.as_deref(), Some(r"C:\certs\client.pem"));
+        assert_eq!(parsed.ssl_key.as_deref(), Some(r"C:\certs\client-key.pem"));
+    }
+
+    #[test]
+    fn ipv6_host_round_trip_serializes_without_url_brackets() {
+        let config = MySqlConnectionConfig::new(
+            "::1",
+            3306,
+            None,
+            "user",
+            "password",
+            MySqlSslMode::Disabled,
+        );
+        let parsed = parse_mysql_dsn(&build_mysql_dsn(&config)).unwrap();
+
+        assert_eq!(parsed.host, "::1");
+        assert!(serialize_option_file(&parsed).contains("host = \"::1\"\n"));
+    }
+
+    #[test]
+    fn option_file_quotes_syntax_characters_and_windows_paths() {
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: Some("app".to_string()),
+            username: "user".to_string(),
+            password: "p a#ss;=\"\\word".to_string(),
+            ssl_mode: MySqlSslMode::Preferred,
+            ssl_ca: None,
+            ssl_cert: None,
+            ssl_key: None,
+        };
+        let contents = serialize_option_file(&target);
+
+        assert!(contents.contains("password = \"p a#ss;=\\\"\\\\word\""));
+        let mut certificate = String::new();
+        push_option(&mut certificate, "ssl-ca", r"C:\certs\server.pem");
+        assert_eq!(certificate, "ssl-ca = \"C:\\\\certs\\\\server.pem\"\n");
+        assert_eq!(
+            quote_option_value(r"C:\certs\server.pem"),
+            r#""C:\\certs\\server.pem""#
+        );
+    }
+
+    #[test]
+    fn server_database_listing_option_file_omits_selected_database() {
+        let mut target = parse_mysql_dsn("mysql://user:password@localhost:3306/app").unwrap();
+        target.database = None;
+
+        let contents = serialize_option_file(&target);
+
+        assert!(!contents.contains("database ="));
+    }
+
+    #[test]
+    fn option_file_serializes_tls_paths_without_option_syntax_confusion() {
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(r"C:\certs\ca #1.pem".to_string()),
+            ssl_cert: Some(r"C:\certs\client.pem".to_string()),
+            ssl_key: Some(r"C:\certs\client-key.pem".to_string()),
+        };
+
+        let contents = serialize_option_file(&target);
+
+        assert!(contents.contains("ssl-mode = \"VERIFY_CA\"\n"));
+        assert!(contents.contains("ssl-ca = \"C:\\\\certs\\\\ca #1.pem\"\n"));
+        assert!(contents.contains("ssl-cert = \"C:\\\\certs\\\\client.pem\"\n"));
+        assert!(contents.contains("ssl-key = \"C:\\\\certs\\\\client-key.pem\"\n"));
+    }
+
+    #[test]
+    fn rejects_encrypted_client_keys_before_process_start() {
+        let directory = tempfile::tempdir().unwrap();
+        let ca = directory.path().join("ca.pem");
+        let cert = directory.path().join("client.pem");
+        let key = directory.path().join("client-key.pem");
+        fs::write(&ca, "-----BEGIN CERTIFICATE-----\nca\n").unwrap();
+        fs::write(&cert, "-----BEGIN CERTIFICATE-----\ncert\n").unwrap();
+        fs::write(&key, "-----BEGIN ENCRYPTED PRIVATE KEY-----\nsecret\n").unwrap();
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(ca.display().to_string()),
+            ssl_cert: Some(cert.display().to_string()),
+            ssl_key: Some(key.display().to_string()),
+        };
+
+        let result = validate_mysql_tls_files(&target);
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::ConnectionFailed(details))
+                if details == "Encrypted MySQL client keys are not supported"
+        ));
+    }
+
+    #[test]
+    fn rejects_traditional_encrypted_client_keys_before_process_start() {
+        let directory = tempfile::tempdir().unwrap();
+        let ca = directory.path().join("ca.pem");
+        let cert = directory.path().join("client.pem");
+        let key = directory.path().join("client-key.pem");
+        fs::write(&ca, "-----BEGIN CERTIFICATE-----\nca\n").unwrap();
+        fs::write(&cert, "-----BEGIN CERTIFICATE-----\ncert\n").unwrap();
+        fs::write(&key, "Proc-Type: 4,ENCRYPTED\nDEK-Info: AES-256-CBC,x\n").unwrap();
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(ca.display().to_string()),
+            ssl_cert: Some(cert.display().to_string()),
+            ssl_key: Some(key.display().to_string()),
+        };
+
+        assert!(validate_mysql_tls_files(&target).is_err());
+    }
+
+    #[test]
+    fn option_file_is_owner_only_and_removed_on_drop() {
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "secret".to_string(),
+            ssl_mode: MySqlSslMode::Disabled,
+            ssl_ca: None,
+            ssl_cert: None,
+            ssl_key: None,
+        };
+        let option_file = MySqlOptionFile::create(&target).unwrap();
+        assert!(option_file.path.is_absolute());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&option_file.path)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+        let path = option_file.path.clone();
+        drop(option_file);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn validates_supported_versions_and_sql_modes() {
+        assert!(is_oracle_mysql_cli_84_version("mysql  Ver 8.4.3 for macos"));
+        assert!(!is_oracle_mysql_cli_84_version(
+            "mysql  Ver 8.0.36 for macos"
+        ));
+        assert!(!is_oracle_mysql_cli_84_version(
+            "mysql  Ver 15.1 Distrib 10.11.8-MariaDB"
+        ));
+        assert!(!is_oracle_mysql_cli_84_version(
+            "mysql  Ver 8.4.3-3 for Linux (Percona Server)"
+        ));
+        assert!(is_oracle_mysql_server_84_version("8.4.3"));
+        assert!(!is_oracle_mysql_server_84_version("8.4.3-TiDB"));
+        assert!(!is_oracle_mysql_server_84_version("8.4.3-Percona"));
+        assert!(validate_sql_mode("STRICT_TRANS_TABLES").is_ok());
+        assert!(validate_sql_mode("STRICT_TRANS_TABLES,ANSI_QUOTES").is_err());
+    }
+
+    #[test]
+    fn uses_tcp_and_keeps_defaults_file_first() {
+        let args = mysql_probe_args(std::path::Path::new("/tmp/sabiql-mysql.cnf"));
+
+        assert_eq!(args[0], "--defaults-file=/tmp/sabiql-mysql.cnf");
+        assert_eq!(args[1], "--no-login-paths");
+        assert_eq!(args[2], "--protocol=TCP");
+        assert!(args.contains(&"--batch".to_string()));
+        assert!(args.contains(&"--raw".to_string()));
+        assert!(args.contains(&"--skip-column-names".to_string()));
+        assert!(args.contains(&"--binary-mode".to_string()));
+        assert!(args.contains(&"--skip-reconnect".to_string()));
+        assert!(
+            args.last()
+                .unwrap()
+                .starts_with("--execute=SELECT JSON_OBJECT")
+        );
+    }
+
+    #[test]
+    fn arguments_do_not_contain_credentials() {
+        let args = mysql_probe_args(std::path::Path::new("/tmp/sabiql-mysql.cnf"));
+
+        assert!(
+            args.iter()
+                .all(|argument| { !argument.contains("password") && !argument.contains("secret") })
+        );
+    }
+
+    #[test]
+    fn classifies_mysql_cli_timeout_errno_before_connection_refusal() {
+        assert!(matches!(
+            classify_mysql_probe_failure(
+                "ERROR 2003 (HY000): Can't connect to MySQL server on 'host:3306' (110)"
+                    .to_string()
+            ),
+            DbOperationError::Timeout(_)
+        ));
+        assert!(matches!(
+            classify_mysql_probe_failure(
+                "ERROR 2003 (HY000): Can't connect to MySQL server on 'host:3306' (111)"
+                    .to_string()
+            ),
+            DbOperationError::ConnectionFailed(_)
+        ));
+    }
+
+    #[test]
+    fn classifies_mysql_tls_probe_failure_for_connection_error() {
+        let error = classify_mysql_probe_failure(
+            "ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed"
+                .to_string(),
+        );
+
+        assert_eq!(
+            ConnectionErrorInfo::from_db_operation_error(&error).kind,
+            ConnectionErrorKind::MySqlTlsHandshakeFailed
+        );
+    }
+}
+
+#[cfg(test)]
+mod query_tests {
+    use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn parses_mysql_xml_without_collapsing_value_boundaries() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<row>
+  <field name="null" xsi:nil="true"/>
+  <field name="empty"></field>
+  <field name="text-null">NULL</field>
+  <field name="special">tab&#9;line&#10;slash\unicode 日本語</field>
+  <field name="json">{"a":[1,true]}</field>
+  <field name="binary-looking">0x41</field>
+</row>
+</resultset>"#;
+
+        let result = parse_mysql_xml(xml.as_bytes()).unwrap();
+
+        assert_eq!(
+            result.columns,
+            vec![
+                "null",
+                "empty",
+                "text-null",
+                "special",
+                "json",
+                "binary-looking"
+            ]
+        );
+        assert_eq!(
+            result.values,
+            vec![vec![
+                QueryValue::Null,
+                QueryValue::Text(String::new()),
+                QueryValue::Text("NULL".to_string()),
+                QueryValue::Text("tab\tline\nslash\\unicode 日本語".to_string()),
+                QueryValue::Text("{\"a\":[1,true]}".to_string()),
+                QueryValue::Text("0x41".to_string()),
+            ]]
+        );
+    }
+
+    #[test]
+    fn parses_numeric_and_binary_values_as_text() {
+        let xml = br#"<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row>
+<field name="integer">18446744073709551615</field>
+<field name="decimal">12345678901234567890.123456789</field>
+<field name="float">1.25e+100</field>
+<field name="binary">0x00FF10</field>
+</row></resultset>"#;
+
+        let result = parse_mysql_xml(xml).unwrap();
+        assert!(
+            result.values[0]
+                .iter()
+                .all(|value| matches!(value, QueryValue::Text(_)))
+        );
+        assert_eq!(result.values[0][0].as_str(), Some("18446744073709551615"));
+        assert_eq!(result.values[0][3].as_str(), Some("0x00FF10"));
+    }
+
+    #[test]
+    fn rejects_multiple_resultsets_instead_of_guessing_the_last_one() {
+        let xml = br#"<resultset><row><field name="value">1</field></row></resultset>
+<resultset><row><field name="value">2</field></row></resultset>"#;
+
+        assert!(matches!(
+            parse_mysql_xml(xml),
+            Err(DbOperationError::QueryFailed(details))
+                if details.contains("more than one resultset")
+        ));
+    }
+
+    #[test]
+    fn accepts_xml_declaration_after_probe_separator_and_empty_resultsets() {
+        let xml = br#"
+<?xml version="1.0" encoding="utf-8"?>
+<resultset></resultset>
+"#;
+
+        let result = parse_mysql_xml(xml).unwrap();
+        assert!(result.columns.is_empty());
+        assert!(result.values.is_empty());
+    }
+
+    #[tokio::test]
+    async fn streams_mysql_xml_rows_into_csv_without_binary_type_inference() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row>
+<field name="comma">a,b</field>
+<field name="quote">a&quot;b</field>
+<field name="newline"><![CDATA[line1
+line2]]></field>
+<field name="tab">a	b</field>
+<field name="unicode">日本語</field>
+<field name="null" xsi:nil="true"/>
+<field name="empty"></field>
+<field name="binary">0x00FF</field>
+</row></resultset>"#;
+        let (mut input, output) = tokio::io::duplex(32);
+        let producer = tokio::spawn(async move {
+            input.write_all(xml.as_bytes()).await.unwrap();
+        });
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("stream.csv");
+        let mut csv_writer = CsvFileWriter::create(path.clone()).await.unwrap();
+        let mut reader = Reader::from_reader(BufReader::new(output));
+        reader.config_mut().trim_text(false);
+
+        stream_mysql_xml_to_csv(&mut reader, &mut csv_writer)
+            .await
+            .unwrap();
+        csv_writer.finish().await.unwrap();
+        producer.await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(path).unwrap(),
+            "comma,quote,newline,tab,unicode,null,empty,binary\n\
+             \"a,b\",\"a\"\"b\",\"line1\n\
+             line2\",a\tb,日本語,,,0x00FF\n"
+                .replace("             ", "")
+        );
+    }
+
+    #[test]
+    fn csv_export_accepts_one_read_only_result_query() {
+        assert!(validate_mysql_export_query("SELECT 1", Some("app")).is_ok());
+        for query in ["TABLE users", "SHOW TABLES", "DESCRIBE users"] {
+            assert!(
+                validate_mysql_export_query(query, Some("app")).is_ok(),
+                "{query}"
+            );
+        }
+        assert!(matches!(
+            validate_mysql_export_query("INSERT INTO users VALUES (1)", Some("app")),
+            Err(DbOperationError::PermissionDenied(_))
+        ));
+        assert!(matches!(
+            validate_mysql_export_query("SELECT 1; SELECT 2", Some("app")),
+            Err(DbOperationError::UnsupportedOperation(details))
+                if details.contains("single read-only result")
+        ));
+    }
+
+    #[test]
+    fn scanner_ignores_semicolons_in_quotes_and_comments() {
+        let query = r#"
+            SELECT 'a; b', "quoted; identifier", `back;tick`
+            /* block ; comment */
+            FROM `table` -- line ; comment
+            WHERE value = 'backslash\\;'
+        "#;
+
+        assert!(validate_mysql_adhoc_query(query).is_ok());
+    }
+
+    #[test]
+    fn scanner_rejects_multiple_statements_before_starting_a_process() {
+        for query in ["SELECT 1; SELECT 2", "SELECT 1;\nSHOW TABLES"] {
+            assert!(matches!(
+                validate_mysql_adhoc_query(query),
+                Err(DbOperationError::UnsupportedOperation(details))
+                    if details.contains("multiple SQL statements")
+            ));
+        }
+    }
+
+    #[test]
+    fn scanner_accepts_read_statements_and_select_ctes_only() {
+        for query in [
+            "SELECT 1",
+            "TABLE users",
+            "SHOW TABLES",
+            "DESCRIBE users",
+            "WITH rows AS (SELECT 1) SELECT * FROM rows",
+            "WITH RECURSIVE rows AS (SELECT 1) SELECT * FROM rows",
+        ] {
+            assert!(validate_mysql_adhoc_query(query).is_ok(), "{query}");
+        }
+        for query in [
+            "INSERT INTO users VALUES (1)",
+            "WITH rows AS (SELECT 1) UPDATE users SET id = 2",
+            "WITH rows AS (SELECT 1) SHOW TABLES",
+        ] {
+            assert!(validate_mysql_adhoc_query(query).is_err(), "{query}");
+        }
+    }
+
+    #[test]
+    fn scanner_rejects_top_level_into_clauses_before_starting_a_process() {
+        for query in [
+            "SELECT id INTO OUTFILE '/tmp/result' FROM users",
+            "SELECT id INTO DUMPFILE '/tmp/result' FROM users",
+            "SELECT id INTO @value FROM users",
+            "TABLE users INTO OUTFILE '/tmp/result'",
+            "WITH rows AS (SELECT 1) SELECT * INTO OUTFILE '/tmp/result' FROM rows",
+        ] {
+            assert!(matches!(
+                validate_mysql_adhoc_query(query),
+                Err(DbOperationError::UnsupportedOperation(details))
+                    if details.contains("SELECT INTO clauses")
+            ));
+        }
+        assert!(
+            validate_mysql_adhoc_query("WITH rows AS (SELECT 'INTO OUTFILE') SELECT * FROM rows")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn scanner_rejects_client_commands_and_version_comments() {
+        for query in [
+            "DELIMITER //\nSELECT 1//",
+            "  charset utf8mb4\nSELECT 1",
+            "source ./script.sql",
+            "system echo unsafe",
+            "\\C /tmp/other.sock\nSELECT 1",
+            "SELECT 1 /*!40101 + 1 */",
+        ] {
+            assert!(matches!(
+                validate_mysql_adhoc_query(query),
+                Err(DbOperationError::UnsupportedOperation(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn mode_probe_requires_marker_and_allowed_mode_before_user_sql() {
+        let probe = MysqlResultSet {
+            columns: vec![
+                "__sabiql_probe".to_string(),
+                "__sabiql_sql_mode".to_string(),
+            ],
+            values: vec![vec![
+                QueryValue::Text("marker".to_string()),
+                QueryValue::Text("STRICT_TRANS_TABLES".to_string()),
+            ]],
+        };
+        assert!(validate_mode_probe(&probe, "marker").is_ok());
+
+        let mut unsupported = probe;
+        unsupported.values[0][1] = QueryValue::Text("ANSI_QUOTES".to_string());
+        assert!(matches!(
+            validate_mode_probe(&unsupported, "marker"),
+            Err(DbOperationError::UnsupportedOperation(details))
+                if details.contains(MYSQL_SQL_MODE_UNSUPPORTED_MARKER)
+        ));
+    }
+
+    #[test]
+    fn arguments_keep_credentials_out_of_argv() {
+        let args = mysql_query_args(std::path::Path::new("/tmp/sabiql-mysql.cnf"));
+
+        assert_eq!(args[0], "--defaults-file=/tmp/sabiql-mysql.cnf");
+        assert_eq!(args[1], "--no-login-paths");
+        for expected in [
+            "--xml",
+            "--binary-as-hex",
+            "--binary-mode",
+            "--unbuffered",
+            "--skip-reconnect",
+            "--default-character-set=utf8mb4",
+        ] {
+            assert!(args.contains(&expected.to_string()), "{expected}");
+        }
+        #[cfg(unix)]
+        {
+            assert!(args.contains(&"--silent".to_string()));
+            assert!(args.contains(&"--prompt=".to_string()));
+            assert!(!args.contains(&"--batch".to_string()));
+        }
+        #[cfg(not(unix))]
+        assert!(args.contains(&"--batch".to_string()));
+        assert!(args.iter().all(|argument| !argument.contains("password")));
+    }
+
+    #[test]
+    fn classifies_mysql_query_failures_by_server_error() {
+        assert!(matches!(
+            classify_mysql_query_failure(
+                b"ERROR 1045 (28000): Access denied for user 'app'@'localhost' (using password: YES)"
+            ),
+            DbOperationError::ConnectionFailed(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1142 (42000): command denied to user"),
+            DbOperationError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(
+                b"ERROR 1044 (42000): Access denied for user 'app' to database 'app'"
+            ),
+            DbOperationError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1146 (42S02): Table does not exist"),
+            DbOperationError::ObjectMissing(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1205 (HY000): Lock wait timeout exceeded"),
+            DbOperationError::LockTimeout(_)
+        ));
+        let masked = classify_mysql_query_failure(b"ERROR password=secret");
+        assert!(!masked.masked_details().contains("secret"));
+    }
+
+    #[test]
+    fn classifies_mysql_tls_query_failures_as_connection_errors() {
+        let error = classify_mysql_query_failure(
+            b"ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed",
+        );
+
+        assert_eq!(
+            ConnectionErrorInfo::from_db_operation_error(&error).kind,
+            ConnectionErrorKind::MySqlTlsHandshakeFailed
+        );
+        assert!(matches!(error, DbOperationError::ConnectionFailed(_)));
+    }
+}
+
+#[cfg(all(test, unix))]
+mod executor_tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn fake_mysql(mode: &str) -> (TempDir, PathBuf, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let option_file = directory.path().join("option.cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let program = directory.path().join("mysql");
+        let probe_response = match mode {
+            "missing" => "exit 0".to_string(),
+            "invalid" => {
+                "printf '%s\\n' '<resultset><row><field name=\"wrong\">x</field></row></resultset>'"
+                    .to_string()
+            }
+            "unsupported" => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_probe\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">ANSI_QUOTES</field></row></resultset>'".to_string(),
+            "timeout" => "while :; do :; done".to_string(),
+            _ => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_probe\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">STRICT_TRANS_TABLES</field></row></resultset>'".to_string(),
+        };
+        let user_response = if mode == "failure" {
+            "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2\n    exit 1"
+        } else {
+            "printf '%s\\n' '<resultset><row><field name=\"value\">ok</field></row></resultset>'"
+        };
+        let session_failure = if mode == "read_only_failure" {
+            "printf '%s\\n' 'ERROR 1227 (42000): access denied to set transaction read only' >&2\n      exit 1"
+        } else {
+            ""
+        };
+        let script = format!(
+            r#"#!/bin/sh
+option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
+log="$option.log"
+phase=probe
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$log"
+  [ "$line" = ";" ] && continue
+  if [ "$phase" = probe ]; then
+    marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)'.*/\\1/")
+    {probe_response}
+    phase=user
+  else
+    case "$line" in
+      "SET SESSION TRANSACTION READ ONLY")
+        {session_failure}
+        ;;
+      *__sabiql_session_marker*)
+        marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
+        printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+        ;;
+      *)
+        {user_response}
+        exit 0
+        ;;
+    esac
+  fi
+done
+"#,
+        );
+        fs::write(&program, script).unwrap();
+        let mut permissions = fs::metadata(&program).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).unwrap();
+        (directory, program, log_file)
+    }
+
+    fn fake_mysql_multi() -> (TempDir, PathBuf, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let option_file = directory.path().join("option.cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let program = directory.path().join("mysql");
+        let script = r#"#!/bin/sh
+option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
+log="$option.log"
+pending_error=0
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$log"
+  case "$line" in
+    *\\q*)
+      exit 0
+      ;;
+    *__sabiql_probe*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_probe.*/\\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
+      ;;
+    "SET SESSION TRANSACTION READ ONLY")
+      ;;
+    *__sabiql_session_marker*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      ;;
+    *__sabiql_marker*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_marker.*/\\1/")
+      rows=0
+      case "$line" in *ROW_COUNT\(\)* ) rows=3 ;; esac
+      printf '%s\n' '<resultset><row><field name="__sabiql_marker">'"$marker"'</field><field name="affected_rows">'"$rows"'</field></row></resultset>'
+      if [ "$pending_error" = 1 ]; then
+        sleep 0.05
+        printf '%s\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2
+        pending_error=0
+      fi
+      ;;
+    *missing_column*)
+      pending_error=1
+      ;;
+    *SELECT*)
+      value=one
+      case "$line" in *SELECT\ 2*) value=two ;; esac
+      printf '%s\n' '<resultset><row><field name="value">'"$value"'</field></row></resultset>'
+      ;;
+    *UPDATE*)
+      printf '%s\n' '<resultset><row><field name="affected">ok</field></row></resultset>'
+      ;;
+    *)
+      printf '%s\n' '<resultset></resultset>'
+      ;;
+  esac
+done
+"#;
+        fs::write(&program, script).unwrap();
+        let mut permissions = fs::metadata(&program).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).unwrap();
+        (directory, program, option_file)
+    }
+
+    #[tokio::test]
+    async fn sends_user_sql_only_after_a_valid_mode_probe() {
+        let (_directory, program, log_file) = fake_mysql("success");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.columns, vec!["value"]);
+        assert_eq!(result.values[0][0].as_str(), Some("ok"));
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+        assert!(log.contains("__sabiql_probe"));
+        assert!(log.contains("SELECT 123"));
+        assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT));
+    }
+
+    #[tokio::test]
+    async fn configures_read_only_session_before_user_sql() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let statements = split_mysql_statements("SELECT 2")
+            .unwrap()
+            .into_iter()
+            .map(|sql| classify_mysql_statement(&sql).unwrap())
+            .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 2",
+            &statements,
+            AccessMode::ReadOnly,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_or_else(|error| {
+            let log = fs::read_to_string(&log_file).unwrap_or_default();
+            panic!("read-only execution failed: {error:?}; log: {log}");
+        });
+
+        assert_eq!(
+            result.result_set.unwrap().values[0][0].as_str(),
+            Some("two")
+        );
+        let log = fs::read_to_string(log_file).unwrap();
+        let session_index = log
+            .find(MYSQL_READ_ONLY_STATEMENT)
+            .expect("read-only session statement");
+        let user_index = log.find("SELECT 2").expect("user statement");
+        assert!(session_index < user_index, "{log}");
+        assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN));
+    }
+
+    #[tokio::test]
+    async fn read_only_session_failure_never_writes_user_sql() {
+        let (_directory, program, log_file) = fake_mysql("read_only_failure");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadOnly,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+        assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
+        assert!(!log.contains("SELECT 123"), "{log}");
+    }
+
+    #[tokio::test]
+    async fn generated_preview_and_metadata_queries_skip_read_only_session_setup() {
+        for query in [
+            "SELECT id FROM app.items ORDER BY id LIMIT 10 OFFSET 0",
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES",
+        ] {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let statements = split_mysql_statements(query)
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
+
+            run_mysql_adhoc_with_program_and_statements(
+                OsStr::new(&program),
+                &option_file,
+                query,
+                &statements,
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT), "{query}: {log}");
+        }
+    }
+
+    #[test]
+    fn read_only_rejects_temporary_table_dml_before_starting_mysql() {
+        let (_directory, _program, option_file) = fake_mysql_multi();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let query = "CREATE TEMPORARY TABLE temp_items (id INT); INSERT INTO temp_items VALUES (1); DROP TEMPORARY TABLE temp_items";
+
+        let result = validate_mysql_multi_query(query, Some("app"), AccessMode::ReadOnly);
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::PermissionDenied(details))
+                if details.contains("read-only mode blocks MySQL write statements")
+        ));
+        assert!(!log_file.exists());
+    }
+
+    #[test]
+    fn read_only_rejects_read_write_overrides_before_starting_mysql() {
+        for query in [
+            "SET SESSION TRANSACTION READ WRITE",
+            "START TRANSACTION READ WRITE",
+        ] {
+            let (_directory, _program, option_file) = fake_mysql_multi();
+            let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+
+            let result = validate_mysql_multi_query(query, Some("app"), AccessMode::ReadOnly);
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::UnsupportedOperation(_))
+            ));
+            assert!(!log_file.exists(), "{query}");
+        }
+    }
+
+    #[tokio::test]
+    async fn exports_mysql_xml_rows_through_the_shared_csv_writer() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let path = option_file.with_file_name("export.csv");
+
+        export_mysql_csv_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 1",
+            path.clone(),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(fs::read_to_string(path).unwrap(), "value\none\n");
+    }
+
+    #[tokio::test]
+    async fn export_failure_removes_the_partial_file() {
+        let (_directory, program, option_file) = fake_mysql("failure");
+        let output_directory = tempfile::tempdir().unwrap();
+        let final_path = output_directory.path().join("export.csv");
+
+        let result = export_to_path(final_path.clone(), |path| {
+            export_mysql_csv_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 1",
+                path,
+                Duration::from_secs(5),
+            )
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert!(!final_path.exists());
+        assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn export_timeout_kills_the_process_and_removes_the_partial_file() {
+        let (_directory, program, option_file) = fake_mysql("timeout");
+        let output_directory = tempfile::tempdir().unwrap();
+        let final_path = output_directory.path().join("export.csv");
+
+        let result = export_to_path(final_path.clone(), |path| {
+            export_mysql_csv_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 1",
+                path,
+                Duration::from_millis(50),
+            )
+        })
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::Timeout(_))));
+        assert!(!final_path.exists());
+        assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
+    }
+
+    #[test]
+    fn frames_one_xml_resultset_and_preserves_following_output() {
+        let mut buffer = b"    -> <?xml version=\"1.0\"?>\n<resultset></resultset>\r\n    -> <?xml version=\"1.0\"?>\n<resultset>"
+            .to_vec();
+
+        assert_eq!(
+            take_mysql_resultset_frame(&mut buffer),
+            Some(b"<resultset></resultset>".to_vec())
+        );
+        assert_eq!(
+            take_mysql_resultset_frame(&mut buffer),
+            None,
+            "an incomplete following frame must remain buffered"
+        );
+        assert!(buffer.starts_with(b"\r\n    -> <?xml"));
+    }
+
+    #[test]
+    fn frames_resultset_after_mysql_cli_text() {
+        let mut buffer =
+            b"SELECT 1;\n<?xml version=\"1.0\"?>\nquery text\n<resultset></resultset>".to_vec();
+
+        assert_eq!(
+            take_mysql_resultset_frame(&mut buffer),
+            Some(b"<resultset></resultset>".to_vec())
+        );
+        assert!(buffer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn probe_failure_never_writes_user_sql() {
+        for mode in ["unsupported", "invalid", "missing"] {
+            let (_directory, program, log_file) = fake_mysql(mode);
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_adhoc_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await;
+            assert!(result.is_err(), "{mode}");
+            let log =
+                fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
+            assert!(!log.contains("SELECT 123"), "{mode}: {log}");
+        }
+    }
+
+    #[tokio::test]
+    async fn probe_timeout_kills_the_process_and_discards_output() {
+        let (_directory, program, log_file) = fake_mysql("timeout");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadWrite,
+            Duration::from_millis(50),
+        )
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::Timeout(_))));
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
+        assert!(!log.contains("SELECT 123"));
+    }
+
+    #[tokio::test]
+    async fn nonzero_cli_exit_discards_any_collected_stdout() {
+        let (_directory, program, log_file) = fake_mysql("failure");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn executes_each_statement_and_returns_the_last_user_result() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let statements = split_mysql_statements("UPDATE items SET value = 1; SELECT 2")
+            .unwrap()
+            .into_iter()
+            .map(|sql| classify_mysql_statement(&sql).unwrap())
+            .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "UPDATE items SET value = 1; SELECT 2",
+            &statements,
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("multi execution failed: {error:?}"));
+
+        assert_eq!(
+            result.result_set,
+            Some(MysqlResultSet {
+                columns: vec!["value".to_string()],
+                values: vec![vec![QueryValue::Text("two".to_string())]],
+            })
+        );
+        assert_eq!(result.command_tag, Some(CommandTag::Update(3)));
+        assert_eq!(result.refresh_scope, RefreshScope::Data);
+        let log = fs::read_to_string(log_file).unwrap();
+        assert!(log.contains("UPDATE items SET value = 1"));
+        assert!(log.matches("__sabiql_marker").count() >= 2);
+    }
+
+    #[tokio::test]
+    async fn marks_a_later_failure_after_a_confirmed_change_for_refresh() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let statements =
+            split_mysql_statements("UPDATE items SET value = 1; SELECT missing_column FROM items")
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "UPDATE items SET value = 1; SELECT missing_column FROM items",
+            &statements,
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::QueryFailedAfterChange {
+                refresh_scope: RefreshScope::Data,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_error_reported_after_row_count_marker() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let statements = split_mysql_statements("SELECT missing_column FROM items")
+            .unwrap()
+            .into_iter()
+            .map(|sql| classify_mysql_statement(&sql).unwrap())
+            .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT missing_column FROM items",
+            &statements,
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::QueryFailed(details))
+                if details.contains("missing_column")
+        ));
+    }
+
+    #[test]
+    fn transaction_rollback_removes_pending_data_tag() {
+        let events = vec![
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Begin,
+                target: None,
+                tag: CommandTag::Begin,
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Update { has_where: true },
+                target: Some("items".to_string()),
+                tag: CommandTag::Update(1),
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Rollback,
+                target: None,
+                tag: CommandTag::Rollback,
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Select,
+                target: None,
+                tag: CommandTag::Select(1),
+            },
+        ];
+
+        assert_eq!(
+            aggregate_mysql_command_tag(&events),
+            Some(CommandTag::Select(1))
+        );
+    }
+
+    #[test]
+    fn ddl_implicit_commit_keeps_prior_data_change() {
+        let events = vec![
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Begin,
+                target: None,
+                tag: CommandTag::Begin,
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Insert,
+                target: Some("items".to_string()),
+                tag: CommandTag::Insert(1),
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::CreateTable { temporary: false },
+                target: Some("created".to_string()),
+                tag: CommandTag::Create("TABLE".to_string()),
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Rollback,
+                target: None,
+                tag: CommandTag::Rollback,
+            },
+        ];
+
+        assert_eq!(
+            aggregate_mysql_command_tag(&events),
+            Some(CommandTag::Create("TABLE".to_string()))
+        );
+    }
+}
+
+#[cfg(test)]
+mod resultset_frame_tests {
+    use super::*;
+
+    #[test]
+    fn error_before_resultset_frame_is_not_accepted() {
+        let mut buffer = b"<resultset><row></row></resultset>".to_vec();
+        let error = b"ERROR 1054 (42S22): Unknown column missing_column\n";
+
+        assert!(matches!(
+            take_mysql_resultset_frame_after_error_check(&mut buffer, error),
+            Err(DbOperationError::QueryFailed(_))
+        ));
+        assert_eq!(buffer, b"<resultset><row></row></resultset>");
+    }
+}
+
+#[cfg(all(test, not(unix)))]
+mod pipe_executor_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn pipe_errors_are_checked_before_resultset_frames() {
+        let (mut stdout_writer, mut stdout_reader) = tokio::io::duplex(1024);
+        let (mut stderr_writer, mut stderr_reader) = tokio::io::duplex(1024);
+        stdout_writer
+            .write_all(b"<resultset><row></row></resultset>")
+            .await
+            .unwrap();
+        stderr_writer
+            .write_all(b"ERROR 1054 (42S22): Unknown column missing_column\n")
+            .await
+            .unwrap();
+        drop(stdout_writer);
+        drop(stderr_writer);
+
+        let result = read_one_mysql_resultset_from_pipes(
+            &mut stdout_reader,
+            &mut stderr_reader,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
     }
 }

--- a/src/infra/adapters/mysql/metadata.rs
+++ b/src/infra/adapters/mysql/metadata.rs
@@ -1,0 +1,1536 @@
+use async_trait::async_trait;
+
+use crate::app::ports::outbound::{AccessMode, DbOperationError, MetadataProvider};
+use crate::domain::{
+    Column, ColumnAttributes, DatabaseMetadata, FkAction, ForeignKey, Index, IndexAttributes,
+    IndexType, QueryValue, Schema, Table, TableKind, TableKindInfo, TableSignature, TableSummary,
+    Trigger, TriggerEvent, TriggerTiming,
+};
+
+use super::{
+    MySqlAdapter, MySqlOptionFile, MysqlResultSet, parse_mysql_dsn, run_mysql_adhoc,
+    validate_mysql_values,
+};
+
+const TABLES_QUERY: &str = "SELECT TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') UNION ALL SELECT NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')) ORDER BY TABLE_NAME";
+const PREVIEW_IDENTITY_ALIAS_PREFIX: &str = "__sabiql_row_identity_";
+
+#[derive(Debug, Clone)]
+struct MysqlColumnMetadata {
+    name: String,
+    data_type: String,
+    nullable: bool,
+    default: Option<String>,
+    comment: Option<String>,
+    ordinal_position: i32,
+    primary_key_position: Option<i32>,
+    invisible: bool,
+    generated: bool,
+}
+
+#[derive(Debug, Clone)]
+struct MysqlIndexMetadata {
+    name: String,
+    non_unique: bool,
+    index_type: String,
+    ordinal_position: i32,
+    column_name: String,
+    primary: bool,
+}
+
+#[derive(Debug, Clone)]
+struct MysqlForeignKeyMetadata {
+    name: String,
+    from_schema: String,
+    from_table: String,
+    from_column: String,
+    to_schema: String,
+    to_table: String,
+    to_column: String,
+    ordinal_position: i32,
+    on_update: FkAction,
+    on_delete: FkAction,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PreviewMetadata {
+    pub visible_columns: Vec<Column>,
+    pub order_columns: Vec<String>,
+    pub identity_columns: Vec<Column>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ConvertedPreviewValues {
+    pub visible: Vec<Vec<QueryValue>>,
+    pub identity: Option<Vec<Vec<QueryValue>>>,
+}
+
+#[derive(Debug, Clone)]
+struct MysqlTableMetadata {
+    name: String,
+    kind: TableKind,
+    row_count_estimate: Option<i64>,
+    comment: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct MysqlTriggerMetadata {
+    name: String,
+    timing: TriggerTiming,
+    event: TriggerEvent,
+    definition: String,
+    security_context: Option<String>,
+}
+
+#[async_trait]
+impl MetadataProvider for MySqlAdapter {
+    async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
+        let database = selected_database(dsn)?;
+        let result = execute_metadata_query(dsn, TABLES_QUERY).await?;
+        let tables = parse_table_metadata(&result)?;
+        let mut metadata = DatabaseMetadata::new(database.clone());
+        metadata.schemas = vec![Schema::new(database.clone())];
+        metadata.table_summaries = tables
+            .into_iter()
+            .map(|table| table_summary(&database, table))
+            .collect();
+        Ok(metadata)
+    }
+
+    async fn fetch_table_detail(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Table, DbOperationError> {
+        let metadata = self.fetch_metadata(dsn).await?;
+        fetch_table(dsn, schema, table, &metadata.table_summaries).await
+    }
+
+    async fn fetch_table_columns_and_fks(
+        &self,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Table, DbOperationError> {
+        let metadata = self.fetch_metadata(dsn).await?;
+        fetch_table_columns_and_fks_with_summaries(dsn, schema, table, &metadata.table_summaries)
+            .await
+    }
+
+    async fn fetch_table_signatures(
+        &self,
+        dsn: &str,
+    ) -> Result<Vec<TableSignature>, DbOperationError> {
+        let metadata = self.fetch_metadata(dsn).await?;
+        let mut signatures = Vec::with_capacity(metadata.table_summaries.len());
+        let summaries = metadata.table_summaries;
+        for summary in &summaries {
+            let detail = fetch_table_columns_and_fks_with_summaries(
+                dsn,
+                &summary.schema,
+                &summary.name,
+                &summaries,
+            )
+            .await?;
+            signatures.push(TableSignature {
+                schema: summary.schema.clone(),
+                name: summary.name.clone(),
+                signature: table_signature(&detail),
+            });
+        }
+        Ok(signatures)
+    }
+}
+
+pub(super) async fn fetch_preview_metadata(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<PreviewMetadata, DbOperationError> {
+    find_table(dsn, schema, table).await?;
+    let column_metadata = fetch_columns(dsn, schema, table).await?;
+    let columns = column_metadata
+        .iter()
+        .map(column_from_metadata)
+        .collect::<Vec<_>>();
+    let visible_columns = columns
+        .iter()
+        .filter(|column| !column.is_hidden())
+        .cloned()
+        .collect::<Vec<_>>();
+    if visible_columns.is_empty() {
+        return Err(DbOperationError::MetadataParseFailed(format!(
+            "MySQL object has no visible columns: {schema}.{table}"
+        )));
+    }
+    let primary_key_names = primary_key_names(&column_metadata);
+    let identity_columns = if primary_key_names.iter().any(|name| {
+        columns
+            .iter()
+            .find(|column| &column.name == name)
+            .is_some_and(Column::is_hidden)
+    }) {
+        primary_key_names
+            .iter()
+            .filter_map(|name| columns.iter().find(|column| &column.name == name))
+            .cloned()
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let order_columns = primary_key_names;
+    let order_columns = if order_columns.is_empty() {
+        visible_columns
+            .iter()
+            .map(|column| column.name.clone())
+            .collect()
+    } else {
+        order_columns
+    };
+    Ok(PreviewMetadata {
+        visible_columns,
+        order_columns,
+        identity_columns,
+    })
+}
+
+pub(super) fn build_preview_query(
+    schema: &str,
+    table: &str,
+    order_columns: &[String],
+    visible_columns: &[Column],
+    identity_columns: &[Column],
+    limit: usize,
+    offset: usize,
+) -> String {
+    let visible_select = visible_columns
+        .iter()
+        .map(|column| quote_identifier(&column.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let identity_select = identity_columns
+        .iter()
+        .enumerate()
+        .map(|(index, column)| {
+            format!(
+                "{} AS {}",
+                quote_identifier(&column.name),
+                quote_identifier(&preview_identity_alias(index)),
+            )
+        })
+        .collect::<Vec<_>>();
+    let columns = std::iter::once(visible_select)
+        .chain(identity_select)
+        .filter(|select| !select.is_empty())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let order_by = order_columns
+        .iter()
+        .map(|column| quote_identifier(column))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "SELECT {columns} FROM {}.{} ORDER BY {order_by} LIMIT {limit} OFFSET {offset}",
+        quote_identifier(schema),
+        quote_identifier(table),
+    )
+}
+
+pub(super) fn convert_preview_values(
+    result: &MysqlResultSet,
+    columns: &[Column],
+    identity_columns: &[Column],
+) -> Result<ConvertedPreviewValues, DbOperationError> {
+    let expected_columns = columns
+        .iter()
+        .map(|column| column.name.clone())
+        .chain(
+            identity_columns
+                .iter()
+                .enumerate()
+                .map(|(index, _)| preview_identity_alias(index)),
+        )
+        .collect::<Vec<_>>();
+    if result.values.is_empty() {
+        if result.columns.is_empty() || result.columns == expected_columns {
+            return Ok(ConvertedPreviewValues {
+                visible: Vec::new(),
+                identity: (!identity_columns.is_empty()).then(Vec::new),
+            });
+        }
+        return Err(DbOperationError::MetadataParseFailed(
+            "MySQL preview returned an unexpected column count".to_string(),
+        ));
+    }
+    if result.columns != expected_columns {
+        return Err(DbOperationError::MetadataParseFailed(
+            "MySQL preview returned unexpected columns".to_string(),
+        ));
+    }
+    let rows = result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != expected_columns.len() {
+                return Err(DbOperationError::MetadataParseFailed(
+                    "MySQL preview returned an unexpected row width".to_string(),
+                ));
+            }
+            row.iter()
+                .zip(columns.iter().chain(identity_columns))
+                .map(|(value, column)| Ok(convert_preview_value(value, &column.data_type)))
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let (visible, identity) = rows.into_iter().fold(
+        (Vec::new(), (!identity_columns.is_empty()).then(Vec::new)),
+        |(mut visible, mut identity), row| {
+            let (visible_row, identity_row) = row.split_at(columns.len());
+            visible.push(visible_row.to_vec());
+            if let Some(identity) = identity.as_mut() {
+                identity.push(identity_row.to_vec());
+            }
+            (visible, identity)
+        },
+    );
+    Ok(ConvertedPreviewValues { visible, identity })
+}
+
+fn preview_identity_alias(index: usize) -> String {
+    format!("{PREVIEW_IDENTITY_ALIAS_PREFIX}{index}")
+}
+
+fn convert_preview_value(value: &QueryValue, data_type: &str) -> QueryValue {
+    let QueryValue::Text(value) = value else {
+        return value.clone();
+    };
+    if is_binary_type(data_type)
+        && let Some(bytes) = decode_hex(value)
+    {
+        return QueryValue::Blob(bytes);
+    }
+    if is_numeric_type(data_type) && is_sql_numeric_literal(value) {
+        return QueryValue::SqlLiteral(value.clone());
+    }
+    QueryValue::Text(value.clone())
+}
+
+async fn fetch_table(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+    summaries: &[TableSummary],
+) -> Result<Table, DbOperationError> {
+    let table_metadata = find_table(dsn, schema, table).await?;
+    let columns = fetch_columns(dsn, schema, table).await?;
+    let indexes = fetch_indexes(dsn, schema, table).await?;
+    let foreign_keys = fetch_foreign_keys(dsn, schema, table, summaries).await?;
+    let triggers = fetch_triggers(dsn, schema, table).await?;
+    let source_ddl = fetch_source_ddl(dsn, table, table_metadata.kind).await?;
+    let primary_key = primary_key_names(&columns);
+    let columns = columns.iter().map(column_from_metadata).collect::<Vec<_>>();
+    Ok(Table {
+        schema: schema.to_string(),
+        name: table_metadata.name,
+        owner: None,
+        columns,
+        primary_key: (!primary_key.is_empty()).then_some(primary_key),
+        foreign_keys,
+        indexes,
+        rls: None,
+        triggers,
+        row_count_estimate: table_metadata.row_count_estimate,
+        comment: table_metadata.comment,
+        source_ddl: Some(source_ddl),
+        kind_info: TableKindInfo {
+            kind: table_metadata.kind,
+            ..TableKindInfo::default()
+        },
+    })
+}
+
+async fn fetch_table_columns_and_fks_with_summaries(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+    summaries: &[TableSummary],
+) -> Result<Table, DbOperationError> {
+    let table_metadata = find_table(dsn, schema, table).await?;
+    let columns = fetch_columns(dsn, schema, table).await?;
+    let foreign_keys = fetch_foreign_keys(dsn, schema, table, summaries).await?;
+    let primary_key = primary_key_names(&columns);
+    Ok(Table {
+        schema: schema.to_string(),
+        name: table_metadata.name,
+        owner: None,
+        columns: columns.iter().map(column_from_metadata).collect(),
+        primary_key: (!primary_key.is_empty()).then_some(primary_key),
+        foreign_keys,
+        indexes: Vec::new(),
+        rls: None,
+        triggers: Vec::new(),
+        row_count_estimate: table_metadata.row_count_estimate,
+        comment: table_metadata.comment,
+        source_ddl: None,
+        kind_info: TableKindInfo {
+            kind: table_metadata.kind,
+            ..TableKindInfo::default()
+        },
+    })
+}
+
+async fn find_table(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<MysqlTableMetadata, DbOperationError> {
+    let database = selected_database(dsn)?;
+    if schema != database {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    let result = execute_metadata_query(dsn, TABLES_QUERY).await?;
+    parse_table_metadata(&result)?
+        .into_iter()
+        .find(|candidate| candidate.name == table)
+        .ok_or_else(|| {
+            DbOperationError::ObjectMissing(format!("MySQL table not found: {schema}.{table}"))
+        })
+}
+
+async fn fetch_columns(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
+    let query = format!(
+        "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = {} ORDER BY c.ORDINAL_POSITION",
+        quote_string(table)
+    );
+    let result = execute_metadata_query(dsn, &query).await?;
+    let database = selected_database(dsn)?;
+    if schema != database {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    let columns = parse_column_metadata(&result)?;
+    if columns.is_empty() {
+        return Err(DbOperationError::MetadataParseFailed(format!(
+            "MySQL object has no column metadata: {schema}.{table}"
+        )));
+    }
+    Ok(columns)
+}
+
+async fn execute_metadata_query(
+    dsn: &str,
+    query: &str,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let target = parse_mysql_dsn(dsn)?;
+    validate_mysql_values(&target)?;
+    super::validate_mysql_tls_files(&target)?;
+    let statements = super::validate_mysql_multi_query(
+        query,
+        target.database.as_deref(),
+        AccessMode::ReadWrite,
+    )?;
+    let option_file = MySqlOptionFile::create(&target)?;
+    let result =
+        run_mysql_adhoc(&option_file.path, query, &statements, AccessMode::ReadWrite).await;
+    drop(option_file);
+    result?.result_set.ok_or_else(|| {
+        DbOperationError::MetadataParseFailed(
+            "MySQL metadata query returned no result set".to_string(),
+        )
+    })
+}
+
+fn selected_database(dsn: &str) -> Result<String, DbOperationError> {
+    parse_mysql_dsn(dsn)?.database.ok_or_else(|| {
+        DbOperationError::UnsupportedOperation(
+            "MySQL metadata requires a selected database".to_string(),
+        )
+    })
+}
+
+fn parse_table_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlTableMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &["TABLE_NAME", "TABLE_TYPE", "TABLE_ROWS", "TABLE_COMMENT"],
+    )?;
+    let tables = result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != 4 {
+                return Err(metadata_shape_error("TABLES row"));
+            }
+            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
+                return Ok(None);
+            }
+            let name = required_text(&row[0], "TABLE_NAME")?.to_string();
+            let kind = match required_text(&row[1], "TABLE_TYPE")? {
+                "BASE TABLE" => TableKind::Table,
+                "VIEW" => TableKind::View,
+                value => {
+                    return Err(DbOperationError::MetadataParseFailed(format!(
+                        "unexpected MySQL table type: {value}"
+                    )));
+                }
+            };
+            let row_count_estimate = optional_text(&row[2], "TABLE_ROWS")?
+                .map(|value| {
+                    value.parse::<i64>().map_err(|_| {
+                        DbOperationError::MetadataParseFailed(
+                            "invalid MySQL TABLE_ROWS value".to_string(),
+                        )
+                    })
+                })
+                .transpose()?;
+            let comment = optional_text(&row[3], "TABLE_COMMENT")?
+                .filter(|value| !value.is_empty())
+                .map(str::to_string);
+            Ok(Some(MysqlTableMetadata {
+                name,
+                kind,
+                row_count_estimate,
+                comment,
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(tables.into_iter().flatten().collect())
+}
+
+async fn fetch_indexes(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<Index>, DbOperationError> {
+    let query = format!(
+        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = DATABASE() AND s.TABLE_NAME = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = {}) ORDER BY INDEX_NAME, SEQ_IN_INDEX",
+        quote_string(table),
+        quote_string(table),
+    );
+    let result = execute_metadata_query(dsn, &query).await?;
+    let raw = parse_index_metadata(&result)?;
+    if schema != selected_database(dsn)? {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    Ok(indexes_from_metadata(raw))
+}
+
+async fn fetch_foreign_keys(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+    summaries: &[TableSummary],
+) -> Result<Vec<ForeignKey>, DbOperationError> {
+    let query = format!(
+        "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = DATABASE() AND tc.TABLE_NAME = {} AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_SCHEMA = DATABASE() AND TABLE_NAME = {} AND CONSTRAINT_TYPE = 'FOREIGN KEY') ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
+        quote_string(table),
+        quote_string(table),
+    );
+    let result = execute_metadata_query(dsn, &query).await?;
+    let raw = parse_foreign_key_metadata(&result)?;
+    if schema != selected_database(dsn)? {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    foreign_keys_from_metadata(raw, summaries)
+}
+
+async fn fetch_triggers(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<Trigger>, DbOperationError> {
+    if schema != selected_database(dsn)? {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    let result = execute_metadata_query(dsn, &triggers_query(table)).await?;
+    triggers_from_metadata(parse_trigger_metadata(&result)?)
+}
+
+async fn fetch_source_ddl(
+    dsn: &str,
+    table: &str,
+    kind: TableKind,
+) -> Result<String, DbOperationError> {
+    let result = execute_metadata_query(dsn, &show_create_query(table, kind)).await?;
+    parse_source_ddl(&result, kind)
+}
+
+fn triggers_query(table: &str) -> String {
+    format!(
+        "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {}) ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION",
+        quote_string(table),
+        quote_string(table),
+    )
+}
+
+fn show_create_query(table: &str, kind: TableKind) -> String {
+    let object_type = if kind == TableKind::View {
+        "VIEW"
+    } else {
+        "TABLE"
+    };
+    format!("SHOW CREATE {object_type} {}", quote_identifier(table))
+}
+
+fn parse_trigger_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlTriggerMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &[
+            "TRIGGER_NAME",
+            "ACTION_TIMING",
+            "EVENT_MANIPULATION",
+            "ACTION_STATEMENT",
+            "DEFINER",
+        ],
+    )?;
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != 5 {
+                return Err(metadata_shape_error("TRIGGERS row"));
+            }
+            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
+                return Ok(None);
+            }
+            let timing = required_text(&row[1], "ACTION_TIMING")?
+                .parse::<TriggerTiming>()
+                .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
+            let event = required_text(&row[2], "EVENT_MANIPULATION")?
+                .parse::<TriggerEvent>()
+                .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
+            Ok(Some(MysqlTriggerMetadata {
+                name: required_text(&row[0], "TRIGGER_NAME")?.to_string(),
+                timing,
+                event,
+                definition: required_text(&row[3], "ACTION_STATEMENT")?.to_string(),
+                security_context: optional_text(&row[4], "DEFINER")?.map(str::to_string),
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|rows| rows.into_iter().flatten().collect())
+}
+
+fn triggers_from_metadata(
+    raw: Vec<MysqlTriggerMetadata>,
+) -> Result<Vec<Trigger>, DbOperationError> {
+    let mut triggers = Vec::new();
+    for metadata in raw {
+        if let Some(trigger) = triggers
+            .iter_mut()
+            .find(|trigger: &&mut Trigger| trigger.name == metadata.name)
+        {
+            if trigger.timing != metadata.timing
+                || trigger.definition != metadata.definition
+                || trigger.security_context != metadata.security_context
+            {
+                return Err(metadata_shape_error("TRIGGERS definition"));
+            }
+            trigger.events.push(metadata.event);
+        } else {
+            triggers.push(Trigger {
+                name: metadata.name,
+                timing: metadata.timing,
+                events: vec![metadata.event],
+                definition: metadata.definition,
+                security_context: metadata.security_context,
+            });
+        }
+    }
+    Ok(triggers)
+}
+
+fn parse_source_ddl(result: &MysqlResultSet, kind: TableKind) -> Result<String, DbOperationError> {
+    let expected_columns = if kind == TableKind::View {
+        ["View", "Create View"]
+    } else {
+        ["Table", "Create Table"]
+    };
+    if result.columns.len() < 2
+        || result.columns[0] != expected_columns[0]
+        || result.columns[1] != expected_columns[1]
+        || result.values.len() != 1
+    {
+        return Err(metadata_shape_error("SHOW CREATE result"));
+    }
+    let row = &result.values[0];
+    if row.len() != result.columns.len() {
+        return Err(metadata_shape_error("SHOW CREATE row"));
+    }
+    let ddl = required_text(&row[1], expected_columns[1])?;
+    if ddl.is_empty() {
+        return Err(DbOperationError::MetadataParseFailed(
+            "MySQL SHOW CREATE returned empty DDL".to_string(),
+        ));
+    }
+    Ok(ddl.to_string())
+}
+
+fn parse_column_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &[
+            "COLUMN_NAME",
+            "COLUMN_TYPE",
+            "IS_NULLABLE",
+            "COLUMN_DEFAULT",
+            "EXTRA",
+            "COLUMN_COMMENT",
+            "ORDINAL_POSITION",
+            "PRIMARY_KEY_POSITION",
+        ],
+    )?;
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != 8 {
+                return Err(metadata_shape_error("COLUMNS row"));
+            }
+            let extra = required_text(&row[4], "EXTRA")?;
+            Ok(MysqlColumnMetadata {
+                name: required_text(&row[0], "COLUMN_NAME")?.to_string(),
+                data_type: required_text(&row[1], "COLUMN_TYPE")?.to_string(),
+                nullable: required_text(&row[2], "IS_NULLABLE")? == "YES",
+                default: optional_text(&row[3], "COLUMN_DEFAULT")?.map(str::to_string),
+                comment: optional_text(&row[5], "COLUMN_COMMENT")?
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string),
+                ordinal_position: parse_positive_i32(&row[6], "ORDINAL_POSITION")?,
+                primary_key_position: optional_text(&row[7], "PRIMARY_KEY_POSITION")?
+                    .map(|value| parse_positive_i32_text(value, "PRIMARY_KEY_POSITION"))
+                    .transpose()?,
+                invisible: extra
+                    .split_ascii_whitespace()
+                    .any(|word| word.eq_ignore_ascii_case("INVISIBLE")),
+                generated: extra
+                    .split_ascii_whitespace()
+                    .any(|word| word.eq_ignore_ascii_case("GENERATED")),
+            })
+        })
+        .collect()
+}
+
+fn parse_index_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlIndexMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &[
+            "INDEX_NAME",
+            "NON_UNIQUE",
+            "INDEX_TYPE",
+            "SEQ_IN_INDEX",
+            "COLUMN_NAME",
+            "IS_PRIMARY",
+        ],
+    )?;
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
+                return Ok(None);
+            }
+            if row.len() != 6 {
+                return Err(metadata_shape_error("STATISTICS row"));
+            }
+            Ok(Some(MysqlIndexMetadata {
+                name: required_text(&row[0], "INDEX_NAME")?.to_string(),
+                non_unique: parse_boolean_flag(&row[1], "NON_UNIQUE")?,
+                index_type: required_text(&row[2], "INDEX_TYPE")?.to_string(),
+                ordinal_position: parse_positive_i32(&row[3], "SEQ_IN_INDEX")?,
+                column_name: required_text(&row[4], "COLUMN_NAME")?.to_string(),
+                primary: parse_boolean_flag(&row[5], "IS_PRIMARY")?,
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|rows| rows.into_iter().flatten().collect())
+}
+
+fn parse_foreign_key_metadata(
+    result: &MysqlResultSet,
+) -> Result<Vec<MysqlForeignKeyMetadata>, DbOperationError> {
+    expect_columns(
+        result,
+        &[
+            "CONSTRAINT_NAME",
+            "TABLE_SCHEMA",
+            "TABLE_NAME",
+            "COLUMN_NAME",
+            "REFERENCED_TABLE_SCHEMA",
+            "REFERENCED_TABLE_NAME",
+            "REFERENCED_COLUMN_NAME",
+            "ORDINAL_POSITION",
+            "UPDATE_RULE",
+            "DELETE_RULE",
+        ],
+    )?;
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
+                return Ok(None);
+            }
+            if row.len() != 10 {
+                return Err(metadata_shape_error("foreign key row"));
+            }
+            Ok(Some(MysqlForeignKeyMetadata {
+                name: required_text(&row[0], "CONSTRAINT_NAME")?.to_string(),
+                from_schema: required_text(&row[1], "TABLE_SCHEMA")?.to_string(),
+                from_table: required_text(&row[2], "TABLE_NAME")?.to_string(),
+                from_column: required_text(&row[3], "COLUMN_NAME")?.to_string(),
+                to_schema: required_text(&row[4], "REFERENCED_TABLE_SCHEMA")?.to_string(),
+                to_table: required_text(&row[5], "REFERENCED_TABLE_NAME")?.to_string(),
+                to_column: required_text(&row[6], "REFERENCED_COLUMN_NAME")?.to_string(),
+                ordinal_position: parse_positive_i32(&row[7], "ORDINAL_POSITION")?,
+                on_update: parse_fk_action(&row[8], "UPDATE_RULE")?,
+                on_delete: parse_fk_action(&row[9], "DELETE_RULE")?,
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(|rows| rows.into_iter().flatten().collect())
+}
+
+fn indexes_from_metadata(mut raw: Vec<MysqlIndexMetadata>) -> Vec<Index> {
+    raw.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then(left.ordinal_position.cmp(&right.ordinal_position))
+    });
+    let mut indexes = Vec::new();
+    for column in raw {
+        if let Some(index) = indexes
+            .iter_mut()
+            .find(|index: &&mut Index| index.name == column.name)
+        {
+            index.columns.push(column.column_name);
+            continue;
+        }
+        indexes.push(Index {
+            name: column.name,
+            columns: vec![column.column_name],
+            attributes: IndexAttributes::from_parts(!column.non_unique, column.primary),
+            index_type: column
+                .index_type
+                .to_ascii_lowercase()
+                .parse::<IndexType>()
+                .unwrap_or_else(|never| match never {}),
+            definition: None,
+        });
+    }
+    indexes
+}
+
+fn foreign_keys_from_metadata(
+    mut raw: Vec<MysqlForeignKeyMetadata>,
+    summaries: &[TableSummary],
+) -> Result<Vec<ForeignKey>, DbOperationError> {
+    raw.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then(left.ordinal_position.cmp(&right.ordinal_position))
+    });
+    let mut foreign_keys = Vec::new();
+    for column in raw {
+        let reference_resolved = summaries
+            .iter()
+            .any(|summary| summary.schema == column.to_schema && summary.name == column.to_table);
+        if let Some(foreign_key) = foreign_keys
+            .iter_mut()
+            .find(|foreign_key: &&mut ForeignKey| foreign_key.name == column.name)
+        {
+            if foreign_key.from_schema != column.from_schema
+                || foreign_key.from_table != column.from_table
+                || foreign_key.to_schema != column.to_schema
+                || foreign_key.to_table != column.to_table
+                || foreign_key.on_update != column.on_update
+                || foreign_key.on_delete != column.on_delete
+            {
+                return Err(metadata_shape_error("foreign key constraint columns"));
+            }
+            foreign_key.from_columns.push(column.from_column);
+            foreign_key.to_columns.push(column.to_column);
+            foreign_key.reference_resolved &= reference_resolved;
+            continue;
+        }
+        foreign_keys.push(ForeignKey {
+            name: column.name,
+            from_schema: column.from_schema,
+            from_table: column.from_table,
+            from_columns: vec![column.from_column],
+            to_schema: column.to_schema,
+            to_table: column.to_table,
+            to_columns: vec![column.to_column],
+            on_delete: column.on_delete,
+            on_update: column.on_update,
+            reference_resolved,
+        });
+    }
+    Ok(foreign_keys)
+}
+
+fn column_from_metadata(metadata: &MysqlColumnMetadata) -> Column {
+    let primary_key = metadata.primary_key_position.is_some();
+    let attributes = ColumnAttributes::from_parts(metadata.nullable, primary_key, false)
+        | if metadata.invisible {
+            ColumnAttributes::HIDDEN | ColumnAttributes::READ_ONLY
+        } else {
+            ColumnAttributes::empty()
+        }
+        | if metadata.generated {
+            ColumnAttributes::GENERATED | ColumnAttributes::READ_ONLY
+        } else {
+            ColumnAttributes::empty()
+        };
+    Column {
+        name: metadata.name.clone(),
+        data_type: metadata.data_type.clone(),
+        default: metadata.default.clone(),
+        attributes,
+        comment: metadata.comment.clone(),
+        ordinal_position: metadata.ordinal_position,
+    }
+}
+
+fn primary_key_names(columns: &[MysqlColumnMetadata]) -> Vec<String> {
+    let mut columns = columns
+        .iter()
+        .filter_map(|column| {
+            column
+                .primary_key_position
+                .map(|position| (position, column.name.clone()))
+        })
+        .collect::<Vec<_>>();
+    columns.sort_by_key(|(position, _)| *position);
+    columns.into_iter().map(|(_, name)| name).collect()
+}
+
+fn parse_boolean_flag(value: &QueryValue, field: &str) -> Result<bool, DbOperationError> {
+    match required_text(value, field)? {
+        "0" | "NO" => Ok(false),
+        "1" | "YES" => Ok(true),
+        _ => Err(DbOperationError::MetadataParseFailed(format!(
+            "invalid MySQL metadata boolean: {field}"
+        ))),
+    }
+}
+
+fn parse_fk_action(value: &QueryValue, field: &str) -> Result<FkAction, DbOperationError> {
+    required_text(value, field)?.parse().map_err(|error| {
+        DbOperationError::MetadataParseFailed(format!("invalid MySQL foreign key action: {error}"))
+    })
+}
+
+fn table_signature(table: &Table) -> String {
+    format!(
+        "{:?}|{:?}|{:?}",
+        table.kind_info.kind, table.columns, table.foreign_keys
+    )
+}
+
+fn table_summary(database: &str, table: MysqlTableMetadata) -> TableSummary {
+    TableSummary::new(
+        database.to_string(),
+        table.name,
+        table.row_count_estimate,
+        false,
+    )
+    .with_kind_info(TableKindInfo {
+        kind: table.kind,
+        ..TableKindInfo::default()
+    })
+}
+
+fn expect_columns(result: &MysqlResultSet, expected: &[&str]) -> Result<(), DbOperationError> {
+    if result.columns == expected {
+        Ok(())
+    } else {
+        Err(metadata_shape_error("MySQL metadata columns"))
+    }
+}
+
+fn required_text<'a>(value: &'a QueryValue, field: &str) -> Result<&'a str, DbOperationError> {
+    optional_text(value, field)?.ok_or_else(|| {
+        DbOperationError::MetadataParseFailed(format!("MySQL metadata field is NULL: {field}"))
+    })
+}
+
+fn optional_text<'a>(
+    value: &'a QueryValue,
+    field: &str,
+) -> Result<Option<&'a str>, DbOperationError> {
+    match value {
+        QueryValue::Null => Ok(None),
+        QueryValue::Text(value) | QueryValue::SqlLiteral(value) => Ok(Some(value)),
+        QueryValue::Blob(_) => Err(DbOperationError::MetadataParseFailed(format!(
+            "MySQL metadata field is binary: {field}"
+        ))),
+    }
+}
+
+fn parse_positive_i32(value: &QueryValue, field: &str) -> Result<i32, DbOperationError> {
+    parse_positive_i32_text(required_text(value, field)?, field)
+}
+
+fn parse_positive_i32_text(value: &str, field: &str) -> Result<i32, DbOperationError> {
+    let value = value.parse::<i32>().map_err(|_| {
+        DbOperationError::MetadataParseFailed(format!("invalid MySQL metadata integer: {field}"))
+    })?;
+    if value > 0 {
+        Ok(value)
+    } else {
+        Err(DbOperationError::MetadataParseFailed(format!(
+            "invalid MySQL metadata ordinal: {field}"
+        )))
+    }
+}
+
+fn metadata_shape_error(field: &str) -> DbOperationError {
+    DbOperationError::MetadataParseFailed(format!("unexpected MySQL metadata shape: {field}"))
+}
+
+fn quote_identifier(value: &str) -> String {
+    format!("`{}`", value.replace('`', "``"))
+}
+
+fn quote_string(value: &str) -> String {
+    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "''"))
+}
+
+fn is_binary_type(data_type: &str) -> bool {
+    let name = data_type
+        .split(['(', ' '])
+        .next()
+        .unwrap_or(data_type)
+        .to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        "binary" | "varbinary" | "tinyblob" | "blob" | "mediumblob" | "longblob" | "bit"
+    )
+}
+
+fn is_numeric_type(data_type: &str) -> bool {
+    let name = data_type
+        .split(['(', ' '])
+        .next()
+        .unwrap_or(data_type)
+        .to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        "tinyint"
+            | "smallint"
+            | "mediumint"
+            | "int"
+            | "integer"
+            | "bigint"
+            | "decimal"
+            | "dec"
+            | "numeric"
+            | "fixed"
+            | "float"
+            | "double"
+            | "real"
+    )
+}
+
+fn decode_hex(value: &str) -> Option<Vec<u8>> {
+    let hex = value.strip_prefix("0x")?;
+    if hex.len() % 2 != 0 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    (0..hex.len())
+        .step_by(2)
+        .map(|index| u8::from_str_radix(&hex[index..index + 2], 16).ok())
+        .collect()
+}
+
+fn is_sql_numeric_literal(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+    let mut index = usize::from(matches!(bytes[0], b'+' | b'-'));
+    let integer_start = index;
+    while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+        index += 1;
+    }
+    let has_integer = index > integer_start;
+    let mut has_fraction = false;
+    if bytes.get(index) == Some(&b'.') {
+        has_fraction = true;
+        index += 1;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+    }
+    if !has_integer && !has_fraction {
+        return false;
+    }
+    if matches!(bytes.get(index), Some(b'e' | b'E')) {
+        index += 1;
+        if matches!(bytes.get(index), Some(b'+' | b'-')) {
+            index += 1;
+        }
+        let exponent_start = index;
+        while bytes.get(index).is_some_and(u8::is_ascii_digit) {
+            index += 1;
+        }
+        if exponent_start == index {
+            return false;
+        }
+    }
+    index == bytes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
+        MysqlResultSet {
+            columns: columns.iter().map(|value| (*value).to_string()).collect(),
+            values,
+        }
+    }
+
+    fn column(name: &str, data_type: &str) -> Column {
+        Column {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            default: None,
+            attributes: ColumnAttributes::empty(),
+            comment: None,
+            ordinal_position: 1,
+        }
+    }
+
+    #[test]
+    fn trigger_metadata_preserves_action_definer_and_event_order() {
+        let result = result(
+            &[
+                "TRIGGER_NAME",
+                "ACTION_TIMING",
+                "EVENT_MANIPULATION",
+                "ACTION_STATEMENT",
+                "DEFINER",
+            ],
+            vec![
+                vec![
+                    QueryValue::Text("audit_changes".to_string()),
+                    QueryValue::Text("BEFORE".to_string()),
+                    QueryValue::Text("INSERT".to_string()),
+                    QueryValue::Text("BEGIN\n  SET @seen = 1;\nEND".to_string()),
+                    QueryValue::Text("sabiql@%".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("audit_changes".to_string()),
+                    QueryValue::Text("BEFORE".to_string()),
+                    QueryValue::Text("UPDATE".to_string()),
+                    QueryValue::Text("BEGIN\n  SET @seen = 1;\nEND".to_string()),
+                    QueryValue::Text("sabiql@%".to_string()),
+                ],
+            ],
+        );
+
+        let triggers = triggers_from_metadata(parse_trigger_metadata(&result).unwrap()).unwrap();
+
+        assert_eq!(triggers.len(), 1);
+        assert_eq!(
+            triggers[0].events,
+            [TriggerEvent::Insert, TriggerEvent::Update]
+        );
+        assert_eq!(triggers[0].definition, "BEGIN\n  SET @seen = 1;\nEND");
+        assert_eq!(triggers[0].security_context.as_deref(), Some("sabiql@%"));
+    }
+
+    #[test]
+    fn empty_trigger_sentinel_returns_no_triggers() {
+        let result = result(
+            &[
+                "TRIGGER_NAME",
+                "ACTION_TIMING",
+                "EVENT_MANIPULATION",
+                "ACTION_STATEMENT",
+                "DEFINER",
+            ],
+            vec![vec![
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+            ]],
+        );
+
+        assert!(parse_trigger_metadata(&result).unwrap().is_empty());
+    }
+
+    #[test]
+    fn show_create_query_uses_object_kind_and_identifier_quoting() {
+        assert_eq!(
+            show_create_query("table`name", TableKind::Table),
+            "SHOW CREATE TABLE `table``name`"
+        );
+        assert_eq!(
+            show_create_query("view_name", TableKind::View),
+            "SHOW CREATE VIEW `view_name`"
+        );
+    }
+
+    #[test]
+    fn show_create_parser_preserves_view_ddl_and_extra_server_columns() {
+        let ddl = "CREATE ALGORITHM=UNDEFINED VIEW `v` AS select 1";
+        let result = result(
+            &[
+                "View",
+                "Create View",
+                "character_set_client",
+                "collation_connection",
+            ],
+            vec![vec![
+                QueryValue::Text("v".to_string()),
+                QueryValue::Text(ddl.to_string()),
+                QueryValue::Text("utf8mb4".to_string()),
+                QueryValue::Text("utf8mb4_0900_ai_ci".to_string()),
+            ]],
+        );
+
+        assert_eq!(parse_source_ddl(&result, TableKind::View).unwrap(), ddl);
+    }
+
+    #[test]
+    fn preview_conversion_keeps_text_hex_and_decodes_binary_hex() {
+        let result = result(
+            &["text_value", "binary_value"],
+            vec![vec![
+                QueryValue::Text("0x41".to_string()),
+                QueryValue::Text("0x00FF".to_string()),
+            ]],
+        );
+        let columns = vec![
+            column("text_value", "varchar(20)"),
+            column("binary_value", "blob"),
+        ];
+
+        let values = convert_preview_values(&result, &columns, &[]).expect("conversion succeeds");
+
+        assert_eq!(values.visible[0][0], QueryValue::Text("0x41".to_string()));
+        assert_eq!(values.visible[0][1], QueryValue::Blob(vec![0, 255]));
+    }
+
+    #[test]
+    fn preview_conversion_keeps_numeric_server_literals_without_rounding() {
+        let result = result(
+            &["unsigned_value", "decimal_value", "float_value"],
+            vec![vec![
+                QueryValue::Text("18446744073709551615".to_string()),
+                QueryValue::Text("12345678901234567890.12345678901234567890".to_string()),
+                QueryValue::Text("1.23e+100".to_string()),
+            ]],
+        );
+        let columns = vec![
+            column("unsigned_value", "bigint unsigned"),
+            column("decimal_value", "decimal(65,30)"),
+            column("float_value", "double"),
+        ];
+
+        let values = convert_preview_values(&result, &columns, &[]).expect("conversion succeeds");
+
+        assert_eq!(values.visible[0][0].as_str(), Some("18446744073709551615"));
+        assert!(matches!(values.visible[0][0], QueryValue::SqlLiteral(_)));
+        assert!(matches!(values.visible[0][1], QueryValue::SqlLiteral(_)));
+        assert!(matches!(values.visible[0][2], QueryValue::SqlLiteral(_)));
+    }
+
+    #[test]
+    fn numeric_literal_validation_rejects_partial_values() {
+        assert!(is_sql_numeric_literal("1."));
+        assert!(is_sql_numeric_literal(".5"));
+        assert!(is_sql_numeric_literal("-1.2e-3"));
+        assert!(!is_sql_numeric_literal("1e"));
+        assert!(!is_sql_numeric_literal("nan"));
+    }
+
+    #[test]
+    fn preview_query_lists_visible_columns_and_orders_by_primary_key() {
+        let columns = vec![column("id", "int"), column("display", "text")];
+
+        let query = build_preview_query(
+            "app",
+            "items",
+            &["id".to_string()],
+            &columns,
+            &[],
+            500,
+            1000,
+        );
+
+        assert_eq!(
+            query,
+            "SELECT `id`, `display` FROM `app`.`items` ORDER BY `id` LIMIT 500 OFFSET 1000"
+        );
+    }
+
+    #[test]
+    fn preview_query_appends_aliased_hidden_primary_key_columns() {
+        let visible_columns = vec![column("payload", "text")];
+        let identity_columns = vec![column("id", "int")];
+
+        let query = build_preview_query(
+            "app",
+            "items",
+            &["id".to_string()],
+            &visible_columns,
+            &identity_columns,
+            10,
+            0,
+        );
+
+        assert_eq!(
+            query,
+            "SELECT `payload`, `id` AS `__sabiql_row_identity_0` FROM `app`.`items` ORDER BY `id` LIMIT 10 OFFSET 0"
+        );
+    }
+
+    #[test]
+    fn preview_conversion_separates_aliased_primary_key_values() {
+        let result = result(
+            &["payload", "__sabiql_row_identity_0"],
+            vec![vec![
+                QueryValue::Text("visible".to_string()),
+                QueryValue::Text("42".to_string()),
+            ]],
+        );
+        let visible_columns = vec![column("payload", "text")];
+        let identity_columns = vec![column("id", "int")];
+
+        let values = convert_preview_values(&result, &visible_columns, &identity_columns)
+            .expect("conversion succeeds");
+
+        assert_eq!(
+            values.visible,
+            vec![vec![QueryValue::Text("visible".to_string())]]
+        );
+        assert_eq!(
+            values.identity,
+            Some(vec![vec![QueryValue::SqlLiteral("42".to_string())]])
+        );
+    }
+
+    #[test]
+    fn metadata_parser_preserves_column_and_composite_key_order() {
+        let result = result(
+            &[
+                "COLUMN_NAME",
+                "COLUMN_TYPE",
+                "IS_NULLABLE",
+                "COLUMN_DEFAULT",
+                "EXTRA",
+                "COLUMN_COMMENT",
+                "ORDINAL_POSITION",
+                "PRIMARY_KEY_POSITION",
+            ],
+            vec![
+                vec![
+                    QueryValue::Text("first_key".to_string()),
+                    QueryValue::Text("int".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("2".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("second_key".to_string()),
+                    QueryValue::Text("int".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Text("1".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("generated_value".to_string()),
+                    QueryValue::Text("int".to_string()),
+                    QueryValue::Text("YES".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("STORED GENERATED".to_string()),
+                    QueryValue::Text(String::new()),
+                    QueryValue::Text("3".to_string()),
+                    QueryValue::Null,
+                ],
+            ],
+        );
+
+        let parsed = parse_column_metadata(&result).expect("metadata parses");
+        assert_eq!(primary_key_names(&parsed), ["second_key", "first_key"]);
+        assert_eq!(
+            parsed
+                .iter()
+                .map(|column| column.ordinal_position)
+                .collect::<Vec<_>>(),
+            [1, 2, 3]
+        );
+        assert!(column_from_metadata(&parsed[2]).is_generated());
+    }
+
+    #[test]
+    fn empty_table_list_sentinel_parses_as_no_tables() {
+        let result = result(
+            &["TABLE_NAME", "TABLE_TYPE", "TABLE_ROWS", "TABLE_COMMENT"],
+            vec![vec![
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Null,
+            ]],
+        );
+
+        assert!(
+            parse_table_metadata(&result)
+                .expect("empty table metadata parses")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn groups_indexes_by_name_and_orders_columns_by_sequence() {
+        let result = result(
+            &[
+                "INDEX_NAME",
+                "NON_UNIQUE",
+                "INDEX_TYPE",
+                "SEQ_IN_INDEX",
+                "COLUMN_NAME",
+                "IS_PRIMARY",
+            ],
+            vec![
+                vec![
+                    QueryValue::Text("PRIMARY".to_string()),
+                    QueryValue::Text("0".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Text("second_key".to_string()),
+                    QueryValue::Text("YES".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("PRIMARY".to_string()),
+                    QueryValue::Text("0".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("first_key".to_string()),
+                    QueryValue::Text("YES".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("search_index".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("FULLTEXT".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("body".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                ],
+            ],
+        );
+
+        let indexes = indexes_from_metadata(parse_index_metadata(&result).unwrap());
+
+        assert_eq!(indexes[0].name, "PRIMARY");
+        assert_eq!(indexes[0].columns, ["first_key", "second_key"]);
+        assert!(indexes[0].is_primary());
+        assert_eq!(
+            indexes[1].index_type,
+            IndexType::Other("fulltext".to_string())
+        );
+        assert!(!indexes[1].is_unique());
+    }
+
+    #[test]
+    fn groups_foreign_keys_by_name_and_orders_columns_by_sequence() {
+        let result = result(
+            &[
+                "CONSTRAINT_NAME",
+                "TABLE_SCHEMA",
+                "TABLE_NAME",
+                "COLUMN_NAME",
+                "REFERENCED_TABLE_SCHEMA",
+                "REFERENCED_TABLE_NAME",
+                "REFERENCED_COLUMN_NAME",
+                "ORDINAL_POSITION",
+                "UPDATE_RULE",
+                "DELETE_RULE",
+            ],
+            vec![
+                vec![
+                    QueryValue::Text("fk_child_parent".to_string()),
+                    QueryValue::Text("sabiql_test".to_string()),
+                    QueryValue::Text("child".to_string()),
+                    QueryValue::Text("parent_second".to_string()),
+                    QueryValue::Text("sabiql_test".to_string()),
+                    QueryValue::Text("parent".to_string()),
+                    QueryValue::Text("second_key".to_string()),
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Text("CASCADE".to_string()),
+                    QueryValue::Text("SET NULL".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("fk_child_parent".to_string()),
+                    QueryValue::Text("sabiql_test".to_string()),
+                    QueryValue::Text("child".to_string()),
+                    QueryValue::Text("parent_first".to_string()),
+                    QueryValue::Text("sabiql_test".to_string()),
+                    QueryValue::Text("parent".to_string()),
+                    QueryValue::Text("first_key".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("CASCADE".to_string()),
+                    QueryValue::Text("SET NULL".to_string()),
+                ],
+            ],
+        );
+
+        let summaries = [TableSummary::new(
+            "sabiql_test".to_string(),
+            "parent".to_string(),
+            None,
+            false,
+        )];
+        let foreign_keys =
+            foreign_keys_from_metadata(parse_foreign_key_metadata(&result).unwrap(), &summaries)
+                .unwrap();
+
+        assert_eq!(foreign_keys.len(), 1);
+        assert_eq!(
+            foreign_keys[0].from_columns,
+            ["parent_first", "parent_second"]
+        );
+        assert_eq!(foreign_keys[0].to_columns, ["first_key", "second_key"]);
+        assert_eq!(foreign_keys[0].on_update, FkAction::Cascade);
+        assert_eq!(foreign_keys[0].on_delete, FkAction::SetNull);
+
+        let unresolved =
+            foreign_keys_from_metadata(parse_foreign_key_metadata(&result).unwrap(), &[]).unwrap();
+        assert!(!unresolved[0].is_reference_resolved());
+    }
+}

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1,0 +1,1102 @@
+//! Integration tests for the Oracle MySQL 8.4 server and mysql CLI.
+//!
+//! Start the exact fixture and CLI wrapper with:
+//! bash scripts/mysql_integration.sh test
+
+use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+use sabiql_app::ports::outbound::{
+    AccessMode, ConnectionProbe, DbOperationError, DdlGenerator, DsnBuilder,
+    MYSQL_SQL_MODE_UNSUPPORTED_MARKER, MetadataProvider, QueryExecutor, SqlDialect,
+};
+use sabiql_domain::{
+    CommandTag, DatabaseType, FkAction, IndexType, QueryValue, RefreshScope, TableKind,
+    TriggerEvent, TriggerTiming,
+};
+
+use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, mysql_tls_config, with_mysql_test_db};
+use sabiql_domain::connection::{
+    ConnectionConfig, ConnectionId, ConnectionProfile, MySqlConnectionConfig, MySqlSslMode,
+};
+use sabiql_infra::adapters::mysql::MySqlAdapter;
+
+fn mysql_tls_profile(name: &str, config: MySqlConnectionConfig) -> ConnectionProfile {
+    ConnectionProfile::with_id_and_config(
+        ConnectionId::new(),
+        name,
+        ConnectionConfig::MySQL(config),
+    )
+    .unwrap()
+}
+
+const MYSQL_COMPOSITE_TABLE: &str = "mysql_preview_composite";
+const MYSQL_INVISIBLE_PK_TABLE: &str = "mysql_edit_invisible_pk";
+const MYSQL_INVISIBLE_COMPOSITE_TABLE: &str = "mysql_edit_invisible_composite";
+const MYSQL_GIPK_TABLE: &str = "mysql_edit_gipk";
+const MYSQL_NO_PK_TABLE: &str = "mysql_preview_no_pk";
+const MYSQL_EMPTY_TABLE: &str = "mysql_preview_empty";
+const MYSQL_VIEW: &str = "mysql_preview_view";
+const MYSQL_FK_PARENT: &str = "mysql_metadata_parent";
+const MYSQL_FK_CHILD: &str = "mysql_metadata_child";
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn connects_to_oracle_mysql_84_fixture() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if result.columns != ["id"] || result.values() != [[QueryValue::Text("1".to_string())]]
+            {
+                return Err(format!("unexpected MySQL connection result: {result:?}"));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn connects_to_oracle_mysql_84_fixture_with_ca_and_client_certificate() {
+    let config = mysql_tls_config();
+    let profile = mysql_tls_profile("mysql-tls-integration", config);
+    let adapter = MySqlAdapter::new();
+    let dsn = adapter.build_dsn(&profile);
+
+    adapter.probe(&dsn).await.unwrap();
+    let result = adapter
+        .execute_adhoc(
+            &dsn,
+            &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
+            AccessMode::ReadWrite,
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.values(), [[QueryValue::Text("1".to_string())]]);
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn rejects_oracle_mysql_84_fixture_with_wrong_ca() {
+    let mut config = mysql_tls_config();
+    config.ssl_ca = config.ssl_cert.clone();
+    let profile = mysql_tls_profile("mysql-tls-wrong-ca", config);
+    let adapter = MySqlAdapter::new();
+    let dsn = adapter.build_dsn(&profile);
+    let error = adapter.probe(&dsn).await.unwrap_err();
+    assert_eq!(
+        ConnectionErrorInfo::from_db_operation_error_with_dsn(&error, &dsn).kind,
+        ConnectionErrorKind::MySqlCaVerificationFailed
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn rejects_oracle_mysql_84_fixture_with_wrong_hostname() {
+    let mut config = mysql_tls_config();
+    config.host = "host.docker.internal".to_string();
+    config.ssl_mode = MySqlSslMode::VerifyIdentity;
+    let profile = mysql_tls_profile("mysql-tls-wrong-host", config);
+    let adapter = MySqlAdapter::new();
+    let dsn = adapter.build_dsn(&profile);
+    let error = adapter.probe(&dsn).await.unwrap_err();
+    let error_info = ConnectionErrorInfo::from_db_operation_error_with_dsn(&error, &dsn);
+    assert_eq!(
+        error_info.kind,
+        ConnectionErrorKind::MySqlHostnameVerificationFailed,
+        "masked connection error details: {}",
+        error_info.masked_details()
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn preserves_xml_value_boundaries_for_real_mysql_results() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!(
+                    "SELECT nullable_text, empty_text, unicode_text, JSON_EXTRACT(json_value, '$.array'), JSON_EXTRACT(json_value, '$.text'), blob_value FROM {MYSQL_FIXTURE_TABLE}"
+                ),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("{error:?}"))?;
+        let expected = vec![
+            QueryValue::Null,
+            QueryValue::Text(String::new()),
+            QueryValue::Text("日本語の値 🐬".to_string()),
+            QueryValue::Text("[1, true]".to_string()),
+            QueryValue::Text("\"空文字ではない\"".to_string()),
+            QueryValue::Text("0x00FF10".to_string()),
+        ];
+        if result.values() != [expected] {
+            return Err(format!("unexpected XML values: {:?}", result.values()));
+        }
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn loads_mysql_tables_views_and_column_attributes() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let metadata = db
+                .adapter()
+                .fetch_metadata(db.dsn())
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if metadata
+                .schemas
+                .iter()
+                .map(|schema| schema.name.as_str())
+                .collect::<Vec<_>>()
+                != ["sabiql_test"]
+            {
+                return Err(format!("unexpected MySQL schemas: {:?}", metadata.schemas));
+            }
+            let view = metadata
+                .table_summaries
+                .iter()
+                .find(|summary| summary.name == MYSQL_VIEW)
+                .ok_or_else(|| "MySQL view was not listed".to_string())?;
+            if view.kind_info.kind != TableKind::View {
+                return Err(format!("unexpected MySQL view kind: {:?}", view.kind_info));
+            }
+
+            let detail = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_FIXTURE_TABLE)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            let names = detail
+                .columns
+                .iter()
+                .map(|column| column.name.as_str())
+                .collect::<Vec<_>>();
+            if names
+                != [
+                    "id",
+                    "nullable_text",
+                    "empty_text",
+                    "unicode_text",
+                    "json_value",
+                    "blob_value",
+                    "invisible_value",
+                    "generated_value",
+                    "unsigned_value",
+                    "precise_decimal",
+                    "scientific_value",
+                ]
+            {
+                return Err(format!("unexpected MySQL column order: {names:?}"));
+            }
+            let invisible = detail
+                .columns
+                .iter()
+                .find(|column| column.name == "invisible_value")
+                .ok_or_else(|| "invisible MySQL column was not returned".to_string())?;
+            if !invisible.is_hidden() || !invisible.is_read_only() {
+                return Err(format!(
+                    "unexpected invisible column attributes: {invisible:?}"
+                ));
+            }
+            let generated = detail
+                .columns
+                .iter()
+                .find(|column| column.name == "generated_value")
+                .ok_or_else(|| "generated MySQL column was not returned".to_string())?;
+            if !generated.is_generated() || !generated.is_read_only() {
+                return Err(format!(
+                    "unexpected generated column attributes: {generated:?}"
+                ));
+            }
+            if detail.primary_key != Some(vec!["id".to_string()]) {
+                return Err(format!(
+                    "unexpected MySQL primary key: {:?}",
+                    detail.primary_key
+                ));
+            }
+            if detail.comment.as_deref() != Some("MySQL fixture table")
+                || detail.row_count_estimate.is_none()
+            {
+                return Err(format!(
+                    "unexpected MySQL table info: comment={:?}, rows={:?}",
+                    detail.comment, detail.row_count_estimate
+                ));
+            }
+            if detail.source_ddl().is_none()
+                || db
+                    .adapter()
+                    .generate_ddl(sabiql_domain::DatabaseType::MySQL, &detail)
+                    != detail.source_ddl().unwrap()
+            {
+                return Err(format!(
+                    "unexpected MySQL table DDL: {:?}",
+                    detail.source_ddl()
+                ));
+            }
+            if detail.triggers.len() != 1 {
+                return Err(format!("unexpected MySQL triggers: {:?}", detail.triggers));
+            }
+            let trigger = &detail.triggers[0];
+            if trigger.name != "mysql_cli_fixture_audit"
+                || trigger.timing != TriggerTiming::Before
+                || trigger.events != [TriggerEvent::Update]
+                || trigger.definition != "SET NEW.empty_text = NEW.empty_text"
+                || trigger.security_context.as_deref() != Some("sabiql@%")
+            {
+                return Err(format!("unexpected MySQL trigger: {trigger:?}"));
+            }
+
+            let view_detail = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_VIEW)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if view_detail.source_ddl().is_none()
+                || !view_detail
+                    .source_ddl()
+                    .is_some_and(|ddl| ddl.contains("CREATE") && ddl.contains(MYSQL_VIEW))
+                || db
+                    .adapter()
+                    .generate_ddl(sabiql_domain::DatabaseType::MySQL, &view_detail)
+                    != view_detail.source_ddl().unwrap()
+            {
+                return Err(format!(
+                    "unexpected MySQL view DDL: {:?}",
+                    view_detail.source_ddl()
+                ));
+            }
+
+            let composite = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_COMPOSITE_TABLE)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if composite.primary_key
+                != Some(vec!["second_key".to_string(), "first_key".to_string()])
+            {
+                return Err(format!(
+                    "unexpected composite primary key: {:?}",
+                    composite.primary_key
+                ));
+            }
+            let unique_index = composite
+                .indexes
+                .iter()
+                .find(|index| index.name == "uq_mysql_preview_composite_payload")
+                .ok_or_else(|| "MySQL unique index was not returned".to_string())?;
+            if !unique_index.is_unique() || unique_index.columns != ["payload"] {
+                return Err(format!("unexpected MySQL unique index: {unique_index:?}"));
+            }
+            let fulltext_index = composite
+                .indexes
+                .iter()
+                .find(|index| index.name == "ft_mysql_preview_composite_payload")
+                .ok_or_else(|| "MySQL fulltext index was not returned".to_string())?;
+            if fulltext_index.index_type != IndexType::Other("fulltext".to_string())
+                || fulltext_index.columns != ["payload"]
+            {
+                return Err(format!(
+                    "unexpected MySQL fulltext index: {fulltext_index:?}"
+                ));
+            }
+
+            let parent = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_FK_PARENT)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            let parent_unique_index = parent
+                .indexes
+                .iter()
+                .find(|index| index.name == "uq_mysql_metadata_parent_code")
+                .ok_or_else(|| "MySQL parent unique index was not returned".to_string())?;
+            if !parent_unique_index.is_unique() || parent_unique_index.columns != ["unique_code"] {
+                return Err(format!(
+                    "unexpected MySQL parent unique index: {parent_unique_index:?}"
+                ));
+            }
+
+            let child = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_FK_CHILD)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if child.foreign_keys.len() != 1 {
+                return Err(format!(
+                    "unexpected MySQL foreign keys: {:?}",
+                    child.foreign_keys
+                ));
+            }
+            let foreign_key = &child.foreign_keys[0];
+            if foreign_key.from_columns != ["parent_first", "parent_second"]
+                || foreign_key.to_schema != "sabiql_test"
+                || foreign_key.to_table != MYSQL_FK_PARENT
+                || foreign_key.to_columns != ["first_key", "second_key"]
+                || foreign_key.on_update != FkAction::Cascade
+                || foreign_key.on_delete != FkAction::SetNull
+                || !foreign_key.is_reference_resolved()
+            {
+                return Err(format!("unexpected MySQL foreign key: {foreign_key:?}"));
+            }
+
+            let columns_and_fks = db
+                .adapter()
+                .fetch_table_columns_and_fks(db.dsn(), "sabiql_test", MYSQL_FK_CHILD)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if columns_and_fks.foreign_keys != child.foreign_keys
+                || !columns_and_fks.indexes.is_empty()
+            {
+                return Err(format!(
+                    "unexpected columns-and-fks metadata: {columns_and_fks:?}"
+                ));
+            }
+
+            let signatures = db
+                .adapter()
+                .fetch_table_signatures(db.dsn())
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            let child_signature = signatures
+                .iter()
+                .find(|signature| signature.name == MYSQL_FK_CHILD)
+                .ok_or_else(|| "MySQL child signature was not returned".to_string())?;
+            if !child_signature
+                .signature
+                .contains("fk_mysql_metadata_child_parent")
+            {
+                return Err(format!(
+                    "unexpected MySQL table signature: {child_signature:?}"
+                ));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn previews_mysql_rows_with_visible_columns_types_and_pagination() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_FIXTURE_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if result
+                .columns
+                .iter()
+                .any(|column| column == "invisible_value")
+            {
+                return Err(format!(
+                    "invisible column reached preview: {:?}",
+                    result.columns
+                ));
+            }
+            if result.columns
+                != [
+                    "id",
+                    "nullable_text",
+                    "empty_text",
+                    "unicode_text",
+                    "json_value",
+                    "blob_value",
+                    "generated_value",
+                    "unsigned_value",
+                    "precise_decimal",
+                    "scientific_value",
+                ]
+            {
+                return Err(format!("unexpected preview columns: {:?}", result.columns));
+            }
+            let values = result.values();
+            if values.len() != 1
+                || values[0][5] != QueryValue::Blob(vec![0, 255, 16])
+                || values[0][7] != QueryValue::SqlLiteral("18446744073709551615".to_string())
+                || values[0][8]
+                    != QueryValue::SqlLiteral(
+                        "12345678901234567890123456789012345.123456789012345678901234567890"
+                            .to_string(),
+                    )
+            {
+                return Err(format!("unexpected typed preview values: {values:?}"));
+            }
+            if !result.query.contains("ORDER BY `id`")
+                || !result.query.contains("LIMIT 10 OFFSET 0")
+            {
+                return Err(format!("unexpected preview SQL: {}", result.query));
+            }
+
+            let page = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_NO_PK_TABLE, 1, 1)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if !page
+                .query
+                .contains("ORDER BY `duplicate_value`, `payload` LIMIT 1 OFFSET 1")
+            {
+                return Err(format!("unexpected no-PK preview SQL: {}", page.query));
+            }
+
+            let composite = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_COMPOSITE_TABLE, 1, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if !composite
+                .query
+                .contains("ORDER BY `second_key`, `first_key` LIMIT 1 OFFSET 0")
+            {
+                return Err(format!(
+                    "unexpected composite preview SQL: {}",
+                    composite.query
+                ));
+            }
+
+            let view = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_VIEW, 10, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if view.columns != ["id", "unicode_text"] {
+                return Err(format!(
+                    "unexpected view preview columns: {:?}",
+                    view.columns
+                ));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn previews_empty_mysql_table_with_metadata_columns() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_EMPTY_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if result.columns != ["id", "payload"] || !result.values().is_empty() {
+                return Err(format!("unexpected empty preview: {result:?}"));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn previews_and_writes_rows_using_hidden_mysql_primary_keys() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let invisible = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_INVISIBLE_PK_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("failed to preview invisible primary key: {error:?}"))?;
+            if invisible.columns != ["payload"]
+                || invisible.query.contains("__sabiql_row_identity_")
+                || invisible.values()
+                    != [[QueryValue::Text("invisible single primary key".to_string())]]
+            {
+                return Err(format!(
+                    "unexpected invisible primary key preview: {invisible:?}"
+                ));
+            }
+            let identity = invisible
+                .explicit_row_identity()
+                .ok_or_else(|| "invisible primary key identity was not returned".to_string())?;
+            if identity.columns() != ["id"]
+                || identity.values() != [[QueryValue::SqlLiteral("1".to_string())]]
+            {
+                return Err(format!(
+                    "unexpected invisible primary key identity: {identity:?}"
+                ));
+            }
+
+            let composite = db
+                .adapter()
+                .execute_preview(
+                    db.dsn(),
+                    "sabiql_test",
+                    MYSQL_INVISIBLE_COMPOSITE_TABLE,
+                    10,
+                    0,
+                )
+                .await
+                .map_err(|error| format!("failed to preview invisible composite key: {error:?}"))?;
+            let composite_identity = composite
+                .explicit_row_identity()
+                .ok_or_else(|| "invisible composite identity was not returned".to_string())?;
+            if composite.columns != ["payload"]
+                || composite.query.contains("__sabiql_row_identity_")
+                || composite_identity.columns() != ["second_key", "first_key"]
+                || composite_identity.values()
+                    != [[
+                        QueryValue::SqlLiteral("20".to_string()),
+                        QueryValue::SqlLiteral("1".to_string()),
+                    ]]
+            {
+                return Err(format!(
+                    "unexpected invisible composite preview: {composite:?}"
+                ));
+            }
+
+            let gipk_detail = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_GIPK_TABLE)
+                .await
+                .map_err(|error| format!("failed to fetch GIPK metadata: {error:?}"))?;
+            if gipk_detail.primary_key != Some(vec!["my_row_id".to_string()]) {
+                return Err(format!(
+                    "GIPK was not exposed by INFORMATION_SCHEMA: {:?}",
+                    gipk_detail.primary_key
+                ));
+            }
+            let gipk = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_GIPK_TABLE, 10, 0)
+                .await
+                .map_err(|error| format!("failed to preview GIPK: {error:?}"))?;
+            if gipk.columns != ["payload"]
+                || gipk.query.contains("__sabiql_row_identity_")
+                || gipk
+                    .explicit_row_identity()
+                    .is_none_or(|identity| identity.columns() != ["my_row_id"])
+            {
+                return Err(format!("unexpected GIPK preview: {gipk:?}"));
+            }
+
+            let update_sql = db.adapter().build_update_sql(
+                DatabaseType::MySQL,
+                "sabiql_test",
+                MYSQL_GIPK_TABLE,
+                "payload",
+                &QueryValue::text("updated through GIPK"),
+                &[(
+                    "my_row_id".to_string(),
+                    QueryValue::SqlLiteral("1".to_string()),
+                )],
+            );
+            let update = db
+                .adapter()
+                .execute_write(db.dsn(), &update_sql, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| format!("failed to update through GIPK: {error:?}"))?;
+            if update.affected_rows != 1 {
+                return Err(format!("unexpected GIPK update result: {update:?}"));
+            }
+
+            let delete_sql = db.adapter().build_bulk_delete_sql(
+                DatabaseType::MySQL,
+                "sabiql_test",
+                MYSQL_INVISIBLE_PK_TABLE,
+                &[vec![(
+                    "id".to_string(),
+                    QueryValue::SqlLiteral("1".to_string()),
+                )]],
+            );
+            let delete = db
+                .adapter()
+                .execute_write(db.dsn(), &delete_sql, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| {
+                    format!("failed to delete through invisible primary key: {error:?}")
+                })?;
+            if delete.affected_rows != 1 {
+                return Err(format!(
+                    "unexpected invisible primary key delete result: {delete:?}"
+                ));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn updates_and_bulk_deletes_mysql_rows_with_visible_composite_primary_keys() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let suffix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|error| format!("system clock error: {error}"))?
+                .as_nanos();
+            let table = format!("mysql_sab392_{suffix}");
+            let create = format!(
+                "CREATE TABLE {table} (first_key BIGINT UNSIGNED NOT NULL, second_key INT NOT NULL, payload TEXT NOT NULL, PRIMARY KEY (first_key, second_key))"
+            );
+            db.adapter()
+                .execute_adhoc(db.dsn(), &create, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| format!("failed to create write fixture: {error:?}"))?;
+
+            let result = async {
+                let insert = format!(
+                    "INSERT INTO {table} (first_key, second_key, payload) VALUES (18446744073709551615, 7, 'before'), (42, 8, 'second')"
+                );
+                db.adapter()
+                    .execute_adhoc(db.dsn(), &insert, AccessMode::ReadWrite)
+                    .await
+                    .map_err(|error| format!("failed to seed write fixture: {error:?}"))?;
+
+                let update_sql = db.adapter().build_update_sql(
+                    DatabaseType::MySQL,
+                    "sabiql_test",
+                    &table,
+                    "payload",
+                    &QueryValue::text("O'Reilly\\path"),
+                    &[
+                        (
+                            "first_key".to_string(),
+                            QueryValue::SqlLiteral("18446744073709551615".to_string()),
+                        ),
+                        (
+                            "second_key".to_string(),
+                            QueryValue::SqlLiteral("7".to_string()),
+                        ),
+                    ],
+                );
+                let update = db
+                    .adapter()
+                    .execute_write(db.dsn(), &update_sql, AccessMode::ReadWrite)
+                    .await
+                    .map_err(|error| format!("failed to update MySQL row: {error:?}"))?;
+                if update.affected_rows != 1 {
+                    return Err(format!("unexpected update result: {update:?}"));
+                }
+
+                let changed = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!(
+                            "SELECT payload FROM {table} WHERE first_key = 18446744073709551615 AND second_key = 7"
+                        ),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to read updated row: {error:?}"))?;
+                if changed.values() != [[QueryValue::Text("O'Reilly\\path".to_string())]] {
+                    return Err(format!("unexpected updated row: {changed:?}"));
+                }
+
+                let delete_sql = db.adapter().build_bulk_delete_sql(
+                    DatabaseType::MySQL,
+                    "sabiql_test",
+                    &table,
+                    &[
+                        vec![
+                            (
+                                "first_key".to_string(),
+                                QueryValue::SqlLiteral("18446744073709551615".to_string()),
+                            ),
+                            (
+                                "second_key".to_string(),
+                                QueryValue::SqlLiteral("7".to_string()),
+                            ),
+                        ],
+                        vec![
+                            (
+                                "first_key".to_string(),
+                                QueryValue::SqlLiteral("42".to_string()),
+                            ),
+                            (
+                                "second_key".to_string(),
+                                QueryValue::SqlLiteral("8".to_string()),
+                            ),
+                        ],
+                    ],
+                );
+                let delete = db
+                    .adapter()
+                    .execute_write(db.dsn(), &delete_sql, AccessMode::ReadWrite)
+                    .await
+                    .map_err(|error| format!("failed to delete MySQL rows: {error:?}"))?;
+                if delete.affected_rows != 2 {
+                    return Err(format!("unexpected delete result: {delete:?}"));
+                }
+                Ok(())
+            }
+            .await;
+
+            let drop = format!("DROP TABLE {table}");
+            let _ = db
+                .adapter()
+                .execute_adhoc(db.dsn(), &drop, AccessMode::ReadWrite)
+                .await;
+            result
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+async fn updates_mysql_json_documents_as_whole_values() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let suffix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|error| format!("system clock error: {error}"))?
+                .as_nanos();
+            let table = format!("mysql_sab396_{suffix}");
+            let create = format!(
+                "CREATE TABLE {table} (id INT NOT NULL PRIMARY KEY, payload JSON NOT NULL)"
+            );
+            db.adapter()
+                .execute_adhoc(db.dsn(), &create, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| format!("failed to create JSON fixture: {error:?}"))?;
+
+            let result = async {
+                db.adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!("INSERT INTO {table} VALUES (1, '{{\"a\":1}}')"),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to seed JSON fixture: {error:?}"))?;
+
+                let update_json = db.adapter().build_update_sql(
+                    DatabaseType::MySQL,
+                    "sabiql_test",
+                    &table,
+                    "payload",
+                    &QueryValue::text(r#"{"b":2,"a":1}"#),
+                    &[("id".to_string(), QueryValue::SqlLiteral("1".to_string()))],
+                );
+                if update_json.contains("JSON_SET") {
+                    return Err("JSON update unexpectedly used JSON_SET".to_string());
+                }
+                db.adapter()
+                    .execute_write(db.dsn(), &update_json, AccessMode::ReadWrite)
+                    .await
+                    .map_err(|error| format!("failed to update JSON document: {error:?}"))?;
+
+                let reordered = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!("SELECT JSON_EXTRACT(payload, '$.b'), JSON_EXTRACT(payload, '$.a') FROM {table} WHERE id = 1"),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to read JSON document: {error:?}"))?;
+                if reordered.values()
+                    != [[QueryValue::Text("2".to_string()), QueryValue::Text("1".to_string())]]
+                {
+                    return Err(format!("unexpected updated JSON document: {reordered:?}"));
+                }
+
+                for (json, expected_type) in [("null", "NULL"), (r#""null""#, "STRING")] {
+                    let update = db.adapter().build_update_sql(
+                        DatabaseType::MySQL,
+                        "sabiql_test",
+                        &table,
+                        "payload",
+                        &QueryValue::text(json),
+                        &[("id".to_string(), QueryValue::SqlLiteral("1".to_string()))],
+                    );
+                    db.adapter()
+                        .execute_write(db.dsn(), &update, AccessMode::ReadWrite)
+                        .await
+                        .map_err(|error| format!("failed to update JSON null value: {error:?}"))?;
+                    let value = db
+                        .adapter()
+                        .execute_adhoc(
+                            db.dsn(),
+                            &format!("SELECT JSON_TYPE(payload) FROM {table} WHERE id = 1"),
+                            AccessMode::ReadWrite,
+                        )
+                        .await
+                        .map_err(|error| format!("failed to read JSON type: {error:?}"))?;
+                    if value.values() != [[QueryValue::Text(expected_type.to_string())]] {
+                        return Err(format!("unexpected JSON type: {value:?}"));
+                    }
+                }
+                Ok(())
+            }
+            .await;
+
+            let drop = format!("DROP TABLE {table}");
+            let _ = db
+                .adapter()
+                .execute_adhoc(db.dsn(), &drop, AccessMode::ReadWrite)
+                .await;
+            result
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn executes_multiple_statements_and_returns_only_the_last_result() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!(
+                    "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'multi statement' WHERE id = 1; SELECT empty_text FROM {MYSQL_FIXTURE_TABLE} WHERE id = 1"
+                ),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("{error:?}"))?;
+        if result.columns != ["empty_text"]
+            || result.values() != [[QueryValue::Text("multi statement".to_string())]]
+            || result.command_tag != Some(CommandTag::Update(1))
+            || result.refresh_scope != RefreshScope::Data
+        {
+            return Err(format!("unexpected multi-statement result: {result:?}"));
+        }
+        db.adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!("UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = '' WHERE id = 1"),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("failed to restore fixture: {error:?}"))?;
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn keeps_refresh_scope_and_discards_partial_result_after_a_later_failure() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!(
+                    "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'changed before failure' WHERE id = 1; SELECT missing_column FROM {MYSQL_FIXTURE_TABLE}"
+                ),
+                AccessMode::ReadWrite,
+            )
+            .await;
+        if !matches!(
+            result,
+            Err(DbOperationError::QueryFailedAfterChange {
+                refresh_scope: RefreshScope::Data,
+                ..
+            })
+        ) {
+            return Err(format!("expected partial-change failure: {result:?}"));
+        }
+        db.adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!("UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = '' WHERE id = 1"),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("failed to restore fixture: {error:?}"))?;
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn preserves_explicit_transaction_order_and_scope() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!(
+                    "BEGIN; UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'rolled back' WHERE id = 1; ROLLBACK; SELECT empty_text FROM {MYSQL_FIXTURE_TABLE} WHERE id = 1"
+                ),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("{error:?}"))?;
+        if result.columns != ["empty_text"]
+            || result.values() != [[QueryValue::Text(String::new())]]
+            || result.command_tag != Some(CommandTag::Select(1))
+            || result.refresh_scope != RefreshScope::Data
+        {
+            return Err(format!("unexpected transaction result: {result:?}"));
+        }
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn keeps_temporary_table_state_inside_one_submission() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|error| format!("system clock error: {error}"))?
+            .as_nanos();
+        let table = format!("sabiql_sab386_tmp_{suffix}");
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!(
+                    "CREATE TEMPORARY TABLE {table} (id INT); INSERT INTO {table} VALUES (1), (2); SELECT id FROM {table} ORDER BY id; DROP TEMPORARY TABLE {table}"
+                ),
+                AccessMode::ReadWrite,
+            )
+            .await
+            .map_err(|error| format!("{error:?}"))?;
+        if result.columns != ["id"]
+            || result.values() != [[QueryValue::Text("1".to_string())], [QueryValue::Text("2".to_string())]]
+            || result.command_tag != Some(CommandTag::Insert(2))
+            || result.refresh_scope != RefreshScope::Metadata
+        {
+            return Err(format!("unexpected temporary-table result: {result:?}"));
+        }
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn reports_metadata_scope_when_a_later_ddl_statement_fails() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let suffix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|error| format!("system clock error: {error}"))?
+                .as_nanos();
+            let table = format!("sabiql_sab386_{suffix}");
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("CREATE TABLE {table} (id INT); CREATE TABLE {table} (id INT)"),
+                    AccessMode::ReadWrite,
+                )
+                .await;
+            if !matches!(
+                result,
+                Err(DbOperationError::QueryFailedAfterChange {
+                    refresh_scope: RefreshScope::Metadata,
+                    ..
+                })
+            ) {
+                return Err(format!("expected metadata-scope failure: {result:?}"));
+            }
+            db.adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("DROP TABLE IF EXISTS {table}"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to clean up DDL fixture: {error:?}"))?;
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn discards_real_cli_results_when_query_fails() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let result = db
+            .adapter()
+            .execute_adhoc(
+                db.dsn(),
+                &format!("SELECT missing_column FROM {MYSQL_FIXTURE_TABLE}"),
+                AccessMode::ReadWrite,
+            )
+            .await;
+        if !matches!(result, Err(DbOperationError::QueryFailed(ref details)) if details.contains("missing_column")) {
+            return Err(format!("expected a query failure without a result: {result:?}"));
+        }
+        Ok(())
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn times_out_real_cli_query_and_discards_output() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_adhoc(db.dsn(), "SELECT SLEEP(32)", AccessMode::ReadWrite)
+                .await;
+            if !matches!(result, Err(DbOperationError::Timeout(_))) {
+                return Err(format!("expected a query timeout: {result:?}"));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn rejects_next_process_when_global_sql_mode_is_unsupported() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let original = db.global_sql_mode().await?;
+        let unsupported = if original.is_empty() {
+            "ANSI_QUOTES".to_string()
+        } else {
+            format!("{original},ANSI_QUOTES")
+        };
+        let test_result = async {
+            db.set_global_sql_mode(&unsupported).await?;
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    "SELECT SLEEP(32)",
+                    AccessMode::ReadWrite,
+                )
+                .await;
+            if !matches!(result, Err(DbOperationError::UnsupportedOperation(ref details)) if details.contains(MYSQL_SQL_MODE_UNSUPPORTED_MARKER)) {
+                return Err(format!("expected unsupported sql_mode rejection: {result:?}"));
+            }
+            Ok::<(), String>(())
+        }
+        .await;
+        let restore_result = db.set_global_sql_mode(&original).await;
+        if let Err(error) = restore_result {
+            return Err(format!("failed to restore MySQL global sql_mode: {error}"));
+        }
+        if db.global_sql_mode().await? != original {
+            return Err("MySQL global sql_mode was not restored".to_string());
+        }
+        test_result
+    }))
+    .await;
+}

--- a/src/ui/features/browse/jsonb_detail.rs
+++ b/src/ui/features/browse/jsonb_detail.rs
@@ -9,6 +9,7 @@ use crate::app::model::browse::jsonb_detail::JsonbDetailMode;
 use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::model::shared::render_output::JsonbDetailLayout;
 use crate::app::model::shared::text_input::TextInputLike;
+use crate::app::policy::{FeaturePolicy, FeatureRequirement};
 use crate::features::browse::detail_view::render_detail_search;
 use crate::primitives::atoms::scroll_indicator::{
     VerticalScrollParams, clamp_scroll_offset, render_vertical_scroll_indicator_bar,
@@ -48,12 +49,14 @@ impl JsonbDetail {
         let hints = if is_editing {
             vec![("Esc", "Normal")]
         } else {
-            vec![
-                ("y", "Copy"),
-                ("/", "Search"),
-                ("i", "Insert"),
-                ("Esc", "Close"),
-            ]
+            let feature_policy = FeaturePolicy::new(state.session.active_engine_feature_profile());
+            let mut hints = vec![("y", "Copy")];
+            hints.push(("/", "Search"));
+            if feature_policy.is_enabled(FeatureRequirement::JsonDocumentEdit) {
+                hints.push(("i", "Insert"));
+            }
+            hints.push(("Esc", "Close"));
+            hints
         };
 
         let (_area, inner) = render_modal(

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -23,6 +23,7 @@ use crate::app::update::input::keybindings::{
     sql_modal, sql_modal_confirming, sqlite_diagnostics, table_picker,
     table_picker as table_picker_key,
 };
+use crate::domain::DatabaseType;
 use crate::features::settings::hints::settings_hints;
 use crate::primitives::atoms::key_text;
 use crate::primitives::atoms::spinner_char;
@@ -163,6 +164,9 @@ impl Footer {
                     }
                     if state.ui.focused_pane() == FocusedPane::Explorer {
                         list.push(global::CONNECTIONS.as_hint());
+                    }
+                    if state.session.active_database_type() == Some(DatabaseType::MySQL) {
+                        list.push(global::DATABASE_PICKER.as_hint());
                     }
                     list.push(table_picker_key(keymap_preset).as_hint());
                     list.push(query_history(keymap_preset).as_hint());
@@ -342,7 +346,7 @@ impl Footer {
             InputMode::JsonbDetail => {
                 let feature_policy =
                     FeaturePolicy::new(state.session.active_engine_feature_profile());
-                if !feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
+                if !feature_policy.is_enabled(FeatureRequirement::JsonDocumentDetail) {
                     vec![jsonb_detail::CLOSE.as_hint()]
                 } else if matches!(state.jsonb_detail.mode(), JsonbDetailMode::Searching) {
                     vec![
@@ -351,20 +355,23 @@ impl Footer {
                         jsonb_search::CANCEL.as_hint(),
                     ]
                 } else {
-                    vec![
-                        jsonb_detail::YANK.as_hint(),
-                        jsonb_detail::INSERT.as_hint(),
+                    let mut hints = vec![jsonb_detail::YANK.as_hint()];
+                    if feature_policy.is_enabled(FeatureRequirement::JsonDocumentEdit) {
+                        hints.push(jsonb_detail::INSERT.as_hint());
+                    }
+                    hints.extend([
                         jsonb_detail::SEARCH.as_hint(),
                         jsonb_detail::NEXT_PREV.as_hint(),
                         jsonb_detail::MOVE.as_hint(),
                         jsonb_detail::CLOSE.as_hint(),
-                    ]
+                    ]);
+                    hints
                 }
             }
             InputMode::JsonbEdit => {
                 let feature_policy =
                     FeaturePolicy::new(state.session.active_engine_feature_profile());
-                if feature_policy.is_enabled(FeatureRequirement::JsonbDetail) {
+                if feature_policy.is_enabled(FeatureRequirement::JsonDocumentEdit) {
                     vec![
                         jsonb_edit::ESC_NORMAL.as_hint(),
                         jsonb_edit::MOVE.as_hint(),
@@ -543,6 +550,24 @@ mod tests {
             Footer::get_context_hints(&state),
             vec![jsonb_edit::ESC_NORMAL.as_hint()]
         );
+    }
+
+    #[test]
+    fn mysql_json_detail_shows_edit_hint() {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            DatabaseType::MySQL,
+            "mysql://test",
+        );
+        state.modal.set_mode(InputMode::JsonbDetail);
+
+        let hints = Footer::get_context_hints(&state);
+
+        assert!(hints.contains(&jsonb_detail::INSERT.as_hint()));
+        assert!(hints.contains(&jsonb_detail::YANK.as_hint()));
+        assert!(hints.contains(&jsonb_detail::SEARCH.as_hint()));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

MySQL structured-data workflows span safe grid writes, visible and invisible row identity, JSON inspection and document replacement, and ER generation. Their shared state and feature-policy boundaries need a coherent review without exceeding CodeRabbit's file limit.

## Approach

Review the grid, JSON, and ER workflow files from final MySQL snapshot `e96e8f7d567a014e9650901532bb123cb95131ea` against main snapshot `6c91adfb7dadbb6616b706faadf2ba5a78f39e38`.

This is a synthetic review-only pull request and must not be merged. It intentionally excludes connection and TLS setup, general browsing and DDL presentation, SQL history/completion/export, execution-plan presentation, and final documentation. Shared state, policy, adapter, and fixture files are included only where needed to understand structured-data behavior.

The slice is not a release candidate and is not expected to build independently because adjacent MySQL modules are intentionally absent. The source of truth remains the final `mysql` snapshot above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MySQL connection support, including database selection, TLS configuration, metadata browsing, previews, explain plans, and ER diagrams.
  - Added support for MySQL JSON viewing, formatting, editing, numeric values, binary data, and structured comparisons.
  - Added database-aware query history and refresh behavior.

- **Bug Fixes**
  - Improved editing with hidden or generated primary keys and explicit row identities.
  - Prevented stale connection, query, and diagram results from updating the interface.
  - Improved validation for invalid JSON, numeric values, and unsupported write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->