### PR TITLE
chore: review MySQL execution plans

### DIFF
--- a/src/app/cmd/browse/query.rs
+++ b/src/app/cmd/browse/query.rs
@@ -6,11 +6,13 @@ use tokio::sync::mpsc;
 
 use crate::cmd::effect::Effect;
 use crate::cmd::query_task::QueryTaskRegistry;
-use crate::domain::ConnectionId;
-use crate::domain::QuerySource;
 use crate::domain::command_tag::CommandTag;
-use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
-use crate::domain::sqlite_explain_query_plan_text_from_result;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope, QueryResultStatus};
+use crate::domain::{DatabaseType, QuerySource};
+use crate::domain::{
+    mysql_explain_plan_text_from_result, postgres_explain_plan_text_from_result,
+    sqlite_explain_query_plan_text_from_result,
+};
 use crate::model::app_state::AppState;
 use crate::ports::outbound::{CachedResultExporter, QueryExecutor, QueryHistoryStore};
 use crate::update::action::Action;
@@ -48,24 +50,25 @@ fn save_query_history(
     query_history_store: &Arc<dyn QueryHistoryStore>,
     action_tx: &mpsc::Sender<Action>,
     project_name: &str,
-    connection_id: &ConnectionId,
+    scope: &QueryHistoryScope,
     query: &str,
     result_status: QueryResultStatus,
     affected_rows: Option<u64>,
 ) {
     let store = Arc::clone(query_history_store);
     let tx = action_tx.clone();
-    let entry = QueryHistoryEntry::new(
+    let entry = QueryHistoryEntry::new_with_database(
         query.to_string(),
         utc_now_iso8601(),
-        connection_id.clone(),
+        scope.connection_id.clone(),
+        scope.database.clone(),
         result_status,
         affected_rows,
     );
     let project = project_name.to_string();
-    let conn_id = connection_id.clone();
+    let scope = scope.clone();
     tokio::spawn(async move {
-        if let Err(e) = store.append(&project, &conn_id, &entry).await {
+        if let Err(e) = store.append(&project, &scope, &entry).await {
             let _ = tx.send(Action::QueryHistoryAppendFailed(e)).await;
         }
     });
@@ -137,6 +140,8 @@ pub async fn run(
 
         Effect::ExecuteExplain {
             dsn,
+            database_type,
+            database_generation,
             run_id,
             query,
             source_query,
@@ -149,9 +154,19 @@ pub async fn run(
             query_tasks.spawn(async move {
                 match executor.execute_adhoc(&dsn, &query, access_mode).await {
                     Ok(result) => {
-                        let plan_text = sqlite_explain_query_plan_text_from_result(&result);
+                        let plan_text = match database_type {
+                            DatabaseType::SQLite => {
+                                sqlite_explain_query_plan_text_from_result(&result)
+                            }
+                            DatabaseType::PostgreSQL => {
+                                postgres_explain_plan_text_from_result(&result)
+                            }
+                            DatabaseType::MySQL => mysql_explain_plan_text_from_result(&result),
+                        };
                         tx.send(Action::ExplainCompleted {
                             dsn,
+                            database_type,
+                            database_generation,
                             run_id,
                             query: source_query,
                             plan_text,
@@ -164,6 +179,7 @@ pub async fn run(
                     Err(e) => {
                         tx.send(Action::ExplainFailed {
                             dsn,
+                            database_generation,
                             run_id,
                             error: e,
                             is_analyze,
@@ -187,13 +203,13 @@ pub async fn run(
             let history_store = Arc::clone(query_history_store);
             let history_tx = action_tx.clone();
             let project = state.runtime.project_name().to_string();
-            let conn_id = state.session.active_connection_id().cloned();
+            let history_scope = state.session.query_history_scope();
             let query_for_history = query.clone();
 
             query_tasks.spawn(async move {
                 match executor.execute_adhoc(&dsn, &query, access_mode).await {
                     Ok(result) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             let rows = result
                                 .command_tag
                                 .as_ref()
@@ -202,7 +218,7 @@ pub async fn run(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Success,
                                 rows,
@@ -219,12 +235,12 @@ pub async fn run(
                         .ok();
                     }
                     Err(e) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             save_query_history(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Failed,
                                 None,
@@ -256,18 +272,18 @@ pub async fn run(
             let history_store = Arc::clone(query_history_store);
             let history_tx = action_tx.clone();
             let project = state.runtime.project_name().to_string();
-            let conn_id = state.session.active_connection_id().cloned();
+            let history_scope = state.session.query_history_scope();
             let query_for_history = query.clone();
 
             query_tasks.spawn(async move {
                 match executor.execute_write(&dsn, &query, access_mode).await {
                     Ok(result) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             save_query_history(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Success,
                                 Some(result.affected_rows as u64),
@@ -282,12 +298,12 @@ pub async fn run(
                         .ok();
                     }
                     Err(e) => {
-                        if let Some(cid) = &conn_id {
+                        if let Some(scope) = &history_scope {
                             save_query_history(
                                 &history_store,
                                 &history_tx,
                                 &project,
-                                cid,
+                                scope,
                                 &query_for_history,
                                 QueryResultStatus::Failed,
                                 None,
@@ -779,6 +795,7 @@ mod tests {
 
     mod execute_access_mode {
         use super::*;
+        use crate::domain::DatabaseType;
 
         struct NoopRenderer;
         impl Renderer for NoopRenderer {
@@ -858,6 +875,8 @@ mod tests {
             let action = run_effect(
                 Effect::ExecuteExplain {
                     dsn: "dsn://test".to_string(),
+                    database_type: DatabaseType::PostgreSQL,
+                    database_generation: 0,
                     run_id: 2,
                     query: "EXPLAIN SELECT 1".to_string(),
                     source_query: "SELECT 1".to_string(),

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -1,7 +1,8 @@
-use crate::domain::connection::{ConnectionConfig, ConnectionId};
+use crate::domain::connection::{ConnectionConfig, ConnectionId, DatabaseType};
+use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{QueryValue, Table};
 use crate::ports::outbound::{AccessMode, AppSettings};
-use crate::update::action::Action;
+use crate::update::action::{Action, ConnectionTarget};
 
 #[derive(Debug, Clone)]
 pub enum Effect {
@@ -11,6 +12,16 @@ pub enum Effect {
         id: Option<ConnectionId>,
         name: String,
         config: ConnectionConfig,
+    },
+    ProbeConnection {
+        target: ConnectionTarget,
+        run_id: u64,
+    },
+    FetchMySqlDatabases {
+        connection_id: ConnectionId,
+        dsn: String,
+        connection_generation: u64,
+        database_generation: u64,
     },
     LoadConnectionForEdit {
         id: ConnectionId,
@@ -72,6 +83,8 @@ pub enum Effect {
     },
     ExecuteExplain {
         dsn: String,
+        database_type: DatabaseType,
+        database_generation: u64,
         run_id: u64,
         query: String,
         source_query: String,
@@ -122,6 +135,7 @@ pub enum Effect {
     TriggerCompletion,
 
     GenerateErDiagramFromCache {
+        run_id: u64,
         total_tables: usize,
         project_name: String,
         target_tables: Vec<String>,
@@ -148,7 +162,7 @@ pub enum Effect {
 
     LoadQueryHistory {
         project_name: String,
-        connection_id: ConnectionId,
+        scope: QueryHistoryScope,
     },
 
     SaveSettings {

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use super::explain_context::ExplainContext;
 use super::runtime_state::RuntimeState;
 use crate::domain::connection::{ConnectionProfile, ServiceEntry};
-use crate::domain::{DatabaseType, TableSummary};
+use crate::domain::{Column, DatabaseType, TableSummary};
 use crate::model::browse::cell_detail::CellDetailState;
 use crate::model::browse::inspector_view_model::InspectorViewModel;
 use crate::model::browse::jsonb_detail::JsonbDetailState;
@@ -33,7 +33,9 @@ use crate::policy::preview_cell_text::CellPresentationPolicy;
 use crate::policy::sql::result_query::is_rerunnable_select;
 use crate::policy::table_kind::max_explorer_table_label_width;
 use crate::policy::write::inline_cell_edit::supports_inline_edit;
-use crate::policy::write::write_guardrails::{PreviewWriteability, preview_writeability};
+use crate::policy::write::write_guardrails::{
+    PreviewWriteability, preview_writeability_for_result,
+};
 use crate::ports::outbound::DdlGenerator;
 
 pub struct AppState {
@@ -287,6 +289,20 @@ impl AppState {
             .unwrap_or_default()
     }
 
+    pub fn filtered_databases(&self) -> Vec<&String> {
+        let filter_lower = self
+            .ui
+            .table_picker()
+            .filter_input()
+            .content()
+            .to_lowercase();
+        self.session
+            .available_databases()
+            .iter()
+            .filter(|database| database.to_lowercase().contains(&filter_lower))
+            .collect()
+    }
+
     pub fn er_filtered_tables(&self) -> Vec<&TableSummary> {
         let filter_lower = self.ui.er_picker().filter_input().content().to_lowercase();
         self.session
@@ -371,7 +387,8 @@ impl AppState {
         if !self.query.pagination.matches_table(table_detail) {
             return None;
         }
-        match preview_writeability(table_detail) {
+        let result = self.query.visible_result()?;
+        match preview_writeability_for_result(table_detail, result) {
             PreviewWriteability::Writable => None,
             PreviewWriteability::ReadOnly(reason) => Some(reason),
             PreviewWriteability::MissingStableRowIdentity => Some("table without PRIMARY KEY"),
@@ -381,6 +398,16 @@ impl AppState {
     pub fn can_write_visible_preview(&self) -> bool {
         self.query.can_edit_visible_result()
             && self.visible_preview_target_read_only_reason().is_none()
+    }
+
+    pub fn visible_preview_column(&self, col_idx: usize) -> Option<&Column> {
+        let result = self.query.visible_result()?;
+        let column_name = result.columns.get(col_idx)?;
+        let table_detail = self.session.table_detail()?;
+        table_detail
+            .columns
+            .iter()
+            .find(|column| column.name == *column_name)
     }
 
     pub fn can_edit_selected_cell(&self) -> bool {
@@ -404,28 +431,26 @@ impl AppState {
             return false;
         };
 
-        if let Some(table_detail) = self.session.table_detail()
-            && let Some(column) = table_detail.columns.get(col_idx)
-        {
-            if table_detail
-                .primary_key
-                .as_ref()
-                .is_some_and(|pk| pk.iter().any(|name| name == &column.name))
-            {
-                return false;
-            }
-            if column.is_read_only() {
-                return false;
-            }
+        let Some(column) = self.visible_preview_column(col_idx) else {
+            return false;
+        };
+        let is_primary_key = column.is_primary_key()
+            || self
+                .session
+                .table_detail()
+                .and_then(|table| table.primary_key.as_ref())
+                .is_some_and(|primary_key| primary_key.iter().any(|name| name == &column.name));
+        if is_primary_key || column.is_read_only() {
+            return false;
+        }
 
-            let policy = CellPresentationPolicy::new(
-                self.session.active_database_type_or_default(),
-                column.data_type.as_str(),
-                value.as_str().unwrap_or_default(),
-            );
-            if policy.uses_jsonb_detail_modal() {
-                return true;
-            }
+        let policy = CellPresentationPolicy::new(
+            self.session.active_database_type_or_default(),
+            column.data_type.as_str(),
+            value.as_str().unwrap_or_default(),
+        );
+        if policy.uses_jsonb_detail_modal() {
+            return true;
         }
 
         supports_inline_edit(self.session.active_database_type_or_default(), value)
@@ -435,6 +460,11 @@ impl AppState {
     /// connection and query run, and must be dropped without touching state.
     pub fn is_stale_query_run(&self, dsn: &str, run_id: u64) -> bool {
         !self.session.dsn_matches(dsn) || !self.query.is_current_run(run_id)
+    }
+
+    pub fn is_stale_explain_run(&self, dsn: &str, database_generation: u64, run_id: u64) -> bool {
+        self.is_stale_query_run(dsn, run_id)
+            || self.session.database_generation() != database_generation
     }
 }
 
@@ -447,8 +477,8 @@ mod tests {
 
     use super::*;
     use crate::domain::{
-        Column, ColumnAttributes, ConnectionId, DatabaseMetadata, DatabaseType, QueryResult,
-        QuerySource, QueryValue, Table, TableKind, TableKindInfo,
+        ColumnAttributes, ConnectionId, DatabaseMetadata, DatabaseType, QueryResult, QuerySource,
+        QueryValue, Table, TableKind, TableKindInfo,
     };
     use crate::model::browse::row_detail::RowDetailState;
     use crate::model::er_state::ErStatus;
@@ -589,6 +619,129 @@ mod tests {
         state.result_interaction.activate_cell(0, 1);
 
         assert!(!state.can_edit_selected_cell());
+    }
+
+    #[test]
+    fn can_edit_selected_cell_maps_visible_column_by_name_after_hidden_primary_key() {
+        let mut state = make_state();
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "mysql",
+            DatabaseType::MySQL,
+            "mysql://localhost/test",
+        );
+        state.query.set_current_result(Arc::new(
+            QueryResult::success_with_values(
+                "SELECT `payload` FROM `sabiql_test`.`users`".to_string(),
+                vec!["payload".to_string()],
+                vec![vec![QueryValue::text("before")]],
+                10,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["id".to_string()],
+                vec![vec![QueryValue::SqlLiteral("1".to_string())]],
+            ),
+        ));
+        state
+            .query
+            .pagination
+            .reset_for_table("sabiql_test", "users");
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "sabiql_test".to_string(),
+            name: "users".to_string(),
+            columns: vec![
+                Column {
+                    name: "id".to_string(),
+                    data_type: "INT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::PRIMARY_KEY
+                        | ColumnAttributes::HIDDEN
+                        | ColumnAttributes::READ_ONLY,
+                    comment: None,
+                    ordinal_position: 1,
+                },
+                Column {
+                    name: "payload".to_string(),
+                    data_type: "TEXT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::empty(),
+                    comment: None,
+                    ordinal_position: 2,
+                },
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..test_support::table::minimal("", "")
+        }));
+        state.result_interaction.activate_cell(0, 0);
+
+        assert!(state.can_edit_selected_cell());
+    }
+
+    #[test]
+    fn can_edit_selected_cell_maps_visible_column_by_name_when_hidden_primary_key_is_between_columns()
+     {
+        let mut state = make_state();
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "mysql",
+            DatabaseType::MySQL,
+            "mysql://localhost/test",
+        );
+        state.query.set_current_result(Arc::new(
+            QueryResult::success_with_values(
+                "SELECT `name`, `payload` FROM `sabiql_test`.`users`".to_string(),
+                vec!["name".to_string(), "payload".to_string()],
+                vec![vec![QueryValue::text("Alice"), QueryValue::text("before")]],
+                10,
+                QuerySource::Preview,
+            )
+            .with_explicit_row_identity(
+                vec!["id".to_string()],
+                vec![vec![QueryValue::SqlLiteral("1".to_string())]],
+            ),
+        ));
+        state
+            .query
+            .pagination
+            .reset_for_table("sabiql_test", "users");
+        state.session.set_table_detail_raw(Some(Table {
+            schema: "sabiql_test".to_string(),
+            name: "users".to_string(),
+            columns: vec![
+                Column {
+                    name: "name".to_string(),
+                    data_type: "VARCHAR".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::empty(),
+                    comment: None,
+                    ordinal_position: 1,
+                },
+                Column {
+                    name: "id".to_string(),
+                    data_type: "INT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::PRIMARY_KEY
+                        | ColumnAttributes::HIDDEN
+                        | ColumnAttributes::READ_ONLY,
+                    comment: None,
+                    ordinal_position: 2,
+                },
+                Column {
+                    name: "payload".to_string(),
+                    data_type: "TEXT".to_string(),
+                    default: None,
+                    attributes: ColumnAttributes::empty(),
+                    comment: None,
+                    ordinal_position: 3,
+                },
+            ],
+            primary_key: Some(vec!["id".to_string()]),
+            ..test_support::table::minimal("", "")
+        }));
+        state.result_interaction.activate_cell(0, 1);
+
+        assert!(state.can_edit_selected_cell());
     }
 
     mod pane_geometry {

--- a/src/app/model/explain_context.rs
+++ b/src/app/model/explain_context.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 
+use crate::domain::DatabaseType;
 use crate::domain::explain_plan::{self, ExplainPlan};
 use crate::model::sql_editor::modal::sql_modal_visible_rows;
 
@@ -21,6 +22,7 @@ impl SlotSource {
 #[derive(Debug, Clone)]
 pub struct CompareSlot {
     pub plan: ExplainPlan,
+    pub database_type: DatabaseType,
     pub query_snippet: String,
     pub full_query: String,
     pub source: SlotSource,
@@ -54,6 +56,10 @@ impl ExplainContext {
 
     pub fn plan_query_snippet(&self) -> Option<&str> {
         self.plan_query_snippet.as_deref()
+    }
+
+    pub fn current_plan(&self) -> Option<&ExplainPlan> {
+        self.right.as_ref().map(|slot| &slot.plan)
     }
 
     pub fn error(&self) -> Option<&str> {
@@ -107,16 +113,25 @@ impl ExplainContext {
     pub fn set_plan(
         &mut self,
         text: String,
+        database_type: DatabaseType,
         is_analyze: bool,
         execution_time_ms: u64,
         query: &str,
     ) {
-        let parsed = explain_plan::parse_explain_text(&text, is_analyze, execution_time_ms);
+        let parsed = match database_type {
+            DatabaseType::PostgreSQL | DatabaseType::SQLite => {
+                explain_plan::parse_explain_text(&text, is_analyze, execution_time_ms)
+            }
+            DatabaseType::MySQL => {
+                explain_plan::parse_mysql_tree_explain_text(&text, is_analyze, execution_time_ms)
+            }
+        };
         let snippet = query.lines().next().unwrap_or("").to_string();
         let plan_snippet = snippet.clone();
 
         let new_slot = CompareSlot {
             plan: parsed,
+            database_type,
             query_snippet: snippet,
             full_query: query.to_string(),
             source: SlotSource::AutoLatest,
@@ -240,6 +255,7 @@ mod tests {
 
         ctx.set_plan(
             "Seq Scan  (cost=0.00..100.00 rows=10 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             42,
             "SELECT * FROM users",
@@ -253,10 +269,27 @@ mod tests {
     }
 
     #[test]
+    fn mysql_plan_uses_tree_parser() {
+        let mut ctx = ExplainContext::default();
+
+        ctx.set_plan(
+            "-> Table scan on users  (cost=1.25 rows=2.5)".to_string(),
+            DatabaseType::MySQL,
+            false,
+            0,
+            "SELECT * FROM users",
+        );
+
+        assert_eq!(ctx.right().unwrap().plan.total_cost, Some(1.25));
+        assert_eq!(ctx.right().unwrap().plan.estimated_rows, Some(2.5));
+    }
+
+    #[test]
     fn second_explain_auto_advances_right_to_left() {
         let mut ctx = ExplainContext::default();
         ctx.set_plan(
             "Seq Scan  (cost=0.00..100.00 rows=10 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             0,
             "SELECT * FROM users",
@@ -264,6 +297,7 @@ mod tests {
 
         ctx.set_plan(
             "Index Scan  (cost=0.00..5.00 rows=1 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             0,
             "SELECT * FROM users WHERE id = 1",
@@ -281,18 +315,21 @@ mod tests {
         let mut ctx = ExplainContext::default();
         ctx.set_plan(
             "A  (cost=0.00..10.00 rows=1 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             0,
             "A",
         );
         ctx.set_plan(
             "B  (cost=0.00..20.00 rows=2 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             0,
             "B",
         );
         ctx.set_plan(
             "C  (cost=0.00..30.00 rows=3 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             0,
             "C",
@@ -308,12 +345,14 @@ mod tests {
         let mut ctx = ExplainContext::default();
         ctx.set_plan(
             "A  (cost=0.00..100.00 rows=10 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             0,
             "A",
         );
         ctx.set_plan(
             "B  (cost=0.00..50.00 rows=5 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             0,
             "B",
@@ -337,12 +376,14 @@ mod tests {
         let mut ctx = ExplainContext::default();
         ctx.set_plan(
             "A  (cost=0.00..100.00 rows=10 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             0,
             "A",
         );
         ctx.set_plan(
             "B  (cost=0.00..50.00 rows=5 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             0,
             "B",
@@ -368,6 +409,7 @@ mod tests {
         let mut ctx = ExplainContext::default();
         ctx.set_plan(
             "A  (cost=0.00..10.00 rows=1 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             0,
             "A",
@@ -384,6 +426,7 @@ mod tests {
         for i in 0..15 {
             ctx.set_plan(
                 format!("Scan  (cost=0.00..{i}.00 rows=1 width=32)"),
+                DatabaseType::PostgreSQL,
                 false,
                 0,
                 &format!("Q{i}"),
@@ -399,6 +442,7 @@ mod tests {
 
         ctx.set_plan(
             "Seq Scan  (cost=0.00..10.00 rows=1 width=32)".to_string(),
+            DatabaseType::PostgreSQL,
             false,
             0,
             "SELECT *\nFROM users\nWHERE id = 1",
@@ -410,7 +454,13 @@ mod tests {
     #[test]
     fn line_count_with_plan() {
         let mut ctx = ExplainContext::default();
-        ctx.set_plan("line1\nline2\nline3".to_string(), false, 0, "Q");
+        ctx.set_plan(
+            "line1\nline2\nline3".to_string(),
+            DatabaseType::PostgreSQL,
+            false,
+            0,
+            "Q",
+        );
 
         assert_eq!(ctx.line_count(), 3);
     }

--- a/src/app/model/shared/engine_feature_profile.rs
+++ b/src/app/model/shared/engine_feature_profile.rs
@@ -16,7 +16,8 @@ pub enum InspectorInfoField {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConnectionFeature {
     ErDiagram,
-    JsonbDetail,
+    JsonDocumentDetail,
+    JsonDocumentEdit,
     SqliteDiagnostics,
 }
 
@@ -102,11 +103,36 @@ const SQLITE_INSPECTOR: InspectorProfile = InspectorProfile::new(
         InspectorInfoField::TableFlags,
     ],
 );
+const MYSQL_INSPECTOR: InspectorProfile = InspectorProfile::new(
+    &[
+        InspectorTab::Info,
+        InspectorTab::Columns,
+        InspectorTab::Indexes,
+        InspectorTab::ForeignKeys,
+        InspectorTab::Triggers,
+        InspectorTab::Ddl,
+    ],
+    &[
+        InspectorInfoField::Comment,
+        InspectorInfoField::RowCount,
+        InspectorInfoField::Schema,
+        InspectorInfoField::TableName,
+        InspectorInfoField::TableKind,
+    ],
+);
 
 const NO_CONNECTION_FEATURES: &[ConnectionFeature] = &[];
-const POSTGRESQL_FEATURES: &[ConnectionFeature] =
-    &[ConnectionFeature::ErDiagram, ConnectionFeature::JsonbDetail];
+const POSTGRESQL_FEATURES: &[ConnectionFeature] = &[
+    ConnectionFeature::ErDiagram,
+    ConnectionFeature::JsonDocumentDetail,
+    ConnectionFeature::JsonDocumentEdit,
+];
 const SQLITE_FEATURES: &[ConnectionFeature] = &[ConnectionFeature::SqliteDiagnostics];
+const MYSQL_FEATURES: &[ConnectionFeature] = &[
+    ConnectionFeature::ErDiagram,
+    ConnectionFeature::JsonDocumentDetail,
+    ConnectionFeature::JsonDocumentEdit,
+];
 
 impl EngineFeatureProfile {
     fn new(
@@ -167,10 +193,21 @@ impl EngineFeatureProfile {
         )
     }
 
+    pub fn mysql_like() -> Self {
+        Self::new(
+            MYSQL_INSPECTOR,
+            ExplainProfile::QueryPlanAndAnalyze {
+                comparison: ComparisonSupport::Supported,
+            },
+            MYSQL_FEATURES,
+        )
+    }
+
     pub fn for_database_type(database_type: DatabaseType) -> Self {
         match database_type {
             DatabaseType::PostgreSQL => Self::postgres_like(),
             DatabaseType::SQLite => Self::sqlite_like(),
+            DatabaseType::MySQL => Self::mysql_like(),
         }
     }
 
@@ -207,8 +244,12 @@ impl EngineFeatureProfile {
         )
     }
 
-    pub fn supports_jsonb_detail(&self) -> bool {
-        self.supports_connection_feature(ConnectionFeature::JsonbDetail)
+    pub fn supports_json_document_detail(&self) -> bool {
+        self.supports_connection_feature(ConnectionFeature::JsonDocumentDetail)
+    }
+
+    pub fn supports_json_document_edit(&self) -> bool {
+        self.supports_connection_feature(ConnectionFeature::JsonDocumentEdit)
     }
 
     pub fn supports_sqlite_diagnostics(&self) -> bool {
@@ -336,7 +377,8 @@ mod tests {
         assert!(profile.supports_explain_analyze());
         assert!(profile.supports_plan_comparison());
         assert!(profile.supports_er_diagram());
-        assert!(profile.supports_jsonb_detail());
+        assert!(profile.supports_json_document_detail());
+        assert!(profile.supports_json_document_edit());
         assert!(!profile.supports_sqlite_diagnostics());
         assert!(profile.supports_inspector_tab(InspectorTab::Ddl));
         assert_eq!(
@@ -371,7 +413,8 @@ mod tests {
         assert!(!profile.supports_explain_analyze());
         assert!(!profile.supports_plan_comparison());
         assert!(!profile.supports_er_diagram());
-        assert!(!profile.supports_jsonb_detail());
+        assert!(!profile.supports_json_document_detail());
+        assert!(!profile.supports_json_document_edit());
         assert!(profile.supports_sqlite_diagnostics());
         assert_eq!(
             profile.supported_inspector_tabs(),
@@ -410,6 +453,48 @@ mod tests {
             EngineFeatureProfile::for_database_type(DatabaseType::SQLite),
             EngineFeatureProfile::sqlite_like()
         );
+        assert_eq!(
+            EngineFeatureProfile::for_database_type(DatabaseType::MySQL),
+            EngineFeatureProfile::mysql_like()
+        );
+    }
+
+    #[test]
+    fn mysql_profile_exposes_browse_metadata_ddl_analyze_and_compare() {
+        let profile = EngineFeatureProfile::mysql_like();
+
+        assert!(profile.supports_explain());
+        assert!(profile.supports_explain_analyze());
+        assert!(profile.supports_plan_comparison());
+        assert!(profile.supports_er_diagram());
+        assert!(profile.supports_json_document_detail());
+        assert!(profile.supports_json_document_edit());
+        assert!(!profile.supports_sqlite_diagnostics());
+        assert_eq!(
+            profile.supported_inspector_tabs(),
+            &[
+                InspectorTab::Info,
+                InspectorTab::Columns,
+                InspectorTab::Indexes,
+                InspectorTab::ForeignKeys,
+                InspectorTab::Triggers,
+                InspectorTab::Ddl,
+            ]
+        );
+        assert_eq!(
+            profile.supported_inspector_info_fields(),
+            &[
+                InspectorInfoField::Comment,
+                InspectorInfoField::RowCount,
+                InspectorInfoField::Schema,
+                InspectorInfoField::TableName,
+                InspectorInfoField::TableKind,
+            ]
+        );
+        assert_eq!(
+            profile.supported_sql_modal_tabs(),
+            &[SqlModalTab::Sql, SqlModalTab::Plan, SqlModalTab::Compare]
+        );
     }
 
     #[test]
@@ -420,7 +505,8 @@ mod tests {
         assert!(!profile.supports_explain_analyze());
         assert!(!profile.supports_plan_comparison());
         assert!(!profile.supports_er_diagram());
-        assert!(!profile.supports_jsonb_detail());
+        assert!(!profile.supports_json_document_detail());
+        assert!(!profile.supports_json_document_edit());
         assert!(!profile.supports_sqlite_diagnostics());
         assert_eq!(profile.supported_inspector_tabs(), &[InspectorTab::Info]);
         assert_eq!(

--- a/src/app/policy/sql/mysql_statement.rs
+++ b/src/app/policy/sql/mysql_statement.rs
@@ -1,0 +1,1182 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MysqlStatementKind {
+    Select,
+    Table,
+    Show,
+    Describe,
+    Insert,
+    Replace,
+    Update { has_where: bool },
+    Delete { has_where: bool },
+    CreateTable { temporary: bool },
+    AlterTable,
+    DropTable { temporary: bool },
+    TruncateTable,
+    CreateView,
+    DropView,
+    CreateIndex,
+    DropIndex,
+    Begin,
+    StartTransaction,
+    Commit,
+    Rollback,
+    Savepoint,
+    RollbackToSavepoint,
+    ReleaseSavepoint,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MysqlStatement {
+    pub sql: String,
+    pub kind: MysqlStatementKind,
+    pub target: Option<String>,
+    pub target_database: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MysqlLexError(pub String);
+
+impl fmt::Display for MysqlLexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TokenKind {
+    Word(String),
+    Identifier(String),
+    StringLiteral,
+    Number,
+    Symbol(char),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Token {
+    kind: TokenKind,
+    depth: usize,
+}
+
+pub fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MysqlLexError> {
+    let mut statements = Vec::new();
+    let mut start = 0;
+    let mut index = 0;
+    let mut quote = None;
+    let bytes = sql.as_bytes();
+    let mut depth = 0usize;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if let Some(delimiter) = quote {
+            if byte == b'\\' && delimiter != b'`' {
+                index += 2;
+                continue;
+            }
+            if byte == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                } else {
+                    quote = None;
+                    index += 1;
+                }
+                continue;
+            }
+            index += 1;
+            continue;
+        }
+
+        if is_line_comment_start(bytes, index) {
+            index = skip_line_comment(bytes, index);
+            continue;
+        }
+        if bytes.get(index..index + 2) == Some(b"/*") {
+            index = skip_block_comment(bytes, index)?;
+            continue;
+        }
+        if matches!(byte, b'\'' | b'"' | b'`') {
+            quote = Some(byte);
+            index += 1;
+            continue;
+        }
+        match byte {
+            b'(' => depth += 1,
+            b')' => {
+                depth = depth
+                    .checked_sub(1)
+                    .ok_or_else(|| MysqlLexError("unbalanced MySQL parentheses".to_string()))?;
+            }
+            b';' if depth == 0 => {
+                push_mysql_statement(&mut statements, &sql[start..index]);
+                start = index + 1;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    if quote.is_some() {
+        return Err(MysqlLexError(
+            "unterminated MySQL quoted literal".to_string(),
+        ));
+    }
+    if depth != 0 {
+        return Err(MysqlLexError("unbalanced MySQL parentheses".to_string()));
+    }
+    push_mysql_statement(&mut statements, &sql[start..]);
+    Ok(statements)
+}
+
+fn push_mysql_statement(statements: &mut Vec<String>, fragment: &str) {
+    let trimmed = fragment.trim();
+    if !trimmed.is_empty() && !is_comment_only(trimmed) {
+        statements.push(trimmed.to_string());
+    }
+}
+
+fn is_line_comment_start(bytes: &[u8], index: usize) -> bool {
+    bytes[index] == b'#'
+        || (bytes.get(index..index + 2) == Some(b"--")
+            && bytes.get(index + 2).is_none_or(u8::is_ascii_whitespace))
+}
+
+fn skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() {
+        let byte = bytes[index];
+        index += 1;
+        if byte == b'\n' {
+            break;
+        }
+    }
+    index
+}
+
+fn skip_block_comment(bytes: &[u8], index: usize) -> Result<usize, MysqlLexError> {
+    let mut cursor = index + 2;
+    while cursor + 1 < bytes.len() {
+        if bytes[cursor] == b'*' && bytes[cursor + 1] == b'/' {
+            return Ok(cursor + 2);
+        }
+        cursor += 1;
+    }
+    Err(MysqlLexError(
+        "unterminated MySQL block comment".to_string(),
+    ))
+}
+
+fn is_comment_only(sql: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index].is_ascii_whitespace() {
+            index += 1;
+        } else if is_line_comment_start(bytes, index) {
+            index = skip_line_comment(bytes, index);
+        } else if bytes.get(index..index + 2) == Some(b"/*") {
+            if bytes.get(index + 2) == Some(&b'!') {
+                return false;
+            }
+            index = match skip_block_comment(bytes, index) {
+                Ok(next) => next,
+                Err(_) => return false,
+            };
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MysqlLexError> {
+    let bytes = sql.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    let mut depth = 0usize;
+    let mut leading_executable_version_comment = false;
+
+    while index < bytes.len() {
+        if bytes[index].is_ascii_whitespace() {
+            index += 1;
+            continue;
+        }
+        if is_line_comment_start(bytes, index) {
+            index = skip_line_comment(bytes, index);
+            continue;
+        }
+        if bytes.get(index..index + 2) == Some(b"/*") {
+            let end = skip_block_comment(bytes, index)?;
+            let body = &sql[index + 2..end - 2];
+            if let Some(body) = body.strip_prefix('!') {
+                let body = body.trim_start();
+                let version_len = body.bytes().take_while(u8::is_ascii_digit).count();
+                if version_len == 0 {
+                    return Err(MysqlLexError(
+                        "MySQL version comment has no verifiable version".to_string(),
+                    ));
+                }
+                let content = body[version_len..].trim_start();
+                if content.is_empty() {
+                    return Err(MysqlLexError(
+                        "MySQL version comment has no executable statement".to_string(),
+                    ));
+                }
+                let inner = lex_mysql_statement(content)?;
+                let executable_statement = inner.first().is_some_and(|token| {
+                    matches!(&token.kind, TokenKind::Word(word) if is_mysql_statement_keyword(word))
+                });
+                let contains_statement_separator = inner
+                    .iter()
+                    .any(|token| matches!(token.kind, TokenKind::Symbol(';')));
+                if tokens.is_empty() && executable_statement && !contains_statement_separator {
+                    tokens.extend(inner);
+                    leading_executable_version_comment = true;
+                } else if !inner.is_empty() {
+                    tokens.push(Token {
+                        kind: TokenKind::Word("UNSUPPORTED_VERSION_COMMENT".to_string()),
+                        depth,
+                    });
+                }
+            }
+            index = end;
+            continue;
+        }
+
+        if leading_executable_version_comment {
+            tokens.push(Token {
+                kind: TokenKind::Word("UNSUPPORTED_VERSION_COMMENT".to_string()),
+                depth,
+            });
+            leading_executable_version_comment = false;
+        }
+
+        let byte = bytes[index];
+        if matches!(byte, b'\'' | b'"' | b'`') {
+            let end = skip_quoted(bytes, index, byte)?;
+            let text = &sql[index + 1..end - 1];
+            let kind = if byte == b'`' {
+                TokenKind::Identifier(text.replace("``", "`"))
+            } else {
+                TokenKind::StringLiteral
+            };
+            tokens.push(Token { kind, depth });
+            index = end;
+            continue;
+        }
+        if byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$' {
+            let start = index;
+            index += 1;
+            while index < bytes.len()
+                && (bytes[index].is_ascii_alphanumeric() || matches!(bytes[index], b'_' | b'$'))
+            {
+                index += 1;
+            }
+            let word = sql[start..index].to_ascii_uppercase();
+            tokens.push(Token {
+                kind: TokenKind::Word(word),
+                depth,
+            });
+            continue;
+        }
+        if byte.is_ascii_digit() {
+            index += 1;
+            while index < bytes.len()
+                && (bytes[index].is_ascii_alphanumeric() || matches!(bytes[index], b'.' | b'_'))
+            {
+                index += 1;
+            }
+            tokens.push(Token {
+                kind: TokenKind::Number,
+                depth,
+            });
+            continue;
+        }
+        let kind = TokenKind::Symbol(byte as char);
+        tokens.push(Token { kind, depth });
+        match byte {
+            b'(' => depth += 1,
+            b')' => {
+                depth = depth
+                    .checked_sub(1)
+                    .ok_or_else(|| MysqlLexError("unbalanced MySQL parentheses".to_string()))?;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    Ok(tokens)
+}
+
+fn is_mysql_statement_keyword(word: &str) -> bool {
+    matches!(
+        word,
+        "SELECT"
+            | "TABLE"
+            | "SHOW"
+            | "DESCRIBE"
+            | "DESC"
+            | "WITH"
+            | "INSERT"
+            | "UPDATE"
+            | "DELETE"
+            | "CREATE"
+            | "ALTER"
+            | "DROP"
+            | "TRUNCATE"
+            | "BEGIN"
+            | "START"
+            | "COMMIT"
+            | "ROLLBACK"
+            | "SAVEPOINT"
+            | "RELEASE"
+            | "USE"
+            | "SET"
+            | "LOCK"
+            | "UNLOCK"
+            | "REPLACE"
+            | "CALL"
+            | "DO"
+            | "HANDLER"
+            | "LOAD"
+            | "PREPARE"
+            | "EXECUTE"
+            | "DEALLOCATE"
+            | "XA"
+    )
+}
+
+fn skip_quoted(bytes: &[u8], index: usize, quote: u8) -> Result<usize, MysqlLexError> {
+    let mut cursor = index + 1;
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\\' && quote != b'`' {
+            cursor += 2;
+            continue;
+        }
+        if bytes[cursor] == quote {
+            if bytes.get(cursor + 1) == Some(&quote) {
+                cursor += 2;
+            } else {
+                return Ok(cursor + 1);
+            }
+        } else {
+            cursor += 1;
+        }
+    }
+    Err(MysqlLexError(
+        "unterminated MySQL quoted literal".to_string(),
+    ))
+}
+
+fn word(tokens: &[Token], index: usize) -> Option<&str> {
+    match tokens.get(index)?.kind {
+        TokenKind::Word(ref word) => Some(word),
+        _ => None,
+    }
+}
+
+fn top_level_word(tokens: &[Token], word_value: &str) -> bool {
+    tokens.iter().any(|token| {
+        token.depth == 0 && matches!(&token.kind, TokenKind::Word(word) if word == word_value)
+    })
+}
+
+fn identifier_at(tokens: &[Token], mut index: usize) -> Option<(String, Option<String>, usize)> {
+    while matches!(
+        tokens.get(index).map(|token| &token.kind),
+        Some(TokenKind::Symbol(','))
+    ) {
+        index += 1;
+    }
+    let first = match &tokens.get(index)?.kind {
+        TokenKind::Word(word) => word.clone(),
+        TokenKind::Identifier(identifier) => identifier.clone(),
+        _ => return None,
+    };
+    if matches!(
+        tokens.get(index + 1).map(|token| &token.kind),
+        Some(TokenKind::Symbol('.'))
+    ) {
+        let second = match &tokens.get(index + 2)?.kind {
+            TokenKind::Word(word) => word.clone(),
+            TokenKind::Identifier(identifier) => identifier.clone(),
+            _ => return None,
+        };
+        return Some((second, Some(first), index + 3));
+    }
+    Some((first, None, index + 1))
+}
+
+fn skip_mysql_modifiers(tokens: &[Token], mut index: usize, modifiers: &[&str]) -> usize {
+    while word(tokens, index).is_some_and(|value| modifiers.contains(&value)) {
+        index += 1;
+    }
+    index
+}
+
+fn find_word(tokens: &[Token], value: &str, start: usize) -> Option<usize> {
+    tokens
+        .iter()
+        .enumerate()
+        .skip(start)
+        .find_map(|(index, token)| {
+            (token.depth == 0 && matches!(&token.kind, TokenKind::Word(word) if word == value))
+                .then_some(index)
+        })
+}
+
+fn cte_body_start(tokens: &[Token]) -> Option<usize> {
+    if word(tokens, 0) != Some("WITH") {
+        return None;
+    }
+    let mut index = 1;
+    if word(tokens, index) == Some("RECURSIVE") {
+        index += 1;
+    }
+    loop {
+        if !matches!(
+            tokens.get(index).map(|token| &token.kind),
+            Some(TokenKind::Word(_) | TokenKind::Identifier(_))
+        ) {
+            return None;
+        }
+        index += 1;
+        if matches!(
+            tokens.get(index).map(|token| &token.kind),
+            Some(TokenKind::Symbol('('))
+        ) {
+            index = skip_parenthesized_tokens(tokens, index)?;
+        }
+        if word(tokens, index) != Some("AS") {
+            return None;
+        }
+        index += 1;
+        if !matches!(
+            tokens.get(index).map(|token| &token.kind),
+            Some(TokenKind::Symbol('('))
+        ) {
+            return None;
+        }
+        index = skip_parenthesized_tokens(tokens, index)?;
+        if matches!(
+            tokens.get(index).map(|token| &token.kind),
+            Some(TokenKind::Symbol(','))
+        ) {
+            index += 1;
+            continue;
+        }
+        return Some(index);
+    }
+}
+
+fn skip_parenthesized_tokens(tokens: &[Token], index: usize) -> Option<usize> {
+    if !matches!(
+        tokens.get(index).map(|token| &token.kind),
+        Some(TokenKind::Symbol('('))
+    ) {
+        return None;
+    }
+    let mut depth = 0usize;
+    for (cursor, token) in tokens.iter().enumerate().skip(index) {
+        match token.kind {
+            TokenKind::Symbol('(') => depth += 1,
+            TokenKind::Symbol(')') => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(cursor + 1);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn drop_target_after(
+    tokens: &[Token],
+    index: usize,
+) -> Result<(Option<String>, Option<String>), MysqlLexError> {
+    let (target, database, next) = identifier_at(tokens, index)
+        .ok_or_else(|| MysqlLexError("MySQL statement target is ambiguous".to_string()))?;
+    if tokens[next..]
+        .iter()
+        .any(|token| token.depth == 0 && matches!(token.kind, TokenKind::Symbol(',')))
+    {
+        return Err(MysqlLexError(
+            "MySQL DROP statements must have one target".to_string(),
+        ));
+    }
+    Ok((Some(target), database))
+}
+
+fn effective_start(tokens: &[Token]) -> usize {
+    cte_body_start(tokens).unwrap_or(0)
+}
+
+fn kind_and_target(
+    tokens: &[Token],
+) -> Result<(MysqlStatementKind, Option<String>, Option<String>), MysqlLexError> {
+    let start = effective_start(tokens);
+    let first =
+        word(tokens, start).ok_or_else(|| MysqlLexError("unknown MySQL statement".to_string()))?;
+    let target_after = |index: usize| {
+        identifier_at(tokens, index)
+            .map(|(target, database, _)| (Some(target), database))
+            .ok_or_else(|| MysqlLexError("MySQL statement target is ambiguous".to_string()))
+    };
+
+    let result = match first {
+        "SELECT" => (MysqlStatementKind::Select, None, None),
+        "TABLE" => (MysqlStatementKind::Table, None, None),
+        "SHOW" => (MysqlStatementKind::Show, None, None),
+        "DESCRIBE" | "DESC" => (MysqlStatementKind::Describe, None, None),
+        "INSERT" | "REPLACE" => {
+            let index = if first == "INSERT" {
+                skip_mysql_modifiers(
+                    tokens,
+                    start + 1,
+                    &["LOW_PRIORITY", "DELAYED", "HIGH_PRIORITY", "IGNORE"],
+                )
+            } else {
+                skip_mysql_modifiers(tokens, start + 1, &["LOW_PRIORITY", "DELAYED"])
+            };
+            let target_index = if word(tokens, index) == Some("INTO") {
+                index + 1
+            } else {
+                index
+            };
+            let (target, database) = target_after(target_index)?;
+            let kind = if first == "REPLACE" {
+                MysqlStatementKind::Replace
+            } else {
+                MysqlStatementKind::Insert
+            };
+            (kind, target, database)
+        }
+        "UPDATE" => {
+            let has_where = top_level_word(&tokens[start..], "WHERE");
+            let target_index = skip_mysql_modifiers(tokens, start + 1, &["LOW_PRIORITY", "IGNORE"]);
+            let (target, database) = target_after(target_index)?;
+            (MysqlStatementKind::Update { has_where }, target, database)
+        }
+        "DELETE" => {
+            let has_where = top_level_word(&tokens[start..], "WHERE");
+            let index =
+                skip_mysql_modifiers(tokens, start + 1, &["LOW_PRIORITY", "QUICK", "IGNORE"]);
+            let target_index = if word(tokens, index) == Some("FROM") {
+                index + 1
+            } else {
+                index
+            };
+            let (target, database) = target_after(target_index)?;
+            (MysqlStatementKind::Delete { has_where }, target, database)
+        }
+        "CREATE" => {
+            let mut index = start + 1;
+            let temporary = word(tokens, index) == Some("TEMPORARY");
+            if temporary {
+                index += 1;
+            }
+            match word(tokens, index) {
+                Some("TABLE") => {
+                    index += 1;
+                    if word(tokens, index) == Some("IF") {
+                        index += 3;
+                    }
+                    let (target, database) = target_after(index)?;
+                    (
+                        MysqlStatementKind::CreateTable { temporary },
+                        target,
+                        database,
+                    )
+                }
+                Some("VIEW") => {
+                    let (target, database) = target_after(index + 1)?;
+                    (MysqlStatementKind::CreateView, target, database)
+                }
+                Some("UNIQUE") if word(tokens, index + 1) == Some("INDEX") => {
+                    let on = find_word(tokens, "ON", index + 2).ok_or_else(|| {
+                        MysqlLexError("CREATE INDEX target is ambiguous".to_string())
+                    })?;
+                    let (_, database) = target_after(on + 1)?;
+                    let (index_name, _, _) = identifier_at(tokens, index + 2).ok_or_else(|| {
+                        MysqlLexError("CREATE INDEX name is ambiguous".to_string())
+                    })?;
+                    (MysqlStatementKind::CreateIndex, Some(index_name), database)
+                }
+                Some("INDEX" | "KEY") => {
+                    let on = find_word(tokens, "ON", index + 1).ok_or_else(|| {
+                        MysqlLexError("CREATE INDEX target is ambiguous".to_string())
+                    })?;
+                    let (_, database) = target_after(on + 1)?;
+                    let (index_name, _, _) = identifier_at(tokens, index + 1).ok_or_else(|| {
+                        MysqlLexError("CREATE INDEX name is ambiguous".to_string())
+                    })?;
+                    (MysqlStatementKind::CreateIndex, Some(index_name), database)
+                }
+                _ => {
+                    return Err(MysqlLexError(
+                        "unsupported MySQL CREATE statement".to_string(),
+                    ));
+                }
+            }
+        }
+        "ALTER" => {
+            if word(tokens, start + 1) != Some("TABLE") {
+                return Err(MysqlLexError(
+                    "unsupported MySQL ALTER statement".to_string(),
+                ));
+            }
+            let (target, database) = target_after(start + 2)?;
+            (MysqlStatementKind::AlterTable, target, database)
+        }
+        "DROP" => {
+            let mut index = start + 1;
+            let temporary = word(tokens, index) == Some("TEMPORARY");
+            if temporary {
+                index += 1;
+            }
+            match word(tokens, index) {
+                Some("TABLE") => {
+                    let target_index = if word(tokens, index + 1) == Some("IF") {
+                        index + 3
+                    } else {
+                        index + 1
+                    };
+                    let (target, database) = drop_target_after(tokens, target_index)?;
+                    (
+                        MysqlStatementKind::DropTable { temporary },
+                        target,
+                        database,
+                    )
+                }
+                Some("VIEW") => {
+                    let target_index = if word(tokens, index + 1) == Some("IF") {
+                        index + 3
+                    } else {
+                        index + 1
+                    };
+                    let (target, database) = drop_target_after(tokens, target_index)?;
+                    (MysqlStatementKind::DropView, target, database)
+                }
+                Some("INDEX" | "KEY") => {
+                    let on = find_word(tokens, "ON", index + 1).ok_or_else(|| {
+                        MysqlLexError("DROP INDEX target is ambiguous".to_string())
+                    })?;
+                    let (_, database) = target_after(on + 1)?;
+                    let index_name_index = if word(tokens, index + 1) == Some("IF") {
+                        index + 3
+                    } else {
+                        index + 1
+                    };
+                    let (index_name, _, _) = identifier_at(tokens, index_name_index)
+                        .ok_or_else(|| MysqlLexError("DROP INDEX name is ambiguous".to_string()))?;
+                    (MysqlStatementKind::DropIndex, Some(index_name), database)
+                }
+                _ => {
+                    return Err(MysqlLexError(
+                        "unsupported MySQL DROP statement".to_string(),
+                    ));
+                }
+            }
+        }
+        "TRUNCATE" => {
+            let target_index = if word(tokens, start + 1) == Some("TABLE") {
+                start + 2
+            } else {
+                start + 1
+            };
+            let (target, database) = target_after(target_index)?;
+            (MysqlStatementKind::TruncateTable, target, database)
+        }
+        "BEGIN" => {
+            if tokens.len() != start + 1 {
+                return Err(MysqlLexError(
+                    "BEGIN modifiers are not supported".to_string(),
+                ));
+            }
+            (MysqlStatementKind::Begin, None, None)
+        }
+        "START" if word(tokens, start + 1) == Some("TRANSACTION") => {
+            if tokens.len() != start + 2 {
+                return Err(MysqlLexError(
+                    "START TRANSACTION modifiers are not supported".to_string(),
+                ));
+            }
+            (MysqlStatementKind::StartTransaction, None, None)
+        }
+        "COMMIT" => {
+            if tokens.len() != start + 1 {
+                return Err(MysqlLexError(
+                    "COMMIT modifiers are not supported".to_string(),
+                ));
+            }
+            (MysqlStatementKind::Commit, None, None)
+        }
+        "ROLLBACK" => {
+            if word(tokens, start + 1).is_none() && tokens.len() == start + 1 {
+                (MysqlStatementKind::Rollback, None, None)
+            } else if word(tokens, start + 1) == Some("TO") {
+                let name_index = if word(tokens, start + 2) == Some("SAVEPOINT") {
+                    start + 3
+                } else {
+                    start + 2
+                };
+                if tokens.len() != name_index + 1 {
+                    return Err(MysqlLexError(
+                        "ROLLBACK modifiers are not supported".to_string(),
+                    ));
+                }
+                let (name, database, _) = identifier_at(tokens, name_index).ok_or_else(|| {
+                    MysqlLexError("ROLLBACK SAVEPOINT name is ambiguous".to_string())
+                })?;
+                (
+                    MysqlStatementKind::RollbackToSavepoint,
+                    Some(name),
+                    database,
+                )
+            } else {
+                return Err(MysqlLexError(
+                    "ROLLBACK modifiers are not supported".to_string(),
+                ));
+            }
+        }
+        "SAVEPOINT" if tokens.len() == start + 2 => {
+            let (name, database, _) = identifier_at(tokens, start + 1)
+                .ok_or_else(|| MysqlLexError("SAVEPOINT name is ambiguous".to_string()))?;
+            (MysqlStatementKind::Savepoint, Some(name), database)
+        }
+        "RELEASE" if word(tokens, start + 1) == Some("SAVEPOINT") && tokens.len() == start + 3 => {
+            let (name, database, _) = identifier_at(tokens, start + 2)
+                .ok_or_else(|| MysqlLexError("RELEASE SAVEPOINT name is ambiguous".to_string()))?;
+            (MysqlStatementKind::ReleaseSavepoint, Some(name), database)
+        }
+        _ => {
+            return Err(MysqlLexError(format!(
+                "unsupported MySQL statement: {first}"
+            )));
+        }
+    };
+    Ok(result)
+}
+
+pub fn classify_mysql_statement(sql: &str) -> Result<MysqlStatement, MysqlLexError> {
+    let tokens = lex_mysql_statement(sql)?;
+    if tokens.is_empty() {
+        return Err(MysqlLexError("empty MySQL statement".to_string()));
+    }
+    if tokens.iter().any(|token| {
+        matches!(
+            &token.kind,
+            TokenKind::Word(word) if word == "UNSUPPORTED_VERSION_COMMENT"
+        )
+    }) {
+        return Err(MysqlLexError(
+            "executable MySQL version comment contains another statement".to_string(),
+        ));
+    }
+    let (kind, target, target_database) = kind_and_target(&tokens)?;
+    Ok(MysqlStatement {
+        sql: sql.to_string(),
+        kind,
+        target,
+        target_database,
+    })
+}
+
+pub fn mysql_explain_rejection_message(sql: &str) -> Option<&'static str> {
+    let Ok(statements) = split_mysql_statements(sql) else {
+        return Some("MySQL EXPLAIN requires one valid statement");
+    };
+    if statements.len() != 1 {
+        return Some("MySQL EXPLAIN does not support multiple statements");
+    }
+    if statement_contains_unsupported_mysql_control(sql) {
+        return Some("MySQL EXPLAIN does not support MySQL client commands");
+    }
+
+    let Ok(statement) = classify_mysql_statement(&statements[0]) else {
+        return Some(
+            "MySQL EXPLAIN supports SELECT, TABLE, INSERT, REPLACE, UPDATE, or DELETE statements",
+        );
+    };
+    (!matches!(
+        statement.kind,
+        MysqlStatementKind::Select
+            | MysqlStatementKind::Table
+            | MysqlStatementKind::Insert
+            | MysqlStatementKind::Replace
+            | MysqlStatementKind::Update { .. }
+            | MysqlStatementKind::Delete { .. }
+    ))
+    .then_some(
+        "MySQL EXPLAIN supports SELECT, TABLE, INSERT, REPLACE, UPDATE, or DELETE statements",
+    )
+}
+
+pub fn mysql_tree_explain_query_kind(sql: &str) -> Option<bool> {
+    let trimmed = sql.trim();
+    let (is_analyze, target) = if let Some(target) =
+        strip_ascii_prefix_case_insensitive(trimmed, "EXPLAIN ANALYZE FORMAT=TREE")
+    {
+        (true, target)
+    } else if let Some(target) = strip_ascii_prefix_case_insensitive(trimmed, "EXPLAIN FORMAT=TREE")
+    {
+        (false, target)
+    } else {
+        return None;
+    };
+
+    if target.is_empty() || !target.chars().next().is_some_and(char::is_whitespace) {
+        return None;
+    }
+    let target = target.trim();
+
+    let valid = if is_analyze {
+        !statement_contains_unsupported_mysql_control(target)
+            && split_mysql_statements(target).is_ok_and(|statements| {
+                statements.len() == 1
+                    && classify_mysql_statement(&statements[0]).is_ok_and(|statement| {
+                        matches!(
+                            statement.kind,
+                            MysqlStatementKind::Select | MysqlStatementKind::Table
+                        ) && !has_mysql_read_only_side_effect(target).unwrap_or(true)
+                    })
+            })
+    } else {
+        mysql_explain_rejection_message(target).is_none()
+    };
+    valid.then_some(is_analyze)
+}
+
+fn strip_ascii_prefix_case_insensitive<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
+    text.get(..prefix.len())
+        .filter(|candidate| candidate.eq_ignore_ascii_case(prefix))
+        .map(|_| &text[prefix.len()..])
+}
+
+pub fn has_top_level_into_clause(sql: &str) -> Result<bool, MysqlLexError> {
+    let tokens = lex_mysql_statement(sql)?;
+    Ok(tokens.iter().any(|token| {
+        token.depth == 0 && matches!(&token.kind, TokenKind::Word(word) if word == "INTO")
+    }))
+}
+
+pub fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MysqlLexError> {
+    if has_mysql_version_comment(sql)? {
+        return Ok(true);
+    }
+
+    let tokens = lex_mysql_statement(sql)?;
+    for (index, token) in tokens.iter().enumerate() {
+        if matches!(&token.kind, TokenKind::Word(word) if word == "INTO") {
+            return Ok(true);
+        }
+        if matches!(&token.kind, TokenKind::Word(word) if matches!(
+            word.as_str(),
+            "GET_LOCK" | "RELEASE_LOCK" | "RELEASE_ALL_LOCKS"
+        )) {
+            return Ok(true);
+        }
+        if matches!(&token.kind, TokenKind::Symbol(':'))
+            && matches!(
+                tokens.get(index + 1).map(|token| &token.kind),
+                Some(TokenKind::Symbol('='))
+            )
+        {
+            return Ok(true);
+        }
+        if word_at(&tokens, index) == Some("FOR")
+            && matches!(word_at(&tokens, index + 1), Some("UPDATE" | "SHARE"))
+        {
+            return Ok(true);
+        }
+        if word_at(&tokens, index) == Some("LOCK")
+            && word_at(&tokens, index + 1) == Some("IN")
+            && word_at(&tokens, index + 2) == Some("SHARE")
+            && word_at(&tokens, index + 3) == Some("MODE")
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn word_at(tokens: &[Token], index: usize) -> Option<&str> {
+    match tokens.get(index)?.kind {
+        TokenKind::Word(ref word) => Some(word),
+        _ => None,
+    }
+}
+
+pub fn has_mysql_version_comment(sql: &str) -> Result<bool, MysqlLexError> {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    let mut quote = None;
+
+    while index < bytes.len() {
+        if let Some(delimiter) = quote {
+            if bytes[index] == b'\\' && delimiter != b'`' {
+                index = (index + 2).min(bytes.len());
+            } else if bytes[index] == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                } else {
+                    quote = None;
+                    index += 1;
+                }
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if is_line_comment_start(bytes, index) {
+            index = skip_line_comment(bytes, index);
+            continue;
+        }
+        if bytes.get(index..index + 2) == Some(b"/*") {
+            if bytes.get(index + 2) == Some(&b'!') {
+                return Ok(true);
+            }
+            index = skip_block_comment(bytes, index)?;
+            continue;
+        }
+        if matches!(bytes[index], b'\'' | b'"' | b'`') {
+            quote = Some(bytes[index]);
+        }
+        index += 1;
+    }
+
+    if quote.is_some() {
+        return Err(MysqlLexError(
+            "unterminated MySQL quoted literal".to_string(),
+        ));
+    }
+    Ok(false)
+}
+
+pub fn target_is_selected_database(
+    statement: &MysqlStatement,
+    selected_database: Option<&str>,
+) -> bool {
+    match (statement.target_database.as_deref(), selected_database) {
+        (Some(target_database), Some(selected)) => target_database.eq_ignore_ascii_case(selected),
+        (None, Some(_)) => true,
+        (Some(_) | None, None) => false,
+    }
+}
+
+pub fn statement_contains_unsupported_mysql_control(sql: &str) -> bool {
+    let lower = sql.trim_start().to_ascii_lowercase();
+    [
+        "use ",
+        "use\n",
+        "set ",
+        "set\n",
+        "lock tables",
+        "unlock tables",
+    ]
+    .iter()
+    .any(|prefix| lower.starts_with(prefix))
+        || contains_mysql_client_command(sql)
+}
+
+fn contains_mysql_client_command(sql: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    let mut line_start = true;
+    let mut quote = None;
+    let mut block_comment = false;
+
+    while index < bytes.len() {
+        if let Some(delimiter) = quote {
+            if bytes[index] == b'\\' && delimiter != b'`' {
+                index = (index + 2).min(bytes.len());
+            } else if bytes[index] == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                } else {
+                    quote = None;
+                    index += 1;
+                }
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if block_comment {
+            if bytes.get(index..index + 2) == Some(b"*/") {
+                block_comment = false;
+                index += 2;
+            } else {
+                line_start = bytes[index] == b'\n' || line_start;
+                index += 1;
+            }
+            continue;
+        }
+        if line_start {
+            if matches!(bytes[index], b' ' | b'\t' | b'\r') {
+                index += 1;
+                continue;
+            }
+            if bytes[index] == b'\n' {
+                index += 1;
+                continue;
+            }
+            if bytes[index] == b'\\' {
+                return true;
+            }
+            if bytes.get(index..index + 2) == Some(b"/*") {
+                block_comment = true;
+                index += 2;
+                continue;
+            }
+            if is_line_comment_start(bytes, index) {
+                index = skip_line_comment(bytes, index);
+                continue;
+            }
+            if bytes[index].is_ascii_alphabetic() {
+                let start = index;
+                index += 1;
+                while index < bytes.len()
+                    && (bytes[index].is_ascii_alphanumeric() || bytes[index] == b'_')
+                {
+                    index += 1;
+                }
+                let word = &sql[start..index];
+                if matches!(
+                    word.to_ascii_lowercase().as_str(),
+                    "delimiter" | "charset" | "source" | "system"
+                ) && (index == bytes.len() || bytes[index].is_ascii_whitespace())
+                {
+                    return true;
+                }
+                line_start = false;
+                continue;
+            }
+            line_start = false;
+        }
+
+        if bytes.get(index..index + 2) == Some(b"/*") {
+            block_comment = true;
+            index += 2;
+        } else if is_line_comment_start(bytes, index) {
+            index = skip_line_comment(bytes, index);
+            line_start = true;
+        } else if bytes[index] == b'\n' {
+            line_start = true;
+            index += 1;
+        } else if matches!(bytes[index], b'\'' | b'"' | b'`') {
+            quote = Some(bytes[index]);
+            line_start = false;
+            index += 1;
+        } else {
+            index += 1;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_mysql_comments_quotes_and_backticks() {
+        let sql = "SELECT 'a;\\'b'; # comment;\n SELECT `semi;colon` /* ; */";
+        assert_eq!(split_mysql_statements(sql).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn rejects_ambiguous_quotes() {
+        assert!(split_mysql_statements("SELECT 'unfinished").is_err());
+    }
+
+    #[test]
+    fn classifies_with_and_version_comment() {
+        let statement = classify_mysql_statement(
+            "WITH rows(id) AS (SELECT 1) UPDATE `app`.`items` SET value = 1",
+        )
+        .unwrap();
+        assert!(matches!(statement.kind, MysqlStatementKind::Update { .. }));
+        assert_eq!(statement.target, Some("items".to_string()));
+    }
+
+    #[test]
+    fn rejects_unverifiable_version_comment() {
+        assert!(classify_mysql_statement("/*! SET sql_mode='ANSI_QUOTES' */ SELECT 1").is_err());
+    }
+
+    #[test]
+    fn classifies_leading_version_comment_statement() {
+        assert!(matches!(
+            classify_mysql_statement("/*!80000 SELECT 1 */"),
+            Ok(MysqlStatement {
+                kind: MysqlStatementKind::Select,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_executable_version_comment_clause() {
+        assert!(classify_mysql_statement("SELECT 1 /*!80000 INTO OUTFILE '/tmp/x' */").is_err());
+        assert!(classify_mysql_statement("/*!80000 SELECT 1 */ SELECT 2").is_err());
+        assert!(classify_mysql_statement("/*!80000 SELECT 1; DROP TABLE items */").is_err());
+    }
+
+    #[test]
+    fn rejects_multiple_drop_targets_and_ambiguous_ddl_quotes() {
+        assert!(classify_mysql_statement("DROP TABLE app.keep, other.drop_me").is_err());
+        assert!(classify_mysql_statement("DROP VIEW app.keep, other.drop_me").is_err());
+        assert!(classify_mysql_statement("CREATE TABLE \"items\" (id INT)").is_err());
+    }
+
+    #[test]
+    fn rejects_executable_inline_control_statement() {
+        assert!(
+            classify_mysql_statement("SELECT 1 /*!80000 SET sql_mode='ANSI_QUOTES' */").is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_mysql_client_commands_at_line_start() {
+        for sql in [
+            "DELIMITER //\nSELECT 1//",
+            "charset utf8mb4\nSELECT 1",
+            "source ./script.sql",
+            "system echo unsafe",
+            "\\C /tmp/other.sock\nSELECT 1",
+            "SELECT 1\nsource ./script.sql",
+        ] {
+            assert!(statement_contains_unsupported_mysql_control(sql), "{sql}");
+        }
+        assert!(!statement_contains_unsupported_mysql_control(
+            "SELECT 'source ./script.sql\\n'"
+        ));
+    }
+
+    #[test]
+    fn keeps_index_confirmation_name_separate_from_ddl_database_target() {
+        let statement = classify_mysql_statement("DROP INDEX ix ON app.items").unwrap();
+        assert_eq!(statement.target, Some("IX".to_string()));
+        assert_eq!(statement.target_database, Some("APP".to_string()));
+        let statement = classify_mysql_statement("DROP INDEX IF EXISTS ix ON app.items").unwrap();
+        assert_eq!(statement.target, Some("IX".to_string()));
+    }
+
+    #[test]
+    fn recognizes_generated_tree_explain_queries() {
+        assert_eq!(
+            mysql_tree_explain_query_kind("EXPLAIN FORMAT=TREE UPDATE items SET value = 1"),
+            Some(false)
+        );
+        assert_eq!(
+            mysql_tree_explain_query_kind("EXPLAIN ANALYZE FORMAT=TREE TABLE items"),
+            Some(true)
+        );
+        assert_eq!(
+            mysql_tree_explain_query_kind("EXPLAIN ANALYZE FORMAT=TREE DELETE FROM items"),
+            None
+        );
+    }
+}

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1,5 +1,10 @@
 use super::write_guardrails::{self, RiskLevel};
 use crate::domain::DatabaseType;
+use crate::policy::sql::mysql_statement::{
+    MysqlStatement, MysqlStatementKind, classify_mysql_statement, has_mysql_read_only_side_effect,
+    has_top_level_into_clause, split_mysql_statements,
+    statement_contains_unsupported_mysql_control, target_is_selected_database,
+};
 use crate::policy::sql::sqlite_statement_splitter::split_sqlite_statements;
 use crate::policy::sql::sqlite_transaction::{
     SqliteStatementClassification, SqliteTransactionPolicy, parse_sqlite_pragma,
@@ -24,6 +29,208 @@ pub enum AcknowledgeReason {
     // SQLite cannot run this multi-statement script inside the automatic
     // transaction because one statement changes connection-level settings.
     NonAtomicTransaction,
+    // MySQL EXPLAIN ANALYZE executes an otherwise read-only target statement.
+    AnalyzeExecution,
+}
+
+#[cfg(test)]
+mod mysql_tests {
+    use super::*;
+
+    fn mysql(sql: &str) -> MultiStatementDecision {
+        evaluate_multi_statement_for_database_with_context(DatabaseType::MySQL, Some("app"), sql)
+    }
+
+    #[test]
+    fn max_risk_uses_destructive_confirmation() {
+        let decision = mysql("SELECT 'a;#'; UPDATE items SET value = 1");
+        match decision {
+            MultiStatementDecision::Allow { risk, statements } => {
+                assert_eq!(statements.len(), 2);
+                assert_eq!(risk.risk_level, RiskLevel::High);
+                assert_eq!(
+                    risk.confirmation,
+                    ConfirmationType::TableNameInput {
+                        target: "ITEMS".to_string()
+                    }
+                );
+                assert!(!risk.read_only_allowed);
+            }
+            MultiStatementDecision::Block { reason } => panic!("unexpected block: {reason}"),
+        }
+    }
+
+    #[test]
+    fn accepts_comments_hints_and_version_comments() {
+        assert!(matches!(
+            mysql("SELECT /*+ MAX_EXECUTION_TIME(1000) */ 1 # trailing\n"),
+            MultiStatementDecision::Allow { .. }
+        ));
+        assert!(matches!(
+            mysql("/*!80000 SELECT 1 */"),
+            MultiStatementDecision::Allow { .. }
+        ));
+    }
+
+    #[test]
+    fn read_only_allows_only_side_effect_free_mysql_reads() {
+        for sql in [
+            "SELECT 1",
+            "TABLE items",
+            "SHOW TABLES",
+            "DESCRIBE items",
+            "WITH rows AS (SELECT 1) SELECT * FROM rows",
+        ] {
+            let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
+                panic!("{sql}");
+            };
+            assert!(risk.read_only_allowed, "{sql}");
+        }
+
+        for sql in [
+            "SELECT * FROM items FOR UPDATE",
+            "SELECT * FROM items FOR SHARE",
+            "SELECT * FROM items LOCK IN SHARE MODE",
+            "SELECT @value := value FROM items",
+            "SELECT GET_LOCK('sabiql', 0)",
+            "SELECT RELEASE_LOCK('sabiql')",
+            "SELECT RELEASE_ALL_LOCKS()",
+            "/*!80000 SELECT 1 */",
+        ] {
+            let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
+                panic!("{sql}");
+            };
+            assert!(!risk.read_only_allowed, "{sql}");
+        }
+    }
+
+    #[test]
+    fn explain_targets_share_the_read_only_allowlist() {
+        for sql in ["SELECT 1", "TABLE items", "SHOW TABLES", "DESCRIBE items"] {
+            assert!(evaluate_mysql_explain_target(sql, false).is_some(), "{sql}");
+        }
+        for sql in [
+            "UPDATE items SET value = 1",
+            "SELECT * FROM items FOR UPDATE",
+            "SELECT * FROM items INTO OUTFILE '/tmp/items'",
+            "SELECT 1; SELECT 2",
+            "SELECT 1\nsystem echo unsafe",
+            "SELECT 1\n\\! echo unsafe",
+        ] {
+            assert!(evaluate_mysql_explain_target(sql, false).is_none(), "{sql}");
+            assert!(evaluate_mysql_explain_target(sql, true).is_none(), "{sql}");
+        }
+        for (sql, label) in [("SELECT 1", "SELECT"), ("TABLE items", "TABLE")] {
+            let risk = evaluate_mysql_explain_target(sql, true).expect(sql);
+            assert_eq!(risk.risk_level, RiskLevel::Low);
+            assert!(risk.read_only_allowed);
+            assert_eq!(
+                risk.confirmation,
+                ConfirmationType::Acknowledge {
+                    reason: AcknowledgeReason::AnalyzeExecution,
+                    label: label.to_string(),
+                }
+            );
+        }
+        assert!(evaluate_mysql_explain_target("SHOW TABLES", true).is_none());
+    }
+
+    #[test]
+    fn rejects_unsupported_controls_and_statements_before_execution() {
+        for sql in [
+            "USE app",
+            "SET sql_mode = 'ANSI_QUOTES'",
+            "LOCK TABLES items READ",
+            "UNLOCK TABLES",
+            "REPLACE INTO items VALUES (1)",
+            "CALL do_work()",
+            "LOAD DATA INFILE 'x' INTO TABLE items",
+            "/*! SET sql_mode='ANSI_QUOTES' */ SELECT 1",
+            "SELECT 1\n\\! echo unsafe",
+            "SELECT 1\nsystem echo unsafe",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Block { .. }),
+                "{sql}"
+            );
+        }
+        for sql in [
+            "SELECT 'source ./script.sql\\n'",
+            "SELECT /* source ./script.sql */ 1",
+            "SELECT `system echo unsafe`",
+            "UPDATE items\nSET value = 1 WHERE id = 1",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Allow { .. }),
+                "{sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn ddl_rejects_a_different_database() {
+        assert!(matches!(
+            evaluate_multi_statement_for_database_with_context(
+                DatabaseType::MySQL,
+                Some("app"),
+                "ALTER TABLE other.items ADD COLUMN value INT",
+            ),
+            MultiStatementDecision::Block { .. }
+        ));
+        assert!(matches!(
+            evaluate_multi_statement_for_database_with_context(
+                DatabaseType::MySQL,
+                Some("app"),
+                "ALTER TABLE app.items ADD COLUMN value INT",
+            ),
+            MultiStatementDecision::Allow { .. }
+        ));
+        assert!(matches!(
+            evaluate_multi_statement_for_database_with_context(
+                DatabaseType::MySQL,
+                None,
+                "CREATE TABLE items (id INT)",
+            ),
+            MultiStatementDecision::Block { .. }
+        ));
+        assert!(matches!(
+            mysql("DROP TABLE app.keep, other.drop_me"),
+            MultiStatementDecision::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn transaction_modifiers_are_rejected() {
+        for sql in [
+            "START TRANSACTION READ ONLY",
+            "COMMIT AND CHAIN",
+            "ROLLBACK AND NO CHAIN",
+            "ROLLBACK TO SAVEPOINT named extra",
+            "RELEASE SAVEPOINT named extra",
+            "BEGIN",
+            "BEGIN; UPDATE items SET value = 1",
+            "SAVEPOINT named",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Block { .. }),
+                "{sql}"
+            );
+        }
+        for sql in [
+            "COMMIT",
+            "ROLLBACK",
+            "BEGIN; COMMIT",
+            "START TRANSACTION; ROLLBACK",
+            "BEGIN; SAVEPOINT named; ROLLBACK TO named; RELEASE SAVEPOINT named; COMMIT",
+            "CREATE TEMPORARY TABLE temp_items (id INT); INSERT INTO temp_items VALUES (1); SELECT * FROM temp_items",
+            "CREATE TEMPORARY TABLE temp_items (id INT); DROP TEMPORARY TABLE app.temp_items",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Allow { .. }),
+                "{sql}"
+            );
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,6 +262,351 @@ pub enum MultiStatementDecision {
     Block {
         reason: String,
     },
+}
+
+fn mysql_low(read_only_allowed: bool) -> SqlRiskDecision {
+    SqlRiskDecision {
+        risk_level: RiskLevel::Low,
+        confirmation: ConfirmationType::Immediate,
+        read_only_allowed,
+    }
+}
+
+fn mysql_table_name_input(statement: &MysqlStatement) -> SqlRiskDecision {
+    match statement.target.as_deref() {
+        Some(target) => SqlRiskDecision {
+            risk_level: RiskLevel::High,
+            confirmation: ConfirmationType::TableNameInput {
+                target: target.to_string(),
+            },
+            read_only_allowed: false,
+        },
+        None => SqlRiskDecision {
+            risk_level: RiskLevel::High,
+            confirmation: ConfirmationType::Acknowledge {
+                reason: AcknowledgeReason::TargetNameUnavailable,
+                label: mysql_statement_label(&statement.kind).to_string(),
+            },
+            read_only_allowed: false,
+        },
+    }
+}
+
+fn mysql_statement_risk(statement: &MysqlStatement) -> SqlRiskDecision {
+    match statement.kind {
+        MysqlStatementKind::Select
+        | MysqlStatementKind::Table
+        | MysqlStatementKind::Show
+        | MysqlStatementKind::Describe => {
+            mysql_low(!has_mysql_read_only_side_effect(&statement.sql).unwrap_or(true))
+        }
+        MysqlStatementKind::Begin
+        | MysqlStatementKind::StartTransaction
+        | MysqlStatementKind::Commit
+        | MysqlStatementKind::Rollback
+        | MysqlStatementKind::Savepoint
+        | MysqlStatementKind::RollbackToSavepoint
+        | MysqlStatementKind::ReleaseSavepoint
+        | MysqlStatementKind::Insert
+        | MysqlStatementKind::CreateTable { .. }
+        | MysqlStatementKind::CreateView
+        | MysqlStatementKind::CreateIndex => mysql_low(false),
+        MysqlStatementKind::Replace
+        | MysqlStatementKind::Update { has_where: true }
+        | MysqlStatementKind::Delete { has_where: true }
+        | MysqlStatementKind::AlterTable => SqlRiskDecision {
+            risk_level: RiskLevel::Medium,
+            confirmation: ConfirmationType::Immediate,
+            read_only_allowed: false,
+        },
+        MysqlStatementKind::Update { has_where: false }
+        | MysqlStatementKind::Delete { has_where: false }
+        | MysqlStatementKind::DropTable { .. }
+        | MysqlStatementKind::DropView
+        | MysqlStatementKind::DropIndex
+        | MysqlStatementKind::TruncateTable => mysql_table_name_input(statement),
+    }
+}
+
+pub fn mysql_statement_label(kind: &MysqlStatementKind) -> &'static str {
+    match kind {
+        MysqlStatementKind::Select => "SELECT",
+        MysqlStatementKind::Table => "TABLE",
+        MysqlStatementKind::Show => "SHOW",
+        MysqlStatementKind::Describe => "DESCRIBE",
+        MysqlStatementKind::Insert => "INSERT",
+        MysqlStatementKind::Replace => "REPLACE",
+        MysqlStatementKind::Update { has_where: true } => "UPDATE",
+        MysqlStatementKind::Update { has_where: false } => "UPDATE (no WHERE)",
+        MysqlStatementKind::Delete { has_where: true } => "DELETE",
+        MysqlStatementKind::Delete { has_where: false } => "DELETE (no WHERE)",
+        MysqlStatementKind::CreateTable { temporary: true } => "CREATE TEMPORARY TABLE",
+        MysqlStatementKind::CreateTable { temporary: false } => "CREATE TABLE",
+        MysqlStatementKind::AlterTable => "ALTER TABLE",
+        MysqlStatementKind::DropTable { temporary: true } => "DROP TEMPORARY TABLE",
+        MysqlStatementKind::DropTable { temporary: false } => "DROP TABLE",
+        MysqlStatementKind::TruncateTable => "TRUNCATE TABLE",
+        MysqlStatementKind::CreateView => "CREATE VIEW",
+        MysqlStatementKind::DropView => "DROP VIEW",
+        MysqlStatementKind::CreateIndex => "CREATE INDEX",
+        MysqlStatementKind::DropIndex => "DROP INDEX",
+        MysqlStatementKind::Begin => "BEGIN",
+        MysqlStatementKind::StartTransaction => "START TRANSACTION",
+        MysqlStatementKind::Commit => "COMMIT",
+        MysqlStatementKind::Rollback => "ROLLBACK",
+        MysqlStatementKind::Savepoint => "SAVEPOINT",
+        MysqlStatementKind::RollbackToSavepoint => "ROLLBACK TO SAVEPOINT",
+        MysqlStatementKind::ReleaseSavepoint => "RELEASE SAVEPOINT",
+    }
+}
+
+pub fn mysql_statement_is_schema_modifying(kind: &MysqlStatementKind) -> bool {
+    matches!(
+        kind,
+        MysqlStatementKind::CreateTable { .. }
+            | MysqlStatementKind::AlterTable
+            | MysqlStatementKind::DropTable { .. }
+            | MysqlStatementKind::TruncateTable
+            | MysqlStatementKind::CreateView
+            | MysqlStatementKind::DropView
+            | MysqlStatementKind::CreateIndex
+            | MysqlStatementKind::DropIndex
+    )
+}
+
+pub fn mysql_statement_is_data_modifying(kind: &MysqlStatementKind) -> bool {
+    matches!(
+        kind,
+        MysqlStatementKind::Insert
+            | MysqlStatementKind::Replace
+            | MysqlStatementKind::Update { .. }
+            | MysqlStatementKind::Delete { .. }
+    )
+}
+
+fn mysql_statement_is_persistent_schema_change(kind: &MysqlStatementKind) -> bool {
+    mysql_statement_is_schema_modifying(kind)
+        && !matches!(
+            kind,
+            MysqlStatementKind::CreateTable { temporary: true }
+                | MysqlStatementKind::DropTable { temporary: true }
+        )
+}
+
+fn mysql_target_key(statement: &MysqlStatement, selected_database: Option<&str>) -> Option<String> {
+    Some(format!(
+        "{}:{}",
+        statement
+            .target_database
+            .as_deref()
+            .or(selected_database)
+            .unwrap_or_default()
+            .to_ascii_uppercase(),
+        statement.target.as_deref()?.to_ascii_uppercase()
+    ))
+}
+
+fn mysql_validate_submission_state(
+    planned: &[(MysqlStatement, SqlRiskDecision)],
+    selected_database: Option<&str>,
+) -> Result<(), String> {
+    let mut transaction_open = false;
+    let mut savepoints = Vec::<String>::new();
+    let mut temporary_tables = Vec::<String>::new();
+
+    for (statement, _) in planned {
+        match &statement.kind {
+            MysqlStatementKind::Begin | MysqlStatementKind::StartTransaction => {
+                if transaction_open {
+                    return Err("nested MySQL transactions are not supported".to_string());
+                }
+                transaction_open = true;
+                savepoints.clear();
+            }
+            MysqlStatementKind::Commit | MysqlStatementKind::Rollback => {
+                transaction_open = false;
+                savepoints.clear();
+            }
+            MysqlStatementKind::Savepoint => {
+                if !transaction_open {
+                    return Err("MySQL SAVEPOINT requires an explicit transaction".to_string());
+                }
+                let name = statement
+                    .target
+                    .as_deref()
+                    .ok_or_else(|| "MySQL SAVEPOINT name is ambiguous".to_string())?;
+                savepoints.retain(|current| !current.eq_ignore_ascii_case(name));
+                savepoints.push(name.to_string());
+            }
+            MysqlStatementKind::RollbackToSavepoint => {
+                if !transaction_open {
+                    return Err(
+                        "MySQL ROLLBACK TO SAVEPOINT requires an explicit transaction".to_string(),
+                    );
+                }
+                let name = statement
+                    .target
+                    .as_deref()
+                    .ok_or_else(|| "MySQL SAVEPOINT name is ambiguous".to_string())?;
+                let Some(index) = savepoints
+                    .iter()
+                    .position(|current| current.eq_ignore_ascii_case(name))
+                else {
+                    return Err("MySQL ROLLBACK TO SAVEPOINT name is unknown".to_string());
+                };
+                savepoints.truncate(index + 1);
+            }
+            MysqlStatementKind::ReleaseSavepoint => {
+                if !transaction_open {
+                    return Err(
+                        "MySQL RELEASE SAVEPOINT requires an explicit transaction".to_string()
+                    );
+                }
+                let name = statement
+                    .target
+                    .as_deref()
+                    .ok_or_else(|| "MySQL SAVEPOINT name is ambiguous".to_string())?;
+                let Some(index) = savepoints
+                    .iter()
+                    .position(|current| current.eq_ignore_ascii_case(name))
+                else {
+                    return Err("MySQL RELEASE SAVEPOINT name is unknown".to_string());
+                };
+                savepoints.remove(index);
+            }
+            MysqlStatementKind::CreateTable { temporary: true } => {
+                let key = mysql_target_key(statement, selected_database)
+                    .ok_or_else(|| "MySQL temporary table target is ambiguous".to_string())?;
+                if temporary_tables.iter().any(|current| current == &key) {
+                    return Err("MySQL temporary table is created more than once".to_string());
+                }
+                temporary_tables.push(key);
+            }
+            MysqlStatementKind::DropTable { temporary: true } => {
+                let key = mysql_target_key(statement, selected_database)
+                    .ok_or_else(|| "MySQL temporary table target is ambiguous".to_string())?;
+                let Some(index) = temporary_tables.iter().position(|current| current == &key)
+                else {
+                    return Err(
+                        "MySQL temporary tables must be created and dropped in one submission"
+                            .to_string(),
+                    );
+                };
+                temporary_tables.remove(index);
+            }
+            kind if mysql_statement_is_persistent_schema_change(kind) => {
+                transaction_open = false;
+                savepoints.clear();
+            }
+            _ => {}
+        }
+    }
+
+    if transaction_open {
+        return Err("MySQL explicit transaction must finish in one submission".to_string());
+    }
+    Ok(())
+}
+
+pub fn evaluate_mysql_multi_statement(
+    sql: &str,
+    selected_database: Option<&str>,
+) -> MultiStatementDecision {
+    if statement_contains_unsupported_mysql_control(sql) {
+        return MultiStatementDecision::Block {
+            reason: "unsupported MySQL session or table-lock statement".to_string(),
+        };
+    }
+    let statements = match split_mysql_statements(sql) {
+        Ok(statements) if !statements.is_empty() => statements,
+        Ok(_) => {
+            return MultiStatementDecision::Block {
+                reason: "Empty MySQL input".to_string(),
+            };
+        }
+        Err(error) => {
+            return MultiStatementDecision::Block {
+                reason: error.to_string(),
+            };
+        }
+    };
+
+    let mut planned = Vec::with_capacity(statements.len());
+    for statement_sql in statements {
+        let statement = match classify_mysql_statement(&statement_sql) {
+            Ok(statement) => statement,
+            Err(error) => {
+                return MultiStatementDecision::Block {
+                    reason: error.to_string(),
+                };
+            }
+        };
+        if matches!(statement.kind, MysqlStatementKind::Replace) {
+            return MultiStatementDecision::Block {
+                reason: "MySQL REPLACE execution is not supported".to_string(),
+            };
+        }
+        if matches!(
+            statement.kind,
+            MysqlStatementKind::Select | MysqlStatementKind::Table
+        ) && has_top_level_into_clause(&statement.sql).unwrap_or(true)
+        {
+            return MultiStatementDecision::Block {
+                reason: "MySQL SELECT INTO clauses are not supported".to_string(),
+            };
+        }
+        if mysql_statement_is_schema_modifying(&statement.kind)
+            && !target_is_selected_database(&statement, selected_database)
+        {
+            return MultiStatementDecision::Block {
+                reason: "MySQL DDL target must be in the selected database".to_string(),
+            };
+        }
+        let decision = mysql_statement_risk(&statement);
+        planned.push((statement, decision));
+    }
+
+    if let Err(reason) = mysql_validate_submission_state(&planned, selected_database) {
+        return MultiStatementDecision::Block { reason };
+    }
+
+    let max_risk = planned
+        .iter()
+        .map(|(_, decision)| decision.risk_level)
+        .max()
+        .unwrap_or(RiskLevel::Low);
+    let table_confirmations: Vec<String> = planned
+        .iter()
+        .filter_map(|(_, decision)| match &decision.confirmation {
+            ConfirmationType::TableNameInput { target } => Some(target.clone()),
+            _ => None,
+        })
+        .collect();
+    if table_confirmations.len() > 1 {
+        return MultiStatementDecision::Block {
+            reason: "MySQL statements require separate destructive confirmations".to_string(),
+        };
+    }
+    let confirmation = if let Some(target) = table_confirmations.into_iter().next() {
+        ConfirmationType::TableNameInput { target }
+    } else {
+        ConfirmationType::Immediate
+    };
+    let read_only_allowed = planned
+        .iter()
+        .all(|(_, decision)| decision.read_only_allowed);
+    let statements = planned
+        .iter()
+        .map(|(statement, _)| statement.sql.clone())
+        .collect();
+    MultiStatementDecision::Allow {
+        statements,
+        risk: SqlRiskDecision {
+            risk_level: max_risk,
+            confirmation,
+            read_only_allowed,
+        },
+    }
 }
 
 fn contains_cli_meta_command(database_type: DatabaseType, sql: &str) -> bool {
@@ -134,6 +686,9 @@ pub fn split_statements(sql: &str) -> Vec<String> {
 }
 
 pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> Vec<String> {
+    if database_type == DatabaseType::MySQL {
+        return split_mysql_statements(sql).unwrap_or_default();
+    }
     if database_type == DatabaseType::SQLite {
         return split_sqlite_statements(sql)
             .statements()
@@ -266,6 +821,9 @@ pub fn evaluate_sql_risk_for_database(
     kind: &StatementKind,
     sql: &str,
 ) -> SqlRiskDecision {
+    if database_type == DatabaseType::MySQL {
+        return evaluate_mysql_statement_risk(sql);
+    }
     if database_type == DatabaseType::SQLite
         && let Some(decision) = evaluate_sqlite_specific_risk(sql)
     {
@@ -333,6 +891,56 @@ pub fn evaluate_sql_risk_for_database(
     }
 }
 
+fn evaluate_mysql_statement_risk(sql: &str) -> SqlRiskDecision {
+    if let Ok(statement) = classify_mysql_statement(sql) {
+        return mysql_statement_risk(&statement);
+    }
+
+    SqlRiskDecision {
+        risk_level: RiskLevel::Low,
+        confirmation: ConfirmationType::Acknowledge {
+            reason: AcknowledgeReason::UnknownRisk,
+            label: first_keyword(sql).unwrap_or_else(|| "SQL".to_string()),
+        },
+        read_only_allowed: false,
+    }
+}
+
+pub fn evaluate_mysql_explain_target(sql: &str, analyze: bool) -> Option<SqlRiskDecision> {
+    if statement_contains_unsupported_mysql_control(sql) {
+        return None;
+    }
+    let statements = split_mysql_statements(sql).ok()?;
+    if statements.len() != 1 {
+        return None;
+    }
+    let statement = classify_mysql_statement(&statements[0]).ok()?;
+    let allowed_kind = if analyze {
+        matches!(
+            statement.kind,
+            MysqlStatementKind::Select | MysqlStatementKind::Table
+        )
+    } else {
+        matches!(
+            statement.kind,
+            MysqlStatementKind::Select
+                | MysqlStatementKind::Table
+                | MysqlStatementKind::Show
+                | MysqlStatementKind::Describe
+        )
+    };
+    let mut risk = mysql_statement_risk(&statement);
+    if analyze && risk.read_only_allowed {
+        risk.confirmation = ConfirmationType::Acknowledge {
+            reason: AcknowledgeReason::AnalyzeExecution,
+            label: mysql_statement_label(&statement.kind).to_string(),
+        };
+    }
+    allowed_kind
+        .then_some(risk)
+        .filter(|risk| risk.read_only_allowed)
+}
+
 pub fn evaluate_multi_statement(sql: &str) -> MultiStatementDecision {
     evaluate_multi_statement_for_database(DatabaseType::PostgreSQL, sql)
 }
@@ -341,6 +949,17 @@ pub fn evaluate_multi_statement_for_database(
     database_type: DatabaseType,
     sql: &str,
 ) -> MultiStatementDecision {
+    evaluate_multi_statement_for_database_with_context(database_type, None, sql)
+}
+
+pub fn evaluate_multi_statement_for_database_with_context(
+    database_type: DatabaseType,
+    selected_database: Option<&str>,
+    sql: &str,
+) -> MultiStatementDecision {
+    if database_type == DatabaseType::MySQL {
+        return evaluate_mysql_multi_statement(sql, selected_database);
+    }
     if contains_cli_meta_command(database_type, sql) {
         return MultiStatementDecision::Block {
             reason: "CLI meta-commands are not supported in SQL input".to_string(),
@@ -553,6 +1172,10 @@ pub fn sqlite_specific_label(sql: &str) -> Option<&'static str> {
 }
 
 pub fn adhoc_label_for_statement(database_type: DatabaseType, sql: &str) -> &'static str {
+    if database_type == DatabaseType::MySQL {
+        return classify_mysql_statement(sql)
+            .map_or("SQL", |statement| mysql_statement_label(&statement.kind));
+    }
     let sqlite_label = (database_type == DatabaseType::SQLite)
         .then(|| sqlite_specific_label(sql))
         .flatten();
@@ -565,6 +1188,19 @@ pub fn adhoc_label_for_table_name_confirmation(
     database_type: DatabaseType,
     sql: &str,
 ) -> Option<&'static str> {
+    if database_type == DatabaseType::MySQL {
+        return split_mysql_statements(sql)
+            .ok()?
+            .into_iter()
+            .find_map(|statement| {
+                let statement = classify_mysql_statement(&statement).ok()?;
+                matches!(
+                    mysql_statement_risk(&statement).confirmation,
+                    ConfirmationType::TableNameInput { .. }
+                )
+                .then(|| mysql_statement_label(&statement.kind))
+            });
+    }
     for stmt in split_statements_for_database(database_type, sql) {
         let kind = classify(&stmt);
         let decision = evaluate_sql_risk_for_database(database_type, &kind, &stmt);

--- a/src/app/services.rs
+++ b/src/app/services.rs
@@ -15,16 +15,48 @@ impl AppServices {
     #[cfg(any(test, feature = "test-support"))]
     #[doc(hidden)]
     pub fn stub() -> Self {
+        use crate::policy::sql::mysql_statement::{
+            mysql_explain_rejection_message, mysql_tree_explain_query_kind,
+        };
         use crate::policy::sql::sqlite_explain::build_sqlite_explain_query_plan_sql;
 
-        fn quote_literal(value: &str) -> String {
-            format!("'{}'", value.replace('\'', "''"))
+        fn quote_identifier(database_type: DatabaseType, value: &str) -> String {
+            match database_type {
+                DatabaseType::MySQL => {
+                    format!("`{}`", value.replace('`', "``"))
+                }
+                DatabaseType::PostgreSQL | DatabaseType::SQLite => {
+                    format!("\"{}\"", value.replace('"', "\"\""))
+                }
+            }
+        }
+
+        fn quote_literal(database_type: DatabaseType, value: &str) -> String {
+            if database_type != DatabaseType::MySQL {
+                return format!("'{}'", value.replace('\'', "''"));
+            }
+
+            let mut escaped = String::with_capacity(value.len());
+            for character in value.chars() {
+                match character {
+                    '\0' => escaped.push_str("\\0"),
+                    '\n' => escaped.push_str("\\n"),
+                    '\r' => escaped.push_str("\\r"),
+                    '\t' => escaped.push_str("\\t"),
+                    '\u{0008}' => escaped.push_str("\\b"),
+                    '\u{001a}' => escaped.push_str("\\Z"),
+                    '\\' => escaped.push_str("\\\\"),
+                    '\'' => escaped.push_str("\\'"),
+                    _ => escaped.push(character),
+                }
+            }
+            format!("'{escaped}'")
         }
 
         fn sql_literal(database_type: DatabaseType, value: &QueryValue) -> String {
             match value {
                 QueryValue::Null => "NULL".to_string(),
-                QueryValue::Text(value) => quote_literal(value),
+                QueryValue::Text(value) => quote_literal(database_type, value),
                 QueryValue::SqlLiteral(value) => value.clone(),
                 QueryValue::Blob(bytes) => {
                     let mut hex = String::with_capacity(bytes.len() * 2);
@@ -33,7 +65,9 @@ impl AppServices {
                     }
                     match database_type {
                         DatabaseType::PostgreSQL => format!("'\\x{hex}'"),
-                        DatabaseType::SQLite => format!("X'{}'", hex.to_uppercase()),
+                        DatabaseType::SQLite | DatabaseType::MySQL => {
+                            format!("X'{}'", hex.to_uppercase())
+                        }
                     }
                 }
             }
@@ -45,8 +79,14 @@ impl AppServices {
             value: &QueryValue,
         ) -> String {
             match value {
-                QueryValue::Null => format!("\"{key}\" IS NULL"),
-                _ => format!("\"{key}\" = {}", sql_literal(database_type, value)),
+                QueryValue::Null => {
+                    format!("{} IS NULL", quote_identifier(database_type, key))
+                }
+                _ => format!(
+                    "{} = {}",
+                    quote_identifier(database_type, key),
+                    sql_literal(database_type, value)
+                ),
             }
         }
 
@@ -67,6 +107,9 @@ impl AppServices {
                 match database_type {
                     DatabaseType::PostgreSQL => Some(format!("EXPLAIN {query}")),
                     DatabaseType::SQLite => build_sqlite_explain_query_plan_sql(query),
+                    DatabaseType::MySQL => mysql_explain_rejection_message(query)
+                        .is_none()
+                        .then(|| format!("EXPLAIN FORMAT=TREE {query}")),
                 }
             }
 
@@ -78,6 +121,12 @@ impl AppServices {
                 match database_type {
                     DatabaseType::PostgreSQL => Some(format!("EXPLAIN ANALYZE {query}")),
                     DatabaseType::SQLite => None,
+                    DatabaseType::MySQL => {
+                        let explain = format!("EXPLAIN ANALYZE FORMAT=TREE {query}");
+                        mysql_tree_explain_query_kind(&explain)
+                            .is_some()
+                            .then_some(explain)
+                    }
                 }
             }
 
@@ -90,21 +139,29 @@ impl AppServices {
                 new_value: &QueryValue,
                 pk_pairs: &[(String, QueryValue)],
             ) -> String {
-                let set_clause =
-                    format!("\"{column}\" = {}", sql_literal(database_type, new_value));
+                let set_clause = format!(
+                    "{} = {}",
+                    quote_identifier(database_type, column),
+                    sql_literal(database_type, new_value)
+                );
                 let where_clause = pk_pairs
                     .iter()
                     .map(|(key, value)| equality_predicate(database_type, key, value))
                     .collect::<Vec<_>>()
                     .join(" AND ");
                 match database_type {
-                    DatabaseType::PostgreSQL => {
+                    DatabaseType::PostgreSQL | DatabaseType::MySQL => {
                         format!(
-                            "UPDATE \"{schema}\".\"{table}\" SET {set_clause} WHERE {where_clause}"
+                            "UPDATE {}.{} SET {set_clause} WHERE {where_clause}",
+                            quote_identifier(database_type, schema),
+                            quote_identifier(database_type, table)
                         )
                     }
                     DatabaseType::SQLite => {
-                        format!("UPDATE \"{table}\" SET {set_clause} WHERE {where_clause}")
+                        format!(
+                            "UPDATE {} SET {set_clause} WHERE {where_clause}",
+                            quote_identifier(database_type, table)
+                        )
                     }
                 }
             }
@@ -127,10 +184,19 @@ impl AppServices {
                     .collect::<Vec<_>>()
                     .join(" OR ");
                 match database_type {
-                    DatabaseType::PostgreSQL => {
-                        format!("DELETE FROM \"{schema}\".\"{table}\" WHERE {where_clause}")
+                    DatabaseType::PostgreSQL | DatabaseType::MySQL => {
+                        format!(
+                            "DELETE FROM {}.{} WHERE {where_clause}",
+                            quote_identifier(database_type, schema),
+                            quote_identifier(database_type, table)
+                        )
                     }
-                    DatabaseType::SQLite => format!("DELETE FROM \"{table}\" WHERE {where_clause}"),
+                    DatabaseType::SQLite => {
+                        format!(
+                            "DELETE FROM {} WHERE {where_clause}",
+                            quote_identifier(database_type, table)
+                        )
+                    }
                 }
             }
         }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -1,9 +1,10 @@
+use std::fmt;
 use std::sync::Arc;
 
 use crate::domain::connection::{
-    ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
+    ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType, ServiceEntry,
 };
-use crate::domain::query_history::QueryHistoryEntry;
+use crate::domain::query_history::{QueryHistoryEntry, QueryHistoryScope};
 use crate::model::app_state::AppState;
 use crate::model::browse::jsonb_detail::JsonbDetailMode;
 use crate::model::connection::error::ConnectionErrorInfo;
@@ -11,8 +12,8 @@ use crate::model::shared::focused_pane::FocusedPane;
 use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::key_sequence::Prefix;
 use crate::model::sql_editor::completion::CompletionCandidate;
-use crate::policy::FeatureRequirement;
 use crate::policy::write::write_guardrails::WritePreview;
+use crate::policy::{FeatureRequirement, mask_password};
 use crate::ports::outbound::clipboard::ClipboardError;
 use crate::ports::outbound::connection_store::ConnectionStoreError;
 use crate::ports::outbound::folder_opener::FolderOpenError;
@@ -20,11 +21,10 @@ use crate::ports::outbound::query_history::QueryHistoryError;
 use crate::ports::outbound::settings_store::SettingsStoreError;
 use crate::ports::outbound::{AppSettings, DbOperationError};
 use std::collections::HashMap;
+use url::Url;
 
 use crate::domain::SqliteDiagnosticsSnapshot;
-use crate::domain::{
-    ConnectionId, DatabaseMetadata, DiagnosticField, QueryResult, QuerySource, Table,
-};
+use crate::domain::{DatabaseMetadata, DiagnosticField, QueryResult, QuerySource, Table};
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ConnectionSaveError {
@@ -34,6 +34,11 @@ pub enum ConnectionSaveError {
     Store(#[from] ConnectionStoreError),
     #[error("{0}")]
     Metadata(#[from] DbOperationError),
+    #[error("{error}")]
+    Probe {
+        error: DbOperationError,
+        dsn: String,
+    },
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -44,6 +49,13 @@ pub enum ErDiagramError {
     ExportFailed(String),
     #[error("Task panicked: {0}")]
     TaskPanicked(String),
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{error}")]
+pub struct ErDiagramFailure {
+    pub run_id: u64,
+    pub error: ErDiagramError,
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -192,6 +204,7 @@ pub enum ListMotion {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModalKind {
     TablePicker,
+    DatabasePicker,
     CommandPalette,
     Settings,
     Help,
@@ -228,6 +241,7 @@ pub struct SmartErRefreshError {
 
 #[derive(Debug, Clone)]
 pub struct ErDiagramInfo {
+    pub run_id: u64,
     pub path: String,
     pub table_count: usize,
     pub total_tables: usize,
@@ -249,12 +263,44 @@ pub struct TableTarget {
     pub generation: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ConnectionTarget {
     pub id: ConnectionId,
     pub dsn: String,
     pub name: String,
     pub database_type: DatabaseType,
+    pub database: Option<String>,
+}
+
+impl fmt::Debug for ConnectionTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ConnectionTarget")
+            .field("id", &self.id)
+            .field("dsn", &mask_password(&self.dsn))
+            .field("name", &self.name)
+            .field("database_type", &self.database_type)
+            .field("database", &self.database)
+            .finish()
+    }
+}
+
+impl ConnectionTarget {
+    pub fn with_database(&self, database: &str) -> Option<Self> {
+        let mut url = Url::parse(&self.dsn).ok()?;
+        url.path_segments_mut().ok()?.clear().push(database);
+        Some(Self {
+            dsn: url.to_string(),
+            database: Some(database.to_string()),
+            ..self.clone()
+        })
+    }
+
+    pub fn server_dsn(&self) -> Option<String> {
+        let mut url = Url::parse(&self.dsn).ok()?;
+        url.path_segments_mut().ok()?.clear();
+        Some(url.to_string())
+    }
 }
 
 // Full Action equality is intentionally unavailable: some payloads carry
@@ -347,6 +393,32 @@ pub enum Action {
     ConnectionSetupCancel,
     ConnectionSaveCompleted(ConnectionTarget),
     ConnectionSaveFailed(ConnectionSaveError),
+    ConnectionProbeCompleted {
+        target: ConnectionTarget,
+        run_id: u64,
+    },
+    ConnectionProbeFailed {
+        target: ConnectionTarget,
+        run_id: u64,
+        error: DbOperationError,
+    },
+    SwitchMySqlDatabase {
+        database: String,
+    },
+    MySqlDatabasesLoaded {
+        connection_id: ConnectionId,
+        dsn: String,
+        connection_generation: u64,
+        database_generation: u64,
+        databases: Vec<String>,
+    },
+    MySqlDatabasesFailed {
+        connection_id: ConnectionId,
+        dsn: String,
+        connection_generation: u64,
+        database_generation: u64,
+        error: DbOperationError,
+    },
     ConnectionEditLoaded(Box<ConnectionProfile>),
     ConnectionEditLoadFailed(ConnectionStoreError),
     ShowConnectionError(ConnectionErrorInfo),
@@ -476,6 +548,10 @@ pub enum Action {
         candidates: Vec<CompletionCandidate>,
         trigger_position: usize,
         visible: bool,
+        dsn: Option<String>,
+        connection_generation: u64,
+        database_generation: u64,
+        metadata_generation: u64,
     },
     CompletionAccept,
     CompletionDismiss,
@@ -489,6 +565,8 @@ pub enum Action {
     ExplainAnalyzeCancel,
     ExplainCompleted {
         dsn: String,
+        database_type: DatabaseType,
+        database_generation: u64,
         run_id: u64,
         query: String,
         plan_text: String,
@@ -497,6 +575,7 @@ pub enum Action {
     },
     ExplainFailed {
         dsn: String,
+        database_generation: u64,
         run_id: u64,
         error: DbOperationError,
         is_analyze: bool,
@@ -566,8 +645,8 @@ pub enum Action {
     ToggleReadOnly,
 
     // Query history
-    QueryHistoryLoaded(ConnectionId, Vec<QueryHistoryEntry>),
-    QueryHistoryLoadFailed(ConnectionId, QueryHistoryError),
+    QueryHistoryLoaded(QueryHistoryScope, Vec<QueryHistoryEntry>),
+    QueryHistoryLoadFailed(QueryHistoryScope, QueryHistoryError),
     QueryHistoryAppendFailed(QueryHistoryError),
     QueryHistoryConfirmSelection,
 
@@ -634,7 +713,7 @@ pub enum Action {
     SmartErRefreshCompleted(SmartErRefreshResult),
     SmartErRefreshFailed(SmartErRefreshError),
     ErDiagramOpened(ErDiagramInfo),
-    ErDiagramFailed(ErDiagramError),
+    ErDiagramFailed(ErDiagramFailure),
     ErLogWriteFailed(ErLogError),
 }
 
@@ -649,8 +728,8 @@ impl Action {
 
     pub fn feature_requirement(&self) -> FeatureRequirement {
         use FeatureRequirement::{
-            ErDiagram, Explain, ExplainAnalyze, JsonbDetail, None, PlanComparison,
-            SqliteDiagnostics,
+            ErDiagram, Explain, ExplainAnalyze, JsonDocumentDetail, JsonDocumentEdit, None,
+            PlanComparison, SqliteDiagnostics,
         };
 
         match self {
@@ -704,35 +783,52 @@ impl Action {
             | Self::ToggleModal(ModalKind::JsonbDetail)
             | Self::JsonbYankAll
             | Self::JsonbYankSuccess
-            | Self::JsonbEnterEdit
-            | Self::JsonbAppendInsert
-            | Self::JsonbExitEdit
             | Self::JsonbEnterSearch
             | Self::JsonbExitSearch
             | Self::JsonbSearchNext
             | Self::JsonbSearchPrev
             | Self::JsonbSearchSubmit
             | Self::TextInput {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
                 ..
             }
             | Self::TextBackspace {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
             }
             | Self::TextDelete {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
             }
             | Self::TextKill {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
                 ..
             }
             | Self::TextYank {
-                target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
+                target: InputTarget::JsonbSearch,
             }
             | Self::TextMoveCursor {
                 target: InputTarget::JsonbEdit | InputTarget::JsonbSearch,
                 ..
-            } => JsonbDetail,
+            } => JsonDocumentDetail,
+            Self::JsonbEnterEdit
+            | Self::JsonbAppendInsert
+            | Self::JsonbExitEdit
+            | Self::TextInput {
+                target: InputTarget::JsonbEdit,
+                ..
+            }
+            | Self::TextBackspace {
+                target: InputTarget::JsonbEdit,
+            }
+            | Self::TextDelete {
+                target: InputTarget::JsonbEdit,
+            }
+            | Self::TextKill {
+                target: InputTarget::JsonbEdit,
+                ..
+            }
+            | Self::TextYank {
+                target: InputTarget::JsonbEdit,
+            } => JsonDocumentEdit,
             Self::ExplainRequest
             | Self::Scroll {
                 target: ScrollTarget::ExplainPlan,
@@ -800,7 +896,8 @@ impl Action {
             }
             Self::Paste(_) => match state.input_mode() {
                 InputMode::ErTablePicker => FeatureRequirement::ErDiagram,
-                InputMode::JsonbDetail | InputMode::JsonbEdit => FeatureRequirement::JsonbDetail,
+                InputMode::JsonbDetail => FeatureRequirement::JsonDocumentDetail,
+                InputMode::JsonbEdit => FeatureRequirement::JsonDocumentEdit,
                 _ => FeatureRequirement::None,
             },
             Self::BeginKeySequence(Prefix::G)
@@ -809,7 +906,7 @@ impl Action {
                     InputMode::JsonbDetail | InputMode::JsonbEdit
                 ) =>
             {
-                FeatureRequirement::JsonbDetail
+                FeatureRequirement::JsonDocumentDetail
             }
             _ => self.feature_requirement(),
         }
@@ -820,6 +917,22 @@ impl Action {
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    #[test]
+    fn connection_target_debug_masks_mysql_password() {
+        let target = ConnectionTarget {
+            id: ConnectionId::from_string("mysql"),
+            dsn: "mysql://user:secret@localhost:3306/app".to_string(),
+            name: "MySQL".to_string(),
+            database_type: DatabaseType::MySQL,
+            database: Some("app".to_string()),
+        };
+
+        let debug = format!("{target:?}");
+
+        assert!(!debug.contains("secret"));
+        assert!(debug.contains("mysql://user:****@localhost"));
+    }
 
     #[test]
     fn scroll_action_returns_true() {
@@ -848,6 +961,8 @@ mod tests {
         assert_eq!(
             Action::ExplainCompleted {
                 dsn: "dsn".to_string(),
+                database_type: DatabaseType::PostgreSQL,
+                database_generation: 0,
                 run_id: 1,
                 query: "SELECT 1".to_string(),
                 plan_text: "plan".to_string(),
@@ -860,6 +975,7 @@ mod tests {
         assert_eq!(
             Action::ExplainFailed {
                 dsn: "dsn".to_string(),
+                database_generation: 0,
                 run_id: 1,
                 error: DbOperationError::QueryFailed("error".to_string()),
                 is_analyze: false,
@@ -919,7 +1035,7 @@ mod tests {
         let normal_state = AppState::new("test".to_string());
         assert_eq!(
             Action::JsonbExitEdit.feature_requirement_for_state(&normal_state),
-            FeatureRequirement::JsonbDetail
+            FeatureRequirement::JsonDocumentEdit
         );
     }
 

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -1,5 +1,8 @@
 use crate::cmd::effect::Effect;
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
+use crate::model::connection::error::ConnectionErrorInfo;
+use crate::model::connection::state::ConnectionState;
 use crate::model::shared::input_mode::InputMode;
 use crate::services::AppServices;
 use crate::update::action::{Action, ConnectionTarget};
@@ -7,12 +10,14 @@ use crate::update::query_context::termination_effects;
 
 use crate::update::dispatch_result::DispatchResult;
 
-use super::helpers::{reset_for_new_connection, restore_cache, save_current_cache};
+use super::helpers::{
+    reset_for_database_switch, reset_for_new_connection, restore_cache, save_current_cache,
+};
 
 pub fn reduce_connection_lifecycle(
     state: &mut AppState,
     action: &Action,
-    _now: std::time::Instant,
+    now: std::time::Instant,
     _services: &AppServices,
 ) -> DispatchResult {
     match action {
@@ -21,6 +26,35 @@ pub fn reduce_connection_lifecycle(
                 && state.modal.active_mode() == InputMode::Normal
             {
                 if let Some(dsn) = state.session.dsn().map(str::to_string) {
+                    if state.session.active_database_type() == Some(DatabaseType::MySQL) {
+                        let target = ConnectionTarget {
+                            id: state
+                                .session
+                                .active_connection_id()
+                                .cloned()
+                                .expect("active MySQL connection"),
+                            dsn,
+                            name: state
+                                .session
+                                .active_connection_name()
+                                .unwrap_or_default()
+                                .to_string(),
+                            database_type: DatabaseType::MySQL,
+                            database: state.session.active_database().map(str::to_string),
+                        };
+                        let run_id = state.session.begin_connection_probe(
+                            &target.id,
+                            &target.name,
+                            target.database_type,
+                            &target.dsn,
+                            target.database.as_deref(),
+                        );
+                        state.session.mark_connecting();
+                        return DispatchResult::handled_with(vec![Effect::ProbeConnection {
+                            target,
+                            run_id,
+                        }]);
+                    }
                     let run_id = state.session.begin_connecting(&dsn);
                     DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
                 } else {
@@ -37,9 +71,34 @@ pub fn reduce_connection_lifecycle(
                 dsn,
                 name,
                 database_type,
+                database,
             } = target;
 
-            if let Some(current_id) = state.session.active_connection_id().cloned() {
+            if *database_type == DatabaseType::MySQL {
+                if state.session.active_database_type() != Some(DatabaseType::MySQL)
+                    && let Some(current_id) = state.session.active_connection_id().cloned()
+                {
+                    let cache = save_current_cache(state);
+                    state.connection_caches.save(&current_id, cache);
+                }
+                let run_id = state.session.begin_connection_probe(
+                    id,
+                    name,
+                    *database_type,
+                    dsn,
+                    database.as_deref(),
+                );
+                return DispatchResult::handled_with(vec![Effect::ProbeConnection {
+                    target: target.clone(),
+                    run_id,
+                }]);
+            }
+
+            state.session.clear_connection_probe();
+
+            if state.session.active_database_type() != Some(DatabaseType::MySQL)
+                && let Some(current_id) = state.session.active_connection_id().cloned()
+            {
                 let cache = save_current_cache(state);
                 state.connection_caches.save(&current_id, cache);
             }
@@ -57,7 +116,7 @@ pub fn reduce_connection_lifecycle(
                 DispatchResult::handled_with(termination_effects(&state.query, effects))
             } else {
                 // No cache: reset and fetch metadata
-                reset_for_new_connection(state, id, dsn, name, *database_type);
+                reset_for_new_connection(state, id, dsn, name, *database_type, database.as_deref());
                 let run_id = state.session.begin_connecting(dsn);
                 DispatchResult::handled_with(termination_effects(
                     &state.query,
@@ -72,23 +131,197 @@ pub fn reduce_connection_lifecycle(
             }
         }
 
+        Action::ConnectionProbeCompleted { target, run_id } => {
+            let ConnectionTarget {
+                id,
+                dsn,
+                name,
+                database_type,
+                database,
+            } = target;
+            if *database_type != DatabaseType::MySQL
+                || !state.session.is_current_connection_probe(
+                    id,
+                    name,
+                    *database_type,
+                    dsn,
+                    database.as_deref(),
+                    *run_id,
+                )
+            {
+                return DispatchResult::handled();
+            }
+            reset_for_new_connection(state, id, dsn, name, *database_type, database.as_deref());
+            state.session.mark_probe_connected(database.is_some());
+            state.session.clear_connection_probe();
+            let mut effects = vec![Effect::ClearCompletionEngineCache];
+            if database.is_none() {
+                state.ui.set_database_picker(true);
+                state.modal.set_mode(InputMode::TablePicker);
+                if let (Some(connection_id), Some(server_dsn)) = (
+                    state.session.active_connection_id().cloned(),
+                    state.session.server_dsn(),
+                ) {
+                    effects.push(Effect::FetchMySqlDatabases {
+                        connection_id,
+                        dsn: server_dsn,
+                        connection_generation: state.session.connection_generation(),
+                        database_generation: state.session.database_generation(),
+                    });
+                }
+            } else {
+                let metadata_run_id = state.session.begin_metadata_refresh();
+                effects.push(Effect::FetchMetadata {
+                    dsn: dsn.clone(),
+                    run_id: metadata_run_id,
+                });
+            }
+            DispatchResult::handled_with(termination_effects(&state.query, effects))
+        }
+
+        Action::SwitchMySqlDatabase { database } => {
+            if state.session.active_database_type() != Some(DatabaseType::MySQL)
+                || !matches!(
+                    state.session.connection_state(),
+                    ConnectionState::Connected | ConnectionState::AwaitingDatabase
+                )
+            {
+                return DispatchResult::handled();
+            }
+            let Some(target) = (|| {
+                let target = ConnectionTarget {
+                    id: state.session.active_connection_id()?.clone(),
+                    dsn: state.session.dsn()?.to_string(),
+                    name: state.session.active_connection_name()?.to_string(),
+                    database_type: DatabaseType::MySQL,
+                    database: state.session.active_database().map(str::to_string),
+                };
+                target.with_database(database)
+            })() else {
+                state.messages.set_error_at(
+                    "Unable to build the selected MySQL database target".to_string(),
+                    now,
+                );
+                return DispatchResult::handled();
+            };
+            reset_for_database_switch(state, &target);
+            state.ui.set_database_picker(false);
+            state.modal.set_mode(InputMode::Normal);
+            let metadata_run_id = state.session.begin_metadata_refresh();
+            DispatchResult::handled_with(termination_effects(
+                &state.query,
+                vec![
+                    Effect::ClearCompletionEngineCache,
+                    Effect::FetchMetadata {
+                        dsn: target.dsn,
+                        run_id: metadata_run_id,
+                    },
+                ],
+            ))
+        }
+
+        Action::MySqlDatabasesLoaded {
+            connection_id,
+            dsn,
+            connection_generation,
+            database_generation,
+            databases,
+        } => {
+            if !state.session.is_current_database_fetch(
+                connection_id,
+                dsn,
+                *connection_generation,
+                *database_generation,
+            ) {
+                return DispatchResult::handled();
+            }
+            state.session.set_available_databases(databases.clone());
+            if state.session.available_databases().is_empty() {
+                state
+                    .messages
+                    .set_error_at("No selectable MySQL databases are visible".to_string(), now);
+            }
+            DispatchResult::handled()
+        }
+
+        Action::MySqlDatabasesFailed {
+            connection_id,
+            dsn,
+            connection_generation,
+            database_generation,
+            error,
+        } => {
+            if !state.session.is_current_database_fetch(
+                connection_id,
+                dsn,
+                *connection_generation,
+                *database_generation,
+            ) {
+                return DispatchResult::handled();
+            }
+            state.messages.set_error_at(error.user_message(), now);
+            if state.session.active_database().is_none() {
+                state.ui.set_database_picker(false);
+                state.session.mark_connection_failed(error.user_message());
+                state
+                    .connection_error
+                    .set_error(ConnectionErrorInfo::from_db_operation_error(error));
+                state.modal.replace_mode(InputMode::ConnectionError);
+            }
+            DispatchResult::handled()
+        }
+
+        Action::ConnectionProbeFailed {
+            target,
+            run_id,
+            error,
+        } => {
+            if target.database_type != DatabaseType::MySQL
+                || !state.session.is_current_connection_probe(
+                    &target.id,
+                    &target.name,
+                    target.database_type,
+                    &target.dsn,
+                    target.database.as_deref(),
+                    *run_id,
+                )
+            {
+                return DispatchResult::handled();
+            }
+            if state.session.dsn_matches(&target.dsn) {
+                state.session.mark_connection_failed(error.user_message());
+            }
+            state.connection_error.set_error(
+                ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
+            );
+            state.modal.replace_mode(InputMode::ConnectionError);
+            DispatchResult::handled()
+        }
+
         _ => DispatchResult::pass(),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
-    use crate::domain::ConnectionId;
     use crate::domain::connection::DatabaseType;
+    use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
+    use crate::domain::{ConnectionId, DatabaseMetadata, MetadataState};
     use crate::model::connection::cache::ConnectionCache;
+    use crate::model::connection::error::ConnectionErrorKind;
     use crate::model::connection::state::ConnectionState;
     use crate::model::er_state::ErStatus;
+    use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::inspector_tab::InspectorTab;
     use crate::model::shared::ui_state::ResultNavMode;
+    use crate::ports::outbound::DbOperationError;
     use crate::test_support::connection::{
         assert_explain_state_cleared, assert_sqlite_diagnostics_cleared,
     };
+    use crate::update::reducer::reduce as reduce_app;
 
     fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
         reduce_connection_lifecycle(
@@ -106,6 +339,7 @@ mod tests {
             dsn: format!("postgres://localhost/{name}"),
             name: name.to_string(),
             database_type: DatabaseType::PostgreSQL,
+            database: None,
         })
     }
 
@@ -133,6 +367,76 @@ mod tests {
             let saved = state.connection_caches.get(&current_id).unwrap();
             assert_eq!(saved.explorer_selected, 5);
             assert_eq!(saved.inspector_tab, InspectorTab::Indexes);
+        }
+
+        fn assert_non_mysql_cache_survives_mysql_switch(
+            database_type: DatabaseType,
+            dsn: &str,
+            name: &str,
+        ) {
+            let mut state = AppState::new("test".to_string());
+            let source_id = ConnectionId::from_string("source");
+            let mysql_id = ConnectionId::from_string("mysql");
+            let source = ConnectionTarget {
+                id: source_id.clone(),
+                dsn: dsn.to_string(),
+                name: name.to_string(),
+                database_type,
+                database: None,
+            };
+
+            state
+                .session
+                .activate_connection_with_dsn(&source_id, name, database_type, dsn);
+            state.ui.set_explorer_selected_raw(5);
+            state.ui.set_inspector_tab(InspectorTab::Indexes);
+
+            let mysql = ConnectionTarget {
+                id: mysql_id,
+                dsn: "mysql://user@localhost:3306/app".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .expect("switching to MySQL should probe the connection");
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target: mysql,
+                    run_id,
+                },
+            );
+
+            reduce(&mut state, &Action::SwitchConnection(source));
+
+            assert_eq!(state.session.active_connection_id(), Some(&source_id));
+            assert_eq!(state.ui.explorer_selected(), 5);
+            assert_eq!(state.ui.inspector_tab(), InspectorTab::Indexes);
+        }
+
+        #[test]
+        fn restores_postgres_cache_after_switching_through_mysql() {
+            assert_non_mysql_cache_survives_mysql_switch(
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/current",
+                "postgres",
+            );
+        }
+
+        #[test]
+        fn restores_sqlite_cache_after_switching_through_mysql() {
+            assert_non_mysql_cache_survives_mysql_switch(
+                DatabaseType::SQLite,
+                "sqlite:///tmp/current.db",
+                "sqlite",
+            );
         }
 
         #[test]
@@ -190,6 +494,7 @@ mod tests {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 name: "app.db".to_string(),
                 database_type: DatabaseType::SQLite,
+                database: None,
             });
             reduce(&mut state, &action);
 
@@ -206,24 +511,28 @@ mod tests {
             let dsn = match database_type {
                 DatabaseType::PostgreSQL => format!("postgres://localhost/{name}"),
                 DatabaseType::SQLite => format!("sqlite:///tmp/{name}.db"),
+                DatabaseType::MySQL => format!("mysql://user@localhost/{name}"),
             };
             Action::SwitchConnection(ConnectionTarget {
                 id,
                 dsn,
                 name: name.to_string(),
                 database_type,
+                database: None,
             })
         }
 
         fn seed_explain_state(state: &mut AppState) {
             state.explain.set_plan(
                 "Seq Scan  (cost=0.00..100.00 rows=10 width=32)".to_string(),
+                DatabaseType::PostgreSQL,
                 false,
                 0,
                 "SELECT * FROM users",
             );
             state.explain.set_plan(
                 "Index Scan  (cost=0.00..5.00 rows=1 width=32)".to_string(),
+                DatabaseType::PostgreSQL,
                 false,
                 0,
                 "SELECT * FROM users WHERE id = 1",
@@ -437,6 +746,7 @@ mod tests {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 name: "app.db".to_string(),
                 database_type: DatabaseType::SQLite,
+                database: None,
             });
             let effects = reduce(&mut state, &action).unwrap();
 
@@ -478,6 +788,7 @@ mod tests {
                 dsn: "sqlite:///tmp/app.db".to_string(),
                 name: "app.db".to_string(),
                 database_type: DatabaseType::SQLite,
+                database: None,
             });
             let effects = reduce(&mut state, &action).unwrap();
 
@@ -541,6 +852,7 @@ mod tests {
 
     mod connection_state_tests {
         use super::*;
+        use crate::update::connection::error::reduce_connection_error;
 
         #[test]
         fn sqlite_try_connect_fetches_metadata() {
@@ -565,6 +877,545 @@ mod tests {
             assert_eq!(
                 state.session.connection_state(),
                 ConnectionState::Connecting
+            );
+        }
+
+        #[test]
+        fn mysql_switch_probes_without_fetching_metadata() {
+            let mut state = AppState::new("test".to_string());
+            let target = ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "mysql://user@localhost:3306/app?ssl-mode=PREFERRED".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            };
+
+            let effects = reduce(&mut state, &Action::SwitchConnection(target.clone())).unwrap();
+
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::ProbeConnection { target: actual, .. } if actual.dsn == target.dsn
+            )));
+            assert!(
+                !effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
+        }
+
+        #[test]
+        fn mysql_switch_invalidates_previous_metadata_failure() {
+            let mut state = AppState::new("test".to_string());
+            let postgres = ConnectionTarget {
+                id: ConnectionId::from_string("postgres-b"),
+                dsn: "postgres://localhost/b".to_string(),
+                name: "postgres-b".to_string(),
+                database_type: DatabaseType::PostgreSQL,
+                database: None,
+            };
+            let postgres_effects =
+                reduce(&mut state, &Action::SwitchConnection(postgres.clone())).unwrap();
+            let postgres_run_id = postgres_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::FetchMetadata { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-c"),
+                dsn: "mysql://user@localhost:3306/c?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-c".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("c".to_string()),
+            };
+            let mysql_effects =
+                reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = mysql_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::MetadataFailed {
+                    dsn: postgres.dsn,
+                    run_id: postgres_run_id,
+                    error: DbOperationError::ConnectionFailed("stale postgres".to_string()),
+                },
+            );
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                },
+            );
+
+            assert_eq!(
+                state.session.active_database_type(),
+                Some(DatabaseType::MySQL)
+            );
+            assert!(state.session.connection_state().is_connected());
+            assert_eq!(state.modal.active_mode(), InputMode::Normal);
+            assert!(state.connection_error.error_info().is_none());
+        }
+
+        #[test]
+        fn mysql_probe_failure_does_not_leave_previous_connecting_state() {
+            let mut state = AppState::new("test".to_string());
+            let postgres = ConnectionTarget {
+                id: ConnectionId::from_string("postgres-b"),
+                dsn: "postgres://localhost/b".to_string(),
+                name: "postgres-b".to_string(),
+                database_type: DatabaseType::PostgreSQL,
+                database: None,
+            };
+            let _ = reduce(&mut state, &Action::SwitchConnection(postgres)).unwrap();
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-c"),
+                dsn: "mysql://user@localhost:3306/c?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-c".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("c".to_string()),
+            };
+            let mysql_effects =
+                reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = mysql_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            assert!(state.session.connection_state().is_not_connected());
+            assert!(matches!(
+                state.session.metadata_state(),
+                MetadataState::NotLoaded
+            ));
+            assert!(!state.session.is_reloading());
+        }
+
+        #[test]
+        fn mysql_probe_failure_finishes_previous_reload() {
+            let mut state = AppState::new("test".to_string());
+            let postgres_id = ConnectionId::from_string("postgres-b");
+            state.session.activate_connection_with_dsn(
+                &postgres_id,
+                "postgres-b",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/b",
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            let _ = state.session.begin_reload();
+            assert!(state.session.is_reloading());
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-c"),
+                dsn: "mysql://user@localhost:3306/c?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-c".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("c".to_string()),
+            };
+            let mysql_effects =
+                reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = mysql_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            assert!(state.session.connection_state().is_connected());
+            assert!(!state.session.is_reloading());
+        }
+
+        #[test]
+        fn stale_mysql_probe_completion_is_ignored_after_switch() {
+            let mut state = AppState::new("test".to_string());
+            let first = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-a"),
+                dsn: "mysql://user@localhost:3306/a?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-a".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("a".to_string()),
+            };
+            let second = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+
+            let first_effects =
+                reduce(&mut state, &Action::SwitchConnection(first.clone())).unwrap();
+            let first_run_id = first_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(&mut state, &Action::SwitchConnection(second));
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target: first,
+                    run_id: first_run_id,
+                },
+            );
+
+            assert_eq!(state.session.active_connection_id(), None);
+            assert_eq!(state.session.dsn(), None);
+        }
+
+        #[test]
+        fn stale_mysql_probe_failure_is_ignored_after_switch() {
+            let mut state = AppState::new("test".to_string());
+            let first = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-a"),
+                dsn: "mysql://user@localhost:3306/a?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-a".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("a".to_string()),
+            };
+            let second = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+
+            let first_effects =
+                reduce(&mut state, &Action::SwitchConnection(first.clone())).unwrap();
+            let first_run_id = first_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(&mut state, &Action::SwitchConnection(second));
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: first,
+                    run_id: first_run_id,
+                    error: DbOperationError::ConnectionFailed("stale".to_string()),
+                },
+            );
+
+            assert_eq!(state.modal.active_mode(), InputMode::Normal);
+            assert!(state.connection_error.error_info().is_none());
+        }
+
+        #[test]
+        fn retry_after_mysql_switch_failure_reprobes_failed_target() {
+            let mut state = AppState::new("test".to_string());
+            let target = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(target.clone())).unwrap();
+            let first_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: target.clone(),
+                    run_id: first_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+
+            let (retry_target, retry_run_id) = retry_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { target, run_id } => Some((target, *run_id)),
+                    _ => None,
+                })
+                .unwrap();
+            assert_eq!(retry_target.dsn, target.dsn);
+            assert_eq!(retry_target.id, target.id);
+            assert_ne!(retry_run_id, first_run_id);
+        }
+
+        #[test]
+        fn retry_after_mysql_switch_failure_preserves_connected_previous_target() {
+            let mut state = AppState::new("test".to_string());
+            let postgres_id = ConnectionId::from_string("postgres-a");
+            let postgres_dsn = "postgres://localhost/a".to_string();
+            state.session.activate_connection_with_dsn(
+                &postgres_id,
+                "postgres-a",
+                DatabaseType::PostgreSQL,
+                &postgres_dsn,
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            state
+                .session
+                .set_metadata(Some(Arc::new(DatabaseMetadata::new("a".to_string()))));
+            state.session.set_metadata_state(MetadataState::Loaded);
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let first_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql.clone(),
+                    run_id: first_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+            assert!(state.session.connection_state().is_connected());
+            assert_eq!(state.session.metadata_state(), &MetadataState::Loaded);
+            let retry_run_id = retry_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: retry_run_id,
+                    error: DbOperationError::ConnectionFailed("refused again".to_string()),
+                },
+            );
+
+            assert_eq!(state.session.dsn(), Some(postgres_dsn.as_str()));
+            assert!(state.session.connection_state().is_connected());
+            assert_eq!(state.session.metadata_state(), &MetadataState::Loaded);
+            assert!(!state.session.is_reloading());
+        }
+
+        #[test]
+        fn postgres_reload_retry_does_not_use_old_mysql_probe_target() {
+            let mut state = AppState::new("test".to_string());
+            let postgres_id = ConnectionId::from_string("postgres-a");
+            let postgres_dsn = "postgres://localhost/a".to_string();
+            state.session.activate_connection_with_dsn(
+                &postgres_id,
+                "postgres-a",
+                DatabaseType::PostgreSQL,
+                &postgres_dsn,
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+
+            let mysql = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(mysql.clone())).unwrap();
+            let mysql_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: mysql,
+                    run_id: mysql_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            let reload_run_id = state.session.begin_reload();
+            assert!(state.session.pending_connection_probe().is_none());
+            reduce_app(
+                &mut state,
+                Action::MetadataFailed {
+                    dsn: postgres_dsn.clone(),
+                    run_id: reload_run_id,
+                    error: DbOperationError::ConnectionFailed("reload refused".to_string()),
+                },
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+            assert!(retry_effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchMetadata { dsn, .. } if dsn == &postgres_dsn
+            )));
+            assert!(
+                !retry_effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ProbeConnection { .. }))
+            );
+        }
+
+        #[test]
+        fn mysql_probe_without_database_enters_awaiting_database() {
+            let mut state = AppState::new("test".to_string());
+            let target = ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "mysql://user@localhost:3306?ssl-mode=PREFERRED".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: None,
+            };
+
+            let run_id = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+            let effects = reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted { target, run_id },
+            )
+            .unwrap();
+
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ClearCompletionEngineCache))
+            );
+            assert!(state.session.connection_state().is_awaiting_database());
+            assert!(matches!(
+                state.session.metadata_state(),
+                MetadataState::NotLoaded
+            ));
+        }
+
+        #[test]
+        fn mysql_probe_failure_never_enters_connected_state() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::new();
+            let dsn = "mysql://user@localhost:3306/app?ssl-mode=PREFERRED".to_string();
+            state.session.activate_connection_with_target(
+                &id,
+                "mysql",
+                DatabaseType::MySQL,
+                &dsn,
+                Some("app"),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connecting);
+            let target = ConnectionTarget {
+                id,
+                dsn,
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            };
+            let run_id = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target,
+                    run_id,
+                    error: DbOperationError::ConnectionFailed(
+                        "ERROR 1045: Access denied for user 'user'".to_string(),
+                    ),
+                },
+            );
+
+            assert!(!state.session.connection_state().is_connected());
+            assert!(state.session.connection_state().is_failed());
+            assert_eq!(state.modal.active_mode(), InputMode::ConnectionError);
+            assert_eq!(
+                state.connection_error.error_info().unwrap().kind,
+                ConnectionErrorKind::AuthFailed
             );
         }
 
@@ -703,6 +1554,235 @@ mod tests {
                     .iter()
                     .any(|e| matches!(e, Effect::ClearCompletionEngineCache))
             );
+        }
+    }
+
+    mod mysql_database_tests {
+        use super::*;
+        use crate::update::action::ErDiagramInfo;
+
+        fn mysql_target(id: &ConnectionId, database: Option<&str>) -> ConnectionTarget {
+            let database = database.map(str::to_string);
+            let dsn = format!(
+                "mysql://user:secret@localhost:3306/{}?ssl-mode=PREFERRED",
+                database.as_deref().unwrap_or("")
+            );
+            ConnectionTarget {
+                id: id.clone(),
+                dsn,
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database,
+            }
+        }
+
+        #[test]
+        fn connection_without_database_opens_picker_and_fetches_server_databases() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, None);
+            let probe_run_id = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                None,
+            );
+
+            let effects = reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target,
+                    run_id: probe_run_id,
+                },
+            )
+            .unwrap();
+
+            assert!(state.session.connection_state().is_awaiting_database());
+            assert_eq!(state.session.active_database(), None);
+            assert!(state.ui.database_picker());
+            assert_eq!(state.input_mode(), InputMode::TablePicker);
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchMySqlDatabases { connection_id, .. } if connection_id == &id
+            )));
+        }
+
+        #[test]
+        fn database_selection_resets_context_and_preserves_read_only() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, Some("app"));
+            state.session.activate_connection_with_target(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+            state.session.mark_probe_connected(true);
+            state.session.enable_read_only();
+            state.session.set_available_databases(vec![
+                "information_schema".to_string(),
+                "analytics".to_string(),
+            ]);
+            state.ui.set_database_picker(true);
+            state.modal.set_mode(InputMode::TablePicker);
+            let stale_er_run_id = state.er_preparation.start_waiting_run();
+            state.er_preparation.mark_rendering();
+            state
+                .query_history_picker
+                .replace_entries(&[QueryHistoryEntry::new(
+                    "SELECT old_database".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    id,
+                    QueryResultStatus::Success,
+                    None,
+                )]);
+
+            let effects = reduce_app(
+                &mut state,
+                Action::ConfirmSelection,
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.session.active_database(), Some("analytics"));
+            assert!(
+                state
+                    .session
+                    .dsn()
+                    .is_some_and(|dsn| dsn.contains("/analytics"))
+            );
+            assert!(state.session.metadata().is_none());
+            assert!(state.session.is_read_only());
+            assert_eq!(
+                state.session.available_databases(),
+                ["analytics".to_string()]
+            );
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert!(state.query_history_picker.entries().is_empty());
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
+
+            let effects = reduce_app(
+                &mut state,
+                Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id: stale_er_run_id,
+                    path: "stale.svg".to_string(),
+                    table_count: 1,
+                    total_tables: 1,
+                }),
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.is_empty());
+            assert!(state.messages.last_success().is_none());
+        }
+
+        #[test]
+        fn database_switch_closes_query_history_picker_and_discards_entries() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, Some("app"));
+            state.session.activate_connection_with_target(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+            state.session.mark_probe_connected(true);
+            state.modal.set_mode(InputMode::QueryHistoryPicker);
+            state.sql_modal.completion_mut_for_test().visible = true;
+            state.explain.set_plan(
+                "-> Table scan on users  (cost=1 rows=10)".to_string(),
+                DatabaseType::MySQL,
+                false,
+                1,
+                "SELECT * FROM users",
+            );
+            state.explain.set_plan(
+                "-> Index lookup on users  (cost=0.5 rows=1)".to_string(),
+                DatabaseType::MySQL,
+                false,
+                1,
+                "SELECT * FROM users WHERE id = 1",
+            );
+            state
+                .query_history_picker
+                .replace_entries(&[QueryHistoryEntry::new_with_database(
+                    "SELECT from app".to_string(),
+                    "2026-03-13T12:00:00Z".to_string(),
+                    id,
+                    Some("app".to_string()),
+                    QueryResultStatus::Success,
+                    None,
+                )]);
+
+            let effects = reduce_app(
+                &mut state,
+                Action::SwitchMySqlDatabase {
+                    database: "analytics".to_string(),
+                },
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.session.active_database(), Some("analytics"));
+            assert_eq!(state.input_mode(), InputMode::Normal);
+            assert!(state.query_history_picker.entries().is_empty());
+            assert!(!state.sql_modal.completion().visible);
+            assert!(state.explain.left().is_none());
+            assert!(state.explain.right().is_none());
+            assert!(state.explain.history().is_empty());
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ClearCompletionEngineCache))
+            );
+        }
+
+        #[test]
+        fn stale_database_list_from_previous_connection_generation_is_ignored() {
+            let mut state = AppState::new("test".to_string());
+            let id = ConnectionId::from_string("mysql");
+            let target = mysql_target(&id, None);
+            state.session.activate_connection_with_target(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                None,
+            );
+            state.session.mark_probe_connected(false);
+            let stale_generation = state.session.connection_generation();
+            let _ = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                None,
+            );
+            let server_dsn = state.session.server_dsn().unwrap();
+            let database_generation = state.session.database_generation();
+
+            let _ = reduce(
+                &mut state,
+                &Action::MySqlDatabasesLoaded {
+                    connection_id: id,
+                    dsn: server_dsn,
+                    connection_generation: stale_generation,
+                    database_generation,
+                    databases: vec!["stale".to_string()],
+                },
+            );
+
+            assert!(state.session.available_databases().is_empty());
         }
     }
 }

--- a/src/app/update/connection/selector.rs
+++ b/src/app/update/connection/selector.rs
@@ -51,10 +51,24 @@ pub(super) fn reduce_connection_selector(
             DispatchResult::handled()
         }
         Action::DeleteConnection(id) => {
+            if state
+                .session
+                .pending_connection_probe()
+                .is_some_and(|pending| pending.id == *id)
+            {
+                state.session.clear_connection_probe();
+            }
             DispatchResult::handled_with(vec![Effect::DeleteConnection { id: id.clone() }])
         }
         Action::ConnectionDeleted(id) => {
             let was_active = state.session.active_connection_id() == Some(id);
+            if state
+                .session
+                .pending_connection_probe()
+                .is_some_and(|pending| pending.id == *id)
+            {
+                state.session.clear_connection_probe();
+            }
             if was_active {
                 reset_active_connection_state(state);
             }
@@ -111,7 +125,7 @@ pub(super) fn reduce_connection_selector(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::connection::{ConnectionProfile, DatabaseType, SslMode};
+    use crate::domain::connection::{ConnectionId, ConnectionProfile, DatabaseType, SslMode};
     use crate::model::connection::list::build_connection_list;
     use crate::model::shared::ui_state::ResultNavMode;
 
@@ -293,9 +307,13 @@ mod tests {
         use crate::model::er_state::ErStatus;
         use crate::model::shared::inspector_tab::InspectorTab;
         use crate::model::sql_editor::modal::SqlModalTab;
+        use crate::ports::outbound::DbOperationError;
+        use crate::services::AppServices;
         use crate::test_support::connection::{
             assert_explain_state_cleared, assert_sqlite_diagnostics_cleared,
         };
+        use crate::update::action::ConnectionTarget;
+        use crate::update::connection::lifecycle::reduce_connection_lifecycle;
 
         #[test]
         fn removes_connection_from_list() {
@@ -313,6 +331,107 @@ mod tests {
 
             assert_eq!(state.connections().len(), 1);
             assert_eq!(state.connections()[0].name.as_str(), "Second");
+        }
+
+        #[test]
+        fn deleting_pending_probe_target_invalidates_delayed_completion() {
+            let mut state = AppState::new("test".to_string());
+            let current_id = ConnectionId::from_string("postgres-a");
+            let deleted = create_profile("MySQL");
+            let deleted_id = deleted.id.clone();
+            state.set_connections(vec![deleted, create_profile("Other")]);
+            state.session.activate_connection_with_dsn(
+                &current_id,
+                "postgres-a",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/a",
+            );
+            let target = ConnectionTarget {
+                id: deleted_id.clone(),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "MySQL".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let probe_run_id = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+
+            reduce_connection_selector(
+                &mut state,
+                &Action::ConnectionDeleted(deleted_id),
+                Instant::now(),
+            );
+            reduce_connection_lifecycle(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target,
+                    run_id: probe_run_id,
+                },
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.session.active_connection_id(), Some(&current_id));
+            assert!(state.session.pending_connection_probe().is_none());
+        }
+
+        #[test]
+        fn delete_start_invalidates_probe_failure_before_delete_completion() {
+            let mut state = AppState::new("test".to_string());
+            let current_id = ConnectionId::from_string("postgres-a");
+            let deleted = create_profile("MySQL");
+            let deleted_id = deleted.id.clone();
+            state.set_connections(vec![deleted, create_profile("Other")]);
+            state.session.activate_connection_with_dsn(
+                &current_id,
+                "postgres-a",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/a",
+            );
+            let target = ConnectionTarget {
+                id: deleted_id.clone(),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "MySQL".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let probe_run_id = state.session.begin_connection_probe(
+                &target.id,
+                &target.name,
+                target.database_type,
+                &target.dsn,
+                target.database.as_deref(),
+            );
+
+            reduce_connection_selector(
+                &mut state,
+                &Action::DeleteConnection(deleted_id.clone()),
+                Instant::now(),
+            );
+            reduce_connection_lifecycle(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target,
+                    run_id: probe_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            reduce_connection_selector(
+                &mut state,
+                &Action::ConnectionDeleted(deleted_id),
+                Instant::now(),
+            );
+
+            assert_eq!(state.modal.active_mode(), InputMode::Normal);
+            assert!(state.connection_error.error_info().is_none());
+            assert_eq!(state.session.active_connection_id(), Some(&current_id));
         }
 
         #[test]
@@ -370,12 +489,14 @@ mod tests {
             state.sql_modal.set_active_tab(SqlModalTab::Compare);
             state.explain.set_plan(
                 "Seq Scan  (cost=0.00..100.00 rows=10 width=32)".to_string(),
+                DatabaseType::PostgreSQL,
                 false,
                 0,
                 "SELECT * FROM users",
             );
             state.explain.set_plan(
                 "Index Scan  (cost=0.00..5.00 rows=1 width=32)".to_string(),
+                DatabaseType::PostgreSQL,
                 false,
                 0,
                 "SELECT * FROM users WHERE id = 1",
@@ -433,9 +554,13 @@ mod tests {
             state.ui.set_inspector_scroll_offset(17);
             state.ui.set_inspector_horizontal_offset(23);
             state.sql_modal.set_active_tab(SqlModalTab::Plan);
-            state
-                .explain
-                .set_plan("SCAN users".to_string(), false, 0, "SELECT * FROM users");
+            state.explain.set_plan(
+                "SCAN users".to_string(),
+                DatabaseType::SQLite,
+                false,
+                0,
+                "SELECT * FROM users",
+            );
             state.explain.set_error("stale error".to_string());
             let diagnostics_run_id = state.sqlite_diagnostics.begin_fetch();
             state

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -1,11 +1,14 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
 use crate::policy::sql::statement_classifier;
-use crate::policy::write::sql_risk::{ConfirmationType, evaluate_sql_risk_for_database};
+use crate::policy::write::sql_risk::{
+    ConfirmationType, evaluate_mysql_explain_target, evaluate_sql_risk_for_database,
+};
 use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
 use crate::update::action::Action;
@@ -42,8 +45,19 @@ pub(super) fn reduce_analyze(
                 );
                 return DispatchResult::handled();
             }
-            let kind = statement_classifier::classify(&content);
-            let risk = evaluate_sql_risk_for_database(database_type, &kind, &content);
+            let risk = if database_type == DatabaseType::MySQL {
+                let Some(risk) = evaluate_mysql_explain_target(&content, true) else {
+                    show_explain_error_on_plan(
+                        state,
+                        "MySQL EXPLAIN ANALYZE only supports side-effect-free SELECT or TABLE statements",
+                    );
+                    return DispatchResult::handled();
+                };
+                risk
+            } else {
+                let kind = statement_classifier::classify(&content);
+                evaluate_sql_risk_for_database(database_type, &kind, &content)
+            };
 
             if state.session.is_read_only() && !risk.read_only_allowed {
                 show_explain_error_on_plan(
@@ -75,8 +89,11 @@ pub(super) fn reduce_analyze(
                         return DispatchResult::handled();
                     };
                     let run_id = begin_explain_running(state, now);
+                    let database_generation = state.session.database_generation();
                     return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                         dsn,
+                        database_type,
+                        database_generation,
                         run_id,
                         query: explain_query,
                         source_query: content,
@@ -103,6 +120,12 @@ pub(super) fn reduce_analyze(
                 && let Some(dsn) = state.session.dsn().map(String::from)
             {
                 let database_type = state.session.active_database_type_or_default();
+                if database_type == DatabaseType::MySQL
+                    && evaluate_mysql_explain_target(&query, true).is_none()
+                {
+                    finish_explain_unsupported_analyze(state);
+                    return DispatchResult::handled();
+                }
                 let Some(explain_query) = services
                     .sql_dialect
                     .build_explain_analyze_sql(database_type, &query)
@@ -111,8 +134,11 @@ pub(super) fn reduce_analyze(
                     return DispatchResult::handled();
                 };
                 let run_id = begin_explain_running(state, now);
+                let database_generation = state.session.database_generation();
                 return DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                     dsn,
+                    database_type,
+                    database_generation,
                     run_id,
                     query: explain_query,
                     source_query: query,

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -13,6 +13,9 @@ pub(super) fn explain_unsupported_query_message(database_type: DatabaseType) -> 
             "EXPLAIN QUERY PLAN supports SELECT, INSERT, UPDATE, DELETE, or REPLACE statements"
         }
         DatabaseType::PostgreSQL => "EXPLAIN is unavailable for this statement",
+        DatabaseType::MySQL => {
+            "MySQL EXPLAIN supports SELECT, TABLE, INSERT, REPLACE, UPDATE, or DELETE statements"
+        }
     }
 }
 
@@ -30,6 +33,7 @@ pub(super) fn explain_unsupported_analyze_message(database_type: DatabaseType) -
     match database_type {
         DatabaseType::SQLite => "EXPLAIN ANALYZE is not supported for SQLite",
         DatabaseType::PostgreSQL => "EXPLAIN ANALYZE is unavailable for this statement",
+        DatabaseType::MySQL => "EXPLAIN ANALYZE is unavailable for this connection",
     }
 }
 
@@ -37,7 +41,9 @@ pub(super) fn mark_explain_unsupported_query(state: &mut AppState, content: &str
     let database_type = state.session.active_database_type_or_default();
     let message = match database_type {
         DatabaseType::SQLite => explain_unsupported_sqlite_query_message(content),
-        DatabaseType::PostgreSQL => explain_unsupported_query_message(database_type),
+        DatabaseType::PostgreSQL | DatabaseType::MySQL => {
+            explain_unsupported_query_message(database_type)
+        }
     };
     show_explain_error_on_plan(state, message);
 }
@@ -96,13 +102,18 @@ pub(super) fn begin_explain_running(state: &mut AppState, now: Instant) -> u64 {
 pub(super) fn finish_explain_success(
     state: &mut AppState,
     plan_text: String,
+    database_type: DatabaseType,
     is_analyze: bool,
     execution_time_ms: u64,
     query: &str,
 ) {
-    state
-        .explain
-        .set_plan(plan_text, is_analyze, execution_time_ms, query);
+    state.explain.set_plan(
+        plan_text,
+        database_type,
+        is_analyze,
+        execution_time_ms,
+        query,
+    );
     state.sql_modal.enter_normal();
     state.sql_modal.set_active_tab(SqlModalTab::Plan);
     state.query.mark_idle();

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -34,9 +34,11 @@ fn reduce_explain(state: &mut AppState, action: &Action, now: Instant) -> Dispat
 mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
+    use crate::domain::DatabaseType;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::text_input::TextInputLike;
     use crate::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
+    use crate::policy::write::sql_risk::AcknowledgeReason;
     use crate::ports::outbound::AccessMode;
     use crate::services::AppServices;
     use crate::update::action::{ScrollAmount, ScrollDirection, ScrollTarget};
@@ -176,6 +178,172 @@ mod tests {
                 SqlModalStatus::ConfirmingAnalyzeHigh { .. }
                     | SqlModalStatus::ConfirmingAnalyzeRisk { .. }
             ));
+        }
+
+        #[test]
+        fn mysql_select_emits_tree_explain_effect_and_enables_compare() {
+            let mut state = sql_modal_state();
+            state.sql_modal.editor.set_content("SELECT 1".to_string());
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(matches!(
+                &effects[0],
+                Effect::ExecuteExplain {
+                    query,
+                    database_type: DatabaseType::MySQL,
+                    is_analyze: false,
+                    access_mode: AccessMode::ReadOnly,
+                    ..
+                } if query == "EXPLAIN FORMAT=TREE SELECT 1"
+            ));
+            assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Plan);
+            assert!(
+                state
+                    .session
+                    .active_engine_feature_profile()
+                    .supports_explain_analyze()
+            );
+            assert!(
+                state
+                    .session
+                    .active_engine_feature_profile()
+                    .supports_plan_comparison()
+            );
+        }
+
+        #[test]
+        fn mysql_dml_emits_tree_explain_without_running_the_statement() {
+            let mut state = sql_modal_state();
+            state
+                .sql_modal
+                .editor
+                .set_content("UPDATE users SET active = TRUE".to_string());
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(matches!(
+                &effects[0],
+                Effect::ExecuteExplain {
+                    query,
+                    database_type: DatabaseType::MySQL,
+                    is_analyze: false,
+                    access_mode: AccessMode::ReadOnly,
+                    ..
+                } if query == "EXPLAIN FORMAT=TREE UPDATE users SET active = TRUE"
+            ));
+        }
+
+        #[test]
+        fn mysql_explain_rejects_locking_reads() {
+            let mut state = sql_modal_state();
+            state
+                .sql_modal
+                .editor
+                .set_content("SELECT * FROM users FOR UPDATE".to_string());
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.explain.error.as_deref(),
+                Some("MySQL EXPLAIN only supports side-effect-free read statements")
+            );
+        }
+
+        #[test]
+        fn mysql_ddl_reports_supported_statement_boundary() {
+            let mut state = sql_modal_state();
+            state
+                .sql_modal
+                .editor
+                .set_content("CREATE TABLE users(id INT)".to_string());
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.explain.error.as_deref(),
+                Some(
+                    "MySQL EXPLAIN supports SELECT, TABLE, INSERT, REPLACE, UPDATE, or DELETE statements",
+                )
+            );
+        }
+
+        #[test]
+        fn mysql_client_command_reports_client_command_boundary() {
+            let mut state = sql_modal_state();
+            state
+                .sql_modal
+                .editor
+                .set_content("\\C /tmp/other.sock".to_string());
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.explain.error.as_deref(),
+                Some("MySQL EXPLAIN does not support MySQL client commands")
+            );
+        }
+
+        #[test]
+        fn mysql_multiple_statements_reports_statement_boundary() {
+            let mut state = sql_modal_state();
+            state
+                .sql_modal
+                .editor
+                .set_content("SELECT 1; SELECT 2".to_string());
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.explain.error.as_deref(),
+                Some("MySQL EXPLAIN does not support multiple statements")
+            );
         }
 
         #[test]
@@ -384,6 +552,107 @@ mod tests {
         }
 
         #[test]
+        fn mysql_select_requires_execution_confirmation() {
+            let mut state = sql_modal_state();
+            state.sql_modal.editor.set_content("SELECT 1".to_string());
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainAnalyzeRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::ConfirmingAnalyzeRisk {
+                    query,
+                    reason: AcknowledgeReason::AnalyzeExecution,
+                } if query == "SELECT 1"
+            ));
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainAnalyzeConfirm,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(matches!(
+                &effects[0],
+                Effect::ExecuteExplain {
+                    query,
+                    database_type: DatabaseType::MySQL,
+                    is_analyze: true,
+                    access_mode: AccessMode::ReadWrite,
+                    ..
+                } if query == "EXPLAIN ANALYZE FORMAT=TREE SELECT 1"
+            ));
+        }
+
+        #[test]
+        fn mysql_table_requires_execution_confirmation() {
+            let mut state = sql_modal_state();
+            state
+                .sql_modal
+                .editor
+                .set_content("TABLE items".to_string());
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainAnalyzeRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::ConfirmingAnalyzeRisk {
+                    query,
+                    reason: AcknowledgeReason::AnalyzeExecution,
+                } if query == "TABLE items"
+            ));
+        }
+
+        #[test]
+        fn mysql_write_analyze_is_rejected_before_confirmation() {
+            let mut state = sql_modal_state();
+            state
+                .sql_modal
+                .editor
+                .set_content("UPDATE items SET value = 1".to_string());
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainAnalyzeRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(
+                state.explain.error.as_deref(),
+                Some(
+                    "MySQL EXPLAIN ANALYZE only supports side-effect-free SELECT or TABLE statements"
+                )
+            );
+            assert!(!matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::ConfirmingAnalyzeHigh { .. }
+                    | SqlModalStatus::ConfirmingAnalyzeRisk { .. }
+            ));
+        }
+
+        #[test]
         fn insert_executes_immediately() {
             let mut state = sql_modal_state();
             state
@@ -585,6 +854,49 @@ mod tests {
         }
 
         #[test]
+        fn mysql_read_only_confirms_select_analyze_with_read_only_access_mode() {
+            let mut state = sql_modal_state();
+            state.sql_modal.editor.set_content("SELECT 1".to_string());
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+            state.session.enable_read_only();
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainAnalyzeRequest,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::ConfirmingAnalyzeRisk {
+                    reason: AcknowledgeReason::AnalyzeExecution,
+                    ..
+                }
+            ));
+
+            let effects = dispatch_explain(
+                &mut state,
+                &Action::ExplainAnalyzeConfirm,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .unwrap();
+
+            assert!(matches!(
+                &effects[0],
+                Effect::ExecuteExplain {
+                    query,
+                    is_analyze: true,
+                    access_mode: AccessMode::ReadOnly,
+                    ..
+                } if query == "EXPLAIN ANALYZE FORMAT=TREE SELECT 1"
+            ));
+        }
+
+        #[test]
         fn read_only_blocks_insert_analyze() {
             let mut state = sql_modal_state();
             state
@@ -726,11 +1038,14 @@ mod tests {
             activate_postgres_connection(&mut state);
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            let database_generation = state.session.database_generation();
 
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
                     dsn: "dsn://test".to_string(),
+                    database_type: DatabaseType::PostgreSQL,
+                    database_generation,
                     run_id: 1,
                     query: "SELECT 1".to_string(),
                     plan_text: "Seq Scan".to_string(),
@@ -747,19 +1062,58 @@ mod tests {
         }
 
         #[test]
+        fn mysql_completion_uses_tree_parser() {
+            let mut state = sql_modal_state();
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+            let _ = state.query.begin_running(Instant::now());
+            state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            let database_generation = state.session.database_generation();
+
+            reduce_explain(
+                &mut state,
+                &Action::ExplainCompleted {
+                    dsn: "mysql://test".to_string(),
+                    database_type: DatabaseType::MySQL,
+                    database_generation,
+                    run_id: 1,
+                    query: "SELECT 1".to_string(),
+                    plan_text: "-> Table scan on users  (cost=1.25 rows=2.5)".to_string(),
+                    is_analyze: false,
+                    execution_time_ms: 42,
+                },
+                Instant::now(),
+            );
+
+            let plan = state.explain.right().expect("MySQL plan").plan.clone();
+            assert_eq!(plan.total_cost, Some(1.25));
+            assert_eq!(plan.estimated_rows, Some(2.5));
+            assert_eq!(
+                plan.raw_text,
+                "-> Table scan on users  (cost=1.25 rows=2.5)"
+            );
+        }
+
+        #[test]
         fn mismatched_dsn_does_not_replace_plan() {
             let mut state = sql_modal_state();
             test_fixtures::activate_postgres_connection(&mut state, "dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
-            state
-                .explain
-                .set_plan("Original".to_string(), false, 10, "SELECT old");
+            let database_generation = state.session.database_generation();
+            state.explain.set_plan(
+                "Original".to_string(),
+                DatabaseType::PostgreSQL,
+                false,
+                10,
+                "SELECT old",
+            );
 
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
                     dsn: "dsn://stale".to_string(),
+                    database_type: DatabaseType::PostgreSQL,
+                    database_generation,
                     run_id: 1,
                     query: "SELECT stale".to_string(),
                     plan_text: "Stale".to_string(),
@@ -776,6 +1130,50 @@ mod tests {
             );
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
         }
+
+        #[test]
+        fn mismatched_database_generation_does_not_replace_plan() {
+            let mut state = sql_modal_state();
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+            let database_generation = state.session.database_generation();
+            let run_id = state.query.begin_running(Instant::now());
+            state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            state.explain.set_plan(
+                "original".to_string(),
+                DatabaseType::MySQL,
+                false,
+                10,
+                "SELECT old",
+            );
+
+            let id = state.session.active_connection_id().cloned().unwrap();
+            let name = state.session.active_connection_name().unwrap().to_string();
+            state.session.activate_connection_with_target(
+                &id,
+                &name,
+                DatabaseType::MySQL,
+                "mysql://test",
+                Some("analytics"),
+            );
+
+            reduce_explain(
+                &mut state,
+                &Action::ExplainCompleted {
+                    dsn: "mysql://test".to_string(),
+                    database_type: DatabaseType::MySQL,
+                    database_generation,
+                    run_id,
+                    query: "SELECT stale".to_string(),
+                    plan_text: "stale".to_string(),
+                    is_analyze: false,
+                    execution_time_ms: 42,
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(state.explain.plan_text(), Some("original"));
+            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
+        }
     }
 
     mod explain_failed {
@@ -788,11 +1186,13 @@ mod tests {
             activate_postgres_connection(&mut state);
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+            let database_generation = state.session.database_generation();
 
             reduce_explain(
                 &mut state,
                 &Action::ExplainFailed {
                     dsn: "dsn://test".to_string(),
+                    database_generation,
                     run_id: 1,
                     error: DbOperationError::QueryFailed("syntax error".to_string()),
                     is_analyze: false,
@@ -815,14 +1215,20 @@ mod tests {
             test_fixtures::activate_postgres_connection(&mut state, "dsn://current");
             let _ = state.query.begin_running(Instant::now());
             state.sql_modal.set_status_for_test(SqlModalStatus::Running);
-            state
-                .explain
-                .set_plan("Original".to_string(), false, 10, "SELECT old");
+            let database_generation = state.session.database_generation();
+            state.explain.set_plan(
+                "Original".to_string(),
+                DatabaseType::PostgreSQL,
+                false,
+                10,
+                "SELECT old",
+            );
 
             reduce_explain(
                 &mut state,
                 &Action::ExplainFailed {
                     dsn: "dsn://stale".to_string(),
+                    database_generation,
                     run_id: 1,
                     error: DbOperationError::QueryFailed("syntax error".to_string()),
                     is_analyze: false,
@@ -842,9 +1248,13 @@ mod tests {
         #[test]
         fn sqlite_connection_rejects_compare_edit_query_with_error() {
             let mut state = sql_modal_state();
-            state
-                .explain
-                .set_plan("stale plan".to_string(), false, 1, "SELECT stale");
+            state.explain.set_plan(
+                "stale plan".to_string(),
+                DatabaseType::PostgreSQL,
+                false,
+                1,
+                "SELECT stale",
+            );
             state
                 .sql_modal
                 .editor
@@ -874,6 +1284,7 @@ mod tests {
             state.sql_modal.editor.set_content("SELECT 1".to_string());
             activate_postgres_connection(&mut state);
             let now = Instant::now();
+            let database_generation = state.session.database_generation();
 
             // Step 1: First EXPLAIN
             reduce_explain(&mut state, &Action::ExplainRequest, now);
@@ -881,6 +1292,8 @@ mod tests {
                 &mut state,
                 &Action::ExplainCompleted {
                     dsn: "dsn://test".to_string(),
+                    database_type: DatabaseType::PostgreSQL,
+                    database_generation,
                     run_id: 1,
                     query: "SELECT 1".to_string(),
                     plan_text: "Seq Scan  (cost=0.00..100.00 rows=10 width=32)".to_string(),
@@ -895,10 +1308,13 @@ mod tests {
             // Step 2: Second EXPLAIN — auto-advance moves right→left
             state.sql_modal.editor.set_content("SELECT 2".to_string());
             reduce_explain(&mut state, &Action::ExplainRequest, now);
+            let database_generation = state.session.database_generation();
             reduce_explain(
                 &mut state,
                 &Action::ExplainCompleted {
                     dsn: "dsn://test".to_string(),
+                    database_type: DatabaseType::PostgreSQL,
+                    database_generation,
                     run_id: 2,
                     query: "SELECT 2".to_string(),
                     plan_text: "Index Scan  (cost=0.00..5.00 rows=1 width=32)".to_string(),
@@ -951,7 +1367,9 @@ mod tests {
                 .map(|i| format!("line{i}"))
                 .collect::<Vec<_>>()
                 .join("\n");
-            state.explain.set_plan(long_plan, false, 0, "Q1");
+            state
+                .explain
+                .set_plan(long_plan, DatabaseType::PostgreSQL, false, 0, "Q1");
 
             reduce_explain(
                 &mut state,
@@ -974,7 +1392,9 @@ mod tests {
                 .map(|i| format!("line{i}"))
                 .collect::<Vec<_>>()
                 .join("\n");
-            state.explain.set_plan(long_plan, false, 0, "Q1");
+            state
+                .explain
+                .set_plan(long_plan, DatabaseType::PostgreSQL, false, 0, "Q1");
             let modal_inner = ExplainContext::modal_inner_height(state.ui.terminal_height());
             let max = state.explain.line_count().saturating_sub(modal_inner);
             state.explain.scroll_offset = max;
@@ -1017,8 +1437,12 @@ mod tests {
                 .map(|i| format!("  ->  Node{i}  (cost=0.00..{i}.00 rows=1 width=32)"))
                 .collect::<Vec<_>>()
                 .join("\n");
-            state.explain.set_plan(long_plan.clone(), false, 0, "Q1");
-            state.explain.set_plan(long_plan, false, 0, "Q2");
+            state
+                .explain
+                .set_plan(long_plan.clone(), DatabaseType::PostgreSQL, false, 0, "Q1");
+            state
+                .explain
+                .set_plan(long_plan, DatabaseType::PostgreSQL, false, 0, "Q2");
 
             reduce_explain(
                 &mut state,
@@ -1041,8 +1465,12 @@ mod tests {
                 .map(|i| format!("  ->  Node{i}  (cost=0.00..{i}.00 rows=1 width=32)"))
                 .collect::<Vec<_>>()
                 .join("\n");
-            state.explain.set_plan(long_plan.clone(), false, 0, "Q1");
-            state.explain.set_plan(long_plan, false, 0, "Q2");
+            state
+                .explain
+                .set_plan(long_plan.clone(), DatabaseType::PostgreSQL, false, 0, "Q1");
+            state
+                .explain
+                .set_plan(long_plan, DatabaseType::PostgreSQL, false, 0, "Q2");
 
             let max = state.explain.compare_max_scroll(state.ui.terminal_height());
 
@@ -1082,7 +1510,9 @@ mod tests {
                 .map(|i| format!("  ->  Node{i}  (cost=0.00..{i}.00 rows=1 width=32)"))
                 .collect::<Vec<_>>()
                 .join("\n");
-            state.explain.set_plan(long_plan, false, 0, "Q1");
+            state
+                .explain
+                .set_plan(long_plan, DatabaseType::PostgreSQL, false, 0, "Q1");
 
             reduce_explain(
                 &mut state,

--- a/src/app/update/explain/output.rs
+++ b/src/app/update/explain/output.rs
@@ -14,18 +14,21 @@ pub(super) fn reduce_output(
     match action {
         Action::ExplainCompleted {
             dsn,
+            database_type,
+            database_generation,
             run_id,
             query,
             plan_text,
             is_analyze,
             execution_time_ms,
         } => {
-            if state.is_stale_query_run(dsn, *run_id) {
+            if state.is_stale_explain_run(dsn, *database_generation, *run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_success(
                 state,
                 plan_text.clone(),
+                *database_type,
                 *is_analyze,
                 *execution_time_ms,
                 query,
@@ -34,9 +37,13 @@ pub(super) fn reduce_output(
         }
 
         Action::ExplainFailed {
-            dsn, run_id, error, ..
+            dsn,
+            database_generation,
+            run_id,
+            error,
+            ..
         } => {
-            if state.is_stale_query_run(dsn, *run_id) {
+            if state.is_stale_explain_run(dsn, *database_generation, *run_id) {
                 return DispatchResult::handled();
             }
             finish_explain_error(state, error.user_message());

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -1,9 +1,14 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
+use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
+use crate::policy::sql::mysql_statement::{
+    MysqlStatementKind, classify_mysql_statement, mysql_explain_rejection_message,
+};
+use crate::policy::write::sql_risk::evaluate_mysql_explain_target;
 use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
@@ -34,8 +39,33 @@ pub(super) fn reduce_request(
                 return DispatchResult::handled();
             }
             let database_type = state.session.active_database_type_or_default();
-            if is_multi_statement(database_type, &content) {
+            if database_type == DatabaseType::MySQL {
+                if let Some(message) = mysql_explain_rejection_message(&content) {
+                    show_explain_error_on_plan(state, message);
+                    return DispatchResult::handled();
+                }
+            } else if is_multi_statement(database_type, &content) {
                 show_explain_error_on_plan(state, "EXPLAIN does not support multiple statements");
+                return DispatchResult::handled();
+            }
+            let mysql_explain_dml = database_type == DatabaseType::MySQL
+                && classify_mysql_statement(&content).is_ok_and(|statement| {
+                    matches!(
+                        statement.kind,
+                        MysqlStatementKind::Insert
+                            | MysqlStatementKind::Replace
+                            | MysqlStatementKind::Update { .. }
+                            | MysqlStatementKind::Delete { .. }
+                    )
+                });
+            if database_type == DatabaseType::MySQL
+                && !mysql_explain_dml
+                && evaluate_mysql_explain_target(&content, false).is_none()
+            {
+                show_explain_error_on_plan(
+                    state,
+                    "MySQL EXPLAIN only supports side-effect-free read statements",
+                );
                 return DispatchResult::handled();
             }
 
@@ -56,9 +86,12 @@ pub(super) fn reduce_request(
                 }
             };
             let run_id = begin_explain_running(state, now);
+            let database_generation = state.session.database_generation();
 
             DispatchResult::handled_with(vec![Effect::ExecuteExplain {
                 dsn,
+                database_type,
+                database_generation,
                 run_id,
                 query,
                 source_query: content,

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -99,6 +99,23 @@ fn reduce_inner(
 
         Action::ConfirmSelection => {
             if state.modal.active_mode() == InputMode::TablePicker {
+                if state.ui.database_picker() {
+                    let database = state
+                        .filtered_databases()
+                        .get(state.ui.table_picker().selected())
+                        .map(|database| (*database).clone());
+                    if let Some(database) = database {
+                        state.modal.set_mode(InputMode::Normal);
+                        state.ui.set_database_picker(false);
+                        return reduce(
+                            state,
+                            Action::SwitchMySqlDatabase { database },
+                            now,
+                            services,
+                        );
+                    }
+                    return vec![];
+                }
                 let table = state
                     .filtered_tables()
                     .get(state.ui.table_picker().selected())
@@ -335,6 +352,7 @@ mod tests {
             assert_unsupported_action_is_a_noop(
                 &mut state,
                 Action::ErDiagramOpened(ErDiagramInfo {
+                    run_id: 0,
                     path: "diagram.svg".to_string(),
                     table_count: 1,
                     total_tables: 1,
@@ -412,6 +430,8 @@ mod tests {
                 &mut explain_state,
                 Action::ExplainCompleted {
                     dsn: "sqlite://test.db".to_string(),
+                    database_type: DatabaseType::SQLite,
+                    database_generation: 0,
                     run_id: 1,
                     query: "SELECT 1".to_string(),
                     plan_text: "QUERY PLAN".to_string(),
@@ -424,6 +444,7 @@ mod tests {
                 &mut explain_state,
                 Action::ExplainFailed {
                     dsn: "sqlite://test.db".to_string(),
+                    database_generation: 0,
                     run_id: 1,
                     error: DbOperationError::QueryFailed("error".to_string()),
                     is_analyze: true,
@@ -1560,6 +1581,7 @@ mod tests {
     mod effect_producing_actions {
         use super::*;
         use crate::domain::{DatabaseMetadata, MetadataState};
+        use crate::model::connection::state::ConnectionState;
 
         #[test]
         fn load_metadata_with_dsn_returns_fetch_effect() {
@@ -1677,6 +1699,74 @@ mod tests {
 
             assert_eq!(effects.len(), 1);
             assert!(matches!(effects[0], Effect::ExecuteAdhoc { .. }));
+        }
+
+        #[test]
+        fn awaiting_mysql_database_blocks_adhoc_execution() {
+            let mut state = create_test_state();
+            let id = ConnectionId::from_string("mysql-awaiting");
+            state.session.activate_connection_with_target(
+                &id,
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://user@localhost:3306",
+                None,
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::AwaitingDatabase);
+            state.modal.set_mode(InputMode::TablePicker);
+            state.ui.set_database_picker(true);
+            reduce(
+                &mut state,
+                Action::CloseModal(ModalKind::DatabasePicker),
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let effects = reduce(
+                &mut state,
+                Action::ExecuteAdhoc("SELECT 1".to_string()),
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.is_empty());
+            assert!(!state.query.is_running());
+        }
+
+        #[test]
+        fn awaiting_mysql_database_blocks_write_execution() {
+            let mut state = create_test_state();
+            let id = ConnectionId::from_string("mysql-awaiting");
+            state.session.activate_connection_with_target(
+                &id,
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://user@localhost:3306",
+                None,
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::AwaitingDatabase);
+            state.modal.set_mode(InputMode::TablePicker);
+            state.ui.set_database_picker(true);
+            reduce(
+                &mut state,
+                Action::CloseModal(ModalKind::DatabasePicker),
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            let effects = reduce(
+                &mut state,
+                Action::ExecuteWrite("UPDATE t SET v = 1".to_string()),
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.is_empty());
+            assert!(!state.query.is_running());
         }
     }
 
@@ -2025,6 +2115,7 @@ mod tests {
                     dsn: "postgres://db.example.com/mydb".to_string(),
                     name: "Test Connection".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2541,6 +2632,7 @@ mod tests {
                     dsn: "postgres://localhost/test".to_string(),
                     name: "Test".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2579,6 +2671,7 @@ mod tests {
                     dsn: "postgres://localhost/other".to_string(),
                     name: "Other".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2631,6 +2724,7 @@ mod tests {
                     dsn: "postgres://localhost/cached".to_string(),
                     name: "Cached".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 now,
                 &AppServices::stub(),
@@ -2682,6 +2776,7 @@ mod tests {
                     dsn: "postgres://localhost/b".to_string(),
                     name: "B".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 Instant::now(),
                 &AppServices::stub(),
@@ -2694,6 +2789,7 @@ mod tests {
                     dsn: dsn_a.clone(),
                     name: "A".to_string(),
                     database_type: DatabaseType::PostgreSQL,
+                    database: None,
                 }),
                 Instant::now(),
                 &AppServices::stub(),

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -25,6 +25,7 @@ pub fn dispatch_sql_modal(state: &mut AppState, action: &Action, now: Instant) -
 mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
+    use crate::domain::DatabaseType;
     use crate::model::shared::flash_timer::FlashId;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::text_input::{TextInputLike, TextInputState};
@@ -1049,9 +1050,14 @@ mod tests {
                     top_node_type: None,
                     total_cost: None,
                     estimated_rows: None,
+                    actual_start_ms: None,
+                    actual_end_ms: None,
+                    actual_rows: None,
+                    loops: None,
                     is_analyze,
                     execution_time_ms: ms,
                 },
+                database_type: DatabaseType::PostgreSQL,
                 query_snippet: "SELECT 1".to_string(),
                 full_query: "SELECT 1".to_string(),
                 source,
@@ -1236,10 +1242,15 @@ mod tests {
                     raw_text: "Seq Scan on users  (cost=0.00..100.00 rows=10 width=32)".to_string(),
                     top_node_type: Some("Seq Scan".to_string()),
                     total_cost: Some(100.0),
-                    estimated_rows: Some(10),
+                    estimated_rows: Some(10.0),
+                    actual_start_ms: None,
+                    actual_end_ms: None,
+                    actual_rows: None,
+                    loops: None,
                     is_analyze: false,
                     execution_time_ms: 420,
                 },
+                database_type: DatabaseType::PostgreSQL,
                 query_snippet: "SELECT *".to_string(),
                 full_query: "SELECT * FROM users".to_string(),
                 source: SlotSource::AutoPrevious,
@@ -1250,10 +1261,15 @@ mod tests {
                         .to_string(),
                     top_node_type: Some("Index Scan".to_string()),
                     total_cost: Some(5.0),
-                    estimated_rows: Some(1),
+                    estimated_rows: Some(1.0),
+                    actual_start_ms: None,
+                    actual_end_ms: None,
+                    actual_rows: None,
+                    loops: None,
                     is_analyze: false,
                     execution_time_ms: 50,
                 },
+                database_type: DatabaseType::PostgreSQL,
                 query_snippet: "SELECT *".to_string(),
                 full_query: "SELECT * FROM users WHERE id=1".to_string(),
                 source: SlotSource::AutoLatest,

--- a/src/app/update/test_fixtures.rs
+++ b/src/app/update/test_fixtures.rs
@@ -20,6 +20,15 @@ pub fn activate_sqlite_connection(state: &mut AppState, dsn: &str) {
     );
 }
 
+pub fn activate_mysql_connection(state: &mut AppState, dsn: &str) {
+    state.session.activate_connection_with_dsn(
+        &ConnectionId::new(),
+        "mysql",
+        DatabaseType::MySQL,
+        dsn,
+    );
+}
+
 pub fn assert_connection_save_fetch_effects(effects: &[Effect], database_type: DatabaseType) {
     match database_type {
         DatabaseType::SQLite => {
@@ -42,6 +51,10 @@ pub fn assert_connection_save_fetch_effects(effects: &[Effect], database_type: D
             assert!(matches!(effects[0], Effect::CancelActiveQuery));
             assert!(matches!(effects[1], Effect::ClearCompletionEngineCache));
             assert!(matches!(effects[2], Effect::FetchMetadata { .. }));
+        }
+        DatabaseType::MySQL => {
+            assert_eq!(effects.len(), 1);
+            assert!(matches!(effects[0], Effect::ClearCompletionEngineCache));
         }
     }
 }

--- a/src/domain/explain_plan.rs
+++ b/src/domain/explain_plan.rs
@@ -7,7 +7,11 @@ pub struct ExplainPlan {
     pub raw_text: String,
     pub top_node_type: Option<String>,
     pub total_cost: Option<f64>,
-    pub estimated_rows: Option<u64>,
+    pub estimated_rows: Option<f64>,
+    pub actual_start_ms: Option<f64>,
+    pub actual_end_ms: Option<f64>,
+    pub actual_rows: Option<f64>,
+    pub loops: Option<u64>,
     pub is_analyze: bool,
     pub execution_time_ms: u64,
 }
@@ -89,6 +93,21 @@ pub fn sqlite_explain_query_plan_text_from_result(result: &QueryResult) -> Strin
     })
 }
 
+fn first_result_column_text(result: &QueryResult) -> String {
+    (0..result.data_row_count())
+        .filter_map(|row_idx| result.display_value_at(row_idx, 0))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn postgres_explain_plan_text_from_result(result: &QueryResult) -> String {
+    first_result_column_text(result)
+}
+
+pub fn mysql_explain_plan_text_from_result(result: &QueryResult) -> String {
+    first_result_column_text(result)
+}
+
 impl ExplainPlan {
     pub fn execution_secs(&self) -> f64 {
         self.execution_time_ms as f64 / 1000.0
@@ -113,7 +132,7 @@ const IMPROVED_THRESHOLD: f64 = 0.9;
 const WORSENED_THRESHOLD: f64 = 1.1;
 const MAX_REASONS: usize = 3;
 
-fn parse_cost_fragment(line: &str) -> Option<(f64, u64)> {
+fn parse_cost_fragment(line: &str) -> Option<(f64, f64)> {
     let cost_start = line.find("(cost=")?;
     let after_cost = line.get(cost_start + 6..)?;
     let dots = after_cost.find("..")?;
@@ -125,11 +144,139 @@ fn parse_cost_fragment(line: &str) -> Option<(f64, u64)> {
     let rows_marker = after_dots.find("rows=")?;
     let after_rows = after_dots.get(rows_marker + 5..)?;
     let rows_end = after_rows
-        .find(|c: char| !c.is_ascii_digit())
+        .find(|c: char| c.is_whitespace() || c == ')')
         .unwrap_or(after_rows.len());
-    let rows: u64 = after_rows.get(..rows_end)?.parse().ok()?;
+    let rows: f64 = after_rows.get(..rows_end)?.parse().ok()?;
 
     Some((total_cost, rows))
+}
+
+fn parse_mysql_cost_fragment(line: &str) -> (Option<f64>, Option<f64>) {
+    let Some(cost_start) = line.find("(cost=") else {
+        return (None, None);
+    };
+    let Some(after_cost) = line.get(cost_start + 6..) else {
+        return (None, None);
+    };
+    let cost_end = after_cost
+        .find(|c: char| c.is_whitespace() || c == ')')
+        .unwrap_or(after_cost.len());
+    let cost_token = after_cost.get(..cost_end).unwrap_or_default();
+    let total_cost_token = cost_token
+        .rsplit_once("..")
+        .map_or(cost_token, |(_, total)| total);
+    let total_cost = parse_mysql_metric(total_cost_token);
+
+    let estimated_rows = line.find("rows=").and_then(|rows_start| {
+        let after_rows = line.get(rows_start + 5..)?;
+        let rows_end = after_rows
+            .find(|c: char| c.is_whitespace() || c == ')')
+            .unwrap_or(after_rows.len());
+        parse_mysql_metric(after_rows.get(..rows_end)?)
+    });
+
+    (total_cost, estimated_rows)
+}
+
+fn parse_mysql_metric(token: &str) -> Option<f64> {
+    let value: f64 = token.parse().ok()?;
+    (value.is_finite() && value >= 0.0).then_some(value)
+}
+
+fn mysql_node_name(line: &str) -> Option<String> {
+    let node_name = line
+        .split("(cost=")
+        .next()
+        .unwrap_or("")
+        .trim()
+        .trim_start_matches("->")
+        .trim();
+    (!node_name.is_empty()).then(|| node_name.to_string())
+}
+
+fn parse_mysql_loops(token: &str) -> Option<u64> {
+    let token = token.trim();
+    let (mantissa, exponent) = token
+        .split_once(['e', 'E'])
+        .map_or((token, 0i64), |(mantissa, exponent)| {
+            (mantissa, exponent.parse().unwrap_or(i64::MIN))
+        });
+    if exponent == i64::MIN || mantissa.is_empty() {
+        return None;
+    }
+
+    let mantissa = mantissa.strip_prefix('+').unwrap_or(mantissa);
+    if mantissa.starts_with('-') || mantissa.is_empty() {
+        return None;
+    }
+    let mut parts = mantissa.split('.');
+    let whole = parts.next().unwrap_or_default();
+    let fraction = parts.next().unwrap_or_default();
+    if parts.next().is_some()
+        || whole.is_empty() && fraction.is_empty()
+        || !whole.bytes().all(|byte| byte.is_ascii_digit())
+        || !fraction.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+
+    let digits = format!("{whole}{fraction}");
+    let decimal_places = fraction.len() as i64 - exponent;
+    let significant = if decimal_places > 0 {
+        let decimal_places = usize::try_from(decimal_places).ok()?;
+        if decimal_places > digits.len()
+            || !digits[digits.len() - decimal_places..]
+                .bytes()
+                .all(|byte| byte == b'0')
+        {
+            return None;
+        }
+        &digits[..digits.len() - decimal_places]
+    } else {
+        &digits
+    };
+
+    let trailing_zeroes = usize::try_from(decimal_places.saturating_neg()).ok()?;
+    let significant = significant.trim_start_matches('0');
+    if significant.is_empty() {
+        return Some(0);
+    }
+    if significant.len().saturating_add(trailing_zeroes) > 20 {
+        return None;
+    }
+
+    let mut integer = significant.to_string();
+    integer.push_str(&"0".repeat(trailing_zeroes));
+    if integer.len() == 20 && integer.as_str() > u64::MAX.to_string().as_str() {
+        return None;
+    }
+    integer.parse().ok()
+}
+
+fn parse_mysql_actual_fragment(line: &str) -> (Option<f64>, Option<f64>, Option<f64>, Option<u64>) {
+    let Some(start) = line.find("(actual time=") else {
+        return (None, None, None, None);
+    };
+    let fragment = line.get(start + 1..).unwrap_or_default();
+    let mut actual_start_ms = None;
+    let mut actual_end_ms = None;
+    let mut actual_rows = None;
+    let mut loops = None;
+
+    for token in fragment.split_whitespace() {
+        if let Some(time) = token.strip_prefix("time=") {
+            if let Some((start, end)) = time.split_once("..") {
+                actual_start_ms = parse_mysql_metric(start);
+                actual_end_ms = parse_mysql_metric(end.trim_end_matches(')'));
+            }
+        } else if let Some(rows) = token.strip_prefix("rows=") {
+            actual_rows = parse_mysql_metric(rows.trim_end_matches(')'));
+        } else if let Some(value) = token.strip_prefix("loops=") {
+            loops = parse_mysql_loops(value.trim_end_matches(')'));
+        }
+    }
+
+    (actual_start_ms, actual_end_ms, actual_rows, loops)
 }
 
 pub fn parse_explain_text(text: &str, is_analyze: bool, execution_time_ms: u64) -> ExplainPlan {
@@ -160,6 +307,57 @@ pub fn parse_explain_text(text: &str, is_analyze: bool, execution_time_ms: u64) 
         top_node_type,
         total_cost,
         estimated_rows,
+        actual_start_ms: None,
+        actual_end_ms: None,
+        actual_rows: None,
+        loops: None,
+        is_analyze,
+        execution_time_ms,
+    }
+}
+
+pub fn parse_mysql_tree_explain_text(
+    text: &str,
+    is_analyze: bool,
+    execution_time_ms: u64,
+) -> ExplainPlan {
+    let first_cost_line = text.lines().find(|line| line.contains("(cost="));
+    let (
+        top_node_type,
+        total_cost,
+        estimated_rows,
+        actual_start_ms,
+        actual_end_ms,
+        actual_rows,
+        loops,
+    ) = first_cost_line.map_or((None, None, None, None, None, None, None), |line| {
+        let (cost, rows) = parse_mysql_cost_fragment(line);
+        let (cost, rows) = match (cost, rows) {
+            (Some(cost), Some(rows)) => (Some(cost), Some(rows)),
+            _ => (None, None),
+        };
+        let (actual_start_ms, actual_end_ms, actual_rows, loops) =
+            parse_mysql_actual_fragment(line);
+        (
+            mysql_node_name(line),
+            cost,
+            rows,
+            actual_start_ms,
+            actual_end_ms,
+            actual_rows,
+            loops,
+        )
+    });
+
+    ExplainPlan {
+        raw_text: text.to_string(),
+        top_node_type,
+        total_cost,
+        estimated_rows,
+        actual_start_ms,
+        actual_end_ms,
+        actual_rows,
+        loops,
         is_analyze,
         execution_time_ms,
     }
@@ -211,7 +409,7 @@ pub fn compare_plans(baseline: &ExplainPlan, current: &ExplainPlan) -> Compariso
         }
 
         if let (Some(b_rows), Some(c_rows)) = (baseline.estimated_rows, current.estimated_rows)
-            && b_rows != c_rows
+            && b_rows.partial_cmp(&c_rows) != Some(std::cmp::Ordering::Equal)
         {
             reasons.push(format!("Estimated rows: {b_rows} \u{2192} {c_rows}"));
         }
@@ -227,6 +425,7 @@ pub fn compare_plans(baseline: &ExplainPlan, current: &ExplainPlan) -> Compariso
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::query_result::QuerySource;
 
     mod parse {
         use super::*;
@@ -238,7 +437,7 @@ mod tests {
 
             assert_eq!(plan.top_node_type.as_deref(), Some("Seq Scan on users"));
             assert_eq!(plan.total_cost, Some(1000.0));
-            assert_eq!(plan.estimated_rows, Some(100));
+            assert_eq!(plan.estimated_rows, Some(100.0));
             assert!(!plan.is_analyze);
             assert_eq!(plan.execution_time_ms, 42);
         }
@@ -254,7 +453,7 @@ Sort  (cost=0.00..1234.56 rows=100 width=32)
 
             assert_eq!(plan.top_node_type.as_deref(), Some("Sort"));
             assert_eq!(plan.total_cost, Some(1234.56));
-            assert_eq!(plan.estimated_rows, Some(100));
+            assert_eq!(plan.estimated_rows, Some(100.0));
         }
 
         #[test]
@@ -266,7 +465,7 @@ Execution Time: 0.600 ms";
             let plan = parse_explain_text(text, true, 1);
 
             assert_eq!(plan.total_cost, Some(1000.0));
-            assert_eq!(plan.estimated_rows, Some(100));
+            assert_eq!(plan.estimated_rows, Some(100.0));
             assert!(plan.is_analyze);
         }
 
@@ -280,7 +479,7 @@ Execution Time: 0.600 ms";
                 Some("Index Scan using idx_users_email on users")
             );
             assert_eq!(plan.total_cost, Some(8.30));
-            assert_eq!(plan.estimated_rows, Some(1));
+            assert_eq!(plan.estimated_rows, Some(1.0));
         }
 
         #[test]
@@ -309,17 +508,137 @@ Execution Time: 0.600 ms";
             assert!(plan.top_node_type.is_none());
             assert!(plan.total_cost.is_none());
         }
+
+        #[test]
+        fn mysql_tree_parses_decimal_and_scientific_values() {
+            let text = "-> Filter: (id > 10)  (cost=1.25e-1..2.5 rows=3.75e+2)\n    -> Table scan on users  (cost=0.1 rows=1)";
+            let plan = parse_mysql_tree_explain_text(text, false, 7);
+
+            assert_eq!(plan.top_node_type.as_deref(), Some("Filter: (id > 10)"));
+            assert_eq!(plan.total_cost, Some(2.5));
+            assert_eq!(plan.estimated_rows, Some(375.0));
+            assert_eq!(plan.raw_text, text);
+        }
+
+        #[test]
+        fn mysql_tree_supports_single_cost_value() {
+            let plan = parse_mysql_tree_explain_text(
+                "-> Table scan on users  (cost=1.25 rows=2.5)",
+                false,
+                0,
+            );
+
+            assert_eq!(plan.total_cost, Some(1.25));
+            assert_eq!(plan.estimated_rows, Some(2.5));
+        }
+
+        #[test]
+        fn mysql_tree_keeps_raw_text_when_node_metrics_are_unavailable() {
+            let text = "-> Filter: (id > 10)  (cost=unknown rows=unknown)";
+            let plan = parse_mysql_tree_explain_text(text, false, 0);
+
+            assert_eq!(plan.raw_text, text);
+            assert_eq!(plan.top_node_type.as_deref(), Some("Filter: (id > 10)"));
+            assert!(plan.total_cost.is_none());
+            assert!(plan.estimated_rows.is_none());
+        }
+
+        #[test]
+        fn mysql_tree_rejects_non_finite_or_negative_comparison_metrics() {
+            for metrics in [
+                "cost=NaN rows=1",
+                "cost=1 rows=NaN",
+                "cost=-1 rows=1",
+                "cost=1 rows=-1",
+            ] {
+                let text = format!("-> Table scan on users  ({metrics})");
+                let plan = parse_mysql_tree_explain_text(&text, false, 0);
+
+                assert_eq!(plan.raw_text, text);
+                assert!(plan.total_cost.is_none(), "{metrics}");
+                assert!(plan.estimated_rows.is_none(), "{metrics}");
+            }
+        }
+
+        #[test]
+        fn mysql_tree_parses_top_level_actual_metrics() {
+            let text = "-> Table scan on users  (cost=1.25 rows=2.5) (actual time=0.010..0.500 rows=95 loops=1)";
+            let plan = parse_mysql_tree_explain_text(text, true, 7);
+
+            assert_eq!(plan.actual_start_ms, Some(0.010));
+            assert_eq!(plan.actual_end_ms, Some(0.500));
+            assert_eq!(plan.actual_rows, Some(95.0));
+            assert_eq!(plan.loops, Some(1));
+        }
+
+        #[test]
+        fn mysql_tree_parses_scientific_loop_count() {
+            let plan = parse_mysql_tree_explain_text(
+                "-> Table scan on users  (cost=1 rows=1) (actual time=0..1 rows=1 loops=1e+6)",
+                true,
+                0,
+            );
+
+            assert_eq!(plan.loops, Some(1_000_000));
+        }
+
+        #[test]
+        fn mysql_tree_rejects_invalid_loop_counts_but_keeps_raw_text() {
+            for loops in ["1.5", "-1", "NaN", "inf", "1e309", "18446744073709551616"] {
+                let text = format!(
+                    "-> Table scan on users  (cost=1 rows=1) (actual time=0..1 rows=1 loops={loops})"
+                );
+                let plan = parse_mysql_tree_explain_text(&text, true, 0);
+
+                assert_eq!(plan.loops, None, "{loops}");
+                assert_eq!(plan.raw_text, text, "{loops}");
+            }
+        }
+
+        #[test]
+        fn mysql_tree_marks_missing_actual_metrics_unavailable() {
+            let plan =
+                parse_mysql_tree_explain_text("-> Table scan on users  (cost=1 rows=1)", true, 0);
+
+            assert_eq!(plan.actual_start_ms, None);
+            assert_eq!(plan.actual_end_ms, None);
+            assert_eq!(plan.actual_rows, None);
+            assert_eq!(plan.loops, None);
+        }
+    }
+
+    #[test]
+    fn mysql_plan_text_uses_the_first_result_column_without_sqlite_tree_reconstruction() {
+        let result = QueryResult::success(
+            "EXPLAIN FORMAT=TREE SELECT 1".to_string(),
+            vec!["EXPLAIN".to_string(), "ignored".to_string()],
+            vec![
+                vec!["-> first".to_string(), "x".to_string()],
+                vec!["  -> second".to_string(), "y".to_string()],
+            ],
+            0,
+            QuerySource::Adhoc,
+        );
+
+        assert_eq!(
+            mysql_explain_plan_text_from_result(&result),
+            "-> first\n  -> second"
+        );
     }
 
     mod compare {
         use super::*;
 
-        fn make_plan(cost: Option<f64>, rows: Option<u64>, node: Option<&str>) -> ExplainPlan {
+        fn make_plan(cost: Option<f64>, rows: Option<f64>, node: Option<&str>) -> ExplainPlan {
             ExplainPlan {
                 raw_text: String::new(),
                 top_node_type: node.map(ToString::to_string),
                 total_cost: cost,
                 estimated_rows: rows,
+                actual_start_ms: None,
+                actual_end_ms: None,
+                actual_rows: None,
+                loops: None,
                 is_analyze: false,
                 execution_time_ms: 0,
             }
@@ -327,8 +646,8 @@ Execution Time: 0.600 ms";
 
         #[test]
         fn improved_when_cost_drops_below_threshold() {
-            let baseline = make_plan(Some(1000.0), Some(100), Some("Seq Scan"));
-            let current = make_plan(Some(500.0), Some(100), Some("Seq Scan"));
+            let baseline = make_plan(Some(1000.0), Some(100.0), Some("Seq Scan"));
+            let current = make_plan(Some(500.0), Some(100.0), Some("Seq Scan"));
 
             let result = compare_plans(&baseline, &current);
 
@@ -337,8 +656,8 @@ Execution Time: 0.600 ms";
 
         #[test]
         fn worsened_when_cost_exceeds_threshold() {
-            let baseline = make_plan(Some(100.0), Some(10), Some("Index Scan"));
-            let current = make_plan(Some(1000.0), Some(10), Some("Seq Scan"));
+            let baseline = make_plan(Some(100.0), Some(10.0), Some("Index Scan"));
+            let current = make_plan(Some(1000.0), Some(10.0), Some("Seq Scan"));
 
             let result = compare_plans(&baseline, &current);
 
@@ -347,8 +666,8 @@ Execution Time: 0.600 ms";
 
         #[test]
         fn similar_within_threshold() {
-            let baseline = make_plan(Some(100.0), Some(10), Some("Seq Scan"));
-            let current = make_plan(Some(105.0), Some(10), Some("Seq Scan"));
+            let baseline = make_plan(Some(100.0), Some(10.0), Some("Seq Scan"));
+            let current = make_plan(Some(105.0), Some(10.0), Some("Seq Scan"));
 
             let result = compare_plans(&baseline, &current);
 
@@ -409,8 +728,8 @@ Execution Time: 0.600 ms";
 
         #[test]
         fn node_type_change_in_reasons() {
-            let baseline = make_plan(Some(1000.0), Some(100), Some("Seq Scan"));
-            let current = make_plan(Some(10.0), Some(1), Some("Index Scan"));
+            let baseline = make_plan(Some(1000.0), Some(100.0), Some("Seq Scan"));
+            let current = make_plan(Some(10.0), Some(1.0), Some("Index Scan"));
 
             let result = compare_plans(&baseline, &current);
 
@@ -424,8 +743,8 @@ Execution Time: 0.600 ms";
 
         #[test]
         fn same_node_type_not_in_reasons() {
-            let baseline = make_plan(Some(100.0), Some(10), Some("Seq Scan"));
-            let current = make_plan(Some(105.0), Some(10), Some("Seq Scan"));
+            let baseline = make_plan(Some(100.0), Some(10.0), Some("Seq Scan"));
+            let current = make_plan(Some(105.0), Some(10.0), Some("Seq Scan"));
 
             let result = compare_plans(&baseline, &current);
 
@@ -439,8 +758,8 @@ Execution Time: 0.600 ms";
 
         #[test]
         fn row_estimate_change_in_reasons() {
-            let baseline = make_plan(Some(100.0), Some(1000), Some("Seq Scan"));
-            let current = make_plan(Some(105.0), Some(10), Some("Seq Scan"));
+            let baseline = make_plan(Some(100.0), Some(1000.0), Some("Seq Scan"));
+            let current = make_plan(Some(105.0), Some(10.0), Some("Seq Scan"));
 
             let result = compare_plans(&baseline, &current);
 
@@ -454,8 +773,8 @@ Execution Time: 0.600 ms";
 
         #[test]
         fn same_row_estimate_not_in_reasons() {
-            let baseline = make_plan(Some(100.0), Some(10), Some("Seq Scan"));
-            let current = make_plan(Some(105.0), Some(10), Some("Seq Scan"));
+            let baseline = make_plan(Some(100.0), Some(10.0), Some("Seq Scan"));
+            let current = make_plan(Some(105.0), Some(10.0), Some("Seq Scan"));
 
             let result = compare_plans(&baseline, &current);
 
@@ -469,8 +788,8 @@ Execution Time: 0.600 ms";
 
         #[test]
         fn reasons_capped_at_max() {
-            let baseline = make_plan(Some(1000.0), Some(100), Some("Seq Scan"));
-            let current = make_plan(Some(10.0), Some(1), Some("Index Scan"));
+            let baseline = make_plan(Some(1000.0), Some(100.0), Some("Seq Scan"));
+            let current = make_plan(Some(10.0), Some(1.0), Some("Index Scan"));
 
             let result = compare_plans(&baseline, &current);
 
@@ -495,6 +814,26 @@ Execution Time: 0.600 ms";
             let result = compare_plans(&baseline, &current);
 
             assert_eq!(result.verdict, ComparisonVerdict::Similar);
+        }
+
+        #[test]
+        fn actual_metrics_do_not_change_comparison_verdict() {
+            let mut baseline = make_plan(Some(100.0), Some(10.0), Some("Table scan"));
+            baseline.actual_start_ms = Some(1.0);
+            baseline.actual_end_ms = Some(2.0);
+            baseline.actual_rows = Some(10.0);
+            baseline.loops = Some(1);
+
+            let mut current = baseline.clone();
+            current.actual_start_ms = Some(100.0);
+            current.actual_end_ms = Some(200.0);
+            current.actual_rows = Some(1_000.0);
+            current.loops = Some(10);
+
+            assert_eq!(
+                compare_plans(&baseline, &current).verdict,
+                ComparisonVerdict::Similar
+            );
         }
     }
 }

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -23,11 +23,14 @@ pub use command_tag::CommandTag;
 #[cfg(test)]
 pub use er::ErFkInfo;
 pub use er::ErTableInfo;
-pub use explain_plan::sqlite_explain_query_plan_text_from_result;
+pub use explain_plan::{
+    mysql_explain_plan_text_from_result, postgres_explain_plan_text_from_result,
+    sqlite_explain_query_plan_text_from_result,
+};
 pub use foreign_key::{FkAction, ForeignKey, UNRESOLVED_FK_COLUMN};
 pub use index::{Index, IndexAttributes, IndexType};
 pub use metadata::{DatabaseMetadata, MetadataState};
-pub use query_result::{QueryResult, QuerySource, QueryValue};
+pub use query_result::{ExplicitRowIdentity, QueryResult, QuerySource, QueryValue, RefreshScope};
 pub use rls::{RlsCommand, RlsInfo, RlsPolicy};
 pub use schema::Schema;
 pub use sqlite_diagnostics::{DiagnosticField, SqliteDiagnosticsSnapshot};
@@ -38,6 +41,7 @@ pub use write_result::WriteExecutionResult;
 
 pub use connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, ConnectionProfileError, DatabaseType,
-    PostgresConnectionConfig, SqliteConnectionConfig, SqliteConnectionConfigError, SqlitePathError,
-    SslMode, classify_sqlite_metadata_error, classify_sqlite_read_error, sqlite_path_from_dsn,
+    MySqlConnectionConfig, MySqlSslMode, PostgresConnectionConfig, SqliteConnectionConfig,
+    SqliteConnectionConfigError, SqlitePathError, SslMode, classify_sqlite_metadata_error,
+    classify_sqlite_read_error, sqlite_path_from_dsn,
 };

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -1,15 +1,67 @@
-use async_trait::async_trait;
+use std::ffi::OsStr;
+use std::fmt::Write as _;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
 
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+
+use async_trait::async_trait;
+use quick_xml::Reader;
+use quick_xml::events::Event;
+use serde::Deserialize;
+#[cfg(unix)]
+use tokio::fs::File as TokioFile;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, ReadBuf};
+use tokio::process::Child;
+use tokio::process::Command;
+#[cfg(not(unix))]
+use tokio::process::{ChildStderr, ChildStdin, ChildStdout};
+use tokio::time::timeout;
+use url::Url;
+use uuid::Uuid;
+
+#[cfg(test)]
+use crate::adapters::csv_export::export_to_path;
+use crate::adapters::csv_export::{CsvFileWriter, export_to_downloads};
+#[cfg(test)]
+use crate::app::policy::sql::mysql_statement::split_mysql_statements;
+use crate::app::policy::sql::mysql_statement::{
+    MysqlStatement, MysqlStatementKind, classify_mysql_statement, mysql_explain_rejection_message,
+    mysql_tree_explain_query_kind,
+};
+use crate::app::policy::write::sql_risk::{
+    MultiStatementDecision, evaluate_mysql_multi_statement, mysql_statement_is_data_modifying,
+    mysql_statement_is_schema_modifying,
+};
 use crate::app::ports::outbound::{
-    AccessMode, DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider, QueryExecutor,
-    SqlDialect,
+    AccessMode, ConnectionProbe, DatabaseCli, DbOperationError, DdlGenerator, DsnBuilder,
+    MYSQL_CLI_VERSION_REQUIRED_MARKER, MYSQL_SERVER_VERSION_REQUIRED_MARKER,
+    MYSQL_SQL_MODE_UNSUPPORTED_MARKER, QueryExecutor, SqlDialect,
 };
-use crate::domain::connection::{ConnectionProfile, DatabaseType};
+use crate::domain::connection::{
+    ConnectionProfile, DatabaseType, MySqlConnectionConfig, MySqlSslMode,
+};
 use crate::domain::{
-    DatabaseMetadata, QueryResult, QueryValue, Table, TableSignature, WriteExecutionResult,
+    CommandTag, QueryResult, QuerySource, QueryValue, RefreshScope, Table, WriteExecutionResult,
 };
+
+mod metadata;
 
 pub struct MySqlAdapter;
+
+const MYSQL_PROBE_TIMEOUT: Duration = Duration::from_secs(11);
+const MYSQL_QUERY_TIMEOUT: Duration = Duration::from_secs(31);
+const MYSQL_PROBE_QUERY: &str = "SELECT JSON_OBJECT('database', DATABASE(), 'user', CURRENT_USER(), 'version', VERSION(), 'sql_mode', @@SESSION.sql_mode)";
+const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
+const MYSQL_SESSION_MARKER_COLUMN: &str = "__sabiql_session_marker";
+static OPTION_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 impl MySqlAdapter {
     pub fn new() -> Self {
@@ -24,144 +76,4493 @@ impl Default for MySqlAdapter {
 }
 
 #[async_trait]
-impl MetadataProvider for MySqlAdapter {
-    async fn fetch_metadata(&self, _dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_detail(
-        &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-    ) -> Result<Table, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_columns_and_fks(
-        &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-    ) -> Result<Table, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-
-    async fn fetch_table_signatures(
-        &self,
-        _dsn: &str,
-    ) -> Result<Vec<TableSignature>, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
-    }
-}
-
-#[async_trait]
 impl QueryExecutor for MySqlAdapter {
     async fn execute_preview(
         &self,
-        _dsn: &str,
-        _schema: &str,
-        _table: &str,
-        _limit: usize,
-        _offset: usize,
+        dsn: &str,
+        schema: &str,
+        table: &str,
+        limit: usize,
+        offset: usize,
     ) -> Result<QueryResult, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures mysql execution time at the I/O boundary"
+        )]
+        let start = Instant::now();
+        let preview = metadata::fetch_preview_metadata(dsn, schema, table).await?;
+        let query = metadata::build_preview_query(
+            schema,
+            table,
+            &preview.order_columns,
+            &preview.visible_columns,
+            &preview.identity_columns,
+            limit,
+            offset,
+        );
+        let display_query = metadata::build_preview_query(
+            schema,
+            table,
+            &preview.order_columns,
+            &preview.visible_columns,
+            &[],
+            limit,
+            offset,
+        );
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        let statements =
+            validate_mysql_multi_query(&query, target.database.as_deref(), AccessMode::ReadWrite)?;
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc(
+            &option_file.path,
+            &query,
+            &statements,
+            AccessMode::ReadWrite,
+        )
+        .await;
+        drop(option_file);
+        let result_set = result?.result_set.ok_or_else(|| {
+            DbOperationError::MetadataParseFailed(
+                "MySQL preview query returned no result set".to_string(),
+            )
+        })?;
+        let values = metadata::convert_preview_values(
+            &result_set,
+            &preview.visible_columns,
+            &preview.identity_columns,
+        )?;
+        let elapsed = start.elapsed().as_millis() as u64;
+
+        let mut query_result = QueryResult::success_with_values(
+            display_query,
+            preview
+                .visible_columns
+                .iter()
+                .map(|column| column.name.clone())
+                .collect(),
+            values.visible,
+            elapsed,
+            QuerySource::Preview,
+        );
+        if let Some(identity_values) = values.identity {
+            query_result = query_result.with_explicit_row_identity(
+                preview
+                    .identity_columns
+                    .iter()
+                    .map(|column| column.name.clone())
+                    .collect(),
+                identity_values,
+            );
+        }
+        Ok(query_result)
     }
 
     async fn execute_adhoc(
         &self,
-        _dsn: &str,
-        _query: &str,
-        _access_mode: AccessMode,
+        dsn: &str,
+        query: &str,
+        access_mode: AccessMode,
     ) -> Result<QueryResult, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+
+        if mysql_tree_explain_query_kind(query).is_some() {
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "infra measures mysql execution time at the I/O boundary"
+            )]
+            let start = Instant::now();
+            let option_file = MySqlOptionFile::create(&target)?;
+            let result = run_mysql_single_statement(&option_file.path, query, access_mode).await;
+            drop(option_file);
+            let result_set = result?;
+            return Ok(QueryResult::success_with_values(
+                query.to_string(),
+                result_set.columns,
+                result_set.values,
+                start.elapsed().as_millis() as u64,
+                QuerySource::Adhoc,
+            ));
+        }
+
+        let statements =
+            validate_mysql_multi_query(query, target.database.as_deref(), access_mode)?;
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures mysql execution time at the I/O boundary"
+        )]
+        let start = Instant::now();
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc(&option_file.path, query, &statements, access_mode).await;
+        drop(option_file);
+        let execution = result?;
+        let elapsed = start.elapsed().as_millis() as u64;
+        let mut result = match execution.result_set {
+            Some(result_set) => QueryResult::success_with_values(
+                query.to_string(),
+                result_set.columns,
+                result_set.values,
+                elapsed,
+                QuerySource::Adhoc,
+            ),
+            None => QueryResult::success(
+                query.to_string(),
+                Vec::new(),
+                Vec::new(),
+                elapsed,
+                QuerySource::Adhoc,
+            ),
+        };
+        if let Some(tag) = execution.command_tag {
+            result = result.with_command_tag(tag);
+        }
+        Ok(result.with_refresh_scope(execution.refresh_scope))
     }
 
     async fn execute_write(
         &self,
-        _dsn: &str,
-        _query: &str,
-        _access_mode: AccessMode,
+        dsn: &str,
+        query: &str,
+        access_mode: AccessMode,
     ) -> Result<WriteExecutionResult, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        let statements =
+            validate_mysql_multi_query(query, target.database.as_deref(), access_mode)?;
+
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "infra measures mysql execution time at the I/O boundary"
+        )]
+        let start = Instant::now();
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc(&option_file.path, query, &statements, access_mode).await;
+        drop(option_file);
+        let execution = result?;
+        let affected_rows = execution
+            .command_tag
+            .and_then(|tag| tag.affected_rows())
+            .ok_or_else(|| {
+                DbOperationError::CommandTagParseFailed(
+                    "MySQL write did not return an affected row count".to_string(),
+                )
+            })?;
+        let affected_rows = usize::try_from(affected_rows).map_err(|_| {
+            DbOperationError::CommandTagParseFailed(
+                "MySQL affected row count does not fit in usize".to_string(),
+            )
+        })?;
+
+        Ok(WriteExecutionResult {
+            affected_rows,
+            execution_time_ms: start.elapsed().as_millis() as u64,
+        })
     }
 
-    async fn count_query_rows(&self, _dsn: &str, _query: &str) -> Result<usize, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+    async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        validate_mysql_export_query(query, target.database.as_deref())?;
+
+        let result = self.execute_adhoc(dsn, query, AccessMode::ReadOnly).await?;
+        let value = result
+            .values()
+            .first()
+            .and_then(|row| row.first())
+            .and_then(QueryValue::as_str)
+            .ok_or_else(|| {
+                DbOperationError::QueryFailed(
+                    "MySQL row count query returned an invalid result".to_string(),
+                )
+            })?;
+        value.parse::<usize>().map_err(|_| {
+            DbOperationError::QueryFailed("MySQL row count was not an integer".to_string())
+        })
     }
 
     async fn export_to_csv(
         &self,
-        _dsn: &str,
-        _query: &str,
-        _file_name: &str,
+        dsn: &str,
+        query: &str,
+        file_name: &str,
     ) -> Result<std::path::PathBuf, DbOperationError> {
-        Err(DbOperationError::ConnectionFailed(
-            "MySQL adapter not yet implemented".to_string(),
-        ))
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        validate_mysql_export_query(query, target.database.as_deref())?;
+
+        let query = query.to_string();
+        export_to_downloads(file_name, move |path| async move {
+            export_mysql_csv_to_file(target, &query, path).await
+        })
+        .await
     }
 }
 
 impl DdlGenerator for MySqlAdapter {
-    fn generate_ddl(&self, _database_type: DatabaseType, _table: &Table) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+    fn generate_ddl(&self, _database_type: DatabaseType, table: &Table) -> String {
+        table.source_ddl().unwrap_or_default().to_string()
     }
 }
 
 impl SqlDialect for MySqlAdapter {
-    fn build_explain_sql(&self, _database_type: DatabaseType, _query: &str) -> Option<String> {
-        None
+    fn build_explain_sql(&self, _database_type: DatabaseType, query: &str) -> Option<String> {
+        if mysql_explain_rejection_message(query).is_some() {
+            return None;
+        }
+        Some(format!("EXPLAIN FORMAT=TREE {query}"))
     }
 
     fn build_explain_analyze_sql(
         &self,
         _database_type: DatabaseType,
-        _query: &str,
+        query: &str,
     ) -> Option<String> {
-        None
+        mysql_tree_explain_query_kind(&format!("EXPLAIN ANALYZE FORMAT=TREE {query}"))?;
+        Some(format!("EXPLAIN ANALYZE FORMAT=TREE {query}"))
     }
 
     fn build_update_sql(
         &self,
         _database_type: DatabaseType,
-        _schema: &str,
-        _table: &str,
-        _column: &str,
-        _new_value: &QueryValue,
-        _pk_pairs: &[(String, QueryValue)],
+        schema: &str,
+        table: &str,
+        column: &str,
+        new_value: &QueryValue,
+        pk_pairs: &[(String, QueryValue)],
     ) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+        let where_clause = pk_pairs
+            .iter()
+            .map(|(column, value)| mysql_equality_predicate(column, value))
+            .collect::<Vec<_>>()
+            .join(" AND ");
+
+        format!(
+            "UPDATE {}.{}\nSET {} = {}\nWHERE {};",
+            mysql_quote_identifier(schema),
+            mysql_quote_identifier(table),
+            mysql_quote_identifier(column),
+            mysql_sql_literal(new_value),
+            where_clause
+        )
     }
 
     fn build_bulk_delete_sql(
         &self,
         _database_type: DatabaseType,
-        _schema: &str,
-        _table: &str,
-        _pk_pairs_per_row: &[Vec<(String, QueryValue)>],
+        schema: &str,
+        table: &str,
+        pk_pairs_per_row: &[Vec<(String, QueryValue)>],
     ) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+        assert!(
+            !pk_pairs_per_row.is_empty(),
+            "pk_pairs_per_row must not be empty"
+        );
+
+        let predicates = pk_pairs_per_row
+            .iter()
+            .map(|pairs| {
+                pairs
+                    .iter()
+                    .map(|(column, value)| mysql_equality_predicate(column, value))
+                    .collect::<Vec<_>>()
+                    .join(" AND ")
+            })
+            .collect::<Vec<_>>();
+        let where_clause = if predicates.len() == 1 {
+            predicates[0].clone()
+        } else {
+            predicates
+                .into_iter()
+                .map(|predicate| format!("({predicate})"))
+                .collect::<Vec<_>>()
+                .join(" OR ")
+        };
+
+        format!(
+            "DELETE FROM {}.{}\nWHERE {};",
+            mysql_quote_identifier(schema),
+            mysql_quote_identifier(table),
+            where_clause
+        )
+    }
+}
+
+fn mysql_quote_identifier(value: &str) -> String {
+    format!("`{}`", value.replace('`', "``"))
+}
+
+fn mysql_sql_literal(value: &QueryValue) -> String {
+    match value {
+        QueryValue::Null => "NULL".to_string(),
+        QueryValue::Text(value) => mysql_quote_string(value),
+        QueryValue::SqlLiteral(value) => value.clone(),
+        QueryValue::Blob(bytes) => {
+            let mut hex = String::with_capacity(bytes.len() * 2);
+            for byte in bytes {
+                let _ = write!(hex, "{byte:02X}");
+            }
+            format!("X'{hex}'")
+        }
+    }
+}
+
+fn mysql_quote_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\0' => escaped.push_str("\\0"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            '\u{0008}' => escaped.push_str("\\b"),
+            '\u{001a}' => escaped.push_str("\\Z"),
+            '\\' => escaped.push_str("\\\\"),
+            '\'' => escaped.push_str("\\'"),
+            _ => escaped.push(character),
+        }
+    }
+    format!("'{escaped}'")
+}
+
+fn mysql_equality_predicate(column: &str, value: &QueryValue) -> String {
+    let column = mysql_quote_identifier(column);
+    match value {
+        QueryValue::Null => format!("{column} IS NULL"),
+        _ => format!("{column} = {}", mysql_sql_literal(value)),
+    }
+}
+
+#[cfg(test)]
+mod write_sql_tests {
+    use super::*;
+
+    #[test]
+    fn update_quotes_identifiers_and_mysql_string_escapes() {
+        let adapter = MySqlAdapter::new();
+        let sql = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "db`name",
+            "table`name",
+            "value`name",
+            &QueryValue::text("O'Reilly\\path\n\t\0"),
+            &[
+                (
+                    "id`part".to_string(),
+                    QueryValue::SqlLiteral("18446744073709551615".into()),
+                ),
+                ("tenant".to_string(), QueryValue::Null),
+            ],
+        );
+
+        assert_eq!(
+            sql,
+            "UPDATE \x60db\x60\x60name\x60.\x60table\x60\x60name\x60\nSET \x60value\x60\x60name\x60 = 'O\\'Reilly\\\\path\\n\\t\\0'\nWHERE \x60id\x60\x60part\x60 = 18446744073709551615 AND \x60tenant\x60 IS NULL;"
+        );
+    }
+
+    #[test]
+    fn update_uses_text_datetime_and_blob_literals_without_coercion() {
+        let adapter = MySqlAdapter::new();
+        let sql = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "events",
+            "payload",
+            &QueryValue::Blob(vec![0, 255, 16]),
+            &[(
+                "created_at".to_string(),
+                QueryValue::text("2026-08-13 12:34:56"),
+            )],
+        );
+
+        assert_eq!(
+            sql,
+            "UPDATE `sabiql_test`.`events`\nSET `payload` = X'00FF10'\nWHERE `created_at` = '2026-08-13 12:34:56';"
+        );
+    }
+
+    #[test]
+    fn json_document_update_keeps_json_null_distinct_from_string_null() {
+        let adapter = MySqlAdapter::new();
+        let json_null = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "documents",
+            "payload",
+            &QueryValue::text("null"),
+            &[("id".to_string(), QueryValue::SqlLiteral("1".into()))],
+        );
+        let string_null = adapter.build_update_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "documents",
+            "payload",
+            &QueryValue::text(r#""null""#),
+            &[("id".to_string(), QueryValue::SqlLiteral("1".into()))],
+        );
+
+        assert!(json_null.contains("SET `payload` = 'null'"));
+        assert!(string_null.contains("SET `payload` = '\"null\"'"));
+        assert_ne!(json_null, string_null);
+    }
+
+    #[test]
+    fn bulk_delete_targets_each_composite_primary_key_row() {
+        let adapter = MySqlAdapter::new();
+        let sql = adapter.build_bulk_delete_sql(
+            DatabaseType::MySQL,
+            "sabiql_test",
+            "items",
+            &[
+                vec![
+                    ("first".to_string(), QueryValue::SqlLiteral("1".into())),
+                    ("second".to_string(), QueryValue::SqlLiteral("20".into())),
+                ],
+                vec![
+                    ("first".to_string(), QueryValue::SqlLiteral("2".into())),
+                    ("second".to_string(), QueryValue::SqlLiteral("10".into())),
+                ],
+            ],
+        );
+
+        assert_eq!(
+            sql,
+            "DELETE FROM `sabiql_test`.`items`\nWHERE (`first` = 1 AND `second` = 20) OR (`first` = 2 AND `second` = 10);"
+        );
     }
 }
 
 impl DsnBuilder for MySqlAdapter {
-    fn build_dsn(&self, _profile: &ConnectionProfile) -> String {
-        unimplemented!("MySQL adapter not yet implemented")
+    fn build_dsn(&self, profile: &ConnectionProfile) -> String {
+        let config = profile
+            .mysql_config()
+            .expect("MySQL profile requires MySQL config");
+        build_mysql_dsn(config)
+    }
+}
+
+#[cfg(test)]
+mod explain_tests {
+    use super::*;
+
+    #[test]
+    fn builds_tree_explain_for_select_table_and_dml() {
+        let adapter = MySqlAdapter::new();
+
+        for query in [
+            "SELECT * FROM users",
+            "TABLE users",
+            "INSERT INTO users VALUES (1)",
+            "REPLACE INTO users VALUES (1)",
+            "REPLACE users VALUES (1)",
+            "REPLACE LOW_PRIORITY INTO users VALUES (1)",
+            "REPLACE DELAYED users VALUES (1)",
+            "UPDATE users SET name = 'Ada' WHERE id = 1",
+            "DELETE FROM users WHERE id = 1",
+        ] {
+            assert_eq!(
+                adapter.build_explain_sql(DatabaseType::MySQL, query),
+                Some(format!("EXPLAIN FORMAT=TREE {query}")),
+                "{query}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_mysql_explain_for_unsupported_input() {
+        let adapter = MySqlAdapter::new();
+
+        for query in [
+            "CREATE TABLE users(id INT)",
+            "DROP TABLE users",
+            "\\C /tmp/other.sock",
+            "SELECT 1; SELECT 2",
+        ] {
+            assert_eq!(
+                adapter.build_explain_sql(DatabaseType::MySQL, query),
+                None,
+                "{query}"
+            );
+        }
+    }
+
+    #[test]
+    fn builds_tree_explain_analyze_only_for_side_effect_free_reads() {
+        let adapter = MySqlAdapter::new();
+
+        for query in ["SELECT * FROM users", "TABLE users"] {
+            assert_eq!(
+                adapter.build_explain_analyze_sql(DatabaseType::MySQL, query),
+                Some(format!("EXPLAIN ANALYZE FORMAT=TREE {query}")),
+                "{query}"
+            );
+        }
+
+        for query in [
+            "UPDATE users SET name = 'Ada' WHERE id = 1",
+            "DELETE FROM users WHERE id = 1",
+            "INSERT INTO users VALUES (1)",
+            "REPLACE INTO users VALUES (1)",
+            "SELECT * FROM users FOR UPDATE",
+            "SELECT 1; SELECT 2",
+        ] {
+            assert_eq!(
+                adapter.build_explain_analyze_sql(DatabaseType::MySQL, query),
+                None,
+                "{query}"
+            );
+        }
+    }
+}
+
+#[async_trait]
+impl ConnectionProbe for MySqlAdapter {
+    async fn probe(&self, dsn: &str) -> Result<(), DbOperationError> {
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        self.check_cli_version().await?;
+
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = self.run_probe(&option_file.path).await;
+        drop(option_file);
+        let output = result?;
+
+        if !output.status.success() {
+            return Err(classify_mysql_probe_failure(clean_stderr(&output.stderr)));
+        }
+
+        let response: MySqlProbeResponse = serde_json::from_slice(&output.stdout)?;
+        let _ = (&response.database, &response.user);
+        validate_server_version(&response.version)?;
+        validate_sql_mode(&response.sql_mode)?;
+        Ok(())
+    }
+
+    async fn fetch_databases(&self, dsn: &str) -> Result<Vec<String>, DbOperationError> {
+        let mut target = parse_mysql_dsn(dsn)?;
+        target.database = None;
+        validate_mysql_values(&target)?;
+        self.check_cli_version().await?;
+
+        let option_file = MySqlOptionFile::create(&target)?;
+        let statements = validate_mysql_multi_query("SHOW DATABASES", None, AccessMode::ReadWrite)?;
+        let result = run_mysql_adhoc(
+            &option_file.path,
+            "SHOW DATABASES",
+            &statements,
+            AccessMode::ReadWrite,
+        )
+        .await;
+        drop(option_file);
+        result.map(|execution| {
+            execution
+                .result_set
+                .unwrap_or(MysqlResultSet {
+                    columns: Vec::new(),
+                    values: Vec::new(),
+                })
+                .values
+                .into_iter()
+                .filter_map(|mut row| row.drain(..).next())
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect()
+        })
+    }
+}
+
+impl MySqlAdapter {
+    async fn check_cli_version(&self) -> Result<(), DbOperationError> {
+        let output = run_mysql_command(["--version"], None).await?;
+        let version_output = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if !output.status.success() || !is_oracle_mysql_cli_84_version(&version_output) {
+            return Err(DbOperationError::UnsupportedOperation(format!(
+                "{MYSQL_CLI_VERSION_REQUIRED_MARKER}: {}",
+                version_output.trim()
+            )));
+        }
+        Ok(())
+    }
+
+    async fn run_probe(
+        &self,
+        option_file: &PathBuf,
+    ) -> Result<std::process::Output, DbOperationError> {
+        let args = mysql_probe_args(option_file);
+        run_mysql_command(args, Some(option_file)).await
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct MySqlProbeResponse {
+    database: Option<String>,
+    user: String,
+    version: String,
+    sql_mode: String,
+}
+
+#[derive(Debug)]
+struct MySqlDsn {
+    host: String,
+    port: u16,
+    database: Option<String>,
+    username: String,
+    password: String,
+    ssl_mode: MySqlSslMode,
+    ssl_ca: Option<String>,
+    ssl_cert: Option<String>,
+    ssl_key: Option<String>,
+}
+
+fn build_mysql_dsn(config: &MySqlConnectionConfig) -> String {
+    let mut url = Url::parse("mysql://localhost").expect("static MySQL URL is valid");
+    url.set_username(&config.username)
+        .expect("MySQL username is valid URL data");
+    url.set_password(Some(&config.password))
+        .expect("MySQL password is valid URL data");
+    let host = normalize_mysql_host(&config.host);
+    let host = if host.contains(':') && !host.starts_with('[') {
+        format!("[{host}]")
+    } else {
+        host
+    };
+    url.set_host(Some(&host))
+        .expect("validated MySQL host is valid URL data");
+    url.set_port(Some(config.port))
+        .expect("MySQL port is valid URL data");
+    if let Some(database) = config.database.as_deref() {
+        url.path_segments_mut()
+            .expect("MySQL URL supports path segments")
+            .push(database);
+    }
+    url.query_pairs_mut()
+        .append_pair("ssl-mode", &config.ssl_mode.to_string());
+    if let Some(path) = config.ssl_ca.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-ca", path);
+    }
+    if let Some(path) = config.ssl_cert.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-cert", path);
+    }
+    if let Some(path) = config.ssl_key.as_deref() {
+        url.query_pairs_mut().append_pair("ssl-key", path);
+    }
+    url.to_string()
+}
+
+fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
+    let url = Url::parse(dsn).map_err(|error| {
+        DbOperationError::ConnectionFailed(format!("Invalid MySQL DSN: {error}"))
+    })?;
+    if url.scheme() != "mysql" {
+        return Err(DbOperationError::ConnectionFailed(
+            "Invalid MySQL DSN scheme".to_string(),
+        ));
+    }
+    let host = url.host_str().ok_or_else(|| {
+        DbOperationError::ConnectionFailed("MySQL DSN is missing a host".to_string())
+    })?;
+    let host = normalize_mysql_host(host);
+    let username = decode_url_component(url.username())?;
+    let password = decode_url_component(url.password().unwrap_or_default())?;
+    let database = url
+        .path_segments()
+        .and_then(|mut segments| segments.next())
+        .filter(|segment| !segment.is_empty())
+        .map(decode_url_component)
+        .transpose()?;
+    let ssl_mode = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-mode").then(|| parse_ssl_mode(&value)))
+        .transpose()?
+        .unwrap_or_default();
+    let ssl_ca = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-ca").then(|| value.into_owned()));
+    let ssl_cert = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-cert").then(|| value.into_owned()));
+    let ssl_key = url
+        .query_pairs()
+        .find_map(|(key, value)| (key == "ssl-key").then(|| value.into_owned()));
+
+    Ok(MySqlDsn {
+        host,
+        port: url.port().unwrap_or(3306),
+        database,
+        username,
+        password,
+        ssl_mode,
+        ssl_ca,
+        ssl_cert,
+        ssl_key,
+    })
+}
+
+fn normalize_mysql_host(host: &str) -> String {
+    host.strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host)
+        .to_string()
+}
+
+fn parse_ssl_mode(value: &str) -> Result<MySqlSslMode, DbOperationError> {
+    match value {
+        "DISABLED" => Ok(MySqlSslMode::Disabled),
+        "PREFERRED" => Ok(MySqlSslMode::Preferred),
+        "REQUIRED" => Ok(MySqlSslMode::Required),
+        "VERIFY_CA" => Ok(MySqlSslMode::VerifyCa),
+        "VERIFY_IDENTITY" => Ok(MySqlSslMode::VerifyIdentity),
+        _ => Err(DbOperationError::ConnectionFailed(
+            "Invalid MySQL TLS mode".to_string(),
+        )),
+    }
+}
+
+fn decode_url_component(value: &str) -> Result<String, DbOperationError> {
+    urlencoding::decode(value)
+        .map(std::borrow::Cow::into_owned)
+        .map_err(|error| DbOperationError::ConnectionFailed(format!("Invalid MySQL DSN: {error}")))
+}
+
+fn validate_mysql_values(target: &MySqlDsn) -> Result<(), DbOperationError> {
+    let values = [
+        target.host.as_str(),
+        target.username.as_str(),
+        target.password.as_str(),
+    ];
+    if target
+        .database
+        .as_deref()
+        .into_iter()
+        .chain(values)
+        .any(|value| value.chars().any(char::is_control))
+    {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL connection settings contain a control character".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_mysql_tls_files(target: &MySqlDsn) -> Result<(), DbOperationError> {
+    let has_tls_path =
+        target.ssl_ca.is_some() || target.ssl_cert.is_some() || target.ssl_key.is_some();
+    if target.ssl_mode == MySqlSslMode::Disabled && has_tls_path {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL TLS paths require an enabled TLS mode".to_string(),
+        ));
+    }
+    if matches!(
+        target.ssl_mode,
+        MySqlSslMode::VerifyCa | MySqlSslMode::VerifyIdentity
+    ) && target.ssl_ca.is_none()
+    {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL CA path is required for certificate verification".to_string(),
+        ));
+    }
+    if target.ssl_cert.is_some() != target.ssl_key.is_some() {
+        return Err(DbOperationError::ConnectionFailed(
+            "MySQL client certificate and key must be specified together".to_string(),
+        ));
+    }
+
+    for (kind, path) in [
+        ("CA", target.ssl_ca.as_deref()),
+        ("client certificate", target.ssl_cert.as_deref()),
+        ("client key", target.ssl_key.as_deref()),
+    ] {
+        let Some(path) = path else { continue };
+        let metadata = fs::metadata(path).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} path cannot be accessed: {error}"
+            ))
+        })?;
+        if !metadata.is_file() {
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} path is not a regular file"
+            )));
+        }
+        let contents = fs::read(path).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!("MySQL {kind} cannot be read: {error}"))
+        })?;
+        let text = String::from_utf8_lossy(&contents);
+        if matches!(kind, "CA" | "client certificate") && !text.contains("BEGIN CERTIFICATE") {
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "MySQL {kind} is not a PEM certificate"
+            )));
+        }
+        if kind == "client key" {
+            if text.contains("BEGIN ENCRYPTED PRIVATE KEY")
+                || text
+                    .lines()
+                    .any(|line| line.trim().eq_ignore_ascii_case("Proc-Type: 4,ENCRYPTED"))
+            {
+                return Err(DbOperationError::ConnectionFailed(
+                    "Encrypted MySQL client keys are not supported".to_string(),
+                ));
+            }
+            if ![
+                "BEGIN PRIVATE KEY",
+                "BEGIN RSA PRIVATE KEY",
+                "BEGIN EC PRIVATE KEY",
+            ]
+            .iter()
+            .any(|marker| text.contains(marker))
+            {
+                return Err(DbOperationError::ConnectionFailed(
+                    "MySQL client key is not a PEM private key".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn contains_unsupported_mysql_product(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    ["mariadb", "percona", "tidb", "vitess", "aurora"]
+        .iter()
+        .any(|product| lower.contains(product))
+}
+
+fn is_oracle_mysql_cli_84_version(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("mysql")
+        && !contains_unsupported_mysql_product(value)
+        && version_major_minor(value) == Some((8, 4))
+}
+
+fn is_oracle_mysql_server_84_version(value: &str) -> bool {
+    !contains_unsupported_mysql_product(value) && version_major_minor(value) == Some((8, 4))
+}
+
+fn validate_server_version(version: &str) -> Result<(), DbOperationError> {
+    if is_oracle_mysql_server_84_version(version) {
+        Ok(())
+    } else {
+        Err(DbOperationError::UnsupportedOperation(format!(
+            "{MYSQL_SERVER_VERSION_REQUIRED_MARKER}: {version}"
+        )))
+    }
+}
+
+fn validate_sql_mode(sql_mode: &str) -> Result<(), DbOperationError> {
+    let unsupported = sql_mode.split(',').map(str::trim).any(|mode| {
+        mode.eq_ignore_ascii_case("NO_BACKSLASH_ESCAPES")
+            || mode.eq_ignore_ascii_case("ANSI_QUOTES")
+    });
+    if unsupported {
+        Err(DbOperationError::UnsupportedOperation(format!(
+            "{MYSQL_SQL_MODE_UNSUPPORTED_MARKER}: {sql_mode}"
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn version_major_minor(value: &str) -> Option<(u32, u32)> {
+    let mut numbers = value
+        .split(|character: char| !character.is_ascii_digit())
+        .filter(|part| !part.is_empty())
+        .filter_map(|part| part.parse::<u32>().ok());
+    Some((numbers.next()?, numbers.next()?))
+}
+
+fn mysql_probe_args(option_file: &std::path::Path) -> Vec<String> {
+    vec![
+        format!("--defaults-file={}", option_file.display()),
+        "--no-login-paths".to_string(),
+        "--protocol=TCP".to_string(),
+        "--connect-timeout=10".to_string(),
+        "--batch".to_string(),
+        "--raw".to_string(),
+        "--skip-column-names".to_string(),
+        "--binary-mode".to_string(),
+        "--skip-reconnect".to_string(),
+        format!("--execute={MYSQL_PROBE_QUERY}"),
+    ]
+}
+
+async fn run_mysql_command<I, S>(
+    args: I,
+    option_file: Option<&PathBuf>,
+) -> Result<std::process::Output, DbOperationError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new("mysql");
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .env_remove("MYSQL_PWD")
+        .env_remove("MYSQL_PASSWORD")
+        .kill_on_drop(true);
+    if option_file.is_some() {
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    }
+
+    match timeout(MYSQL_PROBE_TIMEOUT, command.output()).await {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(error)) if error.kind() == io::ErrorKind::NotFound => {
+            Err(DbOperationError::CommandNotFound {
+                command: DatabaseCli::MySql,
+                details: error.to_string(),
+            })
+        }
+        Ok(Err(error)) => Err(DbOperationError::ConnectionFailed(error.to_string())),
+        Err(_) => Err(DbOperationError::Timeout(
+            "mysql probe exceeded the connection timeout".to_string(),
+        )),
+    }
+}
+
+fn clean_stderr(stderr: &[u8]) -> String {
+    let text = String::from_utf8_lossy(stderr).trim().to_string();
+    if text.is_empty() {
+        "mysql probe failed".to_string()
+    } else {
+        text
+    }
+}
+
+fn classify_mysql_probe_failure(stderr: String) -> DbOperationError {
+    if is_mysql_connect_timeout_message(&stderr) {
+        DbOperationError::Timeout(stderr)
+    } else {
+        DbOperationError::ConnectionFailed(stderr)
+    }
+}
+
+fn is_mysql_connect_timeout_message(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("can't connect to mysql server")
+        && (lower.contains("(110)") || lower.contains("(10060)"))
+}
+
+struct MySqlOptionFile {
+    path: PathBuf,
+}
+
+impl MySqlOptionFile {
+    fn create(target: &MySqlDsn) -> Result<Self, DbOperationError> {
+        validate_mysql_tls_files(target)?;
+        let sequence = OPTION_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "sabiql-mysql-{}-{sequence}.cnf",
+            std::process::id()
+        ));
+        if !path.is_absolute() {
+            path = std::env::current_dir()
+                .map_err(|error| DbOperationError::ConnectionFailed(error.to_string()))?
+                .join(path);
+        }
+
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        std::os::unix::fs::OpenOptionsExt::mode(&mut options, 0o600);
+        let mut file = options.open(&path).map_err(|error| {
+            DbOperationError::ConnectionFailed(format!(
+                "Unable to create MySQL option file: {error}"
+            ))
+        })?;
+        let contents = serialize_option_file(target);
+        if let Err(error) = file.write_all(contents.as_bytes()) {
+            let _ = fs::remove_file(&path);
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "Unable to write MySQL option file: {error}"
+            )));
+        }
+        Ok(Self { path })
+    }
+}
+
+impl Drop for MySqlOptionFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn serialize_option_file(target: &MySqlDsn) -> String {
+    let mut contents = String::from("[client]\n");
+    push_option(&mut contents, "host", &target.host);
+    push_option(&mut contents, "port", &target.port.to_string());
+    push_option(&mut contents, "user", &target.username);
+    push_option(&mut contents, "password", &target.password);
+    if let Some(database) = target.database.as_deref() {
+        push_option(&mut contents, "database", database);
+    }
+    push_option(&mut contents, "ssl-mode", &target.ssl_mode.to_string());
+    if let Some(path) = target.ssl_ca.as_deref() {
+        push_option(&mut contents, "ssl-ca", path);
+    }
+    if let Some(path) = target.ssl_cert.as_deref() {
+        push_option(&mut contents, "ssl-cert", path);
+    }
+    if let Some(path) = target.ssl_key.as_deref() {
+        push_option(&mut contents, "ssl-key", path);
+    }
+    contents
+}
+
+fn push_option(contents: &mut String, key: &str, value: &str) {
+    contents.push_str(key);
+    contents.push_str(" = ");
+    contents.push_str(&quote_option_value(value));
+    contents.push('\n');
+}
+
+fn quote_option_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            _ => escaped.push(character),
+        }
+    }
+    format!("\"{escaped}\"")
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MysqlResultSet {
+    columns: Vec<String>,
+    values: Vec<Vec<QueryValue>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct MysqlExecutionResult {
+    result_set: Option<MysqlResultSet>,
+    command_tag: Option<CommandTag>,
+    refresh_scope: RefreshScope,
+}
+
+struct MysqlCommandEvent {
+    kind: MysqlStatementKind,
+    target: Option<String>,
+    tag: CommandTag,
+}
+
+fn validate_mysql_multi_query(
+    query: &str,
+    selected_database: Option<&str>,
+    access_mode: AccessMode,
+) -> Result<Vec<MysqlStatement>, DbOperationError> {
+    let decision = evaluate_mysql_multi_statement(query, selected_database);
+    let (statements, risk) = match decision {
+        MultiStatementDecision::Allow { statements, risk } => (statements, risk),
+        MultiStatementDecision::Block { reason } => {
+            return Err(DbOperationError::UnsupportedOperation(reason));
+        }
+    };
+    if access_mode.is_read_only() && !risk.read_only_allowed {
+        return Err(DbOperationError::PermissionDenied(
+            "read-only mode blocks MySQL write statements".to_string(),
+        ));
+    }
+    statements
+        .iter()
+        .map(|statement| {
+            classify_mysql_statement(statement)
+                .map_err(|error| DbOperationError::UnsupportedOperation(error.to_string()))
+        })
+        .collect()
+}
+
+fn validate_mysql_export_query(
+    query: &str,
+    selected_database: Option<&str>,
+) -> Result<(), DbOperationError> {
+    let statements = validate_mysql_multi_query(query, selected_database, AccessMode::ReadOnly)?;
+    if statements.len() != 1
+        || !matches!(
+            statements[0].kind,
+            MysqlStatementKind::Select
+                | MysqlStatementKind::Table
+                | MysqlStatementKind::Show
+                | MysqlStatementKind::Describe
+        )
+    {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL CSV export supports a single read-only result query".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+struct MysqlProcess {
+    child: Child,
+    #[cfg(unix)]
+    pty: MysqlPty,
+    #[cfg(not(unix))]
+    stdin: ChildStdin,
+    #[cfg(not(unix))]
+    stdout: ChildStdout,
+    #[cfg(not(unix))]
+    stderr: ChildStderr,
+    #[cfg(not(unix))]
+    pending: Vec<u8>,
+    #[cfg(not(unix))]
+    pending_stderr: Vec<u8>,
+}
+
+#[cfg(unix)]
+struct MysqlPty {
+    input: TokioFile,
+    output: TokioFile,
+    pending: Vec<u8>,
+}
+
+impl MysqlProcess {
+    fn spawn_with_program(
+        program: &OsStr,
+        option_file: &std::path::Path,
+    ) -> Result<Self, DbOperationError> {
+        #[cfg(unix)]
+        {
+            Self::spawn_with_pty(program, option_file)
+        }
+
+        #[cfg(not(unix))]
+        {
+            let mut command = Command::new(program);
+            command
+                .args(mysql_query_args(option_file))
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .env_remove("MYSQL_PWD")
+                .env_remove("MYSQL_PASSWORD")
+                .kill_on_drop(true);
+            let mut child = command.spawn().map_err(|error| {
+                if error.kind() == io::ErrorKind::NotFound {
+                    DbOperationError::CommandNotFound {
+                        command: DatabaseCli::MySql,
+                        details: error.to_string(),
+                    }
+                } else {
+                    DbOperationError::ConnectionFailed(error.to_string())
+                }
+            })?;
+            let stdin = child.stdin.take().ok_or_else(|| {
+                DbOperationError::QueryFailed("mysql stdin was not piped".to_string())
+            })?;
+            let stdout = child.stdout.take().ok_or_else(|| {
+                DbOperationError::QueryFailed("mysql stdout was not piped".to_string())
+            })?;
+            let stderr = child.stderr.take().ok_or_else(|| {
+                DbOperationError::QueryFailed("mysql stderr was not piped".to_string())
+            })?;
+            return Ok(Self {
+                child,
+                stdin,
+                stdout,
+                stderr,
+                pending: Vec::new(),
+                pending_stderr: Vec::new(),
+            });
+        }
+    }
+
+    #[cfg(unix)]
+    fn spawn_with_pty(
+        program: &OsStr,
+        option_file: &std::path::Path,
+    ) -> Result<Self, DbOperationError> {
+        let (master, slave) = create_mysql_pty().map_err(|error| {
+            DbOperationError::ConnectionFailed(format!("Unable to create MySQL PTY: {error}"))
+        })?;
+        let mut command = Command::new(program);
+        command
+            .args(mysql_query_args(option_file))
+            .stdin(Stdio::from(slave.try_clone().map_err(|error| {
+                DbOperationError::ConnectionFailed(error.to_string())
+            })?))
+            .stdout(Stdio::from(slave.try_clone().map_err(|error| {
+                DbOperationError::ConnectionFailed(error.to_string())
+            })?))
+            .stderr(Stdio::from(slave))
+            .env_remove("MYSQL_PWD")
+            .env_remove("MYSQL_PASSWORD")
+            .kill_on_drop(true);
+        let child = command.spawn().map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                DbOperationError::CommandNotFound {
+                    command: DatabaseCli::MySql,
+                    details: error.to_string(),
+                }
+            } else {
+                DbOperationError::ConnectionFailed(error.to_string())
+            }
+        })?;
+        let output = TokioFile::from_std(
+            master
+                .try_clone()
+                .map_err(|error| DbOperationError::ConnectionFailed(error.to_string()))?,
+        );
+        let input = TokioFile::from_std(master);
+        Ok(Self {
+            child,
+            pty: MysqlPty {
+                input,
+                output,
+                pending: Vec::new(),
+            },
+        })
+    }
+}
+
+#[cfg(unix)]
+fn create_mysql_pty() -> io::Result<(std::fs::File, std::fs::File)> {
+    let mut master = -1;
+    let mut slave = -1;
+    let result = unsafe {
+        libc::openpty(
+            &raw mut master,
+            &raw mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let slave_file = unsafe { std::fs::File::from_raw_fd(slave) };
+    let master_file = unsafe { std::fs::File::from_raw_fd(master) };
+    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+    if unsafe { libc::tcgetattr(slave_file.as_raw_fd(), termios.as_mut_ptr()) } == 0 {
+        let mut termios = unsafe { termios.assume_init() };
+        termios.c_lflag &= !(libc::ECHO | libc::ECHONL);
+        termios.c_oflag &= !libc::OPOST;
+        let _ =
+            unsafe { libc::tcsetattr(slave_file.as_raw_fd(), libc::TCSANOW, &raw const termios) };
+    }
+    Ok((master_file, slave_file))
+}
+
+async fn run_mysql_adhoc(
+    option_file: &std::path::Path,
+    query: &str,
+    statements: &[MysqlStatement],
+    access_mode: AccessMode,
+) -> Result<MysqlExecutionResult, DbOperationError> {
+    run_mysql_adhoc_with_program_and_statements(
+        OsStr::new("mysql"),
+        option_file,
+        query,
+        statements,
+        access_mode,
+        MYSQL_QUERY_TIMEOUT,
+    )
+    .await
+}
+
+async fn export_mysql_csv_to_file(
+    target: MySqlDsn,
+    query: &str,
+    path: PathBuf,
+) -> Result<(), DbOperationError> {
+    let option_file = MySqlOptionFile::create(&target)?;
+    let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
+    let result = timeout(
+        MYSQL_QUERY_TIMEOUT,
+        run_mysql_export_process(&mut process, query, path),
+    )
+    .await;
+    match result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_export_process(
+    process: &mut MysqlProcess,
+    query: &str,
+    path: PathBuf,
+) -> Result<(), DbOperationError> {
+    let marker = Uuid::new_v4().simple().to_string();
+    let probe_query =
+        format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");
+    write_mysql_statement(process, &probe_query).await?;
+    let probe_xml = read_one_mysql_resultset(process).await?;
+    let probe = parse_mysql_xml(&probe_xml)?;
+    validate_mode_probe(&probe, &marker)?;
+
+    write_mysql_statement(process, query).await?;
+    let mut csv_writer = CsvFileWriter::create(path).await?;
+    stream_mysql_resultset_to_csv(process, &mut csv_writer).await?;
+
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .shutdown()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let tail = {
+        write_mysql_input(process, b"\\q\n").await?;
+        read_pty_all(&mut process.pty)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?
+    };
+
+    #[cfg(not(unix))]
+    let (_stdout, stderr) =
+        tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    #[cfg(not(unix))]
+    let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+
+    let status = process
+        .child
+        .wait()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(unix)]
+    let error_bytes = tail.as_slice();
+    #[cfg(not(unix))]
+    let error_bytes = stderr.as_slice();
+    if !status.success() {
+        return Err(classify_mysql_query_failure(error_bytes));
+    }
+
+    csv_writer.finish().await
+}
+
+async fn stream_mysql_resultset_to_csv(
+    process: &mut MysqlProcess,
+    csv_writer: &mut CsvFileWriter,
+) -> Result<(), DbOperationError> {
+    #[cfg(unix)]
+    {
+        let source = MysqlExportPtySource {
+            pty: &mut process.pty,
+            error_output: Vec::new(),
+        };
+        let mut reader = Reader::from_reader(BufReader::new(source));
+        reader.config_mut().trim_text(false);
+        let result = stream_mysql_xml_to_csv(&mut reader, csv_writer).await;
+        let buffered = reader.into_inner();
+        let unread = buffered.buffer().to_vec();
+        let source = buffered.into_inner();
+        source.pty.pending.extend(unread);
+        if !source.error_output.is_empty() {
+            return Err(classify_mysql_query_failure(&source.error_output));
+        }
+        result
+    }
+
+    #[cfg(not(unix))]
+    {
+        let source = MysqlExportPipeSource {
+            stdout: &mut process.stdout,
+            stderr: &mut process.stderr,
+            pending: &mut process.pending,
+            error_output: Vec::new(),
+            stderr_buffer: [0; 4096],
+            stderr_closed: false,
+            stdout_closed: false,
+        };
+        let mut reader = Reader::from_reader(BufReader::new(source));
+        reader.config_mut().trim_text(false);
+        let result = stream_mysql_xml_to_csv(&mut reader, csv_writer).await;
+        let buffered = reader.into_inner();
+        let unread = buffered.buffer().to_vec();
+        let source = buffered.into_inner();
+        source.pending.extend(unread);
+        if has_mysql_cli_error(&source.error_output) {
+            return Err(classify_mysql_query_failure(&source.error_output));
+        }
+        return result;
+    }
+}
+
+async fn stream_mysql_xml_to_csv<R>(
+    reader: &mut Reader<BufReader<R>>,
+    csv_writer: &mut CsvFileWriter,
+) -> Result<(), DbOperationError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = Vec::new();
+    let mut resultset_count = 0;
+    let mut in_resultset = false;
+    let mut current_row: Option<Vec<(String, String)>> = None;
+    let mut current_field: Option<MysqlField> = None;
+    let mut columns: Option<Vec<String>> = None;
+
+    loop {
+        let event = reader
+            .read_event_into_async(&mut buffer)
+            .await
+            .map_err(|error| {
+                DbOperationError::QueryFailed(format!("invalid MySQL XML result: {error}"))
+            })?;
+        match event {
+            Event::Start(element) => match element.name().as_ref() {
+                b"resultset" => {
+                    if in_resultset || resultset_count > 0 {
+                        return Err(DbOperationError::QueryFailed(
+                            "mysql returned more than one resultset".to_string(),
+                        ));
+                    }
+                    resultset_count += 1;
+                    in_resultset = true;
+                }
+                b"row" if in_resultset && current_row.is_none() => {
+                    current_row = Some(Vec::new());
+                }
+                b"field" if current_row.is_some() && current_field.is_none() => {
+                    current_field = Some(parse_mysql_field(&element)?);
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected element in MySQL XML result".to_string(),
+                    ));
+                }
+            },
+            Event::Empty(element) if element.name().as_ref() == b"field" => {
+                let row = current_row.as_mut().ok_or_else(|| {
+                    DbOperationError::QueryFailed("MySQL XML field is outside a row".to_string())
+                })?;
+                if current_field.is_some() {
+                    return Err(DbOperationError::QueryFailed(
+                        "nested MySQL XML fields are not supported".to_string(),
+                    ));
+                }
+                row.push(parse_mysql_field(&element)?.finish_raw());
+            }
+            Event::Text(text) => {
+                let text = text.unescape().map_err(|error| {
+                    DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
+                })?;
+                if let Some(field) = current_field.as_mut() {
+                    field.value.push_str(&text);
+                } else if !text.chars().all(char::is_whitespace) {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected text in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::CData(data) => {
+                if let Some(field) = current_field.as_mut() {
+                    field
+                        .value
+                        .push_str(std::str::from_utf8(data.as_ref()).map_err(|error| {
+                            DbOperationError::QueryFailed(format!(
+                                "invalid MySQL XML text: {error}"
+                            ))
+                        })?);
+                } else {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected CDATA in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::End(element) => match element.name().as_ref() {
+                b"field" => {
+                    let row = current_row.as_mut().ok_or_else(|| {
+                        DbOperationError::QueryFailed(
+                            "MySQL XML field is outside a row".to_string(),
+                        )
+                    })?;
+                    let field = current_field.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML field end".to_string())
+                    })?;
+                    row.push(field.finish_raw());
+                }
+                b"row" => {
+                    let row = current_row.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML row end".to_string())
+                    })?;
+                    let row_columns = row.iter().map(|(name, _)| name.clone()).collect::<Vec<_>>();
+                    if let Some(columns) = columns.as_ref() {
+                        if row_columns != *columns {
+                            return Err(DbOperationError::QueryFailed(
+                                "MySQL XML rows have inconsistent fields".to_string(),
+                            ));
+                        }
+                    } else {
+                        csv_writer.write_record(row_columns.iter()).await?;
+                        columns = Some(row_columns);
+                    }
+                    csv_writer
+                        .write_record(row.iter().map(|(_, value)| value))
+                        .await?;
+                }
+                b"resultset" => {
+                    if !in_resultset || current_row.is_some() || current_field.is_some() {
+                        return Err(DbOperationError::QueryFailed(
+                            "malformed MySQL XML resultset".to_string(),
+                        ));
+                    }
+                    return Ok(());
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected MySQL XML closing element".to_string(),
+                    ));
+                }
+            },
+            Event::Decl(_) | Event::Comment(_) => {}
+            Event::Eof => break,
+            _ => {
+                return Err(DbOperationError::QueryFailed(
+                    "unexpected event in MySQL XML result".to_string(),
+                ));
+            }
+        }
+        buffer.clear();
+    }
+
+    if resultset_count != 1 || in_resultset || current_row.is_some() || current_field.is_some() {
+        return Err(DbOperationError::QueryFailed(
+            "MySQL XML result did not contain one complete resultset".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+struct MysqlExportPtySource<'a> {
+    pty: &'a mut MysqlPty,
+    error_output: Vec<u8>,
+}
+
+#[cfg(unix)]
+impl MysqlExportPtySource<'_> {
+    fn capture_error(&mut self, bytes: &[u8]) {
+        if self.error_output.is_empty() && has_mysql_cli_error(bytes) {
+            self.error_output
+                .extend_from_slice(&bytes[..bytes.len().min(32 * 1024)]);
+        }
+    }
+}
+
+#[cfg(unix)]
+impl AsyncRead for MysqlExportPtySource<'_> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if !this.pty.pending.is_empty() {
+            let count = buffer.remaining().min(this.pty.pending.len());
+            let bytes = this.pty.pending.drain(..count).collect::<Vec<_>>();
+            this.capture_error(&bytes);
+            buffer.put_slice(&bytes);
+            return Poll::Ready(Ok(()));
+        }
+
+        let filled_before = buffer.filled().len();
+        let result = Pin::new(&mut this.pty.output).poll_read(cx, buffer);
+        if matches!(&result, Poll::Ready(Ok(()))) {
+            this.capture_error(&buffer.filled()[filled_before..]);
+        }
+        result
+    }
+}
+
+#[cfg(not(unix))]
+struct MysqlExportPipeSource<'a, O, E> {
+    stdout: &'a mut O,
+    stderr: &'a mut E,
+    pending: &'a mut Vec<u8>,
+    error_output: Vec<u8>,
+    stderr_buffer: [u8; 4096],
+    stderr_closed: bool,
+    stdout_closed: bool,
+}
+
+#[cfg(not(unix))]
+impl<O, E> MysqlExportPipeSource<'_, O, E>
+where
+    O: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
+    fn capture_error(&mut self, bytes: &[u8]) {
+        let remaining = (32usize * 1024).saturating_sub(self.error_output.len());
+        if remaining > 0 {
+            self.error_output
+                .extend_from_slice(&bytes[..bytes.len().min(remaining)]);
+        }
+    }
+
+    fn poll_stderr(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+        if self.stderr_closed {
+            return Poll::Ready(Ok(0));
+        }
+        let result = {
+            let mut read_buffer = ReadBuf::new(&mut self.stderr_buffer);
+            match Pin::new(&mut *self.stderr).poll_read(cx, &mut read_buffer) {
+                Poll::Ready(Ok(())) => Poll::Ready(Ok(read_buffer.filled().to_vec())),
+                Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+                Poll::Pending => Poll::Pending,
+            }
+        };
+        match result {
+            Poll::Ready(Ok(bytes)) => {
+                if bytes.is_empty() {
+                    self.stderr_closed = true;
+                } else {
+                    self.capture_error(&bytes);
+                }
+                Poll::Ready(Ok(bytes.len()))
+            }
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(not(unix))]
+impl<O, E> AsyncRead for MysqlExportPipeSource<'_, O, E>
+where
+    O: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        let stderr_count = match this.poll_stderr(cx) {
+            Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+            Poll::Pending => 0,
+            Poll::Ready(Ok(count)) => count,
+        };
+        if !this.pending.is_empty() {
+            let count = buffer.remaining().min(this.pending.len());
+            let bytes = this.pending.drain(..count).collect::<Vec<_>>();
+            buffer.put_slice(&bytes);
+            return Poll::Ready(Ok(()));
+        }
+
+        if this.stdout_closed {
+            if this.stderr_closed {
+                return Poll::Ready(Ok(()));
+            }
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        }
+
+        let filled_before = buffer.filled().len();
+        let result = Pin::new(&mut *this.stdout).poll_read(cx, buffer);
+        if let Poll::Ready(Ok(())) = &result {
+            let count = buffer.filled().len() - filled_before;
+            if count == 0 {
+                this.stdout_closed = true;
+                if !this.stderr_closed {
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+            }
+        } else if matches!(&result, Poll::Pending) && stderr_count > 0 {
+            cx.waker().wake_by_ref();
+        }
+        result
+    }
+}
+
+#[cfg(all(test, not(unix)))]
+mod export_pipe_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn consumes_stderr_while_streaming_stdout() {
+        let (mut stdout_writer, mut stdout_reader) = tokio::io::duplex(64);
+        let (mut stderr_writer, mut stderr_reader) = tokio::io::duplex(64);
+        let stdout = b"<resultset><row><field name=\"value\">ok</field></row></resultset>".to_vec();
+        let stderr = format!(
+            "ERROR 1146 (42S02): Table 'app.missing' doesn't exist\n{}",
+            "warning\n".repeat(16 * 1024)
+        )
+        .into_bytes();
+
+        let stdout_task = tokio::spawn(async move {
+            stdout_writer.write_all(&stdout).await.unwrap();
+        });
+        let stderr_task = tokio::spawn(async move {
+            stderr_writer.write_all(&stderr).await.unwrap();
+        });
+
+        let mut source = MysqlExportPipeSource {
+            stdout: &mut stdout_reader,
+            stderr: &mut stderr_reader,
+            pending: &mut Vec::new(),
+            error_output: Vec::new(),
+            stderr_buffer: [0; 4096],
+            stderr_closed: false,
+            stdout_closed: false,
+        };
+        let mut output = Vec::new();
+        source.read_to_end(&mut output).await.unwrap();
+        stdout_task.await.unwrap();
+        stderr_task.await.unwrap();
+
+        assert!(output.starts_with(b"<resultset>"));
+        assert!(has_mysql_cli_error(&source.error_output));
+        assert!(matches!(
+            classify_mysql_query_failure(&source.error_output),
+            DbOperationError::ObjectMissing(_)
+        ));
+    }
+}
+
+#[cfg(test)]
+async fn export_mysql_csv_with_program(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+    path: PathBuf,
+    execution_timeout: Duration,
+) -> Result<(), DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+    let result = timeout(
+        execution_timeout,
+        run_mysql_export_process(&mut process, query, path),
+    )
+    .await;
+    match result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+async fn run_mysql_adhoc_with_program(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+    access_mode: AccessMode,
+    execution_timeout: Duration,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+    let result = timeout(
+        execution_timeout,
+        run_mysql_single_statement_process(&mut process, query, access_mode),
+    )
+    .await;
+    match result {
+        Ok(Ok(result_set)) => Ok(result_set),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_single_statement(
+    option_file: &std::path::Path,
+    query: &str,
+    access_mode: AccessMode,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), option_file)?;
+    let result = timeout(
+        MYSQL_QUERY_TIMEOUT,
+        run_mysql_single_statement_process(&mut process, query, access_mode),
+    )
+    .await;
+    match result {
+        Ok(Ok(result_set)) => Ok(result_set),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_single_statement_process(
+    process: &mut MysqlProcess,
+    query: &str,
+    access_mode: AccessMode,
+) -> Result<MysqlResultSet, DbOperationError> {
+    let marker = Uuid::new_v4().simple().to_string();
+    let probe_query =
+        format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");
+    write_mysql_statement(process, &probe_query).await?;
+    let probe_xml = read_one_mysql_resultset(process).await?;
+    let probe = parse_mysql_xml(&probe_xml)?;
+    validate_mode_probe(&probe, &marker)?;
+    configure_mysql_session(process, access_mode).await?;
+
+    write_mysql_statement(process, query).await?;
+
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .shutdown()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let (stdout, tail) = {
+        let stdout = read_one_mysql_resultset(process).await?;
+        write_mysql_input(process, b"\\q\n").await?;
+        let tail = read_pty_all(&mut process.pty)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        (stdout, tail)
+    };
+
+    #[cfg(not(unix))]
+    let (stdout, stderr) =
+        tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    #[cfg(not(unix))]
+    let stdout = stdout.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    #[cfg(not(unix))]
+    let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+
+    let status = process
+        .child
+        .wait()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(unix)]
+    let error_bytes = tail.as_slice();
+    #[cfg(not(unix))]
+    let error_bytes = stderr.as_slice();
+    if !status.success() {
+        return Err(classify_mysql_query_failure(error_bytes));
+    }
+    parse_mysql_xml(&stdout)
+}
+
+async fn run_mysql_adhoc_with_program_and_statements(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+    statements: &[MysqlStatement],
+    access_mode: AccessMode,
+    execution_timeout: Duration,
+) -> Result<MysqlExecutionResult, DbOperationError> {
+    let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+    let result = timeout(
+        execution_timeout,
+        run_mysql_adhoc_process(&mut process, query, statements, access_mode),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(result_set)) => Ok(result_set),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(&mut process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
+async fn run_mysql_adhoc_process(
+    process: &mut MysqlProcess,
+    _query: &str,
+    statements: &[MysqlStatement],
+    access_mode: AccessMode,
+) -> Result<MysqlExecutionResult, DbOperationError> {
+    let probe_marker = Uuid::new_v4().simple().to_string();
+    let probe_query = format!(
+        "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
+    );
+    write_mysql_statement(process, &probe_query).await?;
+    let probe_xml = read_one_mysql_resultset(process).await?;
+    let probe = parse_mysql_xml(&probe_xml)?;
+    validate_mode_probe(&probe, &probe_marker)?;
+    configure_mysql_session(process, access_mode).await?;
+
+    let mut last_result_set = None;
+    let mut command_tags = Vec::with_capacity(statements.len());
+    let mut refresh_scope = RefreshScope::None;
+
+    for statement in statements {
+        let marker = Uuid::new_v4().simple().to_string();
+        let statement_scope = mysql_refresh_scope(&statement.kind);
+        refresh_scope = refresh_scope.merge(statement_scope);
+        if let Err(error) = write_mysql_statement(process, &statement.sql).await {
+            return Err(query_failed_after_change(error, refresh_scope));
+        }
+        let marker_query =
+            format!("SELECT '{marker}' AS __sabiql_marker, ROW_COUNT() AS affected_rows");
+        if let Err(error) = write_mysql_statement(process, &marker_query).await {
+            return Err(query_failed_after_change(error, refresh_scope));
+        }
+        let first_xml = match read_one_mysql_resultset(process).await {
+            Ok(xml) => xml,
+            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+        };
+        let first_result = match parse_mysql_xml(&first_xml) {
+            Ok(result) => result,
+            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+        };
+        let (user_result, marker_result) = if is_mysql_row_count_marker(&first_result, &marker) {
+            (None, first_result)
+        } else {
+            let xml = match read_one_mysql_resultset(process).await {
+                Ok(xml) => xml,
+                Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+            };
+            let marker_result = match parse_mysql_xml(&xml) {
+                Ok(result) => result,
+                Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+            };
+            (Some(first_result), marker_result)
+        };
+        let affected_rows = match mysql_row_count_marker(&marker_result, &marker) {
+            Ok(rows) => rows,
+            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+        };
+        if let Some(result) = user_result {
+            last_result_set = Some(result);
+        }
+        let tag = mysql_command_tag(&statement.kind, affected_rows, last_result_set.as_ref());
+        command_tags.push(MysqlCommandEvent {
+            kind: statement.kind.clone(),
+            target: statement.target.clone(),
+            tag,
+        });
+    }
+
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .shutdown()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let tail = {
+        write_mysql_input(process, b"\\q\n").await?;
+        let tail = read_pty_all(&mut process.pty)
+            .await
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        trace_mysql_frame("discard tail", tail.len());
+        trace_mysql_error(&tail);
+        tail
+    };
+
+    #[cfg(not(unix))]
+    let (_stdout, stderr) =
+        tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    #[cfg(not(unix))]
+    let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+
+    let status = process
+        .child
+        .wait()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+
+    #[cfg(unix)]
+    let error_bytes = tail.as_slice();
+    #[cfg(not(unix))]
+    let error_bytes = stderr.as_slice();
+    if has_mysql_cli_error(error_bytes) {
+        return Err(query_failed_after_change(
+            classify_mysql_query_failure(error_bytes),
+            refresh_scope,
+        ));
+    }
+    if !status.success() {
+        return Err(query_failed_after_change(
+            classify_mysql_query_failure(error_bytes),
+            refresh_scope,
+        ));
+    }
+
+    Ok(MysqlExecutionResult {
+        result_set: last_result_set,
+        command_tag: aggregate_mysql_command_tag(&command_tags),
+        refresh_scope,
+    })
+}
+
+async fn configure_mysql_session(
+    process: &mut MysqlProcess,
+    access_mode: AccessMode,
+) -> Result<(), DbOperationError> {
+    if !access_mode.is_read_only() {
+        return Ok(());
+    }
+
+    let marker = Uuid::new_v4().simple().to_string();
+    write_mysql_statement(process, MYSQL_READ_ONLY_STATEMENT).await?;
+    write_mysql_statement(
+        process,
+        &format!("SELECT '{marker}' AS {MYSQL_SESSION_MARKER_COLUMN}"),
+    )
+    .await?;
+    loop {
+        let result = read_one_mysql_resultset(process).await?;
+        let result = parse_mysql_xml(&result)?;
+        if result.columns.is_empty() && result.values.is_empty() {
+            continue;
+        }
+        return validate_mysql_session_marker(&result, &marker);
+    }
+}
+
+fn validate_mysql_session_marker(
+    result: &MysqlResultSet,
+    marker: &str,
+) -> Result<(), DbOperationError> {
+    if result.columns != [MYSQL_SESSION_MARKER_COLUMN]
+        || result.values.len() != 1
+        || result.values[0].len() != 1
+        || result.values[0][0].as_str() != Some(marker)
+    {
+        return Err(DbOperationError::QueryFailed(
+            "mysql read-only session marker did not match".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn query_failed_after_change(
+    error: DbOperationError,
+    refresh_scope: RefreshScope,
+) -> DbOperationError {
+    if refresh_scope == RefreshScope::None {
+        error
+    } else {
+        DbOperationError::QueryFailedAfterChange {
+            details: error.masked_details(),
+            refresh_scope,
+        }
+    }
+}
+
+fn is_mysql_row_count_marker(result: &MysqlResultSet, marker: &str) -> bool {
+    result.columns == ["__sabiql_marker", "affected_rows"]
+        && result.values.len() == 1
+        && result.values[0].first().and_then(QueryValue::as_str) == Some(marker)
+}
+
+fn mysql_row_count_marker(result: &MysqlResultSet, marker: &str) -> Result<i64, DbOperationError> {
+    if !is_mysql_row_count_marker(result, marker) || result.values[0].len() != 2 {
+        return Err(DbOperationError::QueryFailed(
+            "mysql ROW_COUNT marker did not match the executed statement".to_string(),
+        ));
+    }
+    let value = result.values[0][1].as_str().ok_or_else(|| {
+        DbOperationError::QueryFailed("mysql ROW_COUNT marker was NULL".to_string())
+    })?;
+    value.parse::<i64>().map_err(|_| {
+        DbOperationError::QueryFailed("mysql ROW_COUNT marker was not an integer".to_string())
+    })
+}
+
+fn mysql_command_tag(
+    kind: &MysqlStatementKind,
+    affected_rows: i64,
+    user_result: Option<&MysqlResultSet>,
+) -> CommandTag {
+    let rows = || u64::try_from(affected_rows.max(0)).unwrap_or(0);
+    match kind {
+        MysqlStatementKind::Select
+        | MysqlStatementKind::Table
+        | MysqlStatementKind::Show
+        | MysqlStatementKind::Describe => {
+            CommandTag::Select(user_result.map_or(0, |result| result.values.len() as u64))
+        }
+        MysqlStatementKind::Insert | MysqlStatementKind::Replace => CommandTag::Insert(rows()),
+        MysqlStatementKind::Update { .. } => CommandTag::Update(rows()),
+        MysqlStatementKind::Delete { .. } => CommandTag::Delete(rows()),
+        MysqlStatementKind::CreateTable { temporary: true } => {
+            CommandTag::Other("CREATE TEMPORARY TABLE".to_string())
+        }
+        MysqlStatementKind::CreateTable { temporary: false } => {
+            CommandTag::Create("TABLE".to_string())
+        }
+        MysqlStatementKind::AlterTable => CommandTag::Alter("TABLE".to_string()),
+        MysqlStatementKind::DropTable { temporary: true } => {
+            CommandTag::Other("DROP TEMPORARY TABLE".to_string())
+        }
+        MysqlStatementKind::DropTable { temporary: false } => CommandTag::Drop("TABLE".to_string()),
+        MysqlStatementKind::TruncateTable => CommandTag::Truncate,
+        MysqlStatementKind::CreateView => CommandTag::Create("VIEW".to_string()),
+        MysqlStatementKind::DropView => CommandTag::Drop("VIEW".to_string()),
+        MysqlStatementKind::CreateIndex => CommandTag::Create("INDEX".to_string()),
+        MysqlStatementKind::DropIndex => CommandTag::Drop("INDEX".to_string()),
+        MysqlStatementKind::Begin | MysqlStatementKind::StartTransaction => CommandTag::Begin,
+        MysqlStatementKind::Commit => CommandTag::Commit,
+        MysqlStatementKind::Rollback | MysqlStatementKind::RollbackToSavepoint => {
+            CommandTag::Rollback
+        }
+        MysqlStatementKind::Savepoint => CommandTag::Other("SAVEPOINT".to_string()),
+        MysqlStatementKind::ReleaseSavepoint => CommandTag::Other("RELEASE SAVEPOINT".to_string()),
+    }
+}
+
+fn mysql_refresh_scope(kind: &MysqlStatementKind) -> RefreshScope {
+    if mysql_statement_is_schema_modifying(kind) {
+        RefreshScope::Metadata
+    } else if mysql_statement_is_data_modifying(kind) {
+        RefreshScope::Data
+    } else {
+        RefreshScope::None
+    }
+}
+
+fn mysql_statement_is_persistent_schema_change(kind: &MysqlStatementKind) -> bool {
+    mysql_statement_is_schema_modifying(kind)
+        && !matches!(
+            kind,
+            MysqlStatementKind::CreateTable { temporary: true }
+                | MysqlStatementKind::DropTable { temporary: true }
+        )
+}
+
+#[derive(Default)]
+struct MysqlPendingTransactionTags {
+    data: Vec<CommandTag>,
+    savepoints: Vec<(String, usize)>,
+}
+
+fn apply_pending_mysql_data(
+    pending: MysqlPendingTransactionTags,
+    committed_data: &mut Option<CommandTag>,
+) {
+    if let Some(tag) = pending.data.last() {
+        *committed_data = Some(tag.clone());
+    }
+}
+
+fn aggregate_mysql_command_tag(events: &[MysqlCommandEvent]) -> Option<CommandTag> {
+    let mut committed_schema = None;
+    let mut committed_data = None;
+    let mut pending = None;
+    let mut last_tag = None;
+
+    for event in events {
+        last_tag = Some(event.tag.clone());
+        match &event.kind {
+            MysqlStatementKind::Begin | MysqlStatementKind::StartTransaction => {
+                pending = Some(MysqlPendingTransactionTags::default());
+            }
+            MysqlStatementKind::Commit => {
+                if let Some(transaction) = pending.take() {
+                    apply_pending_mysql_data(transaction, &mut committed_data);
+                }
+            }
+            MysqlStatementKind::Rollback => {
+                pending = None;
+            }
+            MysqlStatementKind::Savepoint => {
+                if let Some(transaction) = pending.as_mut()
+                    && let Some(name) = event.target.as_deref()
+                {
+                    transaction
+                        .savepoints
+                        .retain(|(current, _)| !current.eq_ignore_ascii_case(name));
+                    transaction
+                        .savepoints
+                        .push((name.to_string(), transaction.data.len()));
+                }
+            }
+            MysqlStatementKind::RollbackToSavepoint => {
+                if let Some(transaction) = pending.as_mut()
+                    && let Some(name) = event.target.as_deref()
+                    && let Some(index) = transaction
+                        .savepoints
+                        .iter()
+                        .position(|(current, _)| current.eq_ignore_ascii_case(name))
+                {
+                    transaction.data.truncate(transaction.savepoints[index].1);
+                    transaction.savepoints.truncate(index + 1);
+                }
+            }
+            MysqlStatementKind::ReleaseSavepoint => {
+                if let Some(transaction) = pending.as_mut()
+                    && let Some(name) = event.target.as_deref()
+                    && let Some(index) = transaction
+                        .savepoints
+                        .iter()
+                        .position(|(current, _)| current.eq_ignore_ascii_case(name))
+                {
+                    transaction.savepoints.remove(index);
+                }
+            }
+            MysqlStatementKind::CreateTable { temporary: true }
+            | MysqlStatementKind::DropTable { temporary: true } => {}
+            kind if mysql_statement_is_persistent_schema_change(kind) => {
+                if let Some(transaction) = pending.take() {
+                    apply_pending_mysql_data(transaction, &mut committed_data);
+                }
+                committed_schema = Some(event.tag.clone());
+            }
+            kind if mysql_statement_is_data_modifying(kind) => {
+                if let Some(transaction) = pending.as_mut() {
+                    transaction.data.push(event.tag.clone());
+                } else {
+                    committed_data = Some(event.tag.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    committed_schema.or(committed_data).or(last_tag)
+}
+
+async fn write_mysql_statement(
+    process: &mut MysqlProcess,
+    query: &str,
+) -> Result<(), DbOperationError> {
+    let query = query.trim_end();
+    write_mysql_input(process, query.as_bytes()).await?;
+    if query.ends_with(';') {
+        write_mysql_input(process, b"\n").await
+    } else if mysql_statement_has_trailing_line_comment(query) {
+        write_mysql_input(process, b"\n;\n").await
+    } else {
+        write_mysql_input(process, b";\n").await
+    }
+}
+
+fn mysql_statement_has_trailing_line_comment(sql: &str) -> bool {
+    let bytes = sql.as_bytes();
+    let mut index = 0;
+    let mut quote = None;
+    let mut line_comment = false;
+    while index < bytes.len() {
+        if let Some(delimiter) = quote {
+            if bytes[index] == b'\\' && delimiter != b'`' {
+                index += 2;
+            } else if bytes[index] == delimiter {
+                if bytes.get(index + 1) == Some(&delimiter) {
+                    index += 2;
+                } else {
+                    quote = None;
+                    index += 1;
+                }
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+        if line_comment {
+            if bytes[index] == b'\n' {
+                line_comment = false;
+            }
+            index += 1;
+            continue;
+        }
+        if matches!(bytes[index], b'\'' | b'"' | b'`') {
+            quote = Some(bytes[index]);
+            index += 1;
+        } else if mysql_is_line_comment_start(bytes, index) {
+            let comment_start = index;
+            index = mysql_skip_line_comment(bytes, index);
+            line_comment = !bytes[comment_start..index].contains(&b'\n');
+        } else if bytes.get(index..index + 2) == Some(b"/*") {
+            index = mysql_skip_block_comment(bytes, index);
+        } else {
+            index += 1;
+        }
+    }
+    line_comment
+}
+
+fn mysql_is_line_comment_start(bytes: &[u8], index: usize) -> bool {
+    bytes[index] == b'#'
+        || (bytes.get(index..index + 2) == Some(b"--")
+            && bytes.get(index + 2).is_none_or(u8::is_ascii_whitespace))
+}
+
+fn mysql_skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() {
+        let byte = bytes[index];
+        index += 1;
+        if byte == b'\n' {
+            break;
+        }
+    }
+    index
+}
+
+fn mysql_skip_block_comment(bytes: &[u8], index: usize) -> usize {
+    let mut cursor = index + 2;
+    while cursor + 1 < bytes.len() {
+        if bytes[cursor] == b'*' && bytes[cursor + 1] == b'/' {
+            return cursor + 2;
+        }
+        cursor += 1;
+    }
+    bytes.len()
+}
+
+async fn write_mysql_input(
+    process: &mut MysqlProcess,
+    input: &[u8],
+) -> Result<(), DbOperationError> {
+    #[cfg(unix)]
+    process
+        .pty
+        .input
+        .write_all(input)
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .write_all(input)
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(unix)]
+    process
+        .pty
+        .input
+        .flush()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    #[cfg(not(unix))]
+    process
+        .stdin
+        .flush()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    Ok(())
+}
+
+async fn cleanup_mysql_process(process: &mut MysqlProcess) {
+    let _ = process.child.kill().await;
+    #[cfg(unix)]
+    let _ = read_pty_all(&mut process.pty).await;
+    #[cfg(not(unix))]
+    let _ = tokio::join!(read_all(&mut process.stdout), read_all(&mut process.stderr));
+    let _ = process.child.wait().await;
+}
+
+async fn read_one_mysql_resultset(process: &mut MysqlProcess) -> Result<Vec<u8>, DbOperationError> {
+    #[cfg(unix)]
+    {
+        return read_one_pty_resultset(&mut process.pty).await;
+    }
+    #[cfg(not(unix))]
+    read_one_mysql_resultset_from_pipes(
+        &mut process.stdout,
+        &mut process.stderr,
+        &mut process.pending,
+        &mut process.pending_stderr,
+    )
+    .await
+}
+
+#[cfg(unix)]
+async fn read_one_pty_resultset(pty: &mut MysqlPty) -> Result<Vec<u8>, DbOperationError> {
+    let mut chunk = [0; 4096];
+    loop {
+        if has_mysql_cli_error(&pty.pending) {
+            trace_mysql_error(&pty.pending);
+            return Err(classify_mysql_query_failure(&pty.pending));
+        }
+        if let Some(frame) = take_mysql_resultset_frame(&mut pty.pending) {
+            trace_mysql_frame("receive resultset", frame.len());
+            return Ok(frame);
+        }
+        let count = match pty.output.read(&mut chunk).await {
+            Ok(count) => count,
+            Err(error) if error.raw_os_error() == Some(libc::EIO) => 0,
+            Err(error) => return Err(DbOperationError::ConnectionLost(error.to_string())),
+        };
+        if count == 0 {
+            return Err(DbOperationError::EmptyResponse(
+                "mysql query returned no resultset".to_string(),
+            ));
+        }
+        pty.pending.extend_from_slice(&chunk[..count]);
+    }
+}
+
+#[cfg(unix)]
+async fn read_pty_all(pty: &mut MysqlPty) -> io::Result<Vec<u8>> {
+    let mut output = std::mem::take(&mut pty.pending);
+    let mut chunk = [0; 4096];
+    loop {
+        match pty.output.read(&mut chunk).await {
+            Ok(0) => return Ok(output),
+            Ok(count) => output.extend_from_slice(&chunk[..count]),
+            Err(error) if error.raw_os_error() == Some(libc::EIO) => return Ok(output),
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn has_mysql_cli_error(output: &[u8]) -> bool {
+    output
+        .split(|byte| *byte == b'\n' || *byte == b'\r')
+        .any(|line| {
+            let mut line = line;
+            while line
+                .first()
+                .is_some_and(|byte| byte.is_ascii_whitespace() || byte.is_ascii_control())
+            {
+                line = &line[1..];
+            }
+            line.starts_with(b"ERROR ") || line == b"ERROR"
+        })
+}
+
+fn take_mysql_resultset_frame(buffer: &mut Vec<u8>) -> Option<Vec<u8>> {
+    let (start, end) = mysql_resultset_frame_bounds(buffer)?;
+    let frame = buffer[start..end].to_vec();
+    buffer.drain(..end);
+    Some(frame)
+}
+
+fn mysql_resultset_frame_bounds(buffer: &[u8]) -> Option<(usize, usize)> {
+    let start = find_bytes(buffer, b"<resultset")?;
+    let end = buffer[start..]
+        .windows(b"</resultset>".len())
+        .position(|window| window == b"</resultset>")?
+        + start
+        + b"</resultset>".len();
+    Some((start, end))
+}
+
+#[cfg(any(not(unix), test))]
+fn take_mysql_resultset_frame_after_error_check(
+    buffer: &mut Vec<u8>,
+    error_output: &[u8],
+) -> Result<Option<Vec<u8>>, DbOperationError> {
+    if has_mysql_cli_error(error_output) {
+        trace_mysql_error(error_output);
+        return Err(classify_mysql_query_failure(error_output));
+    }
+    Ok(take_mysql_resultset_frame(buffer))
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn trace_mysql_frame(kind: &str, bytes: usize) {
+    if std::env::var_os("SABIQL_MYSQL_TRANSCRIPT").is_some() {
+        write_mysql_transcript_line(&format!("sabiql mysql frame: {kind}, bytes={bytes}"));
+    }
+}
+
+fn trace_mysql_error(output: &[u8]) {
+    if std::env::var_os("SABIQL_MYSQL_TRANSCRIPT").is_some() && has_mysql_cli_error(output) {
+        write_mysql_transcript_line("sabiql mysql frame: ERROR line observed");
+    }
+}
+
+fn write_mysql_transcript_line(line: &str) {
+    let mut stderr = io::stderr();
+    let _ = stderr.write_all(line.as_bytes());
+    let _ = stderr.write_all(b"\n");
+}
+
+#[cfg(not(unix))]
+async fn read_all<R>(reader: &mut R) -> io::Result<Vec<u8>>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).await?;
+    Ok(output)
+}
+
+#[cfg(not(unix))]
+async fn read_one_mysql_resultset_from_pipes<R, E>(
+    reader: &mut R,
+    stderr: &mut E,
+    pending: &mut Vec<u8>,
+    pending_stderr: &mut Vec<u8>,
+) -> Result<Vec<u8>, DbOperationError>
+where
+    R: AsyncRead + Unpin,
+    E: AsyncRead + Unpin,
+{
+    let mut chunk = [0; 4096];
+    let mut stderr_chunk = [0; 4096];
+    let mut stderr_closed = false;
+    loop {
+        if mysql_resultset_frame_bounds(pending).is_some() && !stderr_closed {
+            tokio::select! {
+                biased;
+                result = stderr.read(&mut stderr_chunk) => {
+                    let count = result.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+                    if count == 0 {
+                        stderr_closed = true;
+                    } else {
+                        pending_stderr.extend_from_slice(&stderr_chunk[..count]);
+                    }
+                }
+                _ = tokio::task::yield_now() => {}
+            }
+        }
+        if let Some(frame) = take_mysql_resultset_frame_after_error_check(pending, pending_stderr)?
+        {
+            trace_mysql_frame("receive resultset", frame.len());
+            return Ok(frame);
+        }
+        if stderr_closed {
+            let count = reader
+                .read(&mut chunk)
+                .await
+                .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+            if count == 0 {
+                return Err(DbOperationError::EmptyResponse(
+                    "mysql mode probe returned no resultset".to_string(),
+                ));
+            }
+            pending.extend_from_slice(&chunk[..count]);
+        } else {
+            tokio::select! {
+                result = reader.read(&mut chunk) => {
+                    let count = result.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+                    if count == 0 {
+                        return Err(DbOperationError::EmptyResponse(
+                            "mysql mode probe returned no resultset".to_string(),
+                        ));
+                    }
+                    pending.extend_from_slice(&chunk[..count]);
+                }
+                result = stderr.read(&mut stderr_chunk) => {
+                    let count = result.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+                    if count == 0 {
+                        stderr_closed = true;
+                    } else {
+                        pending_stderr.extend_from_slice(&stderr_chunk[..count]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn mysql_query_args(option_file: &std::path::Path) -> Vec<String> {
+    let args = vec![
+        format!("--defaults-file={}", option_file.display()),
+        "--no-login-paths".to_string(),
+        "--protocol=TCP".to_string(),
+        "--connect-timeout=10".to_string(),
+        "--xml".to_string(),
+        "--binary-as-hex".to_string(),
+        "--binary-mode".to_string(),
+        "--unbuffered".to_string(),
+        "--skip-reconnect".to_string(),
+        "--default-character-set=utf8mb4".to_string(),
+        "--silent".to_string(),
+        "--prompt=".to_string(),
+    ];
+    #[cfg(not(unix))]
+    return args
+        .into_iter()
+        .chain(std::iter::once("--batch".to_string()))
+        .collect();
+    #[cfg(unix)]
+    args
+}
+
+fn validate_mode_probe(result: &MysqlResultSet, marker: &str) -> Result<(), DbOperationError> {
+    if result.values.len() != 1 || result.columns != ["__sabiql_probe", "__sabiql_sql_mode"] {
+        return Err(DbOperationError::QueryFailed(
+            "mysql sql_mode probe returned an unexpected result".to_string(),
+        ));
+    }
+    let values = &result.values[0];
+    if values.len() != 2 {
+        return Err(DbOperationError::QueryFailed(
+            "mysql sql_mode probe returned an unexpected result".to_string(),
+        ));
+    }
+    if values[0].as_str() != Some(marker) {
+        return Err(DbOperationError::QueryFailed(
+            "mysql sql_mode probe marker did not match".to_string(),
+        ));
+    }
+    let mode = values[1].as_str().ok_or_else(|| {
+        DbOperationError::QueryFailed("mysql sql_mode probe returned no mode".to_string())
+    })?;
+    validate_sql_mode(mode)
+}
+
+fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {
+    let details = clean_mysql_stderr(stderr, "mysql query failed");
+    let lower = details.to_ascii_lowercase();
+    let error_code = mysql_server_error_code(&lower);
+    if is_mysql_tls_error(&lower) {
+        DbOperationError::ConnectionFailed(details)
+    } else if is_mysql_connect_timeout_message(&details)
+        || lower.contains("connect timeout")
+        || lower.contains("connection timed out")
+    {
+        DbOperationError::Timeout(details)
+    } else if matches!(error_code, Some(1044 | 1142 | 1143 | 1227))
+        || lower.contains("command denied")
+    {
+        DbOperationError::PermissionDenied(details)
+    } else if error_code == Some(1045)
+        || lower.contains("access denied")
+        || lower.contains("authentication")
+    {
+        DbOperationError::ConnectionFailed(details)
+    } else if lower.contains("lost connection") || lower.contains("server has gone away") {
+        DbOperationError::ConnectionLost(details)
+    } else if lower.contains("lock wait timeout") || lower.contains("deadlock found") {
+        DbOperationError::LockTimeout(details)
+    } else if lower.contains("doesn't exist") || lower.contains("does not exist") {
+        DbOperationError::ObjectMissing(details)
+    } else if lower.contains("duplicate entry") {
+        DbOperationError::UniqueViolation(details)
+    } else if lower.contains("query execution was interrupted")
+        || lower.contains("query was interrupted")
+    {
+        DbOperationError::Canceled(details)
+    } else {
+        DbOperationError::QueryFailed(details)
+    }
+}
+
+fn is_mysql_tls_error(lowercase_details: &str) -> bool {
+    [
+        "error 2026",
+        "tls/ssl error",
+        "ssl connection error",
+        "ssl handshake",
+        "tls handshake",
+        "handshake failure",
+        "tlsv1 alert",
+        "certificate verify failed",
+        "certificate verification failure",
+        "certificate validation failure",
+        "unable to get local issuer",
+        "self-signed certificate",
+        "unknown ca",
+        "certificate required",
+        "peer did not return a certificate",
+    ]
+    .iter()
+    .any(|marker| lowercase_details.contains(marker))
+}
+
+fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
+    let marker = "error ";
+    let start = lowercase_details.find(marker)? + marker.len();
+    let digits = &lowercase_details[start..];
+    let end = digits
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(digits.len());
+    digits[..end].parse().ok()
+}
+
+fn clean_mysql_stderr(stderr: &[u8], fallback: &str) -> String {
+    let text = String::from_utf8_lossy(stderr).trim().to_string();
+    if text.is_empty() {
+        fallback.to_string()
+    } else {
+        text
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
+enum MysqlToken {
+    Word(String),
+    OpenParen,
+    CloseParen,
+    Comma,
+    Other,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MysqlReadStatement {
+    Select,
+    Table,
+    Show,
+    Describe,
+}
+
+#[cfg(test)]
+fn validate_mysql_adhoc_query(query: &str) -> Result<(), DbOperationError> {
+    let tokens = scan_mysql_sql(query)?;
+    let first = tokens.first().ok_or_else(|| {
+        DbOperationError::UnsupportedOperation("empty MySQL statement".to_string())
+    })?;
+    let kind = match first {
+        MysqlToken::Word(word) => match word.as_str() {
+            "SELECT" => Some(MysqlReadStatement::Select),
+            "TABLE" => Some(MysqlReadStatement::Table),
+            "SHOW" => Some(MysqlReadStatement::Show),
+            "DESCRIBE" => Some(MysqlReadStatement::Describe),
+            "WITH" => classify_with_statement(&tokens),
+            _ => None,
+        },
+        _ => None,
+    };
+    if kind.is_some() && has_top_level_into_clause(&tokens) {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL SELECT INTO clauses are not supported".to_string(),
+        ));
+    }
+    kind.map(|_| ()).ok_or_else(|| {
+        DbOperationError::UnsupportedOperation(
+            "only a single SELECT, TABLE, SHOW, DESCRIBE, or SELECT CTE is supported".to_string(),
+        )
+    })
+}
+
+#[cfg(test)]
+fn has_top_level_into_clause(tokens: &[MysqlToken]) -> bool {
+    let mut depth = 0usize;
+    for token in tokens {
+        match token {
+            MysqlToken::OpenParen => depth += 1,
+            MysqlToken::CloseParen => depth = depth.saturating_sub(1),
+            MysqlToken::Word(word) if depth == 0 && word == "INTO" => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+fn scan_mysql_sql(query: &str) -> Result<Vec<MysqlToken>, DbOperationError> {
+    let chars: Vec<char> = query.chars().collect();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    let mut line_start = true;
+    let mut semicolons = 0;
+    let mut statement_ended = false;
+    while index < chars.len() {
+        let character = chars[index];
+        if line_start && matches!(character, ' ' | '\t' | '\r') {
+            index += 1;
+            continue;
+        }
+        if line_start && character == '\\' {
+            return Err(unsupported_client_command("backslash command"));
+        }
+        if line_start && character.is_ascii_alphabetic() {
+            let start = index;
+            while index < chars.len()
+                && (chars[index].is_ascii_alphanumeric() || chars[index] == '_')
+            {
+                index += 1;
+            }
+            let word: String = chars[start..index].iter().collect();
+            if matches!(
+                word.to_ascii_lowercase().as_str(),
+                "delimiter" | "charset" | "source" | "system"
+            ) && (index == chars.len() || chars[index].is_whitespace())
+            {
+                return Err(unsupported_client_command(&word));
+            }
+            if statement_ended {
+                return Err(unsupported_client_command("multiple SQL statements"));
+            }
+            tokens.push(MysqlToken::Word(word.to_ascii_uppercase()));
+            line_start = false;
+            continue;
+        }
+        if character == '\n' {
+            line_start = true;
+            index += 1;
+            continue;
+        }
+        if character.is_whitespace() {
+            index += 1;
+            continue;
+        }
+        if character == '#' {
+            skip_line_comment(&chars, &mut index, &mut line_start);
+            continue;
+        }
+        if character == '-'
+            && chars.get(index + 1) == Some(&'-')
+            && chars.get(index + 2).is_none_or(|next| next.is_whitespace())
+        {
+            skip_line_comment(&chars, &mut index, &mut line_start);
+            continue;
+        }
+        if character == '/' && chars.get(index + 1) == Some(&'*') {
+            if chars.get(index + 2) == Some(&'!') {
+                return Err(unsupported_client_command("MySQL version comment"));
+            }
+            skip_block_comment(&chars, &mut index, &mut line_start)?;
+            continue;
+        }
+        if matches!(character, '\'' | '"' | '`') {
+            if statement_ended {
+                return Err(unsupported_client_command("multiple SQL statements"));
+            }
+            skip_quoted_literal(&chars, &mut index, character)?;
+            line_start = false;
+            tokens.push(MysqlToken::Other);
+            continue;
+        }
+        match character {
+            ';' => {
+                semicolons += 1;
+                if semicolons > 1 {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                if tokens.is_empty() {
+                    return Err(unsupported_client_command("empty MySQL statement"));
+                }
+                statement_ended = true;
+                index += 1;
+            }
+            '(' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::OpenParen);
+                line_start = false;
+                index += 1;
+            }
+            ')' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::CloseParen);
+                line_start = false;
+                index += 1;
+            }
+            ',' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::Comma);
+                line_start = false;
+                index += 1;
+            }
+            character if character.is_ascii_alphabetic() || character == '_' => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                let start = index;
+                while index < chars.len()
+                    && (chars[index].is_ascii_alphanumeric() || matches!(chars[index], '_' | '$'))
+                {
+                    index += 1;
+                }
+                let word: String = chars[start..index].iter().collect();
+                tokens.push(MysqlToken::Word(word.to_ascii_uppercase()));
+                line_start = false;
+            }
+            _ => {
+                if statement_ended {
+                    return Err(unsupported_client_command("multiple SQL statements"));
+                }
+                tokens.push(MysqlToken::Other);
+                line_start = false;
+                index += 1;
+            }
+        }
+    }
+    if tokens.is_empty() || query.trim_start().starts_with(';') {
+        return Err(unsupported_client_command("empty MySQL statement"));
+    }
+    Ok(tokens)
+}
+
+#[cfg(test)]
+fn skip_line_comment(chars: &[char], index: &mut usize, line_start: &mut bool) {
+    while *index < chars.len() {
+        let character = chars[*index];
+        *index += 1;
+        if character == '\n' {
+            *line_start = true;
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+fn skip_block_comment(
+    chars: &[char],
+    index: &mut usize,
+    line_start: &mut bool,
+) -> Result<(), DbOperationError> {
+    *index += 2;
+    while *index < chars.len() {
+        if chars[*index] == '\n' {
+            *line_start = true;
+        }
+        if chars[*index] == '*' && chars.get(*index + 1) == Some(&'/') {
+            *index += 2;
+            return Ok(());
+        }
+        *index += 1;
+    }
+    Err(unsupported_client_command("unterminated block comment"))
+}
+
+#[cfg(test)]
+fn skip_quoted_literal(
+    chars: &[char],
+    index: &mut usize,
+    quote: char,
+) -> Result<(), DbOperationError> {
+    *index += 1;
+    while *index < chars.len() {
+        if chars[*index] == '\\' {
+            *index += 2;
+            continue;
+        }
+        if chars[*index] == quote {
+            if chars.get(*index + 1) == Some(&quote) {
+                *index += 2;
+            } else {
+                *index += 1;
+                return Ok(());
+            }
+        } else {
+            *index += 1;
+        }
+    }
+    Err(unsupported_client_command("unterminated quoted literal"))
+}
+
+#[cfg(test)]
+fn classify_with_statement(tokens: &[MysqlToken]) -> Option<MysqlReadStatement> {
+    let mut index = 1;
+    if matches!(tokens.get(index), Some(MysqlToken::Word(word)) if word == "RECURSIVE") {
+        index += 1;
+    }
+    loop {
+        if !matches!(
+            tokens.get(index),
+            Some(MysqlToken::Word(_) | MysqlToken::Other)
+        ) {
+            return None;
+        }
+        index += 1;
+        if matches!(tokens.get(index), Some(MysqlToken::OpenParen)) {
+            index = skip_parenthesized(tokens, index)?;
+        }
+        if !matches!(tokens.get(index), Some(MysqlToken::Word(word)) if word == "AS") {
+            return None;
+        }
+        index += 1;
+        if !matches!(tokens.get(index), Some(MysqlToken::OpenParen)) {
+            return None;
+        }
+        index = skip_parenthesized(tokens, index)?;
+        if matches!(tokens.get(index), Some(MysqlToken::Comma)) {
+            index += 1;
+            continue;
+        }
+        return match tokens.get(index) {
+            Some(MysqlToken::Word(word)) if word == "SELECT" => Some(MysqlReadStatement::Select),
+            _ => None,
+        };
+    }
+}
+
+#[cfg(test)]
+fn skip_parenthesized(tokens: &[MysqlToken], mut index: usize) -> Option<usize> {
+    let mut depth = 0;
+    while let Some(token) = tokens.get(index) {
+        match token {
+            MysqlToken::OpenParen => depth += 1,
+            MysqlToken::CloseParen => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(index + 1);
+                }
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+fn unsupported_client_command(command: &str) -> DbOperationError {
+    DbOperationError::UnsupportedOperation(format!("unsupported MySQL {command}"))
+}
+
+fn parse_mysql_xml(xml: &[u8]) -> Result<MysqlResultSet, DbOperationError> {
+    let mut reader = Reader::from_reader(xml);
+    reader.config_mut().trim_text(false);
+    let mut buffer = Vec::new();
+    let mut resultset_count = 0;
+    let mut in_resultset = false;
+    let mut current_row: Option<Vec<(String, QueryValue)>> = None;
+    let mut current_field: Option<MysqlField> = None;
+    let mut rows = Vec::new();
+    let mut columns = Vec::new();
+
+    loop {
+        let event = reader.read_event_into(&mut buffer).map_err(|error| {
+            DbOperationError::QueryFailed(format!("invalid MySQL XML result: {error}"))
+        })?;
+        match event {
+            Event::Start(element) => match element.name().as_ref() {
+                b"resultset" => {
+                    if in_resultset || resultset_count > 0 {
+                        return Err(DbOperationError::QueryFailed(
+                            "mysql returned more than one resultset".to_string(),
+                        ));
+                    }
+                    resultset_count += 1;
+                    in_resultset = true;
+                }
+                b"row" if in_resultset && current_row.is_none() => {
+                    current_row = Some(Vec::new());
+                }
+                b"field" if current_row.is_some() && current_field.is_none() => {
+                    current_field = Some(parse_mysql_field(&element)?);
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected element in MySQL XML result".to_string(),
+                    ));
+                }
+            },
+            Event::Empty(element) if element.name().as_ref() == b"field" => {
+                let row = current_row.as_mut().ok_or_else(|| {
+                    DbOperationError::QueryFailed("MySQL XML field is outside a row".to_string())
+                })?;
+                if current_field.is_some() {
+                    return Err(DbOperationError::QueryFailed(
+                        "nested MySQL XML fields are not supported".to_string(),
+                    ));
+                }
+                let field = parse_mysql_field(&element)?;
+                row.push(field.finish());
+            }
+            Event::Text(text) => {
+                let text = text.unescape().map_err(|error| {
+                    DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
+                })?;
+                if let Some(field) = current_field.as_mut() {
+                    field.value.push_str(&text);
+                } else if !text.chars().all(char::is_whitespace) {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected text in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::CData(data) => {
+                if let Some(field) = current_field.as_mut() {
+                    field
+                        .value
+                        .push_str(std::str::from_utf8(data.as_ref()).map_err(|error| {
+                            DbOperationError::QueryFailed(format!(
+                                "invalid MySQL XML text: {error}"
+                            ))
+                        })?);
+                } else {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected CDATA in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::End(element) => match element.name().as_ref() {
+                b"field" => {
+                    let row = current_row.as_mut().ok_or_else(|| {
+                        DbOperationError::QueryFailed(
+                            "MySQL XML field is outside a row".to_string(),
+                        )
+                    })?;
+                    let field = current_field.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML field end".to_string())
+                    })?;
+                    row.push(field.finish());
+                }
+                b"row" => {
+                    let row = current_row.take().ok_or_else(|| {
+                        DbOperationError::QueryFailed("unexpected MySQL XML row end".to_string())
+                    })?;
+                    if columns.is_empty() {
+                        columns = row.iter().map(|(name, _)| name.clone()).collect();
+                    } else if row.len() != columns.len()
+                        || row
+                            .iter()
+                            .zip(&columns)
+                            .any(|((name, _), column)| name != column)
+                    {
+                        return Err(DbOperationError::QueryFailed(
+                            "MySQL XML rows have inconsistent fields".to_string(),
+                        ));
+                    }
+                    rows.push(row.into_iter().map(|(_, value)| value).collect());
+                }
+                b"resultset" => {
+                    if !in_resultset || current_row.is_some() || current_field.is_some() {
+                        return Err(DbOperationError::QueryFailed(
+                            "malformed MySQL XML resultset".to_string(),
+                        ));
+                    }
+                    in_resultset = false;
+                }
+                _ => {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected MySQL XML closing element".to_string(),
+                    ));
+                }
+            },
+            Event::Decl(_) | Event::Comment(_) => {}
+            Event::Eof => break,
+            _ => {
+                return Err(DbOperationError::QueryFailed(
+                    "unexpected event in MySQL XML result".to_string(),
+                ));
+            }
+        }
+        buffer.clear();
+    }
+
+    if resultset_count != 1 || in_resultset || current_row.is_some() || current_field.is_some() {
+        return Err(DbOperationError::QueryFailed(
+            "MySQL XML result did not contain one complete resultset".to_string(),
+        ));
+    }
+    Ok(MysqlResultSet {
+        columns,
+        values: rows,
+    })
+}
+
+struct MysqlField {
+    name: String,
+    value: String,
+    is_null: bool,
+}
+
+impl MysqlField {
+    fn finish(self) -> (String, QueryValue) {
+        let value = if self.is_null {
+            QueryValue::Null
+        } else {
+            QueryValue::Text(self.value)
+        };
+        (self.name, value)
+    }
+
+    fn finish_raw(self) -> (String, String) {
+        let value = if self.is_null {
+            String::new()
+        } else {
+            self.value
+        };
+        (self.name, value)
+    }
+}
+
+fn parse_mysql_field(
+    element: &quick_xml::events::BytesStart<'_>,
+) -> Result<MysqlField, DbOperationError> {
+    let mut name = None;
+    let mut is_null = false;
+    for attribute in element.attributes() {
+        let attribute = attribute.map_err(|error| {
+            DbOperationError::QueryFailed(format!("invalid MySQL XML field: {error}"))
+        })?;
+        let value = attribute.unescape_value().map_err(|error| {
+            DbOperationError::QueryFailed(format!("invalid MySQL XML field: {error}"))
+        })?;
+        match attribute.key.as_ref() {
+            b"name" => name = Some(value.into_owned()),
+            b"xsi:nil" | b"nil" => is_null = matches!(value.as_ref(), "true" | "1"),
+            _ => {}
+        }
+    }
+    let name = name
+        .ok_or_else(|| DbOperationError::QueryFailed("MySQL XML field has no name".to_string()))?;
+    Ok(MysqlField {
+        name,
+        value: String::new(),
+        is_null,
+    })
+}
+
+#[cfg(test)]
+mod probe_tests {
+    use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+
+    use super::*;
+
+    #[test]
+    fn builds_and_parses_mysql_dsn_with_encoded_components() {
+        let config = MySqlConnectionConfig::new(
+            "db.example",
+            3307,
+            Some("app/schema".to_string()),
+            "user name",
+            "p@ss#word",
+            MySqlSslMode::Required,
+        );
+        let dsn = build_mysql_dsn(&config);
+        let parsed = parse_mysql_dsn(&dsn).unwrap();
+
+        assert_eq!(parsed.host, "db.example");
+        assert_eq!(parsed.port, 3307);
+        assert_eq!(parsed.database.as_deref(), Some("app/schema"));
+        assert_eq!(parsed.username, "user name");
+        assert_eq!(parsed.password, "p@ss#word");
+        assert_eq!(parsed.ssl_mode, MySqlSslMode::Required);
+    }
+
+    #[test]
+    fn builds_and_parses_mysql_dsn_with_tls_paths() {
+        let config = MySqlConnectionConfig::new(
+            "db.example",
+            3307,
+            Some("app".to_string()),
+            "user",
+            "password",
+            MySqlSslMode::VerifyIdentity,
+        )
+        .with_tls_paths(
+            Some(r"C:\certs\ca #1.pem".to_string()),
+            Some(r"C:\certs\client.pem".to_string()),
+            Some(r"C:\certs\client-key.pem".to_string()),
+        );
+        let parsed = parse_mysql_dsn(&build_mysql_dsn(&config)).unwrap();
+
+        assert_eq!(parsed.ssl_mode, MySqlSslMode::VerifyIdentity);
+        assert_eq!(parsed.ssl_ca.as_deref(), Some(r"C:\certs\ca #1.pem"));
+        assert_eq!(parsed.ssl_cert.as_deref(), Some(r"C:\certs\client.pem"));
+        assert_eq!(parsed.ssl_key.as_deref(), Some(r"C:\certs\client-key.pem"));
+    }
+
+    #[test]
+    fn ipv6_host_round_trip_serializes_without_url_brackets() {
+        let config = MySqlConnectionConfig::new(
+            "::1",
+            3306,
+            None,
+            "user",
+            "password",
+            MySqlSslMode::Disabled,
+        );
+        let parsed = parse_mysql_dsn(&build_mysql_dsn(&config)).unwrap();
+
+        assert_eq!(parsed.host, "::1");
+        assert!(serialize_option_file(&parsed).contains("host = \"::1\"\n"));
+    }
+
+    #[test]
+    fn option_file_quotes_syntax_characters_and_windows_paths() {
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: Some("app".to_string()),
+            username: "user".to_string(),
+            password: "p a#ss;=\"\\word".to_string(),
+            ssl_mode: MySqlSslMode::Preferred,
+            ssl_ca: None,
+            ssl_cert: None,
+            ssl_key: None,
+        };
+        let contents = serialize_option_file(&target);
+
+        assert!(contents.contains("password = \"p a#ss;=\\\"\\\\word\""));
+        let mut certificate = String::new();
+        push_option(&mut certificate, "ssl-ca", r"C:\certs\server.pem");
+        assert_eq!(certificate, "ssl-ca = \"C:\\\\certs\\\\server.pem\"\n");
+        assert_eq!(
+            quote_option_value(r"C:\certs\server.pem"),
+            r#""C:\\certs\\server.pem""#
+        );
+    }
+
+    #[test]
+    fn server_database_listing_option_file_omits_selected_database() {
+        let mut target = parse_mysql_dsn("mysql://user:password@localhost:3306/app").unwrap();
+        target.database = None;
+
+        let contents = serialize_option_file(&target);
+
+        assert!(!contents.contains("database ="));
+    }
+
+    #[test]
+    fn option_file_serializes_tls_paths_without_option_syntax_confusion() {
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(r"C:\certs\ca #1.pem".to_string()),
+            ssl_cert: Some(r"C:\certs\client.pem".to_string()),
+            ssl_key: Some(r"C:\certs\client-key.pem".to_string()),
+        };
+
+        let contents = serialize_option_file(&target);
+
+        assert!(contents.contains("ssl-mode = \"VERIFY_CA\"\n"));
+        assert!(contents.contains("ssl-ca = \"C:\\\\certs\\\\ca #1.pem\"\n"));
+        assert!(contents.contains("ssl-cert = \"C:\\\\certs\\\\client.pem\"\n"));
+        assert!(contents.contains("ssl-key = \"C:\\\\certs\\\\client-key.pem\"\n"));
+    }
+
+    #[test]
+    fn rejects_encrypted_client_keys_before_process_start() {
+        let directory = tempfile::tempdir().unwrap();
+        let ca = directory.path().join("ca.pem");
+        let cert = directory.path().join("client.pem");
+        let key = directory.path().join("client-key.pem");
+        fs::write(&ca, "-----BEGIN CERTIFICATE-----\nca\n").unwrap();
+        fs::write(&cert, "-----BEGIN CERTIFICATE-----\ncert\n").unwrap();
+        fs::write(&key, "-----BEGIN ENCRYPTED PRIVATE KEY-----\nsecret\n").unwrap();
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(ca.display().to_string()),
+            ssl_cert: Some(cert.display().to_string()),
+            ssl_key: Some(key.display().to_string()),
+        };
+
+        let result = validate_mysql_tls_files(&target);
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::ConnectionFailed(details))
+                if details == "Encrypted MySQL client keys are not supported"
+        ));
+    }
+
+    #[test]
+    fn rejects_traditional_encrypted_client_keys_before_process_start() {
+        let directory = tempfile::tempdir().unwrap();
+        let ca = directory.path().join("ca.pem");
+        let cert = directory.path().join("client.pem");
+        let key = directory.path().join("client-key.pem");
+        fs::write(&ca, "-----BEGIN CERTIFICATE-----\nca\n").unwrap();
+        fs::write(&cert, "-----BEGIN CERTIFICATE-----\ncert\n").unwrap();
+        fs::write(&key, "Proc-Type: 4,ENCRYPTED\nDEK-Info: AES-256-CBC,x\n").unwrap();
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "password".to_string(),
+            ssl_mode: MySqlSslMode::VerifyCa,
+            ssl_ca: Some(ca.display().to_string()),
+            ssl_cert: Some(cert.display().to_string()),
+            ssl_key: Some(key.display().to_string()),
+        };
+
+        assert!(validate_mysql_tls_files(&target).is_err());
+    }
+
+    #[test]
+    fn option_file_is_owner_only_and_removed_on_drop() {
+        let target = MySqlDsn {
+            host: "localhost".to_string(),
+            port: 3306,
+            database: None,
+            username: "user".to_string(),
+            password: "secret".to_string(),
+            ssl_mode: MySqlSslMode::Disabled,
+            ssl_ca: None,
+            ssl_cert: None,
+            ssl_key: None,
+        };
+        let option_file = MySqlOptionFile::create(&target).unwrap();
+        assert!(option_file.path.is_absolute());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&option_file.path)
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+        let path = option_file.path.clone();
+        drop(option_file);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn validates_supported_versions_and_sql_modes() {
+        assert!(is_oracle_mysql_cli_84_version("mysql  Ver 8.4.3 for macos"));
+        assert!(!is_oracle_mysql_cli_84_version(
+            "mysql  Ver 8.0.36 for macos"
+        ));
+        assert!(!is_oracle_mysql_cli_84_version(
+            "mysql  Ver 15.1 Distrib 10.11.8-MariaDB"
+        ));
+        assert!(!is_oracle_mysql_cli_84_version(
+            "mysql  Ver 8.4.3-3 for Linux (Percona Server)"
+        ));
+        assert!(is_oracle_mysql_server_84_version("8.4.3"));
+        assert!(!is_oracle_mysql_server_84_version("8.4.3-TiDB"));
+        assert!(!is_oracle_mysql_server_84_version("8.4.3-Percona"));
+        assert!(validate_sql_mode("STRICT_TRANS_TABLES").is_ok());
+        assert!(validate_sql_mode("STRICT_TRANS_TABLES,ANSI_QUOTES").is_err());
+    }
+
+    #[test]
+    fn uses_tcp_and_keeps_defaults_file_first() {
+        let args = mysql_probe_args(std::path::Path::new("/tmp/sabiql-mysql.cnf"));
+
+        assert_eq!(args[0], "--defaults-file=/tmp/sabiql-mysql.cnf");
+        assert_eq!(args[1], "--no-login-paths");
+        assert_eq!(args[2], "--protocol=TCP");
+        assert!(args.contains(&"--batch".to_string()));
+        assert!(args.contains(&"--raw".to_string()));
+        assert!(args.contains(&"--skip-column-names".to_string()));
+        assert!(args.contains(&"--binary-mode".to_string()));
+        assert!(args.contains(&"--skip-reconnect".to_string()));
+        assert!(
+            args.last()
+                .unwrap()
+                .starts_with("--execute=SELECT JSON_OBJECT")
+        );
+    }
+
+    #[test]
+    fn arguments_do_not_contain_credentials() {
+        let args = mysql_probe_args(std::path::Path::new("/tmp/sabiql-mysql.cnf"));
+
+        assert!(
+            args.iter()
+                .all(|argument| { !argument.contains("password") && !argument.contains("secret") })
+        );
+    }
+
+    #[test]
+    fn classifies_mysql_cli_timeout_errno_before_connection_refusal() {
+        assert!(matches!(
+            classify_mysql_probe_failure(
+                "ERROR 2003 (HY000): Can't connect to MySQL server on 'host:3306' (110)"
+                    .to_string()
+            ),
+            DbOperationError::Timeout(_)
+        ));
+        assert!(matches!(
+            classify_mysql_probe_failure(
+                "ERROR 2003 (HY000): Can't connect to MySQL server on 'host:3306' (111)"
+                    .to_string()
+            ),
+            DbOperationError::ConnectionFailed(_)
+        ));
+    }
+
+    #[test]
+    fn classifies_mysql_tls_probe_failure_for_connection_error() {
+        let error = classify_mysql_probe_failure(
+            "ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed"
+                .to_string(),
+        );
+
+        assert_eq!(
+            ConnectionErrorInfo::from_db_operation_error(&error).kind,
+            ConnectionErrorKind::MySqlTlsHandshakeFailed
+        );
+    }
+}
+
+#[cfg(test)]
+mod query_tests {
+    use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn parses_mysql_xml_without_collapsing_value_boundaries() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<row>
+  <field name="null" xsi:nil="true"/>
+  <field name="empty"></field>
+  <field name="text-null">NULL</field>
+  <field name="special">tab&#9;line&#10;slash\unicode 日本語</field>
+  <field name="json">{"a":[1,true]}</field>
+  <field name="binary-looking">0x41</field>
+</row>
+</resultset>"#;
+
+        let result = parse_mysql_xml(xml.as_bytes()).unwrap();
+
+        assert_eq!(
+            result.columns,
+            vec![
+                "null",
+                "empty",
+                "text-null",
+                "special",
+                "json",
+                "binary-looking"
+            ]
+        );
+        assert_eq!(
+            result.values,
+            vec![vec![
+                QueryValue::Null,
+                QueryValue::Text(String::new()),
+                QueryValue::Text("NULL".to_string()),
+                QueryValue::Text("tab\tline\nslash\\unicode 日本語".to_string()),
+                QueryValue::Text("{\"a\":[1,true]}".to_string()),
+                QueryValue::Text("0x41".to_string()),
+            ]]
+        );
+    }
+
+    #[test]
+    fn parses_numeric_and_binary_values_as_text() {
+        let xml = br#"<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row>
+<field name="integer">18446744073709551615</field>
+<field name="decimal">12345678901234567890.123456789</field>
+<field name="float">1.25e+100</field>
+<field name="binary">0x00FF10</field>
+</row></resultset>"#;
+
+        let result = parse_mysql_xml(xml).unwrap();
+        assert!(
+            result.values[0]
+                .iter()
+                .all(|value| matches!(value, QueryValue::Text(_)))
+        );
+        assert_eq!(result.values[0][0].as_str(), Some("18446744073709551615"));
+        assert_eq!(result.values[0][3].as_str(), Some("0x00FF10"));
+    }
+
+    #[test]
+    fn rejects_multiple_resultsets_instead_of_guessing_the_last_one() {
+        let xml = br#"<resultset><row><field name="value">1</field></row></resultset>
+<resultset><row><field name="value">2</field></row></resultset>"#;
+
+        assert!(matches!(
+            parse_mysql_xml(xml),
+            Err(DbOperationError::QueryFailed(details))
+                if details.contains("more than one resultset")
+        ));
+    }
+
+    #[test]
+    fn accepts_xml_declaration_after_probe_separator_and_empty_resultsets() {
+        let xml = br#"
+<?xml version="1.0" encoding="utf-8"?>
+<resultset></resultset>
+"#;
+
+        let result = parse_mysql_xml(xml).unwrap();
+        assert!(result.columns.is_empty());
+        assert!(result.values.is_empty());
+    }
+
+    #[tokio::test]
+    async fn streams_mysql_xml_rows_into_csv_without_binary_type_inference() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8"?>
+<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row>
+<field name="comma">a,b</field>
+<field name="quote">a&quot;b</field>
+<field name="newline"><![CDATA[line1
+line2]]></field>
+<field name="tab">a	b</field>
+<field name="unicode">日本語</field>
+<field name="null" xsi:nil="true"/>
+<field name="empty"></field>
+<field name="binary">0x00FF</field>
+</row></resultset>"#;
+        let (mut input, output) = tokio::io::duplex(32);
+        let producer = tokio::spawn(async move {
+            input.write_all(xml.as_bytes()).await.unwrap();
+        });
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("stream.csv");
+        let mut csv_writer = CsvFileWriter::create(path.clone()).await.unwrap();
+        let mut reader = Reader::from_reader(BufReader::new(output));
+        reader.config_mut().trim_text(false);
+
+        stream_mysql_xml_to_csv(&mut reader, &mut csv_writer)
+            .await
+            .unwrap();
+        csv_writer.finish().await.unwrap();
+        producer.await.unwrap();
+
+        assert_eq!(
+            fs::read_to_string(path).unwrap(),
+            "comma,quote,newline,tab,unicode,null,empty,binary\n\
+             \"a,b\",\"a\"\"b\",\"line1\n\
+             line2\",a\tb,日本語,,,0x00FF\n"
+                .replace("             ", "")
+        );
+    }
+
+    #[test]
+    fn csv_export_accepts_one_read_only_result_query() {
+        assert!(validate_mysql_export_query("SELECT 1", Some("app")).is_ok());
+        for query in ["TABLE users", "SHOW TABLES", "DESCRIBE users"] {
+            assert!(
+                validate_mysql_export_query(query, Some("app")).is_ok(),
+                "{query}"
+            );
+        }
+        assert!(matches!(
+            validate_mysql_export_query("INSERT INTO users VALUES (1)", Some("app")),
+            Err(DbOperationError::PermissionDenied(_))
+        ));
+        assert!(matches!(
+            validate_mysql_export_query("SELECT 1; SELECT 2", Some("app")),
+            Err(DbOperationError::UnsupportedOperation(details))
+                if details.contains("single read-only result")
+        ));
+    }
+
+    #[test]
+    fn scanner_ignores_semicolons_in_quotes_and_comments() {
+        let query = r#"
+            SELECT 'a; b', "quoted; identifier", `back;tick`
+            /* block ; comment */
+            FROM `table` -- line ; comment
+            WHERE value = 'backslash\\;'
+        "#;
+
+        assert!(validate_mysql_adhoc_query(query).is_ok());
+    }
+
+    #[test]
+    fn scanner_rejects_multiple_statements_before_starting_a_process() {
+        for query in ["SELECT 1; SELECT 2", "SELECT 1;\nSHOW TABLES"] {
+            assert!(matches!(
+                validate_mysql_adhoc_query(query),
+                Err(DbOperationError::UnsupportedOperation(details))
+                    if details.contains("multiple SQL statements")
+            ));
+        }
+    }
+
+    #[test]
+    fn scanner_accepts_read_statements_and_select_ctes_only() {
+        for query in [
+            "SELECT 1",
+            "TABLE users",
+            "SHOW TABLES",
+            "DESCRIBE users",
+            "WITH rows AS (SELECT 1) SELECT * FROM rows",
+            "WITH RECURSIVE rows AS (SELECT 1) SELECT * FROM rows",
+        ] {
+            assert!(validate_mysql_adhoc_query(query).is_ok(), "{query}");
+        }
+        for query in [
+            "INSERT INTO users VALUES (1)",
+            "WITH rows AS (SELECT 1) UPDATE users SET id = 2",
+            "WITH rows AS (SELECT 1) SHOW TABLES",
+        ] {
+            assert!(validate_mysql_adhoc_query(query).is_err(), "{query}");
+        }
+    }
+
+    #[test]
+    fn scanner_rejects_top_level_into_clauses_before_starting_a_process() {
+        for query in [
+            "SELECT id INTO OUTFILE '/tmp/result' FROM users",
+            "SELECT id INTO DUMPFILE '/tmp/result' FROM users",
+            "SELECT id INTO @value FROM users",
+            "TABLE users INTO OUTFILE '/tmp/result'",
+            "WITH rows AS (SELECT 1) SELECT * INTO OUTFILE '/tmp/result' FROM rows",
+        ] {
+            assert!(matches!(
+                validate_mysql_adhoc_query(query),
+                Err(DbOperationError::UnsupportedOperation(details))
+                    if details.contains("SELECT INTO clauses")
+            ));
+        }
+        assert!(
+            validate_mysql_adhoc_query("WITH rows AS (SELECT 'INTO OUTFILE') SELECT * FROM rows")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn scanner_rejects_client_commands_and_version_comments() {
+        for query in [
+            "DELIMITER //\nSELECT 1//",
+            "  charset utf8mb4\nSELECT 1",
+            "source ./script.sql",
+            "system echo unsafe",
+            "\\C /tmp/other.sock\nSELECT 1",
+            "SELECT 1 /*!40101 + 1 */",
+        ] {
+            assert!(matches!(
+                validate_mysql_adhoc_query(query),
+                Err(DbOperationError::UnsupportedOperation(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn mode_probe_requires_marker_and_allowed_mode_before_user_sql() {
+        let probe = MysqlResultSet {
+            columns: vec![
+                "__sabiql_probe".to_string(),
+                "__sabiql_sql_mode".to_string(),
+            ],
+            values: vec![vec![
+                QueryValue::Text("marker".to_string()),
+                QueryValue::Text("STRICT_TRANS_TABLES".to_string()),
+            ]],
+        };
+        assert!(validate_mode_probe(&probe, "marker").is_ok());
+
+        let mut unsupported = probe;
+        unsupported.values[0][1] = QueryValue::Text("ANSI_QUOTES".to_string());
+        assert!(matches!(
+            validate_mode_probe(&unsupported, "marker"),
+            Err(DbOperationError::UnsupportedOperation(details))
+                if details.contains(MYSQL_SQL_MODE_UNSUPPORTED_MARKER)
+        ));
+    }
+
+    #[test]
+    fn arguments_keep_credentials_out_of_argv() {
+        let args = mysql_query_args(std::path::Path::new("/tmp/sabiql-mysql.cnf"));
+
+        assert_eq!(args[0], "--defaults-file=/tmp/sabiql-mysql.cnf");
+        assert_eq!(args[1], "--no-login-paths");
+        for expected in [
+            "--xml",
+            "--binary-as-hex",
+            "--binary-mode",
+            "--unbuffered",
+            "--skip-reconnect",
+            "--default-character-set=utf8mb4",
+        ] {
+            assert!(args.contains(&expected.to_string()), "{expected}");
+        }
+        #[cfg(unix)]
+        {
+            assert!(args.contains(&"--silent".to_string()));
+            assert!(args.contains(&"--prompt=".to_string()));
+            assert!(!args.contains(&"--batch".to_string()));
+        }
+        #[cfg(not(unix))]
+        assert!(args.contains(&"--batch".to_string()));
+        assert!(args.iter().all(|argument| !argument.contains("password")));
+    }
+
+    #[test]
+    fn classifies_mysql_query_failures_by_server_error() {
+        assert!(matches!(
+            classify_mysql_query_failure(
+                b"ERROR 1045 (28000): Access denied for user 'app'@'localhost' (using password: YES)"
+            ),
+            DbOperationError::ConnectionFailed(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1142 (42000): command denied to user"),
+            DbOperationError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(
+                b"ERROR 1044 (42000): Access denied for user 'app' to database 'app'"
+            ),
+            DbOperationError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1146 (42S02): Table does not exist"),
+            DbOperationError::ObjectMissing(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1205 (HY000): Lock wait timeout exceeded"),
+            DbOperationError::LockTimeout(_)
+        ));
+        let masked = classify_mysql_query_failure(b"ERROR password=secret");
+        assert!(!masked.masked_details().contains("secret"));
+    }
+
+    #[test]
+    fn classifies_mysql_tls_query_failures_as_connection_errors() {
+        let error = classify_mysql_query_failure(
+            b"ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed",
+        );
+
+        assert_eq!(
+            ConnectionErrorInfo::from_db_operation_error(&error).kind,
+            ConnectionErrorKind::MySqlTlsHandshakeFailed
+        );
+        assert!(matches!(error, DbOperationError::ConnectionFailed(_)));
+    }
+}
+
+#[cfg(all(test, unix))]
+mod executor_tests {
+    use std::os::unix::fs::PermissionsExt;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn fake_mysql(mode: &str) -> (TempDir, PathBuf, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let option_file = directory.path().join("option.cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let program = directory.path().join("mysql");
+        let probe_response = match mode {
+            "missing" => "exit 0".to_string(),
+            "invalid" => {
+                "printf '%s\\n' '<resultset><row><field name=\"wrong\">x</field></row></resultset>'"
+                    .to_string()
+            }
+            "unsupported" => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_probe\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">ANSI_QUOTES</field></row></resultset>'".to_string(),
+            "timeout" => "while :; do :; done".to_string(),
+            _ => "printf '%s\\n' '<resultset><row><field name=\"__sabiql_probe\">'\"$marker\"'</field><field name=\"__sabiql_sql_mode\">STRICT_TRANS_TABLES</field></row></resultset>'".to_string(),
+        };
+        let user_response = if mode == "failure" {
+            "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2\n    exit 1"
+        } else {
+            "printf '%s\\n' '<resultset><row><field name=\"value\">ok</field></row></resultset>'"
+        };
+        let session_failure = if mode == "read_only_failure" {
+            "printf '%s\\n' 'ERROR 1227 (42000): access denied to set transaction read only' >&2\n      exit 1"
+        } else {
+            ""
+        };
+        let script = format!(
+            r#"#!/bin/sh
+option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
+log="$option.log"
+phase=probe
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$log"
+  [ "$line" = ";" ] && continue
+  if [ "$phase" = probe ]; then
+    marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)'.*/\\1/")
+    {probe_response}
+    phase=user
+  else
+    case "$line" in
+      "SET SESSION TRANSACTION READ ONLY")
+        {session_failure}
+        ;;
+      *__sabiql_session_marker*)
+        marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
+        printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+        ;;
+      *)
+        {user_response}
+        exit 0
+        ;;
+    esac
+  fi
+done
+"#,
+        );
+        fs::write(&program, script).unwrap();
+        let mut permissions = fs::metadata(&program).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).unwrap();
+        (directory, program, log_file)
+    }
+
+    fn fake_mysql_multi() -> (TempDir, PathBuf, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let option_file = directory.path().join("option.cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let program = directory.path().join("mysql");
+        let script = r#"#!/bin/sh
+option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
+log="$option.log"
+pending_error=0
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$log"
+  case "$line" in
+    *\\q*)
+      exit 0
+      ;;
+    *__sabiql_probe*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_probe.*/\\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_probe">'"$marker"'</field><field name="__sabiql_sql_mode">STRICT_TRANS_TABLES</field></row></resultset>'
+      ;;
+    "SET SESSION TRANSACTION READ ONLY")
+      ;;
+    *__sabiql_session_marker*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      ;;
+    *__sabiql_marker*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_marker.*/\\1/")
+      rows=0
+      case "$line" in *ROW_COUNT\(\)* ) rows=3 ;; esac
+      printf '%s\n' '<resultset><row><field name="__sabiql_marker">'"$marker"'</field><field name="affected_rows">'"$rows"'</field></row></resultset>'
+      if [ "$pending_error" = 1 ]; then
+        sleep 0.05
+        printf '%s\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2
+        pending_error=0
+      fi
+      ;;
+    *missing_column*)
+      pending_error=1
+      ;;
+    *SELECT*)
+      value=one
+      case "$line" in *SELECT\ 2*) value=two ;; esac
+      printf '%s\n' '<resultset><row><field name="value">'"$value"'</field></row></resultset>'
+      ;;
+    *UPDATE*)
+      printf '%s\n' '<resultset><row><field name="affected">ok</field></row></resultset>'
+      ;;
+    *)
+      printf '%s\n' '<resultset></resultset>'
+      ;;
+  esac
+done
+"#;
+        fs::write(&program, script).unwrap();
+        let mut permissions = fs::metadata(&program).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).unwrap();
+        (directory, program, option_file)
+    }
+
+    #[tokio::test]
+    async fn sends_user_sql_only_after_a_valid_mode_probe() {
+        let (_directory, program, log_file) = fake_mysql("success");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.columns, vec!["value"]);
+        assert_eq!(result.values[0][0].as_str(), Some("ok"));
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+        assert!(log.contains("__sabiql_probe"));
+        assert!(log.contains("SELECT 123"));
+        assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT));
+    }
+
+    #[tokio::test]
+    async fn configures_read_only_session_before_user_sql() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let statements = split_mysql_statements("SELECT 2")
+            .unwrap()
+            .into_iter()
+            .map(|sql| classify_mysql_statement(&sql).unwrap())
+            .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 2",
+            &statements,
+            AccessMode::ReadOnly,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_or_else(|error| {
+            let log = fs::read_to_string(&log_file).unwrap_or_default();
+            panic!("read-only execution failed: {error:?}; log: {log}");
+        });
+
+        assert_eq!(
+            result.result_set.unwrap().values[0][0].as_str(),
+            Some("two")
+        );
+        let log = fs::read_to_string(log_file).unwrap();
+        let session_index = log
+            .find(MYSQL_READ_ONLY_STATEMENT)
+            .expect("read-only session statement");
+        let user_index = log.find("SELECT 2").expect("user statement");
+        assert!(session_index < user_index, "{log}");
+        assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN));
+    }
+
+    #[tokio::test]
+    async fn read_only_session_failure_never_writes_user_sql() {
+        let (_directory, program, log_file) = fake_mysql("read_only_failure");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadOnly,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(result.is_err());
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+        assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
+        assert!(!log.contains("SELECT 123"), "{log}");
+    }
+
+    #[tokio::test]
+    async fn generated_preview_and_metadata_queries_skip_read_only_session_setup() {
+        for query in [
+            "SELECT id FROM app.items ORDER BY id LIMIT 10 OFFSET 0",
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES",
+        ] {
+            let (_directory, program, option_file) = fake_mysql_multi();
+            let statements = split_mysql_statements(query)
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
+
+            run_mysql_adhoc_with_program_and_statements(
+                OsStr::new(&program),
+                &option_file,
+                query,
+                &statements,
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await
+            .unwrap();
+
+            let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+            assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT), "{query}: {log}");
+        }
+    }
+
+    #[test]
+    fn read_only_rejects_temporary_table_dml_before_starting_mysql() {
+        let (_directory, _program, option_file) = fake_mysql_multi();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let query = "CREATE TEMPORARY TABLE temp_items (id INT); INSERT INTO temp_items VALUES (1); DROP TEMPORARY TABLE temp_items";
+
+        let result = validate_mysql_multi_query(query, Some("app"), AccessMode::ReadOnly);
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::PermissionDenied(details))
+                if details.contains("read-only mode blocks MySQL write statements")
+        ));
+        assert!(!log_file.exists());
+    }
+
+    #[test]
+    fn read_only_rejects_read_write_overrides_before_starting_mysql() {
+        for query in [
+            "SET SESSION TRANSACTION READ WRITE",
+            "START TRANSACTION READ WRITE",
+        ] {
+            let (_directory, _program, option_file) = fake_mysql_multi();
+            let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+
+            let result = validate_mysql_multi_query(query, Some("app"), AccessMode::ReadOnly);
+
+            assert!(matches!(
+                result,
+                Err(DbOperationError::UnsupportedOperation(_))
+            ));
+            assert!(!log_file.exists(), "{query}");
+        }
+    }
+
+    #[tokio::test]
+    async fn exports_mysql_xml_rows_through_the_shared_csv_writer() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let path = option_file.with_file_name("export.csv");
+
+        export_mysql_csv_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 1",
+            path.clone(),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(fs::read_to_string(path).unwrap(), "value\none\n");
+    }
+
+    #[tokio::test]
+    async fn export_failure_removes_the_partial_file() {
+        let (_directory, program, option_file) = fake_mysql("failure");
+        let output_directory = tempfile::tempdir().unwrap();
+        let final_path = output_directory.path().join("export.csv");
+
+        let result = export_to_path(final_path.clone(), |path| {
+            export_mysql_csv_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 1",
+                path,
+                Duration::from_secs(5),
+            )
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert!(!final_path.exists());
+        assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn export_timeout_kills_the_process_and_removes_the_partial_file() {
+        let (_directory, program, option_file) = fake_mysql("timeout");
+        let output_directory = tempfile::tempdir().unwrap();
+        let final_path = output_directory.path().join("export.csv");
+
+        let result = export_to_path(final_path.clone(), |path| {
+            export_mysql_csv_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 1",
+                path,
+                Duration::from_millis(50),
+            )
+        })
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::Timeout(_))));
+        assert!(!final_path.exists());
+        assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
+    }
+
+    #[test]
+    fn frames_one_xml_resultset_and_preserves_following_output() {
+        let mut buffer = b"    -> <?xml version=\"1.0\"?>\n<resultset></resultset>\r\n    -> <?xml version=\"1.0\"?>\n<resultset>"
+            .to_vec();
+
+        assert_eq!(
+            take_mysql_resultset_frame(&mut buffer),
+            Some(b"<resultset></resultset>".to_vec())
+        );
+        assert_eq!(
+            take_mysql_resultset_frame(&mut buffer),
+            None,
+            "an incomplete following frame must remain buffered"
+        );
+        assert!(buffer.starts_with(b"\r\n    -> <?xml"));
+    }
+
+    #[test]
+    fn frames_resultset_after_mysql_cli_text() {
+        let mut buffer =
+            b"SELECT 1;\n<?xml version=\"1.0\"?>\nquery text\n<resultset></resultset>".to_vec();
+
+        assert_eq!(
+            take_mysql_resultset_frame(&mut buffer),
+            Some(b"<resultset></resultset>".to_vec())
+        );
+        assert!(buffer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn probe_failure_never_writes_user_sql() {
+        for mode in ["unsupported", "invalid", "missing"] {
+            let (_directory, program, log_file) = fake_mysql(mode);
+            let option_file = log_file.with_extension("cnf");
+            fs::write(&option_file, "[client]\n").unwrap();
+            let result = run_mysql_adhoc_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await;
+            assert!(result.is_err(), "{mode}");
+            let log =
+                fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
+            assert!(!log.contains("SELECT 123"), "{mode}: {log}");
+        }
+    }
+
+    #[tokio::test]
+    async fn probe_timeout_kills_the_process_and_discards_output() {
+        let (_directory, program, log_file) = fake_mysql("timeout");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadWrite,
+            Duration::from_millis(50),
+        )
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::Timeout(_))));
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
+        assert!(!log.contains("SELECT 123"));
+    }
+
+    #[tokio::test]
+    async fn nonzero_cli_exit_discards_any_collected_stdout() {
+        let (_directory, program, log_file) = fake_mysql("failure");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn executes_each_statement_and_returns_the_last_user_result() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let statements = split_mysql_statements("UPDATE items SET value = 1; SELECT 2")
+            .unwrap()
+            .into_iter()
+            .map(|sql| classify_mysql_statement(&sql).unwrap())
+            .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "UPDATE items SET value = 1; SELECT 2",
+            &statements,
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("multi execution failed: {error:?}"));
+
+        assert_eq!(
+            result.result_set,
+            Some(MysqlResultSet {
+                columns: vec!["value".to_string()],
+                values: vec![vec![QueryValue::Text("two".to_string())]],
+            })
+        );
+        assert_eq!(result.command_tag, Some(CommandTag::Update(3)));
+        assert_eq!(result.refresh_scope, RefreshScope::Data);
+        let log = fs::read_to_string(log_file).unwrap();
+        assert!(log.contains("UPDATE items SET value = 1"));
+        assert!(log.matches("__sabiql_marker").count() >= 2);
+    }
+
+    #[tokio::test]
+    async fn marks_a_later_failure_after_a_confirmed_change_for_refresh() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let statements =
+            split_mysql_statements("UPDATE items SET value = 1; SELECT missing_column FROM items")
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "UPDATE items SET value = 1; SELECT missing_column FROM items",
+            &statements,
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::QueryFailedAfterChange {
+                refresh_scope: RefreshScope::Data,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_error_reported_after_row_count_marker() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let statements = split_mysql_statements("SELECT missing_column FROM items")
+            .unwrap()
+            .into_iter()
+            .map(|sql| classify_mysql_statement(&sql).unwrap())
+            .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT missing_column FROM items",
+            &statements,
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::QueryFailed(details))
+                if details.contains("missing_column")
+        ));
+    }
+
+    #[test]
+    fn transaction_rollback_removes_pending_data_tag() {
+        let events = vec![
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Begin,
+                target: None,
+                tag: CommandTag::Begin,
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Update { has_where: true },
+                target: Some("items".to_string()),
+                tag: CommandTag::Update(1),
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Rollback,
+                target: None,
+                tag: CommandTag::Rollback,
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Select,
+                target: None,
+                tag: CommandTag::Select(1),
+            },
+        ];
+
+        assert_eq!(
+            aggregate_mysql_command_tag(&events),
+            Some(CommandTag::Select(1))
+        );
+    }
+
+    #[test]
+    fn ddl_implicit_commit_keeps_prior_data_change() {
+        let events = vec![
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Begin,
+                target: None,
+                tag: CommandTag::Begin,
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Insert,
+                target: Some("items".to_string()),
+                tag: CommandTag::Insert(1),
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::CreateTable { temporary: false },
+                target: Some("created".to_string()),
+                tag: CommandTag::Create("TABLE".to_string()),
+            },
+            MysqlCommandEvent {
+                kind: MysqlStatementKind::Rollback,
+                target: None,
+                tag: CommandTag::Rollback,
+            },
+        ];
+
+        assert_eq!(
+            aggregate_mysql_command_tag(&events),
+            Some(CommandTag::Create("TABLE".to_string()))
+        );
+    }
+}
+
+#[cfg(test)]
+mod resultset_frame_tests {
+    use super::*;
+
+    #[test]
+    fn error_before_resultset_frame_is_not_accepted() {
+        let mut buffer = b"<resultset><row></row></resultset>".to_vec();
+        let error = b"ERROR 1054 (42S22): Unknown column missing_column\n";
+
+        assert!(matches!(
+            take_mysql_resultset_frame_after_error_check(&mut buffer, error),
+            Err(DbOperationError::QueryFailed(_))
+        ));
+        assert_eq!(buffer, b"<resultset><row></row></resultset>");
+    }
+}
+
+#[cfg(all(test, not(unix)))]
+mod pipe_executor_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn pipe_errors_are_checked_before_resultset_frames() {
+        let (mut stdout_writer, mut stdout_reader) = tokio::io::duplex(1024);
+        let (mut stderr_writer, mut stderr_reader) = tokio::io::duplex(1024);
+        stdout_writer
+            .write_all(b"<resultset><row></row></resultset>")
+            .await
+            .unwrap();
+        stderr_writer
+            .write_all(b"ERROR 1054 (42S22): Unknown column missing_column\n")
+            .await
+            .unwrap();
+        drop(stdout_writer);
+        drop(stderr_writer);
+
+        let result = read_one_mysql_resultset_from_pipes(
+            &mut stdout_reader,
+            &mut stderr_reader,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
     }
 }

--- a/src/tests/render_snapshots/overlays.rs
+++ b/src/tests/render_snapshots/overlays.rs
@@ -188,6 +188,25 @@ fn sql_modal_analyze_unknown_risk_acknowledge() {
 }
 
 #[test]
+fn sql_modal_analyze_read_only_acknowledge() {
+    let mut state = connected_state();
+    let mut terminal = create_test_terminal();
+
+    state.modal.set_mode(InputMode::SqlModal);
+    state
+        .sql_modal
+        .set_status_for_test(SqlModalStatus::ConfirmingAnalyzeRisk {
+            query: "SELECT * FROM users".to_string(),
+            reason: AcknowledgeReason::AnalyzeExecution,
+        });
+    state.sql_modal.set_active_tab(SqlModalTab::Plan);
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn sql_modal_cursor_at_head() {
     let mut state = create_test_state();
     let mut terminal = create_test_terminal();
@@ -699,6 +718,7 @@ fn sql_modal_plan_tab_with_plan_text() {
     state.sql_modal.set_active_tab(SqlModalTab::Plan);
     state.explain.set_plan(
         "Seq Scan on users  (cost=0.00..35.50 rows=2550 width=36)\n  Filter: (id > 10)".to_string(),
+        DatabaseType::PostgreSQL,
         false,
         42,
         "SELECT * FROM users WHERE id > 10",
@@ -747,6 +767,7 @@ fn sql_modal_compare_tab_right_only() {
     state.explain.set_plan(
         "Seq Scan on users  (cost=0.00..10.20 rows=10 width=3273)\n  Filter: email_verified"
             .to_string(),
+        DatabaseType::PostgreSQL,
         false,
         40,
         "SELECT * FROM users WHERE email_verified",
@@ -769,6 +790,7 @@ fn sql_modal_compare_tab_with_verdict() {
     state.explain.set_plan(
         "Seq Scan on users  (cost=0.00..1000.00 rows=2550 width=36)\n  Filter: (id > 10)"
             .to_string(),
+        DatabaseType::PostgreSQL,
         false,
         100,
         "SELECT * FROM users WHERE id > 10",
@@ -777,6 +799,7 @@ fn sql_modal_compare_tab_with_verdict() {
     state.explain.set_plan(
         "Index Scan using idx_users_id on users  (cost=0.28..8.30 rows=1 width=36)\n  Index Cond: (id > 10)"
             .to_string(),
+        DatabaseType::PostgreSQL,
         false,
         5,
         "SELECT * FROM users WHERE id > 10",
@@ -797,6 +820,7 @@ fn sql_modal_compare_tab_unavailable() {
     // First EXPLAIN with unparseable text
     state.explain.set_plan(
         "CREATE TABLE foo (id int)".to_string(),
+        DatabaseType::PostgreSQL,
         false,
         0,
         "CREATE TABLE foo",
@@ -804,6 +828,7 @@ fn sql_modal_compare_tab_unavailable() {
     // Second EXPLAIN with also unparseable text — auto-advances first to left
     state.explain.set_plan(
         "ALTER TABLE foo ADD COLUMN bar text".to_string(),
+        DatabaseType::PostgreSQL,
         false,
         0,
         "ALTER TABLE foo",
@@ -826,6 +851,7 @@ fn sql_modal_compare_tab_narrow_stacked() {
     state.explain.set_plan(
         "Seq Scan on users  (cost=0.00..1000.00 rows=2550 width=36)\n  Filter: (id > 10)"
             .to_string(),
+        DatabaseType::PostgreSQL,
         false,
         100,
         "SELECT * FROM users WHERE id > 10",
@@ -834,6 +860,7 @@ fn sql_modal_compare_tab_narrow_stacked() {
     state.explain.set_plan(
         "Index Scan using idx_users_id on users  (cost=0.28..8.30 rows=1 width=36)\n  Index Cond: (id > 10)"
             .to_string(),
+        DatabaseType::PostgreSQL,
         false,
         5,
         "SELECT * FROM users WHERE id > 10",
@@ -893,6 +920,7 @@ fn sqlite_sql_modal_plan_tab_labels_query_plan() {
     state.sql_modal.set_active_tab(SqlModalTab::Plan);
     state.explain.set_plan(
         "SEARCH users USING INDEX idx_users_name\n  - SCAN orders".to_string(),
+        DatabaseType::SQLite,
         false,
         42,
         "DELETE FROM users WHERE name = 'alice'",

--- a/src/ui/features/sql_modal/compare.rs
+++ b/src/ui/features/sql_modal/compare.rs
@@ -10,7 +10,8 @@ use crate::app::model::app_state::AppState;
 use crate::app::model::explain_context::CompareSlot;
 use crate::app::model::shared::flash_timer::FlashId;
 use crate::app::update::input::keybindings::sql_modal_compare_explain;
-use crate::domain::explain_plan::{self, ComparisonVerdict};
+use crate::domain::DatabaseType;
+use crate::domain::explain_plan::{self, ComparisonVerdict, ExplainPlan};
 use crate::primitives::atoms::apply_yank_flash_masked;
 use crate::primitives::utils::text_utils::truncate_to_width_with;
 use crate::theme::ThemePalette;
@@ -339,14 +340,10 @@ fn render_stacked_slot(
             flash_mask,
             Line::from(Span::styled(format!(" {}", s.source.label()), active_style)),
         );
-        let time_secs = s.plan.execution_secs();
         push_chrome(
             lines,
             flash_mask,
-            Line::from(Span::styled(
-                format!("  {}  ({:.2}s)", mode_label(s.plan.is_analyze), time_secs),
-                badge_style,
-            )),
+            Line::from(Span::styled(slot_detail_text(Some(s)), badge_style)),
         );
         for line in s.plan.raw_text.lines() {
             push_content(
@@ -383,10 +380,28 @@ fn slot_detail_text(slot: Option<&CompareSlot>) -> String {
     match slot {
         Some(s) => {
             let time_secs = s.plan.execution_secs();
-            format!(" {}  ({:.2}s)", mode_label(s.plan.is_analyze), time_secs)
+            let summary = format!(" {}  ({:.2}s)", mode_label(s.plan.is_analyze), time_secs);
+            if s.database_type == DatabaseType::MySQL && s.plan.is_analyze {
+                format!("{summary}  {}", actual_metrics_text(&s.plan))
+            } else {
+                summary
+            }
         }
         None => " Run EXPLAIN again".to_string(),
     }
+}
+
+fn actual_metrics_text(plan: &ExplainPlan) -> String {
+    let (Some(start), Some(end), Some(rows), Some(loops)) = (
+        plan.actual_start_ms,
+        plan.actual_end_ms,
+        plan.actual_rows,
+        plan.loops,
+    ) else {
+        return "Actual: unavailable".to_string();
+    };
+
+    format!("Actual: time={start:.3}..{end:.3} ms rows={rows} loops={loops}")
 }
 
 fn mode_label(is_analyze: bool) -> &'static str {
@@ -407,7 +422,6 @@ pub(super) fn pad_or_truncate(s: &str, width: usize) -> String {
 mod tests {
     use super::*;
     use crate::app::model::explain_context::SlotSource;
-    use crate::domain::explain_plan::ExplainPlan;
     use crate::theme::DEFAULT_THEME;
 
     mod pad_or_truncate_tests {
@@ -438,10 +452,15 @@ mod tests {
                 raw_text: plan.to_string(),
                 top_node_type: Some("Seq Scan".to_string()),
                 total_cost: Some(10.0),
-                estimated_rows: Some(1),
+                estimated_rows: Some(1.0),
+                actual_start_ms: None,
+                actual_end_ms: None,
+                actual_rows: None,
+                loops: None,
                 is_analyze: false,
                 execution_time_ms: 250,
             },
+            database_type: DatabaseType::PostgreSQL,
             query_snippet: "SELECT 1".to_string(),
             full_query: "SELECT 1".to_string(),
             source: label,
@@ -502,5 +521,29 @@ mod tests {
 
         assert_eq!(lines.len(), flash_mask.len());
         assert!(flash_mask.iter().all(|&flash| !flash));
+    }
+
+    #[test]
+    fn mysql_analyze_slot_summary_shows_actual_metrics() {
+        let mut slot = sample_slot(SlotSource::AutoLatest, "plan");
+        slot.database_type = DatabaseType::MySQL;
+        slot.plan.is_analyze = true;
+        slot.plan.actual_start_ms = Some(0.01);
+        slot.plan.actual_end_ms = Some(0.5);
+        slot.plan.actual_rows = Some(95.0);
+        slot.plan.loops = Some(2);
+
+        let summary = slot_detail_text(Some(&slot));
+
+        assert!(summary.contains("Actual: time=0.010..0.500 ms rows=95 loops=2"));
+    }
+
+    #[test]
+    fn mysql_analyze_slot_summary_marks_missing_actual_metrics_unavailable() {
+        let mut slot = sample_slot(SlotSource::AutoLatest, "plan");
+        slot.database_type = DatabaseType::MySQL;
+        slot.plan.is_analyze = true;
+
+        assert!(slot_detail_text(Some(&slot)).contains("Actual: unavailable"));
     }
 }

--- a/src/ui/features/sql_modal/explain.rs
+++ b/src/ui/features/sql_modal/explain.rs
@@ -15,6 +15,7 @@ use crate::app::policy::write::sql_risk::AcknowledgeReason;
 use crate::app::policy::{FeaturePolicy, FeatureRequirement};
 use crate::app::update::input::keybindings::sql_modal_plan_explain;
 use crate::domain::DatabaseType;
+use crate::domain::explain_plan::ExplainPlan;
 use crate::primitives::atoms::{apply_yank_flash, text_cursor_spans};
 use crate::theme::ThemePalette;
 
@@ -107,7 +108,16 @@ pub fn render(
         ]);
 
         let scroll = state.explain.scroll_offset();
-        let mut lines = vec![header, query_line, Line::raw("")];
+        let mut lines = vec![header, query_line];
+        if state.explain.is_analyze()
+            && state.session.active_database_type_or_default() == DatabaseType::MySQL
+        {
+            lines.push(Line::from(Span::styled(
+                format_actual_metrics(state.explain.current_plan()),
+                Style::default().fg(theme.semantic.text.muted),
+            )));
+        }
+        lines.push(Line::raw(""));
         lines.extend(
             plan_text
                 .lines()
@@ -116,7 +126,11 @@ pub fn render(
         );
 
         let flash_active = state.flash_timers.is_active(FlashId::SqlModal, now);
-        let content_start = 3; // skip header, query snippet, empty line
+        let content_start = lines
+            .iter()
+            .position(|line| line == &Line::raw(""))
+            .unwrap_or(0)
+            + 1;
         apply_yank_flash(&mut lines[content_start..], flash_active, theme);
 
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
@@ -130,6 +144,22 @@ pub fn render(
         frame.render_widget(Paragraph::new(vec![placeholder]), area);
         area.height
     }
+}
+
+fn format_actual_metrics(plan: Option<&ExplainPlan>) -> String {
+    let Some(plan) = plan else {
+        return "  Actual: unavailable".to_string();
+    };
+    let (Some(start), Some(end), Some(rows), Some(loops)) = (
+        plan.actual_start_ms,
+        plan.actual_end_ms,
+        plan.actual_rows,
+        plan.loops,
+    ) else {
+        return "  Actual: unavailable".to_string();
+    };
+
+    format!("  Actual: time={start:.3}..{end:.3} ms rows={rows} loops={loops}")
 }
 
 fn render_scrolled(frame: &mut Frame, area: Rect, lines: Vec<Line>, scroll_offset: usize) {
@@ -236,6 +266,13 @@ fn build_analyze_acknowledge_lines<'a>(
                 " transaction. EXPLAIN ANALYZE will execute it.",
             ],
         ),
+        AcknowledgeReason::AnalyzeExecution => (
+            theme.semantic.status.warning,
+            [
+                " This read-only statement will be executed.",
+                " EXPLAIN ANALYZE will run it and may take time.",
+            ],
+        ),
     };
     let header_style = Style::default()
         .fg(header_color)
@@ -254,6 +291,12 @@ fn build_analyze_acknowledge_lines<'a>(
 
     for text in explanation {
         lines.push(Line::from(Span::styled(text, header_style)));
+    }
+    if matches!(reason, AcknowledgeReason::AnalyzeExecution) {
+        lines.push(Line::from(Span::styled(
+            " Risk: LOW",
+            Style::default().fg(theme.semantic.text.secondary),
+        )));
     }
     lines.push(Line::raw(""));
 

--- a/src/ui/features/sql_modal/mod.rs
+++ b/src/ui/features/sql_modal/mod.rs
@@ -87,6 +87,10 @@ impl SqlModal {
                             " SQL \u{2500}\u{2500} \u{26a0} NON-ATOMIC ",
                             theme.semantic.status.warning,
                         ),
+                        AcknowledgeReason::AnalyzeExecution => (
+                            " SQL \u{2500}\u{2500} \u{26a0} LOW RISK ",
+                            theme.semantic.status.warning,
+                        ),
                     };
                     render_modal_with_border_color(
                         frame,

--- a/src/ui/features/sql_modal/status.rs
+++ b/src/ui/features/sql_modal/status.rs
@@ -212,6 +212,11 @@ fn render_confirming_risk_status(
             Style::default().fg(theme.semantic.status.warning),
             "SQLite must run this script without an automatic transaction",
         ),
+        AcknowledgeReason::AnalyzeExecution => (
+            format!("\u{26a0} LOW RISK  {label}"),
+            Style::default().fg(theme.semantic.status.warning),
+            "EXPLAIN ANALYZE will execute this read-only statement",
+        ),
     };
 
     let line1 = Line::from(Span::styled(badge_text, badge_style));


### PR DESCRIPTION
## Problem

MySQL execution-plan support spans statement admission, safety confirmation, adapter execution, plan parsing, rendering, and comparison. This semantic slice needs a coherent cross-cutting review against the final integration snapshot.

## Background

This review-only pull request selects the final contents of the files owned by PRs #564, #568, and #573.

- Base snapshot: `6c91adfb7dadbb6616b706faadf2ba5a78f39e38`
- MySQL snapshot: `e96e8f7d567a014e9650901532bb123cb95131ea`

This pull request must not be merged.

## Approach

Review MySQL `EXPLAIN FORMAT=TREE`, `EXPLAIN ANALYZE` admission and confirmation, execution-plan parsing and normalization, stale-result protection, plan presentation, and comparison as one responsibility.

Connection/probe/TLS and database switching, browse/metadata/DDL, SQL history/completion/export/read-only behavior, grid/JSON/ER editing, release documentation, and snapshot files are intentionally excluded. Shared files are included only where the execution-plan behavior depends on them.

This synthetic slice is not independently buildable because adjacent MySQL adapter modules are intentionally absent; review the selected files as their exact final-snapshot contents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MySQL connection support, including database selection and switching.
  - Added MySQL SQL parsing, risk assessment, statement labeling, and safer multi-statement handling.
  - Added MySQL `EXPLAIN` and `EXPLAIN ANALYZE` support with plan parsing and execution metrics.
  - Added database-specific query history and explain-plan handling.
  - Added improved JSON document editing and filtering for database results.

- **Bug Fixes**
  - Prevented stale connection, database, and explain results from overwriting current state.
  - Improved protection against editing hidden, primary-key, or read-only columns.
  - Added clearer warnings when `EXPLAIN ANALYZE` executes a read-only query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->