### PR TITLE
fix(mysql): address semantic review findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +296,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -332,6 +363,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +405,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,25 +430,13 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
-dependencies = [
- "encode_unicode",
- "libc",
  "windows-sys 0.61.2",
 ]
 
@@ -416,6 +454,51 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -440,12 +523,6 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -712,6 +789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,7 +853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -916,6 +1008,12 @@ checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
 dependencies = [
  "futures-core",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1229,7 +1327,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1404,14 +1501,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
- "console 0.15.11",
- "number_prefix",
+ "console",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -1430,7 +1527,7 @@ version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
- "console 0.16.3",
+ "console",
  "once_cell",
  "similar",
  "tempfile",
@@ -1475,6 +1572,65 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1758,12 +1914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +2006,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2043,6 +2199,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,15 +2306,6 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
@@ -2187,6 +2340,7 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2442,9 +2596,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2465,9 +2619,9 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2478,7 +2632,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2555,7 +2708,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2564,12 +2717,26 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2583,11 +2750,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2670,7 +2865,7 @@ dependencies = [
  "csv",
  "dirs",
  "libc",
- "quick-xml 0.38.4",
+ "quick-xml",
  "rstest",
  "sabiql-app",
  "sabiql-domain",
@@ -2703,10 +2898,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "self-replace"
@@ -2721,23 +2957,25 @@ dependencies = [
 
 [[package]]
 name = "self_update"
-version = "0.42.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
+checksum = "2e79722b5a505d4ddc77527455a97244e9e8c4c07533ff44cf4421cce7bb6d17"
 dependencies = [
  "either",
  "flate2",
- "hyper",
+ "http",
  "indicatif",
  "log",
- "quick-xml 0.37.5",
+ "quick-xml",
  "regex",
  "reqwest",
  "self-replace",
  "semver",
+ "serde",
  "serde_json",
  "tar",
  "tempfile",
+ "ureq",
  "urlencoding",
  "zip",
  "zipsign-api",
@@ -2798,18 +3036,6 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
  "serde",
 ]
 
@@ -2893,6 +3119,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2924,6 +3166,17 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -3052,10 +3305,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3216,6 +3469,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3223,6 +3477,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -3487,10 +3751,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "encoding_rs",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
 
 [[package]]
 name = "url"
@@ -3509,6 +3813,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3554,6 +3864,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3699,6 +4019,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3800,6 +4129,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -4211,17 +4549,14 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
- "displaydoc",
  "indexmap",
  "memchr",
- "thiserror 2.0.19",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,6 +2149,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
  "tokio",
 ]
 
@@ -2661,7 +2670,7 @@ dependencies = [
  "csv",
  "dirs",
  "libc",
- "quick-xml",
+ "quick-xml 0.38.4",
  "rstest",
  "sabiql-app",
  "sabiql-domain",
@@ -2721,7 +2730,7 @@ dependencies = [
  "hyper",
  "indicatif",
  "log",
- "quick-xml",
+ "quick-xml 0.37.5",
  "regex",
  "reqwest",
  "self-replace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ lru = "0.18"
 libc = "0.2"
 mockall = "0.13"
 nucleo-matcher = "0.3"
-quick-xml = { version = "0.37", features = ["async-tokio"] }
+quick-xml = { version = "0.38", features = ["async-tokio"] }
 ratatui = "0.30"
 rstest = "0.19"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ ratatui = "0.30"
 rstest = "0.19"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-self_update = { version = "0.42", default-features = false, features = ["archive-tar", "archive-zip", "compression-flate2", "rustls"] }
+self_update = { version = "0.44", default-features = false, features = ["archive-tar", "archive-zip", "compression-flate2", "ureq", "rustls"] }
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["sync", "time", "io-util", "process", "rt-multi-thread", "macros", "fs"] }

--- a/scripts/mysql_integration.sh
+++ b/scripts/mysql_integration.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-readonly script_dir="$(cd "$(dirname "$0")" && pwd)"
-readonly repo_root="$(cd "$script_dir/.." && pwd)"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+readonly script_dir
+repo_root="$(cd "$script_dir/.." && pwd)"
+readonly repo_root
 readonly compose_file="$repo_root/compose.yml"
 readonly tls_compose_file="$repo_root/compose.mysql-tls.yml"
 readonly temp_dir="$repo_root/.tmp/mysql"

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -694,9 +694,11 @@ impl CompletionEngine {
 
     fn identifier_before_dot(prefix: &str) -> Option<String> {
         let name = prefix.strip_suffix('.')?.trim_end();
-        if let Some(unquoted) = name.strip_suffix('`') {
-            let start = unquoted.rfind('`')?;
-            return Some(unquoted[start + 1..].replace("``", "`"));
+        if let Some(quoted) = name
+            .strip_prefix('`')
+            .and_then(|value| value.strip_suffix('`'))
+        {
+            return Some(quoted.replace("``", "`"));
         }
 
         let start = name
@@ -1708,6 +1710,34 @@ mod tests {
         }
 
         #[test]
+        fn mysql_escaped_backtick_alias_returns_cached_columns() {
+            let mut e = engine();
+            e.cache_table_detail(
+                "app.users".to_string(),
+                create_table("app", "users", &["id", "name"]),
+            );
+            let metadata = metadata();
+            let sql = "SELECT `x``y`.na FROM `app`.`users` AS `x``y`";
+            let cursor = "SELECT `x``y`.na".chars().count();
+            let candidates = e.get_candidates_for_database(
+                sql,
+                cursor,
+                Some(&metadata),
+                None,
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app"),
+                    available_databases: &[],
+                },
+            );
+
+            assert!(candidates.iter().any(|candidate| {
+                candidate.text == "name" && candidate.kind == CompletionKind::Column
+            }));
+        }
+
+        #[test]
         fn mysql_backtick_database_prefix_returns_selected_tables() {
             let e = engine();
             let metadata = metadata();
@@ -1721,6 +1751,33 @@ mod tests {
                 CompletionDatabaseScope {
                     database_type: DatabaseType::MySQL,
                     active_database: Some("app"),
+                    available_databases: &[],
+                },
+            );
+
+            assert!(candidates.iter().any(|candidate| candidate.text == "users"));
+        }
+
+        #[test]
+        fn mysql_escaped_backtick_database_prefix_returns_selected_tables() {
+            let e = engine();
+            let mut metadata = DatabaseMetadata::new("app`db".to_string());
+            metadata.table_summaries = vec![TableSummary::new(
+                "app`db".to_string(),
+                "users".to_string(),
+                None,
+                false,
+            )];
+            let sql = "SELECT * FROM `app``db`.";
+            let candidates = e.get_candidates_for_database(
+                sql,
+                sql.chars().count(),
+                Some(&metadata),
+                None,
+                &[],
+                CompletionDatabaseScope {
+                    database_type: DatabaseType::MySQL,
+                    active_database: Some("app`db"),
                     available_databases: &[],
                 },
             );

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -694,11 +694,18 @@ impl CompletionEngine {
 
     fn identifier_before_dot(prefix: &str) -> Option<String> {
         let name = prefix.strip_suffix('.')?.trim_end();
-        if let Some(quoted) = name
-            .strip_prefix('`')
-            .and_then(|value| value.strip_suffix('`'))
-        {
-            return Some(quoted.replace("``", "`"));
+        if name.ends_with('`') {
+            let mut chars = name.char_indices().rev();
+            let (closing_index, _) = chars.next()?;
+            while let Some((opening_index, character)) = chars.next() {
+                if character != '`' {
+                    continue;
+                }
+                if chars.next().is_some_and(|(_, previous)| previous == '`') {
+                    continue;
+                }
+                return Some(name[opening_index + 1..closing_index].replace("``", "`"));
+            }
         }
 
         let start = name
@@ -1716,6 +1723,10 @@ mod tests {
                 "app.users".to_string(),
                 create_table("app", "users", &["id", "name"]),
             );
+            e.cache_table_detail(
+                "app.audit".to_string(),
+                create_table("app", "audit", &["id", "secret"]),
+            );
             let metadata = metadata();
             let sql = "SELECT `x``y`.na FROM `app`.`users` AS `x``y`";
             let cursor = "SELECT `x``y`.na".chars().count();
@@ -1735,6 +1746,11 @@ mod tests {
             assert!(candidates.iter().any(|candidate| {
                 candidate.text == "name" && candidate.kind == CompletionKind::Column
             }));
+            assert!(
+                !candidates
+                    .iter()
+                    .any(|candidate| candidate.text == "secret")
+            );
         }
 
         #[test]
@@ -1762,12 +1778,10 @@ mod tests {
         fn mysql_escaped_backtick_database_prefix_returns_selected_tables() {
             let e = engine();
             let mut metadata = DatabaseMetadata::new("app`db".to_string());
-            metadata.table_summaries = vec![TableSummary::new(
-                "app`db".to_string(),
-                "users".to_string(),
-                None,
-                false,
-            )];
+            metadata.table_summaries = vec![
+                TableSummary::new("app`db".to_string(), "users".to_string(), None, false),
+                TableSummary::new("other".to_string(), "events".to_string(), None, false),
+            ];
             let sql = "SELECT * FROM `app``db`.";
             let candidates = e.get_candidates_for_database(
                 sql,
@@ -1783,6 +1797,11 @@ mod tests {
             );
 
             assert!(candidates.iter().any(|candidate| candidate.text == "users"));
+            assert!(
+                !candidates
+                    .iter()
+                    .any(|candidate| candidate.text == "events")
+            );
         }
     }
 

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -107,7 +107,10 @@ pub(crate) async fn run(
                 let probe = Arc::clone(&connection.connection_probe);
                 tokio::spawn(async move {
                     match probe.probe(&target.dsn).await {
-                        Ok(()) => match store.save(&profile) {
+                        Ok(()) => match tokio::task::spawn_blocking(move || store.save(&profile))
+                            .await
+                            .expect("connection store save task panicked")
+                        {
                             Ok(()) => {
                                 tx.send(Action::ConnectionSaveCompleted(target)).await.ok();
                             }
@@ -134,7 +137,10 @@ pub(crate) async fn run(
                 match provider.fetch_metadata(&dsn).await {
                     Ok(metadata) => {
                         cache.set(dsn.clone(), Arc::new(metadata)).await;
-                        match store.save(&profile) {
+                        match tokio::task::spawn_blocking(move || store.save(&profile))
+                            .await
+                            .expect("connection store save task panicked")
+                        {
                             Ok(()) => {
                                 tx.send(Action::ConnectionSaveCompleted(ConnectionTarget {
                                     id,

--- a/src/app/cmd/er/task.rs
+++ b/src/app/cmd/er/task.rs
@@ -160,7 +160,7 @@ mod tests {
             spawn_er_diagram_task(
                 exporter,
                 vec![],
-                1,
+                7,
                 5,
                 temp_dir.path().to_path_buf(),
                 tx,
@@ -172,6 +172,7 @@ mod tests {
             match action {
                 Action::ErDiagramFailed(e) => {
                     assert!(e.to_string().contains("export failed"));
+                    assert_eq!(e.run_id, 7);
                 }
                 _ => panic!("expected ErDiagramFailed, got {action:?}"),
             }
@@ -186,7 +187,7 @@ mod tests {
             spawn_er_diagram_task(
                 exporter,
                 vec![],
-                1,
+                11,
                 5,
                 temp_dir.path().to_path_buf(),
                 tx,
@@ -198,6 +199,7 @@ mod tests {
             match action {
                 Action::ErDiagramFailed(e) => {
                     assert!(e.to_string().contains("Task panicked"));
+                    assert_eq!(e.run_id, 11);
                 }
                 _ => panic!("expected ErDiagramFailed, got {action:?}"),
             }

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -195,13 +195,16 @@ const MYSQL_KEYWORDS: &[&str] = &[
     "EXCEPT",
     "ALL",
     "INSERT",
+    "REPLACE",
     "INTO",
     "VALUES",
+    "CALL",
     "UPDATE",
     "SET",
     "DELETE",
     "CREATE",
     "DROP",
+    "TRUNCATE",
     "ALTER",
     "TABLE",
     "INDEX",
@@ -248,6 +251,9 @@ const MYSQL_KEYWORDS: &[&str] = &[
     "CHARSET",
     "COLLATE",
     "AUTO_INCREMENT",
+    "SAVEPOINT",
+    "RELEASE",
+    "USE",
     "FOR",
     "LOCK",
     "SHARE",
@@ -668,7 +674,19 @@ impl SqlLexer {
     }
 
     fn is_unterminated_backtick(text: &str) -> bool {
-        text.starts_with('`') && text.chars().skip(1).filter(|&c| c == '`').count() % 2 == 0
+        if !text.starts_with('`') {
+            return false;
+        }
+        let mut chars = text.chars().skip(1).peekable();
+        while let Some(ch) = chars.next() {
+            if ch != '`' {
+                continue;
+            }
+            if chars.next_if_eq(&'`').is_none() {
+                return false;
+            }
+        }
+        true
     }
 
     fn is_operator_char(c: char) -> bool {
@@ -1492,6 +1510,18 @@ mod tests {
                 postgres.tokenize("DESCRIBE users", 14)[0].kind,
                 TokenKind::Identifier(_)
             ));
+        }
+
+        #[test]
+        fn mysql_statement_keywords_are_displayed_as_keywords() {
+            let l = mysql_lexer();
+
+            for word in ["TRUNCATE", "REPLACE", "CALL", "SAVEPOINT", "RELEASE", "USE"] {
+                assert!(matches!(
+                    l.tokenize(word, word.len())[0].kind,
+                    TokenKind::Keyword(_)
+                ));
+            }
         }
 
         #[test]

--- a/src/app/policy/sql/mysql_statement.rs
+++ b/src/app/policy/sql/mysql_statement.rs
@@ -57,6 +57,7 @@ enum TokenKind {
 struct Token {
     kind: TokenKind,
     depth: usize,
+    text: String,
 }
 
 pub fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MysqlLexError> {
@@ -235,6 +236,7 @@ fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MysqlLexError> {
                     tokens.push(Token {
                         kind: TokenKind::Word("UNSUPPORTED_VERSION_COMMENT".to_string()),
                         depth,
+                        text: "UNSUPPORTED_VERSION_COMMENT".to_string(),
                     });
                 }
             }
@@ -246,6 +248,7 @@ fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MysqlLexError> {
             tokens.push(Token {
                 kind: TokenKind::Word("UNSUPPORTED_VERSION_COMMENT".to_string()),
                 depth,
+                text: "UNSUPPORTED_VERSION_COMMENT".to_string(),
             });
             leading_executable_version_comment = false;
         }
@@ -259,7 +262,11 @@ fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MysqlLexError> {
             } else {
                 TokenKind::StringLiteral
             };
-            tokens.push(Token { kind, depth });
+            tokens.push(Token {
+                kind,
+                depth,
+                text: text.to_string(),
+            });
             index = end;
             continue;
         }
@@ -271,14 +278,16 @@ fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MysqlLexError> {
             {
                 index += 1;
             }
-            let word = sql[start..index].to_ascii_uppercase();
+            let text = sql[start..index].to_string();
             tokens.push(Token {
-                kind: TokenKind::Word(word),
+                kind: TokenKind::Word(text.to_ascii_uppercase()),
                 depth,
+                text,
             });
             continue;
         }
         if byte.is_ascii_digit() {
+            let start = index;
             index += 1;
             while index < bytes.len()
                 && (bytes[index].is_ascii_alphanumeric() || matches!(bytes[index], b'.' | b'_'))
@@ -288,11 +297,16 @@ fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MysqlLexError> {
             tokens.push(Token {
                 kind: TokenKind::Number,
                 depth,
+                text: sql[start..index].to_string(),
             });
             continue;
         }
         let kind = TokenKind::Symbol(byte as char);
-        tokens.push(Token { kind, depth });
+        tokens.push(Token {
+            kind,
+            depth,
+            text: (byte as char).to_string(),
+        });
         match byte {
             b'(' => depth += 1,
             b')' => {
@@ -387,8 +401,9 @@ fn identifier_at(tokens: &[Token], mut index: usize) -> Option<(String, Option<S
     ) {
         index += 1;
     }
-    let first = match &tokens.get(index)?.kind {
-        TokenKind::Word(word) => word.clone(),
+    let first_token = tokens.get(index)?;
+    let first = match &first_token.kind {
+        TokenKind::Word(_) => first_token.text.clone(),
         TokenKind::Identifier(identifier) => identifier.clone(),
         _ => return None,
     };
@@ -396,8 +411,9 @@ fn identifier_at(tokens: &[Token], mut index: usize) -> Option<(String, Option<S
         tokens.get(index + 1).map(|token| &token.kind),
         Some(TokenKind::Symbol('.'))
     ) {
-        let second = match &tokens.get(index + 2)?.kind {
-            TokenKind::Word(word) => word.clone(),
+        let second_token = tokens.get(index + 2)?;
+        let second = match &second_token.kind {
+            TokenKind::Word(_) => second_token.text.clone(),
             TokenKind::Identifier(identifier) => identifier.clone(),
             _ => return None,
         };
@@ -1158,10 +1174,23 @@ mod tests {
     #[test]
     fn keeps_index_confirmation_name_separate_from_ddl_database_target() {
         let statement = classify_mysql_statement("DROP INDEX ix ON app.items").unwrap();
-        assert_eq!(statement.target, Some("IX".to_string()));
-        assert_eq!(statement.target_database, Some("APP".to_string()));
+        assert_eq!(statement.target, Some("ix".to_string()));
+        assert_eq!(statement.target_database, Some("app".to_string()));
         let statement = classify_mysql_statement("DROP INDEX IF EXISTS ix ON app.items").unwrap();
-        assert_eq!(statement.target, Some("IX".to_string()));
+        assert_eq!(statement.target, Some("ix".to_string()));
+    }
+
+    #[test]
+    fn preserves_confirmation_target_case_for_unquoted_and_quoted_names() {
+        let statement = classify_mysql_statement("DROP TABLE SalesOrder").unwrap();
+        assert_eq!(statement.target, Some("SalesOrder".to_string()));
+
+        let statement = classify_mysql_statement("DROP TABLE SalesDb.SalesOrder").unwrap();
+        assert_eq!(statement.target, Some("SalesOrder".to_string()));
+        assert_eq!(statement.target_database, Some("SalesDb".to_string()));
+
+        let statement = classify_mysql_statement("DROP TABLE `SalesOrder`").unwrap();
+        assert_eq!(statement.target, Some("SalesOrder".to_string()));
     }
 
     #[test]

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -51,13 +51,26 @@ mod mysql_tests {
                 assert_eq!(
                     risk.confirmation,
                     ConfirmationType::TableNameInput {
-                        target: "ITEMS".to_string()
+                        target: "items".to_string()
                     }
                 );
                 assert!(!risk.read_only_allowed);
             }
             MultiStatementDecision::Block { reason } => panic!("unexpected block: {reason}"),
         }
+    }
+
+    #[test]
+    fn confirmation_target_preserves_input_case() {
+        let MultiStatementDecision::Allow { risk, .. } =
+            mysql("UPDATE CustomerOrders SET value = 1")
+        else {
+            panic!("unexpected block");
+        };
+        assert!(matches!(
+            risk.confirmation,
+            ConfirmationType::TableNameInput { ref target } if target == "CustomerOrders"
+        ));
     }
 
     #[test]

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -306,6 +306,24 @@ mod tests {
         }
 
         #[test]
+        fn mysql_cli_not_found_has_oracle_mysql_guidance() {
+            let error = DbOperationError::CommandNotFound {
+                command: DatabaseCli::MySql,
+                details: "mysql: command not found".to_string(),
+            };
+
+            assert_eq!(error.summary(), "mysql not found");
+            assert_eq!(
+                error.hint(),
+                "Install the Oracle MySQL 8.4 client and add it to PATH"
+            );
+            assert_eq!(
+                error.user_message(),
+                "mysql not found: mysql: command not found. Install the Oracle MySQL 8.4 client and add it to PATH."
+            );
+        }
+
+        #[test]
         fn actionable_message_uses_summary_and_hint() {
             let error = DbOperationError::PermissionDenied("permission denied".to_string());
 

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -26,7 +26,7 @@ use url::Url;
 use crate::domain::SqliteDiagnosticsSnapshot;
 use crate::domain::{DatabaseMetadata, DiagnosticField, QueryResult, QuerySource, Table};
 
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Clone, thiserror::Error)]
 pub enum ConnectionSaveError {
     #[error("{0}")]
     Validation(#[from] ConnectionProfileError),
@@ -39,6 +39,21 @@ pub enum ConnectionSaveError {
         error: DbOperationError,
         dsn: String,
     },
+}
+
+impl fmt::Debug for ConnectionSaveError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Validation(error) => formatter.debug_tuple("Validation").field(error).finish(),
+            Self::Store(error) => formatter.debug_tuple("Store").field(error).finish(),
+            Self::Metadata(error) => formatter.debug_tuple("Metadata").field(error).finish(),
+            Self::Probe { error, dsn } => formatter
+                .debug_struct("Probe")
+                .field("error", error)
+                .field("dsn", &mask_password(dsn))
+                .finish(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
@@ -929,6 +944,19 @@ mod tests {
         };
 
         let debug = format!("{target:?}");
+
+        assert!(!debug.contains("secret"));
+        assert!(debug.contains("mysql://user:****@localhost"));
+    }
+
+    #[test]
+    fn connection_save_probe_debug_masks_mysql_password() {
+        let error = ConnectionSaveError::Probe {
+            error: DbOperationError::ConnectionFailed("probe failed".to_string()),
+            dsn: "mysql://user:secret@localhost:3306/app".to_string(),
+        };
+
+        let debug = format!("{error:?}");
 
         assert!(!debug.contains("secret"));
         assert!(debug.contains("mysql://user:****@localhost"));

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -156,6 +156,7 @@ pub fn reduce_connection_lifecycle(
             state.session.clear_connection_probe();
             let mut effects = vec![Effect::ClearCompletionEngineCache];
             if database.is_none() {
+                state.ui.table_picker_mut().clear_filter_and_reset();
                 state.ui.set_database_picker(true);
                 state.modal.set_mode(InputMode::TablePicker);
                 if let (Some(connection_id), Some(server_dsn)) = (
@@ -1579,6 +1580,9 @@ mod tests {
         #[test]
         fn connection_without_database_opens_picker_and_fetches_server_databases() {
             let mut state = AppState::new("test".to_string());
+            state.ui.table_picker_mut().set_pane_height(5);
+            state.ui.table_picker_mut().insert_filter_str("old table");
+            state.ui.table_picker_mut().set_selection(8);
             let id = ConnectionId::from_string("mysql");
             let target = mysql_target(&id, None);
             let probe_run_id = state.session.begin_connection_probe(
@@ -1602,6 +1606,9 @@ mod tests {
             assert_eq!(state.session.active_database(), None);
             assert!(state.ui.database_picker());
             assert_eq!(state.input_mode(), InputMode::TablePicker);
+            assert_eq!(state.ui.table_picker().filter_input().content(), "");
+            assert_eq!(state.ui.table_picker().selected(), 0);
+            assert_eq!(state.ui.table_picker().scroll_offset(), 0);
             assert!(effects.iter().any(|effect| matches!(
                 effect,
                 Effect::FetchMySqlDatabases { connection_id, .. } if connection_id == &id

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -253,6 +253,7 @@ pub fn reduce_connection_setup(
                 state.session.mark_probe_connected(database.is_some());
                 let mut effects = vec![Effect::ClearCompletionEngineCache];
                 if database.is_none() {
+                    state.ui.table_picker_mut().clear_filter_and_reset();
                     state.ui.set_database_picker(true);
                     state.modal.set_mode(InputMode::TablePicker);
                     if let (Some(connection_id), Some(server_dsn)) = (
@@ -1049,6 +1050,29 @@ mod tests {
             assert!(!state.ui.pending_er_picker());
             assert_eq!(state.er_preparation.status(), ErStatus::Idle);
             assert!(state.er_preparation.pending_tables().is_empty());
+        }
+
+        #[test]
+        fn mysql_save_completed_resets_database_picker_state() {
+            let mut state = AppState::new("test".to_string());
+            state.ui.table_picker_mut().set_pane_height(5);
+            state.ui.table_picker_mut().insert_filter_str("old table");
+            state.ui.table_picker_mut().set_selection(8);
+
+            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "mysql://user@localhost:3306".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: None,
+            });
+            reduce(&mut state, &action, Instant::now());
+
+            assert_eq!(state.ui.table_picker().filter_input().content(), "");
+            assert_eq!(state.ui.table_picker().selected(), 0);
+            assert_eq!(state.ui.table_picker().scroll_offset(), 0);
+            assert!(state.ui.database_picker());
+            assert_eq!(state.input_mode(), InputMode::TablePicker);
         }
 
         #[test]

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -24,7 +24,9 @@ mod tests {
     use crate::domain::{ConnectionId, DatabaseMetadata, DatabaseType, TableSummary};
     use crate::model::app_state::AppState;
     use crate::model::er_state::ErStatus;
-    use crate::update::action::{ErDiagramInfo, SmartErRefreshError, SmartErRefreshResult};
+    use crate::update::action::{
+        ErDiagramError, ErDiagramFailure, ErDiagramInfo, SmartErRefreshError, SmartErRefreshResult,
+    };
     use std::sync::Arc;
 
     fn reduce_er(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
@@ -610,6 +612,28 @@ mod tests {
             .unwrap();
 
             assert!(effects.is_empty());
+        }
+
+        #[test]
+        fn failure_after_er_state_reset_does_not_update_message_or_status() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = state.er_preparation.start_waiting_run();
+            state.er_preparation.reset();
+            let before_status = state.er_preparation.status();
+
+            let effects = reduce_er(
+                &mut state,
+                &Action::ErDiagramFailed(ErDiagramFailure {
+                    run_id,
+                    error: ErDiagramError::ExportFailed("stale failure".to_string()),
+                }),
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert!(effects.is_empty());
+            assert_eq!(state.er_preparation.status(), before_status);
+            assert!(state.messages.last_error.is_none());
         }
 
         #[test]

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -425,6 +425,13 @@ mod text_search_tests {
 
 pub fn validate_field(state: &mut ConnectionSetupState, field: ConnectionField) {
     state.clear_validation_error(field);
+    if let Some(other_field) = match field {
+        ConnectionField::SslCert => Some(ConnectionField::SslKey),
+        ConnectionField::SslKey => Some(ConnectionField::SslCert),
+        _ => None,
+    } {
+        state.clear_validation_error(other_field);
+    }
 
     if let Some(max_chars) = field.max_chars() {
         let length = state.field_value(field).chars().count();
@@ -818,6 +825,47 @@ mod tests {
             state.validation_error(ConnectionField::SslKey),
             Some("Both client paths are required")
         );
+    }
+
+    #[test]
+    fn validating_filled_client_key_clears_stale_pair_error() {
+        let mut state = ConnectionSetupState::default();
+        state.set_database_type(DatabaseType::MySQL);
+        state
+            .input_mut(ConnectionField::SslCert)
+            .unwrap()
+            .set_content("client.pem".to_string());
+        validate_field(&mut state, ConnectionField::SslCert);
+
+        state
+            .input_mut(ConnectionField::SslKey)
+            .unwrap()
+            .set_content("client-key.pem".to_string());
+        validate_field(&mut state, ConnectionField::SslKey);
+
+        assert_eq!(state.validation_error(ConnectionField::SslCert), None);
+        assert_eq!(state.validation_error(ConnectionField::SslKey), None);
+    }
+
+    #[test]
+    fn empty_or_complete_client_certificate_pair_is_accepted() {
+        let mut state = ConnectionSetupState::default();
+        state.set_database_type(DatabaseType::MySQL);
+        validate_all(&mut state);
+        assert_eq!(state.validation_error(ConnectionField::SslCert), None);
+        assert_eq!(state.validation_error(ConnectionField::SslKey), None);
+
+        state
+            .input_mut(ConnectionField::SslCert)
+            .unwrap()
+            .set_content("client.pem".to_string());
+        state
+            .input_mut(ConnectionField::SslKey)
+            .unwrap()
+            .set_content("client-key.pem".to_string());
+        validate_all(&mut state);
+        assert_eq!(state.validation_error(ConnectionField::SslCert), None);
+        assert_eq!(state.validation_error(ConnectionField::SslKey), None);
     }
 
     mod delete_refresh_target_bulk {

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -1568,8 +1568,6 @@ where
                 if let Some(field) = current_field.as_mut() {
                     field.value.push_str(&text);
                 } else if !text.chars().all(char::is_whitespace) {
-                    #[cfg(test)]
-                    eprintln!("unexpected MySQL XML text outside field: {text:?}");
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
                     ));
@@ -1580,8 +1578,6 @@ where
                 if let Some(field) = current_field.as_mut() {
                     field.value.push_str(&text);
                 } else if !text.chars().all(char::is_whitespace) {
-                    #[cfg(test)]
-                    eprintln!("unexpected MySQL XML reference outside field: {text:?}");
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
                     ));
@@ -3220,8 +3216,6 @@ fn parse_mysql_xml(xml: &[u8]) -> Result<MysqlResultSet, DbOperationError> {
                 if let Some(field) = current_field.as_mut() {
                     field.value.push_str(&text);
                 } else if !text.chars().all(char::is_whitespace) {
-                    #[cfg(test)]
-                    eprintln!("unexpected MySQL XML text outside field: {text:?}");
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
                     ));
@@ -3232,8 +3226,6 @@ fn parse_mysql_xml(xml: &[u8]) -> Result<MysqlResultSet, DbOperationError> {
                 if let Some(field) = current_field.as_mut() {
                     field.value.push_str(&text);
                 } else if !text.chars().all(char::is_whitespace) {
-                    #[cfg(test)]
-                    eprintln!("unexpected MySQL XML reference outside field: {text:?}");
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
                     ));

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -14,7 +14,8 @@ use std::os::fd::{AsRawFd, FromRawFd};
 
 use async_trait::async_trait;
 use quick_xml::Reader;
-use quick_xml::events::Event;
+use quick_xml::escape::unescape;
+use quick_xml::events::{BytesRef, Event};
 use serde::Deserialize;
 #[cfg(unix)]
 use tokio::fs::File as TokioFile;
@@ -1558,9 +1559,22 @@ where
                 row.push(parse_mysql_field(&element)?.finish_raw());
             }
             Event::Text(text) => {
-                let text = text.unescape().map_err(|error| {
+                let decoded = text.decode().map_err(|error| {
                     DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
                 })?;
+                let text = unescape(&decoded).map_err(|error| {
+                    DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
+                })?;
+                if let Some(field) = current_field.as_mut() {
+                    field.value.push_str(&text);
+                } else if !text.chars().all(char::is_whitespace) {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected text in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::GeneralRef(reference) => {
+                let text = decode_mysql_xml_reference(&reference)?;
                 if let Some(field) = current_field.as_mut() {
                     field.value.push_str(&text);
                 } else if !text.chars().all(char::is_whitespace) {
@@ -3133,6 +3147,15 @@ fn unsupported_client_command(command: &str) -> DbOperationError {
     DbOperationError::UnsupportedOperation(format!("unsupported MySQL {command}"))
 }
 
+fn decode_mysql_xml_reference(reference: &BytesRef<'_>) -> Result<String, DbOperationError> {
+    let reference = reference.decode().map_err(|error| {
+        DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
+    })?;
+    unescape(&format!("&{reference};"))
+        .map(std::borrow::Cow::into_owned)
+        .map_err(|error| DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}")))
+}
+
 fn parse_mysql_xml(xml: &[u8]) -> Result<MysqlResultSet, DbOperationError> {
     let mut reader = Reader::from_reader(xml);
     reader.config_mut().trim_text(false);
@@ -3184,9 +3207,22 @@ fn parse_mysql_xml(xml: &[u8]) -> Result<MysqlResultSet, DbOperationError> {
                 row.push(field.finish());
             }
             Event::Text(text) => {
-                let text = text.unescape().map_err(|error| {
+                let decoded = text.decode().map_err(|error| {
                     DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
                 })?;
+                let text = unescape(&decoded).map_err(|error| {
+                    DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
+                })?;
+                if let Some(field) = current_field.as_mut() {
+                    field.value.push_str(&text);
+                } else if !text.chars().all(char::is_whitespace) {
+                    return Err(DbOperationError::QueryFailed(
+                        "unexpected text in MySQL XML result".to_string(),
+                    ));
+                }
+            }
+            Event::GeneralRef(reference) => {
+                let text = decode_mysql_xml_reference(&reference)?;
                 if let Some(field) = current_field.as_mut() {
                     field.value.push_str(&text);
                 } else if !text.chars().all(char::is_whitespace) {

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -1568,6 +1568,8 @@ where
                 if let Some(field) = current_field.as_mut() {
                     field.value.push_str(&text);
                 } else if !text.chars().all(char::is_whitespace) {
+                    #[cfg(test)]
+                    eprintln!("unexpected MySQL XML text outside field: {text:?}");
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
                     ));
@@ -1578,6 +1580,8 @@ where
                 if let Some(field) = current_field.as_mut() {
                     field.value.push_str(&text);
                 } else if !text.chars().all(char::is_whitespace) {
+                    #[cfg(test)]
+                    eprintln!("unexpected MySQL XML reference outside field: {text:?}");
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
                     ));
@@ -3216,6 +3220,8 @@ fn parse_mysql_xml(xml: &[u8]) -> Result<MysqlResultSet, DbOperationError> {
                 if let Some(field) = current_field.as_mut() {
                     field.value.push_str(&text);
                 } else if !text.chars().all(char::is_whitespace) {
+                    #[cfg(test)]
+                    eprintln!("unexpected MySQL XML text outside field: {text:?}");
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
                     ));
@@ -3226,6 +3232,8 @@ fn parse_mysql_xml(xml: &[u8]) -> Result<MysqlResultSet, DbOperationError> {
                 if let Some(field) = current_field.as_mut() {
                     field.value.push_str(&text);
                 } else if !text.chars().all(char::is_whitespace) {
+                    #[cfg(test)]
+                    eprintln!("unexpected MySQL XML reference outside field: {text:?}");
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
                     ));

--- a/src/infra/adapters/mysql/metadata.rs
+++ b/src/infra/adapters/mysql/metadata.rs
@@ -105,8 +105,7 @@ impl MetadataProvider for MySqlAdapter {
         schema: &str,
         table: &str,
     ) -> Result<Table, DbOperationError> {
-        validate_selected_schema(dsn, schema)?;
-        let snapshot = fetch_metadata_snapshot(dsn).await?;
+        let snapshot = fetch_metadata_snapshot_for_schema(dsn, schema).await?;
         fetch_table(
             dsn,
             schema,
@@ -123,8 +122,7 @@ impl MetadataProvider for MySqlAdapter {
         schema: &str,
         table: &str,
     ) -> Result<Table, DbOperationError> {
-        validate_selected_schema(dsn, schema)?;
-        let snapshot = fetch_metadata_snapshot(dsn).await?;
+        let snapshot = fetch_metadata_snapshot_for_schema(dsn, schema).await?;
         fetch_table_columns_and_fks_with_summaries(
             dsn,
             schema,
@@ -165,8 +163,7 @@ pub(super) async fn fetch_preview_metadata(
     schema: &str,
     table: &str,
 ) -> Result<PreviewMetadata, DbOperationError> {
-    validate_selected_schema(dsn, schema)?;
-    let snapshot = fetch_metadata_snapshot(dsn).await?;
+    let snapshot = fetch_metadata_snapshot_for_schema(dsn, schema).await?;
     find_table(schema, table, &snapshot.tables)?;
     let column_metadata = fetch_columns(dsn, schema, table).await?;
     let columns = column_metadata
@@ -467,7 +464,11 @@ fn selected_database(dsn: &str) -> Result<String, DbOperationError> {
 }
 
 fn validate_selected_schema(dsn: &str, schema: &str) -> Result<(), DbOperationError> {
-    if schema != selected_database(dsn)? {
+    validate_selected_schema_name(&selected_database(dsn)?, schema)
+}
+
+fn validate_selected_schema_name(database: &str, schema: &str) -> Result<(), DbOperationError> {
+    if schema != database {
         return Err(DbOperationError::UnsupportedOperation(
             "MySQL metadata is limited to the selected database".to_string(),
         ));
@@ -476,8 +477,36 @@ fn validate_selected_schema(dsn: &str, schema: &str) -> Result<(), DbOperationEr
 }
 
 async fn fetch_metadata_snapshot(dsn: &str) -> Result<MysqlMetadataSnapshot, DbOperationError> {
+    fetch_metadata_snapshot_with_runner(dsn, None, |query| async move {
+        execute_metadata_query(dsn, &query).await
+    })
+    .await
+}
+
+async fn fetch_metadata_snapshot_for_schema(
+    dsn: &str,
+    schema: &str,
+) -> Result<MysqlMetadataSnapshot, DbOperationError> {
+    fetch_metadata_snapshot_with_runner(dsn, Some(schema), |query| async move {
+        execute_metadata_query(dsn, &query).await
+    })
+    .await
+}
+
+async fn fetch_metadata_snapshot_with_runner<F, Fut>(
+    dsn: &str,
+    requested_schema: Option<&str>,
+    mut run_query: F,
+) -> Result<MysqlMetadataSnapshot, DbOperationError>
+where
+    F: FnMut(String) -> Fut,
+    Fut: std::future::Future<Output = Result<MysqlResultSet, DbOperationError>>,
+{
     let database = selected_database(dsn)?;
-    let result = execute_metadata_query(dsn, TABLES_QUERY).await?;
+    if let Some(schema) = requested_schema {
+        validate_selected_schema_name(&database, schema)?;
+    }
+    let result = run_query(TABLES_QUERY.to_string()).await?;
     let tables = parse_table_metadata(&result)?;
     let table_summaries = tables
         .iter()
@@ -1128,6 +1157,9 @@ fn is_sql_numeric_literal(value: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
 
     fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
@@ -1146,6 +1178,56 @@ mod tests {
             comment: None,
             ordinal_position: 1,
         }
+    }
+
+    #[tokio::test]
+    async fn metadata_snapshot_runs_tables_query_once() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let snapshot = fetch_metadata_snapshot_with_runner("mysql://localhost:3306/app", None, {
+            let calls = Arc::clone(&calls);
+            move |query| {
+                assert_eq!(query, TABLES_QUERY);
+                calls.fetch_add(1, Ordering::SeqCst);
+                async {
+                    Ok(result(
+                        &["TABLE_NAME", "TABLE_TYPE", "TABLE_ROWS", "TABLE_COMMENT"],
+                        vec![vec![
+                            QueryValue::Text("users".to_string()),
+                            QueryValue::Text("BASE TABLE".to_string()),
+                            QueryValue::Text("1".to_string()),
+                            QueryValue::Null,
+                        ]],
+                    ))
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(snapshot.table_summaries[0].name, "users");
+    }
+
+    #[tokio::test]
+    async fn metadata_schema_mismatch_rejects_before_runner() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let error =
+            fetch_metadata_snapshot_with_runner("mysql://localhost:3306/app", Some("other"), {
+                let calls = Arc::clone(&calls);
+                move |_query| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    async { Ok(result(&[], vec![])) }
+                }
+            })
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DbOperationError::UnsupportedOperation(message)
+                if message == "MySQL metadata is limited to the selected database"
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/src/infra/adapters/mysql/metadata.rs
+++ b/src/infra/adapters/mysql/metadata.rs
@@ -74,6 +74,13 @@ struct MysqlTableMetadata {
 }
 
 #[derive(Debug, Clone)]
+struct MysqlMetadataSnapshot {
+    database: String,
+    tables: Vec<MysqlTableMetadata>,
+    table_summaries: Vec<TableSummary>,
+}
+
+#[derive(Debug, Clone)]
 struct MysqlTriggerMetadata {
     name: String,
     timing: TriggerTiming,
@@ -85,15 +92,10 @@ struct MysqlTriggerMetadata {
 #[async_trait]
 impl MetadataProvider for MySqlAdapter {
     async fn fetch_metadata(&self, dsn: &str) -> Result<DatabaseMetadata, DbOperationError> {
-        let database = selected_database(dsn)?;
-        let result = execute_metadata_query(dsn, TABLES_QUERY).await?;
-        let tables = parse_table_metadata(&result)?;
-        let mut metadata = DatabaseMetadata::new(database.clone());
-        metadata.schemas = vec![Schema::new(database.clone())];
-        metadata.table_summaries = tables
-            .into_iter()
-            .map(|table| table_summary(&database, table))
-            .collect();
+        let snapshot = fetch_metadata_snapshot(dsn).await?;
+        let mut metadata = DatabaseMetadata::new(snapshot.database.clone());
+        metadata.schemas = vec![Schema::new(snapshot.database)];
+        metadata.table_summaries = snapshot.table_summaries;
         Ok(metadata)
     }
 
@@ -103,8 +105,16 @@ impl MetadataProvider for MySqlAdapter {
         schema: &str,
         table: &str,
     ) -> Result<Table, DbOperationError> {
-        let metadata = self.fetch_metadata(dsn).await?;
-        fetch_table(dsn, schema, table, &metadata.table_summaries).await
+        validate_selected_schema(dsn, schema)?;
+        let snapshot = fetch_metadata_snapshot(dsn).await?;
+        fetch_table(
+            dsn,
+            schema,
+            table,
+            &snapshot.tables,
+            &snapshot.table_summaries,
+        )
+        .await
     }
 
     async fn fetch_table_columns_and_fks(
@@ -113,24 +123,31 @@ impl MetadataProvider for MySqlAdapter {
         schema: &str,
         table: &str,
     ) -> Result<Table, DbOperationError> {
-        let metadata = self.fetch_metadata(dsn).await?;
-        fetch_table_columns_and_fks_with_summaries(dsn, schema, table, &metadata.table_summaries)
-            .await
+        validate_selected_schema(dsn, schema)?;
+        let snapshot = fetch_metadata_snapshot(dsn).await?;
+        fetch_table_columns_and_fks_with_summaries(
+            dsn,
+            schema,
+            table,
+            &snapshot.tables,
+            &snapshot.table_summaries,
+        )
+        .await
     }
 
     async fn fetch_table_signatures(
         &self,
         dsn: &str,
     ) -> Result<Vec<TableSignature>, DbOperationError> {
-        let metadata = self.fetch_metadata(dsn).await?;
-        let mut signatures = Vec::with_capacity(metadata.table_summaries.len());
-        let summaries = metadata.table_summaries;
-        for summary in &summaries {
+        let snapshot = fetch_metadata_snapshot(dsn).await?;
+        let mut signatures = Vec::with_capacity(snapshot.table_summaries.len());
+        for summary in &snapshot.table_summaries {
             let detail = fetch_table_columns_and_fks_with_summaries(
                 dsn,
                 &summary.schema,
                 &summary.name,
-                &summaries,
+                &snapshot.tables,
+                &snapshot.table_summaries,
             )
             .await?;
             signatures.push(TableSignature {
@@ -148,7 +165,9 @@ pub(super) async fn fetch_preview_metadata(
     schema: &str,
     table: &str,
 ) -> Result<PreviewMetadata, DbOperationError> {
-    find_table(dsn, schema, table).await?;
+    validate_selected_schema(dsn, schema)?;
+    let snapshot = fetch_metadata_snapshot(dsn).await?;
+    find_table(schema, table, &snapshot.tables)?;
     let column_metadata = fetch_columns(dsn, schema, table).await?;
     let columns = column_metadata
         .iter()
@@ -320,9 +339,10 @@ async fn fetch_table(
     dsn: &str,
     schema: &str,
     table: &str,
+    tables: &[MysqlTableMetadata],
     summaries: &[TableSummary],
 ) -> Result<Table, DbOperationError> {
-    let table_metadata = find_table(dsn, schema, table).await?;
+    let table_metadata = find_table(schema, table, tables)?;
     let columns = fetch_columns(dsn, schema, table).await?;
     let indexes = fetch_indexes(dsn, schema, table).await?;
     let foreign_keys = fetch_foreign_keys(dsn, schema, table, summaries).await?;
@@ -354,9 +374,10 @@ async fn fetch_table_columns_and_fks_with_summaries(
     dsn: &str,
     schema: &str,
     table: &str,
+    tables: &[MysqlTableMetadata],
     summaries: &[TableSummary],
 ) -> Result<Table, DbOperationError> {
-    let table_metadata = find_table(dsn, schema, table).await?;
+    let table_metadata = find_table(schema, table, tables)?;
     let columns = fetch_columns(dsn, schema, table).await?;
     let foreign_keys = fetch_foreign_keys(dsn, schema, table, summaries).await?;
     let primary_key = primary_key_names(&columns);
@@ -380,21 +401,15 @@ async fn fetch_table_columns_and_fks_with_summaries(
     })
 }
 
-async fn find_table(
-    dsn: &str,
+fn find_table(
     schema: &str,
     table: &str,
+    tables: &[MysqlTableMetadata],
 ) -> Result<MysqlTableMetadata, DbOperationError> {
-    let database = selected_database(dsn)?;
-    if schema != database {
-        return Err(DbOperationError::UnsupportedOperation(
-            "MySQL metadata is limited to the selected database".to_string(),
-        ));
-    }
-    let result = execute_metadata_query(dsn, TABLES_QUERY).await?;
-    parse_table_metadata(&result)?
-        .into_iter()
+    tables
+        .iter()
         .find(|candidate| candidate.name == table)
+        .cloned()
         .ok_or_else(|| {
             DbOperationError::ObjectMissing(format!("MySQL table not found: {schema}.{table}"))
         })
@@ -405,17 +420,12 @@ async fn fetch_columns(
     schema: &str,
     table: &str,
 ) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
+    validate_selected_schema(dsn, schema)?;
     let query = format!(
         "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = DATABASE() AND c.TABLE_NAME = {} ORDER BY c.ORDINAL_POSITION",
         quote_string(table)
     );
     let result = execute_metadata_query(dsn, &query).await?;
-    let database = selected_database(dsn)?;
-    if schema != database {
-        return Err(DbOperationError::UnsupportedOperation(
-            "MySQL metadata is limited to the selected database".to_string(),
-        ));
-    }
     let columns = parse_column_metadata(&result)?;
     if columns.is_empty() {
         return Err(DbOperationError::MetadataParseFailed(format!(
@@ -453,6 +463,31 @@ fn selected_database(dsn: &str) -> Result<String, DbOperationError> {
         DbOperationError::UnsupportedOperation(
             "MySQL metadata requires a selected database".to_string(),
         )
+    })
+}
+
+fn validate_selected_schema(dsn: &str, schema: &str) -> Result<(), DbOperationError> {
+    if schema != selected_database(dsn)? {
+        return Err(DbOperationError::UnsupportedOperation(
+            "MySQL metadata is limited to the selected database".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn fetch_metadata_snapshot(dsn: &str) -> Result<MysqlMetadataSnapshot, DbOperationError> {
+    let database = selected_database(dsn)?;
+    let result = execute_metadata_query(dsn, TABLES_QUERY).await?;
+    let tables = parse_table_metadata(&result)?;
+    let table_summaries = tables
+        .iter()
+        .cloned()
+        .map(|table| table_summary(&database, table))
+        .collect();
+    Ok(MysqlMetadataSnapshot {
+        database,
+        tables,
+        table_summaries,
     })
 }
 
@@ -511,6 +546,7 @@ async fn fetch_indexes(
     schema: &str,
     table: &str,
 ) -> Result<Vec<Index>, DbOperationError> {
+    validate_selected_schema(dsn, schema)?;
     let query = format!(
         "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = DATABASE() AND s.TABLE_NAME = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = {}) ORDER BY INDEX_NAME, SEQ_IN_INDEX",
         quote_string(table),
@@ -518,11 +554,6 @@ async fn fetch_indexes(
     );
     let result = execute_metadata_query(dsn, &query).await?;
     let raw = parse_index_metadata(&result)?;
-    if schema != selected_database(dsn)? {
-        return Err(DbOperationError::UnsupportedOperation(
-            "MySQL metadata is limited to the selected database".to_string(),
-        ));
-    }
     Ok(indexes_from_metadata(raw))
 }
 
@@ -532,6 +563,7 @@ async fn fetch_foreign_keys(
     table: &str,
     summaries: &[TableSummary],
 ) -> Result<Vec<ForeignKey>, DbOperationError> {
+    validate_selected_schema(dsn, schema)?;
     let query = format!(
         "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = DATABASE() AND tc.TABLE_NAME = {} AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_SCHEMA = DATABASE() AND TABLE_NAME = {} AND CONSTRAINT_TYPE = 'FOREIGN KEY') ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
         quote_string(table),
@@ -539,11 +571,6 @@ async fn fetch_foreign_keys(
     );
     let result = execute_metadata_query(dsn, &query).await?;
     let raw = parse_foreign_key_metadata(&result)?;
-    if schema != selected_database(dsn)? {
-        return Err(DbOperationError::UnsupportedOperation(
-            "MySQL metadata is limited to the selected database".to_string(),
-        ));
-    }
     foreign_keys_from_metadata(raw, summaries)
 }
 
@@ -552,11 +579,7 @@ async fn fetch_triggers(
     schema: &str,
     table: &str,
 ) -> Result<Vec<Trigger>, DbOperationError> {
-    if schema != selected_database(dsn)? {
-        return Err(DbOperationError::UnsupportedOperation(
-            "MySQL metadata is limited to the selected database".to_string(),
-        ));
-    }
+    validate_selected_schema(dsn, schema)?;
     let result = execute_metadata_query(dsn, &triggers_query(table)).await?;
     triggers_from_metadata(parse_trigger_metadata(&result)?)
 }

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -511,32 +511,33 @@ async fn previews_empty_mysql_table_with_metadata_columns() {
 async fn previews_and_writes_rows_using_hidden_mysql_primary_keys() {
     with_mysql_test_db(|db| {
         Box::pin(async move {
-            let invisible = db
+            let result = async {
+                let invisible = db
                 .adapter()
                 .execute_preview(db.dsn(), "sabiql_test", MYSQL_INVISIBLE_PK_TABLE, 10, 0)
                 .await
                 .map_err(|error| format!("failed to preview invisible primary key: {error:?}"))?;
-            if invisible.columns != ["payload"]
-                || invisible.query.contains("__sabiql_row_identity_")
-                || invisible.values()
-                    != [[QueryValue::Text("invisible single primary key".to_string())]]
-            {
-                return Err(format!(
-                    "unexpected invisible primary key preview: {invisible:?}"
-                ));
-            }
-            let identity = invisible
-                .explicit_row_identity()
-                .ok_or_else(|| "invisible primary key identity was not returned".to_string())?;
-            if identity.columns() != ["id"]
-                || identity.values() != [[QueryValue::SqlLiteral("1".to_string())]]
-            {
-                return Err(format!(
-                    "unexpected invisible primary key identity: {identity:?}"
-                ));
-            }
+                if invisible.columns != ["payload"]
+                    || invisible.query.contains("__sabiql_row_identity_")
+                    || invisible.values()
+                        != [[QueryValue::Text("invisible single primary key".to_string())]]
+                {
+                    return Err(format!(
+                        "unexpected invisible primary key preview: {invisible:?}"
+                    ));
+                }
+                let identity = invisible
+                    .explicit_row_identity()
+                    .ok_or_else(|| "invisible primary key identity was not returned".to_string())?;
+                if identity.columns() != ["id"]
+                    || identity.values() != [[QueryValue::SqlLiteral("1".to_string())]]
+                {
+                    return Err(format!(
+                        "unexpected invisible primary key identity: {identity:?}"
+                    ));
+                }
 
-            let composite = db
+                let composite = db
                 .adapter()
                 .execute_preview(
                     db.dsn(),
@@ -550,7 +551,7 @@ async fn previews_and_writes_rows_using_hidden_mysql_primary_keys() {
             let composite_identity = composite
                 .explicit_row_identity()
                 .ok_or_else(|| "invisible composite identity was not returned".to_string())?;
-            if composite.columns != ["payload"]
+                if composite.columns != ["payload"]
                 || composite.query.contains("__sabiql_row_identity_")
                 || composite_identity.columns() != ["second_key", "first_key"]
                 || composite_identity.values()
@@ -558,38 +559,38 @@ async fn previews_and_writes_rows_using_hidden_mysql_primary_keys() {
                         QueryValue::SqlLiteral("20".to_string()),
                         QueryValue::SqlLiteral("1".to_string()),
                     ]]
-            {
-                return Err(format!(
-                    "unexpected invisible composite preview: {composite:?}"
-                ));
-            }
+                {
+                    return Err(format!(
+                        "unexpected invisible composite preview: {composite:?}"
+                    ));
+                }
 
-            let gipk_detail = db
+                let gipk_detail = db
                 .adapter()
                 .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_GIPK_TABLE)
                 .await
                 .map_err(|error| format!("failed to fetch GIPK metadata: {error:?}"))?;
-            if gipk_detail.primary_key != Some(vec!["my_row_id".to_string()]) {
-                return Err(format!(
-                    "GIPK was not exposed by INFORMATION_SCHEMA: {:?}",
-                    gipk_detail.primary_key
-                ));
-            }
-            let gipk = db
+                if gipk_detail.primary_key != Some(vec!["my_row_id".to_string()]) {
+                    return Err(format!(
+                        "GIPK was not exposed by INFORMATION_SCHEMA: {:?}",
+                        gipk_detail.primary_key
+                    ));
+                }
+                let gipk = db
                 .adapter()
                 .execute_preview(db.dsn(), "sabiql_test", MYSQL_GIPK_TABLE, 10, 0)
                 .await
                 .map_err(|error| format!("failed to preview GIPK: {error:?}"))?;
-            if gipk.columns != ["payload"]
+                if gipk.columns != ["payload"]
                 || gipk.query.contains("__sabiql_row_identity_")
                 || gipk
                     .explicit_row_identity()
                     .is_none_or(|identity| identity.columns() != ["my_row_id"])
-            {
-                return Err(format!("unexpected GIPK preview: {gipk:?}"));
-            }
+                {
+                    return Err(format!("unexpected GIPK preview: {gipk:?}"));
+                }
 
-            let update_sql = db.adapter().build_update_sql(
+                let update_sql = db.adapter().build_update_sql(
                 DatabaseType::MySQL,
                 "sabiql_test",
                 MYSQL_GIPK_TABLE,
@@ -600,16 +601,16 @@ async fn previews_and_writes_rows_using_hidden_mysql_primary_keys() {
                     QueryValue::SqlLiteral("1".to_string()),
                 )],
             );
-            let update = db
+                let update = db
                 .adapter()
                 .execute_write(db.dsn(), &update_sql, AccessMode::ReadWrite)
                 .await
                 .map_err(|error| format!("failed to update through GIPK: {error:?}"))?;
-            if update.affected_rows != 1 {
-                return Err(format!("unexpected GIPK update result: {update:?}"));
-            }
+                if update.affected_rows != 1 {
+                    return Err(format!("unexpected GIPK update result: {update:?}"));
+                }
 
-            let delete_sql = db.adapter().build_bulk_delete_sql(
+                let delete_sql = db.adapter().build_bulk_delete_sql(
                 DatabaseType::MySQL,
                 "sabiql_test",
                 MYSQL_INVISIBLE_PK_TABLE,
@@ -618,19 +619,47 @@ async fn previews_and_writes_rows_using_hidden_mysql_primary_keys() {
                     QueryValue::SqlLiteral("1".to_string()),
                 )]],
             );
-            let delete = db
+                let delete = db
                 .adapter()
                 .execute_write(db.dsn(), &delete_sql, AccessMode::ReadWrite)
                 .await
                 .map_err(|error| {
                     format!("failed to delete through invisible primary key: {error:?}")
                 })?;
-            if delete.affected_rows != 1 {
-                return Err(format!(
-                    "unexpected invisible primary key delete result: {delete:?}"
-                ));
+                if delete.affected_rows != 1 {
+                    return Err(format!(
+                        "unexpected invisible primary key delete result: {delete:?}"
+                    ));
+                }
+                Ok::<(), String>(())
             }
-            Ok(())
+            .await;
+
+            let restore_gipk = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    "UPDATE mysql_edit_gipk SET payload = 'generated invisible primary key' WHERE my_row_id = 1",
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to restore GIPK fixture: {error:?}"));
+            let restore_invisible = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    "INSERT INTO mysql_edit_invisible_pk (id, payload) VALUES (1, 'invisible single primary key')",
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to restore invisible primary key fixture: {error:?}"));
+
+            match result {
+                Err(error) => Err(error),
+                Ok(()) => restore_gipk
+                    .map(|_| ())
+                    .and_then(|()| restore_invisible.map(|_| ())),
+            }
         })
     })
     .await;
@@ -649,12 +678,11 @@ async fn updates_and_bulk_deletes_mysql_rows_with_visible_composite_primary_keys
             let create = format!(
                 "CREATE TABLE {table} (first_key BIGINT UNSIGNED NOT NULL, second_key INT NOT NULL, payload TEXT NOT NULL, PRIMARY KEY (first_key, second_key))"
             );
-            db.adapter()
-                .execute_adhoc(db.dsn(), &create, AccessMode::ReadWrite)
-                .await
-                .map_err(|error| format!("failed to create write fixture: {error:?}"))?;
-
             let result = async {
+                db.adapter()
+                    .execute_adhoc(db.dsn(), &create, AccessMode::ReadWrite)
+                    .await
+                    .map_err(|error| format!("failed to create write fixture: {error:?}"))?;
                 let insert = format!(
                     "INSERT INTO {table} (first_key, second_key, payload) VALUES (18446744073709551615, 7, 'before'), (42, 8, 'second')"
                 );
@@ -743,12 +771,16 @@ async fn updates_and_bulk_deletes_mysql_rows_with_visible_composite_primary_keys
             }
             .await;
 
-            let drop = format!("DROP TABLE {table}");
-            let _ = db
+            let drop = format!("DROP TABLE IF EXISTS {table}");
+            let cleanup = db
                 .adapter()
                 .execute_adhoc(db.dsn(), &drop, AccessMode::ReadWrite)
-                .await;
-            result
+                .await
+                .map_err(|error| format!("failed to clean up write fixture: {error:?}"));
+            match result {
+                Err(error) => Err(error),
+                Ok(()) => cleanup.map(|_| ()),
+            }
         })
     })
     .await;
@@ -767,12 +799,11 @@ async fn updates_mysql_json_documents_as_whole_values() {
             let create = format!(
                 "CREATE TABLE {table} (id INT NOT NULL PRIMARY KEY, payload JSON NOT NULL)"
             );
-            db.adapter()
-                .execute_adhoc(db.dsn(), &create, AccessMode::ReadWrite)
-                .await
-                .map_err(|error| format!("failed to create JSON fixture: {error:?}"))?;
-
             let result = async {
+                db.adapter()
+                    .execute_adhoc(db.dsn(), &create, AccessMode::ReadWrite)
+                    .await
+                    .map_err(|error| format!("failed to create JSON fixture: {error:?}"))?;
                 db.adapter()
                     .execute_adhoc(
                         db.dsn(),
@@ -843,12 +874,16 @@ async fn updates_mysql_json_documents_as_whole_values() {
             }
             .await;
 
-            let drop = format!("DROP TABLE {table}");
-            let _ = db
+            let drop = format!("DROP TABLE IF EXISTS {table}");
+            let cleanup = db
                 .adapter()
                 .execute_adhoc(db.dsn(), &drop, AccessMode::ReadWrite)
-                .await;
-            result
+                .await
+                .map_err(|error| format!("failed to clean up JSON fixture: {error:?}"));
+            match result {
+                Err(error) => Err(error),
+                Ok(()) => cleanup.map(|_| ()),
+            }
         })
     })
     .await;
@@ -858,33 +893,41 @@ async fn updates_mysql_json_documents_as_whole_values() {
 #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
 async fn executes_multiple_statements_and_returns_only_the_last_result() {
     with_mysql_test_db(|db| Box::pin(async move {
-        let result = db
-            .adapter()
-            .execute_adhoc(
-                db.dsn(),
-                &format!(
-                    "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'multi statement' WHERE id = 1; SELECT empty_text FROM {MYSQL_FIXTURE_TABLE} WHERE id = 1"
-                ),
-                AccessMode::ReadWrite,
-            )
-            .await
-            .map_err(|error| format!("{error:?}"))?;
-        if result.columns != ["empty_text"]
-            || result.values() != [[QueryValue::Text("multi statement".to_string())]]
-            || result.command_tag != Some(CommandTag::Update(1))
-            || result.refresh_scope != RefreshScope::Data
-        {
-            return Err(format!("unexpected multi-statement result: {result:?}"));
+        let result = async {
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'multi statement' WHERE id = 1; SELECT empty_text FROM {MYSQL_FIXTURE_TABLE} WHERE id = 1"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("{error:?}"))?;
+            if result.columns != ["empty_text"]
+                || result.values() != [[QueryValue::Text("multi statement".to_string())]]
+                || result.command_tag != Some(CommandTag::Update(1))
+                || result.refresh_scope != RefreshScope::Data
+            {
+                return Err(format!("unexpected multi-statement result: {result:?}"));
+            }
+            Ok::<(), String>(())
         }
-        db.adapter()
+        .await;
+        let cleanup = db
+            .adapter()
             .execute_adhoc(
                 db.dsn(),
                 &format!("UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = '' WHERE id = 1"),
                 AccessMode::ReadWrite,
             )
             .await
-            .map_err(|error| format!("failed to restore fixture: {error:?}"))?;
-        Ok(())
+            .map_err(|error| format!("failed to restore fixture: {error:?}"));
+        match result {
+            Err(error) => Err(error),
+            Ok(()) => cleanup.map(|_| ()),
+        }
     }))
     .await;
 }
@@ -893,34 +936,42 @@ async fn executes_multiple_statements_and_returns_only_the_last_result() {
 #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
 async fn keeps_refresh_scope_and_discards_partial_result_after_a_later_failure() {
     with_mysql_test_db(|db| Box::pin(async move {
-        let result = db
-            .adapter()
-            .execute_adhoc(
-                db.dsn(),
-                &format!(
-                    "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'changed before failure' WHERE id = 1; SELECT missing_column FROM {MYSQL_FIXTURE_TABLE}"
-                ),
-                AccessMode::ReadWrite,
-            )
-            .await;
-        if !matches!(
-            result,
-            Err(DbOperationError::QueryFailedAfterChange {
-                refresh_scope: RefreshScope::Data,
-                ..
-            })
-        ) {
-            return Err(format!("expected partial-change failure: {result:?}"));
+        let result = async {
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'changed before failure' WHERE id = 1; SELECT missing_column FROM {MYSQL_FIXTURE_TABLE}"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await;
+            if !matches!(
+                result,
+                Err(DbOperationError::QueryFailedAfterChange {
+                    refresh_scope: RefreshScope::Data,
+                    ..
+                })
+            ) {
+                return Err(format!("expected partial-change failure: {result:?}"));
+            }
+            Ok::<(), String>(())
         }
-        db.adapter()
+        .await;
+        let cleanup = db
+            .adapter()
             .execute_adhoc(
                 db.dsn(),
                 &format!("UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = '' WHERE id = 1"),
                 AccessMode::ReadWrite,
             )
             .await
-            .map_err(|error| format!("failed to restore fixture: {error:?}"))?;
-        Ok(())
+            .map_err(|error| format!("failed to restore fixture: {error:?}"));
+        match result {
+            Err(error) => Err(error),
+            Ok(()) => cleanup.map(|_| ()),
+        }
     }))
     .await;
 }
@@ -1002,24 +1053,30 @@ async fn reports_metadata_scope_when_a_later_ddl_statement_fails() {
                     AccessMode::ReadWrite,
                 )
                 .await;
-            if !matches!(
-                result,
+            let result = if matches!(
+                result.as_ref(),
                 Err(DbOperationError::QueryFailedAfterChange {
                     refresh_scope: RefreshScope::Metadata,
                     ..
                 })
             ) {
-                return Err(format!("expected metadata-scope failure: {result:?}"));
-            }
-            db.adapter()
+                Ok(())
+            } else {
+                Err(format!("expected metadata-scope failure: {result:?}"))
+            };
+            let cleanup = db
+                .adapter()
                 .execute_adhoc(
                     db.dsn(),
                     &format!("DROP TABLE IF EXISTS {table}"),
                     AccessMode::ReadWrite,
                 )
                 .await
-                .map_err(|error| format!("failed to clean up DDL fixture: {error:?}"))?;
-            Ok(())
+                .map_err(|error| format!("failed to clean up DDL fixture: {error:?}"));
+            match result {
+                Err(error) => Err(error),
+                Ok(()) => cleanup.map(|_| ()),
+            }
         })
     })
     .await;


### PR DESCRIPTION
## Problem

The MySQL feature branch has a bounded set of non-blocking correctness, safety, and performance issues identified during semantic review.

## Background

This PR contains only the selected fixes from the first through fourth review groups. Later review groups are intentionally excluded.

## Approach

- Upgrade the infra quick-xml dependency and preserve XML entity decoding.
- Move synchronous connection-store writes out of Tokio workers.
- Revalidate paired TLS fields, reset picker state, preserve confirmation-name case, and mask probe DSNs in Debug output.
- Reuse one MySQL metadata table snapshot and validate schema scope before queries.
- Fix escaped-backtick completion, MySQL display keywords, ER run-id filtering, and integration-fixture cleanup.
- Correct the MySQL integration shell fail-fast declaration.

Validation completed: formatting, focused tests, workspace nextest with all/default features, clippy, release builds, lint checks, self-update backend check, and cargo audit. Docker MySQL integration was blocked by a Docker image blob I/O error; cargo-deny is blocked by the installed version not supporting edition 2024; cargo-machete is unavailable.

## Screenshots

N/A

## Linear Issue Link

N/A