### PR TITLE
fix(mysql): handle final review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,16 +129,18 @@ Open Settings with `,` to switch themes, keymap presets, and the ER diagram brow
 Install the CLI for the database you want to open:
 
 - **PostgreSQL:** `psql` (PostgreSQL client)
-- **MySQL:** Oracle MySQL server 8.4 LTS and the Oracle `mysql` CLI from the 8.4 series
+- **MySQL:** the Oracle `mysql` CLI from the 8.4 series
 - **SQLite:** `sqlite3` (SQLite shell), version 3.41.1 or later.
+
+The supported MySQL server is Oracle MySQL 8.4 LTS. When connecting to a remote TCP server, install the local `mysql` CLI; a local MySQL server is not required.
 
 Optional:
 
-- Graphviz (for ER diagrams on PostgreSQL and MySQL): `brew install graphviz`
+- Graphviz (for ER diagrams on PostgreSQL and MySQL): on macOS, `brew install graphviz`. On Linux or Windows, install Graphviz from the [official Graphviz site](https://graphviz.org/download/) or your platform's package manager.
 
 ### Android / Termux
 
-Android/Termux support is build-only, not full platform support. `cargo install sabiql` should compile on Android, but clipboard yank is unavailable because the desktop clipboard backend is not supported there. Install `psql` for PostgreSQL, `mysql` for MySQL, and `sqlite3` for SQLite.
+Android/Termux support is build-only, not full platform support. `cargo install sabiql` should compile on Android, but clipboard yank is unavailable because the desktop clipboard backend is not supported there. Install `psql` for PostgreSQL, `mysql` for MySQL, and `sqlite3` for SQLite. Graphviz and ER diagram use are not guaranteed on Android/Termux.
 
 ## SQLite Limitations
 
@@ -161,10 +163,10 @@ MySQL support targets Oracle MySQL server 8.4 LTS with the Oracle `mysql` CLI fr
 - **No persistent session state** — sabiql starts a new `mysql` process for each operation. Temporary tables, session variables, and transactions do not carry over to the next SQL submission. Multiple statements in one submission share one process and session.
 - **Supported SQL scope** — The SQL modal supports reads such as `SELECT`, `TABLE`, `SHOW`, and `DESCRIBE`, DML (`INSERT`, `UPDATE`, and `DELETE`), table/view/index DDL, and simple explicit transactions. Database/account/role/replication/server/plugin/routine/event/trigger administration statements are not supported. `REPLACE`, `CALL`, `DO`, `HANDLER`, `LOAD DATA`/`LOAD XML`, table-maintenance statements, prepared statements, XA statements, and compound statements are also rejected.
 - **No session or table-control SQL** — User `USE`, `SET`, `LOCK TABLES`, and `UNLOCK TABLES` statements are rejected. MySQL client commands such as `source`, `system`, `charset`, and backslash commands are rejected, as is `DELIMITER`.
-- **SQL mode** — Connections using `NO_BACKSLASH_ESCAPES` or `ANSI_QUOTES` are rejected. Those modes are required for some MySQL quoting styles that sabiql does not support.
+- **SQL mode** — Connections using `NO_BACKSLASH_ESCAPES` or `ANSI_QUOTES` are rejected because those modes enable escape or identifier-quoting semantics that sabiql does not support.
 - **NUL in text** — The MySQL CLI XML output cannot preserve NUL characters embedded in text values.
 - **Binary values in arbitrary SQL** — Arbitrary SQL results do not include reliable column type metadata, so binary values are kept as the CLI's `0x...` text representation. Known binary columns in table previews are handled as Blob values.
-- **TLS client keys** — Passphrase-protected client keys are not supported. Use an unencrypted PEM private key.
+- **TLS client keys** — Passphrase-protected client keys are not supported. An unencrypted PEM private key can be used, but it weakens at-rest protection; store it with restrictive file permissions.
 - **System databases** — `information_schema`, `mysql`, `performance_schema`, and `sys` are omitted from the MySQL Database Picker.
 - **Grid editing scope** — Views, tables without a retrievable primary key, and generated columns are read-only in the grid. Invisible primary keys and generated invisible primary keys are used for row identity when available but are not shown as grid columns.
 - **CSV representation** — NULL values are exported as empty fields. Known cached Blob values use uppercase hexadecimal strings; binary values from type-unknown arbitrary SQL keep the CLI's `0x...` representation.

--- a/src/app/policy/sql/mysql_statement.rs
+++ b/src/app/policy/sql/mysql_statement.rs
@@ -831,20 +831,7 @@ pub fn mysql_explain_rejection_message(sql: &str) -> Option<&'static str> {
 
 pub fn mysql_tree_explain_query_kind(sql: &str) -> Option<bool> {
     let trimmed = sql.trim();
-    let (is_analyze, target) = if let Some(target) =
-        strip_ascii_prefix_case_insensitive(trimmed, "EXPLAIN ANALYZE FORMAT=TREE")
-    {
-        (true, target)
-    } else if let Some(target) = strip_ascii_prefix_case_insensitive(trimmed, "EXPLAIN FORMAT=TREE")
-    {
-        (false, target)
-    } else {
-        return None;
-    };
-
-    if target.is_empty() || !target.chars().next().is_some_and(char::is_whitespace) {
-        return None;
-    }
+    let (is_analyze, target) = strip_mysql_tree_explain_prefix(trimmed)?;
     let target = target.trim();
 
     let valid = if is_analyze {
@@ -864,10 +851,64 @@ pub fn mysql_tree_explain_query_kind(sql: &str) -> Option<bool> {
     valid.then_some(is_analyze)
 }
 
-fn strip_ascii_prefix_case_insensitive<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
-    text.get(..prefix.len())
-        .filter(|candidate| candidate.eq_ignore_ascii_case(prefix))
-        .map(|_| &text[prefix.len()..])
+fn strip_mysql_tree_explain_prefix(text: &str) -> Option<(bool, &str)> {
+    let mut index = 0;
+    consume_mysql_keyword(text, &mut index, "EXPLAIN")?;
+    consume_required_ascii_whitespace(text, &mut index)?;
+
+    let is_analyze = if consume_mysql_keyword(text, &mut index, "ANALYZE").is_some() {
+        consume_required_ascii_whitespace(text, &mut index)?;
+        true
+    } else {
+        false
+    };
+
+    consume_mysql_keyword(text, &mut index, "FORMAT")?;
+    skip_ascii_whitespace(text, &mut index);
+    if text.as_bytes().get(index) != Some(&b'=') {
+        return None;
+    }
+    index += 1;
+    skip_ascii_whitespace(text, &mut index);
+    consume_mysql_keyword(text, &mut index, "TREE")?;
+
+    let target = text.get(index..)?;
+    if target.is_empty() || !target.as_bytes()[0].is_ascii_whitespace() {
+        return None;
+    }
+    Some((is_analyze, target))
+}
+
+fn consume_mysql_keyword(text: &str, index: &mut usize, keyword: &str) -> Option<()> {
+    let candidate = text.get(*index..(*index).saturating_add(keyword.len()))?;
+    if !candidate.eq_ignore_ascii_case(keyword) {
+        return None;
+    }
+    if text
+        .as_bytes()
+        .get(index.saturating_add(keyword.len()))
+        .is_some_and(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$'))
+    {
+        return None;
+    }
+    *index += keyword.len();
+    Some(())
+}
+
+fn skip_ascii_whitespace(text: &str, index: &mut usize) {
+    while text
+        .as_bytes()
+        .get(*index)
+        .is_some_and(u8::is_ascii_whitespace)
+    {
+        *index += 1;
+    }
+}
+
+fn consume_required_ascii_whitespace(text: &str, index: &mut usize) -> Option<()> {
+    let start = *index;
+    skip_ascii_whitespace(text, index);
+    (*index > start).then_some(())
 }
 
 pub fn has_top_level_into_clause(sql: &str) -> Result<bool, MysqlLexError> {
@@ -1207,5 +1248,30 @@ mod tests {
             mysql_tree_explain_query_kind("EXPLAIN ANALYZE FORMAT=TREE DELETE FROM items"),
             None
         );
+    }
+
+    #[test]
+    fn recognizes_tree_explain_queries_with_whitespace_around_equals() {
+        assert_eq!(
+            mysql_tree_explain_query_kind("EXPLAIN FORMAT = TREE UPDATE items SET value = 1"),
+            Some(false)
+        );
+        assert_eq!(
+            mysql_tree_explain_query_kind("EXPLAIN ANALYZE FORMAT = TREE TABLE items"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn tree_explain_prefix_keeps_keyword_boundaries_and_ignores_non_sql_text() {
+        for sql in [
+            "EXPLAIN FORMAT = JSON SELECT 1",
+            "EXPLAIN FORMAT = TREEish SELECT 1",
+            "EXPLAINFORMAT = TREE SELECT 1",
+            "/* EXPLAIN FORMAT = TREE */ SELECT 1",
+            "SELECT 'EXPLAIN FORMAT = TREE SELECT 1'",
+        ] {
+            assert_eq!(mysql_tree_explain_query_kind(sql), None, "{sql}");
+        }
     }
 }

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -1240,6 +1240,59 @@ mod tests {
             assert_eq!(state.explain.error, None);
             assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
         }
+
+        #[test]
+        fn mismatched_database_generation_does_not_replace_plan_with_error() {
+            let mut state = sql_modal_state();
+            test_fixtures::activate_mysql_connection(&mut state, "mysql://test");
+            state.explain.set_plan(
+                "original plan".to_string(),
+                DatabaseType::MySQL,
+                false,
+                10,
+                "SELECT old",
+            );
+            state.explain.set_plan(
+                "latest plan".to_string(),
+                DatabaseType::MySQL,
+                false,
+                20,
+                "SELECT latest",
+            );
+            let left_query = state.explain.left().unwrap().full_query.clone();
+            let right_query = state.explain.right().unwrap().full_query.clone();
+            let database_generation = state.session.database_generation();
+            let run_id = state.query.begin_running(Instant::now());
+            state.sql_modal.set_status_for_test(SqlModalStatus::Running);
+
+            let id = state.session.active_connection_id().cloned().unwrap();
+            let name = state.session.active_connection_name().unwrap().to_string();
+            state.session.activate_connection_with_target(
+                &id,
+                &name,
+                DatabaseType::MySQL,
+                "mysql://test",
+                Some("analytics"),
+            );
+
+            reduce_explain(
+                &mut state,
+                &Action::ExplainFailed {
+                    dsn: "mysql://test".to_string(),
+                    database_generation,
+                    run_id,
+                    error: DbOperationError::QueryFailed("stale error".to_string()),
+                    is_analyze: false,
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(state.explain.plan_text(), Some("latest plan"));
+            assert_eq!(state.explain.error(), None);
+            assert_eq!(state.explain.left().unwrap().full_query, left_query);
+            assert_eq!(state.explain.right().unwrap().full_query, right_query);
+            assert_eq!(*state.sql_modal.status(), SqlModalStatus::Running);
+        }
     }
 
     mod compare_workflow {


### PR DESCRIPTION
## Problem\n\nMySQL TREE EXPLAIN accepts valid whitespace around the format separator, and stale ExplainFailed responses cannot overwrite current state.\n\n## Background\n\nThe final semantic review identified two focused behavior regressions and four documentation clarifications for the MySQL rollout.\n\n## Approach\n\nKeep the existing run-generation guard and scanner responsibilities, add focused regression coverage, and clarify the local CLI, server, Graphviz, SQL mode, and TLS key requirements without expanding implementation scope.