### PR TITLE
fix(mysql): propagate ER prefetch run identity

### DIFF
--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -144,6 +144,7 @@ pub enum Effect {
         failed_tables: Vec<(String, String)>,
     },
     ExtractFkNeighbors {
+        run_id: u64,
         seed_tables: Vec<String>,
     },
     SmartErRefresh {

--- a/src/app/cmd/er/handler.rs
+++ b/src/app/cmd/er/handler.rs
@@ -56,9 +56,10 @@ pub async fn run(
             )
             .await
         }
-        Effect::ExtractFkNeighbors { seed_tables } => {
-            handle_extract_fk_neighbors(action_tx, completion_engine, seed_tables).await
-        }
+        Effect::ExtractFkNeighbors {
+            run_id,
+            seed_tables,
+        } => handle_extract_fk_neighbors(action_tx, completion_engine, run_id, seed_tables).await,
         Effect::WriteErFailureLog { failed_tables } => {
             handle_write_failure_log(
                 action_tx,
@@ -149,6 +150,7 @@ async fn handle_generate_diagram(
 async fn handle_extract_fk_neighbors(
     action_tx: &mpsc::Sender<Action>,
     completion_engine: &RefCell<CompletionEngine>,
+    run_id: u64,
     seed_tables: Vec<String>,
 ) -> Result<()> {
     let seed_set: HashSet<&str> = seed_tables.iter().map(String::as_str).collect();
@@ -156,7 +158,10 @@ async fn handle_extract_fk_neighbors(
     let neighbors = fk_neighbors_of_seeds(&cached_seeds, &seed_set, &cached_names);
 
     action_tx
-        .send(Action::FkNeighborsDiscovered { tables: neighbors })
+        .send(Action::FkNeighborsDiscovered {
+            run_id,
+            tables: neighbors,
+        })
         .await
         .ok();
     Ok(())

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -534,8 +534,11 @@ pub enum Action {
     StartPrefetchScoped {
         tables: Vec<String>,
     },
-    ExpandPrefetchWithFkNeighbors,
+    ExpandPrefetchWithFkNeighbors {
+        run_id: u64,
+    },
     FkNeighborsDiscovered {
+        run_id: u64,
         tables: Vec<String>,
     },
     ProcessPrefetchQueue {

--- a/src/app/update/browse/metadata/er_neighbors.rs
+++ b/src/app/update/browse/metadata/er_neighbors.rs
@@ -13,14 +13,20 @@ pub(super) fn reduce_er_neighbors(
     now: Instant,
 ) -> DispatchResult {
     match action {
-        Action::ExpandPrefetchWithFkNeighbors => {
-            let seed_tables = state.er_preparation.seed_tables().to_vec();
-            DispatchResult::handled_with(vec![Effect::ExtractFkNeighbors { seed_tables }])
-        }
-        Action::FkNeighborsDiscovered { tables } => {
-            let Some(run_id) = state.sql_modal.active_prefetch_run_id() else {
+        Action::ExpandPrefetchWithFkNeighbors { run_id } => {
+            if !state.sql_modal.is_current_prefetch_run(*run_id) {
                 return DispatchResult::handled();
-            };
+            }
+            let seed_tables = state.er_preparation.seed_tables().to_vec();
+            DispatchResult::handled_with(vec![Effect::ExtractFkNeighbors {
+                run_id: *run_id,
+                seed_tables,
+            }])
+        }
+        Action::FkNeighborsDiscovered { run_id, tables } => {
+            if !state.sql_modal.is_current_prefetch_run(*run_id) {
+                return DispatchResult::handled();
+            }
             state.er_preparation.mark_fk_expanded();
 
             if tables.is_empty() {
@@ -36,7 +42,7 @@ pub(super) fn reduce_er_neighbors(
                     state.sql_modal.queue_table_prefetch(qualified_name.clone());
                 }
             }
-            DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue { run_id }])
+            DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue { run_id: *run_id }])
         }
         _ => DispatchResult::pass(),
     }

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -17,8 +17,11 @@ pub(super) fn check_er_completion(state: &mut AppState, now: Instant) -> Vec<Eff
     }
 
     if !state.er_preparation.fk_expanded() {
+        let Some(run_id) = state.sql_modal.active_prefetch_run_id() else {
+            return vec![];
+        };
         return vec![Effect::DispatchActions(vec![
-            Action::ExpandPrefetchWithFkNeighbors,
+            Action::ExpandPrefetchWithFkNeighbors { run_id },
         ])];
     }
 
@@ -899,6 +902,7 @@ mod tests {
         #[test]
         fn complete_not_fk_expanded_dispatches_expand() {
             let mut state = state_with_dsn("postgres://localhost/test");
+            let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state.er_preparation.mark_fk_unexpanded();
             // pending and fetching are empty → is_complete() = true
@@ -908,7 +912,11 @@ mod tests {
             assert!(effects.iter().any(|e| matches!(
                 e,
                 Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::ExpandPrefetchWithFkNeighbors))
+                    if actions.iter().any(|a| matches!(
+                        a,
+                        Action::ExpandPrefetchWithFkNeighbors { run_id: action_run_id }
+                            if *action_run_id == run_id
+                    ))
             )));
         }
 
@@ -926,6 +934,28 @@ mod tests {
                     if actions.iter().any(|a| matches!(a, Action::ErGenerateFromCache))
             )));
         }
+
+        #[test]
+        fn stale_expand_does_not_start_neighbor_extraction() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let stale_run_id = state.sql_modal.begin_prefetch();
+            let current_run_id = state.sql_modal.begin_prefetch();
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::ExpandPrefetchWithFkNeighbors {
+                    run_id: stale_run_id,
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert_eq!(
+                state.sql_modal.active_prefetch_run_id(),
+                Some(current_run_id)
+            );
+            assert!(effects.is_empty());
+        }
     }
 
     mod fk_neighbors_discovered {
@@ -935,12 +965,15 @@ mod tests {
         #[test]
         fn empty_neighbors_dispatches_generate() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let _ = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting_for_test();
 
             let effects = dispatch_metadata(
                 &mut state,
-                &Action::FkNeighborsDiscovered { tables: vec![] },
+                &Action::FkNeighborsDiscovered {
+                    run_id,
+                    tables: vec![],
+                },
                 Instant::now(),
             )
             .unwrap();
@@ -956,12 +989,13 @@ mod tests {
         #[test]
         fn non_empty_neighbors_adds_to_queue() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let _ = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting_for_test();
 
             let effects = dispatch_metadata(
                 &mut state,
                 &Action::FkNeighborsDiscovered {
+                    run_id,
                     tables: vec!["public.posts".to_string(), "public.tags".to_string()],
                 },
                 Instant::now(),
@@ -998,6 +1032,7 @@ mod tests {
             let effects = dispatch_metadata(
                 &mut state,
                 &Action::FkNeighborsDiscovered {
+                    run_id: 1,
                     tables: vec!["public.posts".to_string()],
                 },
                 Instant::now(),
@@ -1011,9 +1046,35 @@ mod tests {
         }
 
         #[test]
+        fn stale_neighbors_from_previous_run_do_not_mutate_current_run() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let stale_run_id = state.sql_modal.begin_prefetch();
+            let current_run_id = state.sql_modal.begin_prefetch();
+            state.er_preparation.mark_waiting_for_test();
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::FkNeighborsDiscovered {
+                    run_id: stale_run_id,
+                    tables: vec!["public.posts".to_string()],
+                },
+                Instant::now(),
+            )
+            .unwrap();
+
+            assert_eq!(
+                state.sql_modal.active_prefetch_run_id(),
+                Some(current_run_id)
+            );
+            assert!(!state.er_preparation.fk_expanded());
+            assert!(state.er_preparation.pending_tables().is_empty());
+            assert!(effects.is_empty());
+        }
+
+        #[test]
         fn duplicate_neighbors_are_not_requeued() {
             let mut state = state_with_dsn("postgres://localhost/test");
-            let _ = state.sql_modal.begin_prefetch();
+            let run_id = state.sql_modal.begin_prefetch();
             state.er_preparation.mark_waiting_for_test();
             state
                 .er_preparation
@@ -1028,6 +1089,7 @@ mod tests {
             dispatch_metadata(
                 &mut state,
                 &Action::FkNeighborsDiscovered {
+                    run_id,
                     tables: vec![
                         "public.posts".to_string(),
                         "public.tags".to_string(),


### PR DESCRIPTION
## Problem
FK neighbor discovery could complete after a newer prefetch run and apply stale tables to the current ER preparation.

## Background
The asynchronous neighbor extraction action did not retain the prefetch run that started it. Its completion handler instead looked up whichever run was active when the result arrived.

## Approach
Carry the prefetch run identity through the expand action, extraction effect, and discovery action, and ignore mismatched runs at both reducer boundaries. Add regression coverage for stale expansion and stale discovery results.

## Validation
- `cargo test -p sabiql-app`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
- `bash scripts/lint_all.sh`
- `cargo test -p sabiql --no-default-features`
- `cargo test --workspace --all-features` (one unrelated pre-existing SQLite export test fails in this local environment)

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-405
