### PR TITLE
fix(mysql): parse functional index metadata

### DIFF
--- a/scripts/init-mysql.sql
+++ b/scripts/init-mysql.sql
@@ -112,6 +112,23 @@ CREATE TABLE mysql_metadata_child (
 INSERT INTO mysql_metadata_child (parent_first, parent_second, payload)
 VALUES (1, 2, 'child row');
 
+CREATE TABLE mysql_metadata_functional (
+    id INT NOT NULL,
+    payload JSON NOT NULL,
+    sort_key INT NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_mysql_metadata_functional_json (
+        (CAST(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.code')) AS CHAR(32)))
+    ),
+    KEY idx_mysql_metadata_functional_mixed (
+        (CAST(JSON_UNQUOTE(JSON_EXTRACT(payload, '$.code')) AS CHAR(32))),
+        sort_key
+    )
+) CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_metadata_functional (id, payload, sort_key)
+VALUES (1, '{"code":"A-001"}', 10);
+
 CREATE TABLE mysql_preview_no_pk (
     duplicate_value VARCHAR(20) NOT NULL,
     payload TEXT NOT NULL

--- a/src/infra/adapters/mysql/metadata.rs
+++ b/src/infra/adapters/mysql/metadata.rs
@@ -35,6 +35,7 @@ struct MysqlIndexMetadata {
     index_type: String,
     ordinal_position: i32,
     column_name: String,
+    expression: Option<String>,
     primary: bool,
 }
 
@@ -577,7 +578,7 @@ async fn fetch_indexes(
 ) -> Result<Vec<Index>, DbOperationError> {
     validate_selected_schema(dsn, schema)?;
     let query = format!(
-        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = DATABASE() AND s.TABLE_NAME = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = {}) ORDER BY INDEX_NAME, SEQ_IN_INDEX",
+        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.EXPRESSION, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = DATABASE() AND s.TABLE_NAME = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = {}) ORDER BY INDEX_NAME, SEQ_IN_INDEX",
         quote_string(table),
         quote_string(table),
     );
@@ -793,6 +794,7 @@ fn parse_index_metadata(
             "INDEX_TYPE",
             "SEQ_IN_INDEX",
             "COLUMN_NAME",
+            "EXPRESSION",
             "IS_PRIMARY",
         ],
     )?;
@@ -800,19 +802,40 @@ fn parse_index_metadata(
         .values
         .iter()
         .map(|row| {
+            if row.len() != 7 {
+                return Err(metadata_shape_error("STATISTICS row"));
+            }
             if row.iter().all(|value| matches!(value, QueryValue::Null)) {
                 return Ok(None);
             }
-            if row.len() != 6 {
-                return Err(metadata_shape_error("STATISTICS row"));
-            }
+            let column_name = optional_text(&row[4], "COLUMN_NAME")?;
+            let expression = optional_text(&row[5], "EXPRESSION")?;
+            let (column_name, expression) = match (column_name, expression) {
+                (Some(column_name), None) => (column_name.to_string(), None),
+                (None, Some(expression)) => {
+                    let expression = expression.to_string();
+                    (expression.clone(), Some(expression))
+                }
+                (None, None) => {
+                    return Err(DbOperationError::MetadataParseFailed(
+                        "MySQL metadata key part has neither COLUMN_NAME nor EXPRESSION"
+                            .to_string(),
+                    ));
+                }
+                (Some(_), Some(_)) => {
+                    return Err(DbOperationError::MetadataParseFailed(
+                        "MySQL metadata key part has both COLUMN_NAME and EXPRESSION".to_string(),
+                    ));
+                }
+            };
             Ok(Some(MysqlIndexMetadata {
                 name: required_text(&row[0], "INDEX_NAME")?.to_string(),
                 non_unique: parse_boolean_flag(&row[1], "NON_UNIQUE")?,
                 index_type: required_text(&row[2], "INDEX_TYPE")?.to_string(),
                 ordinal_position: parse_positive_i32(&row[3], "SEQ_IN_INDEX")?,
-                column_name: required_text(&row[4], "COLUMN_NAME")?.to_string(),
-                primary: parse_boolean_flag(&row[5], "IS_PRIMARY")?,
+                column_name,
+                expression,
+                primary: parse_boolean_flag(&row[6], "IS_PRIMARY")?,
             }))
         })
         .collect::<Result<Vec<_>, _>>()
@@ -877,18 +900,29 @@ fn indexes_from_metadata(mut raw: Vec<MysqlIndexMetadata>) -> Vec<Index> {
             .find(|index: &&mut Index| index.name == column.name)
         {
             index.columns.push(column.column_name);
+            if let Some(expression) = column.expression {
+                index.attributes = index.attributes | IndexAttributes::EXPRESSION;
+                index.definition = Some(match index.definition.take() {
+                    Some(definition) => format!("{definition}, {expression}"),
+                    None => expression,
+                });
+            }
             continue;
+        }
+        let mut attributes = IndexAttributes::from_parts(!column.non_unique, column.primary);
+        if column.expression.is_some() {
+            attributes = attributes | IndexAttributes::EXPRESSION;
         }
         indexes.push(Index {
             name: column.name,
             columns: vec![column.column_name],
-            attributes: IndexAttributes::from_parts(!column.non_unique, column.primary),
+            attributes,
             index_type: column
                 .index_type
                 .to_ascii_lowercase()
                 .parse::<IndexType>()
                 .unwrap_or_else(|never| match never {}),
-            definition: None,
+            definition: column.expression,
         });
     }
     indexes
@@ -1530,6 +1564,7 @@ mod tests {
                 "INDEX_TYPE",
                 "SEQ_IN_INDEX",
                 "COLUMN_NAME",
+                "EXPRESSION",
                 "IS_PRIMARY",
             ],
             vec![
@@ -1539,6 +1574,7 @@ mod tests {
                     QueryValue::Text("BTREE".to_string()),
                     QueryValue::Text("2".to_string()),
                     QueryValue::Text("second_key".to_string()),
+                    QueryValue::Null,
                     QueryValue::Text("YES".to_string()),
                 ],
                 vec![
@@ -1547,6 +1583,7 @@ mod tests {
                     QueryValue::Text("BTREE".to_string()),
                     QueryValue::Text("1".to_string()),
                     QueryValue::Text("first_key".to_string()),
+                    QueryValue::Null,
                     QueryValue::Text("YES".to_string()),
                 ],
                 vec![
@@ -1555,6 +1592,7 @@ mod tests {
                     QueryValue::Text("FULLTEXT".to_string()),
                     QueryValue::Text("1".to_string()),
                     QueryValue::Text("body".to_string()),
+                    QueryValue::Null,
                     QueryValue::Text("NO".to_string()),
                 ],
             ],
@@ -1570,6 +1608,109 @@ mod tests {
             IndexType::Other("fulltext".to_string())
         );
         assert!(!indexes[1].is_unique());
+    }
+
+    #[test]
+    fn parses_functional_and_mixed_indexes_in_key_part_order() {
+        let result = result(
+            &[
+                "INDEX_NAME",
+                "NON_UNIQUE",
+                "INDEX_TYPE",
+                "SEQ_IN_INDEX",
+                "COLUMN_NAME",
+                "EXPRESSION",
+                "IS_PRIMARY",
+            ],
+            vec![
+                vec![
+                    QueryValue::Text("idx_mixed".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Text("sort_key".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("NO".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("idx_functional".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("lower(`payload`->>'$.code')".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("idx_mixed".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("lower(`payload`->>'$.code')".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                ],
+            ],
+        );
+
+        let indexes = indexes_from_metadata(parse_index_metadata(&result).unwrap());
+        let functional = &indexes[0];
+        assert_eq!(functional.name, "idx_functional");
+        assert_eq!(
+            functional.columns,
+            ["lower(`payload`->>'$.code')".to_string()]
+        );
+        assert!(functional.has_expression());
+        assert_eq!(
+            functional.definition.as_deref(),
+            Some("lower(`payload`->>'$.code')")
+        );
+
+        let mixed = &indexes[1];
+        assert_eq!(mixed.name, "idx_mixed");
+        assert_eq!(
+            mixed.columns,
+            [
+                "lower(`payload`->>'$.code')".to_string(),
+                "sort_key".to_string()
+            ]
+        );
+        assert!(mixed.has_expression());
+        assert_eq!(
+            mixed.definition.as_deref(),
+            Some("lower(`payload`->>'$.code')")
+        );
+    }
+
+    #[test]
+    fn rejects_index_key_part_without_column_or_expression() {
+        let result = result(
+            &[
+                "INDEX_NAME",
+                "NON_UNIQUE",
+                "INDEX_TYPE",
+                "SEQ_IN_INDEX",
+                "COLUMN_NAME",
+                "EXPRESSION",
+                "IS_PRIMARY",
+            ],
+            vec![vec![
+                QueryValue::Text("idx_invalid".to_string()),
+                QueryValue::Text("1".to_string()),
+                QueryValue::Text("BTREE".to_string()),
+                QueryValue::Text("1".to_string()),
+                QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Text("NO".to_string()),
+            ]],
+        );
+
+        let error = parse_index_metadata(&result).unwrap_err();
+        assert!(matches!(
+            error,
+            DbOperationError::MetadataParseFailed(message)
+                if message.contains("neither COLUMN_NAME nor EXPRESSION")
+        ));
     }
 
     #[test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -37,6 +37,7 @@ const MYSQL_EMPTY_TABLE: &str = "mysql_preview_empty";
 const MYSQL_VIEW: &str = "mysql_preview_view";
 const MYSQL_FK_PARENT: &str = "mysql_metadata_parent";
 const MYSQL_FK_CHILD: &str = "mysql_metadata_child";
+const MYSQL_FUNCTIONAL_INDEX: &str = "mysql_metadata_functional";
 
 #[tokio::test]
 #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
@@ -384,6 +385,82 @@ async fn loads_mysql_tables_views_and_column_attributes() {
                 ));
             }
             Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn loads_and_updates_mysql_functional_index_table() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let detail = db
+                .adapter()
+                .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_FUNCTIONAL_INDEX)
+                .await
+                .map_err(|error| format!("failed to fetch functional index metadata: {error:?}"))?;
+
+            let functional = detail
+                .indexes
+                .iter()
+                .find(|index| index.name == "uq_mysql_metadata_functional_json")
+                .ok_or_else(|| "MySQL functional index was not returned".to_string())?;
+            if !functional.is_unique()
+                || !functional.has_expression()
+                || functional.columns.len() != 1
+                || functional.definition.is_none()
+            {
+                return Err(format!("unexpected MySQL functional index: {functional:?}"));
+            }
+
+            let mixed = detail
+                .indexes
+                .iter()
+                .find(|index| index.name == "idx_mysql_metadata_functional_mixed")
+                .ok_or_else(|| "MySQL mixed functional index was not returned".to_string())?;
+            if !mixed.has_expression()
+                || mixed.columns.len() != 2
+                || mixed.columns[1] != "sort_key"
+                || mixed.definition.is_none()
+            {
+                return Err(format!("unexpected MySQL mixed index: {mixed:?}"));
+            }
+
+            let preview = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_FUNCTIONAL_INDEX, 10, 0)
+                .await
+                .map_err(|error| format!("failed to preview functional index table: {error:?}"))?;
+            if preview.columns != ["id", "payload", "sort_key"]
+                || preview.values()
+                    != [[
+                        QueryValue::SqlLiteral("1".to_string()),
+                        QueryValue::Text("{\"code\": \"A-001\"}".to_string()),
+                        QueryValue::SqlLiteral("10".to_string()),
+                    ]]
+            {
+                return Err(format!("unexpected functional index preview: {preview:?}"));
+            }
+
+            let update_sql = db.adapter().build_update_sql(
+                DatabaseType::MySQL,
+                "sabiql_test",
+                MYSQL_FUNCTIONAL_INDEX,
+                "sort_key",
+                &QueryValue::SqlLiteral("20".to_string()),
+                &[("id".to_string(), QueryValue::SqlLiteral("1".to_string()))],
+            );
+            let update = db
+                .adapter()
+                .execute_write(db.dsn(), &update_sql, AccessMode::ReadWrite)
+                .await
+                .map_err(|error| format!("failed to update functional index table: {error:?}"))?;
+            if update.affected_rows != 1 {
+                return Err(format!("unexpected functional index update: {update:?}"));
+            }
+
+            Ok::<(), String>(())
         })
     })
     .await;


### PR DESCRIPTION
<!-- Problem -->
MySQL functional key parts expose a NULL COLUMN_NAME, so table metadata parsing fails for tables with functional indexes.

<!-- Background -->
This prevents Inspector, preview, and row editing from working on affected tables.

<!-- Approach -->
Read INFORMATION_SCHEMA.STATISTICS.EXPRESSION alongside COLUMN_NAME, preserve mixed key parts in ordinal order, and reject malformed key parts without discarding valid indexes.

<!-- Linear Issue Link -->
- Implements https://linear.app/sabiql/issue/SAB-407