### PR TITLE
fix(mysql): load metadata after saving connection

### DIFF
--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -2,6 +2,7 @@ use crate::cmd::effect::Effect;
 use crate::domain::connection::{ConnectionId, DatabaseType};
 use crate::model::app_state::AppState;
 use crate::model::connection::cache::ConnectionCache;
+use crate::model::shared::input_mode::InputMode;
 use crate::model::shared::inspector_tab::InspectorTab;
 use crate::update::action::ConnectionTarget;
 use crate::update::query_context::termination_effects;
@@ -73,6 +74,38 @@ pub(super) fn connection_save_fetch_effects(
             vec![Effect::ClearCompletionEngineCache, fetch],
         )
     }
+}
+
+pub(super) fn mysql_connection_completion_effects(
+    state: &mut AppState,
+    dsn: &str,
+    database: Option<&str>,
+) -> Vec<Effect> {
+    state.session.mark_probe_connected(database.is_some());
+    let mut effects = vec![Effect::ClearCompletionEngineCache];
+    if database.is_none() {
+        state.ui.table_picker_mut().clear_filter_and_reset();
+        state.ui.set_database_picker(true);
+        state.modal.set_mode(InputMode::TablePicker);
+        if let (Some(connection_id), Some(server_dsn)) = (
+            state.session.active_connection_id().cloned(),
+            state.session.server_dsn(),
+        ) {
+            effects.push(Effect::FetchMySqlDatabases {
+                connection_id,
+                dsn: server_dsn,
+                connection_generation: state.session.connection_generation(),
+                database_generation: state.session.database_generation(),
+            });
+        }
+    } else {
+        let run_id = state.session.begin_metadata_refresh();
+        effects.push(Effect::FetchMetadata {
+            dsn: dsn.to_string(),
+            run_id,
+        });
+    }
+    termination_effects(&state.query, effects)
 }
 
 pub(super) fn save_current_cache(state: &AppState) -> ConnectionCache {

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -11,7 +11,8 @@ use crate::update::query_context::termination_effects;
 use crate::update::dispatch_result::DispatchResult;
 
 use super::helpers::{
-    reset_for_database_switch, reset_for_new_connection, restore_cache, save_current_cache,
+    mysql_connection_completion_effects, reset_for_database_switch, reset_for_new_connection,
+    restore_cache, save_current_cache,
 };
 
 pub fn reduce_connection_lifecycle(
@@ -152,32 +153,11 @@ pub fn reduce_connection_lifecycle(
                 return DispatchResult::handled();
             }
             reset_for_new_connection(state, id, dsn, name, *database_type, database.as_deref());
-            state.session.mark_probe_connected(database.is_some());
-            state.session.clear_connection_probe();
-            let mut effects = vec![Effect::ClearCompletionEngineCache];
-            if database.is_none() {
-                state.ui.table_picker_mut().clear_filter_and_reset();
-                state.ui.set_database_picker(true);
-                state.modal.set_mode(InputMode::TablePicker);
-                if let (Some(connection_id), Some(server_dsn)) = (
-                    state.session.active_connection_id().cloned(),
-                    state.session.server_dsn(),
-                ) {
-                    effects.push(Effect::FetchMySqlDatabases {
-                        connection_id,
-                        dsn: server_dsn,
-                        connection_generation: state.session.connection_generation(),
-                        database_generation: state.session.database_generation(),
-                    });
-                }
-            } else {
-                let metadata_run_id = state.session.begin_metadata_refresh();
-                effects.push(Effect::FetchMetadata {
-                    dsn: dsn.clone(),
-                    run_id: metadata_run_id,
-                });
-            }
-            DispatchResult::handled_with(termination_effects(&state.query, effects))
+            DispatchResult::handled_with(mysql_connection_completion_effects(
+                state,
+                dsn,
+                database.as_deref(),
+            ))
         }
 
         Action::SwitchMySqlDatabase { database } => {
@@ -903,6 +883,43 @@ mod tests {
                     .iter()
                     .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
             );
+        }
+
+        #[test]
+        fn mysql_probe_completed_fetches_metadata_for_selected_database() {
+            let mut state = AppState::new("test".to_string());
+            let target = ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "mysql://user@localhost:3306/app".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            };
+            let probe_effects = reduce(&mut state, &Action::SwitchConnection(target.clone()))
+                .expect("switch should start a probe");
+            let probe_run_id = probe_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .expect("switch should include the probe run");
+
+            let effects = reduce(
+                &mut state,
+                &Action::ConnectionProbeCompleted {
+                    target,
+                    run_id: probe_run_id,
+                },
+            )
+            .expect("probe completion should be handled");
+
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchMetadata { dsn, .. } if dsn == "mysql://user@localhost:3306/app"
+            )));
+            assert_eq!(state.session.connection_state(), ConnectionState::Connected);
+            assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
         }
 
         #[test]

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -16,7 +16,8 @@ use crate::update::action::{
     Action, ConnectionSaveError, ConnectionTarget, InputTarget, ModalKind,
 };
 use crate::update::connection::helpers::{
-    connection_save_fetch_effects, reset_for_new_connection, save_current_cache,
+    connection_save_fetch_effects, mysql_connection_completion_effects, reset_for_new_connection,
+    save_current_cache,
 };
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::helpers::{validate_all, validate_field};
@@ -250,25 +251,11 @@ pub fn reduce_connection_setup(
 
             reset_for_new_connection(state, id, dsn, name, *database_type, database.as_deref());
             if *database_type == DatabaseType::MySQL {
-                state.session.mark_probe_connected(database.is_some());
-                let mut effects = vec![Effect::ClearCompletionEngineCache];
-                if database.is_none() {
-                    state.ui.table_picker_mut().clear_filter_and_reset();
-                    state.ui.set_database_picker(true);
-                    state.modal.set_mode(InputMode::TablePicker);
-                    if let (Some(connection_id), Some(server_dsn)) = (
-                        state.session.active_connection_id().cloned(),
-                        state.session.server_dsn(),
-                    ) {
-                        effects.push(Effect::FetchMySqlDatabases {
-                            connection_id,
-                            dsn: server_dsn,
-                            connection_generation: state.session.connection_generation(),
-                            database_generation: state.session.database_generation(),
-                        });
-                    }
-                }
-                return DispatchResult::handled_with(termination_effects(&state.query, effects));
+                return DispatchResult::handled_with(mysql_connection_completion_effects(
+                    state,
+                    dsn,
+                    database.as_deref(),
+                ));
             }
             let run_id = state.session.begin_connecting(dsn);
             DispatchResult::handled_with(connection_save_fetch_effects(
@@ -1073,6 +1060,29 @@ mod tests {
             assert_eq!(state.ui.table_picker().scroll_offset(), 0);
             assert!(state.ui.database_picker());
             assert_eq!(state.input_mode(), InputMode::TablePicker);
+        }
+
+        #[test]
+        fn mysql_save_completed_fetches_metadata_for_selected_database() {
+            let mut state = AppState::new("test".to_string());
+            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
+                id: ConnectionId::new(),
+                dsn: "mysql://user@localhost:3306/app".to_string(),
+                name: "mysql".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("app".to_string()),
+            });
+
+            let effects = reduce(&mut state, &action, Instant::now()).unwrap();
+
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchMetadata { dsn, .. } if dsn == "mysql://user@localhost:3306/app"
+            )));
+            assert_eq!(state.session.connection_state(), ConnectionState::Connected);
+            assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
+            assert!(!state.ui.database_picker());
+            assert_eq!(state.input_mode(), InputMode::Normal);
         }
 
         #[test]


### PR DESCRIPTION
## Problem
Saving a new MySQL connection with a selected database leaves the explorer in the unloaded state.

## Background
The probe completion path starts metadata loading, but the save completion path only clears the completion cache.

## Approach
Share the MySQL connection completion transition between probe and save flows so selected databases fetch metadata and unselected databases open the database picker consistently.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-406