### PR TITLE
fix(mysql): treat spatial columns as binary previews

### DIFF
--- a/src/infra/adapters/mysql/metadata.rs
+++ b/src/infra/adapters/mysql/metadata.rs
@@ -1112,7 +1112,22 @@ fn is_binary_type(data_type: &str) -> bool {
         .to_ascii_lowercase();
     matches!(
         name.as_str(),
-        "binary" | "varbinary" | "tinyblob" | "blob" | "mediumblob" | "longblob" | "bit"
+        "binary"
+            | "varbinary"
+            | "tinyblob"
+            | "blob"
+            | "mediumblob"
+            | "longblob"
+            | "bit"
+            | "geometry"
+            | "point"
+            | "linestring"
+            | "polygon"
+            | "multipoint"
+            | "multilinestring"
+            | "multipolygon"
+            | "geometrycollection"
+            | "geomcollection"
     )
 }
 
@@ -1376,6 +1391,43 @@ mod tests {
 
         assert_eq!(values.visible[0][0], QueryValue::Text("0x41".to_string()));
         assert_eq!(values.visible[0][1], QueryValue::Blob(vec![0, 255]));
+    }
+
+    #[test]
+    fn preview_conversion_decodes_spatial_hex_as_binary() {
+        let result = result(
+            &["location"],
+            vec![vec![QueryValue::Text(
+                "0xE610000001010000000000000000805E40CDCCCCCCCCCC4240".to_string(),
+            )]],
+        );
+        let columns = vec![column("location", "point srid 4326")];
+
+        let values = convert_preview_values(&result, &columns, &[]).expect("conversion succeeds");
+
+        assert_eq!(
+            values.visible[0][0],
+            QueryValue::Blob(vec![
+                0xE6, 0x10, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x80, 0x5E, 0x40, 0xCD, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0x42, 0x40,
+            ])
+        );
+    }
+
+    #[test]
+    fn binary_type_recognizes_mysql_spatial_types() {
+        for data_type in [
+            "geometry",
+            "point srid 4326",
+            "linestring",
+            "polygon",
+            "multipoint",
+            "multilinestring",
+            "multipolygon",
+            "geometrycollection",
+        ] {
+            assert!(is_binary_type(data_type), "{data_type}");
+        }
     }
 
     #[test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -38,6 +38,20 @@ const MYSQL_VIEW: &str = "mysql_preview_view";
 const MYSQL_FK_PARENT: &str = "mysql_metadata_parent";
 const MYSQL_FK_CHILD: &str = "mysql_metadata_child";
 const MYSQL_FUNCTIONAL_INDEX: &str = "mysql_metadata_functional";
+const MYSQL_SPATIAL_TABLE: &str = "demo_warehouses";
+
+fn decode_hex(value: &str) -> Result<Vec<u8>, String> {
+    if value.is_empty() || !value.len().is_multiple_of(2) {
+        return Err(format!("invalid HEX value: {value}"));
+    }
+    (0..value.len())
+        .step_by(2)
+        .map(|index| {
+            u8::from_str_radix(&value[index..index + 2], 16)
+                .map_err(|error| format!("invalid HEX value: {value}: {error}"))
+        })
+        .collect()
+}
 
 #[tokio::test]
 #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
@@ -559,6 +573,50 @@ async fn previews_mysql_rows_with_visible_columns_types_and_pagination() {
                 ));
             }
             Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn previews_mysql_spatial_point_as_binary_equal_to_hex() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let hex_result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    "SELECT HEX(location) FROM demo_warehouses WHERE code = 'TYO001'",
+                    AccessMode::ReadOnly,
+                )
+                .await
+                .map_err(|error| format!("failed to read spatial HEX value: {error:?}"))?;
+            let hex = match hex_result.values().first().and_then(|row| row.first()) {
+                Some(QueryValue::Text(value)) => value,
+                value => return Err(format!("unexpected spatial HEX result: {value:?}")),
+            };
+            let expected = decode_hex(hex)?;
+
+            let preview = db
+                .adapter()
+                .execute_preview(db.dsn(), "sabiql_test", MYSQL_SPATIAL_TABLE, 1, 0)
+                .await
+                .map_err(|error| format!("failed to preview spatial table: {error:?}"))?;
+            let location_index = preview
+                .columns
+                .iter()
+                .position(|column| column == "location")
+                .ok_or_else(|| format!("spatial column missing from preview: {preview:?}"))?;
+            let value = preview
+                .values()
+                .first()
+                .and_then(|row| row.get(location_index))
+                .ok_or_else(|| format!("spatial value missing from preview: {preview:?}"))?;
+            if value != &QueryValue::Blob(expected) {
+                return Err(format!("unexpected spatial preview value: {value:?}"));
+            }
+            Ok::<(), String>(())
         })
     })
     .await;


### PR DESCRIPTION
## Summary

Treat MySQL spatial column values as binary previews so the existing binary display path preserves the raw geometry bytes emitted by the MySQL CLI.

The change covers MySQL geometry types, including `POINT` and SRID-qualified columns, without adding a spatial domain model or changing existing BINARY, VARBINARY, BLOB, or BIT handling. The integration test compares a `POINT` preview value with `HEX(location)` through Oracle MySQL 8.4.10.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
- `scripts/lint_all.sh`
- `cargo nextest run -p sabiql --profile ci-all --all-features`: 184 passed
- `cargo nextest run -p sabiql --profile ci-no-default --no-default-features`: 184 passed
- Oracle MySQL 8.4.10 POINT preview/HEX integration test passed on the task worktree; a later local rerun after rebasing onto the latest `mysql` encountered the fixture user's existing `caching_sha2_password` secure-connection setup before reaching the test assertion.
