### PR TITLE
perf(mysql): limit preview metadata to target table

### DIFF
--- a/src/infra/adapters/mysql/metadata.rs
+++ b/src/infra/adapters/mysql/metadata.rs
@@ -164,8 +164,6 @@ pub(super) async fn fetch_preview_metadata(
     schema: &str,
     table: &str,
 ) -> Result<PreviewMetadata, DbOperationError> {
-    let snapshot = fetch_metadata_snapshot_for_schema(dsn, schema).await?;
-    find_table(schema, table, &snapshot.tables)?;
     let column_metadata = fetch_columns(dsn, schema, table).await?;
     let columns = column_metadata
         .iter()


### PR DESCRIPTION
## Problem
MySQL Preview fetched metadata for every table before loading the selected table's columns.

## Background
This added unnecessary INFORMATION_SCHEMA work for each Preview request.

## Approach
Build Preview metadata directly from the selected table's column metadata. Preserve visible-column filtering, primary-key ordering, and hidden identity handling without adding a separate existence query.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-410