### PR TITLE
fix(mysql): apply read-only sessions to CSV exports

### DIFF
--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -106,6 +106,8 @@ pub async fn run_mysql_cli_script_for_test(
 
 #[cfg(feature = "test-support")]
 #[doc(hidden)]
+/// Runs the export process without client-side query policy validation so integration tests can
+/// verify that the MySQL read-only session rejects a side effect at the server boundary.
 pub async fn export_mysql_csv_to_path_for_test(
     dsn: &str,
     query: &str,
@@ -114,7 +116,6 @@ pub async fn export_mysql_csv_to_path_for_test(
     let target = parse_mysql_dsn(dsn)?;
     validate_mysql_values(&target)?;
     validate_mysql_tls_files(&target)?;
-    validate_mysql_export_query(query, target.database.as_deref())?;
     let query = query.to_string();
     export_to_path(path, move |temporary_path| async move {
         export_mysql_csv_to_file(target, &query, temporary_path).await

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -28,7 +28,7 @@ use tokio::time::timeout;
 use url::Url;
 use uuid::Uuid;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 use crate::adapters::csv_export::export_to_path;
 use crate::adapters::csv_export::{CsvFileWriter, export_to_downloads};
 #[cfg(test)]
@@ -59,6 +59,7 @@ pub struct MySqlAdapter;
 
 const MYSQL_PROBE_TIMEOUT: Duration = Duration::from_secs(11);
 const MYSQL_QUERY_TIMEOUT: Duration = Duration::from_secs(31);
+const MYSQL_EXPORT_TIMEOUT: Duration = Duration::from_secs(MYSQL_QUERY_TIMEOUT.as_secs() * 10);
 const MYSQL_PROBE_QUERY: &str = "SELECT JSON_OBJECT('database', DATABASE(), 'user', CURRENT_USER(), 'version', VERSION(), 'sql_mode', @@SESSION.sql_mode)";
 const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
 const MYSQL_SESSION_MARKER_COLUMN: &str = "__sabiql_session_marker";
@@ -101,6 +102,24 @@ pub async fn run_mysql_cli_script_for_test(
         let _ = process.child.wait().await;
     }
     result
+}
+
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub async fn export_mysql_csv_to_path_for_test(
+    dsn: &str,
+    query: &str,
+    path: PathBuf,
+) -> Result<PathBuf, DbOperationError> {
+    let target = parse_mysql_dsn(dsn)?;
+    validate_mysql_values(&target)?;
+    validate_mysql_tls_files(&target)?;
+    validate_mysql_export_query(query, target.database.as_deref())?;
+    let query = query.to_string();
+    export_to_path(path, move |temporary_path| async move {
+        export_mysql_csv_to_file(target, &query, temporary_path).await
+    })
+    .await
 }
 
 #[async_trait]
@@ -1409,7 +1428,7 @@ async fn export_mysql_csv_to_file(
     let option_file = MySqlOptionFile::create(&target)?;
     let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
     let result = timeout(
-        MYSQL_QUERY_TIMEOUT,
+        MYSQL_EXPORT_TIMEOUT,
         run_mysql_export_process(&mut process, query, path),
     )
     .await;
@@ -1440,6 +1459,7 @@ async fn run_mysql_export_process(
     let probe_xml = read_one_mysql_resultset(process).await?;
     let probe = parse_mysql_xml(&probe_xml)?;
     validate_mode_probe(&probe, &marker)?;
+    configure_mysql_session(process, AccessMode::ReadOnly).await?;
 
     write_mysql_statement(process, query).await?;
     let mut csv_writer = CsvFileWriter::create(path).await?;
@@ -1491,6 +1511,8 @@ async fn stream_mysql_resultset_to_csv(
         let source = MysqlExportPtySource {
             pty: &mut process.pty,
             error_output: Vec::new(),
+            pending: Vec::new(),
+            started: false,
         };
         let mut reader = Reader::from_reader(BufReader::new(source));
         reader.config_mut().trim_text(false);
@@ -1499,6 +1521,7 @@ async fn stream_mysql_resultset_to_csv(
         let unread = buffered.buffer().to_vec();
         let source = buffered.into_inner();
         source.pty.pending.extend(unread);
+        source.pty.pending.extend(source.pending);
         if !source.error_output.is_empty() {
             return Err(classify_mysql_query_failure(&source.error_output));
         }
@@ -1693,6 +1716,8 @@ where
 struct MysqlExportPtySource<'a> {
     pty: &'a mut MysqlPty,
     error_output: Vec<u8>,
+    pending: Vec<u8>,
+    started: bool,
 }
 
 #[cfg(unix)]
@@ -1701,6 +1726,18 @@ impl MysqlExportPtySource<'_> {
         if self.error_output.is_empty() && has_mysql_cli_error(bytes) {
             self.error_output
                 .extend_from_slice(&bytes[..bytes.len().min(32 * 1024)]);
+        }
+    }
+
+    fn discard_before_resultset(&mut self) {
+        const RESULTSET_START: &[u8] = b"<resultset";
+        if let Some(start) = find_bytes(&self.pending, RESULTSET_START) {
+            self.pending.drain(..start);
+            self.started = true;
+        } else {
+            let keep = RESULTSET_START.len().saturating_sub(1);
+            let discard = self.pending.len().saturating_sub(keep);
+            self.pending.drain(..discard);
         }
     }
 }
@@ -1713,20 +1750,53 @@ impl AsyncRead for MysqlExportPtySource<'_> {
         buffer: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         let this = self.get_mut();
-        if !this.pty.pending.is_empty() {
-            let count = buffer.remaining().min(this.pty.pending.len());
-            let bytes = this.pty.pending.drain(..count).collect::<Vec<_>>();
-            this.capture_error(&bytes);
-            buffer.put_slice(&bytes);
-            return Poll::Ready(Ok(()));
-        }
+        loop {
+            if !this.started {
+                if !this.pty.pending.is_empty() {
+                    let bytes = std::mem::take(&mut this.pty.pending);
+                    this.capture_error(&bytes);
+                    this.pending.extend_from_slice(&bytes);
+                }
+                if !this.pending.is_empty() {
+                    this.discard_before_resultset();
+                    if this.started {
+                        continue;
+                    }
+                }
 
-        let filled_before = buffer.filled().len();
-        let result = Pin::new(&mut this.pty.output).poll_read(cx, buffer);
-        if matches!(&result, Poll::Ready(Ok(()))) {
-            this.capture_error(&buffer.filled()[filled_before..]);
+                let mut chunk = [0; 4096];
+                let mut read_buffer = ReadBuf::new(&mut chunk);
+                match Pin::new(&mut this.pty.output).poll_read(cx, &mut read_buffer) {
+                    Poll::Ready(Ok(())) => {
+                        let bytes = read_buffer.filled().to_vec();
+                        if bytes.is_empty() {
+                            return Poll::Ready(Ok(()));
+                        }
+                        this.capture_error(&bytes);
+                        this.pending.extend_from_slice(&bytes);
+                    }
+                    Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+                    Poll::Pending => return Poll::Pending,
+                }
+                continue;
+            }
+
+            if !this.pending.is_empty() {
+                let count = buffer.remaining().min(this.pending.len());
+                let bytes = this.pending.drain(..count).collect::<Vec<_>>();
+                buffer.put_slice(&bytes);
+                return Poll::Ready(Ok(()));
+            }
+
+            {
+                let filled_before = buffer.filled().len();
+                let result = Pin::new(&mut this.pty.output).poll_read(cx, buffer);
+                if matches!(&result, Poll::Ready(Ok(()))) {
+                    this.capture_error(&buffer.filled()[filled_before..]);
+                }
+                return result;
+            }
         }
-        result
     }
 }
 
@@ -2571,7 +2641,9 @@ async fn read_pty_all(pty: &mut MysqlPty) -> io::Result<Vec<u8>> {
         match pty.output.read(&mut chunk).await {
             Ok(0) => return Ok(output),
             Ok(count) => output.extend_from_slice(&chunk[..count]),
-            Err(error) if error.raw_os_error() == Some(libc::EIO) => return Ok(output),
+            Err(error) if matches!(error.raw_os_error(), Some(libc::EIO | libc::EPERM)) => {
+                return Ok(output);
+            }
             Err(error) => return Err(error),
         }
     }
@@ -4289,6 +4361,57 @@ done
         .unwrap();
 
         assert_eq!(fs::read_to_string(path).unwrap(), "value\none\n");
+    }
+
+    #[tokio::test]
+    async fn export_configures_read_only_session_before_user_sql() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let path = option_file.with_file_name("export.csv");
+
+        export_mysql_csv_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 1",
+            path,
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        let log = fs::read_to_string(log_file).unwrap();
+        let session_index = log
+            .find(MYSQL_READ_ONLY_STATEMENT)
+            .expect("read-only session statement");
+        let user_index = log.find("SELECT 1").expect("user statement");
+        assert!(session_index < user_index, "{log}");
+        assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN));
+    }
+
+    #[tokio::test]
+    async fn export_read_only_session_failure_never_writes_user_sql_or_partial_file() {
+        let (_directory, program, option_file) = fake_mysql("read_only_failure");
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let output_directory = tempfile::tempdir().unwrap();
+        let final_path = output_directory.path().join("export.csv");
+
+        let result = export_to_path(final_path.clone(), |path| {
+            export_mysql_csv_with_program(
+                OsStr::new(&program),
+                &option_file,
+                "SELECT 123",
+                path,
+                Duration::from_secs(5),
+            )
+        })
+        .await;
+
+        assert!(result.is_err());
+        let log = fs::read_to_string(log_file).unwrap();
+        assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
+        assert!(!log.contains("SELECT 123"), "{log}");
+        assert!(!final_path.exists());
+        assert_eq!(output_directory.path().read_dir().unwrap().count(), 0);
     }
 
     #[tokio::test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1352,7 +1352,7 @@ async fn exports_with_a_read_only_session_and_rejects_writes() {
             let write_path = output_directory.path().join("write.csv");
             let result = export_mysql_csv_to_path_for_test(
                 db.dsn(),
-                &format!("INSERT INTO {MYSQL_FIXTURE_TABLE} (id) VALUES (2)"),
+                &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE} FOR UPDATE"),
                 write_path.clone(),
             )
             .await;

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1352,11 +1352,15 @@ async fn exports_with_a_read_only_session_and_rejects_writes() {
             let write_path = output_directory.path().join("write.csv");
             let result = export_mysql_csv_to_path_for_test(
                 db.dsn(),
-                &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE} FOR UPDATE"),
+                &format!("INSERT INTO {MYSQL_FIXTURE_TABLE} (id) VALUES (2)"),
                 write_path.clone(),
             )
             .await;
-            if !matches!(result, Err(DbOperationError::PermissionDenied(_))) {
+            if !matches!(
+                result,
+                Err(DbOperationError::QueryFailed(ref details))
+                    if details.contains("READ ONLY")
+            ) {
                 return Err(format!("write export was not rejected: {result:?}"));
             }
             if write_path.exists() {

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -17,9 +17,10 @@ use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, mysql_tls_config, with_m
 use sabiql_domain::connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, MySqlConnectionConfig, MySqlSslMode,
 };
-use sabiql_infra::adapters::mysql::MySqlAdapter;
+use sabiql_infra::adapters::mysql::{MySqlAdapter, export_mysql_csv_to_path_for_test};
 #[cfg(unix)]
 use tempfile::NamedTempFile;
+use tempfile::tempdir;
 
 fn mysql_tls_profile(name: &str, config: MySqlConnectionConfig) -> ConnectionProfile {
     ConnectionProfile::with_id_and_config(
@@ -1321,6 +1322,45 @@ async fn times_out_real_cli_query_and_discards_output() {
                 .await;
             if !matches!(result, Err(DbOperationError::Timeout(_))) {
                 return Err(format!("expected a query timeout: {result:?}"));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn exports_with_a_read_only_session_and_rejects_writes() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let output_directory = tempdir().map_err(|error| error.to_string())?;
+            let path = output_directory.path().join("read_only.csv");
+            let path = export_mysql_csv_to_path_for_test(
+                db.dsn(),
+                "SELECT @@SESSION.transaction_read_only AS transaction_read_only",
+                path,
+            )
+            .await
+            .map_err(|error| format!("read-only CSV export failed: {error:?}"))?;
+            let csv = std::fs::read_to_string(&path)
+                .map_err(|error| format!("failed to read CSV export: {error}"))?;
+            if csv != "transaction_read_only\n1\n" {
+                return Err(format!("unexpected read-only CSV export: {csv:?}"));
+            }
+
+            let write_path = output_directory.path().join("write.csv");
+            let result = export_mysql_csv_to_path_for_test(
+                db.dsn(),
+                &format!("INSERT INTO {MYSQL_FIXTURE_TABLE} (id) VALUES (2)"),
+                write_path.clone(),
+            )
+            .await;
+            if !matches!(result, Err(DbOperationError::PermissionDenied(_))) {
+                return Err(format!("write export was not rejected: {result:?}"));
+            }
+            if write_path.exists() {
+                return Err("write export created an output file".to_string());
             }
             Ok(())
         })


### PR DESCRIPTION
## Problem
MySQL CSV export runs the user query without applying the existing read-only session configuration.

## Background
The export path must enforce the same session-level protection as other read-only MySQL queries while allowing longer-running exports.

## Approach
Apply the existing read-only session setup before sending export SQL, use a dedicated timeout that is ten times the normal query timeout, and preserve temporary-file cleanup on setup or process failure. Add fake CLI and Oracle MySQL 8.4 coverage for ordering, session state, write rejection, and output cleanup.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-409