### PR TITLE
fix(mysql): preserve classified query failures after changes

### DIFF
--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -57,7 +57,8 @@ pub enum DbOperationError {
     QueryFailed(String),
     #[error("Query failed after a change")]
     QueryFailedAfterChange {
-        details: String,
+        #[source]
+        source: Arc<Self>,
         refresh_scope: RefreshScope,
     },
     #[error("Unsupported operation")]
@@ -94,7 +95,7 @@ impl DbOperationError {
             Self::LockTimeout(_) => "Operation blocked by lock or timeout",
             Self::ObjectMissing(_) => "Database object not found",
             Self::QueryFailed(_) => "Query failed",
-            Self::QueryFailedAfterChange { .. } => "Query failed after a change",
+            Self::QueryFailedAfterChange { source, .. } => source.summary(),
             Self::UnsupportedOperation(_) => "Unsupported operation",
             Self::MetadataParseFailed(_) => "Failed to parse database metadata output",
             Self::InvalidJson(_) => "Failed to parse database JSON output",
@@ -121,9 +122,7 @@ impl DbOperationError {
             }
             Self::ObjectMissing(_) => "Check the table, column, or connected database",
             Self::QueryFailed(_) => "Review the database error details and SQL",
-            Self::QueryFailedAfterChange { .. } => {
-                "Some changes may have been committed; refresh the database state before retrying"
-            }
+            Self::QueryFailedAfterChange { source, .. } => source.hint(),
             Self::UnsupportedOperation(_) => "Use a supported operation for this database",
             Self::MetadataParseFailed(_) => {
                 "Check whether the metadata output format changed unexpectedly"
@@ -138,6 +137,52 @@ impl DbOperationError {
         }
     }
 
+    pub fn masked_details(&self) -> String {
+        mask_password(self.raw_details().as_ref())
+    }
+
+    pub fn user_message(&self) -> String {
+        let summary = self.summary();
+        let hint = self.hint();
+        let details = self.masked_details();
+
+        let message = match (details.trim().is_empty(), hint.is_empty()) {
+            (true, true) => summary.to_string(),
+            (true, false) => format!("{summary}. {hint}."),
+            (false, true) => format!("{summary}: {details}"),
+            (false, false) => format!("{summary}: {details}. {hint}."),
+        };
+
+        if matches!(self, Self::QueryFailedAfterChange { .. }) {
+            format!(
+                "{message} Some changes may have been committed; refresh the database state before retrying."
+            )
+        } else {
+            message
+        }
+    }
+
+    pub fn result_message(&self) -> String {
+        let summary = self.summary();
+        let hint = self.hint();
+        let details = self.masked_details();
+
+        let message = match (details.trim().is_empty(), hint.is_empty()) {
+            (true, true) => summary.to_string(),
+            (true, false) => format!("{summary}. {hint}."),
+            (false, true) => format!("{summary}\n\nDetails:\n{details}"),
+            (false, false) => format!("{summary}. {hint}.\n\nDetails:\n{details}"),
+        };
+
+        if matches!(self, Self::QueryFailedAfterChange { .. }) {
+            format!(
+                "{message}\n\nSome changes may have been committed; refresh the database state before retrying."
+            )
+        } else {
+            message
+        }
+    }
+
     pub(crate) fn raw_details(&self) -> Cow<'_, str> {
         match self {
             Self::ConnectionFailed(details)
@@ -148,7 +193,6 @@ impl DbOperationError {
             | Self::LockTimeout(details)
             | Self::ObjectMissing(details)
             | Self::QueryFailed(details)
-            | Self::QueryFailedAfterChange { details, .. }
             | Self::UnsupportedOperation(details)
             | Self::MetadataParseFailed(details)
             | Self::EmptyResponse(details)
@@ -158,36 +202,7 @@ impl DbOperationError {
             | Self::CommandNotFound { details, .. } => Cow::Borrowed(details.as_str()),
             Self::InvalidJson(err) => Cow::Owned(err.to_string()),
             Self::CsvParse(err) => Cow::Owned(err.to_string()),
-        }
-    }
-
-    pub fn masked_details(&self) -> String {
-        mask_password(self.raw_details().as_ref())
-    }
-
-    pub fn user_message(&self) -> String {
-        let summary = self.summary();
-        let hint = self.hint();
-        let details = self.masked_details();
-
-        match (details.trim().is_empty(), hint.is_empty()) {
-            (true, true) => summary.to_string(),
-            (true, false) => format!("{summary}. {hint}."),
-            (false, true) => format!("{summary}: {details}"),
-            (false, false) => format!("{summary}: {details}. {hint}."),
-        }
-    }
-
-    pub fn result_message(&self) -> String {
-        let summary = self.summary();
-        let hint = self.hint();
-        let details = self.masked_details();
-
-        match (details.trim().is_empty(), hint.is_empty()) {
-            (true, true) => summary.to_string(),
-            (true, false) => format!("{summary}. {hint}."),
-            (false, true) => format!("{summary}\n\nDetails:\n{details}"),
-            (false, false) => format!("{summary}. {hint}.\n\nDetails:\n{details}"),
+            Self::QueryFailedAfterChange { source, .. } => source.raw_details(),
         }
     }
 }
@@ -346,16 +361,53 @@ mod tests {
         #[test]
         fn change_failure_warns_about_possible_commits() {
             let error = DbOperationError::QueryFailedAfterChange {
-                details: "syntax error".to_string(),
+                source: Arc::new(DbOperationError::QueryFailed("syntax error".to_string())),
                 refresh_scope: RefreshScope::Metadata,
             };
 
-            assert_eq!(error.summary(), "Query failed after a change");
+            assert_eq!(error.summary(), "Query failed");
+            assert_eq!(error.hint(), "Review the database error details and SQL");
+            assert_eq!(error.masked_details(), "syntax error");
             assert!(
                 error
                     .user_message()
                     .contains("Some changes may have been committed")
             );
+        }
+
+        #[rstest]
+        #[case(DbOperationError::PermissionDenied("permission denied".to_string()))]
+        #[case(DbOperationError::UniqueViolation("duplicate entry".to_string()))]
+        #[case(DbOperationError::ForeignKeyViolation("foreign key failed".to_string()))]
+        #[case(DbOperationError::LockTimeout("lock wait timeout".to_string()))]
+        fn change_failure_preserves_classification(#[case] source: DbOperationError) {
+            let expected_summary = source.summary();
+            let expected_hint = source.hint();
+            let expected_details = source.masked_details();
+            let error = DbOperationError::QueryFailedAfterChange {
+                source: Arc::new(source),
+                refresh_scope: RefreshScope::Data,
+            };
+
+            assert_eq!(error.summary(), expected_summary);
+            assert_eq!(error.hint(), expected_hint);
+            assert_eq!(error.masked_details(), expected_details);
+            assert!(error.user_message().contains(expected_summary));
+            assert!(error.user_message().contains(expected_hint));
+        }
+
+        #[test]
+        fn change_failure_masks_nested_source_details() {
+            let error = DbOperationError::QueryFailedAfterChange {
+                source: Arc::new(DbOperationError::PermissionDenied(
+                    "password=secret".to_string(),
+                )),
+                refresh_scope: RefreshScope::Data,
+            };
+
+            assert_eq!(error.masked_details(), "password=****");
+            assert!(!error.user_message().contains("secret"));
+            assert!(!format!("{error:?}").contains("secret"));
         }
 
         #[test]

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -15,53 +15,6 @@ use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::input::command::{command_to_action, parse_command};
 
-fn refresh_effects_for_scope(
-    state: &mut AppState,
-    refresh_scope: RefreshScope,
-    now: Instant,
-) -> Vec<Effect> {
-    if refresh_scope == RefreshScope::None {
-        return vec![];
-    }
-    let Some(dsn) = state.session.dsn().map(String::from) else {
-        return vec![];
-    };
-
-    let mut effects = vec![];
-
-    if refresh_scope == RefreshScope::Metadata {
-        state.sql_modal.reset_prefetch();
-        state.session.set_table_detail_raw(None);
-        let run_id = state.session.begin_metadata_refresh();
-
-        effects.push(Effect::CacheInvalidate { dsn: dsn.clone() });
-        effects.push(Effect::ClearCompletionEngineCache);
-        effects.push(Effect::FetchMetadata { dsn, run_id });
-    } else if !state.query.pagination.table().is_empty() {
-        let page = state.query.pagination.current_page();
-        let generation = state.session.selection_generation();
-        effects.extend(preview_effect_for_current_table(
-            state, now, page, generation,
-        ));
-    }
-
-    effects
-}
-
-fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -> Vec<Effect> {
-    if result.source != QuerySource::Adhoc || result.is_error() {
-        return vec![];
-    }
-    refresh_effects_for_scope(state, result.refresh_scope, now)
-}
-
-fn reset_view_for_new_result(state: &mut AppState, now: Instant) {
-    state.result_interaction.reset_view();
-    state
-        .query
-        .set_result_highlight(now + Duration::from_millis(500));
-}
-
 pub fn reduce_execution(
     state: &mut AppState,
     action: &Action,
@@ -298,6 +251,53 @@ pub fn reduce_execution(
 
         _ => DispatchResult::pass(),
     }
+}
+
+fn refresh_effects_for_scope(
+    state: &mut AppState,
+    refresh_scope: RefreshScope,
+    now: Instant,
+) -> Vec<Effect> {
+    if refresh_scope == RefreshScope::None {
+        return vec![];
+    }
+    let Some(dsn) = state.session.dsn().map(String::from) else {
+        return vec![];
+    };
+
+    let mut effects = vec![];
+
+    if refresh_scope == RefreshScope::Metadata {
+        state.sql_modal.reset_prefetch();
+        state.session.set_table_detail_raw(None);
+        let run_id = state.session.begin_metadata_refresh();
+
+        effects.push(Effect::CacheInvalidate { dsn: dsn.clone() });
+        effects.push(Effect::ClearCompletionEngineCache);
+        effects.push(Effect::FetchMetadata { dsn, run_id });
+    } else if !state.query.pagination.table().is_empty() {
+        let page = state.query.pagination.current_page();
+        let generation = state.session.selection_generation();
+        effects.extend(preview_effect_for_current_table(
+            state, now, page, generation,
+        ));
+    }
+
+    effects
+}
+
+fn try_adhoc_refresh(state: &mut AppState, result: &QueryResult, now: Instant) -> Vec<Effect> {
+    if result.source != QuerySource::Adhoc || result.is_error() {
+        return vec![];
+    }
+    refresh_effects_for_scope(state, result.refresh_scope, now)
+}
+
+fn reset_view_for_new_result(state: &mut AppState, now: Instant) {
+    state.result_interaction.reset_view();
+    state
+        .query
+        .set_result_highlight(now + Duration::from_millis(500));
 }
 
 #[cfg(test)]
@@ -729,7 +729,9 @@ mod tests {
             let action = query_failed_action(
                 &mut state,
                 DbOperationError::QueryFailedAfterChange {
-                    details: "later statement failed".to_string(),
+                    source: Arc::new(DbOperationError::QueryFailed(
+                        "later statement failed".to_string(),
+                    )),
                     refresh_scope: RefreshScope::Data,
                 },
                 0,
@@ -757,7 +759,9 @@ mod tests {
             let action = query_failed_action(
                 &mut state,
                 DbOperationError::QueryFailedAfterChange {
-                    details: "later DDL failed".to_string(),
+                    source: Arc::new(DbOperationError::QueryFailed(
+                        "later DDL failed".to_string(),
+                    )),
                     refresh_scope: RefreshScope::Metadata,
                 },
                 0,

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -2665,6 +2665,13 @@ async fn read_one_pty_resultset(pty: &mut MysqlPty) -> Result<Vec<u8>, DbOperati
             Err(error) => return Err(DbOperationError::ConnectionLost(error.to_string())),
         };
         if count == 0 {
+            let tail = read_pty_all(pty)
+                .await
+                .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+            if has_mysql_cli_error(&tail) {
+                trace_mysql_error(&tail);
+                return Err(classify_mysql_query_failure(&tail));
+            }
             return Err(DbOperationError::EmptyResponse(
                 "mysql query returned no resultset".to_string(),
             ));
@@ -4272,6 +4279,8 @@ mod executor_tests {
         };
         let user_response = if mode == "failure" {
             "printf '%s\\n' '<resultset><row><field name=\"partial\">row</field></row></resultset>'\n    printf '%s\\n' 'ERROR 1064 (42000): syntax error' >&2\n    exit 1"
+        } else if mode == "no_result_failure" {
+            "printf '%s\\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2\n    exit 1"
         } else {
             "printf '%s\\n' '<resultset><row><field name=\"value\">ok</field></row></resultset>'"
         };
@@ -4744,6 +4753,27 @@ done
         .await;
 
         assert!(matches!(result, Err(DbOperationError::QueryFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn classifies_cli_error_when_no_resultset_is_emitted() {
+        let (_directory, program, log_file) = fake_mysql("no_result_failure");
+        let option_file = log_file.with_extension("cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let result = run_mysql_adhoc_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123",
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::QueryFailed(details))
+                if details.contains("missing_column")
+        ));
     }
 
     #[tokio::test]

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -2152,7 +2152,13 @@ async fn run_mysql_adhoc_process(
         }
         let first_xml = match read_one_mysql_resultset(process).await {
             Ok(xml) => xml,
-            Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
+            Err(error) => {
+                return Err(query_failed_after_mysql_statement(
+                    error,
+                    refresh_scope,
+                    possible_refresh_scope,
+                ));
+            }
         };
         let first_result = match parse_mysql_xml(&first_xml) {
             Ok(result) => result,
@@ -2163,7 +2169,13 @@ async fn run_mysql_adhoc_process(
         } else {
             let xml = match read_one_mysql_resultset(process).await {
                 Ok(xml) => xml,
-                Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
+                Err(error) => {
+                    return Err(query_failed_after_mysql_statement(
+                        error,
+                        refresh_scope,
+                        possible_refresh_scope,
+                    ));
+                }
             };
             let marker_result = match parse_mysql_xml(&xml) {
                 Ok(result) => result,
@@ -2294,6 +2306,32 @@ fn query_failed_after_change(
             refresh_scope,
         }
     }
+}
+
+fn query_failed_after_mysql_statement(
+    error: DbOperationError,
+    refresh_scope: RefreshScope,
+    possible_refresh_scope: RefreshScope,
+) -> DbOperationError {
+    let refresh_scope = if is_mysql_statement_failure(&error) {
+        refresh_scope
+    } else {
+        possible_refresh_scope
+    };
+    query_failed_after_change(error, refresh_scope)
+}
+
+fn is_mysql_statement_failure(error: &DbOperationError) -> bool {
+    matches!(
+        error,
+        DbOperationError::PermissionDenied(_)
+            | DbOperationError::ForeignKeyViolation(_)
+            | DbOperationError::UniqueViolation(_)
+            | DbOperationError::LockTimeout(_)
+            | DbOperationError::ObjectMissing(_)
+            | DbOperationError::QueryFailed(_)
+            | DbOperationError::Canceled(_)
+    )
 }
 
 fn is_mysql_row_count_marker(result: &MysqlResultSet, marker: &str) -> bool {
@@ -4280,18 +4318,32 @@ done
     }
 
     fn fake_mysql_multi() -> (TempDir, PathBuf, PathBuf) {
-        fake_mysql_multi_with_mode(false)
+        fake_mysql_multi_with_mode(false, None)
     }
 
     fn fake_mysql_multi_with_marker_failure() -> (TempDir, PathBuf, PathBuf) {
-        fake_mysql_multi_with_mode(true)
+        fake_mysql_multi_with_mode(true, None)
     }
 
-    fn fake_mysql_multi_with_mode(marker_failure: bool) -> (TempDir, PathBuf, PathBuf) {
+    fn fake_mysql_multi_with_statement_failure(error: &str) -> (TempDir, PathBuf, PathBuf) {
+        fake_mysql_multi_with_mode(false, Some(error))
+    }
+
+    fn fake_mysql_multi_with_mode(
+        marker_failure: bool,
+        statement_error: Option<&str>,
+    ) -> (TempDir, PathBuf, PathBuf) {
         let directory = tempfile::tempdir().unwrap();
         let option_file = directory.path().join("option.cnf");
         fs::write(&option_file, "[client]\n").unwrap();
         let program = directory.path().join("mysql");
+        let update_response = statement_error.map_or_else(
+            || {
+                "printf '%s\\n' '<resultset><row><field name=\"affected\">ok</field></row></resultset>'"
+                    .to_string()
+            },
+            |error| format!("printf '%s\\n' '{error}' >&2"),
+        );
         let marker_response = if marker_failure {
             "printf '%s\\n' '<resultset><row><field name=\"wrong\">x</field></row></resultset>'"
         } else {
@@ -4335,7 +4387,7 @@ while IFS= read -r line; do
       printf '%s\n' '<resultset><row><field name="value">'"$value"'</field></row></resultset>'
       ;;
     *UPDATE*)
-      printf '%s\n' '<resultset><row><field name="affected">ok</field></row></resultset>'
+      {update_response}
       ;;
     *)
       printf '%s\n' '<resultset></resultset>'
@@ -4756,6 +4808,56 @@ done
                 ..
             }) if matches!(&*source, DbOperationError::QueryFailed(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn first_change_statement_failure_keeps_the_classified_error_unwrapped() {
+        for (details, summary) in [
+            (
+                "ERROR 1142 (42000): command denied to user",
+                "Permission denied",
+            ),
+            (
+                "ERROR 1062 (23000): Duplicate entry duplicate_value for key PRIMARY",
+                "Unique constraint violation",
+            ),
+            (
+                "ERROR 1452 (23000): Cannot add or update a child row: a foreign key constraint fails",
+                "Foreign key constraint violation",
+            ),
+            (
+                "ERROR 1205 (HY000): Lock wait timeout exceeded",
+                "Operation blocked by lock or timeout",
+            ),
+        ] {
+            let (_directory, program, option_file) =
+                fake_mysql_multi_with_statement_failure(details);
+            let statements = split_mysql_statements("UPDATE items SET value = 1")
+                .unwrap()
+                .into_iter()
+                .map(|sql| classify_mysql_statement(&sql).unwrap())
+                .collect::<Vec<_>>();
+
+            let result = run_mysql_adhoc_with_program_and_statements(
+                OsStr::new(&program),
+                &option_file,
+                "UPDATE items SET value = 1",
+                &statements,
+                AccessMode::ReadWrite,
+                Duration::from_secs(5),
+            )
+            .await;
+            let error = match result {
+                Ok(_) => panic!("expected the fake MySQL statement to fail"),
+                Err(error) => error,
+            };
+
+            assert_eq!(error.summary(), summary);
+            assert!(!matches!(
+                error,
+                DbOperationError::QueryFailedAfterChange { .. }
+            ));
+        }
     }
 
     #[tokio::test]

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -4847,9 +4847,8 @@ done
                 Duration::from_secs(5),
             )
             .await;
-            let error = match result {
-                Ok(_) => panic!("expected the fake MySQL statement to fail"),
-                Err(error) => error,
+            let Err(error) = result else {
+                panic!("expected the fake MySQL statement to fail");
             };
 
             assert_eq!(error.summary(), summary);

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -5,6 +5,7 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::process::Stdio;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
@@ -2138,7 +2139,6 @@ async fn run_mysql_adhoc_process(
     for statement in statements {
         let marker = Uuid::new_v4().simple().to_string();
         let statement_scope = mysql_refresh_scope(&statement.kind);
-        refresh_scope = refresh_scope.merge(statement_scope);
         if let Err(error) = write_mysql_statement(process, &statement.sql).await {
             return Err(query_failed_after_change(error, refresh_scope));
         }
@@ -2181,6 +2181,7 @@ async fn run_mysql_adhoc_process(
             target: statement.target.clone(),
             tag,
         });
+        refresh_scope = refresh_scope.merge(statement_scope);
     }
 
     #[cfg(not(unix))]
@@ -2286,7 +2287,7 @@ fn query_failed_after_change(
         error
     } else {
         DbOperationError::QueryFailedAfterChange {
-            details: error.masked_details(),
+            source: Arc::new(error),
             refresh_scope,
         }
     }
@@ -2871,6 +2872,10 @@ fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {
         DbOperationError::ConnectionLost(details)
     } else if lower.contains("lock wait timeout") || lower.contains("deadlock found") {
         DbOperationError::LockTimeout(details)
+    } else if matches!(error_code, Some(1215 | 1216 | 1217 | 1451 | 1452))
+        || lower.contains("foreign key constraint")
+    {
+        DbOperationError::ForeignKeyViolation(details)
     } else if lower.contains("doesn't exist") || lower.contains("does not exist") {
         DbOperationError::ObjectMissing(details)
     } else if lower.contains("duplicate entry") {
@@ -4163,6 +4168,12 @@ line2]]></field>
             classify_mysql_query_failure(b"ERROR 1205 (HY000): Lock wait timeout exceeded"),
             DbOperationError::LockTimeout(_)
         ));
+        assert!(matches!(
+            classify_mysql_query_failure(
+                b"ERROR 1452 (23000): Cannot add or update a child row: a foreign key constraint fails"
+            ),
+            DbOperationError::ForeignKeyViolation(_)
+        ));
         let masked = classify_mysql_query_failure(b"ERROR password=secret");
         assert!(!masked.masked_details().contains("secret"));
     }
@@ -4188,6 +4199,19 @@ mod executor_tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    #[test]
+    fn failure_before_a_change_keeps_original_error() {
+        let error = query_failed_after_change(
+            DbOperationError::ForeignKeyViolation("foreign key failed".to_string()),
+            RefreshScope::None,
+        );
+
+        assert!(matches!(
+            error,
+            DbOperationError::ForeignKeyViolation(details) if details == "foreign key failed"
+        ));
+    }
 
     fn fake_mysql(mode: &str) -> (TempDir, PathBuf, PathBuf) {
         let directory = tempfile::tempdir().unwrap();
@@ -4710,9 +4734,10 @@ done
         assert!(matches!(
             result,
             Err(DbOperationError::QueryFailedAfterChange {
+                source,
                 refresh_scope: RefreshScope::Data,
                 ..
-            })
+            }) if matches!(&*source, DbOperationError::QueryFailed(_))
         ));
     }
 

--- a/src/infra/adapters/mysql.rs
+++ b/src/infra/adapters/mysql.rs
@@ -2135,42 +2135,45 @@ async fn run_mysql_adhoc_process(
     let mut last_result_set = None;
     let mut command_tags = Vec::with_capacity(statements.len());
     let mut refresh_scope = RefreshScope::None;
+    let mut scope_before_statement = RefreshScope::None;
 
     for statement in statements {
+        scope_before_statement = refresh_scope;
         let marker = Uuid::new_v4().simple().to_string();
         let statement_scope = mysql_refresh_scope(&statement.kind);
+        let possible_refresh_scope = refresh_scope.merge(statement_scope);
         if let Err(error) = write_mysql_statement(process, &statement.sql).await {
             return Err(query_failed_after_change(error, refresh_scope));
         }
         let marker_query =
             format!("SELECT '{marker}' AS __sabiql_marker, ROW_COUNT() AS affected_rows");
         if let Err(error) = write_mysql_statement(process, &marker_query).await {
-            return Err(query_failed_after_change(error, refresh_scope));
+            return Err(query_failed_after_change(error, possible_refresh_scope));
         }
         let first_xml = match read_one_mysql_resultset(process).await {
             Ok(xml) => xml,
-            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+            Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
         };
         let first_result = match parse_mysql_xml(&first_xml) {
             Ok(result) => result,
-            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+            Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
         };
         let (user_result, marker_result) = if is_mysql_row_count_marker(&first_result, &marker) {
             (None, first_result)
         } else {
             let xml = match read_one_mysql_resultset(process).await {
                 Ok(xml) => xml,
-                Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+                Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
             };
             let marker_result = match parse_mysql_xml(&xml) {
                 Ok(result) => result,
-                Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+                Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
             };
             (Some(first_result), marker_result)
         };
         let affected_rows = match mysql_row_count_marker(&marker_result, &marker) {
             Ok(rows) => rows,
-            Err(error) => return Err(query_failed_after_change(error, refresh_scope)),
+            Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
         };
         if let Some(result) = user_result {
             last_result_set = Some(result);
@@ -2181,7 +2184,7 @@ async fn run_mysql_adhoc_process(
             target: statement.target.clone(),
             tag,
         });
-        refresh_scope = refresh_scope.merge(statement_scope);
+        refresh_scope = possible_refresh_scope;
     }
 
     #[cfg(not(unix))]
@@ -2221,7 +2224,7 @@ async fn run_mysql_adhoc_process(
     if has_mysql_cli_error(error_bytes) {
         return Err(query_failed_after_change(
             classify_mysql_query_failure(error_bytes),
-            refresh_scope,
+            scope_before_statement,
         ));
     }
     if !status.success() {
@@ -4277,11 +4280,33 @@ done
     }
 
     fn fake_mysql_multi() -> (TempDir, PathBuf, PathBuf) {
+        fake_mysql_multi_with_mode(false)
+    }
+
+    fn fake_mysql_multi_with_marker_failure() -> (TempDir, PathBuf, PathBuf) {
+        fake_mysql_multi_with_mode(true)
+    }
+
+    fn fake_mysql_multi_with_mode(marker_failure: bool) -> (TempDir, PathBuf, PathBuf) {
         let directory = tempfile::tempdir().unwrap();
         let option_file = directory.path().join("option.cnf");
         fs::write(&option_file, "[client]\n").unwrap();
         let program = directory.path().join("mysql");
-        let script = r#"#!/bin/sh
+        let marker_response = if marker_failure {
+            "printf '%s\\n' '<resultset><row><field name=\"wrong\">x</field></row></resultset>'"
+        } else {
+            "marker=$(printf '%s\\n' \"$line\" | sed \"s/.*SELECT '\\\\([^']*\\\\)' AS __sabiql_marker.*/\\\\1/\")
+      rows=0
+      case \"$line\" in *ROW_COUNT\\(\\)* ) rows=3 ;; esac
+      printf '%s\\n' '<resultset><row><field name=\"__sabiql_marker\">'\"$marker\"'</field><field name=\"affected_rows\">'\"$rows\"'</field></row></resultset>'
+      if [ \"$pending_error\" = 1 ]; then
+        sleep 0.05
+        printf '%s\\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2
+        pending_error=0
+      fi"
+        };
+        let script = format!(
+            r#"#!/bin/sh
 option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 log="$option.log"
 pending_error=0
@@ -4298,16 +4323,8 @@ while IFS= read -r line; do
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
       printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
       ;;
-    *__sabiql_marker*)
-      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_marker.*/\\1/")
-      rows=0
-      case "$line" in *ROW_COUNT\(\)* ) rows=3 ;; esac
-      printf '%s\n' '<resultset><row><field name="__sabiql_marker">'"$marker"'</field><field name="affected_rows">'"$rows"'</field></row></resultset>'
-      if [ "$pending_error" = 1 ]; then
-        sleep 0.05
-        printf '%s\n' 'ERROR 1054 (42S22): Unknown column missing_column' >&2
-        pending_error=0
-      fi
+      *__sabiql_marker*)
+      {marker_response}
       ;;
     *missing_column*)
       pending_error=1
@@ -4325,7 +4342,8 @@ while IFS= read -r line; do
       ;;
   esac
 done
-"#;
+"#,
+        );
         fs::write(&program, script).unwrap();
         let mut permissions = fs::metadata(&program).unwrap().permissions();
         permissions.set_mode(0o755);
@@ -4709,6 +4727,35 @@ done
         let log = fs::read_to_string(log_file).unwrap();
         assert!(log.contains("UPDATE items SET value = 1"));
         assert!(log.matches("__sabiql_marker").count() >= 2);
+    }
+
+    #[tokio::test]
+    async fn marker_failure_after_a_change_refreshes_the_current_scope() {
+        let (_directory, program, option_file) = fake_mysql_multi_with_marker_failure();
+        let statements = split_mysql_statements("UPDATE items SET value = 1")
+            .unwrap()
+            .into_iter()
+            .map(|sql| classify_mysql_statement(&sql).unwrap())
+            .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements(
+            OsStr::new(&program),
+            &option_file,
+            "UPDATE items SET value = 1",
+            &statements,
+            AccessMode::ReadWrite,
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::QueryFailedAfterChange {
+                source,
+                refresh_scope: RefreshScope::Data,
+                ..
+            }) if matches!(&*source, DbOperationError::QueryFailed(_))
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem
`QueryFailedAfterChange` discarded the original `DbOperationError` classification after a MySQL change, so actionable summaries, hints, and details were lost.

## Background
A multi-statement MySQL submission can fail after an earlier data or schema change has completed, leaving the UI responsible for preserving the error classification while directing the user to refresh state.

## Approach
Retain the original error through an `Arc`-backed recursive variant and delegate classification, details, and password masking to it. Add partial-change and refresh guidance to user-facing messages, keep scope-specific refresh effects, classify MySQL foreign-key failures, and leave failures before a completed change unwrapped.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-412