### PR TITLE
feat(mysql): track table detail lifecycle in inspector

### DIFF
--- a/src/app/cmd/browse/metadata.rs
+++ b/src/app/cmd/browse/metadata.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use crate::cmd::cache::TtlCache;
 use crate::cmd::completion_engine::CompletionEngine;
 use crate::cmd::effect::Effect;
+use crate::cmd::query_task::TableDetailTaskRegistry;
 use crate::cmd::sqlite_path_validate::validate_sqlite_database_path;
 use crate::domain::DatabaseMetadata;
 use crate::domain::sqlite_path_from_dsn;
@@ -21,6 +22,7 @@ pub async fn run(
     metadata_provider: &Arc<dyn MetadataProvider>,
     metadata_cache: &TtlCache<String, Arc<DatabaseMetadata>>,
     sqlite_path_validator: &Arc<dyn SqlitePathValidator>,
+    table_detail_tasks: &TableDetailTaskRegistry,
     _state: &mut AppState,
     completion_engine: &RefCell<CompletionEngine>,
 ) -> Result<()> {
@@ -55,6 +57,7 @@ pub async fn run(
                 table,
                 generation,
                 run_id,
+                table_detail_tasks,
             );
             Ok(())
         }
@@ -195,11 +198,12 @@ fn fetch_table_detail(
     table: String,
     generation: u64,
     run_id: u64,
+    table_detail_tasks: &TableDetailTaskRegistry,
 ) {
     let provider = Arc::clone(metadata_provider);
     let tx = action_tx.clone();
 
-    tokio::spawn(async move {
+    table_detail_tasks.spawn(async move {
         match provider.fetch_table_detail(&dsn, &schema, &table).await {
             Ok(detail) => {
                 tx.send(Action::TableDetailLoaded {

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -98,6 +98,7 @@ pub enum Effect {
         access_mode: AccessMode,
     },
     CancelActiveQuery,
+    CancelActiveTasks,
     CountRowsForExport {
         dsn: String,
         run_id: u64,

--- a/src/app/cmd/query_task.rs
+++ b/src/app/cmd/query_task.rs
@@ -3,38 +3,38 @@ use std::sync::Mutex;
 use tokio::task::AbortHandle;
 
 #[derive(Default)]
-pub struct QueryTaskRegistry {
+pub struct TaskRegistry {
     active: Mutex<Option<AbortHandle>>,
 }
 
-impl QueryTaskRegistry {
-    /// Starts a task after cancelling any currently active query task.
+impl TaskRegistry {
+    /// Starts a task after cancelling any currently active task.
     ///
-    /// The registry is shared by query effects, so it intentionally permits
-    /// only one active task at a time.
+    /// Each registry instance intentionally permits only one active task at a
+    /// time; separate instances are used for queries and table details.
     pub fn spawn<F>(&self, task: F)
     where
         F: Future<Output = ()> + Send + 'static,
     {
         self.cancel();
         let handle = tokio::spawn(task);
-        *self
-            .active
-            .lock()
-            .expect("query task registry lock poisoned") = Some(handle.abort_handle());
+        *self.active.lock().expect("task registry lock poisoned") = Some(handle.abort_handle());
     }
 
     pub fn cancel(&self) {
         let handle = self
             .active
             .lock()
-            .expect("query task registry lock poisoned")
+            .expect("task registry lock poisoned")
             .take();
         if let Some(handle) = handle {
             handle.abort();
         }
     }
 }
+
+pub type QueryTaskRegistry = TaskRegistry;
+pub type TableDetailTaskRegistry = TaskRegistry;
 
 #[cfg(test)]
 mod tests {
@@ -76,5 +76,30 @@ mod tests {
         })
         .await
         .expect("cancelled query task should be dropped");
+    }
+
+    #[tokio::test]
+    async fn cancel_drops_active_table_detail_task() {
+        let registry = TableDetailTaskRegistry::default();
+        let dropped = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = oneshot::channel();
+        let guard = DropSignal(Arc::clone(&dropped));
+
+        registry.spawn(async move {
+            let _guard = guard;
+            started_tx.send(()).ok();
+            std::future::pending::<()>().await;
+        });
+
+        started_rx.await.expect("table detail task should start");
+        registry.cancel();
+
+        timeout(Duration::from_secs(1), async {
+            while !dropped.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled table detail task should be dropped");
     }
 }

--- a/src/app/cmd/query_task.rs
+++ b/src/app/cmd/query_task.rs
@@ -16,9 +16,12 @@ impl TaskRegistry {
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        self.cancel();
+        let mut active = self.active.lock().expect("task registry lock poisoned");
+        if let Some(handle) = active.take() {
+            handle.abort();
+        }
         let handle = tokio::spawn(task);
-        *self.active.lock().expect("task registry lock poisoned") = Some(handle.abort_handle());
+        *active = Some(handle.abort_handle());
     }
 
     pub fn cancel(&self) {

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -103,6 +103,11 @@ impl EffectRunner {
         &self.action_tx
     }
 
+    fn cancel_active_tasks(&self) {
+        self.query_tasks.cancel();
+        self.table_detail_tasks.cancel();
+    }
+
     pub async fn run<T: Renderer>(
         &self,
         effects: Vec<Effect>,
@@ -215,8 +220,7 @@ impl EffectRunner {
             }
 
             Effect::CancelActiveQuery => {
-                self.query_tasks.cancel();
-                self.table_detail_tasks.cancel();
+                self.cancel_active_tasks();
                 Ok(vec![])
             }
 
@@ -787,9 +791,16 @@ mod tests {
                 .expect("pending table detail should start")
                 .expect("started signal should be sent");
 
+            let shutdown_effects = reduce(
+                &mut state,
+                Action::Quit,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(state.should_quit);
             runner
                 .run(
-                    vec![Effect::CancelActiveQuery],
+                    shutdown_effects,
                     &mut renderer,
                     &mut state,
                     &completion_engine,

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -220,6 +220,11 @@ impl EffectRunner {
             }
 
             Effect::CancelActiveQuery => {
+                self.query_tasks.cancel();
+                Ok(vec![])
+            }
+
+            Effect::CancelActiveTasks => {
                 self.cancel_active_tasks();
                 Ok(vec![])
             }

--- a/src/app/cmd/runner.rs
+++ b/src/app/cmd/runner.rs
@@ -14,7 +14,7 @@ use crate::cmd::completion_engine::CompletionEngine;
 use crate::cmd::connection as cmd_connection;
 use crate::cmd::effect::Effect;
 use crate::cmd::er::handler as cmd_er;
-use crate::cmd::query_task::QueryTaskRegistry;
+use crate::cmd::query_task::{QueryTaskRegistry, TableDetailTaskRegistry};
 use crate::cmd::settings as cmd_settings;
 use crate::cmd::sql_editor::completion as cmd_completion;
 use crate::cmd::sql_editor::query_history as cmd_query_history;
@@ -71,6 +71,7 @@ pub struct EffectRunner {
     metadata_cache: TtlCache<String, Arc<DatabaseMetadata>>,
     action_tx: mpsc::Sender<Action>,
     query_tasks: QueryTaskRegistry,
+    table_detail_tasks: TableDetailTaskRegistry,
 }
 
 impl EffectRunner {
@@ -94,6 +95,7 @@ impl EffectRunner {
             metadata_cache,
             action_tx,
             query_tasks: QueryTaskRegistry::default(),
+            table_detail_tasks: TableDetailTaskRegistry::default(),
         }
     }
 
@@ -176,6 +178,9 @@ impl EffectRunner {
             | Effect::DeleteConnection { .. }
             | Effect::SwitchConnection { .. }
             | Effect::SwitchToService { .. }) => {
+                if matches!(&e, Effect::ProbeConnection { .. }) {
+                    self.table_detail_tasks.cancel();
+                }
                 cmd_connection::run(
                     e,
                     &self.action_tx,
@@ -201,6 +206,7 @@ impl EffectRunner {
                     &self.metadata_provider,
                     &self.metadata_cache,
                     &self.connection.sqlite_path_validator,
+                    &self.table_detail_tasks,
                     state,
                     completion_engine,
                 )
@@ -208,11 +214,16 @@ impl EffectRunner {
                 Ok(vec![])
             }
 
+            Effect::CancelActiveQuery => {
+                self.query_tasks.cancel();
+                self.table_detail_tasks.cancel();
+                Ok(vec![])
+            }
+
             e @ (Effect::ExecutePreview { .. }
             | Effect::ExecuteAdhoc { .. }
             | Effect::ExecuteExplain { .. }
             | Effect::ExecuteWrite { .. }
-            | Effect::CancelActiveQuery
             | Effect::CountRowsForExport { .. }
             | Effect::ExportCsv { .. }
             | Effect::ExportCsvFromCache { .. }) => {
@@ -522,7 +533,7 @@ mod tests {
 
         use super::*;
         use crate::domain::connection::{ConnectionId, DatabaseType};
-        use crate::domain::{QueryResult, WriteExecutionResult};
+        use crate::domain::{QueryResult, Table, TableSignature, WriteExecutionResult};
         use crate::model::connection::cache::ConnectionCache;
         use crate::ports::outbound::{AccessMode, DbOperationError};
         use crate::update::action::ConnectionTarget;
@@ -595,6 +606,54 @@ mod tests {
                 _file_name: &str,
             ) -> Result<PathBuf, DbOperationError> {
                 unreachable!("test only starts a preview")
+            }
+        }
+
+        struct PendingTableDetailProvider {
+            started: Mutex<Option<oneshot::Sender<()>>>,
+            dropped: Arc<AtomicBool>,
+        }
+
+        #[async_trait::async_trait]
+        impl MetadataProvider for PendingTableDetailProvider {
+            async fn fetch_metadata(
+                &self,
+                _dsn: &str,
+            ) -> Result<DatabaseMetadata, DbOperationError> {
+                unreachable!("test only starts table detail")
+            }
+
+            async fn fetch_table_detail(
+                &self,
+                _dsn: &str,
+                _schema: &str,
+                _table: &str,
+            ) -> Result<Table, DbOperationError> {
+                let _guard = DropSignal(Arc::clone(&self.dropped));
+                self.started
+                    .lock()
+                    .expect("started signal lock poisoned")
+                    .take()
+                    .expect("table detail should start once")
+                    .send(())
+                    .ok();
+                pending().await
+            }
+
+            async fn fetch_table_columns_and_fks(
+                &self,
+                _dsn: &str,
+                _schema: &str,
+                _table: &str,
+            ) -> Result<Table, DbOperationError> {
+                unreachable!("test only starts table detail")
+            }
+
+            async fn fetch_table_signatures(
+                &self,
+                _dsn: &str,
+            ) -> Result<Vec<TableSignature>, DbOperationError> {
+                unreachable!("test only starts table detail")
             }
         }
 
@@ -685,6 +744,67 @@ mod tests {
             .await
             .expect("context termination should drop the pending query task");
             assert!(!state.query.is_current_run(run_id));
+        }
+
+        #[tokio::test]
+        async fn cancelling_context_drops_pending_table_detail_task() {
+            let (started_tx, started_rx) = oneshot::channel();
+            let dropped = Arc::new(AtomicBool::new(false));
+            let provider = PendingTableDetailProvider {
+                started: Mutex::new(Some(started_tx)),
+                dropped: Arc::clone(&dropped),
+            };
+            let (action_tx, _action_rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner(
+                Arc::new(provider),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(MockConnectionStore::new()),
+                TtlCache::new(300),
+                action_tx,
+            );
+            let mut state = AppState::new("test".to_string());
+            let completion_engine = RefCell::new(CompletionEngine::new());
+            let mut renderer = NoopRenderer;
+
+            runner
+                .run(
+                    vec![Effect::FetchTableDetail {
+                        dsn: "postgres://localhost/current".to_string(),
+                        schema: "public".to_string(),
+                        table: "users".to_string(),
+                        generation: 1,
+                        run_id: 1,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+            timeout(Duration::from_secs(1), started_rx)
+                .await
+                .expect("pending table detail should start")
+                .expect("started signal should be sent");
+
+            runner
+                .run(
+                    vec![Effect::CancelActiveQuery],
+                    &mut renderer,
+                    &mut state,
+                    &completion_engine,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            timeout(Duration::from_secs(1), async {
+                while !dropped.load(Ordering::SeqCst) {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("context cancellation should drop the pending table detail task");
         }
     }
 }

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -246,10 +246,11 @@ impl AppState {
     }
 
     pub fn inspector_view_model(&self, ddl_generator: &dyn DdlGenerator) -> InspectorViewModel {
-        InspectorViewModel::build(
+        InspectorViewModel::build_with_detail_state(
             self.session.active_engine_feature_profile(),
             self.ui.inspector_tab(),
             self.session.table_detail(),
+            self.session.table_detail_state(),
             self.session.active_database_type_or_default(),
             ddl_generator,
         )

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -246,14 +246,24 @@ impl AppState {
     }
 
     pub fn inspector_view_model(&self, ddl_generator: &dyn DdlGenerator) -> InspectorViewModel {
-        InspectorViewModel::build_with_detail_state(
-            self.session.active_engine_feature_profile(),
-            self.ui.inspector_tab(),
-            self.session.table_detail(),
-            self.session.table_detail_state(),
-            self.session.active_database_type_or_default(),
-            ddl_generator,
-        )
+        if self.session.active_database_type() == Some(DatabaseType::MySQL) {
+            InspectorViewModel::build_with_detail_state(
+                self.session.active_engine_feature_profile(),
+                self.ui.inspector_tab(),
+                self.session.table_detail(),
+                self.session.table_detail_state(),
+                DatabaseType::MySQL,
+                ddl_generator,
+            )
+        } else {
+            InspectorViewModel::build(
+                self.session.active_engine_feature_profile(),
+                self.ui.inspector_tab(),
+                self.session.table_detail(),
+                self.session.active_database_type_or_default(),
+                ddl_generator,
+            )
+        }
     }
 
     pub fn jsonb_detail_editor_visible_rows(&self) -> usize {
@@ -481,6 +491,7 @@ mod tests {
         ColumnAttributes, ConnectionId, DatabaseMetadata, DatabaseType, QueryResult, QuerySource,
         QueryValue, Table, TableKind, TableKindInfo,
     };
+    use crate::model::browse::inspector_view_model::{InspectorEmptyState, InspectorLoadState};
     use crate::model::browse::row_detail::RowDetailState;
     use crate::model::er_state::ErStatus;
     use crate::model::shared::focused_pane::FocusedPane;
@@ -489,6 +500,7 @@ mod tests {
     };
     use crate::model::shared::viewport::ViewportPlan;
     use crate::model::sql_editor::modal::FailedPrefetchEntry;
+    use crate::services::AppServices;
     use crate::update::action::Action;
     use crate::update::dispatch_metadata;
     use rstest::rstest;
@@ -527,6 +539,27 @@ mod tests {
             name: "users".to_string(),
             ..test_support::table::minimal("", "")
         }
+    }
+
+    #[test]
+    fn non_mysql_inspector_keeps_legacy_no_table_state() {
+        let mut state = make_state();
+        activate_postgres_connection(&mut state, "postgres://localhost/test");
+        let _ = state
+            .session
+            .select_table("public", "users", &mut state.query);
+
+        let services = AppServices::stub();
+        let view_model = state.inspector_view_model(services.ddl_generator.as_ref());
+
+        assert_eq!(
+            view_model.load_state(),
+            &InspectorLoadState::NoTableSelected
+        );
+        assert_eq!(
+            view_model.empty_state(),
+            Some(InspectorEmptyState::NoTableSelected)
+        );
     }
 
     #[test]

--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -589,11 +589,11 @@ mod tests {
     fn loading_detail_exposes_loading_state_without_stale_rows() {
         let table = table();
         let model = InspectorViewModel::build_with_detail_state(
-            &EngineFeatureProfile::postgres_like(),
+            &EngineFeatureProfile::mysql_like(),
             InspectorTab::Info,
             Some(&table),
             &TableDetailState::Loading,
-            DatabaseType::PostgreSQL,
+            DatabaseType::MySQL,
             &TestDdlGenerator,
         );
 
@@ -606,11 +606,11 @@ mod tests {
     fn failed_detail_exposes_error_state_without_stale_rows() {
         let table = table();
         let model = InspectorViewModel::build_with_detail_state(
-            &EngineFeatureProfile::postgres_like(),
+            &EngineFeatureProfile::mysql_like(),
             InspectorTab::Info,
             Some(&table),
             &TableDetailState::Error("permission denied".to_string()),
-            DatabaseType::PostgreSQL,
+            DatabaseType::MySQL,
             &TestDdlGenerator,
         );
 

--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -1,4 +1,5 @@
 use crate::domain::{DatabaseType, ForeignKey, Index, IndexType, RlsInfo, Table};
+use crate::model::browse::session::TableDetailState;
 use crate::model::shared::engine_feature_profile::{EngineFeatureProfile, InspectorInfoField};
 use crate::model::shared::inspector_tab::InspectorTab;
 use crate::policy::table_kind::{inspector_flags_label, inspector_kind_label};
@@ -7,9 +8,18 @@ use crate::ports::outbound::DdlGenerator;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InspectorViewModel {
     active_tab: InspectorTab,
+    load_state: InspectorLoadState,
     section: Option<InspectorSection>,
     empty_state: Option<InspectorEmptyState>,
     unavailable_reason: Option<InspectorUnavailableReason>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InspectorLoadState {
+    NoTableSelected,
+    Loading,
+    Success,
+    Error(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -123,15 +133,57 @@ impl InspectorViewModel {
         database_type: DatabaseType,
         ddl_generator: &dyn DdlGenerator,
     ) -> Self {
+        let table_detail_state = if table.is_some() {
+            TableDetailState::Loaded
+        } else {
+            TableDetailState::NotSelected
+        };
+        Self::build_with_detail_state(
+            profile,
+            selected_tab,
+            table,
+            &table_detail_state,
+            database_type,
+            ddl_generator,
+        )
+    }
+
+    pub fn build_with_detail_state(
+        profile: &EngineFeatureProfile,
+        selected_tab: InspectorTab,
+        table: Option<&Table>,
+        table_detail_state: &TableDetailState,
+        database_type: DatabaseType,
+        ddl_generator: &dyn DdlGenerator,
+    ) -> Self {
         let active_tab = profile.normalize_inspector_tab(selected_tab);
+        let load_state = match table_detail_state {
+            TableDetailState::NotSelected => InspectorLoadState::NoTableSelected,
+            TableDetailState::Loading => InspectorLoadState::Loading,
+            TableDetailState::Loaded => InspectorLoadState::Success,
+            TableDetailState::Error(error) => InspectorLoadState::Error(error.clone()),
+        };
         let Some(table) = table else {
+            let empty_state = matches!(&load_state, InspectorLoadState::NoTableSelected)
+                .then_some(InspectorEmptyState::NoTableSelected);
             return Self {
                 active_tab,
+                load_state,
                 section: None,
-                empty_state: Some(InspectorEmptyState::NoTableSelected),
+                empty_state,
                 unavailable_reason: None,
             };
         };
+
+        if !matches!(&load_state, InspectorLoadState::Success) {
+            return Self {
+                active_tab,
+                load_state,
+                section: None,
+                empty_state: None,
+                unavailable_reason: None,
+            };
+        }
 
         let (section, empty_state, unavailable_reason) = match active_tab {
             InspectorTab::Info => (
@@ -276,6 +328,7 @@ impl InspectorViewModel {
 
         Self {
             active_tab,
+            load_state,
             section: Some(section),
             empty_state,
             unavailable_reason,
@@ -284,6 +337,10 @@ impl InspectorViewModel {
 
     pub fn active_tab(&self) -> InspectorTab {
         self.active_tab
+    }
+
+    pub fn load_state(&self) -> &InspectorLoadState {
+        &self.load_state
     }
 
     pub fn section(&self) -> Option<&InspectorSection> {
@@ -526,6 +583,42 @@ mod tests {
             Some(InspectorEmptyState::NoTableSelected)
         );
         assert_eq!(model.unavailable_reason(), None);
+    }
+
+    #[test]
+    fn loading_detail_exposes_loading_state_without_stale_rows() {
+        let table = table();
+        let model = InspectorViewModel::build_with_detail_state(
+            &EngineFeatureProfile::postgres_like(),
+            InspectorTab::Info,
+            Some(&table),
+            &TableDetailState::Loading,
+            DatabaseType::PostgreSQL,
+            &TestDdlGenerator,
+        );
+
+        assert_eq!(model.load_state(), &InspectorLoadState::Loading);
+        assert_eq!(model.section(), None);
+        assert_eq!(model.empty_state(), None);
+    }
+
+    #[test]
+    fn failed_detail_exposes_error_state_without_stale_rows() {
+        let table = table();
+        let model = InspectorViewModel::build_with_detail_state(
+            &EngineFeatureProfile::postgres_like(),
+            InspectorTab::Info,
+            Some(&table),
+            &TableDetailState::Error("permission denied".to_string()),
+            DatabaseType::PostgreSQL,
+            &TestDdlGenerator,
+        );
+
+        assert_eq!(
+            model.load_state(),
+            &InspectorLoadState::Error("permission denied".to_string())
+        );
+        assert_eq!(model.section(), None);
     }
 
     #[test]

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -24,6 +24,14 @@ struct ActiveConnection {
     database: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TableDetailState {
+    NotSelected,
+    Loading,
+    Loaded,
+    Error(String),
+}
+
 #[derive(Clone, PartialEq, Eq)]
 pub struct PendingConnectionProbe {
     pub id: ConnectionId,
@@ -72,6 +80,7 @@ pub struct BrowseSession {
     // -- co-dependent: table selection --
     selected_table_key: Option<String>,
     table_detail: Option<Table>,
+    table_detail_state: TableDetailState,
     selection_generation: u64,
 
     // -- lifecycle-gated --
@@ -101,6 +110,7 @@ impl Default for BrowseSession {
             metadata_state: MetadataState::default(),
             selected_table_key: None,
             table_detail: None,
+            table_detail_state: TableDetailState::NotSelected,
             selection_generation: 0,
             metadata: None,
             metadata_run: AsyncRun::default(),
@@ -130,7 +140,9 @@ impl BrowseSession {
         query.clear_current_result();
         self.selected_table_key = Some(format!("{schema}.{table}"));
         self.table_detail = None;
+        self.table_detail_state = TableDetailState::Loading;
         self.selection_generation += 1;
+        self.table_detail_run.clear_active();
         query.pagination.reset_for_table(schema, table);
         self.selection_generation
     }
@@ -139,6 +151,7 @@ impl BrowseSession {
     pub fn set_table_detail(&mut self, detail: Table, generation: u64) -> bool {
         if generation == self.selection_generation {
             self.table_detail = Some(detail);
+            self.table_detail_state = TableDetailState::Loaded;
             true
         } else {
             false
@@ -150,6 +163,7 @@ impl BrowseSession {
         query.clear_current_result();
         self.selected_table_key = None;
         self.table_detail = None;
+        self.table_detail_state = TableDetailState::NotSelected;
         self.selection_generation += 1;
         self.table_detail_run.clear_active();
         query.pagination.reset();
@@ -157,11 +171,29 @@ impl BrowseSession {
 
     #[must_use]
     pub fn begin_table_detail_run(&mut self) -> u64 {
+        if self.selected_table_key.is_some() {
+            self.table_detail = None;
+            self.table_detail_state = TableDetailState::Loading;
+        }
         self.table_detail_run.begin()
     }
 
     pub fn is_current_table_detail_run(&self, run_id: u64) -> bool {
         self.table_detail_run.is_current(run_id)
+    }
+
+    pub fn is_current_table_selection(&self, schema: &str, table: &str, generation: u64) -> bool {
+        generation == self.selection_generation
+            && self.selected_table_key.as_deref() == Some(&format!("{schema}.{table}"))
+    }
+
+    pub fn mark_table_detail_failed(&mut self, generation: u64, error: String) -> bool {
+        if generation == self.selection_generation && self.selected_table_key.is_some() {
+            self.table_detail_state = TableDetailState::Error(error);
+            true
+        } else {
+            false
+        }
     }
 
     // ── Connection lifecycle ─────────────────────────────────────────
@@ -483,6 +515,11 @@ impl BrowseSession {
         self.table_detail.clone_from(&cache.table_detail);
         self.selected_table_key
             .clone_from(&cache.selected_table_key);
+        self.table_detail_state = match (&self.selected_table_key, &self.table_detail) {
+            (Some(_), Some(_)) => TableDetailState::Loaded,
+            (Some(_), None) => TableDetailState::Loading,
+            (None, _) => TableDetailState::NotSelected,
+        };
         self.connection_state = ConnectionState::Connected;
         self.metadata_state = MetadataState::Loaded;
         self.selection_generation = 0;
@@ -517,6 +554,7 @@ impl BrowseSession {
         query.reset_for_context_change();
         self.metadata = None;
         self.table_detail = None;
+        self.table_detail_state = TableDetailState::NotSelected;
         self.selected_table_key = None;
         self.selection_generation = 0;
         self.connection_state = ConnectionState::default();
@@ -562,6 +600,10 @@ impl BrowseSession {
 
     pub fn table_detail(&self) -> Option<&Table> {
         self.table_detail.as_ref()
+    }
+
+    pub fn table_detail_state(&self) -> &TableDetailState {
+        &self.table_detail_state
     }
 
     pub fn selection_generation(&self) -> u64 {
@@ -710,6 +752,13 @@ impl BrowseSession {
 
     pub(crate) fn set_table_detail_raw(&mut self, detail: Option<Table>) {
         self.table_detail = detail;
+        self.table_detail_state = if self.table_detail.is_some() {
+            TableDetailState::Loaded
+        } else if self.selected_table_key.is_some() {
+            TableDetailState::Loading
+        } else {
+            TableDetailState::NotSelected
+        };
     }
 
     #[cfg(test)]
@@ -781,6 +830,7 @@ mod tests {
             let _ = session.select_table("public", "users", &mut query);
 
             assert!(session.table_detail().is_none());
+            assert_eq!(session.table_detail_state(), &TableDetailState::Loading);
         }
 
         #[test]
@@ -849,6 +899,7 @@ mod tests {
 
             assert!(accepted);
             assert!(session.table_detail().is_some());
+            assert_eq!(session.table_detail_state(), &TableDetailState::Loaded);
         }
 
         #[test]
@@ -862,6 +913,57 @@ mod tests {
 
             assert!(!accepted);
             assert!(session.table_detail().is_none());
+        }
+
+        #[test]
+        fn records_error_for_current_generation() {
+            let mut session = BrowseSession::default();
+            let mut query = QueryExecution::default();
+            let generation = session.select_table("public", "users", &mut query);
+
+            assert!(session.mark_table_detail_failed(generation, "boom".to_string()));
+            assert_eq!(
+                session.table_detail_state(),
+                &TableDetailState::Error("boom".to_string())
+            );
+        }
+
+        #[test]
+        fn rejects_error_for_stale_generation() {
+            let mut session = BrowseSession::default();
+            let mut query = QueryExecution::default();
+            let old_generation = session.select_table("public", "users", &mut query);
+            let _ = session.select_table("public", "posts", &mut query);
+
+            assert!(!session.mark_table_detail_failed(old_generation, "boom".to_string()));
+            assert_eq!(session.table_detail_state(), &TableDetailState::Loading);
+        }
+
+        #[test]
+        fn starting_a_new_run_clears_previous_success() {
+            let mut session = BrowseSession::default();
+            let mut query = QueryExecution::default();
+            let generation = session.select_table("public", "users", &mut query);
+            let _ = session.set_table_detail(make_table_detail(), generation);
+
+            let _ = session.begin_table_detail_run();
+
+            assert!(session.table_detail().is_none());
+            assert_eq!(session.table_detail_state(), &TableDetailState::Loading);
+        }
+
+        #[test]
+        fn starting_detail_run_keeps_current_query_result_visible() {
+            let mut session = BrowseSession::default();
+            let mut query = QueryExecution::default();
+            let generation = session.select_table("public", "users", &mut query);
+            let _ = session.set_table_detail(make_table_detail(), generation);
+            query.set_current_result(make_query_result());
+
+            let _ = session.begin_table_detail_run();
+
+            assert!(query.current_result().is_some());
+            assert_eq!(session.table_detail_state(), &TableDetailState::Loading);
         }
     }
 
@@ -879,6 +981,7 @@ mod tests {
 
         assert!(session.selected_table_key().is_none());
         assert!(session.table_detail().is_none());
+        assert_eq!(session.table_detail_state(), &TableDetailState::NotSelected);
         assert!(query.current_result().is_none());
         assert_eq!(query.pagination.current_page(), 0);
     }
@@ -895,6 +998,7 @@ mod tests {
         let accepted = session.set_table_detail(make_table_detail(), pre_clear_gen);
         assert!(!accepted);
         assert!(session.table_detail().is_none());
+        assert_eq!(session.table_detail_state(), &TableDetailState::NotSelected);
     }
 
     #[test]

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -517,8 +517,7 @@ impl BrowseSession {
             .clone_from(&cache.selected_table_key);
         self.table_detail_state = match (&self.selected_table_key, &self.table_detail) {
             (Some(_), Some(_)) => TableDetailState::Loaded,
-            (Some(_), None) => TableDetailState::Loading,
-            (None, _) => TableDetailState::NotSelected,
+            (Some(_), None) | (None, _) => TableDetailState::NotSelected,
         };
         self.connection_state = ConnectionState::Connected;
         self.metadata_state = MetadataState::Loaded;
@@ -1222,6 +1221,27 @@ mod tests {
 
             assert_eq!(new_session.selection_generation(), 0);
             assert!(!new_session.is_reloading());
+        }
+
+        #[test]
+        fn restore_without_table_detail_does_not_claim_loading() {
+            let mut session = BrowseSession::default();
+            session.mark_connected(make_metadata("db"));
+            let mut query = QueryExecution::default();
+            let _ = session.select_table("public", "users", &mut query);
+
+            let cache = session.to_cache(0, InspectorTab::Info, None, ResultHistory::default());
+
+            let mut restored = BrowseSession::default();
+            let mut query = QueryExecution::default();
+            restored.restore_from_cache(&cache, &mut query);
+
+            assert_eq!(restored.selected_table_key(), Some("public.users"));
+            assert_eq!(
+                restored.table_detail_state(),
+                &TableDetailState::NotSelected
+            );
+            assert!(!restored.is_current_table_detail_run(1));
         }
 
         #[test]

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -196,6 +196,18 @@ impl BrowseSession {
         }
     }
 
+    pub fn mark_table_detail_probe_failed(&mut self, error: String) -> bool {
+        if self.selected_table_key.is_some()
+            && self.table_detail.is_none()
+            && self.table_detail_state == TableDetailState::Loading
+        {
+            self.table_detail_state = TableDetailState::Error(error);
+            true
+        } else {
+            false
+        }
+    }
+
     // ── Connection lifecycle ─────────────────────────────────────────
 
     pub fn mark_connecting(&mut self) {

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -62,7 +62,7 @@ mod tests {
     use crate::model::browse::session::TableDetailState;
     use crate::model::sql_editor::modal::FailedPrefetchEntry;
     use crate::ports::outbound::DbOperationError;
-    use crate::update::action::Action;
+    use crate::update::action::{Action, TableTarget};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
@@ -162,6 +162,30 @@ mod tests {
             assert!(matches!(
                 state.session.table_detail_state(),
                 TableDetailState::Error(_)
+            ));
+            assert!(state.messages.last_error().is_some());
+        }
+
+        #[test]
+        fn table_detail_load_without_connection_ends_loading_state() {
+            let mut state = AppState::new("test".to_string());
+            let generation = state
+                .session
+                .select_table("public", "users", &mut state.query);
+
+            dispatch_metadata(
+                &mut state,
+                &Action::LoadTableDetail(TableTarget {
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                    generation,
+                }),
+                Instant::now(),
+            );
+
+            assert!(matches!(
+                state.session.table_detail_state(),
+                TableDetailState::Error(message) if message == "No active connection"
             ));
             assert!(state.messages.last_error().is_some());
         }

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -59,7 +59,9 @@ mod tests {
     use crate::cmd::effect::Effect;
     use crate::domain::{ConnectionId, DatabaseType, Table};
     use crate::model::app_state::AppState;
+    use crate::model::browse::session::TableDetailState;
     use crate::model::sql_editor::modal::FailedPrefetchEntry;
+    use crate::ports::outbound::DbOperationError;
     use crate::update::action::Action;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
@@ -136,6 +138,64 @@ mod tests {
             );
 
             assert!(state.session.table_detail().is_none());
+        }
+
+        #[test]
+        fn current_table_detail_failure_updates_inspector_and_footer() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let generation = state
+                .session
+                .select_table("public", "users", &mut state.query);
+            let run_id = state.session.begin_table_detail_run();
+
+            dispatch_metadata(
+                &mut state,
+                &Action::TableDetailFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    error: DbOperationError::PermissionDenied("denied".to_string()),
+                    generation,
+                },
+                Instant::now(),
+            );
+
+            assert!(matches!(
+                state.session.table_detail_state(),
+                TableDetailState::Error(_)
+            ));
+            assert!(state.messages.last_error().is_some());
+        }
+
+        #[test]
+        fn stale_table_detail_failure_does_not_update_current_inspector() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let stale_generation = state
+                .session
+                .select_table("public", "users", &mut state.query);
+            let _ = state.session.begin_table_detail_run();
+            let current_generation =
+                state
+                    .session
+                    .select_table("public", "orders", &mut state.query);
+            let current_run_id = state.session.begin_table_detail_run();
+
+            dispatch_metadata(
+                &mut state,
+                &Action::TableDetailFailed {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id: current_run_id,
+                    error: DbOperationError::PermissionDenied("denied".to_string()),
+                    generation: stale_generation,
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(state.session.selection_generation(), current_generation);
+            assert_eq!(
+                state.session.table_detail_state(),
+                &TableDetailState::Loading
+            );
+            assert!(state.messages.last_error().is_none());
         }
 
         #[test]
@@ -447,7 +507,6 @@ mod tests {
 
     mod table_detail_cache_failed {
         use super::*;
-        use crate::ports::outbound::DbOperationError;
 
         #[test]
         fn increments_retry_count() {

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -40,8 +40,12 @@ pub(super) fn reduce_table_detail(
                 return DispatchResult::handled();
             }
 
-            if *generation == state.session.selection_generation() {
-                state.messages.set_error_at(error.user_message(), now);
+            let message = error.user_message();
+            if state
+                .session
+                .mark_table_detail_failed(*generation, message.clone())
+            {
+                state.messages.set_error_at(message, now);
             }
             DispatchResult::handled()
         }
@@ -50,18 +54,21 @@ pub(super) fn reduce_table_detail(
             table,
             generation,
         }) => {
-            if let Some(dsn) = state.session.dsn().map(String::from) {
+            if state
+                .session
+                .is_current_table_selection(schema, table, *generation)
+                && let Some(dsn) = state.session.dsn().map(String::from)
+            {
                 let run_id = state.session.begin_table_detail_run();
-                DispatchResult::handled_with(vec![Effect::FetchTableDetail {
+                return DispatchResult::handled_with(vec![Effect::FetchTableDetail {
                     dsn,
                     schema: schema.clone(),
                     table: table.clone(),
                     generation: *generation,
                     run_id,
-                }])
-            } else {
-                DispatchResult::handled()
+                }]);
             }
+            DispatchResult::handled()
         }
         _ => DispatchResult::pass(),
     }

--- a/src/app/update/browse/metadata/table_detail.rs
+++ b/src/app/update/browse/metadata/table_detail.rs
@@ -54,21 +54,32 @@ pub(super) fn reduce_table_detail(
             table,
             generation,
         }) => {
-            if state
+            if !state
                 .session
                 .is_current_table_selection(schema, table, *generation)
-                && let Some(dsn) = state.session.dsn().map(String::from)
             {
-                let run_id = state.session.begin_table_detail_run();
-                return DispatchResult::handled_with(vec![Effect::FetchTableDetail {
-                    dsn,
-                    schema: schema.clone(),
-                    table: table.clone(),
-                    generation: *generation,
-                    run_id,
-                }]);
+                return DispatchResult::handled();
             }
-            DispatchResult::handled()
+
+            let Some(dsn) = state.session.dsn().map(String::from) else {
+                let message = "No active connection".to_string();
+                if state
+                    .session
+                    .mark_table_detail_failed(*generation, message.clone())
+                {
+                    state.messages.set_error_at(message, now);
+                }
+                return DispatchResult::handled();
+            };
+
+            let run_id = state.session.begin_table_detail_run();
+            DispatchResult::handled_with(vec![Effect::FetchTableDetail {
+                dsn,
+                schema: schema.clone(),
+                table: table.clone(),
+                generation: *generation,
+                run_id,
+            }])
         }
         _ => DispatchResult::pass(),
     }

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -161,7 +161,7 @@ pub fn reduce_execution(
             DispatchResult::handled_with(match follow_up {
                 Action::Quit => {
                     state.should_quit = true;
-                    vec![]
+                    vec![Effect::CancelActiveQuery]
                 }
                 Action::ToggleModal(ModalKind::Help) => {
                     state.ui.help_mut().open(HelpOrigin::CommandLine);
@@ -332,15 +332,17 @@ mod tests {
             state.modal.push_mode(InputMode::CommandLine);
             state.command_line_input.set_content("q".to_string());
 
-            dispatch_query(
+            let effects = dispatch_query(
                 &mut state,
                 &Action::CommandLineSubmit,
                 Instant::now(),
                 &AppServices::stub(),
-            );
+            )
+            .unwrap();
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(state.should_quit);
+            assert!(matches!(effects.as_slice(), [Effect::CancelActiveQuery]));
         }
 
         #[test]

--- a/src/app/update/browse/query/execution.rs
+++ b/src/app/update/browse/query/execution.rs
@@ -161,7 +161,7 @@ pub fn reduce_execution(
             DispatchResult::handled_with(match follow_up {
                 Action::Quit => {
                     state.should_quit = true;
-                    vec![Effect::CancelActiveQuery]
+                    vec![Effect::CancelActiveTasks]
                 }
                 Action::ToggleModal(ModalKind::Help) => {
                     state.ui.help_mut().open(HelpOrigin::CommandLine);
@@ -342,7 +342,7 @@ mod tests {
 
             assert_eq!(state.input_mode(), InputMode::Normal);
             assert!(state.should_quit);
-            assert!(matches!(effects.as_slice(), [Effect::CancelActiveQuery]));
+            assert!(matches!(effects.as_slice(), [Effect::CancelActiveTasks]));
         }
 
         #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -89,10 +89,14 @@ pub fn reduce_connection_lifecycle(
                     dsn,
                     database.as_deref(),
                 );
-                return DispatchResult::handled_with(vec![Effect::ProbeConnection {
-                    target: target.clone(),
-                    run_id,
-                }]);
+                state.query.reset_for_context_change();
+                return DispatchResult::handled_with(termination_effects(
+                    &state.query,
+                    vec![Effect::ProbeConnection {
+                        target: target.clone(),
+                        run_id,
+                    }],
+                ));
             }
 
             state.session.clear_connection_probe();
@@ -269,12 +273,11 @@ pub fn reduce_connection_lifecycle(
             {
                 return DispatchResult::handled();
             }
+            let message = error.user_message();
             if state.session.dsn_matches(&target.dsn) {
-                state.session.mark_connection_failed(error.user_message());
+                state.session.mark_connection_failed(message.clone());
             }
-            if state.session.selected_table_key().is_some() {
-                state.session.clear_table_selection(&mut state.query);
-            }
+            state.session.mark_table_detail_probe_failed(message);
             state.connection_error.set_error(
                 ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
             );
@@ -293,7 +296,10 @@ mod tests {
     use super::*;
     use crate::domain::connection::DatabaseType;
     use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
-    use crate::domain::{ConnectionId, DatabaseMetadata, MetadataState};
+    use crate::domain::{
+        ConnectionId, DatabaseMetadata, MetadataState, QueryResult, QuerySource, Table,
+        TableKindInfo,
+    };
     use crate::model::browse::session::TableDetailState;
     use crate::model::connection::cache::ConnectionCache;
     use crate::model::connection::error::ConnectionErrorKind;
@@ -1081,7 +1087,7 @@ mod tests {
         }
 
         #[test]
-        fn mysql_probe_failure_clears_table_selection_after_switch() {
+        fn mysql_probe_failure_ends_loading_without_clearing_selection() {
             let mut state = AppState::new("test".to_string());
             let first = ConnectionTarget {
                 id: ConnectionId::from_string("mysql-a"),
@@ -1131,14 +1137,105 @@ mod tests {
             );
 
             assert!(state.session.connection_state().is_connected());
-            assert!(state.session.selected_table_key().is_none());
+            assert_eq!(state.session.selected_table_key(), Some("public.users"));
             assert!(state.session.table_detail().is_none());
+            assert!(matches!(
+                state.session.table_detail_state(),
+                TableDetailState::Error(_)
+            ));
+            assert_eq!(state.session.selection_generation(), generation);
+            assert!(!state.session.is_current_table_detail_run(detail_run_id));
+        }
+
+        #[test]
+        fn mysql_probe_failure_preserves_loaded_inspector_result_and_cancels_query() {
+            let mut state = AppState::new("test".to_string());
+            let first = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-a"),
+                dsn: "mysql://user@localhost:3306/a?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-a".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("a".to_string()),
+            };
+            state.session.activate_connection_with_target(
+                &first.id,
+                &first.name,
+                first.database_type,
+                &first.dsn,
+                first.database.as_deref(),
+            );
+            state.session.mark_probe_connected(true);
+            state.ui.set_explorer_selected_raw(3);
+            let generation = state
+                .session
+                .select_table("public", "users", &mut state.query);
+            let detail = Table {
+                schema: "public".to_string(),
+                name: "users".to_string(),
+                owner: None,
+                columns: Vec::new(),
+                primary_key: None,
+                foreign_keys: Vec::new(),
+                indexes: Vec::new(),
+                rls: None,
+                triggers: Vec::new(),
+                row_count_estimate: None,
+                comment: None,
+                source_ddl: None,
+                kind_info: TableKindInfo::default(),
+            };
+            assert!(state.session.set_table_detail(detail, generation));
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success(
+                    "SELECT * FROM users".to_string(),
+                    vec!["id".to_string()],
+                    vec![vec!["1".to_string()]],
+                    10,
+                    QuerySource::Preview,
+                )));
+            state.query.pagination.reset_for_table("public", "users");
+            state.query.pagination.set_current_page(2);
+            let query_run_id = state.query.begin_running(std::time::Instant::now());
+
+            let second = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(second.clone())).unwrap();
+            let probe_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            assert!(matches!(effects.first(), Some(Effect::CancelActiveQuery)));
+            assert!(!state.query.is_running());
+            assert!(!state.query.is_current_run(query_run_id));
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: second,
+                    run_id: probe_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            assert!(state.session.connection_state().is_connected());
+            assert_eq!(state.session.selected_table_key(), Some("public.users"));
             assert_eq!(
                 state.session.table_detail_state(),
-                &TableDetailState::NotSelected
+                &TableDetailState::Loaded
             );
-            assert_ne!(state.session.selection_generation(), generation);
-            assert!(!state.session.is_current_table_detail_run(detail_run_id));
+            assert!(state.session.table_detail().is_some());
+            assert!(state.query.current_result().is_some());
+            assert_eq!(state.query.pagination.current_page(), 2);
+            assert_eq!(state.ui.explorer_selected(), 3);
         }
 
         #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -272,6 +272,9 @@ pub fn reduce_connection_lifecycle(
             if state.session.dsn_matches(&target.dsn) {
                 state.session.mark_connection_failed(error.user_message());
             }
+            if state.session.selected_table_key().is_some() {
+                state.session.clear_table_selection(&mut state.query);
+            }
             state.connection_error.set_error(
                 ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
             );
@@ -291,6 +294,7 @@ mod tests {
     use crate::domain::connection::DatabaseType;
     use crate::domain::query_history::{QueryHistoryEntry, QueryResultStatus};
     use crate::domain::{ConnectionId, DatabaseMetadata, MetadataState};
+    use crate::model::browse::session::TableDetailState;
     use crate::model::connection::cache::ConnectionCache;
     use crate::model::connection::error::ConnectionErrorKind;
     use crate::model::connection::state::ConnectionState;
@@ -1074,6 +1078,67 @@ mod tests {
 
             assert!(state.session.connection_state().is_connected());
             assert!(!state.session.is_reloading());
+        }
+
+        #[test]
+        fn mysql_probe_failure_clears_table_selection_after_switch() {
+            let mut state = AppState::new("test".to_string());
+            let first = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-a"),
+                dsn: "mysql://user@localhost:3306/a?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-a".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("a".to_string()),
+            };
+            state.session.activate_connection_with_target(
+                &first.id,
+                &first.name,
+                first.database_type,
+                &first.dsn,
+                first.database.as_deref(),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            let generation = state
+                .session
+                .select_table("public", "users", &mut state.query);
+            let detail_run_id = state.session.begin_table_detail_run();
+
+            let second = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let effects = reduce(&mut state, &Action::SwitchConnection(second.clone())).unwrap();
+            let probe_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: second,
+                    run_id: probe_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            assert!(state.session.connection_state().is_connected());
+            assert!(state.session.selected_table_key().is_none());
+            assert!(state.session.table_detail().is_none());
+            assert_eq!(
+                state.session.table_detail_state(),
+                &TableDetailState::NotSelected
+            );
+            assert_ne!(state.session.selection_generation(), generation);
+            assert!(!state.session.is_current_table_detail_run(detail_run_id));
         }
 
         #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -274,10 +274,13 @@ pub fn reduce_connection_lifecycle(
                 return DispatchResult::handled();
             }
             let message = error.user_message();
-            if state.session.dsn_matches(&target.dsn) {
+            let detail_message = if state.session.dsn_matches(&target.dsn) {
                 state.session.mark_connection_failed(message.clone());
-            }
-            state.session.mark_table_detail_probe_failed(message);
+                message
+            } else {
+                "Load canceled by connection change".to_string()
+            };
+            state.session.mark_table_detail_probe_failed(detail_message);
             state.connection_error.set_error(
                 ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
             );
@@ -1141,7 +1144,7 @@ mod tests {
             assert!(state.session.table_detail().is_none());
             assert!(matches!(
                 state.session.table_detail_state(),
-                TableDetailState::Error(_)
+                TableDetailState::Error(message) if message == "Load canceled by connection change"
             ));
             assert_eq!(state.session.selection_generation(), generation);
             assert!(!state.session.is_current_table_detail_run(detail_run_id));
@@ -1213,7 +1216,7 @@ mod tests {
                     _ => None,
                 })
                 .unwrap();
-            assert!(matches!(effects.first(), Some(Effect::CancelActiveQuery)));
+            assert!(matches!(effects.first(), Some(Effect::CancelActiveTasks)));
             assert!(!state.query.is_running());
             assert!(!state.query.is_current_run(query_run_id));
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -772,7 +772,7 @@ mod tests {
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
             assert!(matches!(
                 effects.as_slice(),
-                [Effect::CancelActiveQuery, Effect::SaveAndConnect { .. }]
+                [Effect::CancelActiveTasks, Effect::SaveAndConnect { .. }]
             ));
         }
 
@@ -784,7 +784,7 @@ mod tests {
             let first_effects = reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
             assert!(first_effects.is_some_and(|effects| matches!(
                 effects.as_slice(),
-                [Effect::CancelActiveQuery, Effect::SaveAndConnect { .. }]
+                [Effect::CancelActiveTasks, Effect::SaveAndConnect { .. }]
             )));
 
             let effects = reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
@@ -814,7 +814,7 @@ mod tests {
             assert!(!state.connection_setup.ssl_dropdown().is_open());
             assert!(matches!(
                 effects.as_slice(),
-                [Effect::CancelActiveQuery, Effect::SaveAndConnect {
+                [Effect::CancelActiveTasks, Effect::SaveAndConnect {
                     config: ConnectionConfig::PostgreSQL(config),
                     ..
                 }] if config.ssl_mode == SslMode::Require
@@ -852,7 +852,7 @@ mod tests {
 
             assert!(matches!(
                 effects.as_slice(),
-                [Effect::CancelActiveQuery, Effect::SaveAndConnect {
+                [Effect::CancelActiveTasks, Effect::SaveAndConnect {
                     name,
                     config: ConnectionConfig::PostgreSQL(config),
                     ..

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -34,7 +34,7 @@ pub(super) fn reduce_confirm_dialog(
             match intent {
                 Some(ConfirmIntent::QuitNoConnection) => {
                     state.should_quit = true;
-                    DispatchResult::handled_with(vec![Effect::CancelActiveQuery])
+                    DispatchResult::handled_with(vec![Effect::CancelActiveTasks])
                 }
                 Some(ConfirmIntent::DeleteConnection(id)) => {
                     DispatchResult::handled_with(vec![Effect::DeleteConnection { id }])

--- a/src/app/update/modal/confirm_dialog.rs
+++ b/src/app/update/modal/confirm_dialog.rs
@@ -34,7 +34,7 @@ pub(super) fn reduce_confirm_dialog(
             match intent {
                 Some(ConfirmIntent::QuitNoConnection) => {
                     state.should_quit = true;
-                    DispatchResult::handled()
+                    DispatchResult::handled_with(vec![Effect::CancelActiveQuery])
                 }
                 Some(ConfirmIntent::DeleteConnection(id)) => {
                     DispatchResult::handled_with(vec![Effect::DeleteConnection { id }])

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -606,7 +606,7 @@ mod tests {
 
                 assert!(state.should_quit);
                 assert!(state.confirm_dialog.intent().is_none());
-                assert!(matches!(effects.as_slice(), [Effect::CancelActiveQuery]));
+                assert!(matches!(effects.as_slice(), [Effect::CancelActiveTasks]));
             }
 
             #[test]

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -606,7 +606,7 @@ mod tests {
 
                 assert!(state.should_quit);
                 assert!(state.confirm_dialog.intent().is_none());
-                assert!(effects.is_empty());
+                assert!(matches!(effects.as_slice(), [Effect::CancelActiveQuery]));
             }
 
             #[test]

--- a/src/app/update/query_context.rs
+++ b/src/app/update/query_context.rs
@@ -9,7 +9,7 @@ pub fn termination_effects(query: &QueryExecution, follow_up: Vec<Effect>) -> Ve
     );
 
     let mut effects = Vec::with_capacity(follow_up.len() + 1);
-    effects.push(Effect::CancelActiveQuery);
+    effects.push(Effect::CancelActiveTasks);
     effects.extend(follow_up);
     effects
 }
@@ -26,7 +26,7 @@ mod tests {
 
         let effects = termination_effects(&query, vec![Effect::ClearCompletionEngineCache]);
 
-        assert!(matches!(effects[0], Effect::CancelActiveQuery));
+        assert!(matches!(effects[0], Effect::CancelActiveTasks));
         assert!(matches!(effects[1], Effect::ClearCompletionEngineCache));
     }
 

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -82,7 +82,7 @@ fn reduce_inner(
         }
         Action::Quit => {
             state.should_quit = true;
-            vec![]
+            vec![Effect::CancelActiveQuery]
         }
         Action::Resize(w, h) => {
             state.ui.set_terminal_width(w);
@@ -227,14 +227,14 @@ mod tests {
         use rstest::rstest;
 
         #[test]
-        fn quit_sets_should_quit_and_returns_no_effects() {
+        fn quit_sets_should_quit_and_cancels_active_tasks() {
             let mut state = create_test_state();
             let now = Instant::now();
 
             let effects = reduce(&mut state, Action::Quit, now, &AppServices::stub());
 
             assert!(state.should_quit);
-            assert!(effects.is_empty());
+            assert!(matches!(effects.as_slice(), [Effect::CancelActiveQuery]));
         }
 
         #[test]
@@ -2209,7 +2209,7 @@ mod tests {
                 .open("", "", ConfirmIntent::QuitNoConnection);
             let now = Instant::now();
 
-            reduce(
+            let effects = reduce(
                 &mut state,
                 Action::ConfirmDialogConfirm,
                 now,
@@ -2218,6 +2218,7 @@ mod tests {
 
             assert!(state.should_quit);
             assert!(state.confirm_dialog.intent().is_none());
+            assert!(matches!(effects.as_slice(), [Effect::CancelActiveQuery]));
         }
 
         #[test]

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -82,7 +82,7 @@ fn reduce_inner(
         }
         Action::Quit => {
             state.should_quit = true;
-            vec![Effect::CancelActiveQuery]
+            vec![Effect::CancelActiveTasks]
         }
         Action::Resize(w, h) => {
             state.ui.set_terminal_width(w);
@@ -123,7 +123,7 @@ fn reduce_inner(
                     .cloned();
                 if let Some(table) = table {
                     state.modal.set_mode(InputMode::Normal);
-                    return select_table(state, &table);
+                    return select_table(state, &table, now);
                 }
             } else if state.modal.active_mode() == InputMode::Normal {
                 if state.connection_error.error_info.is_some() {
@@ -139,7 +139,7 @@ fn reduce_inner(
                     .copied()
                     .cloned();
                 if let Some(table) = table {
-                    return select_table(state, &table);
+                    return select_table(state, &table, now);
                 }
             } else if state.modal.active_mode() == InputMode::CommandPalette {
                 use crate::update::input::palette::palette_action_for_index;
@@ -176,7 +176,7 @@ fn reduce_inner(
     }
 }
 
-fn select_table(state: &mut AppState, table: &TableSummary) -> Vec<Effect> {
+fn select_table(state: &mut AppState, table: &TableSummary, now: Instant) -> Vec<Effect> {
     let generation = state
         .session
         .select_table(&table.schema, &table.name, &mut state.query);
@@ -195,6 +195,12 @@ fn select_table(state: &mut AppState, table: &TableSummary) -> Vec<Effect> {
             generation,
             run_id,
         });
+    } else {
+        let message = "No active connection".to_string();
+        state
+            .session
+            .mark_table_detail_failed(generation, message.clone());
+        state.messages.set_error_at(message, now);
     }
     effects.push(Effect::DispatchActions(vec![Action::ExecutePreview(
         TableTarget {
@@ -212,6 +218,7 @@ mod tests {
 
     use super::*;
     use crate::domain::{ConnectionId, DatabaseType};
+    use crate::model::browse::session::TableDetailState;
     use crate::ports::outbound::DbOperationError;
     use crate::ports::outbound::connection_store::ConnectionStoreError;
     use crate::update::action::ModalKind;
@@ -234,7 +241,7 @@ mod tests {
             let effects = reduce(&mut state, Action::Quit, now, &AppServices::stub());
 
             assert!(state.should_quit);
-            assert!(matches!(effects.as_slice(), [Effect::CancelActiveQuery]));
+            assert!(matches!(effects.as_slice(), [Effect::CancelActiveTasks]));
         }
 
         #[test]
@@ -307,6 +314,21 @@ mod tests {
             reduce(&mut state, action, now, &AppServices::stub());
 
             assert_eq!(state.ui.explorer_selected(), 0);
+        }
+
+        #[test]
+        fn selecting_table_without_connection_does_not_leave_inspector_loading() {
+            let mut state = create_test_state();
+            let now = Instant::now();
+            let table = TableSummary::new("public".to_string(), "users".to_string(), None, false);
+
+            let effects = select_table(&mut state, &table, now);
+
+            assert!(matches!(
+                state.session.table_detail_state(),
+                TableDetailState::Error(message) if message == "No active connection"
+            ));
+            assert!(matches!(effects.first(), Some(Effect::CancelActiveTasks)));
         }
     }
 
@@ -1344,7 +1366,7 @@ mod tests {
             ));
             assert_eq!(state.input_mode(), InputMode::ConnectionError);
             assert!(state.connection_error.error_info.is_some());
-            assert!(matches!(effects.as_slice(), [Effect::CancelActiveQuery]));
+            assert!(matches!(effects.as_slice(), [Effect::CancelActiveTasks]));
         }
 
         #[test]
@@ -2218,7 +2240,7 @@ mod tests {
 
             assert!(state.should_quit);
             assert!(state.confirm_dialog.intent().is_none());
-            assert!(matches!(effects.as_slice(), [Effect::CancelActiveQuery]));
+            assert!(matches!(effects.as_slice(), [Effect::CancelActiveTasks]));
         }
 
         #[test]
@@ -2743,7 +2765,7 @@ mod tests {
             assert!(
                 effects
                     .iter()
-                    .any(|effect| matches!(effect, Effect::CancelActiveQuery))
+                    .any(|effect| matches!(effect, Effect::CancelActiveTasks))
             );
             assert!(
                 effects

--- a/src/app/update/test_fixtures.rs
+++ b/src/app/update/test_fixtures.rs
@@ -37,7 +37,7 @@ pub fn assert_connection_save_fetch_effects(effects: &[Effect], database_type: D
                 panic!("expected Sequence, got {effects:?}");
             };
             assert_eq!(seq.len(), 4);
-            assert!(matches!(seq[0], Effect::CancelActiveQuery));
+            assert!(matches!(seq[0], Effect::CancelActiveTasks));
             assert!(matches!(seq[1], Effect::CacheInvalidate { .. }));
             assert!(matches!(seq[2], Effect::ClearCompletionEngineCache));
             assert!(matches!(seq[3], Effect::FetchMetadata { .. }));
@@ -48,7 +48,7 @@ pub fn assert_connection_save_fetch_effects(effects: &[Effect], database_type: D
                 3,
                 "postgres save should preserve prefetched metadata cache"
             );
-            assert!(matches!(effects[0], Effect::CancelActiveQuery));
+            assert!(matches!(effects[0], Effect::CancelActiveTasks));
             assert!(matches!(effects[1], Effect::ClearCompletionEngineCache));
             assert!(matches!(effects[2], Effect::FetchMetadata { .. }));
         }

--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -9,7 +9,8 @@ use ratatui::widgets::{Cell, Paragraph, Row, Table as RatatuiTable, Wrap};
 use crate::app::model::app_state::AppState;
 use crate::app::model::browse::inspector_view_model::{
     InspectorColumnRow, InspectorEmptyState, InspectorForeignKeyRow, InspectorIndexRow,
-    InspectorInfoRow, InspectorRlsRow, InspectorSection, InspectorTriggerRow, InspectorViewModel,
+    InspectorInfoRow, InspectorLoadState, InspectorRlsRow, InspectorSection, InspectorTriggerRow,
+    InspectorViewModel,
 };
 use crate::app::model::shared::engine_feature_profile::InspectorInfoField;
 use crate::app::model::shared::flash_timer::{FlashId, FlashTimerStore};
@@ -104,6 +105,34 @@ impl Inspector {
         let block = panel_block(" [2] Inspector ", is_focused, theme);
         let inner = block.inner(area);
         frame.render_widget(block, area);
+
+        match view_model.load_state() {
+            InspectorLoadState::NoTableSelected => {
+                frame.render_widget(
+                    Paragraph::new("(select a table)")
+                        .style(Style::default().fg(theme.semantic.text.placeholder)),
+                    inner,
+                );
+                return ViewportPlan::default();
+            }
+            InspectorLoadState::Loading => {
+                frame.render_widget(
+                    Paragraph::new("Loading inspector...")
+                        .style(Style::default().fg(theme.semantic.status.pending)),
+                    inner,
+                );
+                return ViewportPlan::default();
+            }
+            InspectorLoadState::Error(error) => {
+                frame.render_widget(
+                    Paragraph::new(format!("Error: {error}"))
+                        .style(Style::default().fg(theme.semantic.status.error)),
+                    inner,
+                );
+                return ViewportPlan::default();
+            }
+            InspectorLoadState::Success => {}
+        }
 
         if let Some(empty_state) = view_model.empty_state() {
             let style = if matches!(empty_state, InspectorEmptyState::NoTableSelected) {


### PR DESCRIPTION
## Problem
Inspector did not expose table-detail loading or failure state, and in-flight detail requests could outlive table or connection changes.

## Background
SAB-422 requires stale table-detail results to be discarded while keeping the existing footer error and refresh flow.

## Approach
The session owns explicit table-detail state and generation/run guards. A dedicated task registry cancels selected-table detail work on selection/context termination, while the Inspector view renders loading and error states without changing keybindings.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clear loading, empty, and error states when viewing table details.
  * Prevented stale results and errors from replacing the current table selection.
  * Improved error handling when switching MySQL connections or probing unavailable connections.
  * Ensured active queries and table-detail loads are cancelled when quitting or changing context.
* **User Experience**
  * Preserved valid table selections and inspector results when connection changes fail.
  * Prevented outdated table-detail content from appearing during refreshed selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->