### PR TITLE
refactor: split MySQL adapter entrypoint

### DIFF
--- a/src/infra/adapters/mysql/adapter.rs
+++ b/src/infra/adapters/mysql/adapter.rs
@@ -1,34 +1,25 @@
-use std::path::PathBuf;
 use std::time::Instant;
 
 use crate::adapters::csv_export::export_to_downloads;
-#[cfg(feature = "test-support")]
-use crate::adapters::csv_export::export_to_path;
 use crate::app::policy::sql::mysql_statement::mysql_tree_explain_query_kind;
 use crate::app::ports::outbound::{
-    AccessMode, ConnectionProbe, DbOperationError, DdlGenerator, DsnBuilder,
-    MYSQL_CLI_VERSION_REQUIRED_MARKER, QueryExecutor, SqlDialect,
+    AccessMode, ConnectionProbe, DbOperationError, DdlGenerator, DsnBuilder, QueryExecutor,
+    SqlDialect,
 };
 use crate::domain::connection::{ConnectionProfile, DatabaseType};
 use crate::domain::{QueryResult, QuerySource, QueryValue, Table, WriteExecutionResult};
 use async_trait::async_trait;
 
-mod cli;
-mod dsn;
-mod metadata;
-mod option_file;
-mod sql;
-
-use cli::{
-    MYSQL_QUERY_TIMEOUT, MySqlProbeResponse, MysqlMetadataSession, MysqlResultSet,
-    classify_mysql_probe_failure, clean_stderr, export_mysql_csv_to_file,
-    is_oracle_mysql_cli_84_version, mysql_probe_args, run_mysql_adhoc, run_mysql_command,
-    run_mysql_single_statement, validate_mysql_export_query, validate_mysql_multi_query,
-    validate_server_version, validate_sql_mode,
+use super::cli::{
+    check_mysql_cli_version, export_mysql_csv_to_file, run_mysql_adhoc, run_mysql_single_statement,
+    validate_mysql_export_query, validate_mysql_multi_query,
 };
 
-use dsn::{build_mysql_dsn, parse_mysql_dsn, validate_mysql_tls_files, validate_mysql_values};
-use option_file::MySqlOptionFile;
+use super::dsn::{
+    build_mysql_dsn, parse_mysql_dsn, validate_mysql_tls_files, validate_mysql_values,
+};
+use super::option_file::MySqlOptionFile;
+use super::{metadata, sql};
 
 pub struct MySqlAdapter;
 
@@ -44,32 +35,43 @@ impl Default for MySqlAdapter {
     }
 }
 
-#[cfg(all(unix, feature = "test-support"))]
-#[doc(hidden)]
-pub async fn run_mysql_cli_script_for_test(
-    dsn: &str,
-    script: &str,
-) -> Result<Vec<u8>, DbOperationError> {
-    cli::run_mysql_cli_script_for_test(dsn, script).await
-}
-
 #[cfg(feature = "test-support")]
-#[doc(hidden)]
-/// Runs the export process without client-side query policy validation so integration tests can
-/// verify that the MySQL read-only session rejects a side effect at the server boundary.
-pub async fn export_mysql_csv_to_path_for_test(
-    dsn: &str,
-    query: &str,
-    path: PathBuf,
-) -> Result<PathBuf, DbOperationError> {
-    let target = parse_mysql_dsn(dsn)?;
-    validate_mysql_values(&target)?;
-    validate_mysql_tls_files(&target)?;
-    let query = query.to_string();
-    export_to_path(path, move |temporary_path| async move {
-        export_mysql_csv_to_file(target, &query, temporary_path).await
-    })
-    .await
+pub(super) mod test_support {
+    use std::path::PathBuf;
+
+    use crate::adapters::csv_export::export_to_path;
+    use crate::app::ports::outbound::DbOperationError;
+
+    use super::{
+        export_mysql_csv_to_file, parse_mysql_dsn, validate_mysql_tls_files, validate_mysql_values,
+    };
+
+    #[cfg(unix)]
+    #[doc(hidden)]
+    pub async fn run_mysql_cli_script_for_test(
+        dsn: &str,
+        script: &str,
+    ) -> Result<Vec<u8>, DbOperationError> {
+        super::super::cli::run_mysql_cli_script_for_test(dsn, script).await
+    }
+
+    #[doc(hidden)]
+    /// Runs the export process without client-side query policy validation so integration tests can
+    /// verify that the MySQL read-only session rejects a side effect at the server boundary.
+    pub async fn export_mysql_csv_to_path_for_test(
+        dsn: &str,
+        query: &str,
+        path: PathBuf,
+    ) -> Result<PathBuf, DbOperationError> {
+        let target = parse_mysql_dsn(dsn)?;
+        validate_mysql_values(&target)?;
+        validate_mysql_tls_files(&target)?;
+        let query = query.to_string();
+        export_to_path(path, move |temporary_path| async move {
+            export_mysql_csv_to_file(target, &query, temporary_path).await
+        })
+        .await
+    }
 }
 
 #[async_trait]
@@ -362,19 +364,9 @@ impl ConnectionProbe for MySqlAdapter {
         self.check_cli_version().await?;
 
         let option_file = MySqlOptionFile::create(&target)?;
-        let result = self.run_probe(&option_file.path).await;
+        let result = super::cli::probe_mysql_server(&option_file.path).await;
         drop(option_file);
-        let output = result?;
-
-        if !output.status.success() {
-            return Err(classify_mysql_probe_failure(clean_stderr(&output.stderr)));
-        }
-
-        let response: MySqlProbeResponse = serde_json::from_slice(&output.stdout)?;
-        let _ = (&response.database, &response.user);
-        validate_server_version(&response.version)?;
-        validate_sql_mode(&response.sql_mode)?;
-        Ok(())
+        result
     }
 
     async fn fetch_databases(&self, dsn: &str) -> Result<Vec<String>, DbOperationError> {
@@ -394,43 +386,20 @@ impl ConnectionProbe for MySqlAdapter {
         .await;
         drop(option_file);
         result.map(|execution| {
-            execution
-                .result_set
-                .unwrap_or(MysqlResultSet {
-                    columns: Vec::new(),
-                    values: Vec::new(),
-                })
-                .values
-                .into_iter()
-                .filter_map(|mut row| row.drain(..).next())
-                .filter_map(|value| value.as_str().map(str::to_string))
-                .collect()
+            execution.result_set.map_or_else(Vec::new, |result_set| {
+                result_set
+                    .values
+                    .into_iter()
+                    .filter_map(|mut row| row.drain(..).next())
+                    .filter_map(|value| value.as_str().map(str::to_string))
+                    .collect()
+            })
         })
     }
 }
 
 impl MySqlAdapter {
     async fn check_cli_version(&self) -> Result<(), DbOperationError> {
-        let output = run_mysql_command(["--version"], None).await?;
-        let version_output = format!(
-            "{}\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        if !output.status.success() || !is_oracle_mysql_cli_84_version(&version_output) {
-            return Err(DbOperationError::UnsupportedOperation(format!(
-                "{MYSQL_CLI_VERSION_REQUIRED_MARKER}: {}",
-                version_output.trim()
-            )));
-        }
-        Ok(())
-    }
-
-    async fn run_probe(
-        &self,
-        option_file: &PathBuf,
-    ) -> Result<std::process::Output, DbOperationError> {
-        let args = mysql_probe_args(option_file);
-        run_mysql_command(args, Some(option_file)).await
+        check_mysql_cli_version().await
     }
 }

--- a/src/infra/adapters/mysql/cli/mod.rs
+++ b/src/infra/adapters/mysql/cli/mod.rs
@@ -39,8 +39,8 @@ use crate::app::policy::write::sql_risk::{
     mysql_statement_is_schema_modifying,
 };
 use crate::app::ports::outbound::{
-    AccessMode, DatabaseCli, DbOperationError, MYSQL_SERVER_VERSION_REQUIRED_MARKER,
-    MYSQL_SQL_MODE_UNSUPPORTED_MARKER,
+    AccessMode, DatabaseCli, DbOperationError, MYSQL_CLI_VERSION_REQUIRED_MARKER,
+    MYSQL_SERVER_VERSION_REQUIRED_MARKER, MYSQL_SQL_MODE_UNSUPPORTED_MARKER,
 };
 use crate::domain::{CommandTag, QueryValue, RefreshScope};
 
@@ -55,6 +55,34 @@ pub(super) const MYSQL_EXPORT_TIMEOUT: Duration =
 pub(super) const MYSQL_PROBE_QUERY: &str = "SELECT JSON_OBJECT('database', DATABASE(), 'user', CURRENT_USER(), 'version', VERSION(), 'sql_mode', @@SESSION.sql_mode)";
 pub(super) const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
 pub(super) const MYSQL_SESSION_MARKER_COLUMN: &str = "__sabiql_session_marker";
+
+pub(super) async fn check_mysql_cli_version() -> Result<(), DbOperationError> {
+    let output = run_mysql_command(["--version"], None).await?;
+    let version_output = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if !output.status.success() || !is_oracle_mysql_cli_84_version(&version_output) {
+        return Err(DbOperationError::UnsupportedOperation(format!(
+            "{MYSQL_CLI_VERSION_REQUIRED_MARKER}: {}",
+            version_output.trim()
+        )));
+    }
+    Ok(())
+}
+
+pub(super) async fn probe_mysql_server(option_file: &PathBuf) -> Result<(), DbOperationError> {
+    let output = run_mysql_command(mysql_probe_args(option_file), Some(option_file)).await?;
+    if !output.status.success() {
+        return Err(classify_mysql_probe_failure(clean_stderr(&output.stderr)));
+    }
+
+    let response: MySqlProbeResponse = serde_json::from_slice(&output.stdout)?;
+    let _ = (&response.database, &response.user);
+    validate_server_version(&response.version)?;
+    validate_sql_mode(&response.sql_mode)
+}
 
 include!("probe.rs");
 include!("args.rs");

--- a/src/infra/adapters/mysql/metadata.rs
+++ b/src/infra/adapters/mysql/metadata.rs
@@ -11,8 +11,13 @@ use crate::domain::{
 };
 
 use super::{
-    MYSQL_QUERY_TIMEOUT, MySqlAdapter, MySqlOptionFile, MysqlMetadataSession, MysqlResultSet,
-    parse_mysql_dsn, run_mysql_adhoc, validate_mysql_values,
+    adapter::MySqlAdapter,
+    cli::{
+        MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, MysqlResultSet, run_mysql_adhoc,
+        validate_mysql_multi_query,
+    },
+    dsn::{parse_mysql_dsn, validate_mysql_tls_files, validate_mysql_values},
+    option_file::MySqlOptionFile,
 };
 
 const TABLES_QUERY: &str = "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') UNION ALL SELECT NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')) ORDER BY TABLE_SCHEMA, TABLE_NAME";
@@ -351,7 +356,7 @@ async fn fetch_table_detail_in_session_with_program(
 ) -> Result<Table, DbOperationError> {
     let target = parse_mysql_dsn(dsn)?;
     validate_mysql_values(&target)?;
-    super::validate_mysql_tls_files(&target)?;
+    validate_mysql_tls_files(&target)?;
     let database = target.database.as_deref().ok_or_else(|| {
         DbOperationError::UnsupportedOperation(
             "MySQL metadata requires a selected database".to_string(),
@@ -520,12 +525,9 @@ async fn execute_metadata_query(
 ) -> Result<MysqlResultSet, DbOperationError> {
     let target = parse_mysql_dsn(dsn)?;
     validate_mysql_values(&target)?;
-    super::validate_mysql_tls_files(&target)?;
-    let statements = super::validate_mysql_multi_query(
-        query,
-        target.database.as_deref(),
-        AccessMode::ReadWrite,
-    )?;
+    validate_mysql_tls_files(&target)?;
+    let statements =
+        validate_mysql_multi_query(query, target.database.as_deref(), AccessMode::ReadWrite)?;
     let option_file = MySqlOptionFile::create(&target)?;
     let result =
         run_mysql_adhoc(&option_file.path, query, &statements, AccessMode::ReadWrite).await;

--- a/src/infra/adapters/mysql/mod.rs
+++ b/src/infra/adapters/mysql/mod.rs
@@ -1,0 +1,14 @@
+mod adapter;
+mod cli;
+mod dsn;
+mod metadata;
+mod option_file;
+mod sql;
+
+pub use adapter::MySqlAdapter;
+
+#[cfg(all(unix, feature = "test-support"))]
+pub use adapter::test_support::run_mysql_cli_script_for_test;
+
+#[cfg(feature = "test-support")]
+pub use adapter::test_support::export_mysql_csv_to_path_for_test;


### PR DESCRIPTION
## Problem
The MySQL adapter entrypoint still combines module wiring with adapter and CLI integration details, making the release-split implementation difficult to navigate.

## Background
The DSN, option-file, SQL, metadata, and CLI runtimes are already separate responsibilities, but the adapter entrypoint still owns their implementation wiring.

## Approach
Keep the existing MySQL module import paths and behavior while making the entrypoint a private-module hub with limited re-exports. Move outbound port implementations into `adapter.rs`, keep test-support helpers behind a private test module, and keep CLI probe/version parsing behind the private CLI boundary.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-421
