### PR TITLE
chore: enforce test-only item placement

### DIFF
--- a/.claude/rules/style.md
+++ b/.claude/rules/style.md
@@ -1,4 +1,0 @@
-# Rust style
-
-- Follow Newspaper style: place public APIs and high-level processing before internal helpers.
-- Keep `#[cfg(test)]`-only items inside a test module. `#[cfg(test)] use` and shared `feature = "test-support"` items are exceptions to this rule.

--- a/.claude/rules/style.md
+++ b/.claude/rules/style.md
@@ -1,0 +1,4 @@
+# Rust style
+
+- Follow Newspaper style: place public APIs and high-level processing before internal helpers.
+- Keep `#[cfg(test)]`-only items inside a test module. `#[cfg(test)] use` and shared `feature = "test-support"` items are exceptions to this rule.

--- a/scripts/lint_all.sh
+++ b/scripts/lint_all.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 lints=(
   "$SCRIPT_DIR/lint_test_names.sh"
+  "$SCRIPT_DIR/test_lint_test_names.sh"
   "$SCRIPT_DIR/test_nix_dev_env.sh"
 )
 

--- a/scripts/lint_test_names.rb
+++ b/scripts/lint_test_names.rb
@@ -6,7 +6,7 @@ DEFAULT_PATHS = [
   "src",
   "tests",
 ].freeze
-TEST_ONLY_ITEM_PATTERN = /\A(?:(?:pub(?:\([^)]*\))?|unsafe)\s+)*(?:async\s+)?(fn|struct|impl|const|type|static)\b/
+TEST_ONLY_ITEM_PATTERN = /\A(?:(?:pub(?:\([^)]*\))?|unsafe|async|extern(?:\s+"[^"]+")?)\s+)*(fn|struct|impl|const|type|static)\b/
 MODULE_PATTERN = /\A(?:(?:pub(?:\([^)]*\))?|unsafe)\s+)*mod\s+([a-zA-Z0-9_]+)\s*\{/
 
 # This lint only checks mechanically detectable anti-patterns.

--- a/scripts/lint_test_names.rb
+++ b/scripts/lint_test_names.rb
@@ -6,6 +6,8 @@ DEFAULT_PATHS = [
   "src",
   "tests",
 ].freeze
+TEST_ONLY_ITEM_PATTERN = /\A(?:(?:pub(?:\([^)]*\))?|unsafe)\s+)*(?:async\s+)?(fn|struct|impl|const|type|static)\b/
+MODULE_PATTERN = /\A(?:(?:pub(?:\([^)]*\))?|unsafe)\s+)*mod\s+([a-zA-Z0-9_]+)\s*\{/
 
 # This lint only checks mechanically detectable anti-patterns.
 # Category-specific naming still relies on local rules and review.
@@ -150,6 +152,15 @@ def normalized_mod_name(name)
   normalized
 end
 
+def cfg_test_attribute?(stripped)
+  stripped.delete(" \t") == "#[cfg(test)]"
+end
+
+def test_only_item_kind(stripped)
+  match = stripped.match(TEST_ONLY_ITEM_PATTERN)
+  match && match[1]
+end
+
 paths = ARGV.empty? ? DEFAULT_PATHS : ARGV
 errors = []
 
@@ -168,6 +179,7 @@ rust_files(paths).each do |file|
   }
   mod_stack = []
   pending_test_attr = false
+  pending_cfg_test_attr = false
   seen_test_names = {}
 
   lines.each_with_index do |line, idx|
@@ -178,8 +190,32 @@ rust_files(paths).each do |file|
       mod_stack.pop
     end
 
-    if (match = stripped.match(/^mod\s+([a-zA-Z0-9_]+)\s*\{/))
-      mod_stack << { name: match[1], depth: brace_depth + 1 }
+    module_match = stripped.match(MODULE_PATTERN)
+    item_kind = test_only_item_kind(stripped)
+    cfg_test_module = pending_cfg_test_attr
+    module_depth = mod_stack.last&.dig(:depth) || 0
+    at_module_scope = brace_depth == module_depth
+    inside_test_module = mod_stack.any? { |entry| entry[:test_module] }
+
+    if stripped.start_with?("#[")
+      pending_cfg_test_attr ||= cfg_test_attribute?(stripped)
+    elsif pending_cfg_test_attr && (item_kind || module_match)
+      if item_kind && at_module_scope && !inside_test_module
+        errors << "#{rel}:#{line_no} test-only item must be inside a cfg(test) module: #{item_kind}"
+      end
+
+      pending_cfg_test_attr = false
+    elsif pending_cfg_test_attr && !stripped.empty? && !stripped.start_with?("//")
+      pending_cfg_test_attr = false
+    end
+
+    if module_match
+      mod_stack << {
+        name: module_match[1],
+        depth: brace_depth + 1,
+        test_module: cfg_test_module,
+      }
+      pending_cfg_test_attr = false
     end
 
     if stripped.match?(/^#\[(?:test|rstest|tokio::test)\b/) || (pending_test_attr && stripped.start_with?("#["))

--- a/scripts/lint_test_names_test.rb
+++ b/scripts/lint_test_names_test.rb
@@ -58,6 +58,12 @@ class LintTestNamesTest < Minitest::Test
       fn misplaced_function() {}
 
       #[cfg(test)]
+      extern "C" fn misplaced_extern_function() {}
+
+      #[cfg(test)]
+      async unsafe fn misplaced_async_unsafe_function() {}
+
+      #[cfg(test)]
       struct MisplacedStruct;
 
       #[cfg(test)]
@@ -79,7 +85,7 @@ class LintTestNamesTest < Minitest::Test
     RUST
 
     refute status.success?
-    assert_equal 7, stderr.lines.grep(/test-only item must be inside a cfg\(test\) module/).length
+    assert_equal 9, stderr.lines.grep(/test-only item must be inside a cfg\(test\) module/).length
     assert_includes stderr, "fixture.rs"
   end
 

--- a/scripts/lint_test_names_test.rb
+++ b/scripts/lint_test_names_test.rb
@@ -1,0 +1,103 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "open3"
+require "rbconfig"
+require "tmpdir"
+
+SCRIPT = File.expand_path("lint_test_names.rb", __dir__)
+
+class LintTestNamesTest < Minitest::Test
+  def run_lint(source)
+    Dir.mktmpdir do |directory|
+      path = File.join(directory, "fixture.rs")
+      File.write(path, source)
+      return Open3.capture3(RbConfig.ruby, SCRIPT, path)
+    end
+  end
+
+  def test_allows_test_only_items_inside_test_modules
+    stdout, stderr, status = run_lint(<<~RUST)
+      #[cfg(test)]
+      mod tests {
+          #[cfg(test)]
+          fn helper() {}
+
+          #[cfg(test)]
+          struct Fixture;
+
+          #[cfg(test)]
+          impl Fixture {}
+
+          #[cfg(test)]
+          const VALUE: usize = 1;
+
+          #[cfg(test)]
+          type Alias = usize;
+
+          #[cfg(test)]
+          static SHARED: usize = 1;
+      }
+
+      #[cfg(test)]
+      use crate::Fixture;
+
+      #[cfg(feature = "test-support")]
+      fn test_support_helper() {}
+    RUST
+
+    assert status.success?, stderr
+    assert_equal "test-name lint passed\n", stdout
+    assert_empty stderr
+  end
+
+  def test_rejects_test_only_items_at_module_scope
+    _stdout, stderr, status = run_lint(<<~RUST)
+      #[cfg(test)]
+      fn misplaced_function() {}
+
+      #[cfg(test)]
+      struct MisplacedStruct;
+
+      #[cfg(test)]
+      impl MisplacedStruct {}
+
+      #[cfg(test)]
+      const MISPLACED_CONST: usize = 1;
+
+      #[cfg(test)]
+      type MisplacedType = usize;
+
+      #[cfg(test)]
+      static MISPLACED_STATIC: usize = 1;
+
+      mod production {
+          #[cfg(test)]
+          fn nested_function() {}
+      }
+    RUST
+
+    refute status.success?
+    assert_equal 7, stderr.lines.grep(/test-only item must be inside a cfg\(test\) module/).length
+    assert_includes stderr, "fixture.rs"
+  end
+
+  def test_keeps_stacked_attributes_and_test_module_scope_distinct
+    _stdout, stderr, status = run_lint(<<~RUST)
+      #[cfg(test)]
+      #[allow(dead_code)]
+      fn misplaced_function() {}
+
+      #[cfg(test)]
+      mod tests {
+          #[cfg(test)]
+          #[allow(dead_code)]
+          fn helper() {}
+      }
+    RUST
+
+    refute status.success?
+    assert_equal 1, stderr.lines.grep(/test-only item must be inside a cfg\(test\) module/).length
+  end
+end

--- a/scripts/test_lint_test_names.sh
+++ b/scripts/test_lint_test_names.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec ruby "$(dirname "$0")/lint_test_names_test.rb"

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -1218,20 +1218,19 @@ impl CompletionEngine {
 }
 
 #[cfg(test)]
-impl CompletionEngine {
-    fn analyze(&self, content: &str, cursor_pos: usize) -> (String, CompletionContext) {
-        let tokens = self.lexer.tokenize(content, cursor_pos);
-        let sql_context = SqlContext::default();
-        self.analyze_with_context(content, cursor_pos, &sql_context, &tokens)
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use crate::test_support;
 
     use super::*;
     pub use crate::domain::Column;
+
+    impl CompletionEngine {
+        fn analyze(&self, content: &str, cursor_pos: usize) -> (String, CompletionContext) {
+            let tokens = self.lexer.tokenize(content, cursor_pos);
+            let sql_context = SqlContext::default();
+            self.analyze_with_context(content, cursor_pos, &sql_context, &tokens)
+        }
+    }
 
     fn engine() -> CompletionEngine {
         CompletionEngine::new()

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -26,11 +26,6 @@ pub fn dispatch_explain(
 }
 
 #[cfg(test)]
-fn reduce_explain(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
-    dispatch_explain(state, action, now, &AppServices::stub())
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
@@ -45,6 +40,10 @@ mod tests {
     use crate::update::reducer::reduce;
     use crate::update::test_fixtures;
     use std::time::Instant;
+
+    fn reduce_explain(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
+        dispatch_explain(state, action, now, &AppServices::stub())
+    }
 
     fn sql_modal_state() -> AppState {
         let mut state = AppState::new("test".to_string());

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -166,7 +166,7 @@ pub fn global_action_for_with_policy(
 // Action has payload variants without PartialEq, so tests compare by
 // discriminant — except modal actions, where several bindings differ only by
 // ModalKind and the kind must participate in equality.
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub fn same_payload_free_action(actual: &Action, expected: &Action) -> bool {
     match (actual, expected) {
         (Action::OpenModal(a), Action::OpenModal(b))

--- a/src/domain/er.rs
+++ b/src/domain/er.rs
@@ -134,24 +134,6 @@ pub fn fk_reachable_tables(
         .collect()
 }
 
-#[cfg(test)]
-fn make_table(name: &str, schema: &str, fks: Vec<(&str, &str)>) -> ErTableInfo {
-    ErTableInfo {
-        qualified_name: format!("{schema}.{name}"),
-        name: name.to_string(),
-        schema: schema.to_string(),
-        foreign_keys: fks
-            .into_iter()
-            .enumerate()
-            .map(|(i, (from, to))| ErFkInfo {
-                name: format!("fk_{i}"),
-                from_qualified: from.to_string(),
-                to_qualified: to.to_string(),
-            })
-            .collect(),
-    }
-}
-
 impl ErTableInfo {
     pub fn from_table(qualified_name: &str, table: &Table) -> Self {
         Self {
@@ -175,6 +157,23 @@ impl ErTableInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn make_table(name: &str, schema: &str, fks: Vec<(&str, &str)>) -> ErTableInfo {
+        ErTableInfo {
+            qualified_name: format!("{schema}.{name}"),
+            name: name.to_string(),
+            schema: schema.to_string(),
+            foreign_keys: fks
+                .into_iter()
+                .enumerate()
+                .map(|(i, (from, to))| ErFkInfo {
+                    name: format!("fk_{i}"),
+                    from_qualified: from.to_string(),
+                    to_qualified: to.to_string(),
+                })
+                .collect(),
+        }
+    }
 
     mod from_table {
         use super::*;

--- a/src/infra/export/dot.rs
+++ b/src/infra/export/dot.rs
@@ -248,13 +248,6 @@ impl DotExporter<SystemGraphvizRunner, SystemViewerLauncher> {
     }
 }
 
-#[cfg(test)]
-impl<G: GraphvizRunner, V: ViewerLauncher> DotExporter<G, V> {
-    pub fn with_dependencies(graphviz: G, viewer: V) -> Self {
-        Self { graphviz, viewer }
-    }
-}
-
 impl<G, V> DotExporter<G, V> {
     fn escape_dot_string(s: &str) -> String {
         s.replace('\\', "\\\\")
@@ -376,6 +369,12 @@ impl<G: GraphvizRunner + 'static, V: ViewerLauncher + 'static> ErDiagramExporter
 mod tests {
     use super::*;
     use crate::domain::er::ErFkInfo;
+
+    impl<G: GraphvizRunner, V: ViewerLauncher> DotExporter<G, V> {
+        fn with_dependencies(graphviz: G, viewer: V) -> Self {
+            Self { graphviz, viewer }
+        }
+    }
 
     fn make_test_tables() -> Vec<ErTableInfo> {
         vec![

--- a/src/ui/features/browse/result.rs
+++ b/src/ui/features/browse/result.rs
@@ -396,17 +396,6 @@ impl ResultPane {
     }
 }
 
-#[cfg(test)]
-pub(crate) fn calculate_ideal_widths(headers: &[String], rows: &[Vec<String>]) -> Vec<u16> {
-    use unicode_width::UnicodeWidthStr;
-
-    calculate_ideal_widths_with(headers, rows.len(), |row_idx, col_idx| {
-        rows.get(row_idx)
-            .and_then(|row| row.get(col_idx))
-            .map(|cell| UnicodeWidthStr::width(cell.lines().next().unwrap_or(cell)))
-    })
-}
-
 fn calculate_result_ideal_widths(result: &QueryResult) -> Vec<u16> {
     calculate_ideal_widths_with(
         &result.columns,
@@ -484,6 +473,15 @@ mod tests {
     use super::*;
     use crate::domain::QueryValue;
     use rstest::rstest;
+    use unicode_width::UnicodeWidthStr;
+
+    fn calculate_ideal_widths(headers: &[String], rows: &[Vec<String>]) -> Vec<u16> {
+        calculate_ideal_widths_with(headers, rows.len(), |row_idx, col_idx| {
+            rows.get(row_idx)
+                .and_then(|row| row.get(col_idx))
+                .map(|cell| UnicodeWidthStr::width(cell.lines().next().unwrap_or(cell)))
+        })
+    }
 
     mod calculate_ideal_widths_tests {
         use super::*;


### PR DESCRIPTION
## Problem
Test-only Rust items can be declared at module scope, making test-only implementation details appear alongside production code.

## Background
The existing test-name lint did not enforce the repository boundary for `#[cfg(test)]` items, and the intended Newspaper style was not documented.

## Approach
Add a source lint for module-scoped `#[cfg(test)]` functions, structs, impls, consts, types, and statics while allowing test modules, `#[cfg(test)] use`, and `feature = "test-support"` items. Add Ruby regression fixtures and run them through `scripts/lint_all.sh`. Move the existing test-only helpers into test modules or the shared test-support gate, and document the style rule.

## Screenshots

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-423
