### PR TITLE
docs: focus README on product value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,34 @@
 # sabiql
 ![hero](https://github.com/user-attachments/assets/745ab18f-915c-4017-81a6-465c5c5ee11c)
 
-A fast, driver-less TUI to browse, query, and edit PostgreSQL and SQLite databases — no drivers, no setup, just your database CLI (`psql` or `sqlite3`).
+A fast, driver-less TUI for browsing, querying, and editing PostgreSQL and SQLite databases from the terminal. It works with the database CLI you already use: `psql` or `sqlite3`.
 
 [![CI](https://github.com/riii111/sabiql/actions/workflows/ci.yml/badge.svg)](https://github.com/riii111/sabiql/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## Concept
+## Why sabiql?
 
-> Vim-first · Safe by design · Oil-and-vinegar UI · Fast and lightweight
+> Vim-first · Safe by design · Inspired by oil.nvim · Fast and lightweight
 
-sabiql wraps your existing database CLI. For PostgreSQL it uses `psql`; for SQLite it uses `sqlite3`. No Rust database drivers, no connection pools, no extra dependencies. Point it at your database and get a full-featured TUI. Your `psql` config, `.pgpass`, and SSL setup all just work for PostgreSQL connections.
+sabiql brings database browsing, querying, and editing into the terminal without replacing your existing database setup. PostgreSQL connections continue to use your `psql` configuration, `.pgpass`, and SSL settings.
 
-Inspired by [oil.nvim](https://github.com/stevearc/oil.nvim)'s "oil and vinegar" philosophy: UI elements appear only when needed, never occupying your screen permanently. Vim-native keybindings (`j/k`, `dd`, `/`) let you navigate and edit without leaving your muscle memory.
+The interface stays out of your way. Inspired by [oil.nvim](https://github.com/stevearc/oil.nvim)'s "oil and vinegar" philosophy, UI elements appear only when needed. Vim-native keybindings such as `j/k`, `dd`, and `/` keep navigation and editing familiar.
 
-Destructive operations are guarded. Inline edits and row deletions always show a preview modal before touching your data. Read-only mode (`Ctrl+R`) goes further — block all writes at the database client level with a single keystroke.
-
-Built in Rust for minimal memory footprint and near-zero idle CPU. A full-featured alternative to GUI tools like DBeaver or DataGrip, without ever leaving the terminal.
-
-## Query Safety
-
-sabiql treats the SQL modal as SQL-only input. CLI meta-commands such as psql backslash commands and sqlite3 dot commands are rejected instead of being passed to the underlying client.
-
-Read-only mode combines app-level write blocking with the database client guard available for the active adapter. PostgreSQL uses a read-only session option. SQLite also runs every sqlite3 command in safe mode, preventing SQL from accessing files, extensions, or databases outside the selected database file.
-
-PostgreSQL multi-statement SQL runs in one transaction. SQLite wraps transactional writes, including persistent PRAGMAs such as `user_version`, unless the input contains transaction control or a session-side-effect / transaction-incompatible statement such as `PRAGMA journal_mode`, `PRAGMA foreign_keys`, or `PRAGMA synchronous`. SQLite safe mode also rejects operations such as `ATTACH` and `VACUUM` that require capabilities unavailable in safe mode.
+Inline edits and row deletions always show a preview before touching your data. Read-only mode (`Ctrl+R`) also blocks writes at the database client level.
 
 ## Features
+
 ![hero_1000_20fps](https://github.com/user-attachments/assets/06e1900d-b044-4f29-a2a8-7d7bab5bd3a1)
 
-### Core
+- **Browse and inspect** — Find tables with fuzzy search and inspect columns, types, constraints, and indexes
+- **Run SQL** — Write ad-hoc queries with completion for tables, columns, and keywords, then recall them from query history
+- **Edit with previews** — Update cells or delete rows only after reviewing the SQL and its risk level
+- **Browse in read-only mode** (`Ctrl+R`) — Block writes while investigating data
+- **Analyze queries** — View and compare PostgreSQL execution plans or inspect SQLite query plans
+- **Work with data** — Copy cell values, export CSV, and inspect or edit PostgreSQL JSON/JSONB documents
+- **Visualize relationships** — Generate PostgreSQL ER diagrams with Graphviz and open them in your browser
 
-- **Read-Only Mode** (`Ctrl+R`) — Toggle safe-browse mode; writes are blocked at both app and DB session level
-- **SQL Modal** (`s`) — Ad-hoc queries with auto-completion for tables, columns, and keywords; recall previous queries with `Ctrl+O`
-- **ER Diagram** (`e`) — Generate relationship diagrams via Graphviz, opened instantly in your browser (PostgreSQL only)
-- **Inspector Pane** (`2`) — Column details, types, constraints, and indexes for any table
-
-### Editing
-
-- **Inline Cell Editing** (`i` in Result) — Edit cells in-place with a guarded UPDATE preview before committing
-- **Row Deletion** (`dd` in Result) — DELETE with mandatory preview; risk level color-coded (yellow/orange/red)
-- **Yank** (`y`) — Copy any cell value to clipboard
-- **CSV Export** (`Ctrl+E`) — Export query results to a CSV file
-
-### Query Analysis
-
-- **EXPLAIN / EXPLAIN ANALYZE** — PostgreSQL: run your query, then switch tabs to view its execution plan or compare two plans side-by-side.
-- **EXPLAIN QUERY PLAN** — SQLite: view query plans for single SELECT statements in the Plan tab.
-
-### Navigation
-
-- **Fuzzy Search** (`/`) — Incremental table filtering
-- **Focus Mode** (`f`) — Expand any pane to full screen
-- **Settings** (`,`) — Theme, keymap, and ER diagram preferences
-- **Command Palette** (`F1`, `:palette`) — Searchable command list
+Press `?` inside sabiql to see all commands and keybindings.
 
 ## Installation
 
@@ -90,61 +65,30 @@ curl -fsSL https://raw.githubusercontent.com/riii111/sabiql/main/install.sh | sh
 
 ## Quick Start
 
+Launch sabiql and enter your connection details:
+
 ```bash
 sabiql
 ```
 
-For SQLite, you can also pass a database file path or `sqlite://` DSN directly:
+You can also open an existing SQLite database directly:
 
 ```bash
 sabiql /path/to/app.db
-sabiql /path/to/History
-sabiql sqlite:///path/to/app.db
 ```
 
-On first run without a startup argument, enter your connection details. They are saved to your platform config directory:
-
-- macOS: `~/Library/Application Support/sabiql/connections.toml`
-- Linux: `~/.config/sabiql/connections.toml`
-- Windows: `%APPDATA%\sabiql\connections.toml`
-
-Windows support is experimental.
-
-For PostgreSQL, fill in host, port, database, and credentials. For SQLite, set **Type** to `SQLite` and enter the path to a database file (for example `/path/to/app.db`).
-
-Press `?` for help.
-
-Open Settings with `,` to switch themes, keymap presets, and the ER diagram browser command.
-
-> **Note:** If you use sabiql inside an IDE terminal, some default keybindings may conflict with the IDE. Open Settings with `,` and switch the keymap preset to make sabiql work comfortably inside your IDE.
+Use `Ctrl+R` before browsing data when you want to block writes. Press `?` for help, or open Settings with `,` to change the theme and keymap.
 
 ## Requirements
 
 Install the CLI for the database you want to open:
 
 - **PostgreSQL:** `psql` (PostgreSQL client)
-- **SQLite:** `sqlite3` (SQLite shell), version 3.41.1 or later.
+- **SQLite:** `sqlite3` (SQLite shell), version 3.41.1 or later
 
-Optional:
+Graphviz is optional and enables ER diagrams for PostgreSQL. Windows support is experimental.
 
-- Graphviz (for ER diagrams on PostgreSQL): `brew install graphviz`
-
-### Android / Termux
-
-Android/Termux support is build-only, not full platform support. `cargo install sabiql` should compile on Android, but clipboard yank is unavailable because the desktop clipboard backend is not supported there. Install `psql` for PostgreSQL and `sqlite3` for SQLite.
-
-## SQLite Limitations
-
-SQLite support covers browsing, editing, and ad-hoc SQL on regular database files. Compared with PostgreSQL:
-
-- **File paths only** — Use a regular SQLite database file path or a `sqlite://` DSN to that file. The `sqlite://` form treats everything after the prefix as a raw path; it does not percent-decode URI escapes. In-memory databases (`:memory:`) and SQLite URI filenames (`file:...`) are not supported because sabiql starts `sqlite3` per operation; use a temporary database file instead.
-- **No new database files** — Opening a path that does not exist does not create a database.
-- **Main database only** — Attached and temporary databases are not browsed as separate namespaces.
-- **Session state is per operation** — sabiql starts a new `sqlite3` process for each operation. Statements in one SQL modal submission share that process, but `TEMP` tables/views and connection-local `PRAGMA` settings do not carry over to the next SQL execution. Persistent changes to the main database remain available.
-- **Grid editing requires a declared primary key** — Regular tables with a declared `PRIMARY KEY` support grid editing. Tables without a declared primary key, views, and virtual tables remain browsable but are read-only targets in the grid.
-- **Query plans** — SQLite shows `EXPLAIN QUERY PLAN` in the Plan tab. Plan comparison and `EXPLAIN ANALYZE` are PostgreSQL-only.
-- **No ER diagrams** — Graphviz export requires PostgreSQL metadata.
-- **No JSON tree view** — Structured JSON editing is PostgreSQL-only.
+SQLite works with existing, regular database files. See [SQLite support and limitations](docs/sqlite.md) for details.
 
 ## Roadmap
 
@@ -163,7 +107,7 @@ SQLite support covers browsing, editing, and ad-hoc SQL on regular database file
 - [ ] Google Cloud SQL / AlloyDB support
 - [ ] MySQL support
 
-Have a feature request? [Open an issue](https://github.com/riii111/sabiql/issues/new) feedback is welcome!
+Have a feature request? [Open an issue](https://github.com/riii111/sabiql/issues/new). Feedback is welcome!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ A fast, driver-less TUI for browsing, querying, and editing PostgreSQL and SQLit
 [![CI](https://github.com/riii111/sabiql/actions/workflows/ci.yml/badge.svg)](https://github.com/riii111/sabiql/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-## Why sabiql?
+## Concept
 
-> Vim-first · Safe by design · Inspired by oil.nvim · Fast and lightweight
+> Vim-first · Safe by design · Oil-and-vinegar UI · Fast and lightweight
 
 sabiql brings database browsing, querying, and editing into the terminal without replacing your existing database setup. PostgreSQL connections continue to use your `psql` configuration, `.pgpass`, and SSL settings.
 
-The interface stays out of your way. Inspired by [oil.nvim](https://github.com/stevearc/oil.nvim)'s "oil and vinegar" philosophy, UI elements appear only when needed. Vim-native keybindings such as `j/k`, `dd`, and `/` keep navigation and editing familiar.
+Like [oil.nvim](https://github.com/stevearc/oil.nvim), sabiql keeps its interface out of your way. Following oil.nvim's "oil and vinegar" philosophy, UI elements appear only when needed. Vim-native keybindings such as `j/k`, `dd`, and `/` keep navigation and editing familiar.
 
-Inline edits and row deletions always show a preview before touching your data. Read-only mode (`Ctrl+R`) also blocks writes at the database client level.
+Safety follows a plan-before-apply flow familiar from Terraform: inline edits and row deletions show the SQL and its risk level before you confirm the change. Read-only mode (`Ctrl+R`) also blocks writes at the database client level.
 
 ## Features
 
@@ -63,6 +63,17 @@ cd /usr/ports/databases/sabiql/ && make install clean
 curl -fsSL https://raw.githubusercontent.com/riii111/sabiql/main/install.sh | sh
 ```
 
+## Database Setup
+
+sabiql uses the CLI for the database you want to open:
+
+- **To use PostgreSQL:** install `psql`
+- **To use SQLite:** install `sqlite3` version 3.41.1 or later
+
+Graphviz is optional and enables ER diagrams for PostgreSQL. Windows support is experimental.
+
+SQLite works with existing, regular database files. See [SQLite support and limitations](docs/sqlite.md) for details.
+
 ## Quick Start
 
 Launch sabiql and enter your connection details:
@@ -78,17 +89,6 @@ sabiql /path/to/app.db
 ```
 
 Use `Ctrl+R` before browsing data when you want to block writes. Press `?` for help, or open Settings with `,` to change the theme and keymap.
-
-## Requirements
-
-Install the CLI for the database you want to open:
-
-- **PostgreSQL:** `psql` (PostgreSQL client)
-- **SQLite:** `sqlite3` (SQLite shell), version 3.41.1 or later
-
-Graphviz is optional and enables ER diagrams for PostgreSQL. Windows support is experimental.
-
-SQLite works with existing, regular database files. See [SQLite support and limitations](docs/sqlite.md) for details.
 
 ## Roadmap
 

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -1,0 +1,33 @@
+# SQLite support
+
+sabiql supports browsing, editing, and ad-hoc SQL on existing, regular SQLite database files. It requires `sqlite3` version 3.41.1 or later.
+
+## Opening a database
+
+Pass a database file path or a `sqlite://` DSN:
+
+```bash
+sabiql /path/to/app.db
+sabiql /path/to/History
+sabiql sqlite:///path/to/app.db
+```
+
+The `sqlite://` form treats everything after the prefix as a raw path and does not percent-decode URI escapes.
+
+## Limitations
+
+- **Existing file paths only** — In-memory databases (`:memory:`) and SQLite URI filenames (`file:...`) are not supported. Opening a path that does not exist does not create a database.
+- **Main database only** — Attached and temporary databases are not browsed as separate namespaces.
+- **Session state is per operation** — sabiql starts a new `sqlite3` process for each operation. Statements in one SQL modal submission share that process, but `TEMP` tables/views and connection-local `PRAGMA` settings do not carry over to the next SQL execution. Persistent changes to the main database remain available.
+- **Grid editing requires a declared primary key** — Regular tables with a declared `PRIMARY KEY` support grid editing. Tables without a declared primary key, views, and virtual tables remain browsable but are read-only targets in the grid.
+- **Query plans** — SQLite shows `EXPLAIN QUERY PLAN` in the Plan tab. Plan comparison and `EXPLAIN ANALYZE` are PostgreSQL-only.
+- **No ER diagrams** — Graphviz export requires PostgreSQL metadata.
+- **No JSON tree view** — Structured JSON editing is PostgreSQL-only.
+
+## Query safety
+
+sabiql accepts SQL-only input in the SQL modal. sqlite3 dot commands are rejected instead of being passed to the underlying client.
+
+Every sqlite3 command runs in safe mode, preventing SQL from accessing files, extensions, or databases outside the selected database file. Operations such as `ATTACH` and `VACUUM` are unavailable because they require capabilities disabled by safe mode.
+
+sabiql wraps transactional writes, including persistent PRAGMAs such as `user_version`, unless the input contains transaction control or a session-side-effect or transaction-incompatible statement such as `PRAGMA journal_mode`, `PRAGMA foreign_keys`, or `PRAGMA synchronous`.


### PR DESCRIPTION
## Problem

The README mixed the product overview with detailed database behavior and command-level instructions, making it harder for new users to understand the value of sabiql.

## Approach

Refocus the README on the terminal-first workflow, safety, core capabilities, installation, and roadmap. Keep the oil.nvim-inspired design philosophy, direct users to the in-app help for keybindings, and move detailed SQLite behavior into a dedicated reference.