### PR TITLE
docs: align MySQL README with product overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ curl -fsSL https://raw.githubusercontent.com/riii111/sabiql/main/install.sh | sh
 sabiql uses the CLI for the database you want to open:
 
 - **To use PostgreSQL:** install `psql`
-- **To use MySQL:** install the Oracle `mysql` CLI from the 8.4 series and connect to Oracle MySQL 8.4 LTS
+- **To use MySQL:** install `mysql`
 - **To use SQLite:** install `sqlite3` version 3.41.1 or later
 
-When connecting to a remote MySQL server, only the local `mysql` CLI is required; a local MySQL server is not. Graphviz is optional and enables ER diagrams for PostgreSQL and MySQL. Windows support is experimental.
+Graphviz is optional and enables ER diagrams for PostgreSQL and MySQL.
 
-See [MySQL support and limitations](docs/mysql.md) and [SQLite support and limitations](docs/sqlite.md) for database-specific details.
+Windows support is experimental.
+
+See [MySQL support and limitations](docs/mysql.md) and [SQLite support and limitations](docs/sqlite.md) for supported versions and database-specific limitations.
 
 ## Quick Start
 
@@ -103,7 +105,7 @@ Use `Ctrl+R` before browsing data when you want to block writes. Press `?` for h
 - [x] JSON/JSONB support (tree view, editing, validation)
 - [x] Theme switching (Sabiql Dark / Light)
 - [x] SQLite support
-- [x] MySQL support (Oracle MySQL 8.4 server and `mysql` CLI)
+- [x] MySQL support
 - [ ] Neovim integration (`sabiql.nvim`)
 - [ ] Zero-config connection (env vars, `.pgpass`, URI auto-detect)
 - [ ] Google Cloud SQL / AlloyDB support

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sabiql
 ![hero](https://github.com/user-attachments/assets/745ab18f-915c-4017-81a6-465c5c5ee11c)
 
-A fast, driver-less TUI for browsing, querying, and editing PostgreSQL and SQLite databases from the terminal. It works with the database CLI you already use: `psql` or `sqlite3`.
+A fast, driver-less TUI for browsing, querying, and editing PostgreSQL, MySQL, and SQLite databases from the terminal. It works with the database CLI you already use: `psql`, `mysql`, or `sqlite3`.
 
 [![CI](https://github.com/riii111/sabiql/actions/workflows/ci.yml/badge.svg)](https://github.com/riii111/sabiql/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -20,13 +20,13 @@ Safety follows a plan-before-apply flow familiar from Terraform: inline edits an
 
 ![hero_1000_20fps](https://github.com/user-attachments/assets/06e1900d-b044-4f29-a2a8-7d7bab5bd3a1)
 
-- **Browse and inspect** — Find tables with fuzzy search and inspect columns, types, constraints, and indexes
+- **Browse and inspect** — Find tables with fuzzy search, inspect columns, constraints, indexes, foreign keys, triggers, and DDL, or switch MySQL databases without reconnecting
 - **Run SQL** — Write ad-hoc queries with completion for tables, columns, and keywords, then recall them from query history
 - **Edit with previews** — Update cells or delete rows only after reviewing the SQL and its risk level
 - **Browse in read-only mode** (`Ctrl+R`) — Block writes while investigating data
-- **Analyze queries** — View and compare PostgreSQL execution plans or inspect SQLite query plans
-- **Work with data** — Copy cell values, export CSV, and inspect or edit PostgreSQL JSON/JSONB documents
-- **Visualize relationships** — Generate PostgreSQL ER diagrams with Graphviz and open them in your browser
+- **Analyze queries** — View and compare PostgreSQL or MySQL execution plans, or inspect SQLite query plans
+- **Work with data** — Copy cell values, export CSV, and inspect or edit PostgreSQL and MySQL JSON documents
+- **Visualize relationships** — Generate PostgreSQL and MySQL ER diagrams with Graphviz and open them in your browser
 
 Press `?` inside sabiql to see all commands and keybindings.
 
@@ -68,11 +68,12 @@ curl -fsSL https://raw.githubusercontent.com/riii111/sabiql/main/install.sh | sh
 sabiql uses the CLI for the database you want to open:
 
 - **To use PostgreSQL:** install `psql`
+- **To use MySQL:** install the Oracle `mysql` CLI from the 8.4 series and connect to Oracle MySQL 8.4 LTS
 - **To use SQLite:** install `sqlite3` version 3.41.1 or later
 
-Graphviz is optional and enables ER diagrams for PostgreSQL. Windows support is experimental.
+When connecting to a remote MySQL server, only the local `mysql` CLI is required; a local MySQL server is not. Graphviz is optional and enables ER diagrams for PostgreSQL and MySQL. Windows support is experimental.
 
-SQLite works with existing, regular database files. See [SQLite support and limitations](docs/sqlite.md) for details.
+See [MySQL support and limitations](docs/mysql.md) and [SQLite support and limitations](docs/sqlite.md) for database-specific details.
 
 ## Quick Start
 
@@ -102,10 +103,10 @@ Use `Ctrl+R` before browsing data when you want to block writes. Press `?` for h
 - [x] JSON/JSONB support (tree view, editing, validation)
 - [x] Theme switching (Sabiql Dark / Light)
 - [x] SQLite support
+- [x] MySQL support (Oracle MySQL 8.4 server and `mysql` CLI)
 - [ ] Neovim integration (`sabiql.nvim`)
 - [ ] Zero-config connection (env vars, `.pgpass`, URI auto-detect)
 - [ ] Google Cloud SQL / AlloyDB support
-- [ ] MySQL support
 
 Have a feature request? [Open an issue](https://github.com/riii111/sabiql/issues/new). Feedback is welcome!
 

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -1,0 +1,27 @@
+# MySQL support
+
+sabiql supports Oracle MySQL server 8.4 LTS through the Oracle `mysql` CLI from the 8.4 series. MariaDB, Percona Server, TiDB, and other MySQL-compatible products are not formally supported.
+
+## Connecting
+
+MySQL connections use TCP. Unix sockets and Windows named pipes are not supported. When connecting to a remote server, install the local `mysql` CLI; a local MySQL server is not required.
+
+In the connection form, set **Type** to `MySQL`, then enter the host, port, user, password, optional initial database, and TLS mode. If no initial database is set, the database picker opens after the connection succeeds. You can also use the picker later to switch databases without reconnecting.
+
+Passphrase-protected TLS client keys are not supported. An unencrypted PEM private key can be used, but it weakens at-rest protection; store it with restrictive file permissions.
+
+## SQL and session behavior
+
+- **No persistent session state** — sabiql starts a new `mysql` process for each operation. Temporary tables, session variables, and transactions do not carry over to the next SQL submission. Multiple statements in one submission share one process and session.
+- **Supported SQL scope** — The SQL modal supports reads such as `SELECT`, `TABLE`, `SHOW`, and `DESCRIBE`, DML (`INSERT`, `UPDATE`, and `DELETE`), table/view/index DDL, and simple explicit transactions. Database/account/role/replication/server/plugin/routine/event/trigger administration statements are not supported. `REPLACE`, `CALL`, `DO`, `HANDLER`, `LOAD DATA`/`LOAD XML`, table-maintenance statements, prepared statements, XA statements, and compound statements are also rejected.
+- **No session or table-control SQL** — User `USE`, `SET`, `LOCK TABLES`, and `UNLOCK TABLES` statements are rejected. MySQL client commands such as `source`, `system`, `charset`, and backslash commands are rejected, as is `DELIMITER`.
+- **SQL mode** — Connections using `NO_BACKSLASH_ESCAPES` or `ANSI_QUOTES` are rejected because those modes enable escape or identifier-quoting semantics that sabiql does not support.
+- **Read-Only Mode is not a sandbox** — It blocks supported writes at the application and MySQL session levels, but it does not isolate external side effects from user-defined functions (UDFs).
+
+## Data and editing limitations
+
+- **NUL in text** — The MySQL CLI XML output cannot preserve NUL characters embedded in text values.
+- **Binary values in arbitrary SQL** — Arbitrary SQL results do not include reliable column type metadata, so binary values are kept as the CLI's `0x...` text representation. Known binary columns in table previews are handled as Blob values.
+- **System databases** — `information_schema`, `mysql`, `performance_schema`, and `sys` are omitted from the MySQL Database Picker.
+- **Grid editing scope** — Views, tables without a retrievable primary key, and generated columns are read-only in the grid. Invisible primary keys and generated invisible primary keys are used for row identity when available but are not shown as grid columns.
+- **CSV representation** — NULL values are exported as empty fields. Known cached Blob values use uppercase hexadecimal strings; binary values from type-unknown arbitrary SQL keep the CLI's `0x...` representation.

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -1,27 +1,27 @@
 # MySQL support
 
+Use this page to check whether your MySQL server, connection method, and expected workflow are supported.
+
 sabiql supports Oracle MySQL server 8.4 LTS through the Oracle `mysql` CLI from the 8.4 series. MariaDB, Percona Server, TiDB, and other MySQL-compatible products are not formally supported.
 
-## Connecting
+## Connection requirements
 
 MySQL connections use TCP. Unix sockets and Windows named pipes are not supported. When connecting to a remote server, install the local `mysql` CLI; a local MySQL server is not required.
-
-In the connection form, set **Type** to `MySQL`, then enter the host, port, user, password, optional initial database, and TLS mode. If no initial database is set, the database picker opens after the connection succeeds. You can also use the picker later to switch databases without reconnecting.
 
 Passphrase-protected TLS client keys are not supported. An unencrypted PEM private key can be used, but it weakens at-rest protection; store it with restrictive file permissions.
 
 ## SQL and session behavior
 
-- **No persistent session state** — sabiql starts a new `mysql` process for each operation. Temporary tables, session variables, and transactions do not carry over to the next SQL submission. Multiple statements in one submission share one process and session.
-- **Supported SQL scope** — The SQL modal supports reads such as `SELECT`, `TABLE`, `SHOW`, and `DESCRIBE`, DML (`INSERT`, `UPDATE`, and `DELETE`), table/view/index DDL, and simple explicit transactions. Database/account/role/replication/server/plugin/routine/event/trigger administration statements are not supported. `REPLACE`, `CALL`, `DO`, `HANDLER`, `LOAD DATA`/`LOAD XML`, table-maintenance statements, prepared statements, XA statements, and compound statements are also rejected.
+- **No persistent session state** — Temporary tables, session variables, and transactions do not carry over between operations. Multiple statements in one SQL submission share one session.
+- **Supported SQL scope** — The SQL modal supports `SELECT`, `TABLE`, `SHOW`, and `DESCRIBE`; `INSERT`, `UPDATE`, and `DELETE`; table/view/index DDL; and simple explicit transactions. Server administration, stored programs, prepared statements, XA statements, compound statements, table maintenance, `REPLACE`, `DO`, `HANDLER`, and `LOAD DATA`/`LOAD XML` are not supported.
 - **No session or table-control SQL** — User `USE`, `SET`, `LOCK TABLES`, and `UNLOCK TABLES` statements are rejected. MySQL client commands such as `source`, `system`, `charset`, and backslash commands are rejected, as is `DELIMITER`.
 - **SQL mode** — Connections using `NO_BACKSLASH_ESCAPES` or `ANSI_QUOTES` are rejected because those modes enable escape or identifier-quoting semantics that sabiql does not support.
 - **Read-Only Mode is not a sandbox** — It blocks supported writes at the application and MySQL session levels, but it does not isolate external side effects from user-defined functions (UDFs).
 
 ## Data and editing limitations
 
-- **NUL in text** — The MySQL CLI XML output cannot preserve NUL characters embedded in text values.
-- **Binary values in arbitrary SQL** — Arbitrary SQL results do not include reliable column type metadata, so binary values are kept as the CLI's `0x...` text representation. Known binary columns in table previews are handled as Blob values.
+- **NUL in text** — Query results cannot preserve NUL characters embedded in text values.
+- **Binary values in arbitrary SQL** — Binary columns in table previews are handled as Blob values. Binary values returned by arbitrary SQL use the `0x...` text representation.
 - **System databases** — `information_schema`, `mysql`, `performance_schema`, and `sys` are omitted from the MySQL Database Picker.
 - **Grid editing scope** — Views, tables without a retrievable primary key, and generated columns are read-only in the grid. Invisible primary keys and generated invisible primary keys are used for row identity when available but are not shown as grid columns.
-- **CSV representation** — NULL values are exported as empty fields. Known cached Blob values use uppercase hexadecimal strings; binary values from type-unknown arbitrary SQL keep the CLI's `0x...` representation.
+- **CSV representation** — NULL values are exported as empty fields. Blob values use uppercase hexadecimal strings; binary values from arbitrary SQL keep the `0x...` representation.

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -20,9 +20,9 @@ The `sqlite://` form treats everything after the prefix as a raw path and does n
 - **Main database only** — Attached and temporary databases are not browsed as separate namespaces.
 - **Session state is per operation** — sabiql starts a new `sqlite3` process for each operation. Statements in one SQL modal submission share that process, but `TEMP` tables/views and connection-local `PRAGMA` settings do not carry over to the next SQL execution. Persistent changes to the main database remain available.
 - **Grid editing requires a declared primary key** — Regular tables with a declared `PRIMARY KEY` support grid editing. Tables without a declared primary key, views, and virtual tables remain browsable but are read-only targets in the grid.
-- **Query plans** — SQLite shows `EXPLAIN QUERY PLAN` in the Plan tab. Plan comparison and `EXPLAIN ANALYZE` are PostgreSQL-only.
-- **No ER diagrams** — Graphviz export requires PostgreSQL metadata.
-- **No JSON tree view** — Structured JSON editing is PostgreSQL-only.
+- **Query plans** — SQLite shows `EXPLAIN QUERY PLAN` in the Plan tab. Plan comparison and `EXPLAIN ANALYZE` are supported for PostgreSQL and MySQL only.
+- **No ER diagrams** — Graphviz ER export is supported for PostgreSQL and MySQL only.
+- **No JSON tree view** — Structured JSON editing is supported for PostgreSQL and MySQL only.
 
 ## Query safety
 


### PR DESCRIPTION
## Problem

The MySQL branch README mixed the product overview with detailed database behavior and command-level instructions, making it harder for new users to understand the value of sabiql and diverging from the simplified main README.

## Approach

Apply the product-focused README structure to the MySQL branch while preserving MySQL capabilities and setup requirements. Move detailed MySQL and SQLite behavior into dedicated database references and direct users to the in-app help for keybindings.