### PR TITLE
refactor: close test-only imports

### DIFF
--- a/scripts/lint_test_names.rb
+++ b/scripts/lint_test_names.rb
@@ -8,6 +8,7 @@ DEFAULT_PATHS = [
 ].freeze
 TEST_ONLY_ITEM_PATTERN = /\A(?:(?:pub(?:\([^)]*\))?|unsafe|async|extern(?:\s+"[^"]+")?)\s+)*(fn|struct|impl|const|type|static)\b/
 MODULE_PATTERN = /\A(?:(?:pub(?:\([^)]*\))?|unsafe)\s+)*mod\s+([a-zA-Z0-9_]+)\s*\{/
+PRIVATE_TEST_USE_PATTERN = /\Ause\b/
 
 # This lint only checks mechanically detectable anti-patterns.
 # Category-specific naming still relies on local rules and review.
@@ -161,6 +162,10 @@ def test_only_item_kind(stripped)
   match && match[1]
 end
 
+def private_test_use?(stripped)
+  PRIVATE_TEST_USE_PATTERN.match?(stripped)
+end
+
 paths = ARGV.empty? ? DEFAULT_PATHS : ARGV
 errors = []
 
@@ -192,6 +197,7 @@ rust_files(paths).each do |file|
 
     module_match = stripped.match(MODULE_PATTERN)
     item_kind = test_only_item_kind(stripped)
+    private_test_use = private_test_use?(stripped)
     cfg_test_module = pending_cfg_test_attr
     module_depth = mod_stack.last&.dig(:depth) || 0
     at_module_scope = brace_depth == module_depth
@@ -199,9 +205,11 @@ rust_files(paths).each do |file|
 
     if stripped.start_with?("#[")
       pending_cfg_test_attr ||= cfg_test_attribute?(stripped)
-    elsif pending_cfg_test_attr && (item_kind || module_match)
+    elsif pending_cfg_test_attr && (item_kind || module_match || private_test_use)
       if item_kind && at_module_scope && !inside_test_module
         errors << "#{rel}:#{line_no} test-only item must be inside a cfg(test) module: #{item_kind}"
+      elsif private_test_use && at_module_scope && !inside_test_module
+        errors << "#{rel}:#{line_no} test-only use must be inside a cfg(test) module"
       end
 
       pending_cfg_test_attr = false

--- a/scripts/lint_test_names_test.rb
+++ b/scripts/lint_test_names_test.rb
@@ -40,9 +40,6 @@ class LintTestNamesTest < Minitest::Test
           static SHARED: usize = 1;
       }
 
-      #[cfg(test)]
-      use crate::Fixture;
-
       #[cfg(feature = "test-support")]
       fn test_support_helper() {}
     RUST
@@ -105,5 +102,51 @@ class LintTestNamesTest < Minitest::Test
 
     refute status.success?
     assert_equal 1, stderr.lines.grep(/test-only item must be inside a cfg\(test\) module/).length
+  end
+
+  def test_allows_stacked_test_use_tree_inside_test_module
+    stdout, stderr, status = run_lint(<<~RUST)
+      #[cfg(test)]
+      mod tests {
+          #[cfg(test)]
+          #[allow(unused_imports)]
+          use crate::{
+              Fixture,
+              OtherFixture,
+          };
+      }
+
+      #[cfg(any(test, feature = "test-support"))]
+      use crate::SharedFixture;
+
+      #[cfg(feature = "test-support")]
+      use crate::FeatureFixture;
+    RUST
+
+    assert status.success?, stderr
+    assert_equal "test-name lint passed\n", stdout
+    assert_empty stderr
+  end
+
+  def test_rejects_private_test_use_at_module_scope
+    _stdout, stderr, status = run_lint(<<~RUST)
+      #[cfg(test)]
+      #[allow(unused_imports)]
+      use crate::Fixture;
+
+      #[cfg(test)]
+      use crate::{
+          FirstFixture,
+          SecondFixture,
+      };
+
+      mod production {
+          #[cfg(test)]
+          use crate::NestedFixture;
+      }
+    RUST
+
+    refute status.success?
+    assert_equal 3, stderr.lines.grep(/test-only use must be inside a cfg\(test\) module/).length
   end
 end

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -1,8 +1,6 @@
 use std::collections::HashSet;
 
 use crate::cmd::cache::BoundedLruCache;
-#[cfg(test)]
-use crate::domain::ColumnAttributes;
 use crate::domain::{DatabaseMetadata, DatabaseType, Table, TableSummary};
 use crate::model::sql_editor::completion::{CompletionCandidate, CompletionKind};
 use crate::policy::sql::lexer::{SqlContext, SqlLexer, TableReference, Token, TokenKind};
@@ -1219,10 +1217,11 @@ impl CompletionEngine {
 
 #[cfg(test)]
 mod tests {
+    use crate::domain::Column;
+    use crate::domain::ColumnAttributes;
     use crate::test_support;
 
     use super::*;
-    pub use crate::domain::Column;
 
     impl CompletionEngine {
         fn analyze(&self, content: &str, cursor_pos: usize) -> (String, CompletionContext) {

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -1,8 +1,6 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-#[cfg(test)]
-use crate::domain::QueryValue;
 use crate::model::app_state::AppState;
 use crate::model::browse::query_execution::{DeleteRefreshTarget, PostDeleteRowSelection};
 use crate::model::shared::confirm_dialog::ConfirmIntent;
@@ -423,7 +421,7 @@ mod tests {
     use crate::update::test_fixtures;
 
     use crate::domain::connection::ConnectionId;
-    use crate::domain::{ColumnAttributes, DatabaseType, QueryResult, QuerySource};
+    use crate::domain::{ColumnAttributes, DatabaseType, QueryResult, QuerySource, QueryValue};
     use crate::model::browse::query_execution::{
         DeleteRefreshTarget, PREVIEW_PAGE_SIZE, PostDeleteRowSelection, QueryStatus,
     };

--- a/src/app/update/browse/result/edit.rs
+++ b/src/app/update/browse/result/edit.rs
@@ -1,8 +1,6 @@
 use std::time::Instant;
 
 use crate::cmd::effect::Effect;
-#[cfg(test)]
-use crate::domain::ColumnAttributes;
 use crate::model::app_state::AppState;
 use crate::model::shared::input_mode::InputMode;
 use crate::update::action::{Action, InputTarget, ModalKind};
@@ -159,8 +157,10 @@ pub fn reduce_edit(state: &mut AppState, action: &Action, now: Instant) -> Dispa
 
 #[cfg(test)]
 mod tests {
+    use crate::domain::Column;
+    use crate::domain::ColumnAttributes;
+
     use super::*;
-    pub use crate::domain::Column;
     use crate::domain::connection::ConnectionId;
     use crate::domain::{DatabaseType, QueryResult, QuerySource, QueryValue, Table};
     use crate::update::action::{CursorMove, TextKillDirection};

--- a/src/app/update/browse/result/jsonb.rs
+++ b/src/app/update/browse/result/jsonb.rs
@@ -1,6 +1,4 @@
 use crate::cmd::effect::Effect;
-#[cfg(test)]
-use crate::domain::ColumnAttributes;
 use crate::domain::{QuerySource, QueryValue};
 use crate::model::app_state::AppState;
 use crate::model::browse::jsonb_detail::{JsonbDetailMode, JsonbDetailState};
@@ -396,11 +394,12 @@ fn apply_pending_edit_as_draft(state: &mut AppState) {
 
 #[cfg(test)]
 mod tests {
+    use crate::domain::Column;
+    use crate::domain::ColumnAttributes;
     use crate::test_support;
     use crate::update::test_fixtures;
 
     use super::*;
-    pub use crate::domain::Column;
     use crate::domain::connection::ConnectionId;
     use crate::domain::{DatabaseType, QueryResult, QuerySource, Table};
     use crate::services::AppServices;

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -1,7 +1,5 @@
 use std::time::Instant;
 
-#[cfg(test)]
-use crate::domain::ColumnAttributes;
 use crate::model::app_state::AppState;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
@@ -102,6 +100,8 @@ pub fn reduce_selection(state: &mut AppState, action: &Action, now: Instant) -> 
 
 #[cfg(test)]
 mod tests {
+    use crate::domain::ColumnAttributes;
+
     use super::*;
     use crate::domain::Column;
     use crate::domain::{QueryResult, QuerySource, Table};

--- a/src/domain/lib.rs
+++ b/src/domain/lib.rs
@@ -20,8 +20,6 @@ pub mod write_result;
 
 pub use column::{Column, ColumnAttributes};
 pub use command_tag::CommandTag;
-#[cfg(test)]
-pub use er::ErFkInfo;
 pub use er::ErTableInfo;
 pub use explain_plan::{
     mysql_explain_plan_text_from_result, postgres_explain_plan_text_from_result,

--- a/src/infra/adapters/cached_result_exporter.rs
+++ b/src/infra/adapters/cached_result_exporter.rs
@@ -4,9 +4,6 @@ use sabiql_app::ports::outbound::{CachedResultExporter, DbOperationError};
 
 use crate::adapters::csv_export::{CsvFileWriter, export_to_downloads};
 
-#[cfg(test)]
-use crate::adapters::csv_export::CSV_FLUSH_THRESHOLD;
-
 #[derive(Debug, Default, Clone, Copy)]
 pub struct CsvCachedResultExporter;
 
@@ -55,6 +52,8 @@ async fn write_cached_result_csv(
 
 #[cfg(test)]
 mod tests {
+    use crate::adapters::csv_export::CSV_FLUSH_THRESHOLD;
+
     use super::*;
     use tempfile::tempdir;
 

--- a/src/infra/adapters/connection_store.rs
+++ b/src/infra/adapters/connection_store.rs
@@ -10,13 +10,6 @@ use crate::config::connection_config::{
 };
 use crate::domain::connection::{ConnectionId, ConnectionProfile};
 
-#[cfg(test)]
-use super::app_config_file::CONFIG_FILE_NAME;
-#[cfg(test)]
-use crate::domain::connection::{ConnectionConfig, DatabaseType, PostgresConnectionConfig};
-#[cfg(test)]
-use std::path::Path;
-
 pub struct TomlConnectionStore {
     config_dir: PathBuf,
 }
@@ -138,8 +131,11 @@ fn get_config_dir() -> Result<PathBuf, ConnectionStoreError> {
 
 #[cfg(test)]
 mod tests {
+    use super::app_config_file::CONFIG_FILE_NAME;
     use super::*;
     use crate::domain::connection::SslMode;
+    use crate::domain::connection::{ConnectionConfig, DatabaseType, PostgresConnectionConfig};
+    use std::path::Path;
     use tempfile::TempDir;
 
     fn make_test_profile(name: &str) -> ConnectionProfile {

--- a/src/infra/adapters/mysql/cli/mod.rs
+++ b/src/infra/adapters/mysql/cli/mod.rs
@@ -18,8 +18,10 @@ pub(super) use process::{
 };
 pub(super) use xml::MysqlResultSet;
 
-#[cfg(test)]
-pub(super) use process::MysqlProcess;
-
 #[cfg(all(unix, feature = "test-support"))]
 pub(super) use process::run_mysql_cli_script_for_test;
+
+#[cfg(test)]
+pub(super) mod test_support {
+    pub(in crate::adapters::mysql) use super::process::MysqlProcess;
+}

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -96,6 +96,7 @@ mod tests {
     use std::collections::HashSet;
     use std::sync::{Arc, Barrier};
 
+    use super::super::cli::test_support::MysqlProcess;
     use crate::domain::connection::MySqlSslMode;
 
     use super::*;
@@ -231,7 +232,7 @@ mod tests {
         let (result, path) = {
             let option_file = MySqlOptionFile::create(&target()).unwrap();
             let path = option_file.path.clone();
-            let result = super::super::cli::MysqlProcess::spawn_with_program(
+            let result = MysqlProcess::spawn_with_program(
                 std::ffi::OsStr::new("__sabiql_missing_mysql_binary__"),
                 &path,
             );

--- a/src/infra/adapters/settings_store.rs
+++ b/src/infra/adapters/settings_store.rs
@@ -11,9 +11,6 @@ use crate::config::connection_config::{
     CURRENT_VERSION, ConfigVersionCheck, ConnectionConfigFile, is_supported_config_version,
 };
 
-#[cfg(test)]
-use super::app_config_file::CONFIG_FILE_NAME;
-
 pub struct TomlSettingsStore {
     config_dir: PathBuf,
 }
@@ -129,6 +126,8 @@ fn set_app_settings(config: &mut ConnectionConfigFile, settings: AppSettings) {
 
 #[cfg(test)]
 mod tests {
+    use super::app_config_file::CONFIG_FILE_NAME;
+
     use super::*;
     use tempfile::TempDir;
 

--- a/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
+++ b/src/infra/adapters/sqlite/sqlite3/parser/lexer.rs
@@ -11,9 +11,6 @@ use crate::app::policy::sql::sqlite_transaction::{
 };
 use crate::app::ports::outbound::DbOperationError;
 
-#[cfg(test)]
-use crate::app::policy::sql::sqlite_transaction::SqliteStatementClassification;
-
 fn is_ident_char(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || byte == b'_'
 }
@@ -764,6 +761,8 @@ fn statement_emits_result_set(statement: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::app::policy::sql::sqlite_transaction::SqliteStatementClassification;
+
     use super::*;
     use rstest::rstest;
 


### PR DESCRIPTION
## Summary

- Move private `#[cfg(test)]` imports from production module scope into the corresponding test modules.
- Reject direct private `#[cfg(test)] use` declarations in `lint_test_names.rb`, including stacked attributes, use trees, and multiline imports.
- Remove an unused test-only re-export and isolate the required MySQL process helper in an explicit `test_support` module.

## Validation

- `scripts/lint_all.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
- `cargo build --workspace --release`
- `cargo build --workspace --release --no-default-features`
- `cargo insta test --unreferenced=reject -p sabiql`
- `cargo nextest` no-default-features: 185 passed, 38 skipped
- Local all-features `cargo nextest`: 4,872 passed, 5 failed; four MySQL failures passed when rerun individually, while the unrelated SQLite CSV baseline failure remains reproducible alone.
