### PR TITLE
ci: shorten Windows SQLite setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,16 @@ jobs:
       - name: Install SQLite
         shell: pwsh
         run: |
-          choco install sqlite --no-progress -y
-          $sqliteTools = Join-Path $env:ChocolateyInstall 'lib'
-          $sqliteTools = Join-Path $sqliteTools 'SQLite'
-          $sqliteTools = Join-Path $sqliteTools 'tools'
+          $sqliteVersion = '3530400'
+          $sqliteArchive = Join-Path $env:RUNNER_TEMP "sqlite-tools-win-x64-$sqliteVersion.zip"
+          $sqliteTools = Join-Path $env:RUNNER_TEMP 'sqlite-tools'
+          $sqliteUrl = "https://www.sqlite.org/2026/sqlite-tools-win-x64-$sqliteVersion.zip"
+          curl.exe --fail --location --retry 3 --output $sqliteArchive $sqliteUrl
+          $actualHash = (Get-FileHash -Path $sqliteArchive -Algorithm SHA256).Hash
+          if ($actualHash -cne 'F46EE2475DE4CBE287E6E5F7D43C838796B14E7379CD216BDBB28D391429F9FC') {
+            throw "SQLite archive checksum mismatch: $actualHash"
+          }
+          Expand-Archive -Path $sqliteArchive -DestinationPath $sqliteTools
           $sqliteTools | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           & (Join-Path $sqliteTools 'sqlite3.exe') --version
       - run: cargo nextest run --workspace --profile ci-all --all-features --show-progress=none --status-level=fail --final-status-level=fail


### PR DESCRIPTION
## Problem
Windows CI installs SQLite through Chocolatey on every run, adding setup overhead.

## Background
The job needs a real SQLite CLI for Windows-specific execution coverage, but the package-manager install is not part of the test itself.

## Approach
Use SQLite's official pinned Windows x64 tools archive, verify its SHA256 before extraction, and preserve the PATH registration and version smoke. Keep cache settings, both nextest scopes, and the real binary smoke unchanged.