### PR TITLE
fix(mysql): restrict Windows option file ACL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,6 +2878,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,13 @@ unicode-width = "0.2"
 urlencoding = "2"
 url = "2"
 uuid = { version = "1", features = ["v4", "v5"] }
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Threading",
+] }
 
 [package]
 name = "sabiql"

--- a/clippy.toml
+++ b/clippy.toml
@@ -36,6 +36,7 @@ absolute-paths-allowed-crates = [
     "unicode_width",
     "urlencoding",
     "uuid",
+    "windows_sys",
 ]
 
 disallowed-methods = [

--- a/src/infra/Cargo.toml
+++ b/src/infra/Cargo.toml
@@ -32,6 +32,9 @@ sabiql-domain.workspace = true
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows-sys.workspace = true
+
 [target.'cfg(not(target_os = "android"))'.dependencies]
 arboard.workspace = true
 

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -1,5 +1,5 @@
-use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
 use std::path::PathBuf;
 
 use uuid::Uuid;
@@ -28,11 +28,24 @@ impl MySqlOptionFile {
         options.write(true).create_new(true);
         #[cfg(unix)]
         std::os::unix::fs::OpenOptionsExt::mode(&mut options, 0o600);
+        #[cfg(windows)]
+        std::os::windows::fs::OpenOptionsExt::access_mode(
+            &mut options,
+            windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_WRITE
+                | windows_sys::Win32::Storage::FileSystem::WRITE_DAC,
+        );
         let mut file = options.open(&path).map_err(|error| {
             DbOperationError::ConnectionFailed(format!(
                 "Unable to create MySQL option file: {error}"
             ))
         })?;
+        if let Err(error) = set_file_permissions(&file) {
+            drop(file);
+            let _ = fs::remove_file(&path);
+            return Err(DbOperationError::ConnectionFailed(format!(
+                "Unable to secure MySQL option file: {error}"
+            )));
+        }
         let contents = serialize_option_file(target);
         if let Err(error) = file.write_all(contents.as_bytes()) {
             let _ = fs::remove_file(&path);
@@ -42,6 +55,127 @@ impl MySqlOptionFile {
         }
         Ok(Self { path })
     }
+}
+
+#[cfg(unix)]
+fn set_file_permissions(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+fn set_file_permissions(file: &File) -> io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    use std::ptr::{null, null_mut};
+
+    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, HANDLE, LocalFree};
+    use windows_sys::Win32::Security::Authorization::{
+        EXPLICIT_ACCESS_W, GRANT_ACCESS, SetEntriesInAclW, SetSecurityInfo, TRUSTEE_IS_SID,
+        TRUSTEE_IS_USER, TRUSTEE_W,
+    };
+    use windows_sys::Win32::Security::{
+        DACL_SECURITY_INFORMATION, NO_INHERITANCE, PROTECTED_DACL_SECURITY_INFORMATION, TOKEN_QUERY,
+    };
+    use windows_sys::Win32::Storage::FileSystem::{FILE_GENERIC_READ, FILE_GENERIC_WRITE};
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    let mut token: HANDLE = null_mut();
+    let opened = unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) };
+    if opened == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let sid_result = current_user_sid(token);
+    unsafe {
+        CloseHandle(token);
+    }
+    let mut sid = sid_result?;
+
+    let trustee = TRUSTEE_W {
+        pMultipleTrustee: null_mut(),
+        MultipleTrusteeOperation: 0,
+        TrusteeForm: TRUSTEE_IS_SID,
+        TrusteeType: TRUSTEE_IS_USER,
+        ptstrName: sid.as_mut_ptr().cast(),
+    };
+    let access = EXPLICIT_ACCESS_W {
+        grfAccessPermissions: FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+        grfAccessMode: GRANT_ACCESS,
+        grfInheritance: NO_INHERITANCE,
+        Trustee: trustee,
+    };
+    let mut acl = null_mut();
+    let status = unsafe { SetEntriesInAclW(1, &raw const access, null(), &raw mut acl) };
+    if status != ERROR_SUCCESS {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+
+    let status = unsafe {
+        SetSecurityInfo(
+            file.as_raw_handle(),
+            windows_sys::Win32::Security::Authorization::SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            null_mut(),
+            null_mut(),
+            acl,
+            null(),
+        )
+    };
+    unsafe {
+        LocalFree(acl.cast());
+    }
+    if status != ERROR_SUCCESS {
+        return Err(io::Error::from_raw_os_error(status as i32));
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn current_user_sid(token: windows_sys::Win32::Foundation::HANDLE) -> io::Result<Vec<u8>> {
+    use std::ptr::null_mut;
+
+    use windows_sys::Win32::Security::{
+        CopySid, GetLengthSid, GetTokenInformation, TOKEN_USER, TokenUser,
+    };
+
+    let mut required_size = 0;
+    unsafe {
+        GetTokenInformation(token, TokenUser, null_mut(), 0, &raw mut required_size);
+    }
+    if required_size == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let word_count = (required_size as usize).div_ceil(size_of::<u64>());
+    let mut buffer = vec![0_u64; word_count];
+    let success = unsafe {
+        GetTokenInformation(
+            token,
+            TokenUser,
+            buffer.as_mut_ptr().cast(),
+            required_size,
+            &raw mut required_size,
+        )
+    };
+    if success == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let token_user = unsafe { &*buffer.as_ptr().cast::<TOKEN_USER>() };
+    let sid_length = unsafe { GetLengthSid(token_user.User.Sid) };
+    if sid_length == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut sid = vec![0_u8; sid_length as usize];
+    if unsafe { CopySid(sid_length, sid.as_mut_ptr().cast(), token_user.User.Sid) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(sid)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn set_file_permissions(_file: &File) -> io::Result<()> {
+    Ok(())
 }
 
 impl Drop for MySqlOptionFile {
@@ -190,9 +324,108 @@ mod tests {
                 0o600
             );
         }
+        #[cfg(windows)]
+        assert_owner_only_acl(&option_file.path);
         let path = option_file.path.clone();
         drop(option_file);
         assert!(!path.exists());
+    }
+
+    #[cfg(windows)]
+    fn assert_owner_only_acl(path: &std::path::Path) {
+        use std::os::windows::ffi::OsStrExt;
+        use std::ptr::null_mut;
+
+        use windows_sys::Win32::Foundation::{ERROR_SUCCESS, LocalFree};
+        use windows_sys::Win32::Security::Authorization::GetNamedSecurityInfoW;
+        use windows_sys::Win32::Security::{
+            ACCESS_ALLOWED_ACE, AclSizeInformation, DACL_SECURITY_INFORMATION, EqualSid, GetAce,
+            GetAclInformation, GetSecurityDescriptorControl, GetSecurityDescriptorDacl,
+            OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, SE_DACL_PROTECTED,
+        };
+        use windows_sys::Win32::Storage::FileSystem::{FILE_GENERIC_READ, FILE_GENERIC_WRITE};
+
+        let path = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>();
+        let mut owner = null_mut();
+        let mut dacl = null_mut();
+        let mut security_descriptor: PSECURITY_DESCRIPTOR = null_mut();
+        let status = unsafe {
+            GetNamedSecurityInfoW(
+                path.as_ptr(),
+                windows_sys::Win32::Security::Authorization::SE_FILE_OBJECT,
+                OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+                &raw mut owner,
+                null_mut(),
+                &raw mut dacl,
+                null_mut(),
+                &raw mut security_descriptor,
+            )
+        };
+        assert_eq!(status, ERROR_SUCCESS);
+
+        let mut control = 0;
+        let mut revision = 0;
+        assert_ne!(
+            unsafe {
+                GetSecurityDescriptorControl(
+                    security_descriptor,
+                    &raw mut control,
+                    &raw mut revision,
+                )
+            },
+            0
+        );
+        assert_ne!(control & SE_DACL_PROTECTED, 0);
+
+        let mut dacl_present = 0;
+        let mut dacl_defaulted = 0;
+        assert_ne!(
+            unsafe {
+                GetSecurityDescriptorDacl(
+                    security_descriptor,
+                    &raw mut dacl_present,
+                    &raw mut dacl,
+                    &raw mut dacl_defaulted,
+                )
+            },
+            0
+        );
+        assert_ne!(dacl_present, 0);
+        assert!(!dacl.is_null());
+
+        let mut acl_info = windows_sys::Win32::Security::ACL_SIZE_INFORMATION::default();
+        assert_ne!(
+            unsafe {
+                GetAclInformation(
+                    dacl,
+                    (&raw mut acl_info).cast::<std::ffi::c_void>(),
+                    std::mem::size_of_val(&acl_info) as u32,
+                    AclSizeInformation,
+                )
+            },
+            0
+        );
+        assert_eq!(acl_info.AceCount, 1);
+
+        let mut ace = null_mut();
+        assert_ne!(unsafe { GetAce(dacl, 0, &raw mut ace) }, 0);
+        let allowed_ace = unsafe { &*ace.cast::<ACCESS_ALLOWED_ACE>() };
+        assert_eq!(allowed_ace.Header.AceType, 0);
+        assert_eq!(allowed_ace.Header.AceFlags, 0);
+        assert_eq!(
+            allowed_ace.Mask & (FILE_GENERIC_READ | FILE_GENERIC_WRITE),
+            FILE_GENERIC_READ | FILE_GENERIC_WRITE
+        );
+        let ace_sid = std::ptr::addr_of!(allowed_ace.SidStart).cast_mut().cast();
+        assert_ne!(unsafe { EqualSid(owner, ace_sid) }, 0);
+
+        unsafe {
+            LocalFree(security_descriptor.cast());
+        }
     }
 
     #[test]

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -331,29 +331,29 @@ mod tests {
         use std::os::windows::ffi::OsStrExt;
         use std::ptr::null_mut;
 
-        use windows_sys::Win32::Foundation::{ERROR_SUCCESS, LocalFree};
+        use windows_sys::Win32::Foundation::{CloseHandle, ERROR_SUCCESS, LocalFree};
         use windows_sys::Win32::Security::Authorization::GetNamedSecurityInfoW;
         use windows_sys::Win32::Security::{
             ACCESS_ALLOWED_ACE, AclSizeInformation, DACL_SECURITY_INFORMATION, EqualSid, GetAce,
             GetAclInformation, GetSecurityDescriptorControl, GetSecurityDescriptorDacl,
-            OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, SE_DACL_PROTECTED,
+            PSECURITY_DESCRIPTOR, SE_DACL_PROTECTED, TOKEN_QUERY,
         };
         use windows_sys::Win32::Storage::FileSystem::{FILE_GENERIC_READ, FILE_GENERIC_WRITE};
+        use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
         let path = path
             .as_os_str()
             .encode_wide()
             .chain(std::iter::once(0))
             .collect::<Vec<_>>();
-        let mut owner = null_mut();
         let mut dacl = null_mut();
         let mut security_descriptor: PSECURITY_DESCRIPTOR = null_mut();
         let status = unsafe {
             GetNamedSecurityInfoW(
                 path.as_ptr(),
                 windows_sys::Win32::Security::Authorization::SE_FILE_OBJECT,
-                OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
-                &raw mut owner,
+                DACL_SECURITY_INFORMATION,
+                null_mut(),
                 null_mut(),
                 &raw mut dacl,
                 null_mut(),
@@ -416,7 +416,19 @@ mod tests {
             FILE_GENERIC_READ | FILE_GENERIC_WRITE
         );
         let ace_sid = std::ptr::addr_of!(allowed_ace.SidStart).cast_mut().cast();
-        assert_ne!(unsafe { EqualSid(owner, ace_sid) }, 0);
+        let mut token = null_mut();
+        assert_ne!(
+            unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) },
+            0
+        );
+        let current_sid = current_user_sid(token).unwrap();
+        unsafe {
+            CloseHandle(token);
+        }
+        assert_ne!(
+            unsafe { EqualSid(current_sid.as_ptr().cast_mut().cast(), ace_sid) },
+            0
+        );
 
         unsafe {
             LocalFree(security_descriptor.cast());

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -1,5 +1,9 @@
-use std::fs::{self, File, OpenOptions};
-use std::io::{self, Write};
+#[cfg(windows)]
+use std::fs::File;
+use std::fs::{self, OpenOptions};
+#[cfg(windows)]
+use std::io;
+use std::io::Write;
 use std::path::PathBuf;
 
 use uuid::Uuid;
@@ -39,6 +43,7 @@ impl MySqlOptionFile {
                 "Unable to create MySQL option file: {error}"
             ))
         })?;
+        #[cfg(windows)]
         if let Err(error) = set_file_permissions(&file) {
             drop(file);
             let _ = fs::remove_file(&path);
@@ -55,11 +60,6 @@ impl MySqlOptionFile {
         }
         Ok(Self { path })
     }
-}
-
-#[cfg(unix)]
-fn set_file_permissions(_file: &File) -> io::Result<()> {
-    Ok(())
 }
 
 #[cfg(windows)]
@@ -171,11 +171,6 @@ fn current_user_sid(token: windows_sys::Win32::Foundation::HANDLE) -> io::Result
         return Err(io::Error::last_os_error());
     }
     Ok(sid)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn set_file_permissions(_file: &File) -> io::Result<()> {
-    Ok(())
 }
 
 impl Drop for MySqlOptionFile {


### PR DESCRIPTION
## Problem

Windows MySQL option files currently inherit permissions from the temporary directory, so other users may be able to read credentials and TLS paths.

## Background

Unix option files are created with owner-only permissions, but Windows has no equivalent protection in the current implementation.

## Approach

Apply a protected DACL granting the creating user read/write access immediately after creating the empty file and before writing credentials. Remove the file when ACL setup or content writing fails, while preserving Unix 0o600 behavior and Drop cleanup.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-440/windowsのmysql-option-fileを作成者だけに制限する