### PR TITLE
fix: correct MySQL implicit commit and EXPLAIN safety

### DIFF
--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -122,18 +122,7 @@ mod mysql_tests {
     }
 
     #[test]
-    fn explain_target_policy_separates_nonexecuting_explain_from_analyze() {
-        for sql in [
-            "SELECT 1",
-            "TABLE items",
-            "SELECT * FROM items FOR UPDATE",
-            "UPDATE items SET value = 1 WHERE id = 1",
-        ] {
-            assert!(evaluate_mysql_explain_target(sql, false).is_some(), "{sql}");
-        }
-        for sql in ["SHOW TABLES", "DESCRIBE items"] {
-            assert!(evaluate_mysql_explain_target(sql, false).is_none(), "{sql}");
-        }
+    fn explain_analyze_target_rejects_side_effects() {
         for sql in [
             "UPDATE items SET value = 1",
             "SELECT * FROM items FOR UPDATE",
@@ -142,20 +131,19 @@ mod mysql_tests {
             "SELECT id INTO @value FROM items",
             "TABLE items INTO OUTFILE '/tmp/items'",
             "WITH rows AS (SELECT 1) SELECT * INTO OUTFILE '/tmp/items' FROM rows",
-        ] {
-            assert!(evaluate_mysql_explain_target(sql, false).is_some(), "{sql}");
-            assert!(evaluate_mysql_explain_target(sql, true).is_none(), "{sql}");
-        }
-        for sql in [
+            "SHOW TABLES",
+            "DESCRIBE items",
             "SELECT 1; SELECT 2",
             "SELECT 1\nsystem echo unsafe",
             "SELECT 1\n\\! echo unsafe",
         ] {
-            assert!(evaluate_mysql_explain_target(sql, false).is_none(), "{sql}");
-            assert!(evaluate_mysql_explain_target(sql, true).is_none(), "{sql}");
+            assert!(
+                evaluate_mysql_explain_analyze_target(sql).is_none(),
+                "{sql}"
+            );
         }
         for (sql, label) in [("SELECT 1", "SELECT"), ("TABLE items", "TABLE")] {
-            let risk = evaluate_mysql_explain_target(sql, true).expect(sql);
+            let risk = evaluate_mysql_explain_analyze_target(sql).expect(sql);
             assert_eq!(risk.risk_level, RiskLevel::Low);
             assert!(risk.read_only_allowed);
             assert_eq!(
@@ -166,7 +154,7 @@ mod mysql_tests {
                 }
             );
         }
-        assert!(evaluate_mysql_explain_target("SHOW TABLES", true).is_none());
+        assert!(evaluate_mysql_explain_analyze_target("SHOW TABLES").is_none());
     }
 
     #[test]
@@ -574,13 +562,11 @@ fn mysql_validate_submission_state(
                 };
                 temporary_tables.remove(index);
             }
-            kind if mysql_statement_is_persistent_schema_change(kind) => {
-                if transaction_open {
-                    return Err(
-                        "MySQL persistent DDL causes an implicit commit and cannot be rolled back with the surrounding transaction"
-                            .to_string(),
-                    );
-                }
+            kind if transaction_open && mysql_statement_is_persistent_schema_change(kind) => {
+                return Err(
+                    "MySQL persistent DDL causes an implicit commit and cannot be rolled back with the surrounding transaction"
+                        .to_string(),
+                );
             }
             _ => {}
         }
@@ -990,7 +976,7 @@ fn evaluate_mysql_statement_risk(sql: &str) -> SqlRiskDecision {
     }
 }
 
-pub fn evaluate_mysql_explain_target(sql: &str, analyze: bool) -> Option<SqlRiskDecision> {
+pub fn evaluate_mysql_explain_analyze_target(sql: &str) -> Option<SqlRiskDecision> {
     if statement_contains_unsupported_mysql_control(sql) {
         return None;
     }
@@ -999,36 +985,21 @@ pub fn evaluate_mysql_explain_target(sql: &str, analyze: bool) -> Option<SqlRisk
         return None;
     }
     let statement = classify_mysql_statement(&statements[0]).ok()?;
-    let allowed_kind = if analyze {
-        matches!(
-            statement.kind,
-            MysqlStatementKind::Select | MysqlStatementKind::Table
-        )
-    } else {
-        matches!(
-            statement.kind,
-            MysqlStatementKind::Select
-                | MysqlStatementKind::Table
-                | MysqlStatementKind::Insert
-                | MysqlStatementKind::Replace
-                | MysqlStatementKind::Update { .. }
-                | MysqlStatementKind::Delete { .. }
-        )
-    };
-    if !allowed_kind {
+    if !matches!(
+        statement.kind,
+        MysqlStatementKind::Select | MysqlStatementKind::Table
+    ) {
         return None;
     }
 
     let mut risk = mysql_statement_risk(&statement);
-    if analyze {
-        if !risk.read_only_allowed {
-            return None;
-        }
-        risk.confirmation = ConfirmationType::Acknowledge {
-            reason: AcknowledgeReason::AnalyzeExecution,
-            label: mysql_statement_label(&statement.kind).to_string(),
-        };
+    if !risk.read_only_allowed {
+        return None;
     }
+    risk.confirmation = ConfirmationType::Acknowledge {
+        reason: AcknowledgeReason::AnalyzeExecution,
+        label: mysql_statement_label(&statement.kind).to_string(),
+    };
     Some(risk)
 }
 

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -122,9 +122,17 @@ mod mysql_tests {
     }
 
     #[test]
-    fn explain_targets_share_the_read_only_allowlist() {
-        for sql in ["SELECT 1", "TABLE items", "SHOW TABLES", "DESCRIBE items"] {
+    fn explain_target_policy_separates_nonexecuting_explain_from_analyze() {
+        for sql in [
+            "SELECT 1",
+            "TABLE items",
+            "SELECT * FROM items FOR UPDATE",
+            "UPDATE items SET value = 1 WHERE id = 1",
+        ] {
             assert!(evaluate_mysql_explain_target(sql, false).is_some(), "{sql}");
+        }
+        for sql in ["SHOW TABLES", "DESCRIBE items"] {
+            assert!(evaluate_mysql_explain_target(sql, false).is_none(), "{sql}");
         }
         for sql in [
             "UPDATE items SET value = 1",
@@ -134,6 +142,11 @@ mod mysql_tests {
             "SELECT id INTO @value FROM items",
             "TABLE items INTO OUTFILE '/tmp/items'",
             "WITH rows AS (SELECT 1) SELECT * INTO OUTFILE '/tmp/items' FROM rows",
+        ] {
+            assert!(evaluate_mysql_explain_target(sql, false).is_some(), "{sql}");
+            assert!(evaluate_mysql_explain_target(sql, true).is_none(), "{sql}");
+        }
+        for sql in [
             "SELECT 1; SELECT 2",
             "SELECT 1\nsystem echo unsafe",
             "SELECT 1\n\\! echo unsafe",
@@ -267,6 +280,7 @@ mod mysql_tests {
             "COMMIT",
             "ROLLBACK",
             "BEGIN; COMMIT",
+            "BEGIN; UPDATE items SET value = 1 WHERE id = 1; ROLLBACK",
             "START TRANSACTION; ROLLBACK",
             "BEGIN; SAVEPOINT named; ROLLBACK TO named; RELEASE SAVEPOINT named; COMMIT",
             "CREATE TEMPORARY TABLE temp_items (id INT); INSERT INTO temp_items VALUES (1); SELECT * FROM temp_items",
@@ -274,6 +288,25 @@ mod mysql_tests {
         ] {
             assert!(
                 matches!(mysql(sql), MultiStatementDecision::Allow { .. }),
+                "{sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_persistent_ddl_inside_an_explicit_transaction() {
+        for sql in [
+            "BEGIN; UPDATE items SET value = 1 WHERE id = 1; CREATE TABLE new_items (id INT); ROLLBACK",
+            "BEGIN; UPDATE items SET value = 1 WHERE id = 1; ALTER TABLE items ADD COLUMN extra INT; ROLLBACK",
+            "BEGIN; UPDATE items SET value = 1 WHERE id = 1; DROP TABLE items; ROLLBACK",
+            "BEGIN; UPDATE items SET value = 1 WHERE id = 1; TRUNCATE TABLE items; ROLLBACK",
+            "BEGIN; UPDATE items SET value = 1 WHERE id = 1; CREATE VIEW item_view AS SELECT 1; ROLLBACK",
+            "BEGIN; UPDATE items SET value = 1 WHERE id = 1; DROP VIEW item_view; ROLLBACK",
+            "BEGIN; UPDATE items SET value = 1 WHERE id = 1; CREATE INDEX item_index ON items (value); ROLLBACK",
+            "BEGIN; UPDATE items SET value = 1 WHERE id = 1; DROP INDEX item_index ON items; ROLLBACK",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Block { ref reason } if reason.contains("implicit commit")),
                 "{sql}"
             );
         }
@@ -542,8 +575,12 @@ fn mysql_validate_submission_state(
                 temporary_tables.remove(index);
             }
             kind if mysql_statement_is_persistent_schema_change(kind) => {
-                transaction_open = false;
-                savepoints.clear();
+                if transaction_open {
+                    return Err(
+                        "MySQL persistent DDL causes an implicit commit and cannot be rolled back with the surrounding transaction"
+                            .to_string(),
+                    );
+                }
             }
             _ => {}
         }
@@ -972,20 +1009,27 @@ pub fn evaluate_mysql_explain_target(sql: &str, analyze: bool) -> Option<SqlRisk
             statement.kind,
             MysqlStatementKind::Select
                 | MysqlStatementKind::Table
-                | MysqlStatementKind::Show
-                | MysqlStatementKind::Describe
+                | MysqlStatementKind::Insert
+                | MysqlStatementKind::Replace
+                | MysqlStatementKind::Update { .. }
+                | MysqlStatementKind::Delete { .. }
         )
     };
+    if !allowed_kind {
+        return None;
+    }
+
     let mut risk = mysql_statement_risk(&statement);
-    if analyze && risk.read_only_allowed {
+    if analyze {
+        if !risk.read_only_allowed {
+            return None;
+        }
         risk.confirmation = ConfirmationType::Acknowledge {
             reason: AcknowledgeReason::AnalyzeExecution,
             label: mysql_statement_label(&statement.kind).to_string(),
         };
     }
-    allowed_kind
-        .then_some(risk)
-        .filter(|risk| risk.read_only_allowed)
+    Some(risk)
 }
 
 pub fn evaluate_multi_statement(sql: &str) -> MultiStatementDecision {

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -154,7 +154,6 @@ mod mysql_tests {
                 }
             );
         }
-        assert!(evaluate_mysql_explain_analyze_target("SHOW TABLES").is_none());
     }
 
     #[test]

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -7,7 +7,7 @@ use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
 use crate::policy::sql::statement_classifier;
 use crate::policy::write::sql_risk::{
-    ConfirmationType, evaluate_mysql_explain_target, evaluate_sql_risk_for_database,
+    ConfirmationType, evaluate_mysql_explain_analyze_target, evaluate_sql_risk_for_database,
 };
 use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
@@ -46,7 +46,7 @@ pub(super) fn reduce_analyze(
                 return DispatchResult::handled();
             }
             let risk = if database_type == DatabaseType::MySQL {
-                let Some(risk) = evaluate_mysql_explain_target(&content, true) else {
+                let Some(risk) = evaluate_mysql_explain_analyze_target(&content) else {
                     show_explain_error_on_plan(
                         state,
                         "MySQL EXPLAIN ANALYZE only supports side-effect-free SELECT or TABLE statements",
@@ -121,7 +121,7 @@ pub(super) fn reduce_analyze(
             {
                 let database_type = state.session.active_database_type_or_default();
                 if database_type == DatabaseType::MySQL
-                    && evaluate_mysql_explain_target(&query, true).is_none()
+                    && evaluate_mysql_explain_analyze_target(&query).is_none()
                 {
                     finish_explain_unsupported_analyze(state);
                     return DispatchResult::handled();

--- a/src/app/update/explain/mod.rs
+++ b/src/app/update/explain/mod.rs
@@ -248,7 +248,7 @@ mod tests {
         }
 
         #[test]
-        fn mysql_explain_rejects_locking_reads() {
+        fn mysql_explain_emits_tree_explain_for_locking_reads() {
             let mut state = sql_modal_state();
             state
                 .sql_modal
@@ -264,11 +264,16 @@ mod tests {
             )
             .unwrap();
 
-            assert!(effects.is_empty());
-            assert_eq!(
-                state.explain.error.as_deref(),
-                Some("MySQL EXPLAIN only supports side-effect-free read statements")
-            );
+            assert!(matches!(
+                &effects[0],
+                Effect::ExecuteExplain {
+                    query,
+                    database_type: DatabaseType::MySQL,
+                    is_analyze: false,
+                    access_mode: AccessMode::ReadOnly,
+                    ..
+                } if query == "EXPLAIN FORMAT=TREE SELECT * FROM users FOR UPDATE"
+            ));
         }
 
         #[test]

--- a/src/app/update/explain/request.rs
+++ b/src/app/update/explain/request.rs
@@ -5,10 +5,7 @@ use crate::domain::DatabaseType;
 use crate::model::app_state::AppState;
 use crate::model::shared::text_input::TextInputLike;
 use crate::model::sql_editor::modal::SqlModalStatus;
-use crate::policy::sql::mysql_statement::{
-    MysqlStatementKind, classify_mysql_statement, mysql_explain_rejection_message,
-};
-use crate::policy::write::sql_risk::evaluate_mysql_explain_target;
+use crate::policy::sql::mysql_statement::mysql_explain_rejection_message;
 use crate::policy::{FeaturePolicy, FeatureRequirement};
 use crate::ports::outbound::AccessMode;
 use crate::services::AppServices;
@@ -48,27 +45,6 @@ pub(super) fn reduce_request(
                 show_explain_error_on_plan(state, "EXPLAIN does not support multiple statements");
                 return DispatchResult::handled();
             }
-            let mysql_explain_dml = database_type == DatabaseType::MySQL
-                && classify_mysql_statement(&content).is_ok_and(|statement| {
-                    matches!(
-                        statement.kind,
-                        MysqlStatementKind::Insert
-                            | MysqlStatementKind::Replace
-                            | MysqlStatementKind::Update { .. }
-                            | MysqlStatementKind::Delete { .. }
-                    )
-                });
-            if database_type == DatabaseType::MySQL
-                && !mysql_explain_dml
-                && evaluate_mysql_explain_target(&content, false).is_none()
-            {
-                show_explain_error_on_plan(
-                    state,
-                    "MySQL EXPLAIN only supports side-effect-free read statements",
-                );
-                return DispatchResult::handled();
-            }
-
             let query = match services
                 .sql_dialect
                 .build_explain_sql(database_type, &content)

--- a/src/infra/adapters/mysql/sql/explain.rs
+++ b/src/infra/adapters/mysql/sql/explain.rs
@@ -30,6 +30,7 @@ mod tests {
             "REPLACE DELAYED users VALUES (1)",
             "UPDATE users SET name = 'Ada' WHERE id = 1",
             "DELETE FROM users WHERE id = 1",
+            "SELECT * FROM users FOR UPDATE",
         ] {
             assert_eq!(
                 build_explain_sql(query),

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1417,8 +1417,8 @@ async fn rejects_implicit_commit_transaction_and_matches_oracle_mysql_behavior()
         }
 
         let result = async {
-            db.run_pty_script(&format!(
-                "BEGIN;\nUPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'implicit commit' WHERE id = 1;\nCREATE TABLE {table} (id INT);\nROLLBACK;\n"
+            db.run_cli_script(&format!(
+                "BEGIN; UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'implicit commit' WHERE id = 1; CREATE TABLE {table} (id INT); ROLLBACK"
             ))
             .await
             .map_err(|error| format!("raw MySQL implicit-commit check failed: {error}"))?;

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1391,6 +1391,100 @@ async fn preserves_explicit_transaction_order_and_scope() {
     .await;
 }
 
+#[cfg(unix)]
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn rejects_implicit_commit_transaction_and_matches_oracle_mysql_behavior() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|error| format!("system clock error: {error}"))?
+            .as_nanos();
+        let table = format!("sabiql_sab439_{suffix}");
+        let query = format!(
+            "BEGIN; UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'implicit commit' WHERE id = 1; CREATE TABLE {table} (id INT); ROLLBACK"
+        );
+        let validation = db
+            .adapter()
+            .execute_adhoc(db.dsn(), &query, AccessMode::ReadWrite)
+            .await;
+        if !matches!(
+            validation,
+            Err(DbOperationError::UnsupportedOperation(ref details))
+                if details.contains("implicit commit")
+        ) {
+            return Err(format!("implicit-commit transaction was not rejected: {validation:?}"));
+        }
+
+        let result = async {
+            db.run_pty_script(&format!(
+                "BEGIN;\nUPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'implicit commit' WHERE id = 1;\nCREATE TABLE {table} (id INT);\nROLLBACK;\n"
+            ))
+            .await
+            .map_err(|error| format!("raw MySQL implicit-commit check failed: {error}"))?;
+
+            let updated = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("SELECT empty_text FROM {MYSQL_FIXTURE_TABLE} WHERE id = 1"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to read the committed update: {error:?}"))?;
+            let table_exists = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '{table}'"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to read the committed DDL: {error:?}"))?;
+            if updated.values() != [[QueryValue::Text("implicit commit".to_string())]]
+                || table_exists.values() != [[QueryValue::Text("1".to_string())]]
+            {
+                return Err(format!(
+                    "Oracle MySQL did not preserve the implicit commit: updated={updated:?}, table_exists={table_exists:?}"
+                ));
+            }
+            Ok::<(), String>(())
+        }
+        .await;
+        let cleanup = async {
+            db.adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("DROP TABLE IF EXISTS {table}"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to clean up implicit-commit table: {error:?}"))?;
+            db.adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = '' WHERE id = 1"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to restore fixture: {error:?}"))?;
+            Ok::<(), String>(())
+        };
+        match result {
+            Err(error) => {
+                cleanup.await?;
+                Err(error)
+            }
+            Ok(()) => cleanup.await,
+        }
+    }))
+    .await;
+}
+
 #[tokio::test]
 #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
 async fn keeps_temporary_table_state_inside_one_submission() {

--- a/src/tests/harness/mysql.rs
+++ b/src/tests/harness/mysql.rs
@@ -97,6 +97,10 @@ impl MySqlTestDb {
             .await
             .map_err(|error| error.to_string())
     }
+
+    pub async fn run_cli_script(&self, script: &str) -> Result<String, String> {
+        self.run_cli(script).await
+    }
 }
 
 pub async fn with_mysql_test_db<F>(test: F)


### PR DESCRIPTION
Implements https://linear.app/sabiql/issue/SAB-439/mysqlの暗黙commitと通常explainの安全判定を正す

## Summary
- Reject persistent DDL inside explicit MySQL transactions because it implicitly commits.
- Allow non-executing MySQL EXPLAIN for locking reads while retaining EXPLAIN ANALYZE safety checks.
- Add policy and Oracle MySQL 8.4 integration coverage.