### PR TITLE
fix(mysql): isolate Inspector state from failed probes

### DIFF
--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -40,6 +40,9 @@ pub struct PendingConnectionProbe {
     pub dsn: String,
     pub database: Option<String>,
     pub run_id: u64,
+    pub table_detail_dsn: Option<String>,
+    pub table_detail_run_id: Option<u64>,
+    pub table_detail_generation: u64,
 }
 
 impl fmt::Debug for PendingConnectionProbe {
@@ -52,6 +55,12 @@ impl fmt::Debug for PendingConnectionProbe {
             .field("dsn", &mask_password(&self.dsn))
             .field("database", &self.database)
             .field("run_id", &self.run_id)
+            .field(
+                "table_detail_dsn",
+                &self.table_detail_dsn.as_deref().map(mask_password),
+            )
+            .field("table_detail_run_id", &self.table_detail_run_id)
+            .field("table_detail_generation", &self.table_detail_generation)
             .finish()
     }
 }
@@ -196,8 +205,18 @@ impl BrowseSession {
         }
     }
 
-    pub fn mark_table_detail_probe_failed(&mut self, error: String) -> bool {
-        if self.selected_table_key.is_some()
+    pub fn mark_table_detail_probe_failed(&mut self, dsn: &str, error: String) -> bool {
+        let belongs_to_probe = self
+            .pending_connection_probe
+            .as_ref()
+            .is_some_and(|pending| {
+                pending.table_detail_dsn.as_deref() == Some(dsn)
+                    && pending.table_detail_run_id == Some(self.table_detail_run.last_id())
+                    && pending.table_detail_generation == self.selection_generation
+            });
+        if belongs_to_probe
+            && self.dsn_matches(dsn)
+            && self.selected_table_key.is_some()
             && self.table_detail.is_none()
             && self.table_detail_state == TableDetailState::Loading
         {
@@ -226,6 +245,9 @@ impl BrowseSession {
         dsn: &str,
         database: Option<&str>,
     ) -> u64 {
+        let table_detail_dsn = self.dsn.clone();
+        let table_detail_run_id = self.table_detail_run.active_id();
+        let table_detail_generation = self.selection_generation;
         self.cancel_metadata_for_connection_probe();
         self.connection_generation = self.connection_generation.wrapping_add(1);
         let run_id = self.connection_probe_run.begin();
@@ -236,6 +258,9 @@ impl BrowseSession {
             dsn: dsn.to_string(),
             database: database.map(str::to_string),
             run_id,
+            table_detail_dsn,
+            table_detail_run_id,
+            table_detail_generation,
         });
         run_id
     }

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -227,6 +227,25 @@ impl BrowseSession {
         }
     }
 
+    pub fn retry_table_detail_after_probe_failure(&mut self) -> Option<(String, u64, u64)> {
+        let pending = self.pending_connection_probe.as_ref()?;
+        let dsn = pending.table_detail_dsn.clone()?;
+        let generation = pending.table_detail_generation;
+        let run_id = pending.table_detail_run_id?;
+        if run_id != self.table_detail_run.last_id()
+            || generation != self.selection_generation
+            || !self.dsn_matches(&dsn)
+            || self.selected_table_key.is_none()
+            || self.table_detail.is_some()
+            || self.table_detail_state != TableDetailState::Loading
+        {
+            return None;
+        }
+
+        let retry_run_id = self.begin_table_detail_run();
+        Some((dsn, generation, retry_run_id))
+    }
+
     // ── Connection lifecycle ─────────────────────────────────────────
 
     pub fn mark_connecting(&mut self) {

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -274,6 +274,19 @@ pub fn reduce_connection_lifecycle(
                 return DispatchResult::handled();
             }
             let message = error.user_message();
+            let table_detail_retry = if state.session.dsn_matches(&target.dsn) {
+                None
+            } else {
+                state.session.retry_table_detail_after_probe_failure().map(
+                    |(dsn, generation, run_id)| Effect::FetchTableDetail {
+                        dsn,
+                        schema: state.query.pagination.schema().to_string(),
+                        table: state.query.pagination.table().to_string(),
+                        generation,
+                        run_id,
+                    },
+                )
+            };
             if state.session.dsn_matches(&target.dsn) {
                 state
                     .session
@@ -284,7 +297,7 @@ pub fn reduce_connection_lifecycle(
                 ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
             );
             state.modal.replace_mode(InputMode::ConnectionError);
-            DispatchResult::handled()
+            DispatchResult::handled_with(table_detail_retry.into_iter().collect())
         }
 
         _ => DispatchResult::pass(),
@@ -314,7 +327,6 @@ mod tests {
     use crate::test_support::connection::{
         assert_explain_state_cleared, assert_sqlite_diagnostics_cleared,
     };
-    use crate::update::action::TableTarget;
     use crate::update::reducer::reduce as reduce_app;
 
     fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
@@ -1130,14 +1142,15 @@ mod tests {
                 })
                 .unwrap();
 
-            reduce(
+            let retry_effects = reduce(
                 &mut state,
                 &Action::ConnectionProbeFailed {
                     target: second,
                     run_id: probe_run_id,
                     error: DbOperationError::ConnectionFailed("refused".to_string()),
                 },
-            );
+            )
+            .unwrap();
 
             assert!(state.session.connection_state().is_connected());
             assert_eq!(state.session.selected_table_key(), Some("public.users"));
@@ -1148,30 +1161,27 @@ mod tests {
             );
             assert_eq!(state.session.selection_generation(), generation);
             assert!(!state.session.is_current_table_detail_run(detail_run_id));
-
-            let retry_effects = reduce_app(
-                &mut state,
-                Action::LoadTableDetail(TableTarget {
-                    schema: "public".to_string(),
-                    table: "users".to_string(),
-                    generation,
-                }),
-                std::time::Instant::now(),
-                &AppServices::stub(),
-            );
-            assert!(retry_effects.iter().any(|effect| matches!(
-                effect,
-                Effect::FetchTableDetail {
-                    dsn,
-                    schema,
-                    table,
-                    generation: effect_generation,
-                    ..
-                } if dsn == &first.dsn
-                    && schema == "public"
-                    && table == "users"
-                    && *effect_generation == generation
-            )));
+            let retry_run_id = retry_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::FetchTableDetail {
+                        dsn,
+                        schema,
+                        table,
+                        generation: effect_generation,
+                        run_id,
+                    } if dsn == &first.dsn
+                        && schema == "public"
+                        && table == "users"
+                        && *effect_generation == generation =>
+                    {
+                        Some(*run_id)
+                    }
+                    _ => None,
+                })
+                .unwrap();
+            assert_ne!(retry_run_id, detail_run_id);
+            assert!(state.session.is_current_table_detail_run(retry_run_id));
         }
 
         #[test]

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -274,13 +274,12 @@ pub fn reduce_connection_lifecycle(
                 return DispatchResult::handled();
             }
             let message = error.user_message();
-            let detail_message = if state.session.dsn_matches(&target.dsn) {
-                state.session.mark_connection_failed(message.clone());
-                message
-            } else {
-                "Load canceled by connection change".to_string()
-            };
-            state.session.mark_table_detail_probe_failed(detail_message);
+            if state.session.dsn_matches(&target.dsn) {
+                state
+                    .session
+                    .mark_table_detail_probe_failed(&target.dsn, message.clone());
+                state.session.mark_connection_failed(message);
+            }
             state.connection_error.set_error(
                 ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
             );
@@ -315,6 +314,7 @@ mod tests {
     use crate::test_support::connection::{
         assert_explain_state_cleared, assert_sqlite_diagnostics_cleared,
     };
+    use crate::update::action::TableTarget;
     use crate::update::reducer::reduce as reduce_app;
 
     fn reduce(state: &mut AppState, action: &Action) -> Option<Vec<Effect>> {
@@ -1142,12 +1142,36 @@ mod tests {
             assert!(state.session.connection_state().is_connected());
             assert_eq!(state.session.selected_table_key(), Some("public.users"));
             assert!(state.session.table_detail().is_none());
-            assert!(matches!(
+            assert_eq!(
                 state.session.table_detail_state(),
-                TableDetailState::Error(message) if message == "Load canceled by connection change"
-            ));
+                &TableDetailState::Loading
+            );
             assert_eq!(state.session.selection_generation(), generation);
             assert!(!state.session.is_current_table_detail_run(detail_run_id));
+
+            let retry_effects = reduce_app(
+                &mut state,
+                Action::LoadTableDetail(TableTarget {
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                    generation,
+                }),
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+            assert!(retry_effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchTableDetail {
+                    dsn,
+                    schema,
+                    table,
+                    generation: effect_generation,
+                    ..
+                } if dsn == &first.dsn
+                    && schema == "public"
+                    && table == "users"
+                    && *effect_generation == generation
+            )));
         }
 
         #[test]


### PR DESCRIPTION
Implements https://linear.app/sabiql/issue/SAB-437/接続切替失敗後に既存inspectorの読込状態を復旧する

## Summary

- Scope probe-failure Inspector updates to the matching DSN, table-detail run, and selection generation.
- Preserve a previous MySQL connection's loading Inspector state after a different connection's probe fails.
- Cover refetching the selected table detail after the failed switch.

## Validation

- cargo test -p sabiql-app
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo clippy --workspace --all-targets --no-default-features -- -D warnings
- ./scripts/lint_all.sh

Base: mysql