### PR TITLE
Treat MySQL double quotes as completion strings

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -1672,6 +1672,7 @@ mod tests {
                 "# SELECT",
                 "SELECT 'FROM",
                 r#"SELECT "FROM"#,
+                "SELECT \"users.\\\"FROM ",
                 "SELECT `FROM",
                 "SELECT `a``",
             ] {

--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -1668,7 +1668,13 @@ mod tests {
         #[test]
         fn mysql_comments_strings_and_backticks_return_no_candidates() {
             let e = engine();
-            for sql in ["# SELECT", "SELECT 'FROM", "SELECT `FROM", "SELECT `a``"] {
+            for sql in [
+                "# SELECT",
+                "SELECT 'FROM",
+                r#"SELECT "FROM"#,
+                "SELECT `FROM",
+                "SELECT `a``",
+            ] {
                 let candidates = e.get_candidates_for_database(
                     sql,
                     sql.chars().count(),
@@ -1683,6 +1689,38 @@ mod tests {
                 );
 
                 assert!(candidates.is_empty(), "unexpected candidates for {sql}");
+            }
+        }
+
+        #[test]
+        fn resumes_at_quote_and_comment_boundaries() {
+            let e = engine();
+            for sql in [
+                r#"SELECT "users." SEL"#,
+                "SELECT `users` SEL",
+                "SELECT /* comment */ SEL",
+                "SELECT # comment\nSEL",
+            ] {
+                let cursor = sql.chars().count();
+                let candidates = e.get_candidates_for_database(
+                    sql,
+                    cursor,
+                    None,
+                    None,
+                    &[],
+                    CompletionDatabaseScope {
+                        database_type: DatabaseType::MySQL,
+                        active_database: Some("app"),
+                        available_databases: &[],
+                    },
+                );
+
+                assert!(
+                    candidates
+                        .iter()
+                        .any(|candidate| candidate.text == "SELECT"),
+                    "expected completion after boundary in {sql}"
+                );
             }
         }
 

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -532,6 +532,10 @@ impl SqlLexer {
                 }
 
                 LexerState::InDoubleQuoteString => {
+                    if c == '\\' && pos + 1 < end_pos {
+                        pos += 2;
+                        continue;
+                    }
                     // Handle escaped double quotes: ""
                     if c == '"' {
                         if pos + 1 < end_pos && chars[pos + 1] == '"' {

--- a/src/app/policy/sql/lexer.rs
+++ b/src/app/policy/sql/lexer.rs
@@ -48,7 +48,8 @@ pub struct SqlContext {
 enum LexerState {
     Normal,
     InSingleQuote,
-    InDoubleQuote,
+    InDoubleQuoteIdentifier,
+    InDoubleQuoteString,
     InBacktickIdentifier,
     InDollarQuote,
     InLineComment,
@@ -380,10 +381,14 @@ impl SqlLexer {
                         continue;
                     }
 
-                    // Double-quoted identifier: "..."
+                    // MySQL treats double quotes as strings; PostgreSQL treats them as identifiers.
                     if c == '"' {
                         token_start = pos;
-                        state = LexerState::InDoubleQuote;
+                        state = if self.is_mysql() {
+                            LexerState::InDoubleQuoteString
+                        } else {
+                            LexerState::InDoubleQuoteIdentifier
+                        };
                         pos += 1;
                         continue;
                     }
@@ -504,7 +509,7 @@ impl SqlLexer {
                     pos += 1;
                 }
 
-                LexerState::InDoubleQuote => {
+                LexerState::InDoubleQuoteIdentifier => {
                     // Handle escaped double quotes: ""
                     if c == '"' {
                         if pos + 1 < end_pos && chars[pos + 1] == '"' {
@@ -516,6 +521,26 @@ impl SqlLexer {
                         tokens.push(Token {
                             kind: TokenKind::Identifier(text.clone()),
                             text,
+                            start: token_start,
+                            end: pos + 1,
+                        });
+                        state = LexerState::Normal;
+                        pos += 1;
+                        continue;
+                    }
+                    pos += 1;
+                }
+
+                LexerState::InDoubleQuoteString => {
+                    // Handle escaped double quotes: ""
+                    if c == '"' {
+                        if pos + 1 < end_pos && chars[pos + 1] == '"' {
+                            pos += 2;
+                            continue;
+                        }
+                        tokens.push(Token {
+                            kind: TokenKind::StringLiteral,
+                            text: chars[token_start..=pos].iter().collect(),
                             start: token_start,
                             end: pos + 1,
                         });
@@ -635,9 +660,10 @@ impl SqlLexer {
             let text: String = chars[token_start..end_pos].iter().collect();
             let kind = match state {
                 LexerState::InSingleQuote
+                | LexerState::InDoubleQuoteString
                 | LexerState::InDollarQuote
                 | LexerState::InEscapeString => TokenKind::StringLiteral,
-                LexerState::InDoubleQuote => TokenKind::Identifier(text.clone()),
+                LexerState::InDoubleQuoteIdentifier => TokenKind::Identifier(text.clone()),
                 LexerState::InBacktickIdentifier => {
                     TokenKind::BacktickIdentifier(text[1..].to_string())
                 }
@@ -1533,6 +1559,22 @@ mod tests {
             assert!(l.is_in_string_or_comment("SELECT `a``", 11));
             assert!(l.is_in_string_or_comment("SELECT `a``b`", 10));
             assert!(!l.is_in_string_or_comment("SELECT `SEL`", 12));
+        }
+
+        #[test]
+        fn double_quoted_mysql_string_is_not_an_identifier_context() {
+            let l = mysql_lexer();
+            let sql = r#"SELECT "users.""#;
+            let tokens = l.tokenize(sql, sql.chars().count());
+
+            assert!(tokens.iter().any(|token| {
+                matches!(
+                    &token.kind,
+                    TokenKind::StringLiteral if token.text == r#""users.""#
+                )
+            }));
+            assert!(l.is_in_string_or_comment(sql, sql.chars().count()));
+            assert!(!l.is_in_string_or_comment(r#"SELECT "users." FROM "#, 20));
         }
 
         #[test]


### PR DESCRIPTION
## Problem
MySQL completion treated double-quoted text as an identifier and could offer identifier completions from string contents.

## Background
This diverged from the supported MySQL quoting rules because ANSI_QUOTES is rejected for MySQL connections.

## Approach
The SQL lexer now selects a MySQL-specific double-quoted string state while preserving PostgreSQL double-quoted identifiers and existing MySQL backtick handling. Regression tests cover quoted strings, backtick identifiers, and comment boundaries.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-436/mysql補完で二重引用符を文字列として扱う