### PR TITLE
fix(mysql): align DSN preview and Database Picker visibility

### DIFF
--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -362,6 +362,9 @@ fn reference_sections(
     if feature_policy.is_visible(sqlite_diagnostics(keymap_preset).feature_requirement()) {
         open_switch_rows.insert(2, sqlite_diagnostics(keymap_preset));
     }
+    if feature_policy.is_visible(global::DATABASE_PICKER.feature_requirement()) {
+        open_switch_rows.insert(3, &global::DATABASE_PICKER);
+    }
 
     let mut data_action_rows = rows_from_binding_refs(&[
         &global::RELOAD,
@@ -1069,6 +1072,11 @@ mod tests {
         assert!(
             !descriptions
                 .iter()
+                .any(|description| description.contains("MySQL Database Picker"))
+        );
+        assert!(
+            !descriptions
+                .iter()
                 .any(|description| description.contains("JSONB"))
         );
     }
@@ -1109,6 +1117,32 @@ mod tests {
                     .iter()
                     .all(|description| !description.contains("JSONB"))
             );
+        }
+    }
+
+    #[test]
+    fn database_picker_help_row_follows_mysql_feature_policy() {
+        for (database_type, expected_visible) in [
+            (DatabaseType::PostgreSQL, false),
+            (DatabaseType::SQLite, false),
+            (DatabaseType::MySQL, true),
+        ] {
+            let mut state = AppState::new("test".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "database",
+                database_type,
+                "database",
+            );
+            let origin = HelpOrigin::from_state(&state);
+            state.ui.help_mut().open(origin);
+
+            let document = HelpDocument::from_state(&state);
+            let visible = row_descriptions(&document)
+                .iter()
+                .any(|description| description.contains("MySQL Database Picker"));
+
+            assert_eq!(visible, expected_visible);
         }
     }
 

--- a/src/app/model/shared/engine_feature_profile.rs
+++ b/src/app/model/shared/engine_feature_profile.rs
@@ -15,6 +15,7 @@ pub enum InspectorInfoField {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConnectionFeature {
+    DatabasePicker,
     ErDiagram,
     JsonDocumentDetail,
     JsonDocumentEdit,
@@ -129,6 +130,7 @@ const POSTGRESQL_FEATURES: &[ConnectionFeature] = &[
 ];
 const SQLITE_FEATURES: &[ConnectionFeature] = &[ConnectionFeature::SqliteDiagnostics];
 const MYSQL_FEATURES: &[ConnectionFeature] = &[
+    ConnectionFeature::DatabasePicker,
     ConnectionFeature::ErDiagram,
     ConnectionFeature::JsonDocumentDetail,
     ConnectionFeature::JsonDocumentEdit,
@@ -233,6 +235,10 @@ impl EngineFeatureProfile {
 
     pub fn supports_er_diagram(&self) -> bool {
         self.supports_connection_feature(ConnectionFeature::ErDiagram)
+    }
+
+    pub fn supports_database_picker(&self) -> bool {
+        self.supports_connection_feature(ConnectionFeature::DatabasePicker)
     }
 
     pub fn supports_plan_comparison(&self) -> bool {

--- a/src/app/policy/feature_policy.rs
+++ b/src/app/policy/feature_policy.rs
@@ -3,6 +3,7 @@ use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FeatureRequirement {
     None,
+    DatabasePicker,
     ErDiagram,
     JsonDocumentDetail,
     JsonDocumentEdit,
@@ -31,6 +32,7 @@ impl FeaturePolicy {
     pub fn availability(&self, requirement: FeatureRequirement) -> FeatureAvailability {
         let supported = match requirement {
             FeatureRequirement::None => true,
+            FeatureRequirement::DatabasePicker => self.profile.supports_database_picker(),
             FeatureRequirement::ErDiagram => self.profile.supports_er_diagram(),
             FeatureRequirement::JsonDocumentDetail => self.profile.supports_json_document_detail(),
             FeatureRequirement::JsonDocumentEdit => self.profile.supports_json_document_edit(),
@@ -65,6 +67,10 @@ mod tests {
         let policy = FeaturePolicy::new(&EngineFeatureProfile::postgres_like());
 
         assert_eq!(
+            policy.availability(FeatureRequirement::DatabasePicker),
+            FeatureAvailability::Hidden
+        );
+        assert_eq!(
             policy.availability(FeatureRequirement::ErDiagram),
             FeatureAvailability::Enabled
         );
@@ -90,6 +96,10 @@ mod tests {
     fn sqlite_profile_enables_diagnostics_and_hides_postgres_features() {
         let policy = FeaturePolicy::new(&EngineFeatureProfile::sqlite_like());
 
+        assert_eq!(
+            policy.availability(FeatureRequirement::DatabasePicker),
+            FeatureAvailability::Hidden
+        );
         assert_eq!(
             policy.availability(FeatureRequirement::SqliteDiagnostics),
             FeatureAvailability::Enabled
@@ -118,5 +128,12 @@ mod tests {
 
         assert!(policy.is_visible(FeatureRequirement::None));
         assert!(policy.is_enabled(FeatureRequirement::None));
+    }
+
+    #[test]
+    fn mysql_profile_enables_database_picker() {
+        let policy = FeaturePolicy::new(&EngineFeatureProfile::mysql_like());
+
+        assert!(policy.is_enabled(FeatureRequirement::DatabasePicker));
     }
 }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -746,11 +746,16 @@ impl Action {
 
     pub fn feature_requirement(&self) -> FeatureRequirement {
         use FeatureRequirement::{
-            ErDiagram, Explain, ExplainAnalyze, JsonDocumentDetail, JsonDocumentEdit, None,
-            PlanComparison, SqliteDiagnostics,
+            DatabasePicker, ErDiagram, Explain, ExplainAnalyze, JsonDocumentDetail,
+            JsonDocumentEdit, None, PlanComparison, SqliteDiagnostics,
         };
 
         match self {
+            Self::OpenModal(ModalKind::DatabasePicker)
+            | Self::ToggleModal(ModalKind::DatabasePicker)
+            | Self::SwitchMySqlDatabase { .. }
+            | Self::MySqlDatabasesLoaded { .. }
+            | Self::MySqlDatabasesFailed { .. } => DatabasePicker,
             Self::OpenModal(ModalKind::ErTablePicker)
             | Self::ToggleModal(ModalKind::ErTablePicker)
             | Self::ErToggleSelection
@@ -1043,6 +1048,10 @@ mod tests {
             }
             .feature_requirement(),
             FeatureRequirement::ExplainAnalyze
+        );
+        assert_eq!(
+            Action::OpenModal(ModalKind::DatabasePicker).feature_requirement(),
+            FeatureRequirement::DatabasePicker
         );
     }
 

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -617,6 +617,10 @@ mod tests {
     #[test]
     fn feature_requirements_are_attached_to_feature_bindings() {
         assert_eq!(
+            global::DATABASE_PICKER.feature_requirement(),
+            FeatureRequirement::DatabasePicker
+        );
+        assert_eq!(
             global::ER_DIAGRAM.feature_requirement(),
             FeatureRequirement::ErDiagram
         );

--- a/src/app/update/input/palette.rs
+++ b/src/app/update/input/palette.rs
@@ -206,4 +206,20 @@ mod tests {
                 .any(|kb| matches!(kb.action, Action::OpenModal(ModalKind::SqliteDiagnostics)))
         );
     }
+
+    #[test]
+    fn database_picker_palette_command_is_mysql_only() {
+        for (profile, expected_visible) in [
+            (EngineFeatureProfile::postgres_like(), false),
+            (EngineFeatureProfile::sqlite_like(), false),
+            (EngineFeatureProfile::mysql_like(), true),
+        ] {
+            let commands = palette_commands(KeymapPreset::Default, &profile).collect::<Vec<_>>();
+            let visible = commands
+                .iter()
+                .any(|kb| matches!(kb.action, Action::OpenModal(ModalKind::DatabasePicker)));
+
+            assert_eq!(visible, expected_visible);
+        }
+    }
 }

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_palette_overlay.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__overlays__command_palette_overlay.snap
@@ -19,17 +19,17 @@ test_project ▸ test_db ▸ -                                                  
 │                                       ││  q                  Quit application                                            │                                        │
 │                                       ││  ?                  Toggle help                                                 │                                        │
 │                                       ││  Ctrl+P             Open Table Picker                                           │                                        │
-│                                       ││  Ctrl+Shift+B       Open MySQL Database Picker                                  │                                        │
 │                                       ││  ,                  Open Settings                                               │                                        │
 │                                       ││  f                  Toggle Focus mode                                           │                                        │
 │                                       ││  r                  Reload metadata                                             │                                        │
 │                                       ││  s                  Open SQL Editor                                             │                                        │
 │                                       ││  e                  Open ER Diagram                                             │                                        │
 │                                       ││  c                  Open Connection Selector                                    │                                        │
-│                                       ││  Ctrl+E             Export result to CSV                                        │────────────────────────────────────────┘
-│                                       ││  Ctrl+R             Enable Read-Only mode                                       │────────────────────────────────────────┐
-│                                       ││  Ctrl+R             Disable Read-Only mode                                      │                                        │
+│                                       ││  Ctrl+E             Export result to CSV                                        │                                        │
+│                                       ││  Ctrl+R             Enable Read-Only mode                                       │────────────────────────────────────────┘
+│                                       ││  Ctrl+R             Disable Read-Only mode                                      │────────────────────────────────────────┐
 │                                       ││  Ctrl+O             Open Query History                                          │                                        │
+│                                       ││                                                                                 │                                        │
 │                                       ││                                                                                 │                                        │
 │                                       ││                                                                                 │                                        │
 │                                       ││                                                                                 │                                        │

--- a/src/ui/features/connections/setup.rs
+++ b/src/ui/features/connections/setup.rs
@@ -10,8 +10,7 @@ use crate::app::policy::mask_password;
 use crate::app::services::AppServices;
 use crate::app::update::input::keybindings::{connection_setup, connection_setup_save};
 use crate::domain::connection::{
-    ConnectionConfig, ConnectionId, ConnectionProfile, DatabaseType, MySqlConnectionConfig,
-    MySqlSslMode, PostgresConnectionConfig, SslMode,
+    ConnectionId, ConnectionProfile, DatabaseType, MySqlSslMode, SslMode,
 };
 use crate::primitives::atoms::text_cursor_spans;
 use crate::primitives::molecules::{FooterHintBar, render_modal};
@@ -495,39 +494,12 @@ fn focused_placeholder_spans(
 }
 
 fn preview_profile(state: &ConnectionSetupState) -> Option<ConnectionProfile> {
-    let port = state
+    state
         .field_value(ConnectionField::Port)
         .trim()
-        .parse()
-        .unwrap_or_else(|_| {
-            if state.database_type() == DatabaseType::MySQL {
-                3306
-            } else {
-                5432
-            }
-        });
-    let config = match state.database_type() {
-        DatabaseType::MySQL => ConnectionConfig::MySQL(MySqlConnectionConfig::new(
-            state.field_value(ConnectionField::Host).trim(),
-            port,
-            match state.field_value(ConnectionField::Database).trim() {
-                "" => None,
-                database => Some(database.to_string()),
-            },
-            state.field_value(ConnectionField::User).trim(),
-            state.field_value(ConnectionField::Password),
-            state.mysql_ssl_mode(),
-        )),
-        DatabaseType::PostgreSQL => ConnectionConfig::PostgreSQL(PostgresConnectionConfig::new(
-            state.field_value(ConnectionField::Host).trim(),
-            port,
-            state.field_value(ConnectionField::Database).trim(),
-            state.field_value(ConnectionField::User).trim(),
-            state.field_value(ConnectionField::Password),
-            state.ssl_mode(),
-        )),
-        DatabaseType::SQLite => unreachable!("SQLite has no DSN preview"),
-    };
+        .parse::<u16>()
+        .ok()?;
+    let config = state.to_connection_config().ok()?;
     ConnectionProfile::with_id_and_config(ConnectionId::from_string("preview"), "preview", config)
         .ok()
 }
@@ -590,6 +562,7 @@ fn preview_prefix(prefix: &'static str, width: usize) -> &'static str {
 mod tests {
     use super::*;
     use crate::app::model::shared::settings::KeymapPreset;
+    use crate::domain::connection::ConnectionConfig;
 
     fn focus_field(state: &mut ConnectionSetupState, field: ConnectionField) {
         while state.focused_field() != field {
@@ -686,6 +659,53 @@ mod tests {
             .set_content("db example".to_string());
 
         assert!(preview_profile(&form_state).is_none());
+    }
+
+    #[test]
+    fn invalid_port_does_not_panic_during_preview() {
+        let mut form_state = ConnectionSetupState::default();
+        form_state
+            .input_mut(ConnectionField::Port)
+            .unwrap()
+            .set_content("invalid".to_string());
+
+        assert!(preview_profile(&form_state).is_none());
+    }
+
+    #[test]
+    fn mysql_preview_profile_includes_saved_tls_paths() {
+        let mut form_state = ConnectionSetupState::default();
+        form_state.set_database_type(DatabaseType::MySQL);
+        while form_state.focused_field() != ConnectionField::SslMode {
+            form_state.focus_next_field();
+        }
+        form_state.toggle_focused_dropdown();
+        for _ in 0..4 {
+            form_state.dropdown_next();
+        }
+        form_state.confirm_dropdown();
+        form_state
+            .input_mut(ConnectionField::SslCa)
+            .unwrap()
+            .set_content("/etc/mysql/ca.pem".to_string());
+        form_state
+            .input_mut(ConnectionField::SslCert)
+            .unwrap()
+            .set_content("/etc/mysql/client.pem".to_string());
+        form_state
+            .input_mut(ConnectionField::SslKey)
+            .unwrap()
+            .set_content("/etc/mysql/client-key.pem".to_string());
+
+        let profile = preview_profile(&form_state).unwrap();
+
+        let ConnectionConfig::MySQL(config) = profile.config else {
+            panic!("preview profile must be MySQL");
+        };
+        assert_eq!(config.ssl_mode, MySqlSslMode::VerifyIdentity);
+        assert_eq!(config.ssl_ca.as_deref(), Some("/etc/mysql/ca.pem"));
+        assert_eq!(config.ssl_cert.as_deref(), Some("/etc/mysql/client.pem"));
+        assert_eq!(config.ssl_key.as_deref(), Some("/etc/mysql/client-key.pem"));
     }
 
     #[test]

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -23,7 +23,6 @@ use crate::app::update::input::keybindings::{
     sql_modal, sql_modal_confirming, sqlite_diagnostics, table_picker,
     table_picker as table_picker_key,
 };
-use crate::domain::DatabaseType;
 use crate::features::settings::hints::settings_hints;
 use crate::primitives::atoms::key_text;
 use crate::primitives::atoms::spinner_char;
@@ -165,7 +164,7 @@ impl Footer {
                     if state.ui.focused_pane() == FocusedPane::Explorer {
                         list.push(global::CONNECTIONS.as_hint());
                     }
-                    if state.session.active_database_type() == Some(DatabaseType::MySQL) {
+                    if feature_policy.is_enabled(FeatureRequirement::DatabasePicker) {
                         list.push(global::DATABASE_PICKER.as_hint());
                     }
                     list.push(table_picker_key(keymap_preset).as_hint());
@@ -525,6 +524,30 @@ mod tests {
 
         assert_eq!(
             hints.contains(&global::ER_DIAGRAM.as_hint()),
+            expected_visible
+        );
+    }
+
+    #[rstest]
+    #[case(DatabaseType::PostgreSQL, false)]
+    #[case(DatabaseType::SQLite, false)]
+    #[case(DatabaseType::MySQL, true)]
+    fn database_picker_hint_visibility_tracks_feature_policy(
+        #[case] database_type: DatabaseType,
+        #[case] expected_visible: bool,
+    ) {
+        let mut state = AppState::new("test".to_string());
+        state.session.activate_connection_with_dsn(
+            &ConnectionId::new(),
+            "database",
+            database_type,
+            "database",
+        );
+
+        let hints = Footer::get_context_hints(&state);
+
+        assert_eq!(
+            hints.contains(&global::DATABASE_PICKER.as_hint()),
             expected_visible
         );
     }


### PR DESCRIPTION
## Problem
MySQL DSN preview omitted configured TLS certificate paths, and the MySQL-only Database Picker was exposed outside MySQL contexts.

## Background
The preview and saved connection configuration were built separately, while command palette, Help, and footer visibility did not share the feature policy.

## Approach
Use the saved connection configuration as the DSN preview source and classify Database Picker commands, Help, and footer hints with the existing MySQL feature policy.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-438/mysql接続画面とdatabase-pickerの表示を実態へ合わせる