### PR TITLE
fix(mysql): handle long PTY input on macOS

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -26,10 +26,10 @@ use super::policy::mysql_metadata_fallback_kind;
 use super::process::write_mysql_input;
 use super::process::{
     MYSQL_QUERY_TIMEOUT, MysqlProcess, cleanup_mysql_process, configure_mysql_session,
-    mysql_metadata_columns, read_one_mysql_resultset, write_mysql_statement,
+    mysql_metadata_columns, read_one_mysql_resultset, stop_mysql_process, write_mysql_statement,
 };
 #[cfg(unix)]
-use super::pty::{MysqlExportPtySource, read_pty_all};
+use super::pty::{MysqlExportPtySource, read_pty_until_idle};
 use super::xml::{MysqlField, decode_mysql_xml_reference, parse_mysql_field, parse_mysql_xml};
 
 const MYSQL_EXPORT_TIMEOUT: Duration = Duration::from_secs(MYSQL_QUERY_TIMEOUT.as_secs() * 10);
@@ -101,7 +101,7 @@ pub(super) async fn run_mysql_export_process(
     #[cfg(unix)]
     let tail = {
         write_mysql_input(process, b"\x04").await?;
-        read_pty_all(&mut process.pty)
+        read_pty_until_idle(&mut process.pty)
             .await
             .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?
     };
@@ -114,16 +114,12 @@ pub(super) async fn run_mysql_export_process(
     #[cfg(not(unix))]
     let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
 
-    let status = process
-        .child
-        .wait()
-        .await
-        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    let (status, forcibly_stopped) = stop_mysql_process(process).await?;
     #[cfg(unix)]
     let error_bytes = tail.as_slice();
     #[cfg(not(unix))]
     let error_bytes = stderr.as_slice();
-    if !status.success() {
+    if !status.success() && !forcibly_stopped {
         return Err(classify_mysql_query_failure(error_bytes));
     }
 

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -1,6 +1,6 @@
 use std::ffi::OsStr;
 use std::io;
-use std::process::Stdio;
+use std::process::{ExitStatus, Stdio};
 use std::time::Duration;
 
 #[cfg(unix)]
@@ -35,7 +35,9 @@ use super::policy::{
 };
 use super::probe::run_mysql_command;
 #[cfg(unix)]
-use super::pty::{MysqlPty, create_mysql_pty, read_one_pty_resultset, read_pty_all};
+use super::pty::{
+    MysqlPty, create_mysql_pty, read_one_pty_resultset, read_pty_all, read_pty_until_idle,
+};
 #[cfg(unix)]
 use super::xml::trace_mysql_frame;
 use super::xml::{MysqlResultSet, MysqlResultsetFrameScanner, parse_mysql_xml};
@@ -47,6 +49,26 @@ use super::super::option_file::MySqlOptionFile;
 
 pub(in crate::adapters::mysql) const MYSQL_QUERY_TIMEOUT: Duration = Duration::from_secs(31);
 const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
+
+pub(super) async fn stop_mysql_process(
+    process: &mut MysqlProcess,
+) -> Result<(ExitStatus, bool), DbOperationError> {
+    if let Some(status) = process
+        .child
+        .try_wait()
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?
+    {
+        return Ok((status, false));
+    }
+    // Callers drain the PTY first because mysql --binary-mode does not accept quit commands.
+    let _ = process.child.kill().await;
+    let status = process
+        .child
+        .wait()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    Ok((status, true))
+}
 
 pub(in crate::adapters::mysql) struct MysqlProcess {
     pub(super) child: Child,
@@ -209,7 +231,7 @@ impl MysqlMetadataSession {
         #[cfg(unix)]
         let tail = {
             write_mysql_input(&mut self.process, b"\x04").await?;
-            read_pty_all(&mut self.process.pty)
+            read_pty_until_idle(&mut self.process.pty)
                 .await
                 .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?
         };
@@ -222,12 +244,7 @@ impl MysqlMetadataSession {
         #[cfg(not(unix))]
         let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
 
-        let status = self
-            .process
-            .child
-            .wait()
-            .await
-            .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+        let (status, forcibly_stopped) = stop_mysql_process(&mut self.process).await?;
         #[cfg(unix)]
         let error_bytes = tail.as_slice();
         #[cfg(not(unix))]
@@ -235,7 +252,7 @@ impl MysqlMetadataSession {
         if has_mysql_cli_error(error_bytes) {
             return Err(classify_mysql_query_failure(error_bytes));
         }
-        if !status.success() {
+        if !status.success() && !forcibly_stopped {
             return Err(classify_mysql_query_failure(error_bytes));
         }
         Ok(())
@@ -316,7 +333,7 @@ async fn run_mysql_single_statement_process(
     let (stdout, tail) = {
         let stdout = read_one_mysql_resultset(process).await?;
         write_mysql_input(process, b"\x04").await?;
-        let tail = read_pty_all(&mut process.pty)
+        let tail = read_pty_until_idle(&mut process.pty)
             .await
             .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
         (stdout, tail)
@@ -330,16 +347,12 @@ async fn run_mysql_single_statement_process(
     #[cfg(not(unix))]
     let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
 
-    let status = process
-        .child
-        .wait()
-        .await
-        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    let (status, forcibly_stopped) = stop_mysql_process(process).await?;
     #[cfg(unix)]
     let error_bytes = tail.as_slice();
     #[cfg(not(unix))]
     let error_bytes = stderr.as_slice();
-    if !status.success() {
+    if !status.success() && !forcibly_stopped {
         return Err(classify_mysql_query_failure(error_bytes));
     }
     parse_mysql_xml(&stdout)
@@ -484,7 +497,7 @@ async fn run_mysql_adhoc_process(
     #[cfg(unix)]
     let tail = {
         write_mysql_input(process, b"\x04").await?;
-        let tail = read_pty_all(&mut process.pty)
+        let tail = read_pty_until_idle(&mut process.pty)
             .await
             .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
         trace_mysql_frame("discard tail", tail.len());
@@ -498,11 +511,7 @@ async fn run_mysql_adhoc_process(
     #[cfg(not(unix))]
     let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
 
-    let status = process
-        .child
-        .wait()
-        .await
-        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    let (status, forcibly_stopped) = stop_mysql_process(process).await?;
 
     #[cfg(unix)]
     let error_bytes = tail.as_slice();
@@ -514,7 +523,7 @@ async fn run_mysql_adhoc_process(
             scope_before_statement,
         ));
     }
-    if !status.success() {
+    if !status.success() && !forcibly_stopped {
         return Err(query_failed_after_change(
             classify_mysql_query_failure(error_bytes),
             refresh_scope,
@@ -847,7 +856,7 @@ pub(in crate::adapters::mysql) async fn run_mysql_cli_script_for_test(
     let result = async {
         write_mysql_input(&mut process, script.as_bytes()).await?;
         write_mysql_input(&mut process, b"\x04").await?;
-        read_pty_all(&mut process.pty)
+        read_pty_until_idle(&mut process.pty)
             .await
             .map_err(|error| DbOperationError::QueryFailed(error.to_string()))
     }
@@ -855,7 +864,7 @@ pub(in crate::adapters::mysql) async fn run_mysql_cli_script_for_test(
     if result.is_err() {
         cleanup_mysql_process(&mut process).await;
     } else {
-        let _ = process.child.wait().await;
+        let _ = stop_mysql_process(&mut process).await;
     }
     result
 }
@@ -966,8 +975,10 @@ mod tests {
 option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 log="$option.log"
 phase=probe
+eof=$(printf '\004')
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$log"
+  [ "$line" = "$eof" ] && exit 0
   [ "$line" = ";" ] && continue
   if [ "$phase" = probe ]; then
     marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)'.*/\\1/")
@@ -1044,8 +1055,10 @@ option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
 log="$option.log"
 printf 'process=%s\n' "$$" >> "$log"
 pending_error=0
+eof=$(printf '\004')
 while IFS= read -r line; do
   printf '%s\n' "$line" >> "$log"
+  [ "$line" = "$eof" ] && exit 0
   case "$line" in
     *__sabiql_probe*)
       marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_probe.*/\\1/")

--- a/src/infra/adapters/mysql/cli/pty.rs
+++ b/src/infra/adapters/mysql/cli/pty.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use tokio::fs::File as TokioFile;
 use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
@@ -41,8 +42,10 @@ pub(super) fn create_mysql_pty() -> io::Result<(std::fs::File, std::fs::File)> {
     let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
     if unsafe { libc::tcgetattr(slave_file.as_raw_fd(), termios.as_mut_ptr()) } == 0 {
         let mut termios = unsafe { termios.assume_init() };
-        termios.c_lflag &= !(libc::ECHO | libc::ECHONL);
+        termios.c_lflag &= !(libc::ECHO | libc::ECHONL | libc::ICANON);
         termios.c_oflag &= !libc::OPOST;
+        termios.c_cc[libc::VMIN] = 1;
+        termios.c_cc[libc::VTIME] = 0;
         let _ =
             unsafe { libc::tcsetattr(slave_file.as_raw_fd(), libc::TCSANOW, &raw const termios) };
     }
@@ -93,6 +96,24 @@ pub(super) async fn read_pty_all(pty: &mut MysqlPty) -> io::Result<Vec<u8>> {
                 return Ok(output);
             }
             Err(error) => return Err(error),
+        }
+    }
+}
+
+pub(super) async fn read_pty_until_idle(pty: &mut MysqlPty) -> io::Result<Vec<u8>> {
+    let mut output = std::mem::take(&mut pty.pending);
+    pty.frame_scanner.reset();
+    let mut chunk = [0; 4096];
+    loop {
+        let read =
+            tokio::time::timeout(Duration::from_millis(100), pty.output.read(&mut chunk)).await;
+        match read {
+            Err(_) | Ok(Ok(0)) => return Ok(output),
+            Ok(Ok(count)) => output.extend_from_slice(&chunk[..count]),
+            Ok(Err(error)) if matches!(error.raw_os_error(), Some(libc::EIO | libc::EPERM)) => {
+                return Ok(output);
+            }
+            Ok(Err(error)) => return Err(error),
         }
     }
 }

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -438,15 +438,13 @@ transcript=$(dirname "$0")/transcript.log
 printf 'option=%s\nprocess=%s\n' "$option" "$$" >> "$transcript"
 mode=$(basename "$0" | sed 's/^mysql-//')
 trap 'printf "exit=%s\n" "$?" >> "$transcript"' EXIT
-platform=$(uname -s)
-if [ "$platform" = "Darwin" ]; then
-  stty -icanon <&0 2>/dev/null || true
-fi
 if [ "$mode" = "probe-failure" ] || [ "$mode" = "timeout" ]; then
   while [ ! -e "$(dirname "$0")/allow" ]; do sleep 0.001; done
 fi
+eof=$(printf '\004')
 while IFS= read -r line; do
   printf 'query=%s\n' "$line" >> "$transcript"
+  [ "$line" = "$eof" ] && exit 0
   [ "$line" = ";" ] && continue
   if printf '%s\n' "$line" | grep -q '__sabiql_probe'; then
     if [ "$mode" = "probe-failure" ]; then
@@ -489,15 +487,9 @@ while IFS= read -r line; do
       if [ "$mode" = "view" ]; then
         printf '%s\n' '<resultset><row><field name="View">items_view</field><field name="Create View">CREATE VIEW items_view AS SELECT 1</field></row></resultset>'
       fi
-      if [ "$platform" = "Darwin" ]; then
-        stty icanon <&0 2>/dev/null || true
-      fi
       ;;
     *SHOW\ CREATE\ TABLE*)
       printf '%s\n' '<resultset><row><field name="Table">items</field><field name="Create Table">CREATE TABLE items (id int PRIMARY KEY)</field></row></resultset>'
-      if [ "$platform" = "Darwin" ]; then
-        stty icanon <&0 2>/dev/null || true
-      fi
       ;;
     *)
       printf '%s\n' '<resultset></resultset>'
@@ -602,6 +594,33 @@ done
             assert_process_stopped(&transcript);
             assert_option_file_removed(&transcript);
         }
+    }
+
+    #[tokio::test]
+    async fn inspector_detail_sends_foreign_key_query_over_one_kilobyte() {
+        let (_directory, program, transcript) = fake_metadata_cli("table");
+        fetch_table_detail_in_session_with_program(
+            "mysql://user:password@localhost:3306/app",
+            "app",
+            "items",
+            OsStr::new(&program),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        let transcript_text = std::fs::read_to_string(&transcript).unwrap();
+        let foreign_key_query = transcript_text
+            .lines()
+            .find(|line| line.contains("REFERENTIAL_CONSTRAINTS"))
+            .expect("foreign key metadata query");
+        assert!(
+            foreign_key_query.len() > 1024,
+            "foreign key query was unexpectedly short: {} bytes",
+            foreign_key_query.len()
+        );
+        assert_process_stopped(&transcript);
+        assert_option_file_removed(&transcript);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem\n\nOn macOS, the production Unix PTY kept canonical input mode enabled. MySQL Inspector's foreign-key metadata query exceeds the 1024-byte canonical input limit, so the native Oracle MySQL CLI waited for input and the detail request timed out.\n\n## Background\n\nThe fake CLI disabled canonical mode only on Darwin, which masked the production PTY configuration bug in local tests.\n\n## Approach\n\nConfigure the production PTY explicitly for non-canonical input with VMIN=1 and VTIME=0, and remove the fake CLI's Darwin-only workaround. Add a regression test that sends the over-1KB foreign-key query through the Inspector path. PTY cleanup drains the native CLI output before the deliberate EOF stop.\n\n## Validation\n\n- Native macOS Oracle MySQL CLI 8.4.8 with Oracle MySQL server 8.4.10: Inspector detail passed for columns, indexes, foreign keys, triggers, and DDL.\n- Workspace format, all-features/no-default-features clippy, lint, tests, and release builds passed.\n- All-features: 4878 passed, 41 skipped.\n- No default features: 185 passed, 38 skipped.\n\n## Linear Issue Link\n\n- Implements https://linear.app/sabiql/issue/SAB-434