### PR TITLE
fix(mysql): prepare internal reads in read-only sessions

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -85,7 +85,14 @@ pub(super) async fn run_mysql_export_process(
                 "MySQL empty CSV result has no supported metadata fallback".to_string(),
             )
         })?;
-        let columns = mysql_metadata_columns(process, option_file, query, fallback_kind).await?;
+        let columns = mysql_metadata_columns(
+            process,
+            option_file,
+            query,
+            fallback_kind,
+            AccessMode::ReadOnly,
+        )
+        .await?;
         csv_writer.write_record(columns.iter()).await?;
     }
 

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -47,7 +47,7 @@ use super::xml::{
 };
 
 #[cfg(all(unix, feature = "test-support"))]
-use super::super::dsn::{parse_mysql_dsn, validate_mysql_tls_files, validate_mysql_values};
+use super::super::dsn::parse_and_validate_mysql_dsn;
 #[cfg(all(unix, feature = "test-support"))]
 use super::super::option_file::MySqlOptionFile;
 
@@ -228,6 +228,12 @@ impl MysqlMetadataSession {
             format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");
         let result = self.execute(&query).await?;
         validate_mode_probe(&result, &marker)
+    }
+
+    pub(in crate::adapters::mysql) async fn prepare_read_only(
+        &mut self,
+    ) -> Result<(), DbOperationError> {
+        configure_mysql_session(&mut self.process, AccessMode::ReadOnly).await
     }
 
     pub(in crate::adapters::mysql) async fn execute(
@@ -869,9 +875,7 @@ pub(in crate::adapters::mysql) async fn run_mysql_cli_script_for_test(
     dsn: &str,
     script: &str,
 ) -> Result<Vec<u8>, DbOperationError> {
-    let target = parse_mysql_dsn(dsn)?;
-    validate_mysql_values(&target)?;
-    validate_mysql_tls_files(&target)?;
+    let target = parse_and_validate_mysql_dsn(dsn)?;
     let option_file = MySqlOptionFile::create(&target)?;
     let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
     let result = async {
@@ -1219,6 +1223,10 @@ done
                 .expect("spawn fake mysql");
 
         session.probe().await.expect("mode probe");
+        session
+            .prepare_read_only()
+            .await
+            .expect("read-only session setup");
         for query in [
             "SELECT TABLES",
             "SELECT COLUMNS",
@@ -1240,6 +1248,8 @@ done
         );
         let positions = [
             "__sabiql_probe",
+            MYSQL_READ_ONLY_STATEMENT,
+            MYSQL_SESSION_MARKER_COLUMN,
             "SELECT TABLES",
             "SELECT COLUMNS",
             "SELECT INDEXES",
@@ -1274,7 +1284,7 @@ done
     }
 
     #[tokio::test]
-    async fn generated_preview_and_metadata_queries_skip_read_only_session_setup() {
+    async fn generated_preview_and_metadata_queries_configure_read_only_session() {
         for query in [
             "SELECT id FROM app.items ORDER BY id LIMIT 10 OFFSET 0",
             "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES",
@@ -1291,14 +1301,18 @@ done
                 &option_file,
                 query,
                 &statements,
-                AccessMode::ReadWrite,
+                AccessMode::ReadOnly,
                 Duration::from_secs(5),
             )
             .await
             .unwrap();
 
             let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
-            assert!(!log.contains(MYSQL_READ_ONLY_STATEMENT), "{query}: {log}");
+            let session_index = log
+                .find(MYSQL_READ_ONLY_STATEMENT)
+                .expect("read-only session statement");
+            let query_index = log.find(query).expect("generated query");
+            assert!(session_index < query_index, "{query}: {log}");
         }
     }
 

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 #[cfg(unix)]
 use tokio::fs::File as TokioFile;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, Command};
 #[cfg(not(unix))]
 use tokio::process::{ChildStderr, ChildStdin, ChildStdout};
@@ -33,7 +33,7 @@ use super::policy::{
     mysql_row_count_marker, query_failed_after_change, query_failed_after_mysql_statement,
     validate_mysql_session_marker,
 };
-use super::probe::run_mysql_command_with_timeout;
+use super::probe::{run_mysql_command_with_timeout, validate_sql_mode};
 #[cfg(all(unix, feature = "test-support"))]
 use super::pty::read_pty_until_first_byte_then_idle;
 #[cfg(unix)]
@@ -486,6 +486,7 @@ async fn run_mysql_adhoc_process(
                 option_file,
                 &statement.sql,
                 &statement.kind,
+                access_mode,
             )
             .await
             .map_err(|error| query_failed_after_change(error, possible_refresh_scope))?;
@@ -585,16 +586,8 @@ pub(super) async fn write_mysql_statement(
     process: &mut MysqlProcess,
     query: &str,
 ) -> Result<(), DbOperationError> {
-    let query = query.trim_end();
-    trace_mysql_statement(query);
-    write_mysql_input(process, query.as_bytes()).await?;
-    if query.ends_with(';') {
-        write_mysql_input(process, b"\n").await
-    } else if mysql_statement_has_trailing_line_comment(query) {
-        write_mysql_input(process, b"\n;\n").await
-    } else {
-        write_mysql_input(process, b";\n").await
-    }
+    trace_mysql_statement(query.trim_end());
+    write_mysql_input(process, &mysql_statement_input(query)).await
 }
 
 fn mysql_statement_has_trailing_line_comment(sql: &str) -> bool {
@@ -735,6 +728,7 @@ pub(super) async fn mysql_metadata_columns(
     option_file: &std::path::Path,
     query: &str,
     kind: MysqlMetadataFallbackKind,
+    access_mode: AccessMode,
 ) -> Result<Vec<String>, DbOperationError> {
     let query = match kind {
         MysqlMetadataFallbackKind::Select | MysqlMetadataFallbackKind::Table => {
@@ -744,7 +738,7 @@ pub(super) async fn mysql_metadata_columns(
             query.trim().trim_end_matches(';').trim_end().to_string()
         }
     };
-    mysql_metadata_columns_external(option_file, &query).await
+    mysql_metadata_columns_external(option_file, &query, access_mode).await
 }
 
 async fn mysql_metadata_select_columns(
@@ -790,7 +784,27 @@ async fn mysql_metadata_select_columns(
 async fn mysql_metadata_columns_external(
     option_file: &std::path::Path,
     query: &str,
+    access_mode: AccessMode,
 ) -> Result<Vec<String>, DbOperationError> {
+    mysql_metadata_columns_external_with_program(
+        OsStr::new("mysql"),
+        option_file,
+        query,
+        access_mode,
+    )
+    .await
+}
+
+async fn mysql_metadata_columns_external_with_program(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+    access_mode: AccessMode,
+) -> Result<Vec<String>, DbOperationError> {
+    if access_mode.is_read_only() {
+        return run_mysql_metadata_query_with_read_only_session(program, option_file, query).await;
+    }
+
     let mut args = mysql_metadata_args(option_file);
     args.push(format!("--execute={query}"));
     let option_file = option_file.to_path_buf();
@@ -805,6 +819,242 @@ async fn mysql_metadata_columns_external(
         return Err(classify_mysql_query_failure(&output.stderr));
     }
     parse_mysql_metadata_header(&output.stdout, query)
+}
+
+struct MysqlMetadataProcess {
+    child: Child,
+    stdin: Option<tokio::process::ChildStdin>,
+    stdout: BufReader<tokio::process::ChildStdout>,
+    stderr: BufReader<tokio::process::ChildStderr>,
+}
+
+impl MysqlMetadataProcess {
+    fn spawn(program: &OsStr, option_file: &std::path::Path) -> Result<Self, DbOperationError> {
+        let mut command = Command::new(program);
+        command
+            .args(mysql_metadata_args(option_file))
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .env_remove("MYSQL_PWD")
+            .env_remove("MYSQL_PASSWORD")
+            .kill_on_drop(true);
+        let mut child = command.spawn().map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                DbOperationError::CommandNotFound {
+                    command: DatabaseCli::MySql,
+                    details: error.to_string(),
+                }
+            } else {
+                DbOperationError::ConnectionFailed(error.to_string())
+            }
+        })?;
+        let stdin = child.stdin.take().ok_or_else(|| {
+            DbOperationError::QueryFailed("mysql stdin was not piped".to_string())
+        })?;
+        let stdout = child.stdout.take().ok_or_else(|| {
+            DbOperationError::QueryFailed("mysql stdout was not piped".to_string())
+        })?;
+        let stderr = child.stderr.take().ok_or_else(|| {
+            DbOperationError::QueryFailed("mysql stderr was not piped".to_string())
+        })?;
+        Ok(Self {
+            child,
+            stdin: Some(stdin),
+            stdout: BufReader::new(stdout),
+            stderr: BufReader::new(stderr),
+        })
+    }
+
+    async fn write_statement(&mut self, query: &str) -> Result<(), DbOperationError> {
+        let statement = mysql_statement_input(query);
+        self.stdin
+            .as_mut()
+            .ok_or_else(|| DbOperationError::ConnectionLost("mysql stdin was closed".to_string()))?
+            .write_all(&statement)
+            .await
+            .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))
+    }
+
+    async fn read_until_marker(&mut self, marker: &str) -> Result<Vec<u8>, DbOperationError> {
+        let mut output = Vec::new();
+        let mut stdout_closed = false;
+        let mut stderr_closed = false;
+        loop {
+            if stdout_closed && stderr_closed {
+                return Err(DbOperationError::QueryFailed(format!(
+                    "MySQL metadata session marker was not returned: {marker}"
+                )));
+            }
+
+            let mut stdout_line = Vec::new();
+            let mut stderr_line = Vec::new();
+            tokio::select! {
+                result = self.stdout.read_until(b'\n', &mut stdout_line), if !stdout_closed => {
+                    let size = result.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+                    if size == 0 {
+                        stdout_closed = true;
+                    } else {
+                        output.extend_from_slice(&stdout_line);
+                        if String::from_utf8_lossy(&stdout_line).contains(marker) {
+                            return Ok(output);
+                        }
+                    }
+                }
+                result = self.stderr.read_until(b'\n', &mut stderr_line), if !stderr_closed => {
+                    let size = result.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+                    if size == 0 {
+                        stderr_closed = true;
+                    } else if has_mysql_cli_error(&stderr_line) {
+                        return Err(classify_mysql_query_failure(&stderr_line));
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn run_mysql_metadata_query_with_read_only_session(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+) -> Result<Vec<String>, DbOperationError> {
+    run_mysql_metadata_query_with_read_only_session_with_timeout(
+        program,
+        option_file,
+        query,
+        MYSQL_QUERY_TIMEOUT,
+    )
+    .await
+}
+
+async fn run_mysql_metadata_query_with_read_only_session_with_timeout(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+    execution_timeout: Duration,
+) -> Result<Vec<String>, DbOperationError> {
+    match timeout(
+        execution_timeout,
+        run_mysql_metadata_query_with_read_only_session_process(program, option_file, query),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(DbOperationError::Timeout(
+            "mysql query exceeded the execution timeout".to_string(),
+        )),
+    }
+}
+
+async fn run_mysql_metadata_query_with_read_only_session_process(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    query: &str,
+) -> Result<Vec<String>, DbOperationError> {
+    let mut process = MysqlMetadataProcess::spawn(program, option_file)?;
+    let probe_marker = Uuid::new_v4().simple().to_string();
+    let probe_query = format!(
+        "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
+    );
+    process.write_statement(&probe_query).await?;
+    let probe_output = process.read_until_marker(&probe_marker).await?;
+    validate_metadata_mode_probe(&probe_output, &probe_marker)?;
+
+    let session_marker = Uuid::new_v4().simple().to_string();
+    process.write_statement(MYSQL_READ_ONLY_STATEMENT).await?;
+    process
+        .write_statement(&format!(
+            "SELECT '{session_marker}' AS {MYSQL_SESSION_MARKER_COLUMN}"
+        ))
+        .await?;
+    let session_output = process.read_until_marker(&session_marker).await?;
+    validate_metadata_session_marker(&session_output, &session_marker)?;
+
+    process.write_statement(query).await?;
+    let mut stdin = process
+        .stdin
+        .take()
+        .ok_or_else(|| DbOperationError::ConnectionLost("mysql stdin was closed".to_string()))?;
+    stdin
+        .shutdown()
+        .await
+        .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    drop(stdin);
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let (stdout_result, stderr_result, status_result) = tokio::join!(
+        process.stdout.read_to_end(&mut stdout),
+        process.stderr.read_to_end(&mut stderr),
+        process.child.wait(),
+    );
+    stdout_result.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    stderr_result.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    let status =
+        status_result.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
+    if has_mysql_cli_error(&stderr) {
+        return Err(classify_mysql_query_failure(&stderr));
+    }
+    if !status.success() {
+        return Err(classify_mysql_query_failure(&stderr));
+    }
+    parse_mysql_metadata_header(&stdout, query)
+}
+
+fn validate_metadata_mode_probe(output: &[u8], marker: &str) -> Result<(), DbOperationError> {
+    let fields = output
+        .split(|byte| *byte == b'\n')
+        .map(|line| line.strip_suffix(b"\r").unwrap_or(line))
+        .map(|line| line.split(|byte| *byte == b'\t').collect::<Vec<_>>())
+        .find(|fields| {
+            fields
+                .first()
+                .is_some_and(|field| *field == marker.as_bytes())
+        })
+        .ok_or_else(|| {
+            DbOperationError::QueryFailed(
+                "MySQL metadata fallback returned an invalid mode probe".to_string(),
+            )
+        })?;
+    let sql_mode = fields.get(1).ok_or_else(|| {
+        DbOperationError::QueryFailed(
+            "MySQL metadata fallback returned an incomplete mode probe".to_string(),
+        )
+    })?;
+    let sql_mode = String::from_utf8(sql_mode.to_vec())
+        .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+    validate_sql_mode(&sql_mode)
+}
+
+fn validate_metadata_session_marker(output: &[u8], marker: &str) -> Result<(), DbOperationError> {
+    let valid = output
+        .split(|byte| *byte == b'\n')
+        .map(|line| line.strip_suffix(b"\r").unwrap_or(line))
+        .map(|line| line.split(|byte| *byte == b'\t').collect::<Vec<_>>())
+        .any(|fields| {
+            fields
+                .first()
+                .is_some_and(|field| *field == marker.as_bytes())
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(DbOperationError::QueryFailed(
+            "MySQL metadata fallback returned an invalid read-only session marker".to_string(),
+        ))
+    }
+}
+
+fn mysql_statement_input(query: &str) -> Vec<u8> {
+    let query = query.trim_end();
+    let terminator = if query.ends_with(';') {
+        "\n"
+    } else if mysql_statement_has_trailing_line_comment(query) {
+        "\n;\n"
+    } else {
+        ";\n"
+    };
+    [query.as_bytes(), terminator.as_bytes()].concat()
 }
 
 fn parse_mysql_metadata_header(
@@ -857,6 +1107,7 @@ async fn fill_mysql_empty_result_columns(
     option_file: &std::path::Path,
     query: &str,
     kind: &MysqlStatementKind,
+    access_mode: AccessMode,
 ) -> Result<MysqlResultSet, DbOperationError> {
     if !result.columns.is_empty() || !result.values.is_empty() {
         return Ok(result);
@@ -866,7 +1117,8 @@ async fn fill_mysql_empty_result_columns(
             "MySQL empty result has no supported metadata fallback".to_string(),
         )
     })?;
-    result.columns = mysql_metadata_columns(process, option_file, query, fallback_kind).await?;
+    result.columns =
+        mysql_metadata_columns(process, option_file, query, fallback_kind, access_mode).await?;
     Ok(result)
 }
 
@@ -974,8 +1226,8 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let option_file = directory.path().join("option.cnf");
         fs::write(&option_file, "[client]\n").unwrap();
-        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
         let program = directory.path().join("mysql");
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
         let probe_response = match mode {
             "missing" => "exit 0".to_string(),
             "invalid" => {
@@ -1054,6 +1306,51 @@ done
 
     fn fake_mysql_multi_with_tail_failure() -> (TempDir, PathBuf, PathBuf) {
         fake_mysql_multi_with_mode(false, None, true)
+    }
+
+    fn fake_mysql_metadata_columns(fail_read_only: bool) -> (TempDir, PathBuf, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let option_file = directory.path().join("option.cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let program = directory.path().join("mysql");
+        let read_only_failure = if fail_read_only {
+            "printf '%s\\n' 'ERROR 1227 (42000): access denied to set transaction read only' >&2\n      exit 1"
+        } else {
+            ""
+        };
+        let script = format!(
+            r#"#!/bin/sh
+option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
+log="$option.log"
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$log"
+  case "$line" in
+    *__sabiql_probe*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_probe.*/\\1/")
+      printf '%s\t%s\n' '__sabiql_probe' '__sabiql_sql_mode'
+      printf '%s\t%s\n' "$marker" 'STRICT_TRANS_TABLES'
+      ;;
+    *"SET SESSION TRANSACTION READ ONLY"*)
+      {read_only_failure}
+      ;;
+    *__sabiql_session_marker*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\\([^']*\\)' AS __sabiql_session_marker.*/\\1/")
+      printf '%s\n' '__sabiql_session_marker'
+      printf '%s\n' "$marker"
+      ;;
+    *"SHOW DATABASES"*)
+      printf '%s\n' 'Database'
+      ;;
+  esac
+done
+exit 0
+"#,
+        );
+        fs::write(&program, script).unwrap();
+        let mut permissions = fs::metadata(&program).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).unwrap();
+        (directory, program, option_file)
     }
 
     fn fake_mysql_multi_with_mode(
@@ -1314,6 +1611,53 @@ done
             let query_index = log.find(query).expect("generated query");
             assert!(session_index < query_index, "{query}: {log}");
         }
+    }
+
+    #[tokio::test]
+    async fn external_metadata_fallback_configures_read_only_session_before_query() {
+        let (_directory, program, option_file) = fake_mysql_metadata_columns(false);
+        let columns = mysql_metadata_columns_external_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SHOW DATABASES",
+            AccessMode::ReadOnly,
+        )
+        .await
+        .unwrap_or_else(|error| {
+            let log =
+                fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
+            panic!("external metadata fallback failed: {error:?}; log: {log}");
+        });
+
+        assert_eq!(columns, ["Database"]);
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+        let positions = [
+            "__sabiql_probe",
+            MYSQL_READ_ONLY_STATEMENT,
+            MYSQL_SESSION_MARKER_COLUMN,
+            "SHOW DATABASES",
+        ]
+        .into_iter()
+        .map(|query| log.find(query).expect("query in transcript"))
+        .collect::<Vec<_>>();
+        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
+    }
+
+    #[tokio::test]
+    async fn external_metadata_fallback_setup_failure_never_sends_query() {
+        let (_directory, program, option_file) = fake_mysql_metadata_columns(true);
+        let result = mysql_metadata_columns_external_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SHOW DATABASES",
+            AccessMode::ReadOnly,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+        assert!(log.contains(MYSQL_READ_ONLY_STATEMENT));
+        assert!(!log.contains("SHOW DATABASES"), "{log}");
     }
 
     #[tokio::test]

--- a/src/infra/adapters/mysql/cli/pty.rs
+++ b/src/infra/adapters/mysql/cli/pty.rs
@@ -104,6 +104,7 @@ pub(super) async fn read_pty_until_idle(pty: &mut MysqlPty) -> io::Result<Vec<u8
     read_pty_until_idle_from(&mut pty.output, output, false).await
 }
 
+#[cfg(all(unix, feature = "test-support"))]
 pub(super) async fn read_pty_until_first_byte_then_idle(pty: &mut MysqlPty) -> io::Result<Vec<u8>> {
     let output = std::mem::take(&mut pty.pending);
     pty.frame_scanner.reset();

--- a/src/infra/adapters/mysql/connection.rs
+++ b/src/infra/adapters/mysql/connection.rs
@@ -3,15 +3,13 @@ use async_trait::async_trait;
 
 use super::adapter::MySqlAdapter;
 use super::cli::{check_mysql_cli_version, run_mysql_adhoc, validate_mysql_multi_query};
-use super::dsn::{parse_mysql_dsn, validate_mysql_tls_files, validate_mysql_values};
+use super::dsn::parse_and_validate_mysql_dsn;
 use super::option_file::MySqlOptionFile;
 
 #[async_trait]
 impl ConnectionProbe for MySqlAdapter {
     async fn probe(&self, dsn: &str) -> Result<(), DbOperationError> {
-        let target = parse_mysql_dsn(dsn)?;
-        validate_mysql_values(&target)?;
-        validate_mysql_tls_files(&target)?;
+        let target = parse_and_validate_mysql_dsn(dsn)?;
         self.check_cli_version().await?;
 
         let option_file = MySqlOptionFile::create(&target)?;
@@ -21,18 +19,17 @@ impl ConnectionProbe for MySqlAdapter {
     }
 
     async fn fetch_databases(&self, dsn: &str) -> Result<Vec<String>, DbOperationError> {
-        let mut target = parse_mysql_dsn(dsn)?;
+        let mut target = parse_and_validate_mysql_dsn(dsn)?;
         target.database = None;
-        validate_mysql_values(&target)?;
         self.check_cli_version().await?;
 
         let option_file = MySqlOptionFile::create(&target)?;
-        let statements = validate_mysql_multi_query("SHOW DATABASES", None, AccessMode::ReadWrite)?;
+        let statements = validate_mysql_multi_query("SHOW DATABASES", None, AccessMode::ReadOnly)?;
         let result = run_mysql_adhoc(
             &option_file.path,
             "SHOW DATABASES",
             &statements,
-            AccessMode::ReadWrite,
+            AccessMode::ReadOnly,
         )
         .await;
         drop(option_file);

--- a/src/infra/adapters/mysql/dsn.rs
+++ b/src/infra/adapters/mysql/dsn.rs
@@ -113,6 +113,13 @@ pub(super) fn parse_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
     })
 }
 
+pub(super) fn parse_and_validate_mysql_dsn(dsn: &str) -> Result<MySqlDsn, DbOperationError> {
+    let target = parse_mysql_dsn(dsn)?;
+    validate_mysql_values(&target)?;
+    validate_mysql_tls_files(&target)?;
+    Ok(target)
+}
+
 pub(super) fn validate_mysql_values(target: &MySqlDsn) -> Result<(), DbOperationError> {
     let values = [
         Some(target.host.as_str()),

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -11,7 +11,7 @@ use super::cli::{
     export_mysql_csv_to_file, run_mysql_adhoc, run_mysql_single_statement,
     validate_mysql_export_query, validate_mysql_multi_query,
 };
-use super::dsn::{parse_mysql_dsn, validate_mysql_tls_files, validate_mysql_values};
+use super::dsn::parse_and_validate_mysql_dsn;
 use super::metadata;
 use super::option_file::MySqlOptionFile;
 
@@ -22,9 +22,7 @@ pub(super) mod test_support {
     use crate::adapters::csv_export::export_to_path;
     use crate::app::ports::outbound::DbOperationError;
 
-    use super::{
-        export_mysql_csv_to_file, parse_mysql_dsn, validate_mysql_tls_files, validate_mysql_values,
-    };
+    use super::{export_mysql_csv_to_file, parse_and_validate_mysql_dsn};
 
     #[cfg(unix)]
     #[doc(hidden)]
@@ -43,9 +41,7 @@ pub(super) mod test_support {
         query: &str,
         path: PathBuf,
     ) -> Result<PathBuf, DbOperationError> {
-        let target = parse_mysql_dsn(dsn)?;
-        validate_mysql_values(&target)?;
-        validate_mysql_tls_files(&target)?;
+        let target = parse_and_validate_mysql_dsn(dsn)?;
         let query = query.to_string();
         export_to_path(path, move |temporary_path| async move {
             export_mysql_csv_to_file(target, &query, temporary_path).await
@@ -88,19 +84,12 @@ impl QueryExecutor for MySqlAdapter {
             limit,
             offset,
         );
-        let target = parse_mysql_dsn(dsn)?;
-        validate_mysql_values(&target)?;
-        validate_mysql_tls_files(&target)?;
+        let target = parse_and_validate_mysql_dsn(dsn)?;
         let statements =
-            validate_mysql_multi_query(&query, target.database.as_deref(), AccessMode::ReadWrite)?;
+            validate_mysql_multi_query(&query, target.database.as_deref(), AccessMode::ReadOnly)?;
         let option_file = MySqlOptionFile::create(&target)?;
-        let result = run_mysql_adhoc(
-            &option_file.path,
-            &query,
-            &statements,
-            AccessMode::ReadWrite,
-        )
-        .await;
+        let result =
+            run_mysql_adhoc(&option_file.path, &query, &statements, AccessMode::ReadOnly).await;
         drop(option_file);
         let result_set = result?.result_set.ok_or_else(|| {
             DbOperationError::MetadataParseFailed(
@@ -144,9 +133,7 @@ impl QueryExecutor for MySqlAdapter {
         query: &str,
         access_mode: AccessMode,
     ) -> Result<QueryResult, DbOperationError> {
-        let target = parse_mysql_dsn(dsn)?;
-        validate_mysql_values(&target)?;
-        validate_mysql_tls_files(&target)?;
+        let target = parse_and_validate_mysql_dsn(dsn)?;
 
         if mysql_tree_explain_query_kind(query).is_some() {
             #[expect(
@@ -208,9 +195,7 @@ impl QueryExecutor for MySqlAdapter {
         query: &str,
         access_mode: AccessMode,
     ) -> Result<WriteExecutionResult, DbOperationError> {
-        let target = parse_mysql_dsn(dsn)?;
-        validate_mysql_values(&target)?;
-        validate_mysql_tls_files(&target)?;
+        let target = parse_and_validate_mysql_dsn(dsn)?;
         let statements =
             validate_mysql_multi_query(query, target.database.as_deref(), access_mode)?;
 
@@ -244,9 +229,7 @@ impl QueryExecutor for MySqlAdapter {
     }
 
     async fn count_query_rows(&self, dsn: &str, query: &str) -> Result<usize, DbOperationError> {
-        let target = parse_mysql_dsn(dsn)?;
-        validate_mysql_values(&target)?;
-        validate_mysql_tls_files(&target)?;
+        let target = parse_and_validate_mysql_dsn(dsn)?;
         validate_mysql_export_query(query, target.database.as_deref())?;
 
         let result = self.execute_adhoc(dsn, query, AccessMode::ReadOnly).await?;
@@ -271,9 +254,7 @@ impl QueryExecutor for MySqlAdapter {
         query: &str,
         file_name: &str,
     ) -> Result<std::path::PathBuf, DbOperationError> {
-        let target = parse_mysql_dsn(dsn)?;
-        validate_mysql_values(&target)?;
-        validate_mysql_tls_files(&target)?;
+        let target = parse_and_validate_mysql_dsn(dsn)?;
         validate_mysql_export_query(query, target.database.as_deref())?;
 
         let query = query.to_string();

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -6,7 +6,7 @@ use crate::domain::{
 
 use super::super::{
     cli::{MysqlResultSet, run_mysql_adhoc, validate_mysql_multi_query},
-    dsn::{parse_mysql_dsn, validate_mysql_tls_files, validate_mysql_values},
+    dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
     sql::quote_string,
 };
@@ -153,14 +153,11 @@ pub(super) async fn execute_metadata_query(
     dsn: &str,
     query: &str,
 ) -> Result<MysqlResultSet, DbOperationError> {
-    let target = parse_mysql_dsn(dsn)?;
-    validate_mysql_values(&target)?;
-    validate_mysql_tls_files(&target)?;
+    let target = parse_and_validate_mysql_dsn(dsn)?;
     let statements =
-        validate_mysql_multi_query(query, target.database.as_deref(), AccessMode::ReadWrite)?;
+        validate_mysql_multi_query(query, target.database.as_deref(), AccessMode::ReadOnly)?;
     let option_file = MySqlOptionFile::create(&target)?;
-    let result =
-        run_mysql_adhoc(&option_file.path, query, &statements, AccessMode::ReadWrite).await;
+    let result = run_mysql_adhoc(&option_file.path, query, &statements, AccessMode::ReadOnly).await;
     drop(option_file);
     result?.result_set.ok_or_else(|| {
         DbOperationError::MetadataParseFailed(
@@ -170,7 +167,7 @@ pub(super) async fn execute_metadata_query(
 }
 
 fn selected_database(dsn: &str) -> Result<String, DbOperationError> {
-    parse_mysql_dsn(dsn)?.database.ok_or_else(|| {
+    parse_and_validate_mysql_dsn(dsn)?.database.ok_or_else(|| {
         DbOperationError::UnsupportedOperation(
             "MySQL metadata requires a selected database".to_string(),
         )

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -10,7 +10,7 @@ use crate::domain::{
 use super::super::sql::{quote_identifier, quote_string};
 use super::super::{
     cli::{MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, MysqlResultSet},
-    dsn::{parse_mysql_dsn, validate_mysql_tls_files, validate_mysql_values},
+    dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
 };
 use super::catalog::{
@@ -79,9 +79,7 @@ async fn fetch_table_detail_in_session_with_program(
     program: &OsStr,
     timeout: Duration,
 ) -> Result<Table, DbOperationError> {
-    let target = parse_mysql_dsn(dsn)?;
-    validate_mysql_values(&target)?;
-    validate_mysql_tls_files(&target)?;
+    let target = parse_and_validate_mysql_dsn(dsn)?;
     let database = target.database.as_deref().ok_or_else(|| {
         DbOperationError::UnsupportedOperation(
             "MySQL metadata requires a selected database".to_string(),
@@ -119,6 +117,7 @@ async fn fetch_table_detail_with_session(
     table: &str,
 ) -> Result<Table, DbOperationError> {
     session.probe().await?;
+    session.prepare_read_only().await?;
     let tables_result = session.execute(&table_query(schema, table)).await?;
     let snapshot = metadata_snapshot_from_result(database, Some(schema), &tables_result)?;
     let table_metadata = find_table(schema, table, &snapshot.tables)?;
@@ -460,6 +459,16 @@ while IFS= read -r line; do
     continue
   fi
   case "$line" in
+    *"SET SESSION TRANSACTION READ ONLY")
+      ;;
+    *__sabiql_session_marker*)
+      if [ "$mode" = "read-only-failure" ]; then
+        printf '%s\n' 'ERROR 1227 (42000): access denied to validate read-only session' >&2
+        exit 1
+      fi
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)' AS __sabiql_session_marker.*/\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_session_marker">'"$marker"'</field></row></resultset>'
+      ;;
     *TABLES*)
       if [ "$mode" = "empty" ]; then
         printf '%s\n' '<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><field name="TABLE_SCHEMA" xsi:nil="true"/><field name="TABLE_NAME" xsi:nil="true"/><field name="TABLE_TYPE" xsi:nil="true"/><field name="TABLE_ROWS" xsi:nil="true"/><field name="TABLE_COMMENT" xsi:nil="true"/></row></resultset>'
@@ -572,6 +581,8 @@ done
             let labels = if mode == "view" {
                 [
                     "__sabiql_probe",
+                    "SET SESSION TRANSACTION READ ONLY",
+                    "__sabiql_session_marker",
                     "INFORMATION_SCHEMA.TABLES",
                     "INFORMATION_SCHEMA.COLUMNS",
                     "INFORMATION_SCHEMA.STATISTICS",
@@ -582,6 +593,8 @@ done
             } else {
                 [
                     "__sabiql_probe",
+                    "SET SESSION TRANSACTION READ ONLY",
+                    "__sabiql_session_marker",
                     "INFORMATION_SCHEMA.TABLES",
                     "INFORMATION_SCHEMA.COLUMNS",
                     "INFORMATION_SCHEMA.STATISTICS",
@@ -598,6 +611,26 @@ done
             assert_process_stopped(&transcript);
             assert_option_file_removed(&transcript);
         }
+    }
+
+    #[tokio::test]
+    async fn inspector_detail_read_only_setup_failure_never_sends_metadata_sql() {
+        let (_directory, program, transcript) = fake_metadata_cli("read-only-failure");
+        let result = fetch_table_detail_in_session_with_program(
+            "mysql://user:password@localhost:3306/app",
+            "app",
+            "items",
+            OsStr::new(&program),
+            Duration::from_secs(5),
+        )
+        .await;
+
+        let transcript_text = std::fs::read_to_string(&transcript).unwrap();
+        assert!(result.is_err(), "result={result:?}\n{transcript_text}");
+        assert!(transcript_text.contains("SET SESSION TRANSACTION READ ONLY"));
+        assert!(!transcript_text.contains("INFORMATION_SCHEMA.TABLES"));
+        assert_process_stopped(&transcript);
+        assert_option_file_removed(&transcript);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem
Internal MySQL reads could execute without the shared read-only session guard.

## Background
Preview, catalog, database-list, and Inspector detail reads must fail closed before sending internal SQL when read-only session setup cannot be completed.

## Approach
Route internal reads through the existing probe-then-read-only-session path and centralize DSN parsing and validation in a narrow helper while retaining option-file defensive validation.

## Screenshots
Not applicable.

## Linear Issue Link (optional)
- Implements https://linear.app/sabiql/issue/SAB-444