### PR TITLE
refactor(mysql): retain classified statements through execution

### DIFF
--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -64,6 +64,34 @@ mod mysql_tests {
     }
 
     #[test]
+    fn retains_classified_mysql_statements_for_execution() {
+        let MultiStatementDecision::Allow { statements, .. } =
+            evaluate_mysql_multi_statement("UPDATE items SET value = 1; SELECT 2", Some("app"))
+        else {
+            panic!("unexpected block");
+        };
+
+        assert!(matches!(
+            statements[0].kind,
+            MysqlStatementKind::Update { has_where: false }
+        ));
+        assert_eq!(statements[1].sql, "SELECT 2");
+    }
+
+    #[test]
+    fn distinguishes_persistent_mysql_schema_changes_from_temporary_tables() {
+        assert!(mysql_statement_is_persistent_schema_change(
+            &MysqlStatementKind::CreateTable { temporary: false }
+        ));
+        assert!(!mysql_statement_is_persistent_schema_change(
+            &MysqlStatementKind::CreateTable { temporary: true }
+        ));
+        assert!(!mysql_statement_is_persistent_schema_change(
+            &MysqlStatementKind::DropTable { temporary: true }
+        ));
+    }
+
+    #[test]
     fn confirmation_target_preserves_input_case() {
         let MultiStatementDecision::Allow { risk, .. } =
             mysql("UPDATE CustomerOrders SET value = 1")
@@ -321,9 +349,9 @@ pub struct SqlRiskDecision {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MultiStatementDecision {
+pub enum MultiStatementDecision<Statement = String> {
     Allow {
-        statements: Vec<String>,
+        statements: Vec<Statement>,
         risk: SqlRiskDecision,
     },
     Block {
@@ -451,7 +479,7 @@ pub fn mysql_statement_is_data_modifying(kind: &MysqlStatementKind) -> bool {
     )
 }
 
-fn mysql_statement_is_persistent_schema_change(kind: &MysqlStatementKind) -> bool {
+pub fn mysql_statement_is_persistent_schema_change(kind: &MysqlStatementKind) -> bool {
     mysql_statement_is_schema_modifying(kind)
         && !matches!(
             kind,
@@ -580,7 +608,7 @@ fn mysql_validate_submission_state(
 pub fn evaluate_mysql_multi_statement(
     sql: &str,
     selected_database: Option<&str>,
-) -> MultiStatementDecision {
+) -> MultiStatementDecision<MysqlStatement> {
     if statement_contains_unsupported_mysql_control(sql) {
         return MultiStatementDecision::Block {
             reason: "unsupported MySQL session or table-lock statement".to_string(),
@@ -665,8 +693,8 @@ pub fn evaluate_mysql_multi_statement(
         .iter()
         .all(|(_, decision)| decision.read_only_allowed);
     let statements = planned
-        .iter()
-        .map(|(statement, _)| statement.sql.clone())
+        .into_iter()
+        .map(|(statement, _)| statement)
         .collect();
     MultiStatementDecision::Allow {
         statements,
@@ -1019,7 +1047,16 @@ pub fn evaluate_multi_statement_for_database_with_context(
     sql: &str,
 ) -> MultiStatementDecision {
     if database_type == DatabaseType::MySQL {
-        return evaluate_mysql_multi_statement(sql, selected_database);
+        return match evaluate_mysql_multi_statement(sql, selected_database) {
+            MultiStatementDecision::Allow { statements, risk } => MultiStatementDecision::Allow {
+                statements: statements
+                    .into_iter()
+                    .map(|statement| statement.sql)
+                    .collect(),
+                risk,
+            },
+            MultiStatementDecision::Block { reason } => MultiStatementDecision::Block { reason },
+        };
     }
     if contains_cli_meta_command(database_type, sql) {
         return MultiStatementDecision::Block {

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use crate::app::policy::sql::mysql_statement::{
-    MysqlStatement, MysqlStatementKind, classify_mysql_statement, has_mysql_read_only_side_effect,
+    MysqlStatement, MysqlStatementKind, has_mysql_read_only_side_effect,
 };
 use crate::app::policy::write::sql_risk::{
     MultiStatementDecision, evaluate_mysql_multi_statement, mysql_statement_is_data_modifying,
-    mysql_statement_is_schema_modifying,
+    mysql_statement_is_persistent_schema_change, mysql_statement_is_schema_modifying,
 };
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{CommandTag, QueryValue, RefreshScope};
@@ -53,13 +53,7 @@ pub(in crate::adapters::mysql) fn validate_mysql_multi_query(
             "read-only mode blocks MySQL write statements".to_string(),
         ));
     }
-    statements
-        .iter()
-        .map(|statement| {
-            classify_mysql_statement(statement)
-                .map_err(|error| DbOperationError::UnsupportedOperation(error.to_string()))
-        })
-        .collect()
+    Ok(statements)
 }
 
 pub(in crate::adapters::mysql) fn validate_mysql_export_query(
@@ -273,15 +267,6 @@ pub(super) fn mysql_refresh_scope(kind: &MysqlStatementKind) -> RefreshScope {
     } else {
         RefreshScope::None
     }
-}
-
-fn mysql_statement_is_persistent_schema_change(kind: &MysqlStatementKind) -> bool {
-    mysql_statement_is_schema_modifying(kind)
-        && !matches!(
-            kind,
-            MysqlStatementKind::CreateTable { temporary: true }
-                | MysqlStatementKind::DropTable { temporary: true }
-        )
 }
 
 #[derive(Default)]

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -287,14 +287,12 @@ impl MysqlMetadataSession {
 
 pub(in crate::adapters::mysql) async fn run_mysql_adhoc(
     option_file: &std::path::Path,
-    query: &str,
     statements: &[MysqlStatement],
     access_mode: AccessMode,
 ) -> Result<MysqlExecutionResult, DbOperationError> {
     run_mysql_adhoc_with_program_and_statements(
         OsStr::new("mysql"),
         option_file,
-        query,
         statements,
         access_mode,
         MYSQL_QUERY_TIMEOUT,
@@ -383,7 +381,6 @@ async fn run_mysql_single_statement_process(
 async fn run_mysql_adhoc_with_program_and_statements(
     program: &OsStr,
     option_file: &std::path::Path,
-    query: &str,
     statements: &[MysqlStatement],
     access_mode: AccessMode,
     execution_timeout: Duration,
@@ -397,7 +394,7 @@ async fn run_mysql_adhoc_with_program_and_statements(
     let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
     let result = timeout(
         execution_timeout,
-        run_mysql_adhoc_process(&mut process, option_file, query, statements, access_mode),
+        run_mysql_adhoc_process(&mut process, option_file, statements, access_mode),
     )
     .await;
 
@@ -416,10 +413,93 @@ async fn run_mysql_adhoc_with_program_and_statements(
     }
 }
 
+struct MysqlStatementExecution {
+    result_set: Option<MysqlResultSet>,
+    command_event: MysqlCommandEvent,
+    refresh_scope: RefreshScope,
+}
+
+async fn run_mysql_statement(
+    process: &mut MysqlProcess,
+    option_file: &std::path::Path,
+    statement: &MysqlStatement,
+    access_mode: AccessMode,
+    refresh_scope: RefreshScope,
+) -> Result<MysqlStatementExecution, DbOperationError> {
+    let marker = Uuid::new_v4().simple().to_string();
+    let statement_scope = mysql_refresh_scope(&statement.kind);
+    let possible_refresh_scope = refresh_scope.merge(statement_scope);
+    if let Err(error) = write_mysql_statement(process, &statement.sql).await {
+        return Err(query_failed_after_change(error, refresh_scope));
+    }
+    let marker_query =
+        format!("SELECT '{marker}' AS __sabiql_marker, ROW_COUNT() AS affected_rows");
+    if let Err(error) = write_mysql_statement(process, &marker_query).await {
+        return Err(query_failed_after_change(error, possible_refresh_scope));
+    }
+    let first_xml = match read_one_mysql_resultset(process).await {
+        Ok(xml) => xml,
+        Err(error) => {
+            return Err(query_failed_after_mysql_statement(
+                error,
+                refresh_scope,
+                possible_refresh_scope,
+            ));
+        }
+    };
+    let first_result = match parse_mysql_xml(&first_xml) {
+        Ok(result) => result,
+        Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
+    };
+    let (user_result, marker_result) = if is_mysql_row_count_marker(&first_result, &marker) {
+        (None, first_result)
+    } else {
+        let xml = match read_one_mysql_resultset(process).await {
+            Ok(xml) => xml,
+            Err(error) => {
+                return Err(query_failed_after_mysql_statement(
+                    error,
+                    refresh_scope,
+                    possible_refresh_scope,
+                ));
+            }
+        };
+        let marker_result = match parse_mysql_xml(&xml) {
+            Ok(result) => result,
+            Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
+        };
+        let user_result = fill_mysql_empty_result_columns(
+            process,
+            first_result,
+            option_file,
+            &statement.sql,
+            &statement.kind,
+            access_mode,
+        )
+        .await
+        .map_err(|error| query_failed_after_change(error, possible_refresh_scope))?;
+        (Some(user_result), marker_result)
+    };
+    let affected_rows = match mysql_row_count_marker(&marker_result, &marker) {
+        Ok(rows) => rows,
+        Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
+    };
+    let tag = mysql_command_tag(&statement.kind, affected_rows, user_result.as_ref());
+
+    Ok(MysqlStatementExecution {
+        result_set: user_result,
+        command_event: MysqlCommandEvent {
+            kind: statement.kind.clone(),
+            target: statement.target.clone(),
+            tag,
+        },
+        refresh_scope: possible_refresh_scope,
+    })
+}
+
 async fn run_mysql_adhoc_process(
     process: &mut MysqlProcess,
     option_file: &std::path::Path,
-    _query: &str,
     statements: &[MysqlStatement],
     access_mode: AccessMode,
 ) -> Result<MysqlExecutionResult, DbOperationError> {
@@ -438,74 +518,14 @@ async fn run_mysql_adhoc_process(
     let mut refresh_scope = RefreshScope::None;
 
     for statement in statements {
-        let marker = Uuid::new_v4().simple().to_string();
-        let statement_scope = mysql_refresh_scope(&statement.kind);
-        let possible_refresh_scope = refresh_scope.merge(statement_scope);
-        if let Err(error) = write_mysql_statement(process, &statement.sql).await {
-            return Err(query_failed_after_change(error, refresh_scope));
-        }
-        let marker_query =
-            format!("SELECT '{marker}' AS __sabiql_marker, ROW_COUNT() AS affected_rows");
-        if let Err(error) = write_mysql_statement(process, &marker_query).await {
-            return Err(query_failed_after_change(error, possible_refresh_scope));
-        }
-        let first_xml = match read_one_mysql_resultset(process).await {
-            Ok(xml) => xml,
-            Err(error) => {
-                return Err(query_failed_after_mysql_statement(
-                    error,
-                    refresh_scope,
-                    possible_refresh_scope,
-                ));
-            }
-        };
-        let first_result = match parse_mysql_xml(&first_xml) {
-            Ok(result) => result,
-            Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
-        };
-        let (user_result, marker_result) = if is_mysql_row_count_marker(&first_result, &marker) {
-            (None, first_result)
-        } else {
-            let xml = match read_one_mysql_resultset(process).await {
-                Ok(xml) => xml,
-                Err(error) => {
-                    return Err(query_failed_after_mysql_statement(
-                        error,
-                        refresh_scope,
-                        possible_refresh_scope,
-                    ));
-                }
-            };
-            let marker_result = match parse_mysql_xml(&xml) {
-                Ok(result) => result,
-                Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
-            };
-            let user_result = fill_mysql_empty_result_columns(
-                process,
-                first_result,
-                option_file,
-                &statement.sql,
-                &statement.kind,
-                access_mode,
-            )
-            .await
-            .map_err(|error| query_failed_after_change(error, possible_refresh_scope))?;
-            (Some(user_result), marker_result)
-        };
-        let affected_rows = match mysql_row_count_marker(&marker_result, &marker) {
-            Ok(rows) => rows,
-            Err(error) => return Err(query_failed_after_change(error, possible_refresh_scope)),
-        };
-        if let Some(result) = user_result {
+        let execution =
+            run_mysql_statement(process, option_file, statement, access_mode, refresh_scope)
+                .await?;
+        if let Some(result) = execution.result_set {
             last_result_set = Some(result);
         }
-        let tag = mysql_command_tag(&statement.kind, affected_rows, last_result_set.as_ref());
-        command_tags.push(MysqlCommandEvent {
-            kind: statement.kind.clone(),
-            target: statement.target.clone(),
-            tag,
-        });
-        refresh_scope = possible_refresh_scope;
+        command_tags.push(execution.command_event);
+        refresh_scope = execution.refresh_scope;
     }
 
     #[cfg(not(unix))]
@@ -1488,7 +1508,6 @@ done
         let result = run_mysql_adhoc_with_program_and_statements(
             OsStr::new(&program),
             &option_file,
-            "SELECT 2",
             &statements,
             AccessMode::ReadOnly,
             Duration::from_secs(5),
@@ -1596,7 +1615,6 @@ done
             run_mysql_adhoc_with_program_and_statements(
                 OsStr::new(&program),
                 &option_file,
-                query,
                 &statements,
                 AccessMode::ReadOnly,
                 Duration::from_secs(5),
@@ -1885,7 +1903,6 @@ done
         let result = run_mysql_adhoc_with_program_and_statements(
             OsStr::new(&program),
             &option_file,
-            "UPDATE items SET value = 1; SELECT 2",
             &statements,
             AccessMode::ReadWrite,
             Duration::from_secs(5),
@@ -1920,7 +1937,6 @@ done
         let result = run_mysql_adhoc_with_program_and_statements(
             OsStr::new(&program),
             &option_file,
-            query,
             &statements,
             AccessMode::ReadWrite,
             Duration::from_secs(5),
@@ -1949,7 +1965,6 @@ done
         let result = run_mysql_adhoc_with_program_and_statements(
             OsStr::new(&program),
             &option_file,
-            "UPDATE items SET value = 1",
             &statements,
             AccessMode::ReadWrite,
             Duration::from_secs(5),
@@ -1997,7 +2012,6 @@ done
             let result = run_mysql_adhoc_with_program_and_statements(
                 OsStr::new(&program),
                 &option_file,
-                "UPDATE items SET value = 1",
                 &statements,
                 AccessMode::ReadWrite,
                 Duration::from_secs(5),
@@ -2028,7 +2042,6 @@ done
         let result = run_mysql_adhoc_with_program_and_statements(
             OsStr::new(&program),
             &option_file,
-            "UPDATE items SET value = 1; SELECT missing_column FROM items",
             &statements,
             AccessMode::ReadWrite,
             Duration::from_secs(5),
@@ -2057,7 +2070,6 @@ done
         let result = run_mysql_adhoc_with_program_and_statements(
             OsStr::new(&program),
             &option_file,
-            "SELECT missing_column FROM items",
             &statements,
             AccessMode::ReadWrite,
             Duration::from_secs(5),

--- a/src/infra/adapters/mysql/connection.rs
+++ b/src/infra/adapters/mysql/connection.rs
@@ -25,13 +25,7 @@ impl ConnectionProbe for MySqlAdapter {
 
         let option_file = MySqlOptionFile::create(&target)?;
         let statements = validate_mysql_multi_query("SHOW DATABASES", None, AccessMode::ReadOnly)?;
-        let result = run_mysql_adhoc(
-            &option_file.path,
-            "SHOW DATABASES",
-            &statements,
-            AccessMode::ReadOnly,
-        )
-        .await;
+        let result = run_mysql_adhoc(&option_file.path, &statements, AccessMode::ReadOnly).await;
         drop(option_file);
         result.map(|execution| {
             execution.result_set.map_or_else(Vec::new, |result_set| {

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -88,8 +88,7 @@ impl QueryExecutor for MySqlAdapter {
         let statements =
             validate_mysql_multi_query(&query, target.database.as_deref(), AccessMode::ReadOnly)?;
         let option_file = MySqlOptionFile::create(&target)?;
-        let result =
-            run_mysql_adhoc(&option_file.path, &query, &statements, AccessMode::ReadOnly).await;
+        let result = run_mysql_adhoc(&option_file.path, &statements, AccessMode::ReadOnly).await;
         drop(option_file);
         let result_set = result?.result_set.ok_or_else(|| {
             DbOperationError::MetadataParseFailed(
@@ -163,7 +162,7 @@ impl QueryExecutor for MySqlAdapter {
         )]
         let start = Instant::now();
         let option_file = MySqlOptionFile::create(&target)?;
-        let result = run_mysql_adhoc(&option_file.path, query, &statements, access_mode).await;
+        let result = run_mysql_adhoc(&option_file.path, &statements, access_mode).await;
         drop(option_file);
         let execution = result?;
         let elapsed = start.elapsed().as_millis() as u64;
@@ -205,7 +204,7 @@ impl QueryExecutor for MySqlAdapter {
         )]
         let start = Instant::now();
         let option_file = MySqlOptionFile::create(&target)?;
-        let result = run_mysql_adhoc(&option_file.path, query, &statements, access_mode).await;
+        let result = run_mysql_adhoc(&option_file.path, &statements, access_mode).await;
         drop(option_file);
         let execution = result?;
         let affected_rows = execution

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -157,7 +157,7 @@ pub(super) async fn execute_metadata_query(
     let statements =
         validate_mysql_multi_query(query, target.database.as_deref(), AccessMode::ReadOnly)?;
     let option_file = MySqlOptionFile::create(&target)?;
-    let result = run_mysql_adhoc(&option_file.path, query, &statements, AccessMode::ReadOnly).await;
+    let result = run_mysql_adhoc(&option_file.path, &statements, AccessMode::ReadOnly).await;
     drop(option_file);
     result?.result_set.ok_or_else(|| {
         DbOperationError::MetadataParseFailed(


### PR DESCRIPTION
Implements https://linear.app/sabiql/issue/SAB-447

## Summary

- Retain classified MySQL statements through CLI validation and execution.
- Reuse the canonical persistent schema-change policy.
- Isolate one-statement execution while preserving result, command-tag, refresh-scope, and error behavior.

## Validation

- Focused MySQL policy and CLI process tests
- Oracle MySQL 8.4 integration attempted twice; blocked by local Docker containerd image-store I/O error
- Full CI validation will run on this draft PR
