### PR TITLE
fix(ui): hide inspector loading message

### DIFF
--- a/src/ui/features/browse/inspector.rs
+++ b/src/ui/features/browse/inspector.rs
@@ -116,11 +116,6 @@ impl Inspector {
                 return ViewportPlan::default();
             }
             InspectorLoadState::Loading => {
-                frame.render_widget(
-                    Paragraph::new("Loading inspector...")
-                        .style(Style::default().fg(theme.semantic.status.pending)),
-                    inner,
-                );
                 return ViewportPlan::default();
             }
             InspectorLoadState::Error(error) => {


### PR DESCRIPTION
## Problem
The Inspector pane displays `Loading inspector...` while MySQL table details are loading.

## Approach
Keep the Inspector frame and tab bar rendered, while the loading branch leaves the content area empty and returns the default viewport plan.