### PR TITLE
fix(mysql): fetch database candidates for initial database

### DIFF
--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -87,22 +87,22 @@ pub(super) fn mysql_connection_completion_effects(
         state.ui.table_picker_mut().clear_filter_and_reset();
         state.ui.set_database_picker(true);
         state.modal.set_mode(InputMode::TablePicker);
-        if let (Some(connection_id), Some(server_dsn)) = (
-            state.session.active_connection_id().cloned(),
-            state.session.server_dsn(),
-        ) {
-            effects.push(Effect::FetchMySqlDatabases {
-                connection_id,
-                dsn: server_dsn,
-                connection_generation: state.session.connection_generation(),
-                database_generation: state.session.database_generation(),
-            });
-        }
     } else {
         let run_id = state.session.begin_metadata_refresh();
         effects.push(Effect::FetchMetadata {
             dsn: dsn.to_string(),
             run_id,
+        });
+    }
+    if let (Some(connection_id), Some(server_dsn)) = (
+        state.session.active_connection_id().cloned(),
+        state.session.server_dsn(),
+    ) {
+        effects.push(Effect::FetchMySqlDatabases {
+            connection_id,
+            dsn: server_dsn,
+            connection_generation: state.session.connection_generation(),
+            database_generation: state.session.database_generation(),
         });
     }
     termination_effects(&state.query, effects)

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -920,6 +920,9 @@ mod tests {
                 database_type: DatabaseType::MySQL,
                 database: Some("app".to_string()),
             };
+            let server_dsn = target
+                .server_dsn()
+                .expect("MySQL target should have a server DSN");
             let probe_effects = reduce(&mut state, &Action::SwitchConnection(target.clone()))
                 .expect("switch should start a probe");
             let probe_run_id = probe_effects
@@ -933,7 +936,7 @@ mod tests {
             let effects = reduce(
                 &mut state,
                 &Action::ConnectionProbeCompleted {
-                    target,
+                    target: target.clone(),
                     run_id: probe_run_id,
                 },
             )
@@ -942,6 +945,11 @@ mod tests {
             assert!(effects.iter().any(|effect| matches!(
                 effect,
                 Effect::FetchMetadata { dsn, .. } if dsn == "mysql://user@localhost:3306/app"
+            )));
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchMySqlDatabases { connection_id, dsn, .. }
+                    if connection_id == &target.id && dsn == &server_dsn
             )));
             assert_eq!(state.session.connection_state(), ConnectionState::Connected);
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);


### PR DESCRIPTION
## Problem

MySQL connections configured with an initial database did not load the server database candidates.

## Background

The connection probe completed metadata loading for the selected database but only scheduled database listing when no initial database was configured.

## Approach

Schedule the server-scoped MySQL database listing for every successful MySQL probe. Keep metadata loading for the selected database and the database picker flow unchanged.

## Checks

- `RUSTC_WRAPPER= cargo fmt --all -- --check`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets --no-default-features -- -D warnings`
- `RUSTC_WRAPPER= cargo test -p sabiql-app`
- `RUSTC_WRAPPER= cargo test -p sabiql --no-default-features`
- `./scripts/lint_all.sh`
- `RUSTC_WRAPPER= bash scripts/mysql_integration.sh test` (Oracle MySQL 8.4.10: 27 passed)
- `cargo test --workspace --all-features` (two unrelated existing environment-sensitive failures in `sabiql-infra`)

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-452