### PR TITLE
Fix MySQL connection switch retry state

### DIFF
--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -338,6 +338,16 @@ impl BrowseSession {
         self.pending_connection_probe.as_ref()
     }
 
+    pub fn has_pending_connection_switch(&self) -> bool {
+        let Some(pending) = self.pending_connection_probe.as_ref() else {
+            return false;
+        };
+
+        self.active_connection_id()
+            .is_some_and(|id| id != &pending.id)
+            || self.dsn().is_some_and(|dsn| dsn != pending.dsn)
+    }
+
     pub fn clear_connection_probe(&mut self) {
         self.connection_probe_run.clear_active();
         self.pending_connection_probe = None;

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -20,9 +20,14 @@ pub(super) fn reduce_connection_error(
             DispatchResult::handled()
         }
         Action::CloseConnectionError => {
-            state.connection_error.details_expanded = false;
-            state.connection_error.scroll_offset = 0;
-            state.connection_error.clear_copied_feedback();
+            if state.session.has_pending_connection_switch() {
+                state.session.clear_connection_probe();
+                state.connection_error.clear();
+            } else {
+                state.connection_error.details_expanded = false;
+                state.connection_error.scroll_offset = 0;
+                state.connection_error.clear_copied_feedback();
+            }
             state.modal.set_mode(InputMode::Normal);
             DispatchResult::handled()
         }
@@ -149,12 +154,13 @@ pub(super) fn reduce_connection_error(
 mod tests {
     use super::*;
     use crate::domain::{ConnectionId, DatabaseType};
+    use crate::model::connection::error::ConnectionErrorInfo;
     use crate::model::connection::state::ConnectionState;
     use crate::update::test_fixtures;
 
     mod scroll_down {
         use super::*;
-        use crate::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+        use crate::model::connection::error::ConnectionErrorKind;
 
         fn scroll_down_action() -> Action {
             Action::Scroll {
@@ -266,5 +272,45 @@ mod tests {
                 .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
         );
         assert!(state.session.connection_state().is_connecting());
+    }
+
+    #[test]
+    fn close_after_mysql_switch_failure_clears_failed_probe_context() {
+        let mut state = AppState::new("test".to_string());
+        let current_id = ConnectionId::from_string("mysql-a");
+        let target_id = ConnectionId::from_string("mysql-b");
+        state.session.activate_connection_with_target(
+            &current_id,
+            "mysql-a",
+            DatabaseType::MySQL,
+            "mysql://user@localhost:3306/a?ssl-mode=PREFERRED",
+            Some("a"),
+        );
+        state
+            .session
+            .set_connection_state(ConnectionState::Connected);
+
+        let _ = state.session.begin_connection_probe(
+            &target_id,
+            "mysql-b",
+            DatabaseType::MySQL,
+            "mysql://user@localhost:3306/b?ssl-mode=PREFERRED",
+            Some("b"),
+        );
+        state
+            .connection_error
+            .set_error(ConnectionErrorInfo::new("connection refused"));
+        state.modal.set_mode(InputMode::ConnectionError);
+
+        reduce_connection_error(&mut state, &Action::CloseConnectionError, Instant::now());
+
+        assert!(state.session.pending_connection_probe().is_none());
+        assert!(state.connection_error.error_info().is_none());
+        assert_eq!(state.input_mode(), InputMode::Normal);
+        assert!(state.session.connection_state().is_connected());
+        assert_eq!(
+            state.session.dsn(),
+            Some("mysql://user@localhost:3306/a?ssl-mode=PREFERRED")
+        );
     }
 }

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -71,7 +71,9 @@ pub(super) fn reduce_connection_error(
             DispatchResult::handled()
         }
         Action::ReenterConnectionSetup => {
-            if !state.session.can_reenter_connection_setup() {
+            if state.session.has_pending_connection_switch()
+                || !state.session.can_reenter_connection_setup()
+            {
                 return DispatchResult::handled();
             }
             state.connection_error.clear();
@@ -307,6 +309,51 @@ mod tests {
         assert!(state.session.pending_connection_probe().is_none());
         assert!(state.connection_error.error_info().is_none());
         assert_eq!(state.input_mode(), InputMode::Normal);
+        assert!(state.session.connection_state().is_connected());
+        assert_eq!(
+            state.session.dsn(),
+            Some("mysql://user@localhost:3306/a?ssl-mode=PREFERRED")
+        );
+    }
+
+    #[test]
+    fn reenter_after_mysql_switch_failure_preserves_active_connection() {
+        let mut state = AppState::new("test".to_string());
+        let current_id = ConnectionId::from_string("mysql-a");
+        let target_id = ConnectionId::from_string("mysql-b");
+        state.session.activate_connection_with_target(
+            &current_id,
+            "mysql-a",
+            DatabaseType::MySQL,
+            "mysql://user@localhost:3306/a?ssl-mode=PREFERRED",
+            Some("a"),
+        );
+        state
+            .session
+            .set_connection_state(ConnectionState::Connected);
+
+        let _ = state.session.begin_connection_probe(
+            &target_id,
+            "mysql-b",
+            DatabaseType::MySQL,
+            "mysql://user@localhost:3306/b?ssl-mode=PREFERRED",
+            Some("b"),
+        );
+        state
+            .connection_error
+            .set_error(ConnectionErrorInfo::new("connection refused"));
+        state.modal.set_mode(InputMode::ConnectionError);
+
+        reduce_connection_error(&mut state, &Action::ReenterConnectionSetup, Instant::now());
+
+        assert_eq!(state.input_mode(), InputMode::ConnectionError);
+        assert_eq!(
+            state
+                .session
+                .pending_connection_probe()
+                .map(|pending| &pending.id),
+            Some(&target_id)
+        );
         assert!(state.session.connection_state().is_connected());
         assert_eq!(
             state.session.dsn(),

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -67,6 +67,7 @@ pub fn reduce_connection_lifecycle(
         }
 
         Action::SwitchConnection(target) => {
+            state.connection_error.clear();
             let ConnectionTarget {
                 id,
                 dsn,
@@ -1403,6 +1404,90 @@ mod tests {
             assert_eq!(retry_target.dsn, target.dsn);
             assert_eq!(retry_target.id, target.id);
             assert_ne!(retry_run_id, first_run_id);
+        }
+
+        #[test]
+        fn switching_after_mysql_probe_failure_replaces_error_and_retry_target() {
+            let mut state = AppState::new("test".to_string());
+            let current_id = ConnectionId::from_string("mysql-a");
+            state.session.activate_connection_with_target(
+                &current_id,
+                "mysql-a",
+                DatabaseType::MySQL,
+                "mysql://user@localhost:3306/a?ssl-mode=PREFERRED",
+                Some("a"),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+
+            let failed_target = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+            let failed_effects =
+                reduce(&mut state, &Action::SwitchConnection(failed_target.clone())).unwrap();
+            let failed_run_id = failed_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: failed_target,
+                    run_id: failed_run_id,
+                    error: DbOperationError::ConnectionFailed("refused".to_string()),
+                },
+            );
+
+            let retry_target = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-c"),
+                dsn: "mysql://user@localhost:3306/c?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-c".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("c".to_string()),
+            };
+            let retry_effects =
+                reduce(&mut state, &Action::SwitchConnection(retry_target.clone())).unwrap();
+            let retry_run_id = retry_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .unwrap();
+            assert!(state.connection_error.error_info().is_none());
+
+            reduce(
+                &mut state,
+                &Action::ConnectionProbeFailed {
+                    target: retry_target.clone(),
+                    run_id: retry_run_id,
+                    error: DbOperationError::ConnectionFailed("refused again".to_string()),
+                },
+            );
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+            let actual_target = retry_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeConnection { target, .. } => Some(target),
+                    _ => None,
+                })
+                .unwrap();
+            assert_eq!(actual_target.id, retry_target.id);
+            assert_eq!(actual_target.dsn, retry_target.dsn);
         }
 
         #[test]

--- a/src/ui/features/connections/error.rs
+++ b/src/ui/features/connections/error.rs
@@ -172,12 +172,14 @@ impl ConnectionError {
             Style::default().fg(theme.semantic.text.muted),
         )];
 
-        if state.session.can_reenter_connection_setup() {
-            spans.push(key_chip("e", theme));
-            spans.push(Span::raw(" Re-enter  "));
-        } else {
+        if state.session.has_pending_connection_switch()
+            || !state.session.can_reenter_connection_setup()
+        {
             spans.push(key_chip("r", theme));
             spans.push(Span::raw(" Retry  "));
+        } else {
+            spans.push(key_chip("e", theme));
+            spans.push(Span::raw(" Re-enter  "));
         }
 
         spans.extend([

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -291,10 +291,12 @@ impl Footer {
                 hints
             }
             InputMode::ConnectionError => {
-                let first = if state.session.can_reenter_connection_setup() {
-                    connection_error::EDIT.as_hint()
-                } else {
+                let first = if state.session.has_pending_connection_switch()
+                    || !state.session.can_reenter_connection_setup()
+                {
                     connection_error::RETRY.as_hint()
+                } else {
+                    connection_error::EDIT.as_hint()
                 };
                 vec![
                     first,


### PR DESCRIPTION
## Problem

A failed MySQL connection switch left the error and retry state associated with the wrong connection while the failed probe remained pending.

## Approach

Keep the active connection intact, show Retry for the pending switch target, and clear the failed probe context when the switch error is closed. Existing re-entry behavior remains unchanged.

## Validation

- `cargo fmt --all -- --check`
- App, UI, and root package tests
- Workspace clippy with and without default features
- `bash scripts/lint_all.sh`
- `scripts/mysql_integration.sh test` against Oracle MySQL 8.4.10
- `cargo nextest` CI profiles, including 185 no-default-feature tests passing

The full all-features workspace nextest run also exposed three existing export-cleanup failures in unrelated infrastructure tests.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-450
