### PR TITLE
fix(mysql): reject multiple-table mutations

### DIFF
--- a/src/app/policy/sql/mysql_statement.rs
+++ b/src/app/policy/sql/mysql_statement.rs
@@ -290,6 +290,7 @@ mod tests {
             "UPDATE items SET value = (SELECT MAX(value) FROM prices JOIN currencies ON prices.currency_id = currencies.id) WHERE id = 1",
             "DELETE FROM items WHERE id IN (SELECT item_id FROM prices JOIN currencies ON prices.currency_id = currencies.id)",
             "UPDATE items PARTITION (p0, p1) SET value = 1 WHERE id = 1",
+            "UPDATE items USE INDEX FOR JOIN (idx_items) SET value = 1 WHERE id = 1",
             "DELETE FROM items PARTITION (p0, p1) WHERE id = 1",
         ] {
             assert!(classify_mysql_statement(sql).is_ok(), "{sql}");

--- a/src/app/policy/sql/mysql_statement.rs
+++ b/src/app/policy/sql/mysql_statement.rs
@@ -271,6 +271,32 @@ mod tests {
     }
 
     #[test]
+    fn rejects_multiple_table_update_and_delete_statements() {
+        for sql in [
+            "UPDATE items, prices SET items.price = prices.price WHERE items.id = prices.id",
+            "UPDATE items JOIN prices ON items.id = prices.id SET items.price = prices.price",
+            "DELETE items, prices FROM items JOIN prices ON items.id = prices.id",
+            "DELETE FROM items, prices USING items JOIN prices ON items.id = prices.id",
+            "DELETE items FROM items JOIN prices ON items.id = prices.id",
+        ] {
+            let error = classify_mysql_statement(sql).unwrap_err();
+            assert!(error.0.contains("multiple-table"), "{sql}: {error}");
+        }
+    }
+
+    #[test]
+    fn allows_single_table_mutations_with_nested_table_references() {
+        for sql in [
+            "UPDATE items SET value = (SELECT MAX(value) FROM prices JOIN currencies ON prices.currency_id = currencies.id) WHERE id = 1",
+            "DELETE FROM items WHERE id IN (SELECT item_id FROM prices JOIN currencies ON prices.currency_id = currencies.id)",
+            "UPDATE items PARTITION (p0, p1) SET value = 1 WHERE id = 1",
+            "DELETE FROM items PARTITION (p0, p1) WHERE id = 1",
+        ] {
+            assert!(classify_mysql_statement(sql).is_ok(), "{sql}");
+        }
+    }
+
+    #[test]
     fn rejects_executable_inline_control_statement() {
         assert!(
             classify_mysql_statement("SELECT 1 /*!80000 SET sql_mode='ANSI_QUOTES' */").is_err()

--- a/src/app/policy/sql/mysql_statement/classifier.rs
+++ b/src/app/policy/sql/mysql_statement/classifier.rs
@@ -1,4 +1,8 @@
-use super::{MysqlLexError, MysqlStatementKind, lexer::Token, target, transaction};
+use super::{
+    MysqlLexError, MysqlStatementKind,
+    lexer::{Token, TokenKind},
+    target, transaction,
+};
 
 type MysqlClassification = (MysqlStatementKind, Option<String>, Option<String>);
 
@@ -54,9 +58,16 @@ fn classify_mysql_crud_statement(
             Ok((kind, target, database))
         }
         "UPDATE" => {
-            let has_where = target::top_level_word(&tokens[start..], "WHERE");
             let target_index =
                 target::skip_mysql_modifiers(tokens, start + 1, &["LOW_PRIORITY", "IGNORE"]);
+            let set_index = target::find_word(tokens, "SET", target_index)
+                .ok_or_else(|| MysqlLexError("MySQL UPDATE target is ambiguous".to_string()))?;
+            if has_multi_table_reference(tokens, target_index, set_index) {
+                return Err(MysqlLexError(
+                    "MySQL multiple-table UPDATE statements are not supported".to_string(),
+                ));
+            }
+            let has_where = target::top_level_word(&tokens[start..], "WHERE");
             let (target, database) = target::target_after(tokens, target_index)?;
             Ok((MysqlStatementKind::Update { has_where }, target, database))
         }
@@ -67,16 +78,51 @@ fn classify_mysql_crud_statement(
                 start + 1,
                 &["LOW_PRIORITY", "QUICK", "IGNORE"],
             );
-            let target_index = if target::word(tokens, index) == Some("FROM") {
-                index + 1
-            } else {
-                index
-            };
+            if target::word(tokens, index) != Some("FROM") {
+                return Err(MysqlLexError(
+                    "MySQL multiple-table DELETE statements are not supported".to_string(),
+                ));
+            }
+            let target_index = index + 1;
+            let where_index =
+                target::find_word(tokens, "WHERE", target_index).unwrap_or(tokens.len());
+            if has_multi_table_reference(tokens, target_index, where_index)
+                || has_top_level_word(tokens, "USING", target_index, where_index)
+            {
+                return Err(MysqlLexError(
+                    "MySQL multiple-table DELETE statements are not supported".to_string(),
+                ));
+            }
             let (target, database) = target::target_after(tokens, target_index)?;
             Ok((MysqlStatementKind::Delete { has_where }, target, database))
         }
         _ => unreachable!("not a MySQL CRUD statement: {first}"),
     }
+}
+
+fn has_multi_table_reference(tokens: &[Token], start: usize, end: usize) -> bool {
+    tokens
+        .iter()
+        .skip(start)
+        .take(end.saturating_sub(start))
+        .any(|token| {
+            token.depth == 0
+                && match &token.kind {
+                    TokenKind::Symbol(',') => true,
+                    TokenKind::Word(word) => matches!(word.as_str(), "JOIN" | "STRAIGHT_JOIN"),
+                    _ => false,
+                }
+        })
+}
+
+fn has_top_level_word(tokens: &[Token], expected: &str, start: usize, end: usize) -> bool {
+    tokens
+        .iter()
+        .skip(start)
+        .take(end.saturating_sub(start))
+        .any(|token| {
+            token.depth == 0 && matches!(&token.kind, TokenKind::Word(word) if word == expected)
+        })
 }
 
 fn classify_mysql_ddl_statement(

--- a/src/app/policy/sql/mysql_statement/classifier.rs
+++ b/src/app/policy/sql/mysql_statement/classifier.rs
@@ -103,16 +103,26 @@ fn classify_mysql_crud_statement(
 fn has_multi_table_reference(tokens: &[Token], start: usize, end: usize) -> bool {
     tokens
         .iter()
+        .enumerate()
         .skip(start)
         .take(end.saturating_sub(start))
-        .any(|token| {
+        .any(|(index, token)| {
             token.depth == 0
                 && match &token.kind {
                     TokenKind::Symbol(',') => true,
-                    TokenKind::Word(word) => matches!(word.as_str(), "JOIN" | "STRAIGHT_JOIN"),
+                    TokenKind::Word(word) => {
+                        matches!(word.as_str(), "JOIN" | "STRAIGHT_JOIN")
+                            && !is_mysql_index_hint_join(tokens, index)
+                    }
                     _ => false,
                 }
         })
+}
+
+fn is_mysql_index_hint_join(tokens: &[Token], index: usize) -> bool {
+    index >= 2
+        && target::word(tokens, index - 1) == Some("FOR")
+        && matches!(target::word(tokens, index - 2), Some("INDEX" | "KEY"))
 }
 
 fn has_top_level_word(tokens: &[Token], expected: &str, start: usize, end: usize) -> bool {

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -243,6 +243,22 @@ mod mysql_tests {
     }
 
     #[test]
+    fn rejects_multiple_table_update_and_delete_before_execution() {
+        for sql in [
+            "UPDATE items, prices SET items.price = prices.price WHERE items.id = prices.id",
+            "UPDATE items JOIN prices ON items.id = prices.id SET items.price = prices.price",
+            "DELETE items, prices FROM items JOIN prices ON items.id = prices.id",
+            "DELETE FROM items, prices USING items JOIN prices ON items.id = prices.id",
+            "DELETE items FROM items JOIN prices ON items.id = prices.id",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Block { ref reason } if reason.contains("multiple-table")),
+                "{sql}"
+            );
+        }
+    }
+
+    #[test]
     fn ddl_rejects_a_different_database() {
         assert!(matches!(
             evaluate_multi_statement_for_database_with_context(

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1343,6 +1343,94 @@ async fn executes_multiple_statements_and_returns_only_the_last_result() {
 
 #[tokio::test]
 #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn rejects_multiple_table_update_and_delete_before_mysql_cli_execution() {
+    with_mysql_test_db(|db| Box::pin(async move {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|error| format!("system clock error: {error}"))?
+            .as_nanos();
+        let target_table = format!("mysql_sab451_target_{suffix}");
+        let source_table = format!("mysql_sab451_source_{suffix}");
+        let result = async {
+            db.adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "CREATE TABLE {target_table} (id INT PRIMARY KEY, value INT); CREATE TABLE {source_table} (id INT PRIMARY KEY, value INT); INSERT INTO {target_table} VALUES (1, 1); INSERT INTO {source_table} VALUES (1, 2)"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to create multi-table fixtures: {error:?}"))?;
+
+            for query in [
+                format!(
+                    "UPDATE {target_table} AS target JOIN {source_table} AS source ON target.id = source.id SET target.value = source.value"
+                ),
+                format!(
+                    "DELETE target FROM {target_table} AS target JOIN {source_table} AS source ON target.id = source.id"
+                ),
+            ] {
+                let result = db
+                    .adapter()
+                    .execute_adhoc(db.dsn(), &query, AccessMode::ReadWrite)
+                    .await;
+                if !matches!(
+                    result,
+                    Err(DbOperationError::UnsupportedOperation(ref details))
+                        if details.contains("multiple-table")
+                ) {
+                    return Err(format!(
+                        "multiple-table mutation was not rejected safely: {query}: {result:?}"
+                    ));
+                }
+            }
+
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("SELECT value FROM {target_table} WHERE id = 1"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to verify multi-table fixture: {error:?}"))?;
+            if result.values() != [[QueryValue::Text("1".to_string())]] {
+                return Err(format!(
+                    "multi-table mutation changed the fixture: {result:?}"
+                ));
+            }
+            Ok::<(), String>(())
+        }
+        .await;
+        let cleanup = async {
+            for table in [&target_table, &source_table] {
+                db.adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!("DROP TABLE IF EXISTS {table}"),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| {
+                        format!("failed to clean up multi-table fixture {table}: {error:?}")
+                    })?;
+            }
+            Ok::<(), String>(())
+        };
+        match result {
+            Err(error) => {
+                cleanup.await?;
+                Err(error)
+            }
+            Ok(()) => cleanup.await,
+        }
+    }))
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
 async fn keeps_refresh_scope_and_discards_partial_result_after_a_later_failure() {
     with_mysql_test_db(|db| Box::pin(async move {
         let result = async {


### PR DESCRIPTION
## Summary

Reject MySQL multiple-table UPDATE and DELETE statements before mysql CLI execution while preserving supported single-table mutations.

## Validation

- Oracle MySQL 8.4 integration: 28 passed
- workspace tests and no-default-features tests passed
- clippy, lint, and release builds passed