### PR TITLE
fix(mysql): classify connection failures with typed errors

### DIFF
--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -1,8 +1,7 @@
 use crate::policy::password_masking::mask_password;
 use crate::ports::outbound::{
-    DatabaseCli, DbOperationError, MYSQL_CLI_VERSION_REQUIRED_MARKER, MYSQL_CONNECT_TIMEOUT_ERRNOS,
-    MYSQL_SERVER_VERSION_REQUIRED_MARKER, MYSQL_SQL_MODE_UNSUPPORTED_MARKER,
-    SQLITE_SAFE_MODE_REQUIRED_MARKER, SQLITE_TABLE_LIST_REQUIRED_MARKER,
+    ConnectionFailureKind, DatabaseCli, DbOperationError, MYSQL_CONNECT_TIMEOUT_ERRNOS,
+    SQLITE_SAFE_MODE_REQUIRED_MARKER, SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind,
 };
 use sabiql_domain::connection::MySqlSslMode;
 use url::Url;
@@ -184,6 +183,13 @@ impl ConnectionErrorKind {
             Self::Unknown => "See details for more information",
         }
     }
+
+    pub const fn is_retryable(self) -> bool {
+        matches!(
+            self,
+            Self::HostUnreachable | Self::ConnectionLost | Self::Timeout | Self::ConnectionRefused
+        )
+    }
 }
 
 fn is_mysql_connect_timeout_message(value: &str) -> bool {
@@ -223,12 +229,6 @@ fn is_mysql_ca_verification_error(value: &str) -> bool {
         || value.contains("self-signed certificate")
         || value.contains("unknown ca")
         || value.contains("certificate signature failure")
-}
-
-fn is_mysql_ambiguous_certificate_verification_error(value: &str) -> bool {
-    value
-        .to_ascii_lowercase()
-        .contains("error:0a000086:ssl routines::certificate verify failed")
 }
 
 fn mysql_ssl_mode_from_dsn(dsn: &str) -> Option<MySqlSslMode> {
@@ -302,27 +302,38 @@ impl ConnectionErrorInfo {
             DbOperationError::CommandNotFound { .. } => ConnectionErrorKind::CliNotFound,
             DbOperationError::ConnectionLost(_) => ConnectionErrorKind::ConnectionLost,
             DbOperationError::Timeout(_) => ConnectionErrorKind::Timeout,
-            DbOperationError::UnsupportedOperation(details)
-                if details.contains(MYSQL_CLI_VERSION_REQUIRED_MARKER) =>
-            {
-                ConnectionErrorKind::MySqlCliVersionUnsupported
-            }
-            DbOperationError::UnsupportedOperation(details)
-                if details.contains(MYSQL_SERVER_VERSION_REQUIRED_MARKER) =>
-            {
-                ConnectionErrorKind::MySqlServerVersionUnsupported
-            }
-            DbOperationError::UnsupportedOperation(details)
-                if details.contains(MYSQL_SQL_MODE_UNSUPPORTED_MARKER) =>
-            {
-                ConnectionErrorKind::MySqlSqlModeUnsupported
-            }
+            DbOperationError::UnsupportedOperationWithKind { kind, .. } => match kind {
+                UnsupportedOperationKind::ClientVersion => {
+                    ConnectionErrorKind::MySqlCliVersionUnsupported
+                }
+                UnsupportedOperationKind::ServerVersion => {
+                    ConnectionErrorKind::MySqlServerVersionUnsupported
+                }
+                UnsupportedOperationKind::SessionMode => {
+                    ConnectionErrorKind::MySqlSqlModeUnsupported
+                }
+            },
             DbOperationError::UnsupportedOperation(details)
                 if details.contains(SQLITE_TABLE_LIST_REQUIRED_MARKER)
                     || details.contains(SQLITE_SAFE_MODE_REQUIRED_MARKER) =>
             {
                 ConnectionErrorKind::SqliteVersionTooOld
             }
+            DbOperationError::ConnectionFailedWithKind { kind, .. } => match kind {
+                ConnectionFailureKind::TlsHandshake
+                | ConnectionFailureKind::TlsCertificateVerification => {
+                    ConnectionErrorKind::MySqlTlsHandshakeFailed
+                }
+                ConnectionFailureKind::TlsCaVerification => {
+                    ConnectionErrorKind::MySqlCaVerificationFailed
+                }
+                ConnectionFailureKind::TlsHostnameVerification => {
+                    ConnectionErrorKind::MySqlHostnameVerificationFailed
+                }
+                ConnectionFailureKind::TlsClientCertificateRejected => {
+                    ConnectionErrorKind::MySqlClientCertificateRejected
+                }
+            },
             DbOperationError::ConnectionFailed(details) => {
                 classify_sqlite_path_connection_error(details)
                     .unwrap_or_else(|| ConnectionErrorKind::classify(&raw_details))
@@ -336,16 +347,20 @@ impl ConnectionErrorInfo {
         let raw_details = error.raw_details().into_owned();
         let kind = mysql_ssl_mode_from_dsn(dsn)
             .and_then(|ssl_mode| match (ssl_mode, error) {
-                (MySqlSslMode::VerifyCa, DbOperationError::ConnectionFailed(_))
-                    if is_mysql_ambiguous_certificate_verification_error(&raw_details) =>
-                {
-                    Some(ConnectionErrorKind::MySqlCaVerificationFailed)
-                }
-                (MySqlSslMode::VerifyIdentity, DbOperationError::ConnectionFailed(_))
-                    if is_mysql_ambiguous_certificate_verification_error(&raw_details) =>
-                {
-                    Some(ConnectionErrorKind::MySqlHostnameVerificationFailed)
-                }
+                (
+                    MySqlSslMode::VerifyCa,
+                    DbOperationError::ConnectionFailedWithKind {
+                        kind: ConnectionFailureKind::TlsCertificateVerification,
+                        ..
+                    },
+                ) => Some(ConnectionErrorKind::MySqlCaVerificationFailed),
+                (
+                    MySqlSslMode::VerifyIdentity,
+                    DbOperationError::ConnectionFailedWithKind {
+                        kind: ConnectionFailureKind::TlsCertificateVerification,
+                        ..
+                    },
+                ) => Some(ConnectionErrorKind::MySqlHostnameVerificationFailed),
                 _ => None,
             })
             .unwrap_or_else(|| Self::from_db_operation_error(error).kind);
@@ -363,6 +378,19 @@ impl ConnectionErrorInfo {
 
     pub fn masked_details(&self) -> &str {
         &self.masked_details
+    }
+
+    pub fn user_message(&self) -> String {
+        let details = self.masked_details.trim();
+        if details.is_empty() {
+            format!("{}. {}.", self.summary(), self.hint())
+        } else {
+            format!("{}: {}. {}.", self.summary(), details, self.hint())
+        }
+    }
+
+    pub const fn is_retryable(&self) -> bool {
+        self.kind.is_retryable()
     }
 }
 
@@ -585,10 +613,10 @@ mod tests {
 
         #[test]
         fn from_db_operation_error_with_dsn_uses_mysql_tls_mode_for_ambiguous_verification() {
-            let error = DbOperationError::ConnectionFailed(
-                "ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed"
-                    .to_string(),
-            );
+            let error = DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::TlsCertificateVerification,
+                details: "certificate verification failed".to_string(),
+            };
             let ca = ConnectionErrorInfo::from_db_operation_error_with_dsn(
                 &error,
                 "mysql://user:password@localhost:3306/app?ssl-mode=VERIFY_CA",
@@ -661,25 +689,87 @@ mod tests {
 
         #[rstest]
         #[case(
-            MYSQL_CLI_VERSION_REQUIRED_MARKER,
+            UnsupportedOperationKind::ClientVersion,
             ConnectionErrorKind::MySqlCliVersionUnsupported
         )]
         #[case(
-            MYSQL_SERVER_VERSION_REQUIRED_MARKER,
+            UnsupportedOperationKind::ServerVersion,
             ConnectionErrorKind::MySqlServerVersionUnsupported
         )]
         #[case(
-            MYSQL_SQL_MODE_UNSUPPORTED_MARKER,
+            UnsupportedOperationKind::SessionMode,
             ConnectionErrorKind::MySqlSqlModeUnsupported
         )]
         fn from_db_operation_error_classifies_mysql_requirements(
-            #[case] marker: &str,
+            #[case] kind: UnsupportedOperationKind,
             #[case] expected_kind: ConnectionErrorKind,
         ) {
             let info = ConnectionErrorInfo::from_db_operation_error(
-                &DbOperationError::UnsupportedOperation(marker.to_string()),
+                &DbOperationError::UnsupportedOperationWithKind {
+                    kind,
+                    details: "provider details".to_string(),
+                },
             );
+
+            assert_eq!(info.summary(), expected_kind.summary());
+            assert_eq!(info.hint(), expected_kind.hint());
+            assert_eq!(
+                info.user_message(),
+                format!("{}: provider details. {}.", info.summary(), info.hint())
+            );
+            assert!(!info.is_retryable());
             assert_eq!(info.kind, expected_kind);
+        }
+
+        #[rstest]
+        #[case(
+            ConnectionFailureKind::TlsHandshake,
+            ConnectionErrorKind::MySqlTlsHandshakeFailed
+        )]
+        #[case(
+            ConnectionFailureKind::TlsCaVerification,
+            ConnectionErrorKind::MySqlCaVerificationFailed
+        )]
+        #[case(
+            ConnectionFailureKind::TlsHostnameVerification,
+            ConnectionErrorKind::MySqlHostnameVerificationFailed
+        )]
+        #[case(
+            ConnectionFailureKind::TlsClientCertificateRejected,
+            ConnectionErrorKind::MySqlClientCertificateRejected
+        )]
+        fn from_db_operation_error_classifies_typed_mysql_tls(
+            #[case] kind: ConnectionFailureKind,
+            #[case] expected_kind: ConnectionErrorKind,
+        ) {
+            let info = ConnectionErrorInfo::from_db_operation_error(
+                &DbOperationError::ConnectionFailedWithKind {
+                    kind,
+                    details: "tls details".to_string(),
+                },
+            );
+
+            assert_eq!(info.kind, expected_kind);
+            assert_eq!(info.summary(), expected_kind.summary());
+            assert_eq!(info.hint(), expected_kind.hint());
+            assert_eq!(
+                info.user_message(),
+                format!("{}: tls details. {}.", info.summary(), info.hint())
+            );
+            assert!(!info.is_retryable());
+        }
+
+        #[test]
+        fn unknown_connection_error_fails_closed_without_leaking_details() {
+            let info =
+                ConnectionErrorInfo::from_db_operation_error(&DbOperationError::ConnectionFailed(
+                    "password=secret unexpected provider failure".to_string(),
+                ));
+
+            assert_eq!(info.kind, ConnectionErrorKind::Unknown);
+            assert!(!info.masked_details().contains("secret"));
+            assert!(!info.user_message().contains("secret"));
+            assert!(!info.is_retryable());
         }
 
         #[rstest]

--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -65,22 +65,6 @@ impl ConnectionErrorKind {
             return Self::AuthFailed;
         }
 
-        if is_mysql_client_certificate_error(&stderr_lower) {
-            return Self::MySqlClientCertificateRejected;
-        }
-
-        if is_mysql_hostname_verification_error(&stderr_lower) {
-            return Self::MySqlHostnameVerificationFailed;
-        }
-
-        if is_mysql_ca_verification_error(&stderr_lower) {
-            return Self::MySqlCaVerificationFailed;
-        }
-
-        if is_mysql_tls_handshake_error(&stderr_lower) {
-            return Self::MySqlTlsHandshakeFailed;
-        }
-
         if stderr_lower.contains("does not exist")
             && (stderr_lower.contains("database") || stderr_lower.contains("fatal:"))
         {
@@ -199,38 +183,6 @@ fn is_mysql_connect_timeout_message(value: &str) -> bool {
             .any(|errno| value.contains(errno))
 }
 
-fn is_mysql_client_certificate_error(value: &str) -> bool {
-    (value.contains("certificate")
-        && (value.contains("certificate required")
-            || value.contains("client certificate")
-            || value.contains("peer did not return a certificate")
-            || value.contains("bad certificate")))
-        || value.contains("tlsv1 alert certificate required")
-}
-
-fn is_mysql_hostname_verification_error(value: &str) -> bool {
-    value.contains("hostname mismatch")
-        || value.contains("host name mismatch")
-        || value.contains("hostname does not match")
-        || value.contains("host name does not match")
-        || value.contains("hostname verification failed")
-        || value.contains("host name verification failed")
-        || value.contains("certificate name mismatch")
-        || value.contains("certificate does not match")
-        || value.contains("does not match certificate")
-        || value.contains("not valid for the requested host")
-        || value.contains("not valid for hostname")
-        || value.contains("subject alternative name")
-        || (value.contains("verify identity") && value.contains("certificate"))
-}
-
-fn is_mysql_ca_verification_error(value: &str) -> bool {
-    value.contains("unable to get local issuer")
-        || value.contains("self-signed certificate")
-        || value.contains("unknown ca")
-        || value.contains("certificate signature failure")
-}
-
 fn mysql_ssl_mode_from_dsn(dsn: &str) -> Option<MySqlSslMode> {
     let url = Url::parse(dsn).ok()?;
     if url.scheme() != "mysql" {
@@ -249,15 +201,6 @@ fn mysql_ssl_mode_from_dsn(dsn: &str) -> Option<MySqlSslMode> {
             _ => return None,
         })
     })
-}
-
-fn is_mysql_tls_handshake_error(value: &str) -> bool {
-    value.contains("tls/ssl error")
-        || value.contains("ssl handshake")
-        || value.contains("tls handshake")
-        || value.contains("handshake failure")
-        || value.contains("ssl connection error")
-        || value.contains("tlsv1 alert")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -505,46 +448,6 @@ mod tests {
                 ConnectionErrorKind::Timeout
             );
         }
-
-        #[test]
-        fn stderr_as_mysql_tls_error() {
-            assert_eq!(
-                ConnectionErrorKind::classify(
-                    "ERROR 2026 (HY000): TLS/SSL error: certificate verify failed: hostname mismatch"
-                ),
-                ConnectionErrorKind::MySqlHostnameVerificationFailed
-            );
-            assert_eq!(
-                ConnectionErrorKind::classify(
-                    "ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed"
-                ),
-                ConnectionErrorKind::MySqlTlsHandshakeFailed
-            );
-            assert_eq!(
-                ConnectionErrorKind::classify(
-                    "ERROR 2026 (HY000): TLS/SSL error: Certificate validation failure: host name does not match certificate"
-                ),
-                ConnectionErrorKind::MySqlHostnameVerificationFailed
-            );
-            assert_eq!(
-                ConnectionErrorKind::classify(
-                    "ERROR 2026 (HY000): TLS/SSL error: unable to get local issuer certificate"
-                ),
-                ConnectionErrorKind::MySqlCaVerificationFailed
-            );
-            assert_eq!(
-                ConnectionErrorKind::classify(
-                    "ERROR 2026 (HY000): TLS/SSL error: peer did not return a certificate"
-                ),
-                ConnectionErrorKind::MySqlClientCertificateRejected
-            );
-            assert_eq!(
-                ConnectionErrorKind::classify(
-                    "ERROR 2026 (HY000): TLS/SSL error: handshake failure"
-                ),
-                ConnectionErrorKind::MySqlTlsHandshakeFailed
-            );
-        }
     }
 
     mod error_kind {
@@ -763,7 +666,7 @@ mod tests {
         fn unknown_connection_error_fails_closed_without_leaking_details() {
             let info =
                 ConnectionErrorInfo::from_db_operation_error(&DbOperationError::ConnectionFailed(
-                    "password=secret unexpected provider failure".to_string(),
+                    "hostname mismatch password=secret unexpected provider failure".to_string(),
                 ));
 
             assert_eq!(info.kind, ConnectionErrorKind::Unknown);

--- a/src/app/model/connection/error_state.rs
+++ b/src/app/model/connection/error_state.rs
@@ -28,6 +28,12 @@ impl ConnectionErrorState {
         self.error_info.is_some()
     }
 
+    pub fn can_retry(&self) -> bool {
+        self.error_info
+            .as_ref()
+            .is_some_and(ConnectionErrorInfo::is_retryable)
+    }
+
     pub fn details_expanded(&self) -> bool {
         self.details_expanded
     }
@@ -135,6 +141,16 @@ mod tests {
             assert!(!state.details_expanded());
             assert_eq!(state.scroll_offset(), 0);
             assert!(!state.is_copied_visible_at(now()));
+        }
+
+        #[test]
+        fn can_retry_follows_the_classified_error() {
+            let mut state = ConnectionErrorState::default();
+            assert!(!state.can_retry());
+
+            state.set_error(sample_error());
+
+            assert!(state.can_retry());
         }
     }
 

--- a/src/app/ports/outbound/db_operation_error.rs
+++ b/src/app/ports/outbound/db_operation_error.rs
@@ -7,9 +7,6 @@ use crate::policy::password_masking::mask_password;
 
 pub const SQLITE_TABLE_LIST_REQUIRED_MARKER: &str = "SQLITE_TABLE_LIST_REQUIRED";
 pub const SQLITE_SAFE_MODE_REQUIRED_MARKER: &str = "SQLITE_SAFE_MODE_REQUIRED";
-pub const MYSQL_CLI_VERSION_REQUIRED_MARKER: &str = "MYSQL_CLI_VERSION_REQUIRED";
-pub const MYSQL_SERVER_VERSION_REQUIRED_MARKER: &str = "MYSQL_SERVER_VERSION_REQUIRED";
-pub const MYSQL_SQL_MODE_UNSUPPORTED_MARKER: &str = "MYSQL_SQL_MODE_UNSUPPORTED";
 pub const MYSQL_CONNECT_TIMEOUT_ERRNOS: &[&str] = &["(60)", "(110)", "(10060)"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,6 +32,22 @@ impl DatabaseCli {
             Self::MySql => "Install the Oracle MySQL 8.4 client and add it to PATH",
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsupportedOperationKind {
+    ClientVersion,
+    ServerVersion,
+    SessionMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionFailureKind {
+    TlsHandshake,
+    TlsCaVerification,
+    TlsHostnameVerification,
+    TlsClientCertificateRejected,
+    TlsCertificateVerification,
 }
 
 #[derive(Clone, thiserror::Error)]
@@ -64,6 +77,16 @@ pub enum DbOperationError {
     },
     #[error("Unsupported operation")]
     UnsupportedOperation(String),
+    #[error("Unsupported operation")]
+    UnsupportedOperationWithKind {
+        kind: UnsupportedOperationKind,
+        details: String,
+    },
+    #[error("Connection failed")]
+    ConnectionFailedWithKind {
+        kind: ConnectionFailureKind,
+        details: String,
+    },
     #[error("Metadata parse failed")]
     MetadataParseFailed(String),
     #[error("Invalid JSON")]
@@ -98,6 +121,24 @@ impl DbOperationError {
             Self::QueryFailed(_) => "Query failed",
             Self::QueryFailedAfterChange { source, .. } => source.summary(),
             Self::UnsupportedOperation(_) => "Unsupported operation",
+            Self::UnsupportedOperationWithKind { kind, .. } => match kind {
+                UnsupportedOperationKind::ClientVersion => "Unsupported MySQL CLI version",
+                UnsupportedOperationKind::ServerVersion => "Unsupported MySQL server version",
+                UnsupportedOperationKind::SessionMode => "Unsupported MySQL sql_mode",
+            },
+            Self::ConnectionFailedWithKind { kind, .. } => match kind {
+                ConnectionFailureKind::TlsHandshake
+                | ConnectionFailureKind::TlsCertificateVerification => "MySQL TLS handshake failed",
+                ConnectionFailureKind::TlsCaVerification => {
+                    "MySQL server certificate could not be verified"
+                }
+                ConnectionFailureKind::TlsHostnameVerification => {
+                    "MySQL server hostname could not be verified"
+                }
+                ConnectionFailureKind::TlsClientCertificateRejected => {
+                    "MySQL client certificate was rejected"
+                }
+            },
             Self::MetadataParseFailed(_) => "Failed to parse database metadata output",
             Self::InvalidJson(_) => "Failed to parse database JSON output",
             Self::EmptyResponse(_) => "Database returned an empty response",
@@ -125,6 +166,28 @@ impl DbOperationError {
             Self::QueryFailed(_) => "Review the database error details and SQL",
             Self::QueryFailedAfterChange { source, .. } => source.hint(),
             Self::UnsupportedOperation(_) => "Use a supported operation for this database",
+            Self::UnsupportedOperationWithKind { kind, .. } => match kind {
+                UnsupportedOperationKind::ClientVersion => "Install the Oracle MySQL 8.4 client",
+                UnsupportedOperationKind::ServerVersion => "Connect to an Oracle MySQL 8.4 server",
+                UnsupportedOperationKind::SessionMode => {
+                    "Disable NO_BACKSLASH_ESCAPES and ANSI_QUOTES for this connection"
+                }
+            },
+            Self::ConnectionFailedWithKind { kind, .. } => match kind {
+                ConnectionFailureKind::TlsHandshake
+                | ConnectionFailureKind::TlsCertificateVerification => {
+                    "Check that the server and client support the selected TLS settings"
+                }
+                ConnectionFailureKind::TlsCaVerification => {
+                    "Check the CA certificate path and server certificate"
+                }
+                ConnectionFailureKind::TlsHostnameVerification => {
+                    "Use the hostname covered by the server certificate"
+                }
+                ConnectionFailureKind::TlsClientCertificateRejected => {
+                    "Check the client certificate, key, and server account requirements"
+                }
+            },
             Self::MetadataParseFailed(_) => {
                 "Check whether the metadata output format changed unexpectedly"
             }
@@ -195,6 +258,8 @@ impl DbOperationError {
             | Self::ObjectMissing(details)
             | Self::QueryFailed(details)
             | Self::UnsupportedOperation(details)
+            | Self::UnsupportedOperationWithKind { details, .. }
+            | Self::ConnectionFailedWithKind { details, .. }
             | Self::MetadataParseFailed(details)
             | Self::EmptyResponse(details)
             | Self::CommandTagParseFailed(details)
@@ -252,6 +317,14 @@ mod tests {
         #[case(DbOperationError::ObjectMissing("boom".to_string()))]
         #[case(DbOperationError::QueryFailed("boom".to_string()))]
         #[case(DbOperationError::UnsupportedOperation("boom".to_string()))]
+        #[case(DbOperationError::UnsupportedOperationWithKind {
+            kind: UnsupportedOperationKind::ClientVersion,
+            details: "boom".to_string(),
+        })]
+        #[case(DbOperationError::ConnectionFailedWithKind {
+            kind: ConnectionFailureKind::TlsHandshake,
+            details: "boom".to_string(),
+        })]
         #[case(DbOperationError::MetadataParseFailed("boom".to_string()))]
         #[case(DbOperationError::InvalidJson(Arc::new(serde_json::from_str::<i32>("x").unwrap_err())))]
         #[case(DbOperationError::EmptyResponse("boom".to_string()))]

--- a/src/app/ports/outbound/mod.rs
+++ b/src/app/ports/outbound/mod.rs
@@ -32,9 +32,8 @@ pub use config_writer::{ConfigWriter, ConfigWriterError};
 pub use connection_probe::ConnectionProbe;
 pub use connection_store::{ConnectionStore, ConnectionStoreError};
 pub use db_operation_error::{
-    DatabaseCli, DbOperationError, MYSQL_CLI_VERSION_REQUIRED_MARKER, MYSQL_CONNECT_TIMEOUT_ERRNOS,
-    MYSQL_SERVER_VERSION_REQUIRED_MARKER, MYSQL_SQL_MODE_UNSUPPORTED_MARKER,
-    SQLITE_SAFE_MODE_REQUIRED_MARKER, SQLITE_TABLE_LIST_REQUIRED_MARKER,
+    ConnectionFailureKind, DatabaseCli, DbOperationError, MYSQL_CONNECT_TIMEOUT_ERRNOS,
+    SQLITE_SAFE_MODE_REQUIRED_MARKER, SQLITE_TABLE_LIST_REQUIRED_MARKER, UnsupportedOperationKind,
 };
 pub use ddl_generator::DdlGenerator;
 pub use dsn_builder::DsnBuilder;

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -107,6 +107,17 @@ pub(super) fn reduce_connection_error(
                     run_id,
                 }]);
             }
+            if state
+                .session
+                .active_database_type()
+                .is_some_and(|database_type| database_type == DatabaseType::MySQL)
+                && state
+                    .connection_error
+                    .error_info()
+                    .is_some_and(|info| !info.is_retryable())
+            {
+                return DispatchResult::handled();
+            }
             if let Some(dsn) = state.session.dsn().map(String::from) {
                 state.connection_error.clear();
                 if state.session.active_database_type() == Some(DatabaseType::MySQL) {

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -612,7 +612,7 @@ mod tests {
         };
         use crate::model::connection::cache::ConnectionCache;
         use crate::model::connection::error::ConnectionErrorKind;
-        use crate::ports::outbound::DbOperationError;
+        use crate::ports::outbound::{ConnectionFailureKind, DbOperationError};
 
         fn fill_valid_form(state: &mut AppState) {
             state
@@ -669,10 +669,10 @@ mod tests {
                 .set_database_type(DatabaseType::MySQL);
             state.connection_setup.mysql_ssl_mode = MySqlSslMode::VerifyIdentity;
 
-            let error = DbOperationError::ConnectionFailed(
-                "ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed"
-                    .to_string(),
-            );
+            let error = DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::TlsCertificateVerification,
+                details: "certificate verification failed".to_string(),
+            };
             let dsn =
                 "mysql://user:password@localhost:3306/app?ssl-mode=VERIFY_IDENTITY".to_string();
 

--- a/src/infra/adapters/mysql/cli/error.rs
+++ b/src/infra/adapters/mysql/cli/error.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 
 use crate::app::ports::outbound::DbOperationError;
 
-use super::probe::{is_mysql_connect_timeout_message, validate_sql_mode};
+use super::probe::{is_mysql_connect_timeout_message, mysql_tls_failure_kind, validate_sql_mode};
 use super::xml::MysqlResultSet;
 
 pub(super) fn has_mysql_cli_error(output: &[u8]) -> bool {
@@ -69,8 +69,8 @@ pub(super) fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {
     let details = clean_mysql_stderr(stderr, "mysql query failed");
     let lower = details.to_ascii_lowercase();
     let error_code = mysql_server_error_code(&lower);
-    if is_mysql_tls_error(&lower) {
-        DbOperationError::ConnectionFailed(details)
+    if let Some(kind) = mysql_tls_failure_kind(&lower) {
+        DbOperationError::ConnectionFailedWithKind { kind, details }
     } else if is_mysql_connect_timeout_message(&details)
         || lower.contains("connect timeout")
         || lower.contains("connection timed out")
@@ -111,28 +111,6 @@ pub(super) fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {
     }
 }
 
-fn is_mysql_tls_error(lowercase_details: &str) -> bool {
-    [
-        "error 2026",
-        "tls/ssl error",
-        "ssl connection error",
-        "ssl handshake",
-        "tls handshake",
-        "handshake failure",
-        "tlsv1 alert",
-        "certificate verify failed",
-        "certificate verification failure",
-        "certificate validation failure",
-        "unable to get local issuer",
-        "self-signed certificate",
-        "unknown ca",
-        "certificate required",
-        "peer did not return a certificate",
-    ]
-    .iter()
-    .any(|marker| lowercase_details.contains(marker))
-}
-
 fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
     let marker = "error ";
     let start = lowercase_details.find(marker)? + marker.len();
@@ -155,7 +133,7 @@ fn clean_mysql_stderr(stderr: &[u8], fallback: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
+    use crate::app::ports::outbound::ConnectionFailureKind;
 
     #[test]
     fn classifies_mysql_query_failures_by_server_error() {
@@ -220,10 +198,12 @@ mod tests {
             b"ERROR 2026 (HY000): SSL connection error: error:0A000086:SSL routines::certificate verify failed",
         );
 
-        assert_eq!(
-            ConnectionErrorInfo::from_db_operation_error(&error).kind,
-            ConnectionErrorKind::MySqlTlsHandshakeFailed
-        );
-        assert!(matches!(error, DbOperationError::ConnectionFailed(_)));
+        assert!(matches!(
+            error,
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::TlsCertificateVerification,
+                ..
+            }
+        ));
     }
 }

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -363,7 +363,7 @@ pub(super) fn aggregate_mysql_command_tag(events: &[MysqlCommandEvent]) -> Optio
 
 #[cfg(test)]
 mod tests {
-    use crate::app::ports::outbound::MYSQL_SQL_MODE_UNSUPPORTED_MARKER;
+    use crate::app::ports::outbound::UnsupportedOperationKind;
 
     use super::super::error::validate_mode_probe;
     use super::*;
@@ -406,8 +406,10 @@ mod tests {
         unsupported.values[0][1] = QueryValue::Text("ANSI_QUOTES".to_string());
         assert!(matches!(
             validate_mode_probe(&unsupported, "marker"),
-            Err(DbOperationError::UnsupportedOperation(details))
-                if details.contains(MYSQL_SQL_MODE_UNSUPPORTED_MARKER)
+            Err(DbOperationError::UnsupportedOperationWithKind {
+                kind: UnsupportedOperationKind::SessionMode,
+                ..
+            })
         ));
     }
     #[test]

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -9,8 +9,8 @@ use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::app::ports::outbound::{
-    DatabaseCli, DbOperationError, MYSQL_CLI_VERSION_REQUIRED_MARKER, MYSQL_CONNECT_TIMEOUT_ERRNOS,
-    MYSQL_SERVER_VERSION_REQUIRED_MARKER, MYSQL_SQL_MODE_UNSUPPORTED_MARKER,
+    ConnectionFailureKind, DatabaseCli, DbOperationError, MYSQL_CONNECT_TIMEOUT_ERRNOS,
+    UnsupportedOperationKind,
 };
 
 const MYSQL_PROBE_TIMEOUT: Duration = Duration::from_secs(11);
@@ -32,10 +32,10 @@ pub(in crate::adapters::mysql) async fn check_mysql_cli_version() -> Result<(), 
         String::from_utf8_lossy(&output.stderr)
     );
     if !output.status.success() || !is_oracle_mysql_cli_84_version(&version_output) {
-        return Err(DbOperationError::UnsupportedOperation(format!(
-            "{MYSQL_CLI_VERSION_REQUIRED_MARKER}: {}",
-            version_output.trim()
-        )));
+        return Err(DbOperationError::UnsupportedOperationWithKind {
+            kind: UnsupportedOperationKind::ClientVersion,
+            details: version_output.trim().to_string(),
+        });
     }
     Ok(())
 }
@@ -76,9 +76,10 @@ fn validate_server_version(version: &str) -> Result<(), DbOperationError> {
     if is_oracle_mysql_server_84_version(version) {
         Ok(())
     } else {
-        Err(DbOperationError::UnsupportedOperation(format!(
-            "{MYSQL_SERVER_VERSION_REQUIRED_MARKER}: {version}"
-        )))
+        Err(DbOperationError::UnsupportedOperationWithKind {
+            kind: UnsupportedOperationKind::ServerVersion,
+            details: version.to_string(),
+        })
     }
 }
 
@@ -88,9 +89,10 @@ pub(super) fn validate_sql_mode(sql_mode: &str) -> Result<(), DbOperationError> 
             || mode.eq_ignore_ascii_case("ANSI_QUOTES")
     });
     if unsupported {
-        Err(DbOperationError::UnsupportedOperation(format!(
-            "{MYSQL_SQL_MODE_UNSUPPORTED_MARKER}: {sql_mode}"
-        )))
+        Err(DbOperationError::UnsupportedOperationWithKind {
+            kind: UnsupportedOperationKind::SessionMode,
+            details: sql_mode.to_string(),
+        })
     } else {
         Ok(())
     }
@@ -182,9 +184,68 @@ fn clean_stderr(stderr: &[u8]) -> String {
 fn classify_mysql_probe_failure(stderr: String) -> DbOperationError {
     if is_mysql_connect_timeout_message(&stderr) {
         DbOperationError::Timeout(stderr)
+    } else if let Some(kind) = mysql_tls_failure_kind(&stderr.to_ascii_lowercase()) {
+        DbOperationError::ConnectionFailedWithKind {
+            kind,
+            details: stderr,
+        }
     } else {
         DbOperationError::ConnectionFailed(stderr)
     }
+}
+
+pub(super) fn mysql_tls_failure_kind(lowercase_details: &str) -> Option<ConnectionFailureKind> {
+    if lowercase_details.contains("certificate required")
+        || lowercase_details.contains("client certificate")
+        || lowercase_details.contains("peer did not return a certificate")
+        || lowercase_details.contains("bad certificate")
+        || lowercase_details.contains("tlsv1 alert certificate required")
+    {
+        return Some(ConnectionFailureKind::TlsClientCertificateRejected);
+    }
+
+    if lowercase_details.contains("hostname mismatch")
+        || lowercase_details.contains("host name mismatch")
+        || lowercase_details.contains("hostname does not match")
+        || lowercase_details.contains("host name does not match")
+        || lowercase_details.contains("hostname verification failed")
+        || lowercase_details.contains("host name verification failed")
+        || lowercase_details.contains("certificate name mismatch")
+        || lowercase_details.contains("certificate does not match")
+        || lowercase_details.contains("does not match certificate")
+        || lowercase_details.contains("not valid for the requested host")
+        || lowercase_details.contains("not valid for hostname")
+        || lowercase_details.contains("subject alternative name")
+        || (lowercase_details.contains("verify identity")
+            && lowercase_details.contains("certificate"))
+    {
+        return Some(ConnectionFailureKind::TlsHostnameVerification);
+    }
+
+    if lowercase_details.contains("unable to get local issuer")
+        || lowercase_details.contains("self-signed certificate")
+        || lowercase_details.contains("unknown ca")
+        || lowercase_details.contains("certificate signature failure")
+    {
+        return Some(ConnectionFailureKind::TlsCaVerification);
+    }
+
+    if lowercase_details.contains("error:0a000086:ssl routines::certificate verify failed") {
+        return Some(ConnectionFailureKind::TlsCertificateVerification);
+    }
+
+    if lowercase_details.contains("error 2026")
+        || lowercase_details.contains("tls/ssl error")
+        || lowercase_details.contains("ssl handshake")
+        || lowercase_details.contains("tls handshake")
+        || lowercase_details.contains("handshake failure")
+        || lowercase_details.contains("ssl connection error")
+        || lowercase_details.contains("tlsv1 alert")
+    {
+        return Some(ConnectionFailureKind::TlsHandshake);
+    }
+
+    None
 }
 
 pub(super) fn is_mysql_connect_timeout_message(value: &str) -> bool {
@@ -197,8 +258,6 @@ pub(super) fn is_mysql_connect_timeout_message(value: &str) -> bool {
 
 #[cfg(test)]
 mod probe_tests {
-    use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
-
     use super::*;
 
     #[test]
@@ -216,8 +275,21 @@ mod probe_tests {
         assert!(is_oracle_mysql_server_84_version("8.4.3"));
         assert!(!is_oracle_mysql_server_84_version("8.4.3-TiDB"));
         assert!(!is_oracle_mysql_server_84_version("8.4.3-Percona"));
+        assert!(matches!(
+            validate_server_version("8.0.36"),
+            Err(DbOperationError::UnsupportedOperationWithKind {
+                kind: UnsupportedOperationKind::ServerVersion,
+                ..
+            })
+        ));
         assert!(validate_sql_mode("STRICT_TRANS_TABLES").is_ok());
-        assert!(validate_sql_mode("STRICT_TRANS_TABLES,ANSI_QUOTES").is_err());
+        assert!(matches!(
+            validate_sql_mode("STRICT_TRANS_TABLES,ANSI_QUOTES"),
+            Err(DbOperationError::UnsupportedOperationWithKind {
+                kind: UnsupportedOperationKind::SessionMode,
+                ..
+            })
+        ));
     }
 
     #[test]
@@ -280,9 +352,39 @@ mod probe_tests {
                 .to_string(),
         );
 
-        assert_eq!(
-            ConnectionErrorInfo::from_db_operation_error(&error).kind,
-            ConnectionErrorKind::MySqlTlsHandshakeFailed
-        );
+        assert!(matches!(
+            error,
+            DbOperationError::ConnectionFailedWithKind {
+                kind: ConnectionFailureKind::TlsCertificateVerification,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn classifies_mysql_tls_failures_before_the_app_boundary() {
+        for (stderr, expected) in [
+            (
+                "ERROR 2026 (HY000): TLS/SSL error: hostname mismatch",
+                ConnectionFailureKind::TlsHostnameVerification,
+            ),
+            (
+                "ERROR 2026 (HY000): TLS/SSL error: unable to get local issuer certificate",
+                ConnectionFailureKind::TlsCaVerification,
+            ),
+            (
+                "ERROR 2026 (HY000): TLS/SSL error: peer did not return a certificate",
+                ConnectionFailureKind::TlsClientCertificateRejected,
+            ),
+            (
+                "ERROR 2026 (HY000): SSL connection error",
+                ConnectionFailureKind::TlsHandshake,
+            ),
+        ] {
+            assert_eq!(
+                mysql_tls_failure_kind(&stderr.to_ascii_lowercase()),
+                Some(expected)
+            );
+        }
     }
 }

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -5,8 +5,8 @@
 
 use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
 use sabiql_app::ports::outbound::{
-    AccessMode, ConnectionProbe, DbOperationError, DdlGenerator, DsnBuilder,
-    MYSQL_SQL_MODE_UNSUPPORTED_MARKER, MetadataProvider, QueryExecutor, SqlDialect,
+    AccessMode, ConnectionProbe, DbOperationError, DdlGenerator, DsnBuilder, MetadataProvider,
+    QueryExecutor, SqlDialect, UnsupportedOperationKind,
 };
 use sabiql_domain::{
     CommandTag, DatabaseType, FkAction, IndexType, QueryValue, RefreshScope, TableKind,
@@ -1749,37 +1749,43 @@ async fn exports_a_header_only_csv_for_an_empty_result() {
 #[tokio::test]
 #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
 async fn rejects_next_process_when_global_sql_mode_is_unsupported() {
-    with_mysql_test_db(|db| Box::pin(async move {
-        let original = db.global_sql_mode().await?;
-        let unsupported = if original.is_empty() {
-            "ANSI_QUOTES".to_string()
-        } else {
-            format!("{original},ANSI_QUOTES")
-        };
-        let test_result = async {
-            db.set_global_sql_mode(&unsupported).await?;
-            let result = db
-                .adapter()
-                .execute_adhoc(
-                    db.dsn(),
-                    "SELECT SLEEP(32)",
-                    AccessMode::ReadWrite,
-                )
-                .await;
-            if !matches!(result, Err(DbOperationError::UnsupportedOperation(ref details)) if details.contains(MYSQL_SQL_MODE_UNSUPPORTED_MARKER)) {
-                return Err(format!("expected unsupported sql_mode rejection: {result:?}"));
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let original = db.global_sql_mode().await?;
+            let unsupported = if original.is_empty() {
+                "ANSI_QUOTES".to_string()
+            } else {
+                format!("{original},ANSI_QUOTES")
+            };
+            let test_result = async {
+                db.set_global_sql_mode(&unsupported).await?;
+                let result = db
+                    .adapter()
+                    .execute_adhoc(db.dsn(), "SELECT SLEEP(32)", AccessMode::ReadWrite)
+                    .await;
+                if !matches!(
+                    result,
+                    Err(DbOperationError::UnsupportedOperationWithKind {
+                        kind: UnsupportedOperationKind::SessionMode,
+                        ..
+                    })
+                ) {
+                    return Err(format!(
+                        "expected unsupported sql_mode rejection: {result:?}"
+                    ));
+                }
+                Ok::<(), String>(())
             }
-            Ok::<(), String>(())
-        }
-        .await;
-        let restore_result = db.set_global_sql_mode(&original).await;
-        if let Err(error) = restore_result {
-            return Err(format!("failed to restore MySQL global sql_mode: {error}"));
-        }
-        if db.global_sql_mode().await? != original {
-            return Err("MySQL global sql_mode was not restored".to_string());
-        }
-        test_result
-    }))
+            .await;
+            let restore_result = db.set_global_sql_mode(&original).await;
+            if let Err(error) = restore_result {
+                return Err(format!("failed to restore MySQL global sql_mode: {error}"));
+            }
+            if db.global_sql_mode().await? != original {
+                return Err("MySQL global sql_mode was not restored".to_string());
+            }
+            test_result
+        })
+    })
     .await;
 }

--- a/src/ui/features/connections/error.rs
+++ b/src/ui/features/connections/error.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use ratatui::prelude::*;
 use ratatui::widgets::{Paragraph, Wrap};
 
+use crate::domain::DatabaseType;
 use crate::theme::ThemePalette;
 
 use crate::app::model::app_state::AppState;
@@ -167,6 +168,11 @@ impl ConnectionError {
         theme: &ThemePalette,
     ) {
         let error_state = &state.connection_error;
+        let can_retry = state
+            .session
+            .active_database_type()
+            .is_some_and(|database_type| database_type == DatabaseType::MySQL)
+            && error_state.can_retry();
         let mut spans = vec![Span::styled(
             "Actions: ",
             Style::default().fg(theme.semantic.text.muted),
@@ -174,6 +180,7 @@ impl ConnectionError {
 
         if state.session.has_pending_connection_switch()
             || !state.session.can_reenter_connection_setup()
+            || can_retry
         {
             spans.push(key_chip("r", theme));
             spans.push(Span::raw(" Retry  "));

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -23,6 +23,7 @@ use crate::app::update::input::keybindings::{
     sql_modal, sql_modal_confirming, sqlite_diagnostics, table_picker,
     table_picker as table_picker_key,
 };
+use crate::domain::DatabaseType;
 use crate::features::settings::hints::settings_hints;
 use crate::primitives::atoms::key_text;
 use crate::primitives::atoms::spinner_char;
@@ -291,8 +292,14 @@ impl Footer {
                 hints
             }
             InputMode::ConnectionError => {
+                let can_retry = state
+                    .session
+                    .active_database_type()
+                    .is_some_and(|database_type| database_type == DatabaseType::MySQL)
+                    && state.connection_error.can_retry();
                 let first = if state.session.has_pending_connection_switch()
                     || !state.session.can_reenter_connection_setup()
+                    || can_retry
                 {
                     connection_error::RETRY.as_hint()
                 } else {


### PR DESCRIPTION
Replace MySQL connection error marker classification with bounded typed variants. Preserve existing summaries, hints, masked details, pending-probe Retry behavior, and PostgreSQL/SQLite classification. Validation: format, workspace check, clippy, focused tests, and Oracle MySQL 8.4 integration passed; one unchanged SQLite export test fails locally in the full workspace run.