### PR TITLE
test(mysql): verify read-only adhoc session

### DIFF
--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -20,9 +20,28 @@ pub(super) mod test_support {
     use std::path::PathBuf;
 
     use crate::adapters::csv_export::export_to_path;
-    use crate::app::ports::outbound::DbOperationError;
+    use crate::app::ports::outbound::{AccessMode, DbOperationError};
 
-    use super::{export_mysql_csv_to_file, parse_and_validate_mysql_dsn};
+    use super::{
+        MySqlOptionFile, export_mysql_csv_to_file, parse_and_validate_mysql_dsn, run_mysql_adhoc,
+        validate_mysql_multi_query,
+    };
+
+    #[doc(hidden)]
+    /// Runs the normal adhoc CLI process with a read-only session without the app-side policy
+    /// gate so integration tests can verify server-side rejection of a side effect.
+    pub async fn execute_mysql_adhoc_with_read_only_session_for_test(
+        dsn: &str,
+        query: &str,
+    ) -> Result<(), DbOperationError> {
+        let target = parse_and_validate_mysql_dsn(dsn)?;
+        let statements =
+            validate_mysql_multi_query(query, target.database.as_deref(), AccessMode::ReadWrite)?;
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc(&option_file.path, &statements, AccessMode::ReadOnly).await;
+        drop(option_file);
+        result.map(|_| ())
+    }
 
     #[cfg(unix)]
     #[doc(hidden)]

--- a/src/infra/adapters/mysql/mod.rs
+++ b/src/infra/adapters/mysql/mod.rs
@@ -13,4 +13,6 @@ pub use adapter::MySqlAdapter;
 pub use executor::test_support::run_mysql_cli_script_for_test;
 
 #[cfg(feature = "test-support")]
-pub use executor::test_support::export_mysql_csv_to_path_for_test;
+pub use executor::test_support::{
+    execute_mysql_adhoc_with_read_only_session_for_test, export_mysql_csv_to_path_for_test,
+};

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -18,7 +18,10 @@ use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, mysql_tls_config, with_m
 use sabiql_domain::connection::{
     ConnectionConfig, ConnectionId, ConnectionProfile, MySqlConnectionConfig, MySqlSslMode,
 };
-use sabiql_infra::adapters::mysql::{MySqlAdapter, export_mysql_csv_to_path_for_test};
+use sabiql_infra::adapters::mysql::{
+    MySqlAdapter, execute_mysql_adhoc_with_read_only_session_for_test,
+    export_mysql_csv_to_path_for_test,
+};
 #[cfg(unix)]
 use tempfile::NamedTempFile;
 use tempfile::tempdir;
@@ -1720,6 +1723,65 @@ async fn times_out_real_cli_query_and_discards_output() {
                 .await;
             if !matches!(result, Err(DbOperationError::Timeout(_))) {
                 return Err(format!("expected a query timeout: {result:?}"));
+            }
+            Ok(())
+        })
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+async fn applies_read_only_session_before_adhoc_sql_and_preserves_fixture() {
+    with_mysql_test_db(|db| {
+        Box::pin(async move {
+            let result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "SELECT @@SESSION.transaction_read_only AS transaction_read_only, id, empty_text FROM {MYSQL_FIXTURE_TABLE}"
+                    ),
+                    AccessMode::ReadOnly,
+                )
+                .await
+                .map_err(|error| format!("read-only adhoc query failed: {error:?}"))?;
+            if result.columns != ["transaction_read_only", "id", "empty_text"]
+                || result.values()
+                    != [[
+                        QueryValue::Text("1".to_string()),
+                        QueryValue::Text("1".to_string()),
+                        QueryValue::Text(String::new()),
+                    ]]
+            {
+                return Err(format!("unexpected read-only adhoc result: {result:?}"));
+            }
+
+            let write = execute_mysql_adhoc_with_read_only_session_for_test(
+                db.dsn(),
+                &format!(
+                    "UPDATE {MYSQL_FIXTURE_TABLE} SET empty_text = 'read-only mutation' WHERE id = 1"
+                ),
+            )
+                .await;
+            if !matches!(write, Err(DbOperationError::QueryFailed(ref details)) if details.contains("READ ONLY"))
+            {
+                return Err(format!("read-only adhoc write was not rejected: {write:?}"));
+            }
+
+            let fixture = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("SELECT id, empty_text FROM {MYSQL_FIXTURE_TABLE}"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("fixture verification failed: {error:?}"))?;
+            if fixture.values()
+                != [[QueryValue::Text("1".to_string()), QueryValue::Text(String::new())]]
+            {
+                return Err(format!("read-only write changed the fixture: {fixture:?}"));
             }
             Ok(())
         })


### PR DESCRIPTION
## Problem

The real Oracle MySQL integration suite did not cover Read-Only session enforcement through the normal adhoc path.

## Background

The existing coverage used fake CLI responses for adhoc session setup and a separate CSV export path for server-side rejection.

## Approach

Add an Oracle MySQL 8.4 integration test that observes the Read-Only session before user SQL, reaches the normal adhoc CLI process to verify server-side write rejection, and confirms the fixture remains unchanged.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-449