### PR TITLE
refactor(mysql): reuse metadata session

### DIFF
--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -1,3 +1,6 @@
+use std::ffi::OsStr;
+use std::time::Duration;
+
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{
     Column, ColumnAttributes, FkAction, ForeignKey, QueryValue, TableKind, TableKindInfo,
@@ -5,7 +8,10 @@ use crate::domain::{
 };
 
 use super::super::{
-    cli::{MysqlResultSet, run_mysql_adhoc, validate_mysql_multi_query},
+    cli::{
+        MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, MysqlResultSet, run_mysql_adhoc,
+        validate_mysql_multi_query,
+    },
     dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
     sql::quote_string,
@@ -64,17 +70,6 @@ pub(super) async fn fetch_metadata_snapshot(
     metadata_snapshot_from_result(&database, None, &result)
 }
 
-pub(super) async fn fetch_table_metadata(
-    dsn: &str,
-    schema: &str,
-    table: &str,
-) -> Result<MysqlMetadataSnapshot, DbOperationError> {
-    let database = selected_database(dsn)?;
-    validate_selected_schema_name(&database, schema)?;
-    let result = execute_metadata_query(dsn, &table_query(schema, table)).await?;
-    metadata_snapshot_from_result(&database, Some(schema), &result)
-}
-
 pub(super) async fn fetch_columns(
     dsn: &str,
     schema: &str,
@@ -82,20 +77,7 @@ pub(super) async fn fetch_columns(
 ) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
     validate_selected_schema(dsn, schema)?;
     let result = execute_metadata_query(dsn, &columns_query(schema, table)).await?;
-    let columns = parse_columns_for_table(&result, schema, table)?;
-    Ok(columns)
-}
-
-pub(super) async fn fetch_foreign_keys(
-    dsn: &str,
-    schema: &str,
-    table: &str,
-    summaries: &[TableSummary],
-) -> Result<Vec<ForeignKey>, DbOperationError> {
-    validate_selected_schema(dsn, schema)?;
-    let result = execute_metadata_query(dsn, &foreign_keys_query(schema, table)).await?;
-    let raw = parse_foreign_key_metadata(&result)?;
-    foreign_keys_from_metadata(raw, summaries)
+    parse_columns_for_table(&result, schema, table)
 }
 
 pub(super) fn find_table(
@@ -114,10 +96,7 @@ pub(super) fn find_table(
 
 pub(super) fn table_query(schema: &str, table: &str) -> String {
     format!(
-        "SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_ROWS, t.TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_SCHEMA = {} AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') AND (t.TABLE_NAME = {} OR EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = {} AND tc.TABLE_SCHEMA = {} AND tc.TABLE_NAME = {} AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' AND kcu.REFERENCED_TABLE_SCHEMA = t.TABLE_SCHEMA AND kcu.REFERENCED_TABLE_NAME = t.TABLE_NAME)) UNION ALL SELECT NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_SCHEMA = {} AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') AND t.TABLE_NAME = {}) ORDER BY TABLE_SCHEMA, TABLE_NAME",
-        quote_string(schema),
-        quote_string(table),
-        quote_string(schema),
+        "SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_ROWS, t.TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_SCHEMA = {} AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') AND t.TABLE_NAME = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_SCHEMA = {} AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') AND t.TABLE_NAME = {}) ORDER BY TABLE_SCHEMA, TABLE_NAME",
         quote_string(schema),
         quote_string(table),
         quote_string(schema),
@@ -166,7 +145,57 @@ pub(super) async fn execute_metadata_query(
     })
 }
 
-fn selected_database(dsn: &str) -> Result<String, DbOperationError> {
+pub(super) async fn execute_metadata_queries_in_session(
+    dsn: &str,
+    queries: &[&str],
+) -> Result<Vec<MysqlResultSet>, DbOperationError> {
+    execute_metadata_queries_in_session_with_program(
+        dsn,
+        queries,
+        OsStr::new("mysql"),
+        MYSQL_QUERY_TIMEOUT,
+    )
+    .await
+}
+
+async fn execute_metadata_queries_in_session_with_program(
+    dsn: &str,
+    queries: &[&str],
+    program: &OsStr,
+    timeout: Duration,
+) -> Result<Vec<MysqlResultSet>, DbOperationError> {
+    let target = parse_and_validate_mysql_dsn(dsn)?;
+    let option_file = MySqlOptionFile::create(&target)?;
+    let mut session = MysqlMetadataSession::spawn_with_program(program, &option_file.path)?;
+    let result = tokio::time::timeout(timeout, async {
+        session.probe().await?;
+        session.prepare_read_only().await?;
+        let mut results = Vec::with_capacity(queries.len());
+        for query in queries {
+            results.push(session.execute(query).await?);
+        }
+        session.finish().await?;
+        Ok(results)
+    })
+    .await;
+    let result = match result {
+        Ok(Ok(results)) => Ok(results),
+        Ok(Err(error)) => {
+            session.cleanup().await;
+            Err(error)
+        }
+        Err(_) => {
+            session.cleanup().await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    };
+    drop(option_file);
+    result
+}
+
+pub(super) fn selected_database(dsn: &str) -> Result<String, DbOperationError> {
     parse_and_validate_mysql_dsn(dsn)?.database.ok_or_else(|| {
         DbOperationError::UnsupportedOperation(
             "MySQL metadata requires a selected database".to_string(),
@@ -385,7 +414,7 @@ pub(super) fn parse_foreign_key_metadata(
 
 pub(super) fn foreign_keys_from_metadata(
     mut raw: Vec<MysqlForeignKeyMetadata>,
-    summaries: &[TableSummary],
+    database: &str,
 ) -> Result<Vec<ForeignKey>, DbOperationError> {
     raw.sort_by(|left, right| {
         left.name
@@ -394,9 +423,7 @@ pub(super) fn foreign_keys_from_metadata(
     });
     let mut foreign_keys = Vec::new();
     for column in raw {
-        let reference_resolved = summaries
-            .iter()
-            .any(|summary| summary.schema == column.to_schema && summary.name == column.to_table);
+        let reference_resolved = column.to_schema.eq_ignore_ascii_case(database);
         if let Some(foreign_key) = foreign_keys
             .iter_mut()
             .find(|foreign_key: &&mut ForeignKey| foreign_key.name == column.name)
@@ -718,6 +745,7 @@ mod tests {
             assert!(query.contains(&quote_string(schema)));
             assert!(query.contains(&quote_string(table)));
         }
+        assert!(!table_query(schema, table).contains("KEY_COLUMN_USAGE"));
     }
 
     #[test]
@@ -789,14 +817,8 @@ mod tests {
             ],
         );
 
-        let summaries = [TableSummary::new(
-            "sabiql_test".to_string(),
-            "parent".to_string(),
-            None,
-            false,
-        )];
         let foreign_keys =
-            foreign_keys_from_metadata(parse_foreign_key_metadata(&result).unwrap(), &summaries)
+            foreign_keys_from_metadata(parse_foreign_key_metadata(&result).unwrap(), "sabiql_test")
                 .unwrap();
 
         assert_eq!(foreign_keys.len(), 1);
@@ -807,9 +829,11 @@ mod tests {
         assert_eq!(foreign_keys[0].to_columns, ["first_key", "second_key"]);
         assert_eq!(foreign_keys[0].on_update, FkAction::Cascade);
         assert_eq!(foreign_keys[0].on_delete, FkAction::SetNull);
+        assert!(foreign_keys[0].is_reference_resolved());
 
         let unresolved =
-            foreign_keys_from_metadata(parse_foreign_key_metadata(&result).unwrap(), &[]).unwrap();
+            foreign_keys_from_metadata(parse_foreign_key_metadata(&result).unwrap(), "other")
+                .unwrap();
         assert!(!unresolved[0].is_reference_resolved());
     }
 }

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -1,16 +1,15 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::app::ports::outbound::DbOperationError;
-use crate::domain::{
-    FkAction, QueryValue, Table, TableKind, TableKindInfo, TableSignature, TableSummary,
-};
+use crate::domain::{FkAction, QueryValue, Table, TableKind, TableKindInfo, TableSignature};
 
 use super::super::cli::MysqlResultSet;
 use super::catalog::{
-    MysqlColumnMetadata, MysqlForeignKeyMetadata, MysqlTableMetadata, column_from_metadata,
-    execute_metadata_query, expect_columns, fetch_metadata_snapshot, foreign_keys_from_metadata,
-    metadata_shape_error, parse_column_metadata_row, parse_foreign_key_metadata, primary_key_names,
-    required_text,
+    MysqlColumnMetadata, MysqlForeignKeyMetadata, MysqlTableMetadata, TABLES_QUERY,
+    column_from_metadata, execute_metadata_queries_in_session, expect_columns,
+    foreign_keys_from_metadata, metadata_shape_error, metadata_snapshot_from_result,
+    parse_column_metadata_row, parse_foreign_key_metadata, primary_key_names, required_text,
+    selected_database,
 };
 
 #[derive(Debug, Clone)]
@@ -23,14 +22,22 @@ struct MysqlSignatureColumnMetadata {
 pub(super) async fn fetch_table_signatures(
     dsn: &str,
 ) -> Result<Vec<TableSignature>, DbOperationError> {
-    let snapshot = fetch_metadata_snapshot(dsn).await?;
-    let columns = execute_metadata_query(dsn, SIGNATURE_COLUMNS_QUERY).await?;
-    let foreign_keys = execute_metadata_query(dsn, SIGNATURE_FOREIGN_KEYS_QUERY).await?;
+    let database = selected_database(dsn)?;
+    let results = execute_metadata_queries_in_session(
+        dsn,
+        &[
+            TABLES_QUERY,
+            SIGNATURE_COLUMNS_QUERY,
+            SIGNATURE_FOREIGN_KEYS_QUERY,
+        ],
+    )
+    .await?;
+    let snapshot = metadata_snapshot_from_result(&database, None, &results[0])?;
     table_signatures_from_metadata(
         &snapshot.tables,
-        &snapshot.table_summaries,
-        parse_signature_column_metadata(&columns)?,
-        parse_foreign_key_metadata(&foreign_keys)?,
+        &database,
+        parse_signature_column_metadata(&results[1])?,
+        parse_foreign_key_metadata(&results[2])?,
     )
 }
 
@@ -74,7 +81,7 @@ fn parse_signature_column_metadata(
 
 fn table_signatures_from_metadata(
     tables: &[MysqlTableMetadata],
-    summaries: &[TableSummary],
+    database: &str,
     columns: Vec<MysqlSignatureColumnMetadata>,
     foreign_keys: Vec<MysqlForeignKeyMetadata>,
 ) -> Result<Vec<TableSignature>, DbOperationError> {
@@ -136,7 +143,7 @@ fn table_signatures_from_metadata(
             let primary_key = primary_key_names(&columns);
             let foreign_keys = foreign_keys_from_metadata(
                 foreign_keys_by_table.remove(&key).unwrap_or_default(),
-                summaries,
+                database,
             )?;
             let detail = Table {
                 schema: table.schema.clone(),
@@ -313,17 +320,6 @@ mod tests {
         }
     }
 
-    fn table_summary(table: MysqlTableMetadata) -> TableSummary {
-        TableSummary::new(table.schema, table.name, table.row_count_estimate, false).with_kind_info(
-            TableKindInfo {
-                kind: table.kind,
-                is_strict: false,
-                without_rowid: false,
-                virtual_module: None,
-            },
-        )
-    }
-
     fn signature_table() -> Table {
         Table {
             schema: "app".to_string(),
@@ -466,11 +462,6 @@ mod tests {
                 comment: None,
             },
         ];
-        let summaries = tables
-            .iter()
-            .cloned()
-            .map(table_summary)
-            .collect::<Vec<_>>();
         let columns = parse_signature_column_metadata(&result(
             &[
                 "TABLE_SCHEMA",
@@ -553,7 +544,7 @@ mod tests {
         .unwrap();
 
         let signatures =
-            table_signatures_from_metadata(&tables, &summaries, columns, foreign_keys).unwrap();
+            table_signatures_from_metadata(&tables, "App", columns, foreign_keys).unwrap();
 
         assert_eq!(signatures.len(), 2);
         assert_eq!(signatures[0].qualified_name(), "App.child");
@@ -570,14 +561,8 @@ mod tests {
             row_count_estimate: None,
             comment: None,
         }];
-        let summaries = tables
-            .iter()
-            .cloned()
-            .map(table_summary)
-            .collect::<Vec<_>>();
-
-        let error = table_signatures_from_metadata(&tables, &summaries, Vec::new(), Vec::new())
-            .unwrap_err();
+        let error =
+            table_signatures_from_metadata(&tables, "app", Vec::new(), Vec::new()).unwrap_err();
 
         assert!(matches!(
             error,

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use crate::app::ports::outbound::DbOperationError;
 use crate::domain::{
-    Index, IndexAttributes, IndexType, QueryValue, Table, TableKind, TableKindInfo, TableSummary,
+    ForeignKey, Index, IndexAttributes, IndexType, QueryValue, Table, TableKind, TableKindInfo,
     Trigger, TriggerEvent, TriggerTiming,
 };
 
@@ -14,11 +14,12 @@ use super::super::{
     option_file::MySqlOptionFile,
 };
 use super::catalog::{
-    MysqlTableMetadata, column_from_metadata, columns_query, expect_columns, fetch_columns,
-    fetch_foreign_keys, fetch_table_metadata, find_table, foreign_keys_from_metadata,
+    MysqlColumnMetadata, MysqlTableMetadata, column_from_metadata, columns_query,
+    execute_metadata_queries_in_session, expect_columns, find_table, foreign_keys_from_metadata,
     foreign_keys_query, metadata_shape_error, metadata_snapshot_from_result, optional_text,
     parse_boolean_flag, parse_columns_for_table, parse_foreign_key_metadata, parse_positive_i32,
-    primary_key_names, required_text, table_query, validate_selected_schema_name,
+    primary_key_names, required_text, selected_database, table_query,
+    validate_selected_schema_name,
 };
 
 #[derive(Debug, Clone)]
@@ -61,15 +62,26 @@ pub(super) async fn fetch_table_columns_and_fks(
     schema: &str,
     table: &str,
 ) -> Result<Table, DbOperationError> {
-    let snapshot = fetch_table_metadata(dsn, schema, table).await?;
-    fetch_table_columns_and_fks_with_summaries(
+    let database = selected_database(dsn)?;
+    validate_selected_schema_name(&database, schema)?;
+    let table_query = table_query(schema, table);
+    let columns_query = columns_query(schema, table);
+    let foreign_keys_query = foreign_keys_query(schema, table);
+    let results = execute_metadata_queries_in_session(
         dsn,
-        schema,
-        table,
-        &snapshot.tables,
-        &snapshot.table_summaries,
+        &[&table_query, &columns_query, &foreign_keys_query],
     )
-    .await
+    .await?;
+    let snapshot = metadata_snapshot_from_result(&database, Some(schema), &results[0])?;
+    let table_metadata = find_table(schema, table, &snapshot.tables)?;
+    let columns = parse_columns_for_table(&results[1], schema, table)?;
+    let foreign_keys =
+        foreign_keys_from_metadata(parse_foreign_key_metadata(&results[2])?, &database)?;
+    Ok(table_from_columns_and_foreign_keys(
+        table_metadata,
+        columns,
+        foreign_keys,
+    ))
 }
 
 async fn fetch_table_detail_in_session_with_program(
@@ -132,7 +144,7 @@ async fn fetch_table_detail_with_session(
     )?);
     let foreign_keys = foreign_keys_from_metadata(
         parse_foreign_key_metadata(&session.execute(&foreign_keys_query(schema, table)).await?)?,
-        &snapshot.table_summaries,
+        database,
     )?;
     let triggers = triggers_from_metadata(parse_trigger_metadata(
         &session.execute(&triggers_query(table)).await?,
@@ -168,18 +180,13 @@ async fn fetch_table_detail_with_session(
     })
 }
 
-async fn fetch_table_columns_and_fks_with_summaries(
-    dsn: &str,
-    schema: &str,
-    table: &str,
-    tables: &[MysqlTableMetadata],
-    summaries: &[TableSummary],
-) -> Result<Table, DbOperationError> {
-    let table_metadata = find_table(schema, table, tables)?;
-    let columns = fetch_columns(dsn, schema, table).await?;
-    let foreign_keys = fetch_foreign_keys(dsn, schema, table, summaries).await?;
+fn table_from_columns_and_foreign_keys(
+    table_metadata: MysqlTableMetadata,
+    columns: Vec<MysqlColumnMetadata>,
+    foreign_keys: Vec<ForeignKey>,
+) -> Table {
     let primary_key = primary_key_names(&columns);
-    Ok(Table {
+    Table {
         schema: table_metadata.schema,
         name: table_metadata.name,
         owner: None,
@@ -198,7 +205,7 @@ async fn fetch_table_columns_and_fks_with_summaries(
             without_rowid: false,
             virtual_module: None,
         },
-    })
+    }
 }
 
 fn indexes_query(table: &str) -> String {


### PR DESCRIPTION
## Problem
MySQL table signatures and columns-plus-foreign-keys metadata each started separate `mysql` processes, repeating option-file loading, the SQL mode probe, and read-only session setup.

## Background
The existing `MysqlMetadataSession` already supports ordered metadata resultsets for Inspector, while targeted table metadata also queried unrelated referenced tables to resolve same-database foreign keys.

## Approach
Reuse one existing metadata session for the table, columns, and foreign-key queries in both metadata paths. Limit targeted table lookup to the requested table and resolve foreign keys from MySQL's selected-database referential-integrity boundary, leaving cross-database references unresolved.

## Linear Issue Link (optional)
- Parent: https://linear.app/sabiql/issue/SAB-368