### PR TITLE
Fail closed on unsupported MySQL SQL

### DIFF
--- a/src/app/policy/sql/sqlite_transaction.rs
+++ b/src/app/policy/sql/sqlite_transaction.rs
@@ -255,7 +255,8 @@ mod tests {
     use crate::policy::write::sql_risk::split_statements_for_database;
 
     fn policy_for(sql: &str) -> SqliteTransactionPolicy {
-        let statements = split_statements_for_database(DatabaseType::SQLite, sql);
+        let statements = split_statements_for_database(DatabaseType::SQLite, sql)
+            .expect("SQLite statement splitting does not produce MySQL lexer errors");
         sqlite_transaction_policy(&statements)
     }
 

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1045,20 +1045,24 @@ fn high_acknowledge(kind: &StatementKind) -> SqlRiskDecision {
 
 pub fn evaluate_sql_risk(kind: &StatementKind, sql: &str) -> SqlRiskDecision {
     evaluate_sql_risk_for_database(DatabaseType::PostgreSQL, kind, sql)
+        .expect("PostgreSQL SQL risk evaluation is supported")
 }
 
 pub fn evaluate_sql_risk_for_database(
     database_type: DatabaseType,
     kind: &StatementKind,
     sql: &str,
-) -> SqlRiskDecision {
+) -> Option<SqlRiskDecision> {
+    if database_type == DatabaseType::MySQL {
+        return None;
+    }
     if database_type == DatabaseType::SQLite
         && let Some(decision) = evaluate_sqlite_specific_risk(sql)
     {
-        return decision;
+        return Some(decision);
     }
 
-    match kind {
+    Some(match kind {
         StatementKind::Select | StatementKind::Transaction => low_immediate(),
         StatementKind::Insert | StatementKind::Create => SqlRiskDecision {
             risk_level: RiskLevel::Low,
@@ -1116,7 +1120,7 @@ pub fn evaluate_sql_risk_for_database(
             },
             None => high_acknowledge(kind),
         },
-    }
+    })
 }
 
 pub fn evaluate_mysql_explain_analyze_target(sql: &str) -> Option<SqlRiskDecision> {
@@ -1199,7 +1203,11 @@ pub fn evaluate_multi_statement_for_database_with_context(
 
     for stmt in &statements {
         let kind = classify(stmt);
-        let decision = evaluate_sql_risk_for_database(database_type, &kind, stmt);
+        let Some(decision) = evaluate_sql_risk_for_database(database_type, &kind, stmt) else {
+            return MultiStatementDecision::Block {
+                reason: "SQL risk evaluation is not supported for this database".to_string(),
+            };
+        };
         decisions.push((stmt.clone(), kind, decision));
     }
 
@@ -1427,7 +1435,7 @@ pub fn adhoc_label_for_table_name_confirmation(
     };
     for stmt in statements {
         let kind = classify(&stmt);
-        let decision = evaluate_sql_risk_for_database(database_type, &kind, &stmt);
+        let decision = evaluate_sql_risk_for_database(database_type, &kind, &stmt)?;
         if matches!(
             decision.confirmation,
             ConfirmationType::TableNameInput { .. }
@@ -1855,7 +1863,8 @@ mod tests {
             fn sqlite_read_only_pragma_returns_low_immediate() {
                 let sql = "PRAGMA table_info(users)";
                 let result =
-                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
 
                 assert_eq!(result.risk_level, RiskLevel::Low);
                 assert!(result.read_only_allowed);
@@ -1866,7 +1875,8 @@ mod tests {
             fn sqlite_allowlisted_parameterized_pragma_returns_low_immediate() {
                 let sql = "PRAGMA index_info(users_name_idx)";
                 let result =
-                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
 
                 assert_eq!(result.risk_level, RiskLevel::Low);
                 assert!(result.read_only_allowed);
@@ -1888,7 +1898,8 @@ mod tests {
             #[case::wal_checkpoint("PRAGMA wal_checkpoint")]
             fn sqlite_dangerous_pragma_requires_acknowledgment(#[case] sql: &str) {
                 let result =
-                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
 
                 assert_eq!(result.risk_level, RiskLevel::High);
                 assert!(!result.read_only_allowed);
@@ -1905,7 +1916,8 @@ mod tests {
             fn sqlite_non_dangerous_pragma_assignment_is_medium_write() {
                 let sql = "PRAGMA user_version = 3";
                 let result =
-                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
 
                 assert_eq!(result.risk_level, RiskLevel::Medium);
                 assert!(!result.read_only_allowed);
@@ -1916,7 +1928,8 @@ mod tests {
             fn sqlite_non_allowlisted_parameterized_pragma_is_medium_write() {
                 let sql = "PRAGMA user_version(3)";
                 let result =
-                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
 
                 assert_eq!(result.risk_level, RiskLevel::Medium);
                 assert!(!result.read_only_allowed);
@@ -1935,7 +1948,8 @@ mod tests {
             #[case::analyze("ANALYZE users", "ANALYZE")]
             fn requires_acknowledgment(#[case] sql: &str, #[case] expected_label: &str) {
                 let result =
-                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
 
                 assert_eq!(result.risk_level, RiskLevel::High);
                 assert!(!result.read_only_allowed);
@@ -1997,7 +2011,8 @@ mod tests {
                 #[case] expected_target: &str,
             ) {
                 let result =
-                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
 
                 assert_eq!(result.risk_level, RiskLevel::High);
                 assert!(!result.read_only_allowed);
@@ -2057,7 +2072,8 @@ mod tests {
                 #[case] expected_target: &str,
             ) {
                 let result =
-                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
 
                 assert_eq!(result.risk_level, RiskLevel::High);
                 assert!(!result.read_only_allowed);
@@ -2074,7 +2090,8 @@ mod tests {
                 #[case] sql: &str,
             ) {
                 let result =
-                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
 
                 assert_eq!(result.risk_level, RiskLevel::Low);
                 assert!(matches!(result.confirmation, ConfirmationType::Immediate));
@@ -2084,7 +2101,8 @@ mod tests {
             fn sqlite_drop_multiple_index_requires_acknowledgment() {
                 let sql = "DROP INDEX a, b";
                 let result =
-                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql);
+                    evaluate_sql_risk_for_database(DatabaseType::SQLite, &classify(sql), sql)
+                        .expect("SQLite SQL risk evaluation is supported");
 
                 assert_eq!(result.risk_level, RiskLevel::High);
                 assert!(!result.read_only_allowed);
@@ -2680,6 +2698,20 @@ mod tests {
                     }
                 }
             }
+        }
+    }
+
+    #[test]
+    fn rejects_mysql_single_statement_risk_entry() {
+        for sql in [
+            "BEGIN WORK",
+            "REPLACE INTO items VALUES (1)",
+            "MERGE INTO items USING source ON items.id = source.id",
+        ] {
+            assert!(
+                evaluate_sql_risk_for_database(DatabaseType::MySQL, &classify(sql), sql).is_none(),
+                "{sql}"
+            );
         }
     }
 }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1073,7 +1073,7 @@ pub fn evaluate_sql_risk_for_database(
             // Empty / comment-only input has nothing to execute; gating it
             // would show a confirm dialog for a no-op.
             if sql.trim().is_empty() || is_comment_only(sql) {
-                return low_immediate();
+                return Some(low_immediate());
             }
             SqlRiskDecision {
                 risk_level: RiskLevel::Low,

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1,8 +1,8 @@
 use super::write_guardrails::{self, RiskLevel};
 use crate::domain::DatabaseType;
 use crate::policy::sql::mysql_statement::{
-    MysqlStatement, MysqlStatementKind, classify_mysql_statement, has_mysql_read_only_side_effect,
-    has_top_level_into_clause, split_mysql_statements,
+    MysqlLexError, MysqlStatement, MysqlStatementKind, classify_mysql_statement,
+    has_mysql_read_only_side_effect, has_top_level_into_clause, split_mysql_statements,
     statement_contains_unsupported_mysql_control, target_is_selected_database,
 };
 use crate::policy::sql::sqlite_statement_splitter::split_sqlite_statements;
@@ -36,6 +36,7 @@ pub enum AcknowledgeReason {
 #[cfg(test)]
 mod mysql_tests {
     use super::*;
+    use rstest::rstest;
 
     fn mysql(sql: &str) -> MultiStatementDecision {
         evaluate_multi_statement_for_database_with_context(DatabaseType::MySQL, Some("app"), sql)
@@ -268,6 +269,31 @@ mod mysql_tests {
             mysql("WITH rows AS (SELECT 'INTO OUTFILE') SELECT * FROM rows"),
             MultiStatementDecision::Allow { .. }
         ));
+    }
+
+    #[rstest]
+    #[case::unterminated_quote("SELECT 'unfinished")]
+    #[case::unterminated_comment("SELECT 1 /* unfinished")]
+    #[case::unsupported_statement("MERGE INTO items USING source ON items.id = source.id")]
+    #[case::replace("REPLACE INTO items VALUES (1)")]
+    #[case::begin_work("BEGIN WORK")]
+    fn invalid_mysql_scripts_are_blocked_before_execution(#[case] sql: &str) {
+        assert!(
+            matches!(mysql(sql), MultiStatementDecision::Block { .. }),
+            "{sql}"
+        );
+        assert!(
+            evaluate_mysql_explain_analyze_target(sql).is_none(),
+            "{sql}"
+        );
+    }
+
+    #[test]
+    fn preserves_mysql_split_errors_for_callers() {
+        assert!(split_statements_for_database(DatabaseType::MySQL, "SELECT 'unfinished").is_err());
+        assert!(
+            split_statements_for_database(DatabaseType::MySQL, "SELECT 1 /* unfinished").is_err()
+        );
     }
 
     #[test]
@@ -884,22 +910,26 @@ fn contains_cli_meta_command(database_type: DatabaseType, sql: &str) -> bool {
 
 pub fn split_statements(sql: &str) -> Vec<String> {
     split_statements_for_database(DatabaseType::PostgreSQL, sql)
+        .expect("PostgreSQL statement splitting is infallible")
 }
 
-pub fn split_statements_for_database(database_type: DatabaseType, sql: &str) -> Vec<String> {
+pub fn split_statements_for_database(
+    database_type: DatabaseType,
+    sql: &str,
+) -> Result<Vec<String>, MysqlLexError> {
     if database_type == DatabaseType::MySQL {
-        return split_mysql_statements(sql).unwrap_or_default();
+        return split_mysql_statements(sql);
     }
     if database_type == DatabaseType::SQLite {
-        return split_sqlite_statements(sql)
+        return Ok(split_sqlite_statements(sql)
             .statements()
             .iter()
             .filter(|statement| !is_comment_only(statement))
             .map(|statement| (*statement).to_string())
-            .collect();
+            .collect());
     }
 
-    split_postgres_statements(sql)
+    Ok(split_postgres_statements(sql))
 }
 
 fn split_postgres_statements(sql: &str) -> Vec<String> {
@@ -1022,9 +1052,6 @@ pub fn evaluate_sql_risk_for_database(
     kind: &StatementKind,
     sql: &str,
 ) -> SqlRiskDecision {
-    if database_type == DatabaseType::MySQL {
-        return evaluate_mysql_statement_risk(sql);
-    }
     if database_type == DatabaseType::SQLite
         && let Some(decision) = evaluate_sqlite_specific_risk(sql)
     {
@@ -1092,21 +1119,6 @@ pub fn evaluate_sql_risk_for_database(
     }
 }
 
-fn evaluate_mysql_statement_risk(sql: &str) -> SqlRiskDecision {
-    if let Ok(statement) = classify_mysql_statement(sql) {
-        return mysql_statement_risk(&statement);
-    }
-
-    SqlRiskDecision {
-        risk_level: RiskLevel::Low,
-        confirmation: ConfirmationType::Acknowledge {
-            reason: AcknowledgeReason::UnknownRisk,
-            label: first_keyword(sql).unwrap_or_else(|| "SQL".to_string()),
-        },
-        read_only_allowed: false,
-    }
-}
-
 pub fn evaluate_mysql_explain_analyze_target(sql: &str) -> Option<SqlRiskDecision> {
     if statement_contains_unsupported_mysql_control(sql) {
         return None;
@@ -1168,7 +1180,14 @@ pub fn evaluate_multi_statement_for_database_with_context(
         };
     }
 
-    let statements = split_statements_for_database(database_type, sql);
+    let statements = match split_statements_for_database(database_type, sql) {
+        Ok(statements) => statements,
+        Err(error) => {
+            return MultiStatementDecision::Block {
+                reason: error.to_string(),
+            };
+        }
+    };
 
     if statements.is_empty() {
         return MultiStatementDecision::Block {
@@ -1403,7 +1422,10 @@ pub fn adhoc_label_for_table_name_confirmation(
                 .then(|| mysql_statement_label(&statement.kind))
             });
     }
-    for stmt in split_statements_for_database(database_type, sql) {
+    let Ok(statements) = split_statements_for_database(database_type, sql) else {
+        return None;
+    };
+    for stmt in statements {
         let kind = classify(&stmt);
         let decision = evaluate_sql_risk_for_database(database_type, &kind, &stmt);
         if matches!(

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -56,7 +56,15 @@ pub(super) fn reduce_analyze(
                 risk
             } else {
                 let kind = statement_classifier::classify(&content);
-                evaluate_sql_risk_for_database(database_type, &kind, &content)
+                let Some(risk) = evaluate_sql_risk_for_database(database_type, &kind, &content)
+                else {
+                    show_explain_error_on_plan(
+                        state,
+                        "EXPLAIN ANALYZE risk evaluation is not supported for this database",
+                    );
+                    return DispatchResult::handled();
+                };
+                risk
             };
 
             if state.session.is_read_only() && !risk.read_only_allowed {

--- a/src/app/update/explain/analyze.rs
+++ b/src/app/update/explain/analyze.rs
@@ -38,7 +38,7 @@ pub(super) fn reduce_analyze(
                 return DispatchResult::handled();
             }
             let database_type = state.session.active_database_type_or_default();
-            if is_multi_statement(database_type, &content) {
+            if database_type != DatabaseType::MySQL && is_multi_statement(database_type, &content) {
                 show_explain_error_on_plan(
                     state,
                     "EXPLAIN ANALYZE does not support multiple statements",

--- a/src/app/update/explain/helpers.rs
+++ b/src/app/update/explain/helpers.rs
@@ -75,7 +75,8 @@ pub(super) fn finish_explain_unsupported_analyze(state: &mut AppState) {
 }
 
 pub(super) fn is_multi_statement(database_type: DatabaseType, content: &str) -> bool {
-    split_statements_for_database(database_type, content).len() > 1
+    split_statements_for_database(database_type, content)
+        .is_ok_and(|statements| statements.len() > 1)
 }
 
 pub(super) fn mark_explain_unavailable(state: &mut AppState) {


### PR DESCRIPTION
## Problem
MySQL statement-splitting failures were flattened into an empty statement list, and the single-statement risk path could acknowledge unsupported SQL.

## Background
A future caller could accidentally execute SQL that the multi-statement safety path rejects.

## Approach
Preserve MySQL lexer errors for callers, keep MySQL execution and EXPLAIN paths fail closed for malformed or unsupported statements, and remove the lenient single-statement fallback. Existing supported SQL and PostgreSQL/SQLite risk behavior remain unchanged.