### PR TITLE
fix(mysql): configure Unix PTY as raw

### DIFF
--- a/src/infra/adapters/mysql/cli/pty.rs
+++ b/src/infra/adapters/mysql/cli/pty.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
@@ -37,17 +37,23 @@ pub(super) fn create_mysql_pty() -> io::Result<(std::fs::File, std::fs::File)> {
 
     let slave_file = unsafe { std::fs::File::from_raw_fd(slave) };
     let master_file = unsafe { std::fs::File::from_raw_fd(master) };
-    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
-    if unsafe { libc::tcgetattr(slave_file.as_raw_fd(), termios.as_mut_ptr()) } == 0 {
-        let mut termios = unsafe { termios.assume_init() };
-        termios.c_lflag &= !(libc::ECHO | libc::ECHONL | libc::ICANON);
-        termios.c_oflag &= !libc::OPOST;
-        termios.c_cc[libc::VMIN] = 1;
-        termios.c_cc[libc::VTIME] = 0;
-        let _ =
-            unsafe { libc::tcsetattr(slave_file.as_raw_fd(), libc::TCSANOW, &raw const termios) };
-    }
+    configure_mysql_pty(slave_file.as_raw_fd())?;
     Ok((master_file, slave_file))
+}
+
+fn configure_mysql_pty(fd: RawFd) -> io::Result<()> {
+    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+    if unsafe { libc::tcgetattr(fd, termios.as_mut_ptr()) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut termios = unsafe { termios.assume_init() };
+    unsafe { libc::cfmakeraw(&raw mut termios) };
+    termios.c_cc[libc::VMIN] = 1;
+    termios.c_cc[libc::VTIME] = 0;
+    if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw const termios) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 pub(super) async fn read_one_pty_resultset(
@@ -264,6 +270,40 @@ mod tests {
             frame_scanner: MysqlResultsetFrameScanner::default(),
         };
         (output_file, pty)
+    }
+
+    #[test]
+    fn configures_mysql_pty_as_raw_with_single_byte_reads() {
+        let (_master, slave) = create_mysql_pty().expect("create test PTY");
+        let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+
+        assert_eq!(
+            unsafe { libc::tcgetattr(slave.as_raw_fd(), termios.as_mut_ptr()) },
+            0
+        );
+        let termios = unsafe { termios.assume_init() };
+
+        assert_eq!(
+            termios.c_iflag
+                & (libc::BRKINT | libc::ICRNL | libc::INPCK | libc::ISTRIP | libc::IXON),
+            0
+        );
+        assert_eq!(termios.c_oflag & libc::OPOST, 0);
+        assert_eq!(
+            termios.c_lflag
+                & (libc::ECHO | libc::ECHONL | libc::ICANON | libc::IEXTEN | libc::ISIG),
+            0
+        );
+        assert_eq!(termios.c_cflag & libc::CS8, libc::CS8);
+        assert_eq!(termios.c_cc[libc::VMIN], 1);
+        assert_eq!(termios.c_cc[libc::VTIME], 0);
+    }
+
+    #[test]
+    fn reports_termios_get_failure() {
+        let error = configure_mysql_pty(-1).expect_err("invalid fd must fail");
+
+        assert_eq!(error.raw_os_error(), Some(libc::EBADF));
     }
 
     #[tokio::test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -91,6 +91,35 @@ mod connection {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn preserves_control_characters_in_real_mysql_pty_input() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
+                let mut script = b"SELECT HEX(_binary '".to_vec();
+                script.extend_from_slice(&[0x03, 0x0d, 0x11, 0x13]);
+                script.extend_from_slice(b"') AS control_bytes;\n");
+                let script = String::from_utf8(script).map_err(|error| error.to_string())?;
+                let output = db
+                    .run_pty_script(&script)
+                    .await
+                    .map_err(|error| format!("failed to run MySQL CLI: {error}"))?;
+                if !output
+                    .windows(b">030D1113</field>".len())
+                    .any(|window| window == b">030D1113</field>")
+                {
+                    return Err(format!(
+                        "MySQL CLI changed control-byte input: {}",
+                        String::from_utf8_lossy(&output)
+                    ));
+                }
+                Ok(())
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
     async fn connects_to_oracle_mysql_84_fixture_with_ca_and_client_certificate() {
         let config = mysql_tls_config();


### PR DESCRIPTION
## Problem
Unix MySQL PTYs only disabled echo, canonical input, and output post-processing, so the terminal line discipline could still consume control bytes before `mysql` received them.

## Background
Signals, flow control, and carriage-return conversion can alter SQL input or interrupt the CLI process when control characters occur inside values.

## Approach
Configure the slave PTY with `cfmakeraw`, explicitly set `VMIN=1` and `VTIME=0`, and propagate `termios` setup failures through the existing error boundary. Add Unix flag/error regression tests and a real Oracle MySQL 8.4 CLI PTY test for control-byte input.

## Validation
- Oracle MySQL 8.4.10 server/CLI integration: 31/31 passed, including the new control-byte PTY test.
- `cargo fmt`, custom lint, all-features and no-default-features clippy: passed.
- no-default-features nextest: 185/185 passed.
- Release builds and snapshot rejection: passed.
- Workspace all-features nextest: 1 unrelated existing SQLite test fails under local SQLite 3.51.0 (`export_to_csv_missing_table_returns_object_missing_and_removes_file`); 4463 passed.