### PR TITLE
fix(mysql): classify server errors by code

### DIFF
--- a/src/infra/adapters/mysql/cli/error.rs
+++ b/src/infra/adapters/mysql/cli/error.rs
@@ -69,7 +69,9 @@ pub(super) fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {
     let details = clean_mysql_stderr(stderr, "mysql query failed");
     let lower = details.to_ascii_lowercase();
     let error_code = mysql_server_error_code(&lower);
-    if let Some(kind) = mysql_tls_failure_kind(&lower) {
+    if (error_code.is_none() || error_code == Some(2026))
+        && let Some(kind) = mysql_tls_failure_kind(&lower)
+    {
         DbOperationError::ConnectionFailedWithKind { kind, details }
     } else if let Some(error_code) = error_code {
         classify_mysql_server_error(error_code, &details, &lower)
@@ -237,6 +239,9 @@ mod tests {
             b"ERROR 9999 (HY000): Duplicate entry duplicate_value for key PRIMARY",
         );
 
+        assert!(matches!(error, DbOperationError::QueryFailed(_)));
+
+        let error = classify_mysql_query_failure(b"ERROR 9999 (HY000): SSL connection error");
         assert!(matches!(error, DbOperationError::QueryFailed(_)));
     }
 

--- a/src/infra/adapters/mysql/cli/error.rs
+++ b/src/infra/adapters/mysql/cli/error.rs
@@ -71,34 +71,27 @@ pub(super) fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {
     let error_code = mysql_server_error_code(&lower);
     if let Some(kind) = mysql_tls_failure_kind(&lower) {
         DbOperationError::ConnectionFailedWithKind { kind, details }
+    } else if let Some(error_code) = error_code {
+        classify_mysql_server_error(error_code, &details, &lower)
+            .unwrap_or(DbOperationError::QueryFailed(details))
     } else if is_mysql_connect_timeout_message(&details)
         || lower.contains("connect timeout")
         || lower.contains("connection timed out")
     {
         DbOperationError::Timeout(details)
-    } else if matches!(error_code, Some(1044 | 1142 | 1143 | 1227))
-        || lower.contains("command denied")
-    {
+    } else if lower.contains("command denied") {
         DbOperationError::PermissionDenied(details)
-    } else if error_code == Some(1049) || lower.contains("unknown database") {
+    } else if lower.contains("unknown database") {
         DbOperationError::ConnectionFailed(details)
-    } else if matches!(error_code, Some(1054 | 1146))
-        || lower.contains("doesn't exist")
-        || lower.contains("does not exist")
-    {
+    } else if lower.contains("doesn't exist") || lower.contains("does not exist") {
         DbOperationError::ObjectMissing(details)
-    } else if error_code == Some(1045)
-        || lower.contains("access denied")
-        || lower.contains("authentication")
-    {
+    } else if lower.contains("access denied") || lower.contains("authentication") {
         DbOperationError::ConnectionFailed(details)
     } else if lower.contains("lost connection") || lower.contains("server has gone away") {
         DbOperationError::ConnectionLost(details)
     } else if lower.contains("lock wait timeout") || lower.contains("deadlock found") {
         DbOperationError::LockTimeout(details)
-    } else if matches!(error_code, Some(1215 | 1216 | 1217 | 1451 | 1452))
-        || lower.contains("foreign key constraint")
-    {
+    } else if lower.contains("foreign key constraint") {
         DbOperationError::ForeignKeyViolation(details)
     } else if lower.contains("duplicate entry") {
         DbOperationError::UniqueViolation(details)
@@ -109,6 +102,32 @@ pub(super) fn classify_mysql_query_failure(stderr: &[u8]) -> DbOperationError {
     } else {
         DbOperationError::QueryFailed(details)
     }
+}
+
+fn classify_mysql_server_error(
+    error_code: u32,
+    details: &str,
+    lowercase_details: &str,
+) -> Option<DbOperationError> {
+    let error = |constructor: fn(String) -> DbOperationError| constructor(details.to_string());
+
+    Some(match error_code {
+        1022 | 1062 => error(DbOperationError::UniqueViolation),
+        1044 | 1142 | 1143 | 1227 => error(DbOperationError::PermissionDenied),
+        1045 | 1049 => error(DbOperationError::ConnectionFailed),
+        1051 | 1054 | 1109 | 1146 => error(DbOperationError::ObjectMissing),
+        1205 | 1213 => error(DbOperationError::LockTimeout),
+        1215 | 1216 | 1217 | 1451 | 1452 => error(DbOperationError::ForeignKeyViolation),
+        1317 => error(DbOperationError::Canceled),
+        2006 | 2013 => error(DbOperationError::ConnectionLost),
+        2003 if is_mysql_connect_timeout_message(details)
+            || lowercase_details.contains("connect timeout")
+            || lowercase_details.contains("connection timed out") =>
+        {
+            DbOperationError::Timeout(details.to_string())
+        }
+        _ => return None,
+    })
 }
 
 fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
@@ -158,6 +177,14 @@ mod tests {
             DbOperationError::ObjectMissing(_)
         ));
         assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1051 (42S02): generic failure"),
+            DbOperationError::ObjectMissing(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1109 (42S02): generic failure"),
+            DbOperationError::ObjectMissing(_)
+        ));
+        assert!(matches!(
             classify_mysql_query_failure(b"ERROR 1142 (42000): command denied to user"),
             DbOperationError::PermissionDenied(_)
         ));
@@ -176,6 +203,18 @@ mod tests {
             DbOperationError::LockTimeout(_)
         ));
         assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1213 (40001): generic failure"),
+            DbOperationError::LockTimeout(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1022 (23000): generic failure"),
+            DbOperationError::UniqueViolation(_)
+        ));
+        assert!(matches!(
+            classify_mysql_query_failure(b"ERROR 1062 (23000): generic failure"),
+            DbOperationError::UniqueViolation(_)
+        ));
+        assert!(matches!(
             classify_mysql_query_failure(
                 b"ERROR 1452 (23000): Cannot add or update a child row: a foreign key constraint fails"
             ),
@@ -190,6 +229,23 @@ mod tests {
         assert!(!has_mysql_cli_error(b"ERROR"));
         assert!(!has_mysql_cli_error(b"ERROR 1"));
         assert!(has_mysql_cli_error(b"ERROR 1054"));
+    }
+
+    #[test]
+    fn does_not_use_wording_to_classify_an_unknown_server_error_code() {
+        let error = classify_mysql_query_failure(
+            b"ERROR 9999 (HY000): Duplicate entry duplicate_value for key PRIMARY",
+        );
+
+        assert!(matches!(error, DbOperationError::QueryFailed(_)));
+    }
+
+    #[test]
+    fn uses_wording_when_mysql_error_code_is_not_present() {
+        assert!(matches!(
+            classify_mysql_query_failure(b"duplicate entry duplicate_value for key PRIMARY"),
+            DbOperationError::UniqueViolation(_)
+        ));
     }
 
     #[test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1890,6 +1890,109 @@ mod query_execution {
 
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn classifies_real_mysql_server_errors_by_server_code() {
+        with_mysql_test_db(|db| Box::pin(async move {
+            let suffix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|error| format!("system clock error: {error}"))?
+                .as_nanos();
+            let lock_table = format!("sabiql_mrf2_05_lock_{suffix}");
+            let missing_table = format!("sabiql_mrf2_05_missing_{suffix}");
+            let result = async {
+                let missing = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!("SELECT id FROM {missing_table}"),
+                        AccessMode::ReadWrite,
+                    )
+                    .await;
+                if !matches!(missing, Err(DbOperationError::ObjectMissing(_))) {
+                    return Err(format!("missing object was not classified: {missing:?}"));
+                }
+
+                let duplicate = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        "CREATE TEMPORARY TABLE sabiql_mrf2_05_duplicate (id INT PRIMARY KEY); INSERT INTO sabiql_mrf2_05_duplicate VALUES (1); INSERT INTO sabiql_mrf2_05_duplicate VALUES (1)",
+                        AccessMode::ReadWrite,
+                    )
+                    .await;
+                if !matches!(
+                    &duplicate,
+                    Err(DbOperationError::QueryFailedAfterChange { source, .. })
+                        if matches!(&**source, DbOperationError::UniqueViolation(_))
+                ) {
+                    return Err(format!("duplicate error was not classified: {duplicate:?}"));
+                }
+
+                db.adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!(
+                            "CREATE TABLE {lock_table} (id INT PRIMARY KEY, value INT NOT NULL); INSERT INTO {lock_table} VALUES (1, 0), (2, 0)"
+                        ),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to create lock fixture: {error:?}"))?;
+
+                let first_query = format!(
+                    "BEGIN; UPDATE {lock_table} SET value = value + 1 WHERE id = 1; SELECT SLEEP(1); UPDATE {lock_table} SET value = value + 1 WHERE id = 2; COMMIT"
+                );
+                let second_query = format!(
+                    "BEGIN; UPDATE {lock_table} SET value = value + 1 WHERE id = 2; SELECT SLEEP(1); UPDATE {lock_table} SET value = value + 1 WHERE id = 1; COMMIT"
+                );
+                let first = db.adapter().execute_adhoc(
+                    db.dsn(),
+                    &first_query,
+                    AccessMode::ReadWrite,
+                );
+                let second = db.adapter().execute_adhoc(
+                    db.dsn(),
+                    &second_query,
+                    AccessMode::ReadWrite,
+                );
+                let (first, second) = tokio::join!(first, second);
+                let lock_error = match (first, second) {
+                    (Err(error), _) | (_, Err(error)) => Some(error),
+                    (Ok(_), Ok(_)) => None,
+                };
+                match lock_error.as_ref() {
+                    Some(error) if error.summary() == "Operation blocked by lock or timeout" => {}
+                    _ => {
+                        return Err(format!(
+                            "deadlock error was not classified: {lock_error:?}"
+                        ));
+                    }
+                }
+
+                Ok::<(), String>(())
+            }
+            .await;
+            let cleanup = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!("DROP TABLE IF EXISTS {lock_table}"),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("failed to clean up lock fixture: {error:?}"));
+            match result {
+                Err(error) => {
+                    cleanup?;
+                    Err(error)
+                }
+                Ok(()) => cleanup.map(|_| ()),
+            }
+        }))
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
     async fn times_out_real_cli_query_and_discards_output() {
         with_mysql_test_db(|db| {
             Box::pin(async move {


### PR DESCRIPTION
## Problem
MySQL server errors with known numeric codes can be misclassified when their English messages differ, causing semantic database errors to fall through to QueryFailed.

## Background
Object-missing, duplicate, and lock errors should remain stable across server wording and locale changes while unknown codes fail closed.

## Approach
Classify the confirmed Oracle MySQL server codes before the existing wording fallback, preserving the existing summaries and user-facing details. Keep wording classification only for output without a server code, and add unit plus Oracle MySQL 8.4 coverage for representative failures.

## Linear Issue Link (optional)

- Related to https://linear.app/sabiql/issue/SAB-368