### PR TITLE
fix(mysql): classify CSV exports by dialect

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -30,6 +30,7 @@ use crate::model::sql_editor::modal::SqlModalContext;
 use crate::model::sql_editor::query_history::QueryHistoryPickerState;
 use crate::model::sqlite::diagnostics::SqliteDiagnosticsState;
 use crate::policy::preview_cell_text::CellPresentationPolicy;
+use crate::policy::sql::mysql_export::mysql_export_plan;
 use crate::policy::sql::result_query::is_rerunnable_select;
 use crate::policy::table_kind::max_explorer_table_label_width;
 use crate::policy::write::inline_cell_edit::supports_inline_edit;
@@ -384,10 +385,11 @@ impl AppState {
         if result.is_error() {
             return false;
         }
-        if self.session.active_database_type() == Some(DatabaseType::SQLite) {
-            return true;
+        match self.session.active_database_type() {
+            Some(DatabaseType::SQLite) => true,
+            Some(DatabaseType::MySQL) => mysql_export_plan(&result.query).is_some(),
+            _ => is_rerunnable_select(&result.query),
         }
-        is_rerunnable_select(&result.query)
     }
 
     pub fn visible_preview_target_read_only_reason(&self) -> Option<&'static str> {
@@ -1241,6 +1243,32 @@ mod tests {
             state.query.set_current_result(Arc::new(result));
 
             assert!(!state.can_request_csv_export());
+        }
+
+        #[rstest]
+        #[case("SELECT id FROM users")]
+        #[case("TABLE users")]
+        #[case("SHOW TABLES")]
+        #[case("DESCRIBE users")]
+        fn mysql_csv_export_allows_supported_result_queries(#[case] query: &str) {
+            let mut state = make_state();
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://localhost/test",
+            );
+            state
+                .query
+                .set_current_result(Arc::new(QueryResult::success(
+                    query.to_string(),
+                    vec!["column".to_string()],
+                    vec![vec!["value".to_string()]],
+                    10,
+                    QuerySource::Adhoc,
+                )));
+
+            assert!(state.can_request_csv_export());
         }
 
         #[test]

--- a/src/app/policy/sql/mod.rs
+++ b/src/app/policy/sql/mod.rs
@@ -1,4 +1,5 @@
 pub mod lexer;
+pub mod mysql_export;
 pub mod mysql_statement;
 pub mod result_query;
 pub mod sqlite_explain;

--- a/src/app/policy/sql/mysql_export.rs
+++ b/src/app/policy/sql/mysql_export.rs
@@ -1,0 +1,51 @@
+use super::mysql_statement::{
+    MysqlStatementKind, classify_mysql_statement, split_mysql_statements,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MysqlExportPlan {
+    CountRows,
+    UseResultRowCount,
+}
+
+pub fn mysql_export_plan(query: &str) -> Option<MysqlExportPlan> {
+    let statements = split_mysql_statements(query).ok()?;
+    let [statement] = statements.as_slice() else {
+        return None;
+    };
+    let statement = classify_mysql_statement(statement).ok()?;
+
+    match statement.kind {
+        MysqlStatementKind::Select => Some(MysqlExportPlan::CountRows),
+        MysqlStatementKind::Table | MysqlStatementKind::Show | MysqlStatementKind::Describe => {
+            Some(MysqlExportPlan::UseResultRowCount)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::select("SELECT id FROM users", MysqlExportPlan::CountRows)]
+    #[case::table("TABLE users", MysqlExportPlan::UseResultRowCount)]
+    #[case::show("SHOW TABLES", MysqlExportPlan::UseResultRowCount)]
+    #[case::describe("DESCRIBE users", MysqlExportPlan::UseResultRowCount)]
+    fn plans_supported_mysql_export_queries(
+        #[case] query: &str,
+        #[case] expected: MysqlExportPlan,
+    ) {
+        assert_eq!(mysql_export_plan(query), Some(expected));
+    }
+
+    #[rstest]
+    #[case::insert("INSERT INTO users VALUES (1)")]
+    #[case::multiple_statements("SELECT 1; SELECT 2")]
+    #[case::unknown("GRANT SELECT ON users TO 'user'")]
+    fn rejects_queries_without_a_safe_mysql_export_plan(#[case] query: &str) {
+        assert_eq!(mysql_export_plan(query), None);
+    }
+}

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -6,6 +6,7 @@ use crate::domain::{DatabaseType, QuerySource, QueryValue};
 use crate::model::app_state::AppState;
 use crate::model::shared::confirm_dialog::{ConfirmIntent, CsvExportCacheSnapshot};
 use crate::model::shared::input_mode::InputMode;
+use crate::policy::sql::mysql_export::{MysqlExportPlan, mysql_export_plan};
 use crate::policy::sql::sqlite_export::{SqliteExportPlan, sqlite_export_plan};
 use crate::services::AppServices;
 use crate::update::action::Action;
@@ -73,12 +74,71 @@ fn dispatch_cached_csv_export(
     }
 }
 
-fn dispatch_rerunnable_csv_export(
+enum RerunnableCsvRowCount {
+    QueryDatabase,
+    Known(usize),
+}
+
+fn dispatch_counted_rerunnable_csv_export(
+    state: &mut AppState,
     dsn: String,
     run_id: u64,
     export_query: String,
     file_name: String,
+    row_count: Option<usize>,
 ) -> DispatchResult {
+    let needs_confirm = match row_count {
+        Some(count) => count > LARGE_EXPORT_THRESHOLD,
+        None => true,
+    };
+    if needs_confirm {
+        let msg = match row_count {
+            Some(n) => format!("Export {n} rows to CSV? This may take a while."),
+            None => "Row count unknown. Export to CSV?".to_string(),
+        };
+        state.confirm_dialog.open(
+            "Confirm CSV Export",
+            msg,
+            ConfirmIntent::CsvExportRerunnable {
+                dsn,
+                run_id,
+                export_query,
+                file_name,
+                row_count,
+            },
+        );
+        state.modal.push_mode(InputMode::ConfirmDialog);
+        DispatchResult::handled()
+    } else {
+        DispatchResult::handled_with(vec![Effect::ExportCsv {
+            dsn,
+            run_id,
+            query: export_query,
+            file_name,
+            row_count,
+        }])
+    }
+}
+
+fn dispatch_rerunnable_csv_export(
+    state: &mut AppState,
+    dsn: String,
+    run_id: u64,
+    export_query: String,
+    file_name: String,
+    row_count: RerunnableCsvRowCount,
+) -> DispatchResult {
+    if let RerunnableCsvRowCount::Known(row_count) = row_count {
+        return dispatch_counted_rerunnable_csv_export(
+            state,
+            dsn,
+            run_id,
+            export_query,
+            file_name,
+            Some(row_count),
+        );
+    }
+
     let stripped = export_query.trim_end().trim_end_matches(';').to_string();
     let count_query = format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count");
     DispatchResult::handled_with(vec![Effect::CountRowsForExport {
@@ -120,7 +180,14 @@ pub fn reduce_pagination(
                     }
                     SqliteExportPlan::RerunnableQuery { query } => {
                         let run_id = state.query.begin_running(now);
-                        return dispatch_rerunnable_csv_export(dsn, run_id, query, file_name);
+                        return dispatch_rerunnable_csv_export(
+                            state,
+                            dsn,
+                            run_id,
+                            query,
+                            file_name,
+                            RerunnableCsvRowCount::QueryDatabase,
+                        );
                     }
                     SqliteExportPlan::CachedResult { row_count } => {
                         let columns = result.columns.clone();
@@ -139,8 +206,34 @@ pub fn reduce_pagination(
                 }
             }
 
+            if state.session.active_database_type() == Some(DatabaseType::MySQL) {
+                let Some(plan) = mysql_export_plan(&export_query) else {
+                    return DispatchResult::handled();
+                };
+                let row_count = match plan {
+                    MysqlExportPlan::CountRows => RerunnableCsvRowCount::QueryDatabase,
+                    MysqlExportPlan::UseResultRowCount => RerunnableCsvRowCount::Known(row_count),
+                };
+                let run_id = state.query.begin_running(now);
+                return dispatch_rerunnable_csv_export(
+                    state,
+                    dsn,
+                    run_id,
+                    export_query,
+                    file_name,
+                    row_count,
+                );
+            }
+
             let run_id = state.query.begin_running(now);
-            dispatch_rerunnable_csv_export(dsn, run_id, export_query, file_name)
+            dispatch_rerunnable_csv_export(
+                state,
+                dsn,
+                run_id,
+                export_query,
+                file_name,
+                RerunnableCsvRowCount::QueryDatabase,
+            )
         }
 
         Action::CsvExportRowsCounted {
@@ -154,38 +247,14 @@ pub fn reduce_pagination(
                 return DispatchResult::handled();
             }
 
-            let needs_confirm = match row_count {
-                Some(n) => *n > LARGE_EXPORT_THRESHOLD,
-                None => true,
-            };
-
-            if needs_confirm {
-                let msg = match row_count {
-                    Some(n) => format!("Export {n} rows to CSV? This may take a while."),
-                    None => "Row count unknown. Export to CSV?".to_string(),
-                };
-                state.confirm_dialog.open(
-                    "Confirm CSV Export",
-                    msg,
-                    ConfirmIntent::CsvExportRerunnable {
-                        dsn: dsn.clone(),
-                        run_id: *run_id,
-                        export_query: export_query.clone(),
-                        file_name: file_name.clone(),
-                        row_count: *row_count,
-                    },
-                );
-                state.modal.push_mode(InputMode::ConfirmDialog);
-                DispatchResult::handled()
-            } else {
-                DispatchResult::handled_with(vec![Effect::ExportCsv {
-                    dsn: dsn.clone(),
-                    run_id: *run_id,
-                    query: export_query.clone(),
-                    file_name: file_name.clone(),
-                    row_count: *row_count,
-                }])
-            }
+            dispatch_counted_rerunnable_csv_export(
+                state,
+                dsn.clone(),
+                *run_id,
+                export_query.clone(),
+                file_name.clone(),
+                *row_count,
+            )
         }
 
         Action::ExecuteCsvExport {
@@ -931,6 +1000,58 @@ mod tests {
                 };
                 assert_eq!(columns, &["message"]);
                 assert_eq!(values, &vec![vec![QueryValue::text("a\0bc")]]);
+            }
+        }
+
+        mod mysql {
+            use super::*;
+
+            fn mysql_state(query: &str) -> AppState {
+                let mut state = AppState::new("test_project".to_string());
+                test_fixtures::activate_mysql_connection(&mut state, "mysql://localhost/test");
+                state
+                    .query
+                    .set_current_result(Arc::new(QueryResult::success(
+                        query.to_string(),
+                        vec!["column".to_string()],
+                        vec![vec!["value".to_string()]],
+                        1,
+                        QuerySource::Adhoc,
+                    )));
+                state
+            }
+
+            #[rstest]
+            #[case::select("SELECT 1", true)]
+            #[case::table("TABLE users", false)]
+            #[case::show("SHOW TABLES", false)]
+            #[case::describe("DESCRIBE users", false)]
+            fn uses_count_only_for_mysql_select(#[case] query: &str, #[case] expects_count: bool) {
+                let mut state = mysql_state(query);
+
+                let effects = dispatch_query(
+                    &mut state,
+                    &Action::RequestCsvExport,
+                    Instant::now(),
+                    &AppServices::stub(),
+                )
+                .unwrap();
+
+                assert_eq!(effects.len(), 1);
+                assert_eq!(
+                    matches!(&effects[0], Effect::CountRowsForExport { .. }),
+                    expects_count
+                );
+                assert_eq!(
+                    matches!(
+                        &effects[0],
+                        Effect::ExportCsv {
+                            row_count: Some(1),
+                            ..
+                        }
+                    ),
+                    !expects_count
+                );
             }
         }
     }

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use crate::adapters::csv_export::export_to_downloads;
 use crate::app::policy::sql::mysql_statement::mysql_tree_explain_query_kind;
 use crate::app::ports::outbound::{AccessMode, DbOperationError, QueryExecutor};
-use crate::domain::{QueryResult, QuerySource, QueryValue, WriteExecutionResult};
+use crate::domain::{QueryResult, QuerySource, WriteExecutionResult};
 use async_trait::async_trait;
 
 use super::adapter::MySqlAdapter;
@@ -251,19 +251,7 @@ impl QueryExecutor for MySqlAdapter {
         validate_mysql_export_query(query, target.database.as_deref())?;
 
         let result = self.execute_adhoc(dsn, query, AccessMode::ReadOnly).await?;
-        let value = result
-            .values()
-            .first()
-            .and_then(|row| row.first())
-            .and_then(QueryValue::as_str)
-            .ok_or_else(|| {
-                DbOperationError::QueryFailed(
-                    "MySQL row count query returned an invalid result".to_string(),
-                )
-            })?;
-        value.parse::<usize>().map_err(|_| {
-            DbOperationError::QueryFailed("MySQL row count was not an integer".to_string())
-        })
+        parse_mysql_count_result(&result)
     }
 
     async fn export_to_csv(
@@ -280,5 +268,66 @@ impl QueryExecutor for MySqlAdapter {
             export_mysql_csv_to_file(target, &query, path).await
         })
         .await
+    }
+}
+
+fn parse_mysql_count_result(result: &QueryResult) -> Result<usize, DbOperationError> {
+    let value = match result.values() {
+        [row] => match row.as_slice() {
+            [value] => value.as_str(),
+            _ => None,
+        },
+        _ => None,
+    }
+    .ok_or_else(|| {
+        DbOperationError::QueryFailed(
+            "MySQL row count query returned an invalid result".to_string(),
+        )
+    })?;
+
+    value.parse::<usize>().map_err(|_| {
+        DbOperationError::QueryFailed("MySQL row count was not an integer".to_string())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::QueryValue;
+
+    fn count_result(values: Vec<Vec<QueryValue>>) -> QueryResult {
+        QueryResult::success_with_values(
+            "SELECT COUNT(*)".to_string(),
+            vec!["COUNT(*)".to_string()],
+            values,
+            0,
+            QuerySource::Adhoc,
+        )
+    }
+
+    #[test]
+    fn parses_a_single_integer_count_result() {
+        assert_eq!(
+            parse_mysql_count_result(&count_result(vec![vec![QueryValue::text("42")]])).unwrap(),
+            42
+        );
+    }
+
+    #[test]
+    fn rejects_an_empty_count_result() {
+        assert!(matches!(
+            parse_mysql_count_result(&count_result(Vec::new())),
+            Err(DbOperationError::QueryFailed(details))
+                if details == "MySQL row count query returned an invalid result"
+        ));
+    }
+
+    #[test]
+    fn rejects_a_non_integer_count_result() {
+        assert!(matches!(
+            parse_mysql_count_result(&count_result(vec![vec![QueryValue::text("unknown")]])),
+            Err(DbOperationError::QueryFailed(details))
+                if details == "MySQL row count was not an integer"
+        ));
     }
 }

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2014,7 +2014,7 @@ mod csv_export {
 
     use super::shared::MYSQL_EMPTY_TABLE;
     use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, with_mysql_test_db};
-    use sabiql_app::ports::outbound::DbOperationError;
+    use sabiql_app::ports::outbound::{DbOperationError, QueryExecutor};
     use sabiql_infra::adapters::mysql::export_mysql_csv_to_path_for_test;
     use tempfile::tempdir;
 
@@ -2054,6 +2054,76 @@ mod csv_export {
                 }
                 if write_path.exists() {
                     return Err("write export created an output file".to_string());
+                }
+                Ok(())
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+    async fn exports_each_supported_mysql_result_statement() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
+                let output_directory = tempdir().map_err(|error| error.to_string())?;
+                for (name, query) in [
+                    ("select", format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}")),
+                    ("table", format!("TABLE {MYSQL_EMPTY_TABLE}")),
+                    ("show", format!("SHOW TABLES LIKE '{MYSQL_FIXTURE_TABLE}'")),
+                    ("describe", format!("DESCRIBE {MYSQL_FIXTURE_TABLE}")),
+                ] {
+                    let path = export_mysql_csv_to_path_for_test(
+                        db.dsn(),
+                        &query,
+                        output_directory.path().join(format!("{name}.csv")),
+                    )
+                    .await
+                    .map_err(|error| format!("{name} CSV export failed: {error:?}"))?;
+                    let csv = std::fs::read_to_string(&path)
+                        .map_err(|error| format!("failed to read {name} CSV export: {error}"))?;
+                    if csv.trim().is_empty() {
+                        return Err(format!("{name} CSV export was empty"));
+                    }
+                }
+                Ok(())
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+    async fn count_query_rows_rejects_empty_and_non_integer_results() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
+                let empty = db
+                    .adapter()
+                    .count_query_rows(
+                        db.dsn(),
+                        &format!("SELECT id FROM {MYSQL_EMPTY_TABLE} WHERE FALSE"),
+                    )
+                    .await;
+                if !matches!(
+                    empty,
+                    Err(DbOperationError::QueryFailed(ref details))
+                        if details.contains("invalid result")
+                ) {
+                    return Err(format!("empty count result was accepted: {empty:?}"));
+                }
+
+                let non_integer = db
+                    .adapter()
+                    .count_query_rows(db.dsn(), "SELECT 'not-a-count'")
+                    .await;
+                if !matches!(
+                    non_integer,
+                    Err(DbOperationError::QueryFailed(ref details))
+                        if details.contains("not an integer")
+                ) {
+                    return Err(format!(
+                        "non-integer count result was accepted: {non_integer:?}"
+                    ));
                 }
                 Ok(())
             })


### PR DESCRIPTION
## Problem
MySQL TABLE, SHOW, and DESCRIBE result queries were blocked or sent through PostgreSQL-style COUNT wrapping, so their CSV export path could not run.

## Background
The CSV entry point shared PostgreSQL rerun logic for non-SQLite databases, while MySQL supports these result-producing statements with different syntax.

## Approach
Classify supported MySQL export queries explicitly: SELECT uses the existing COUNT path, while TABLE, SHOW, and DESCRIBE reuse the fetched result count. Invalid MySQL count results fail closed and preserve the existing unknown-count confirmation. PostgreSQL and SQLite paths remain unchanged.

## Validation
Oracle MySQL 8.4.10 server/CLI integration, all-features and no-default-features clippy/tests, snapshots, lint, and release builds pass.