### PR TITLE
perf(mysql): avoid duplicate empty result execution

### DIFF
--- a/src/infra/adapters/mysql/cli/mod.rs
+++ b/src/infra/adapters/mysql/cli/mod.rs
@@ -14,7 +14,8 @@ pub(super) use export::export_mysql_csv_to_file;
 pub(super) use policy::{validate_mysql_export_query, validate_mysql_multi_query};
 pub(super) use probe::{check_mysql_cli_version, probe_mysql_server};
 pub(super) use process::{
-    MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, run_mysql_adhoc, run_mysql_single_statement,
+    MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, run_mysql_adhoc,
+    run_mysql_adhoc_with_expected_columns, run_mysql_single_statement,
 };
 pub(super) use xml::MysqlResultSet;
 

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -240,9 +240,24 @@ impl MysqlMetadataSession {
         &mut self,
         query: &str,
     ) -> Result<MysqlResultSet, DbOperationError> {
+        self.execute_with_expected_columns(query, &[]).await
+    }
+
+    pub(in crate::adapters::mysql) async fn execute_with_expected_columns(
+        &mut self,
+        query: &str,
+        expected_columns: &[&str],
+    ) -> Result<MysqlResultSet, DbOperationError> {
         write_mysql_statement(&mut self.process, query).await?;
         let xml = read_one_mysql_resultset(&mut self.process).await?;
-        parse_mysql_xml(&xml)
+        let mut result = parse_mysql_xml(&xml)?;
+        if result.columns.is_empty() && result.values.is_empty() {
+            result.columns = expected_columns
+                .iter()
+                .map(|column| (*column).to_string())
+                .collect();
+        }
+        Ok(result)
     }
 
     pub(in crate::adapters::mysql) async fn finish(&mut self) -> Result<(), DbOperationError> {
@@ -290,11 +305,29 @@ pub(in crate::adapters::mysql) async fn run_mysql_adhoc(
     statements: &[MysqlStatement],
     access_mode: AccessMode,
 ) -> Result<MysqlExecutionResult, DbOperationError> {
-    run_mysql_adhoc_with_program_and_statements(
+    run_mysql_adhoc_with_program_and_statements_and_expected_columns(
         OsStr::new("mysql"),
         option_file,
         statements,
         access_mode,
+        None,
+        MYSQL_QUERY_TIMEOUT,
+    )
+    .await
+}
+
+pub(in crate::adapters::mysql) async fn run_mysql_adhoc_with_expected_columns(
+    option_file: &std::path::Path,
+    statements: &[MysqlStatement],
+    access_mode: AccessMode,
+    expected_columns: &[&str],
+) -> Result<MysqlExecutionResult, DbOperationError> {
+    run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+        OsStr::new("mysql"),
+        option_file,
+        statements,
+        access_mode,
+        Some(expected_columns),
         MYSQL_QUERY_TIMEOUT,
     )
     .await
@@ -378,11 +411,12 @@ async fn run_mysql_single_statement_process(
     parse_mysql_xml(&stdout)
 }
 
-async fn run_mysql_adhoc_with_program_and_statements(
+async fn run_mysql_adhoc_with_program_and_statements_and_expected_columns(
     program: &OsStr,
     option_file: &std::path::Path,
     statements: &[MysqlStatement],
     access_mode: AccessMode,
+    expected_columns: Option<&[&str]>,
     execution_timeout: Duration,
 ) -> Result<MysqlExecutionResult, DbOperationError> {
     if mysql_metadata_fallback_has_unsupported_session_state(statements) {
@@ -394,7 +428,13 @@ async fn run_mysql_adhoc_with_program_and_statements(
     let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
     let result = timeout(
         execution_timeout,
-        run_mysql_adhoc_process(&mut process, option_file, statements, access_mode),
+        run_mysql_adhoc_process(
+            &mut process,
+            option_file,
+            statements,
+            access_mode,
+            expected_columns,
+        ),
     )
     .await;
 
@@ -424,6 +464,7 @@ async fn run_mysql_statement(
     option_file: &std::path::Path,
     statement: &MysqlStatement,
     access_mode: AccessMode,
+    expected_columns: Option<&[&str]>,
     refresh_scope: RefreshScope,
 ) -> Result<MysqlStatementExecution, DbOperationError> {
     let marker = Uuid::new_v4().simple().to_string();
@@ -475,6 +516,7 @@ async fn run_mysql_statement(
             &statement.sql,
             &statement.kind,
             access_mode,
+            expected_columns,
         )
         .await
         .map_err(|error| query_failed_after_change(error, possible_refresh_scope))?;
@@ -502,6 +544,7 @@ async fn run_mysql_adhoc_process(
     option_file: &std::path::Path,
     statements: &[MysqlStatement],
     access_mode: AccessMode,
+    expected_columns: Option<&[&str]>,
 ) -> Result<MysqlExecutionResult, DbOperationError> {
     let probe_marker = Uuid::new_v4().simple().to_string();
     let probe_query = format!(
@@ -516,11 +559,20 @@ async fn run_mysql_adhoc_process(
     let mut last_result_set = None;
     let mut command_tags = Vec::with_capacity(statements.len());
     let mut refresh_scope = RefreshScope::None;
+    let expected_columns = (statements.len() == 1)
+        .then_some(expected_columns)
+        .flatten();
 
     for statement in statements {
-        let execution =
-            run_mysql_statement(process, option_file, statement, access_mode, refresh_scope)
-                .await?;
+        let execution = run_mysql_statement(
+            process,
+            option_file,
+            statement,
+            access_mode,
+            expected_columns,
+            refresh_scope,
+        )
+        .await?;
         if let Some(result) = execution.result_set {
             last_result_set = Some(result);
         }
@@ -1147,8 +1199,16 @@ async fn fill_mysql_empty_result_columns(
     query: &str,
     kind: &MysqlStatementKind,
     access_mode: AccessMode,
+    expected_columns: Option<&[&str]>,
 ) -> Result<MysqlResultSet, DbOperationError> {
     if !result.columns.is_empty() || !result.values.is_empty() {
+        return Ok(result);
+    }
+    if let Some(expected_columns) = expected_columns {
+        result.columns = expected_columns
+            .iter()
+            .map(|column| (*column).to_string())
+            .collect();
         return Ok(result);
     }
     let fallback_kind = mysql_metadata_fallback_kind(kind).ok_or_else(|| {
@@ -1478,9 +1538,16 @@ while IFS= read -r line; do
       pending_error=1
       ;;
     *SELECT*)
-      value=one
-      case "$line" in *SELECT\ 2*) value=two ;; esac
-      printf '%s\n' '<resultset><row><field name="value">'"$value"'</field></row></resultset>'
+      case "$line" in
+        *WHERE\ FALSE*)
+          printf '%s\n' '<resultset></resultset>'
+          ;;
+        *)
+          value=one
+          case "$line" in *SELECT\ 2*) value=two ;; esac
+          printf '%s\n' '<resultset><row><field name="value">'"$value"'</field></row></resultset>'
+          ;;
+      esac
       ;;
     *UPDATE*)
       last_statement=update
@@ -1538,11 +1605,12 @@ done
             .map(|sql| classify_mysql_statement(&sql).unwrap())
             .collect::<Vec<_>>();
 
-        let result = run_mysql_adhoc_with_program_and_statements(
+        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
             OsStr::new(&program),
             &option_file,
             &statements,
             AccessMode::ReadOnly,
+            None,
             Duration::from_secs(5),
         )
         .await
@@ -1562,6 +1630,35 @@ done
         let user_index = log.find("SELECT 2").expect("user statement");
         assert!(session_index < user_index, "{log}");
         assert!(log.contains(MYSQL_SESSION_MARKER_COLUMN));
+    }
+
+    #[tokio::test]
+    async fn known_empty_result_uses_expected_columns_without_replaying_query() {
+        let (_directory, program, option_file) = fake_mysql_multi();
+        let query = "SELECT 1 AS first_alias WHERE FALSE";
+        let statements = split_mysql_statements(query)
+            .unwrap()
+            .into_iter()
+            .map(|sql| classify_mysql_statement(&sql).unwrap())
+            .collect::<Vec<_>>();
+
+        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+            OsStr::new(&program),
+            &option_file,
+            &statements,
+            AccessMode::ReadOnly,
+            Some(&["first_alias"]),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("known empty result");
+        let result_set = result.result_set.expect("result set");
+        assert_eq!(result_set.columns, ["first_alias"]);
+        assert!(result_set.values.is_empty());
+
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+        assert_eq!(log.matches(query).count(), 1, "{log}");
+        assert!(!log.contains("__sabiql_metadata_inner"));
     }
 
     #[tokio::test]
@@ -1586,6 +1683,12 @@ done
         ] {
             session.execute(query).await.expect("metadata resultset");
         }
+        let empty_result = session
+            .execute_with_expected_columns("EMPTY_RESULT", &["known_column"])
+            .await
+            .expect("empty metadata resultset");
+        assert_eq!(empty_result.columns, ["known_column"]);
+        assert!(empty_result.values.is_empty());
         session.finish().await.expect("finish fake mysql");
 
         let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
@@ -1645,11 +1748,12 @@ done
                 .map(|sql| classify_mysql_statement(&sql).unwrap())
                 .collect::<Vec<_>>();
 
-            run_mysql_adhoc_with_program_and_statements(
+            run_mysql_adhoc_with_program_and_statements_and_expected_columns(
                 OsStr::new(&program),
                 &option_file,
                 &statements,
                 AccessMode::ReadOnly,
+                None,
                 Duration::from_secs(5),
             )
             .await
@@ -1959,11 +2063,12 @@ done
             .map(|sql| classify_mysql_statement(&sql).unwrap())
             .collect::<Vec<_>>();
 
-        let result = run_mysql_adhoc_with_program_and_statements(
+        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
             OsStr::new(&program),
             &option_file,
             &statements,
             AccessMode::ReadWrite,
+            None,
             Duration::from_secs(5),
         )
         .await
@@ -1993,11 +2098,12 @@ done
             .map(|sql| classify_mysql_statement(&sql).unwrap())
             .collect::<Vec<_>>();
 
-        let result = run_mysql_adhoc_with_program_and_statements(
+        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
             OsStr::new(&program),
             &option_file,
             &statements,
             AccessMode::ReadWrite,
+            None,
             Duration::from_secs(5),
         )
         .await;
@@ -2021,11 +2127,12 @@ done
             .map(|sql| classify_mysql_statement(&sql).unwrap())
             .collect::<Vec<_>>();
 
-        let result = run_mysql_adhoc_with_program_and_statements(
+        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
             OsStr::new(&program),
             &option_file,
             &statements,
             AccessMode::ReadWrite,
+            None,
             Duration::from_secs(5),
         )
         .await;
@@ -2068,11 +2175,12 @@ done
                 .map(|sql| classify_mysql_statement(&sql).unwrap())
                 .collect::<Vec<_>>();
 
-            let result = run_mysql_adhoc_with_program_and_statements(
+            let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
                 OsStr::new(&program),
                 &option_file,
                 &statements,
                 AccessMode::ReadWrite,
+                None,
                 Duration::from_secs(5),
             )
             .await;
@@ -2098,11 +2206,12 @@ done
                 .map(|sql| classify_mysql_statement(&sql).unwrap())
                 .collect::<Vec<_>>();
 
-        let result = run_mysql_adhoc_with_program_and_statements(
+        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
             OsStr::new(&program),
             &option_file,
             &statements,
             AccessMode::ReadWrite,
+            None,
             Duration::from_secs(5),
         )
         .await;
@@ -2126,11 +2235,12 @@ done
             .map(|sql| classify_mysql_statement(&sql).unwrap())
             .collect::<Vec<_>>();
 
-        let result = run_mysql_adhoc_with_program_and_statements(
+        let result = run_mysql_adhoc_with_program_and_statements_and_expected_columns(
             OsStr::new(&program),
             &option_file,
             &statements,
             AccessMode::ReadWrite,
+            None,
             Duration::from_secs(5),
         )
         .await;

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -8,8 +8,8 @@ use async_trait::async_trait;
 
 use super::adapter::MySqlAdapter;
 use super::cli::{
-    export_mysql_csv_to_file, run_mysql_adhoc, run_mysql_single_statement,
-    validate_mysql_export_query, validate_mysql_multi_query,
+    export_mysql_csv_to_file, run_mysql_adhoc, run_mysql_adhoc_with_expected_columns,
+    run_mysql_single_statement, validate_mysql_export_query, validate_mysql_multi_query,
 };
 use super::dsn::parse_and_validate_mysql_dsn;
 use super::metadata;
@@ -106,8 +106,20 @@ impl QueryExecutor for MySqlAdapter {
         let target = parse_and_validate_mysql_dsn(dsn)?;
         let statements =
             validate_mysql_multi_query(&query, target.database.as_deref(), AccessMode::ReadOnly)?;
+        let expected_columns =
+            metadata::preview_result_columns(&preview.visible_columns, &preview.identity_columns);
+        let expected_columns = expected_columns
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
         let option_file = MySqlOptionFile::create(&target)?;
-        let result = run_mysql_adhoc(&option_file.path, &statements, AccessMode::ReadOnly).await;
+        let result = run_mysql_adhoc_with_expected_columns(
+            &option_file.path,
+            &statements,
+            AccessMode::ReadOnly,
+            &expected_columns,
+        )
+        .await;
         drop(option_file);
         let result_set = result?.result_set.ok_or_else(|| {
             DbOperationError::MetadataParseFailed(

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -1,23 +1,49 @@
 use std::ffi::OsStr;
 use std::time::Duration;
 
-use crate::app::ports::outbound::{AccessMode, DbOperationError};
+use crate::app::ports::outbound::DbOperationError;
 use crate::domain::{
     Column, ColumnAttributes, FkAction, ForeignKey, QueryValue, TableKind, TableKindInfo,
     TableSummary,
 };
 
 use super::super::{
-    cli::{
-        MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, MysqlResultSet, run_mysql_adhoc,
-        validate_mysql_multi_query,
-    },
+    cli::{MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, MysqlResultSet},
     dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
     sql::quote_string,
 };
 
-pub(super) const TABLES_QUERY: &str = "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') UNION ALL SELECT NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')) ORDER BY TABLE_SCHEMA, TABLE_NAME";
+pub(super) const TABLES_QUERY: &str = "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') ORDER BY TABLE_SCHEMA, TABLE_NAME";
+pub(super) const TABLES_RESULT_COLUMNS: &[&str] = &[
+    "TABLE_SCHEMA",
+    "TABLE_NAME",
+    "TABLE_TYPE",
+    "TABLE_ROWS",
+    "TABLE_COMMENT",
+];
+pub(super) const COLUMN_METADATA_RESULT_COLUMNS: &[&str] = &[
+    "COLUMN_NAME",
+    "COLUMN_TYPE",
+    "IS_NULLABLE",
+    "COLUMN_DEFAULT",
+    "EXTRA",
+    "COLUMN_COMMENT",
+    "ORDINAL_POSITION",
+    "PRIMARY_KEY_POSITION",
+];
+pub(super) const FOREIGN_KEY_RESULT_COLUMNS: &[&str] = &[
+    "CONSTRAINT_NAME",
+    "TABLE_SCHEMA",
+    "TABLE_NAME",
+    "COLUMN_NAME",
+    "REFERENCED_TABLE_SCHEMA",
+    "REFERENCED_TABLE_NAME",
+    "REFERENCED_COLUMN_NAME",
+    "ORDINAL_POSITION",
+    "UPDATE_RULE",
+    "DELETE_RULE",
+];
 
 #[derive(Debug, Clone)]
 pub(super) struct MysqlColumnMetadata {
@@ -66,7 +92,7 @@ pub(super) async fn fetch_metadata_snapshot(
     dsn: &str,
 ) -> Result<MysqlMetadataSnapshot, DbOperationError> {
     let database = selected_database(dsn)?;
-    let result = execute_metadata_query(dsn, TABLES_QUERY).await?;
+    let result = execute_metadata_query(dsn, TABLES_QUERY, TABLES_RESULT_COLUMNS).await?;
     metadata_snapshot_from_result(&database, None, &result)
 }
 
@@ -76,7 +102,12 @@ pub(super) async fn fetch_columns(
     table: &str,
 ) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
     validate_selected_schema(dsn, schema)?;
-    let result = execute_metadata_query(dsn, &columns_query(schema, table)).await?;
+    let result = execute_metadata_query(
+        dsn,
+        &columns_query(schema, table),
+        COLUMN_METADATA_RESULT_COLUMNS,
+    )
+    .await?;
     parse_columns_for_table(&result, schema, table)
 }
 
@@ -96,9 +127,7 @@ pub(super) fn find_table(
 
 pub(super) fn table_query(schema: &str, table: &str) -> String {
     format!(
-        "SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_ROWS, t.TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_SCHEMA = {} AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') AND t.TABLE_NAME = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_SCHEMA = {} AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') AND t.TABLE_NAME = {}) ORDER BY TABLE_SCHEMA, TABLE_NAME",
-        quote_string(schema),
-        quote_string(table),
+        "SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_ROWS, t.TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_SCHEMA = {} AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') AND t.TABLE_NAME = {} ORDER BY TABLE_SCHEMA, TABLE_NAME",
         quote_string(schema),
         quote_string(table),
     )
@@ -106,9 +135,7 @@ pub(super) fn table_query(schema: &str, table: &str) -> String {
 
 pub(super) fn columns_query(schema: &str, table: &str) -> String {
     format!(
-        "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = {} AND c.TABLE_NAME = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = {} AND TABLE_NAME = {}) ORDER BY ORDINAL_POSITION",
-        quote_string(schema),
-        quote_string(table),
+        "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = {} AND c.TABLE_NAME = {} ORDER BY ORDINAL_POSITION",
         quote_string(schema),
         quote_string(table),
     )
@@ -131,23 +158,22 @@ pub(super) fn parse_columns_for_table(
 pub(super) async fn execute_metadata_query(
     dsn: &str,
     query: &str,
+    expected_columns: &[&str],
 ) -> Result<MysqlResultSet, DbOperationError> {
-    let target = parse_and_validate_mysql_dsn(dsn)?;
-    let statements =
-        validate_mysql_multi_query(query, target.database.as_deref(), AccessMode::ReadOnly)?;
-    let option_file = MySqlOptionFile::create(&target)?;
-    let result = run_mysql_adhoc(&option_file.path, &statements, AccessMode::ReadOnly).await;
-    drop(option_file);
-    result?.result_set.ok_or_else(|| {
-        DbOperationError::MetadataParseFailed(
-            "MySQL metadata query returned no result set".to_string(),
-        )
-    })
+    execute_metadata_queries_in_session(dsn, &[(query, expected_columns)])
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            DbOperationError::MetadataParseFailed(
+                "MySQL metadata query returned no result set".to_string(),
+            )
+        })
 }
 
 pub(super) async fn execute_metadata_queries_in_session(
     dsn: &str,
-    queries: &[&str],
+    queries: &[(&str, &[&str])],
 ) -> Result<Vec<MysqlResultSet>, DbOperationError> {
     execute_metadata_queries_in_session_with_program(
         dsn,
@@ -160,7 +186,7 @@ pub(super) async fn execute_metadata_queries_in_session(
 
 async fn execute_metadata_queries_in_session_with_program(
     dsn: &str,
-    queries: &[&str],
+    queries: &[(&str, &[&str])],
     program: &OsStr,
     timeout: Duration,
 ) -> Result<Vec<MysqlResultSet>, DbOperationError> {
@@ -171,8 +197,12 @@ async fn execute_metadata_queries_in_session_with_program(
         session.probe().await?;
         session.prepare_read_only().await?;
         let mut results = Vec::with_capacity(queries.len());
-        for query in queries {
-            results.push(session.execute(query).await?);
+        for (query, expected_columns) in queries {
+            results.push(
+                session
+                    .execute_with_expected_columns(query, expected_columns)
+                    .await?,
+            );
         }
         session.finish().await?;
         Ok(results)
@@ -239,25 +269,13 @@ pub(super) fn metadata_snapshot_from_result(
 fn parse_table_metadata(
     result: &MysqlResultSet,
 ) -> Result<Vec<MysqlTableMetadata>, DbOperationError> {
-    expect_columns(
-        result,
-        &[
-            "TABLE_SCHEMA",
-            "TABLE_NAME",
-            "TABLE_TYPE",
-            "TABLE_ROWS",
-            "TABLE_COMMENT",
-        ],
-    )?;
-    let tables = result
+    expect_columns(result, TABLES_RESULT_COLUMNS)?;
+    result
         .values
         .iter()
         .map(|row| {
             if row.len() != 5 {
                 return Err(metadata_shape_error("TABLES row"));
-            }
-            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
-                return Ok(None);
             }
             let schema = required_text(&row[0], "TABLE_SCHEMA")?.to_string();
             let name = required_text(&row[1], "TABLE_NAME")?.to_string();
@@ -282,24 +300,20 @@ fn parse_table_metadata(
             let comment = optional_text(&row[4], "TABLE_COMMENT")?
                 .filter(|value| !value.is_empty())
                 .map(str::to_string);
-            Ok(Some(MysqlTableMetadata {
+            Ok(MysqlTableMetadata {
                 schema,
                 name,
                 kind,
                 row_count_estimate,
                 comment,
-            }))
+            })
         })
-        .collect::<Result<Vec<_>, _>>()?;
-    Ok(tables.into_iter().flatten().collect())
+        .collect()
 }
 
 pub(super) fn foreign_keys_query(schema: &str, table: &str) -> String {
     format!(
-        "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = {} AND tc.TABLE_SCHEMA = {} AND tc.TABLE_NAME = {} AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = {} AND TABLE_SCHEMA = {} AND TABLE_NAME = {} AND CONSTRAINT_TYPE = 'FOREIGN KEY') ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
-        quote_string(schema),
-        quote_string(schema),
-        quote_string(table),
+        "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = {} AND tc.TABLE_SCHEMA = {} AND tc.TABLE_NAME = {} AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
         quote_string(schema),
         quote_string(schema),
         quote_string(table),
@@ -309,19 +323,7 @@ pub(super) fn foreign_keys_query(schema: &str, table: &str) -> String {
 fn parse_column_metadata(
     result: &MysqlResultSet,
 ) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
-    expect_columns(
-        result,
-        &[
-            "COLUMN_NAME",
-            "COLUMN_TYPE",
-            "IS_NULLABLE",
-            "COLUMN_DEFAULT",
-            "EXTRA",
-            "COLUMN_COMMENT",
-            "ORDINAL_POSITION",
-            "PRIMARY_KEY_POSITION",
-        ],
-    )?;
+    expect_columns(result, COLUMN_METADATA_RESULT_COLUMNS)?;
     result
         .values
         .iter()
@@ -329,13 +331,9 @@ fn parse_column_metadata(
             if row.len() != 8 {
                 return Err(metadata_shape_error("COLUMNS row"));
             }
-            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
-                return Ok(None);
-            }
-            Ok(Some(parse_column_metadata_row(row, "COLUMNS row")?))
+            parse_column_metadata_row(row, "COLUMNS row")
         })
-        .collect::<Result<Vec<_>, _>>()
-        .map(|rows| rows.into_iter().flatten().collect())
+        .collect()
 }
 
 pub(super) fn parse_column_metadata_row(
@@ -370,32 +368,15 @@ pub(super) fn parse_column_metadata_row(
 pub(super) fn parse_foreign_key_metadata(
     result: &MysqlResultSet,
 ) -> Result<Vec<MysqlForeignKeyMetadata>, DbOperationError> {
-    expect_columns(
-        result,
-        &[
-            "CONSTRAINT_NAME",
-            "TABLE_SCHEMA",
-            "TABLE_NAME",
-            "COLUMN_NAME",
-            "REFERENCED_TABLE_SCHEMA",
-            "REFERENCED_TABLE_NAME",
-            "REFERENCED_COLUMN_NAME",
-            "ORDINAL_POSITION",
-            "UPDATE_RULE",
-            "DELETE_RULE",
-        ],
-    )?;
+    expect_columns(result, FOREIGN_KEY_RESULT_COLUMNS)?;
     result
         .values
         .iter()
         .map(|row| {
-            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
-                return Ok(None);
-            }
             if row.len() != 10 {
                 return Err(metadata_shape_error("foreign key row"));
             }
-            Ok(Some(MysqlForeignKeyMetadata {
+            Ok(MysqlForeignKeyMetadata {
                 name: required_text(&row[0], "CONSTRAINT_NAME")?.to_string(),
                 from_schema: required_text(&row[1], "TABLE_SCHEMA")?.to_string(),
                 from_table: required_text(&row[2], "TABLE_NAME")?.to_string(),
@@ -406,10 +387,9 @@ pub(super) fn parse_foreign_key_metadata(
                 ordinal_position: parse_positive_i32(&row[7], "ORDINAL_POSITION")?,
                 on_update: parse_fk_action(&row[8], "UPDATE_RULE")?,
                 on_delete: parse_fk_action(&row[9], "DELETE_RULE")?,
-            }))
+            })
         })
-        .collect::<Result<Vec<_>, _>>()
-        .map(|rows| rows.into_iter().flatten().collect())
+        .collect()
 }
 
 pub(super) fn foreign_keys_from_metadata(
@@ -689,29 +669,8 @@ mod tests {
     }
 
     #[test]
-    fn empty_columns_sentinel_maps_to_missing_table() {
-        let result = result(
-            &[
-                "COLUMN_NAME",
-                "COLUMN_TYPE",
-                "IS_NULLABLE",
-                "COLUMN_DEFAULT",
-                "EXTRA",
-                "COLUMN_COMMENT",
-                "ORDINAL_POSITION",
-                "PRIMARY_KEY_POSITION",
-            ],
-            vec![vec![
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-            ]],
-        );
+    fn empty_columns_result_maps_to_missing_table() {
+        let result = result(COLUMN_METADATA_RESULT_COLUMNS, Vec::new());
 
         let error = parse_columns_for_table(&result, "app", "missing").unwrap_err();
         assert!(matches!(error, DbOperationError::ObjectMissing(_)));
@@ -737,6 +696,7 @@ mod tests {
             )
         );
 
+        assert!(!TABLES_QUERY.contains("UNION ALL SELECT NULL"));
         for query in [
             table_query(schema, table),
             columns_query(schema, table),
@@ -744,28 +704,14 @@ mod tests {
         ] {
             assert!(query.contains(&quote_string(schema)));
             assert!(query.contains(&quote_string(table)));
+            assert!(!query.contains("UNION ALL SELECT NULL"));
         }
         assert!(!table_query(schema, table).contains("KEY_COLUMN_USAGE"));
     }
 
     #[test]
-    fn empty_table_list_sentinel_parses_as_no_tables() {
-        let result = result(
-            &[
-                "TABLE_SCHEMA",
-                "TABLE_NAME",
-                "TABLE_TYPE",
-                "TABLE_ROWS",
-                "TABLE_COMMENT",
-            ],
-            vec![vec![
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-            ]],
-        );
+    fn empty_table_list_result_parses_as_no_tables() {
+        let result = result(TABLES_RESULT_COLUMNS, Vec::new());
 
         assert!(
             parse_table_metadata(&result)

--- a/src/infra/adapters/mysql/metadata/mod.rs
+++ b/src/infra/adapters/mysql/metadata/mod.rs
@@ -10,7 +10,9 @@ mod preview;
 mod signature;
 mod table_detail;
 
-pub(super) use preview::{build_preview_query, convert_preview_values, fetch_preview_metadata};
+pub(super) use preview::{
+    build_preview_query, convert_preview_values, fetch_preview_metadata, preview_result_columns,
+};
 
 #[async_trait]
 impl MetadataProvider for MySqlAdapter {

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -118,16 +118,7 @@ pub(in crate::adapters::mysql) fn convert_preview_values(
     columns: &[Column],
     identity_columns: &[Column],
 ) -> Result<ConvertedPreviewValues, DbOperationError> {
-    let expected_columns = columns
-        .iter()
-        .map(|column| column.name.clone())
-        .chain(
-            identity_columns
-                .iter()
-                .enumerate()
-                .map(|(index, _)| preview_identity_alias(index)),
-        )
-        .collect::<Vec<_>>();
+    let expected_columns = preview_result_columns(columns, identity_columns);
     if result.values.is_empty() {
         if result.columns.is_empty() || result.columns == expected_columns {
             return Ok(ConvertedPreviewValues {
@@ -171,6 +162,22 @@ pub(in crate::adapters::mysql) fn convert_preview_values(
         },
     );
     Ok(ConvertedPreviewValues { visible, identity })
+}
+
+pub(in crate::adapters::mysql) fn preview_result_columns(
+    columns: &[Column],
+    identity_columns: &[Column],
+) -> Vec<String> {
+    columns
+        .iter()
+        .map(|column| column.name.clone())
+        .chain(
+            identity_columns
+                .iter()
+                .enumerate()
+                .map(|(index, _)| preview_identity_alias(index)),
+        )
+        .collect()
 }
 
 fn preview_identity_alias(index: usize) -> String {

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -1,15 +1,15 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::app::ports::outbound::DbOperationError;
-use crate::domain::{FkAction, QueryValue, Table, TableKind, TableKindInfo, TableSignature};
+use crate::domain::{FkAction, Table, TableKind, TableKindInfo, TableSignature};
 
 use super::super::cli::MysqlResultSet;
 use super::catalog::{
-    MysqlColumnMetadata, MysqlForeignKeyMetadata, MysqlTableMetadata, TABLES_QUERY,
-    column_from_metadata, execute_metadata_queries_in_session, expect_columns,
-    foreign_keys_from_metadata, metadata_shape_error, metadata_snapshot_from_result,
-    parse_column_metadata_row, parse_foreign_key_metadata, primary_key_names, required_text,
-    selected_database,
+    FOREIGN_KEY_RESULT_COLUMNS, MysqlColumnMetadata, MysqlForeignKeyMetadata, MysqlTableMetadata,
+    TABLES_QUERY, TABLES_RESULT_COLUMNS, column_from_metadata, execute_metadata_queries_in_session,
+    expect_columns, foreign_keys_from_metadata, metadata_shape_error,
+    metadata_snapshot_from_result, parse_column_metadata_row, parse_foreign_key_metadata,
+    primary_key_names, required_text, selected_database,
 };
 
 #[derive(Debug, Clone)]
@@ -26,9 +26,9 @@ pub(super) async fn fetch_table_signatures(
     let results = execute_metadata_queries_in_session(
         dsn,
         &[
-            TABLES_QUERY,
-            SIGNATURE_COLUMNS_QUERY,
-            SIGNATURE_FOREIGN_KEYS_QUERY,
+            (TABLES_QUERY, TABLES_RESULT_COLUMNS),
+            (SIGNATURE_COLUMNS_QUERY, SIGNATURE_COLUMNS_RESULT_COLUMNS),
+            (SIGNATURE_FOREIGN_KEYS_QUERY, FOREIGN_KEY_RESULT_COLUMNS),
         ],
     )
     .await?;
@@ -44,21 +44,7 @@ pub(super) async fn fetch_table_signatures(
 fn parse_signature_column_metadata(
     result: &MysqlResultSet,
 ) -> Result<Vec<MysqlSignatureColumnMetadata>, DbOperationError> {
-    expect_columns(
-        result,
-        &[
-            "TABLE_SCHEMA",
-            "TABLE_NAME",
-            "COLUMN_NAME",
-            "COLUMN_TYPE",
-            "IS_NULLABLE",
-            "COLUMN_DEFAULT",
-            "EXTRA",
-            "COLUMN_COMMENT",
-            "ORDINAL_POSITION",
-            "PRIMARY_KEY_POSITION",
-        ],
-    )?;
+    expect_columns(result, SIGNATURE_COLUMNS_RESULT_COLUMNS)?;
     result
         .values
         .iter()
@@ -66,17 +52,13 @@ fn parse_signature_column_metadata(
             if row.len() != 10 {
                 return Err(metadata_shape_error("signature COLUMNS row"));
             }
-            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
-                return Ok(None);
-            }
-            Ok(Some(MysqlSignatureColumnMetadata {
+            Ok(MysqlSignatureColumnMetadata {
                 schema: required_text(&row[0], "TABLE_SCHEMA")?.to_string(),
                 table: required_text(&row[1], "TABLE_NAME")?.to_string(),
                 column: parse_column_metadata_row(&row[2..], "signature COLUMNS row")?,
-            }))
+            })
         })
-        .collect::<Result<Vec<_>, _>>()
-        .map(|rows| rows.into_iter().flatten().collect())
+        .collect()
 }
 
 fn table_signatures_from_metadata(
@@ -305,13 +287,25 @@ fn foreign_key_action_name(action: &FkAction) -> &'static str {
     }
 }
 
-const SIGNATURE_COLUMNS_QUERY: &str = "SELECT c.TABLE_SCHEMA, c.TABLE_NAME, c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = DATABASE() UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE()) ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION";
-const SIGNATURE_FOREIGN_KEYS_QUERY: &str = "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = DATABASE() AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_SCHEMA = DATABASE() AND CONSTRAINT_TYPE = 'FOREIGN KEY') ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION";
+const SIGNATURE_COLUMNS_QUERY: &str = "SELECT c.TABLE_SCHEMA, c.TABLE_NAME, c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = DATABASE() ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION";
+const SIGNATURE_COLUMNS_RESULT_COLUMNS: &[&str] = &[
+    "TABLE_SCHEMA",
+    "TABLE_NAME",
+    "COLUMN_NAME",
+    "COLUMN_TYPE",
+    "IS_NULLABLE",
+    "COLUMN_DEFAULT",
+    "EXTRA",
+    "COLUMN_COMMENT",
+    "ORDINAL_POSITION",
+    "PRIMARY_KEY_POSITION",
+];
+const SIGNATURE_FOREIGN_KEYS_QUERY: &str = "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = DATABASE() AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION";
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{Column, ColumnAttributes, ForeignKey};
+    use crate::domain::{Column, ColumnAttributes, ForeignKey, QueryValue};
 
     fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
         MysqlResultSet {

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use crate::app::ports::outbound::DbOperationError;
 use crate::domain::{
-    ForeignKey, Index, IndexAttributes, IndexType, QueryValue, Table, TableKind, TableKindInfo,
-    Trigger, TriggerEvent, TriggerTiming,
+    ForeignKey, Index, IndexAttributes, IndexType, Table, TableKind, TableKindInfo, Trigger,
+    TriggerEvent, TriggerTiming,
 };
 
 use super::super::sql::{quote_identifier, quote_string};
@@ -14,7 +14,8 @@ use super::super::{
     option_file::MySqlOptionFile,
 };
 use super::catalog::{
-    MysqlColumnMetadata, MysqlTableMetadata, column_from_metadata, columns_query,
+    COLUMN_METADATA_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS, MysqlColumnMetadata,
+    MysqlTableMetadata, TABLES_RESULT_COLUMNS, column_from_metadata, columns_query,
     execute_metadata_queries_in_session, expect_columns, find_table, foreign_keys_from_metadata,
     foreign_keys_query, metadata_shape_error, metadata_snapshot_from_result, optional_text,
     parse_boolean_flag, parse_columns_for_table, parse_foreign_key_metadata, parse_positive_i32,
@@ -69,7 +70,11 @@ pub(super) async fn fetch_table_columns_and_fks(
     let foreign_keys_query = foreign_keys_query(schema, table);
     let results = execute_metadata_queries_in_session(
         dsn,
-        &[&table_query, &columns_query, &foreign_keys_query],
+        &[
+            (table_query.as_str(), TABLES_RESULT_COLUMNS),
+            (columns_query.as_str(), COLUMN_METADATA_RESULT_COLUMNS),
+            (foreign_keys_query.as_str(), FOREIGN_KEY_RESULT_COLUMNS),
+        ],
     )
     .await?;
     let snapshot = metadata_snapshot_from_result(&database, Some(schema), &results[0])?;
@@ -130,28 +135,49 @@ async fn fetch_table_detail_with_session(
 ) -> Result<Table, DbOperationError> {
     session.probe().await?;
     session.prepare_read_only().await?;
-    let tables_result = session.execute(&table_query(schema, table)).await?;
+    let tables_result = session
+        .execute_with_expected_columns(&table_query(schema, table), TABLES_RESULT_COLUMNS)
+        .await?;
     let snapshot = metadata_snapshot_from_result(database, Some(schema), &tables_result)?;
     let table_metadata = find_table(schema, table, &snapshot.tables)?;
 
     let columns = parse_columns_for_table(
-        &session.execute(&columns_query(schema, table)).await?,
+        &session
+            .execute_with_expected_columns(
+                &columns_query(schema, table),
+                COLUMN_METADATA_RESULT_COLUMNS,
+            )
+            .await?,
         schema,
         table,
     )?;
     let indexes = indexes_from_metadata(parse_index_metadata(
-        &session.execute(&indexes_query(table)).await?,
+        &session
+            .execute_with_expected_columns(&indexes_query(table), INDEX_RESULT_COLUMNS)
+            .await?,
     )?);
     let foreign_keys = foreign_keys_from_metadata(
-        parse_foreign_key_metadata(&session.execute(&foreign_keys_query(schema, table)).await?)?,
+        parse_foreign_key_metadata(
+            &session
+                .execute_with_expected_columns(
+                    &foreign_keys_query(schema, table),
+                    FOREIGN_KEY_RESULT_COLUMNS,
+                )
+                .await?,
+        )?,
         database,
     )?;
     let triggers = triggers_from_metadata(parse_trigger_metadata(
-        &session.execute(&triggers_query(table)).await?,
+        &session
+            .execute_with_expected_columns(&triggers_query(table), TRIGGER_RESULT_COLUMNS)
+            .await?,
     )?)?;
     let source_ddl = parse_source_ddl(
         &session
-            .execute(&show_create_query(table, table_metadata.kind))
+            .execute_with_expected_columns(
+                &show_create_query(table, table_metadata.kind),
+                show_create_result_columns(table_metadata.kind),
+            )
             .await?,
         table_metadata.kind,
     )?;
@@ -208,18 +234,43 @@ fn table_from_columns_and_foreign_keys(
     }
 }
 
+const INDEX_RESULT_COLUMNS: &[&str] = &[
+    "INDEX_NAME",
+    "NON_UNIQUE",
+    "INDEX_TYPE",
+    "SEQ_IN_INDEX",
+    "COLUMN_NAME",
+    "EXPRESSION",
+    "IS_PRIMARY",
+];
+const TRIGGER_RESULT_COLUMNS: &[&str] = &[
+    "TRIGGER_NAME",
+    "ACTION_TIMING",
+    "EVENT_MANIPULATION",
+    "ACTION_STATEMENT",
+    "DEFINER",
+];
+const TABLE_SHOW_CREATE_RESULT_COLUMNS: &[&str] = &["Table", "Create Table"];
+const VIEW_SHOW_CREATE_RESULT_COLUMNS: &[&str] = &["View", "Create View"];
+
+fn show_create_result_columns(kind: TableKind) -> &'static [&'static str] {
+    if kind == TableKind::View {
+        VIEW_SHOW_CREATE_RESULT_COLUMNS
+    } else {
+        TABLE_SHOW_CREATE_RESULT_COLUMNS
+    }
+}
+
 fn indexes_query(table: &str) -> String {
     format!(
-        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.EXPRESSION, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = DATABASE() AND s.TABLE_NAME = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = {}) ORDER BY INDEX_NAME, SEQ_IN_INDEX",
-        quote_string(table),
+        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.EXPRESSION, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = DATABASE() AND s.TABLE_NAME = {} ORDER BY INDEX_NAME, SEQ_IN_INDEX",
         quote_string(table),
     )
 }
 
 fn triggers_query(table: &str) -> String {
     format!(
-        "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {} UNION ALL SELECT NULL, NULL, NULL, NULL, NULL FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {}) ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION",
-        quote_string(table),
+        "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {} ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION",
         quote_string(table),
     )
 }
@@ -236,16 +287,7 @@ fn show_create_query(table: &str, kind: TableKind) -> String {
 fn parse_trigger_metadata(
     result: &MysqlResultSet,
 ) -> Result<Vec<MysqlTriggerMetadata>, DbOperationError> {
-    expect_columns(
-        result,
-        &[
-            "TRIGGER_NAME",
-            "ACTION_TIMING",
-            "EVENT_MANIPULATION",
-            "ACTION_STATEMENT",
-            "DEFINER",
-        ],
-    )?;
+    expect_columns(result, TRIGGER_RESULT_COLUMNS)?;
     result
         .values
         .iter()
@@ -253,25 +295,21 @@ fn parse_trigger_metadata(
             if row.len() != 5 {
                 return Err(metadata_shape_error("TRIGGERS row"));
             }
-            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
-                return Ok(None);
-            }
             let timing = required_text(&row[1], "ACTION_TIMING")?
                 .parse::<TriggerTiming>()
                 .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
             let event = required_text(&row[2], "EVENT_MANIPULATION")?
                 .parse::<TriggerEvent>()
                 .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
-            Ok(Some(MysqlTriggerMetadata {
+            Ok(MysqlTriggerMetadata {
                 name: required_text(&row[0], "TRIGGER_NAME")?.to_string(),
                 timing,
                 event,
                 definition: required_text(&row[3], "ACTION_STATEMENT")?.to_string(),
                 security_context: optional_text(&row[4], "DEFINER")?.map(str::to_string),
-            }))
+            })
         })
-        .collect::<Result<Vec<_>, _>>()
-        .map(|rows| rows.into_iter().flatten().collect())
+        .collect()
 }
 
 fn triggers_from_metadata(
@@ -332,27 +370,13 @@ fn parse_source_ddl(result: &MysqlResultSet, kind: TableKind) -> Result<String, 
 fn parse_index_metadata(
     result: &MysqlResultSet,
 ) -> Result<Vec<MysqlIndexMetadata>, DbOperationError> {
-    expect_columns(
-        result,
-        &[
-            "INDEX_NAME",
-            "NON_UNIQUE",
-            "INDEX_TYPE",
-            "SEQ_IN_INDEX",
-            "COLUMN_NAME",
-            "EXPRESSION",
-            "IS_PRIMARY",
-        ],
-    )?;
+    expect_columns(result, INDEX_RESULT_COLUMNS)?;
     result
         .values
         .iter()
         .map(|row| {
             if row.len() != 7 {
                 return Err(metadata_shape_error("STATISTICS row"));
-            }
-            if row.iter().all(|value| matches!(value, QueryValue::Null)) {
-                return Ok(None);
             }
             let column_name = optional_text(&row[4], "COLUMN_NAME")?;
             let expression = optional_text(&row[5], "EXPRESSION")?;
@@ -374,7 +398,7 @@ fn parse_index_metadata(
                     ));
                 }
             };
-            Ok(Some(MysqlIndexMetadata {
+            Ok(MysqlIndexMetadata {
                 name: required_text(&row[0], "INDEX_NAME")?.to_string(),
                 non_unique: parse_boolean_flag(&row[1], "NON_UNIQUE")?,
                 index_type: required_text(&row[2], "INDEX_TYPE")?.to_string(),
@@ -382,10 +406,9 @@ fn parse_index_metadata(
                 column_name,
                 expression,
                 primary: parse_boolean_flag(&row[6], "IS_PRIMARY")?,
-            }))
+            })
         })
-        .collect::<Result<Vec<_>, _>>()
-        .map(|rows| rows.into_iter().flatten().collect())
+        .collect()
 }
 
 fn indexes_from_metadata(mut raw: Vec<MysqlIndexMetadata>) -> Vec<Index> {
@@ -478,7 +501,7 @@ while IFS= read -r line; do
       ;;
     *TABLES*)
       if [ "$mode" = "empty" ]; then
-        printf '%s\n' '<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><field name="TABLE_SCHEMA" xsi:nil="true"/><field name="TABLE_NAME" xsi:nil="true"/><field name="TABLE_TYPE" xsi:nil="true"/><field name="TABLE_ROWS" xsi:nil="true"/><field name="TABLE_COMMENT" xsi:nil="true"/></row></resultset>'
+        printf '%s\n' '<resultset></resultset>'
       elif [ "$mode" = "view" ]; then
         printf '%s\n' '<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><field name="TABLE_SCHEMA">app</field><field name="TABLE_NAME">items_view</field><field name="TABLE_TYPE">VIEW</field><field name="TABLE_ROWS" xsi:nil="true"/><field name="TABLE_COMMENT">view comment</field></row></resultset>'
       else
@@ -641,7 +664,7 @@ done
     }
 
     #[tokio::test]
-    async fn inspector_detail_sends_foreign_key_query_over_one_kilobyte() {
+    async fn inspector_detail_sends_foreign_key_query_without_sentinel() {
         let (_directory, program, transcript) = fake_metadata_cli("table");
         fetch_table_detail_in_session_with_program(
             "mysql://user:password@localhost:3306/app",
@@ -658,11 +681,7 @@ done
             .lines()
             .find(|line| line.contains("REFERENTIAL_CONSTRAINTS"))
             .expect("foreign key metadata query");
-        assert!(
-            foreign_key_query.len() > 1024,
-            "foreign key query was unexpectedly short: {} bytes",
-            foreign_key_query.len()
-        );
+        assert!(!foreign_key_query.contains("UNION ALL SELECT NULL"));
         assert_process_stopped(&transcript);
         assert_option_file_removed(&transcript);
     }
@@ -783,6 +802,7 @@ done
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::QueryValue;
 
     fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
         MysqlResultSet {
@@ -831,23 +851,8 @@ mod tests {
     }
 
     #[test]
-    fn empty_trigger_sentinel_returns_no_triggers() {
-        let result = result(
-            &[
-                "TRIGGER_NAME",
-                "ACTION_TIMING",
-                "EVENT_MANIPULATION",
-                "ACTION_STATEMENT",
-                "DEFINER",
-            ],
-            vec![vec![
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-                QueryValue::Null,
-            ]],
-        );
+    fn empty_trigger_result_returns_no_triggers() {
+        let result = result(TRIGGER_RESULT_COLUMNS, Vec::new());
 
         assert!(parse_trigger_metadata(&result).unwrap().is_empty());
     }


### PR DESCRIPTION
## Problem
MySQL metadata queries use NULL sentinel rows, and known empty preview results can trigger an unnecessary metadata fallback execution.

## Background
Metadata and preview callers already know the result columns, but the shared CLI path cannot distinguish those cases from arbitrary queries with unknown columns.

## Approach
The existing MysqlMetadataSession and MySQL CLI path now accept expected columns for metadata and preview queries, using them when a result is empty while retaining the minimal fallback for arbitrary adhoc and SHOW/DESCRIBE paths.

## Screenshots


## Linear Issue Link (optional)
