### PR TITLE
fix(mysql): reflect single-column unique metadata

### DIFF
--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::time::Duration;
 
@@ -32,6 +33,7 @@ pub(super) const COLUMN_METADATA_RESULT_COLUMNS: &[&str] = &[
     "ORDINAL_POSITION",
     "PRIMARY_KEY_POSITION",
 ];
+pub(super) const UNIQUE_COLUMN_RESULT_COLUMNS: &[&str] = &["COLUMN_NAME"];
 pub(super) const FOREIGN_KEY_RESULT_COLUMNS: &[&str] = &[
     "CONSTRAINT_NAME",
     "TABLE_SCHEMA",
@@ -46,6 +48,12 @@ pub(super) const FOREIGN_KEY_RESULT_COLUMNS: &[&str] = &[
 ];
 
 #[derive(Debug, Clone)]
+enum MysqlColumnUnique {
+    None,
+    SingleColumnIndex,
+}
+
+#[derive(Debug, Clone)]
 pub(super) struct MysqlColumnMetadata {
     name: String,
     data_type: String,
@@ -54,6 +62,7 @@ pub(super) struct MysqlColumnMetadata {
     comment: Option<String>,
     pub(super) ordinal_position: i32,
     primary_key_position: Option<i32>,
+    unique: MysqlColumnUnique,
     invisible: bool,
     generated: bool,
 }
@@ -102,13 +111,23 @@ pub(super) async fn fetch_columns(
     table: &str,
 ) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
     validate_selected_schema(dsn, schema)?;
-    let result = execute_metadata_query(
+    let results = execute_metadata_queries_in_session(
         dsn,
-        &columns_query(schema, table),
-        COLUMN_METADATA_RESULT_COLUMNS,
+        &[
+            (
+                &columns_query(schema, table),
+                COLUMN_METADATA_RESULT_COLUMNS,
+            ),
+            (
+                &unique_columns_query(schema, table),
+                UNIQUE_COLUMN_RESULT_COLUMNS,
+            ),
+        ],
     )
     .await?;
-    parse_columns_for_table(&result, schema, table)
+    let mut columns = parse_columns_for_table(&results[0], schema, table)?;
+    mark_single_column_unique(&mut columns, &parse_unique_column_metadata(&results[1])?);
+    Ok(columns)
 }
 
 pub(super) fn find_table(
@@ -136,6 +155,14 @@ pub(super) fn table_query(schema: &str, table: &str) -> String {
 pub(super) fn columns_query(schema: &str, table: &str) -> String {
     format!(
         "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = {} AND c.TABLE_NAME = {} ORDER BY ORDINAL_POSITION",
+        quote_string(schema),
+        quote_string(table),
+    )
+}
+
+pub(super) fn unique_columns_query(schema: &str, table: &str) -> String {
+    format!(
+        "SELECT MIN(s.COLUMN_NAME) AS COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = {} AND s.TABLE_NAME = {} AND s.NON_UNIQUE = 0 AND s.INDEX_NAME <> 'PRIMARY' GROUP BY s.INDEX_NAME HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1 ORDER BY s.INDEX_NAME",
         quote_string(schema),
         quote_string(table),
     )
@@ -356,6 +383,7 @@ pub(super) fn parse_column_metadata_row(
         primary_key_position: optional_text(&row[7], "PRIMARY_KEY_POSITION")?
             .map(|value| parse_positive_i32_text(value, "PRIMARY_KEY_POSITION"))
             .transpose()?,
+        unique: MysqlColumnUnique::None,
         invisible: extra
             .split_ascii_whitespace()
             .any(|word| word.eq_ignore_ascii_case("INVISIBLE")),
@@ -440,17 +468,19 @@ pub(super) fn foreign_keys_from_metadata(
 
 pub(super) fn column_from_metadata(metadata: &MysqlColumnMetadata) -> Column {
     let primary_key = metadata.primary_key_position.is_some();
-    let attributes = ColumnAttributes::from_parts(metadata.nullable, primary_key, false)
-        | if metadata.invisible {
-            ColumnAttributes::HIDDEN | ColumnAttributes::READ_ONLY
-        } else {
-            ColumnAttributes::empty()
-        }
-        | if metadata.generated {
-            ColumnAttributes::GENERATED | ColumnAttributes::READ_ONLY
-        } else {
-            ColumnAttributes::empty()
-        };
+    let attributes = ColumnAttributes::from_parts(
+        metadata.nullable,
+        primary_key,
+        matches!(metadata.unique, MysqlColumnUnique::SingleColumnIndex),
+    ) | if metadata.invisible {
+        ColumnAttributes::HIDDEN | ColumnAttributes::READ_ONLY
+    } else {
+        ColumnAttributes::empty()
+    } | if metadata.generated {
+        ColumnAttributes::GENERATED | ColumnAttributes::READ_ONLY
+    } else {
+        ColumnAttributes::empty()
+    };
     Column {
         name: metadata.name.clone(),
         data_type: metadata.data_type.clone(),
@@ -458,6 +488,35 @@ pub(super) fn column_from_metadata(metadata: &MysqlColumnMetadata) -> Column {
         attributes,
         comment: metadata.comment.clone(),
         ordinal_position: metadata.ordinal_position,
+    }
+}
+
+pub(super) fn parse_unique_column_metadata(
+    result: &MysqlResultSet,
+) -> Result<HashSet<String>, DbOperationError> {
+    expect_columns(result, UNIQUE_COLUMN_RESULT_COLUMNS)?;
+    result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != 1 {
+                return Err(metadata_shape_error("single-column UNIQUE row"));
+            }
+            Ok(required_text(&row[0], "COLUMN_NAME")?.to_string())
+        })
+        .collect()
+}
+
+pub(super) fn mark_single_column_unique(
+    columns: &mut [MysqlColumnMetadata],
+    unique_columns: &HashSet<String>,
+) {
+    for column in columns {
+        column.unique = if unique_columns.contains(&column.name) {
+            MysqlColumnUnique::SingleColumnIndex
+        } else {
+            MysqlColumnUnique::None
+        };
     }
 }
 
@@ -677,6 +736,47 @@ mod tests {
     }
 
     #[test]
+    fn single_column_unique_metadata_sets_only_matching_column_attribute() {
+        let columns = parse_column_metadata(&result(
+            COLUMN_METADATA_RESULT_COLUMNS,
+            vec![
+                vec![
+                    QueryValue::Text("id".to_string()),
+                    QueryValue::Text("int".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text(String::new()),
+                    QueryValue::Null,
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("1".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("email".to_string()),
+                    QueryValue::Text("varchar(255)".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text(String::new()),
+                    QueryValue::Null,
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Null,
+                ],
+            ],
+        ))
+        .unwrap();
+        let unique_columns = parse_unique_column_metadata(&result(
+            UNIQUE_COLUMN_RESULT_COLUMNS,
+            vec![vec![QueryValue::Text("email".to_string())]],
+        ))
+        .unwrap();
+        let mut columns = columns;
+
+        mark_single_column_unique(&mut columns, &unique_columns);
+
+        assert!(!column_from_metadata(&columns[0]).is_unique());
+        assert!(column_from_metadata(&columns[1]).is_unique());
+    }
+
+    #[test]
     fn targeted_metadata_queries_escape_schema_and_table_literals() {
         let schema = "app\\\n\r\t\u{0008}\u{001a}'";
         let table = "items\\\n\r\t\u{0008}\u{001a}'";
@@ -700,6 +800,7 @@ mod tests {
         for query in [
             table_query(schema, table),
             columns_query(schema, table),
+            unique_columns_query(schema, table),
             foreign_keys_query(schema, table),
         ] {
             assert!(query.contains(&quote_string(schema)));
@@ -707,6 +808,10 @@ mod tests {
             assert!(!query.contains("UNION ALL SELECT NULL"));
         }
         assert!(!table_query(schema, table).contains("KEY_COLUMN_USAGE"));
+        let unique_query = unique_columns_query(schema, table);
+        assert!(unique_query.contains("INDEX_NAME <> 'PRIMARY'"));
+        assert!(unique_query.contains("HAVING COUNT(*) = 1"));
+        assert!(unique_query.contains("COUNT(s.COLUMN_NAME) = 1"));
     }
 
     #[test]

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -7,7 +7,7 @@ use super::super::cli::MysqlResultSet;
 use super::catalog::{
     FOREIGN_KEY_RESULT_COLUMNS, MysqlColumnMetadata, MysqlForeignKeyMetadata, MysqlTableMetadata,
     TABLES_QUERY, TABLES_RESULT_COLUMNS, column_from_metadata, execute_metadata_queries_in_session,
-    expect_columns, foreign_keys_from_metadata, metadata_shape_error,
+    expect_columns, foreign_keys_from_metadata, mark_single_column_unique, metadata_shape_error,
     metadata_snapshot_from_result, parse_column_metadata_row, parse_foreign_key_metadata,
     primary_key_names, required_text, selected_database,
 };
@@ -29,6 +29,10 @@ pub(super) async fn fetch_table_signatures(
             (TABLES_QUERY, TABLES_RESULT_COLUMNS),
             (SIGNATURE_COLUMNS_QUERY, SIGNATURE_COLUMNS_RESULT_COLUMNS),
             (SIGNATURE_FOREIGN_KEYS_QUERY, FOREIGN_KEY_RESULT_COLUMNS),
+            (
+                SIGNATURE_UNIQUE_COLUMNS_QUERY,
+                SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS,
+            ),
         ],
     )
     .await?;
@@ -38,6 +42,7 @@ pub(super) async fn fetch_table_signatures(
         &database,
         parse_signature_column_metadata(&results[1])?,
         parse_foreign_key_metadata(&results[2])?,
+        parse_signature_unique_column_metadata(&results[3])?,
     )
 }
 
@@ -66,6 +71,7 @@ fn table_signatures_from_metadata(
     database: &str,
     columns: Vec<MysqlSignatureColumnMetadata>,
     foreign_keys: Vec<MysqlForeignKeyMetadata>,
+    mut unique_columns_by_table: HashMap<String, HashSet<String>>,
 ) -> Result<Vec<TableSignature>, DbOperationError> {
     let known_tables: HashSet<(String, String)> = tables
         .iter()
@@ -105,6 +111,15 @@ fn table_signatures_from_metadata(
             .push(foreign_key);
     }
 
+    if unique_columns_by_table
+        .keys()
+        .any(|name| !tables.iter().any(|table| table.name == *name))
+    {
+        return Err(metadata_shape_error(
+            "signature UNIQUE metadata references unknown table",
+        ));
+    }
+
     tables
         .iter()
         .map(|table| {
@@ -122,6 +137,10 @@ fn table_signatures_from_metadata(
                 )));
             }
             columns.sort_by_key(|column| column.ordinal_position);
+            let unique_columns = unique_columns_by_table
+                .remove(&table.name)
+                .unwrap_or_default();
+            mark_single_column_unique(&mut columns, &unique_columns);
             let primary_key = primary_key_names(&columns);
             let foreign_keys = foreign_keys_from_metadata(
                 foreign_keys_by_table.remove(&key).unwrap_or_default(),
@@ -300,7 +319,26 @@ const SIGNATURE_COLUMNS_RESULT_COLUMNS: &[&str] = &[
     "ORDINAL_POSITION",
     "PRIMARY_KEY_POSITION",
 ];
+const SIGNATURE_UNIQUE_COLUMNS_QUERY: &str = "SELECT s.TABLE_NAME, MIN(s.COLUMN_NAME) AS COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = DATABASE() AND s.NON_UNIQUE = 0 AND s.INDEX_NAME <> 'PRIMARY' GROUP BY s.TABLE_NAME, s.INDEX_NAME HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1 ORDER BY s.TABLE_NAME, s.INDEX_NAME";
+const SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS: &[&str] = &["TABLE_NAME", "COLUMN_NAME"];
 const SIGNATURE_FOREIGN_KEYS_QUERY: &str = "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = DATABASE() AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION";
+
+fn parse_signature_unique_column_metadata(
+    result: &MysqlResultSet,
+) -> Result<HashMap<String, HashSet<String>>, DbOperationError> {
+    expect_columns(result, SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS)?;
+    let mut unique_columns_by_table = HashMap::new();
+    for row in &result.values {
+        if row.len() != 2 {
+            return Err(metadata_shape_error("signature UNIQUE row"));
+        }
+        unique_columns_by_table
+            .entry(required_text(&row[0], "TABLE_NAME")?.to_string())
+            .or_insert_with(HashSet::new)
+            .insert(required_text(&row[1], "COLUMN_NAME")?.to_string());
+    }
+    Ok(unique_columns_by_table)
+}
 
 #[cfg(test)]
 mod tests {
@@ -537,13 +575,34 @@ mod tests {
         ))
         .unwrap();
 
-        let signatures =
-            table_signatures_from_metadata(&tables, "App", columns, foreign_keys).unwrap();
+        let unique_columns = parse_signature_unique_column_metadata(&result(
+            SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS,
+            vec![vec![
+                QueryValue::Text("child".to_string()),
+                QueryValue::Text("parent_id".to_string()),
+            ]],
+        ))
+        .unwrap();
+        let signatures = table_signatures_from_metadata(
+            &tables,
+            "App",
+            columns.clone(),
+            foreign_keys.clone(),
+            unique_columns,
+        )
+        .unwrap();
+        let signatures_without_unique =
+            table_signatures_from_metadata(&tables, "App", columns, foreign_keys, HashMap::new())
+                .unwrap();
 
         assert_eq!(signatures.len(), 2);
         assert_eq!(signatures[0].qualified_name(), "App.child");
         assert!(signatures[0].signature.contains("id"));
         assert!(signatures[0].signature.contains("fk_child_parent"));
+        assert_ne!(
+            signatures[0].signature,
+            signatures_without_unique[0].signature
+        );
     }
 
     #[test]
@@ -556,7 +615,8 @@ mod tests {
             comment: None,
         }];
         let error =
-            table_signatures_from_metadata(&tables, "app", Vec::new(), Vec::new()).unwrap_err();
+            table_signatures_from_metadata(&tables, "app", Vec::new(), Vec::new(), HashMap::new())
+                .unwrap_err();
 
         assert!(matches!(
             error,

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::time::Duration;
 
@@ -15,12 +16,13 @@ use super::super::{
 };
 use super::catalog::{
     COLUMN_METADATA_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS, MysqlColumnMetadata,
-    MysqlTableMetadata, TABLES_RESULT_COLUMNS, column_from_metadata, columns_query,
-    execute_metadata_queries_in_session, expect_columns, find_table, foreign_keys_from_metadata,
-    foreign_keys_query, metadata_shape_error, metadata_snapshot_from_result, optional_text,
-    parse_boolean_flag, parse_columns_for_table, parse_foreign_key_metadata, parse_positive_i32,
-    primary_key_names, required_text, selected_database, table_query,
-    validate_selected_schema_name,
+    MysqlTableMetadata, TABLES_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, column_from_metadata,
+    columns_query, execute_metadata_queries_in_session, expect_columns, find_table,
+    foreign_keys_from_metadata, foreign_keys_query, mark_single_column_unique,
+    metadata_shape_error, metadata_snapshot_from_result, optional_text, parse_boolean_flag,
+    parse_columns_for_table, parse_foreign_key_metadata, parse_positive_i32,
+    parse_unique_column_metadata, primary_key_names, required_text, selected_database, table_query,
+    unique_columns_query, validate_selected_schema_name,
 };
 
 #[derive(Debug, Clone)]
@@ -67,21 +69,24 @@ pub(super) async fn fetch_table_columns_and_fks(
     validate_selected_schema_name(&database, schema)?;
     let table_query = table_query(schema, table);
     let columns_query = columns_query(schema, table);
+    let unique_columns_query = unique_columns_query(schema, table);
     let foreign_keys_query = foreign_keys_query(schema, table);
     let results = execute_metadata_queries_in_session(
         dsn,
         &[
             (table_query.as_str(), TABLES_RESULT_COLUMNS),
             (columns_query.as_str(), COLUMN_METADATA_RESULT_COLUMNS),
+            (unique_columns_query.as_str(), UNIQUE_COLUMN_RESULT_COLUMNS),
             (foreign_keys_query.as_str(), FOREIGN_KEY_RESULT_COLUMNS),
         ],
     )
     .await?;
     let snapshot = metadata_snapshot_from_result(&database, Some(schema), &results[0])?;
     let table_metadata = find_table(schema, table, &snapshot.tables)?;
-    let columns = parse_columns_for_table(&results[1], schema, table)?;
+    let mut columns = parse_columns_for_table(&results[1], schema, table)?;
+    mark_single_column_unique(&mut columns, &parse_unique_column_metadata(&results[2])?);
     let foreign_keys =
-        foreign_keys_from_metadata(parse_foreign_key_metadata(&results[2])?, &database)?;
+        foreign_keys_from_metadata(parse_foreign_key_metadata(&results[3])?, &database)?;
     Ok(table_from_columns_and_foreign_keys(
         table_metadata,
         columns,
@@ -141,7 +146,7 @@ async fn fetch_table_detail_with_session(
     let snapshot = metadata_snapshot_from_result(database, Some(schema), &tables_result)?;
     let table_metadata = find_table(schema, table, &snapshot.tables)?;
 
-    let columns = parse_columns_for_table(
+    let mut columns = parse_columns_for_table(
         &session
             .execute_with_expected_columns(
                 &columns_query(schema, table),
@@ -151,11 +156,14 @@ async fn fetch_table_detail_with_session(
         schema,
         table,
     )?;
-    let indexes = indexes_from_metadata(parse_index_metadata(
+    let raw_indexes = parse_index_metadata(
         &session
             .execute_with_expected_columns(&indexes_query(table), INDEX_RESULT_COLUMNS)
             .await?,
-    )?);
+    )?;
+    let unique_single_columns = unique_single_columns_from_metadata(&raw_indexes);
+    mark_single_column_unique(&mut columns, &unique_single_columns);
+    let indexes = indexes_from_metadata(raw_indexes);
     let foreign_keys = foreign_keys_from_metadata(
         parse_foreign_key_metadata(
             &session
@@ -452,6 +460,27 @@ fn indexes_from_metadata(mut raw: Vec<MysqlIndexMetadata>) -> Vec<Index> {
     indexes
 }
 
+fn unique_single_columns_from_metadata(raw: &[MysqlIndexMetadata]) -> HashSet<String> {
+    let mut indexes_by_name: HashMap<&str, Vec<&MysqlIndexMetadata>> = HashMap::new();
+    for index in raw
+        .iter()
+        .filter(|index| !index.non_unique && !index.primary)
+    {
+        indexes_by_name
+            .entry(index.name.as_str())
+            .or_default()
+            .push(index);
+    }
+
+    indexes_by_name
+        .into_values()
+        .filter_map(|parts| {
+            let part = parts.first()?;
+            (parts.len() == 1 && part.expression.is_none()).then(|| part.column_name.clone())
+        })
+        .collect()
+}
+
 #[cfg(all(test, unix))]
 mod session_tests {
     use std::os::unix::fs::PermissionsExt;
@@ -516,6 +545,9 @@ while IFS= read -r line; do
       else
         printf '%s\n' '<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><field name="COLUMN_NAME">id</field><field name="COLUMN_TYPE">int</field><field name="IS_NULLABLE">NO</field><field name="COLUMN_DEFAULT" xsi:nil="true"/><field name="EXTRA"></field><field name="COLUMN_COMMENT" xsi:nil="true"/><field name="ORDINAL_POSITION">1</field><field name="PRIMARY_KEY_POSITION">1</field></row></resultset>'
       fi
+      ;;
+    *GROUP\ BY\ s.INDEX_NAME*)
+      printf '%s\n' '<resultset></resultset>'
       ;;
     *STATISTICS*)
       printf '%s\n' '<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><field name="INDEX_NAME">PRIMARY</field><field name="NON_UNIQUE">0</field><field name="INDEX_TYPE">BTREE</field><field name="SEQ_IN_INDEX">1</field><field name="COLUMN_NAME" xsi:nil="true"/><field name="EXPRESSION">expr</field><field name="IS_PRIMARY">YES</field></row></resultset>'
@@ -943,6 +975,76 @@ mod tests {
             IndexType::Other("fulltext".to_string())
         );
         assert!(!indexes[1].is_unique());
+    }
+
+    #[test]
+    fn single_column_unique_indexes_exclude_primary_composite_regular_and_functional_indexes() {
+        let result = result(
+            INDEX_RESULT_COLUMNS,
+            vec![
+                vec![
+                    QueryValue::Text("uq_email".to_string()),
+                    QueryValue::Text("0".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("email".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("NO".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("uq_pair".to_string()),
+                    QueryValue::Text("0".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("first_key".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("NO".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("uq_pair".to_string()),
+                    QueryValue::Text("0".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Text("second_key".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("NO".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("PRIMARY".to_string()),
+                    QueryValue::Text("0".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("id".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("idx_email".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("email".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("NO".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("uq_expression".to_string()),
+                    QueryValue::Text("0".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("lower(`email`)".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                ],
+            ],
+        );
+
+        let raw = parse_index_metadata(&result).unwrap();
+
+        assert_eq!(
+            unique_single_columns_from_metadata(&raw),
+            HashSet::from(["email".to_string()])
+        );
     }
 
     #[test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -444,7 +444,7 @@ mod metadata_fetch {
         with_mysql_test_db(|db| {
             Box::pin(async move {
                 let composite_index = "uq_mysql_metadata_child_composite";
-                let single_index = "uq_mysql_metadata_child_payload";
+                let single_index = "uq_mysql_metadata_child_parent_first";
                 db.adapter()
                     .execute_adhoc(
                         db.dsn(),
@@ -512,13 +512,15 @@ mod metadata_fetch {
                     .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_FK_CHILD)
                     .await
                     .map_err(|error| format!("failed to fetch single unique metadata: {error:?}"))?;
-                let payload = detail
+                let parent_first = detail
                     .columns
                     .iter()
                     .find(|column| column.name == "parent_first")
                     .ok_or_else(|| "single unique column was not returned".to_string())?;
-                if !payload.is_unique() {
-                    return Err(format!("single unique column was not marked: {payload:?}"));
+                if !parent_first.is_unique() {
+                    return Err(format!(
+                        "single unique column was not marked: {parent_first:?}"
+                    ));
                 }
 
                 let light = db
@@ -526,12 +528,12 @@ mod metadata_fetch {
                     .fetch_table_columns_and_fks(db.dsn(), "sabiql_test", MYSQL_FK_CHILD)
                     .await
                     .map_err(|error| format!("failed to fetch light metadata: {error:?}"))?;
-                let light_payload = light
+                let light_parent_first = light
                     .columns
                     .iter()
                     .find(|column| column.name == "parent_first")
                     .ok_or_else(|| "light metadata omitted single unique column".to_string())?;
-                if !light_payload.is_unique() || !light.indexes.is_empty() {
+                if !light_parent_first.is_unique() || !light.indexes.is_empty() {
                     return Err(format!("unexpected light unique metadata: {light:?}"));
                 }
 

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -149,7 +149,7 @@ mod metadata_fetch {
 
     use super::shared::{MYSQL_COMPOSITE_TABLE, MYSQL_VIEW};
     use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, with_mysql_test_db};
-    use sabiql_app::ports::outbound::{DdlGenerator, MetadataProvider};
+    use sabiql_app::ports::outbound::{AccessMode, DdlGenerator, MetadataProvider, QueryExecutor};
     use sabiql_domain::{FkAction, IndexType, TableKind, TriggerEvent, TriggerTiming};
 
     const MYSQL_FK_PARENT: &str = "mysql_metadata_parent";
@@ -339,6 +339,16 @@ mod metadata_fetch {
                         "unexpected MySQL parent unique index: {parent_unique_index:?}"
                     ));
                 }
+                let parent_unique_column = parent
+                    .columns
+                    .iter()
+                    .find(|column| column.name == "unique_code")
+                    .ok_or_else(|| "MySQL unique column was not returned".to_string())?;
+                if !parent_unique_column.is_unique() {
+                    return Err(format!(
+                        "unexpected MySQL unique column attributes: {parent_unique_column:?}"
+                    ));
+                }
 
                 let child = db
                     .adapter()
@@ -392,6 +402,134 @@ mod metadata_fetch {
                     return Err(format!(
                         "unexpected MySQL table signature: {child_signature:?}"
                     ));
+                }
+                Ok(())
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn reflects_single_column_unique_metadata_in_columns_and_signatures() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
+                let composite_index = "uq_mysql_metadata_child_composite";
+                let single_index = "uq_mysql_metadata_child_payload";
+                db.adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!(
+                            "ALTER TABLE {MYSQL_FK_CHILD} ADD UNIQUE KEY {composite_index} (payload(10), parent_first)"
+                        ),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to add composite unique index: {error:?}"))?;
+
+                let composite = db
+                    .adapter()
+                    .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_FK_CHILD)
+                    .await
+                    .map_err(|error| format!("failed to fetch composite unique metadata: {error:?}"))?;
+                if composite
+                    .columns
+                    .iter()
+                    .filter(|column| {
+                        ["parent_first", "payload"].contains(&column.name.as_str())
+                    })
+                    .any(sabiql_domain::Column::is_unique)
+                {
+                    return Err(format!(
+                        "composite unique index marked a column unique: {composite:?}"
+                    ));
+                }
+                if !composite
+                    .indexes
+                    .iter()
+                    .any(|index| index.name == composite_index && index.is_unique())
+                {
+                    return Err(format!(
+                        "composite unique index was not displayed: {composite:?}"
+                    ));
+                }
+                db.adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!("ALTER TABLE {MYSQL_FK_CHILD} DROP INDEX {composite_index}"),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to drop composite unique index: {error:?}"))?;
+
+                let before = db
+                    .adapter()
+                    .fetch_table_signatures(db.dsn())
+                    .await
+                    .map_err(|error| format!("failed to fetch baseline signatures: {error:?}"))?;
+                db.adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!(
+                            "ALTER TABLE {MYSQL_FK_CHILD} ADD UNIQUE KEY {single_index} (parent_first)"
+                        ),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to add single-column unique index: {error:?}"))?;
+
+                let detail = db
+                    .adapter()
+                    .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_FK_CHILD)
+                    .await
+                    .map_err(|error| format!("failed to fetch single unique metadata: {error:?}"))?;
+                let payload = detail
+                    .columns
+                    .iter()
+                    .find(|column| column.name == "parent_first")
+                    .ok_or_else(|| "single unique column was not returned".to_string())?;
+                if !payload.is_unique() {
+                    return Err(format!("single unique column was not marked: {payload:?}"));
+                }
+
+                let light = db
+                    .adapter()
+                    .fetch_table_columns_and_fks(db.dsn(), "sabiql_test", MYSQL_FK_CHILD)
+                    .await
+                    .map_err(|error| format!("failed to fetch light metadata: {error:?}"))?;
+                let light_payload = light
+                    .columns
+                    .iter()
+                    .find(|column| column.name == "parent_first")
+                    .ok_or_else(|| "light metadata omitted single unique column".to_string())?;
+                if !light_payload.is_unique() || !light.indexes.is_empty() {
+                    return Err(format!("unexpected light unique metadata: {light:?}"));
+                }
+
+                let after_add = db
+                    .adapter()
+                    .fetch_table_signatures(db.dsn())
+                    .await
+                    .map_err(|error| format!("failed to fetch changed signatures: {error:?}"))?;
+                if before == after_add {
+                    return Err("single unique index did not change the table signature".to_string());
+                }
+
+                db.adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!("ALTER TABLE {MYSQL_FK_CHILD} DROP INDEX {single_index}"),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to drop single-column unique index: {error:?}"))?;
+                let after_drop = db
+                    .adapter()
+                    .fetch_table_signatures(db.dsn())
+                    .await
+                    .map_err(|error| format!("failed to fetch restored signatures: {error:?}"))?;
+                if before != after_drop {
+                    return Err("dropping the single unique index did not restore the signature".to_string());
                 }
                 Ok(())
             })


### PR DESCRIPTION
## Problem
MySQL column metadata always reports `unique=false`, so single-column UNIQUE changes do not reach column attributes or table signatures.

## Background
The existing metadata and signature paths expose indexes separately but do not project single-column UNIQUE constraints into column metadata.

## Approach
Derive column-level uniqueness from the existing `INFORMATION_SCHEMA.STATISTICS` metadata only for non-primary unique indexes with exactly one non-functional column. Composite, primary, regular, and functional indexes keep their existing behavior across detail, light metadata, preview, and signature paths.