### PR TITLE
refactor(mysql): move metadata SQL into sql module

### DIFF
--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -14,6 +14,7 @@ use super::cli::{
 use super::dsn::parse_and_validate_mysql_dsn;
 use super::metadata;
 use super::option_file::MySqlOptionFile;
+use super::sql;
 
 #[cfg(feature = "test-support")]
 pub(super) mod test_support {
@@ -85,7 +86,7 @@ impl QueryExecutor for MySqlAdapter {
         )]
         let start = Instant::now();
         let preview = metadata::fetch_preview_metadata(dsn, schema, table).await?;
-        let query = metadata::build_preview_query(
+        let query = sql::build_preview_query(
             schema,
             table,
             &preview.order_columns,
@@ -94,7 +95,7 @@ impl QueryExecutor for MySqlAdapter {
             limit,
             offset,
         );
-        let display_query = metadata::build_preview_query(
+        let display_query = sql::build_preview_query(
             schema,
             table,
             &preview.order_columns,

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -12,40 +12,11 @@ use super::super::{
     cli::{MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, MysqlResultSet},
     dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
-    sql::quote_string,
+    sql::{
+        COLUMN_METADATA_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS, TABLES_QUERY,
+        TABLES_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, columns_query, unique_columns_query,
+    },
 };
-
-pub(super) const TABLES_QUERY: &str = "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') ORDER BY TABLE_SCHEMA, TABLE_NAME";
-pub(super) const TABLES_RESULT_COLUMNS: &[&str] = &[
-    "TABLE_SCHEMA",
-    "TABLE_NAME",
-    "TABLE_TYPE",
-    "TABLE_ROWS",
-    "TABLE_COMMENT",
-];
-pub(super) const COLUMN_METADATA_RESULT_COLUMNS: &[&str] = &[
-    "COLUMN_NAME",
-    "COLUMN_TYPE",
-    "IS_NULLABLE",
-    "COLUMN_DEFAULT",
-    "EXTRA",
-    "COLUMN_COMMENT",
-    "ORDINAL_POSITION",
-    "PRIMARY_KEY_POSITION",
-];
-pub(super) const UNIQUE_COLUMN_RESULT_COLUMNS: &[&str] = &["COLUMN_NAME"];
-pub(super) const FOREIGN_KEY_RESULT_COLUMNS: &[&str] = &[
-    "CONSTRAINT_NAME",
-    "TABLE_SCHEMA",
-    "TABLE_NAME",
-    "COLUMN_NAME",
-    "REFERENCED_TABLE_SCHEMA",
-    "REFERENCED_TABLE_NAME",
-    "REFERENCED_COLUMN_NAME",
-    "ORDINAL_POSITION",
-    "UPDATE_RULE",
-    "DELETE_RULE",
-];
 
 #[derive(Debug, Clone)]
 enum MysqlColumnUnique {
@@ -142,30 +113,6 @@ pub(super) fn find_table(
         .ok_or_else(|| {
             DbOperationError::ObjectMissing(format!("MySQL table not found: {schema}.{table}"))
         })
-}
-
-pub(super) fn table_query(schema: &str, table: &str) -> String {
-    format!(
-        "SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_ROWS, t.TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_SCHEMA = {} AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') AND t.TABLE_NAME = {} ORDER BY TABLE_SCHEMA, TABLE_NAME",
-        quote_string(schema),
-        quote_string(table),
-    )
-}
-
-pub(super) fn columns_query(schema: &str, table: &str) -> String {
-    format!(
-        "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = {} AND c.TABLE_NAME = {} ORDER BY ORDINAL_POSITION",
-        quote_string(schema),
-        quote_string(table),
-    )
-}
-
-pub(super) fn unique_columns_query(schema: &str, table: &str) -> String {
-    format!(
-        "SELECT MIN(s.COLUMN_NAME) AS COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = {} AND s.TABLE_NAME = {} AND s.NON_UNIQUE = 0 AND s.INDEX_NAME <> 'PRIMARY' GROUP BY s.INDEX_NAME HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1 ORDER BY s.INDEX_NAME",
-        quote_string(schema),
-        quote_string(table),
-    )
 }
 
 pub(super) fn parse_columns_for_table(
@@ -336,15 +283,6 @@ fn parse_table_metadata(
             })
         })
         .collect()
-}
-
-pub(super) fn foreign_keys_query(schema: &str, table: &str) -> String {
-    format!(
-        "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = {} AND tc.TABLE_SCHEMA = {} AND tc.TABLE_NAME = {} AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
-        quote_string(schema),
-        quote_string(schema),
-        quote_string(table),
-    )
 }
 
 fn parse_column_metadata(
@@ -774,44 +712,6 @@ mod tests {
 
         assert!(!column_from_metadata(&columns[0]).is_unique());
         assert!(column_from_metadata(&columns[1]).is_unique());
-    }
-
-    #[test]
-    fn targeted_metadata_queries_escape_schema_and_table_literals() {
-        let schema = "app\\\n\r\t\u{0008}\u{001a}'";
-        let table = "items\\\n\r\t\u{0008}\u{001a}'";
-
-        assert_eq!(
-            quote_string(schema),
-            format!(
-                "'app{}{}{}{}{}{}{}'",
-                r"\\", r"\n", r"\r", r"\t", r"\b", r"\Z", r"\'",
-            )
-        );
-        assert_eq!(
-            quote_string(table),
-            format!(
-                "'items{}{}{}{}{}{}{}'",
-                r"\\", r"\n", r"\r", r"\t", r"\b", r"\Z", r"\'",
-            )
-        );
-
-        assert!(!TABLES_QUERY.contains("UNION ALL SELECT NULL"));
-        for query in [
-            table_query(schema, table),
-            columns_query(schema, table),
-            unique_columns_query(schema, table),
-            foreign_keys_query(schema, table),
-        ] {
-            assert!(query.contains(&quote_string(schema)));
-            assert!(query.contains(&quote_string(table)));
-            assert!(!query.contains("UNION ALL SELECT NULL"));
-        }
-        assert!(!table_query(schema, table).contains("KEY_COLUMN_USAGE"));
-        let unique_query = unique_columns_query(schema, table);
-        assert!(unique_query.contains("INDEX_NAME <> 'PRIMARY'"));
-        assert!(unique_query.contains("HAVING COUNT(*) = 1"));
-        assert!(unique_query.contains("COUNT(s.COLUMN_NAME) = 1"));
     }
 
     #[test]

--- a/src/infra/adapters/mysql/metadata/mod.rs
+++ b/src/infra/adapters/mysql/metadata/mod.rs
@@ -10,9 +10,7 @@ mod preview;
 mod signature;
 mod table_detail;
 
-pub(super) use preview::{
-    build_preview_query, convert_preview_values, fetch_preview_metadata, preview_result_columns,
-};
+pub(super) use preview::{convert_preview_values, fetch_preview_metadata, preview_result_columns};
 
 #[async_trait]
 impl MetadataProvider for MySqlAdapter {

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -2,10 +2,8 @@ use crate::app::ports::outbound::DbOperationError;
 use crate::domain::{Column, QueryValue};
 
 use super::super::cli::MysqlResultSet;
-use super::super::sql::quote_identifier;
+use super::super::sql::preview_identity_alias;
 use super::catalog::{column_from_metadata, fetch_columns, primary_key_names};
-
-const PREVIEW_IDENTITY_ALIAS_PREFIX: &str = "__sabiql_row_identity_";
 
 #[derive(Debug, Clone)]
 pub(in crate::adapters::mysql) struct PreviewMetadata {
@@ -69,48 +67,6 @@ pub(in crate::adapters::mysql) async fn fetch_preview_metadata(
         order_columns,
         identity_columns,
     })
-}
-
-pub(in crate::adapters::mysql) fn build_preview_query(
-    schema: &str,
-    table: &str,
-    order_columns: &[String],
-    visible_columns: &[Column],
-    identity_columns: &[Column],
-    limit: usize,
-    offset: usize,
-) -> String {
-    let visible_select = visible_columns
-        .iter()
-        .map(|column| quote_identifier(&column.name))
-        .collect::<Vec<_>>()
-        .join(", ");
-    let identity_select = identity_columns
-        .iter()
-        .enumerate()
-        .map(|(index, column)| {
-            format!(
-                "{} AS {}",
-                quote_identifier(&column.name),
-                quote_identifier(&preview_identity_alias(index)),
-            )
-        })
-        .collect::<Vec<_>>();
-    let columns = std::iter::once(visible_select)
-        .chain(identity_select)
-        .filter(|select| !select.is_empty())
-        .collect::<Vec<_>>()
-        .join(", ");
-    let order_by = order_columns
-        .iter()
-        .map(|column| quote_identifier(column))
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!(
-        "SELECT {columns} FROM {}.{} ORDER BY {order_by} LIMIT {limit} OFFSET {offset}",
-        quote_identifier(schema),
-        quote_identifier(table),
-    )
 }
 
 pub(in crate::adapters::mysql) fn convert_preview_values(
@@ -178,10 +134,6 @@ pub(in crate::adapters::mysql) fn preview_result_columns(
                 .map(|(index, _)| preview_identity_alias(index)),
         )
         .collect()
-}
-
-fn preview_identity_alias(index: usize) -> String {
-    format!("{PREVIEW_IDENTITY_ALIAS_PREFIX}{index}")
 }
 
 fn convert_preview_value(value: &QueryValue, data_type: &str) -> QueryValue {
@@ -410,47 +362,6 @@ mod tests {
         assert!(is_sql_numeric_literal("-1.2e-3"));
         assert!(!is_sql_numeric_literal("1e"));
         assert!(!is_sql_numeric_literal("nan"));
-    }
-
-    #[test]
-    fn preview_query_lists_visible_columns_and_orders_by_primary_key() {
-        let columns = vec![column("id", "int"), column("display", "text")];
-
-        let query = build_preview_query(
-            "app",
-            "items",
-            &["id".to_string()],
-            &columns,
-            &[],
-            500,
-            1000,
-        );
-
-        assert_eq!(
-            query,
-            "SELECT `id`, `display` FROM `app`.`items` ORDER BY `id` LIMIT 500 OFFSET 1000"
-        );
-    }
-
-    #[test]
-    fn preview_query_appends_aliased_hidden_primary_key_columns() {
-        let visible_columns = vec![column("payload", "text")];
-        let identity_columns = vec![column("id", "int")];
-
-        let query = build_preview_query(
-            "app",
-            "items",
-            &["id".to_string()],
-            &visible_columns,
-            &identity_columns,
-            10,
-            0,
-        );
-
-        assert_eq!(
-            query,
-            "SELECT `payload`, `id` AS `__sabiql_row_identity_0` FROM `app`.`items` ORDER BY `id` LIMIT 10 OFFSET 0"
-        );
     }
 
     #[test]

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -4,12 +4,17 @@ use crate::app::ports::outbound::DbOperationError;
 use crate::domain::{FkAction, Table, TableKind, TableKindInfo, TableSignature};
 
 use super::super::cli::MysqlResultSet;
+use super::super::sql::{
+    FOREIGN_KEY_RESULT_COLUMNS, SIGNATURE_COLUMNS_QUERY, SIGNATURE_COLUMNS_RESULT_COLUMNS,
+    SIGNATURE_FOREIGN_KEYS_QUERY, SIGNATURE_UNIQUE_COLUMNS_QUERY,
+    SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS, TABLES_QUERY, TABLES_RESULT_COLUMNS,
+};
 use super::catalog::{
-    FOREIGN_KEY_RESULT_COLUMNS, MysqlColumnMetadata, MysqlForeignKeyMetadata, MysqlTableMetadata,
-    TABLES_QUERY, TABLES_RESULT_COLUMNS, column_from_metadata, execute_metadata_queries_in_session,
-    expect_columns, foreign_keys_from_metadata, mark_single_column_unique, metadata_shape_error,
-    metadata_snapshot_from_result, parse_column_metadata_row, parse_foreign_key_metadata,
-    primary_key_names, required_text, selected_database,
+    MysqlColumnMetadata, MysqlForeignKeyMetadata, MysqlTableMetadata, column_from_metadata,
+    execute_metadata_queries_in_session, expect_columns, foreign_keys_from_metadata,
+    mark_single_column_unique, metadata_shape_error, metadata_snapshot_from_result,
+    parse_column_metadata_row, parse_foreign_key_metadata, primary_key_names, required_text,
+    selected_database,
 };
 
 #[derive(Debug, Clone)]
@@ -305,23 +310,6 @@ fn foreign_key_action_name(action: &FkAction) -> &'static str {
         FkAction::SetDefault => "set-default",
     }
 }
-
-const SIGNATURE_COLUMNS_QUERY: &str = "SELECT c.TABLE_SCHEMA, c.TABLE_NAME, c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = DATABASE() ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION";
-const SIGNATURE_COLUMNS_RESULT_COLUMNS: &[&str] = &[
-    "TABLE_SCHEMA",
-    "TABLE_NAME",
-    "COLUMN_NAME",
-    "COLUMN_TYPE",
-    "IS_NULLABLE",
-    "COLUMN_DEFAULT",
-    "EXTRA",
-    "COLUMN_COMMENT",
-    "ORDINAL_POSITION",
-    "PRIMARY_KEY_POSITION",
-];
-const SIGNATURE_UNIQUE_COLUMNS_QUERY: &str = "SELECT s.TABLE_NAME, MIN(s.COLUMN_NAME) AS COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = DATABASE() AND s.NON_UNIQUE = 0 AND s.INDEX_NAME <> 'PRIMARY' GROUP BY s.TABLE_NAME, s.INDEX_NAME HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1 ORDER BY s.TABLE_NAME, s.INDEX_NAME";
-const SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS: &[&str] = &["TABLE_NAME", "COLUMN_NAME"];
-const SIGNATURE_FOREIGN_KEYS_QUERY: &str = "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = DATABASE() AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION";
 
 fn parse_signature_unique_column_metadata(
     result: &MysqlResultSet,

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -8,21 +8,24 @@ use crate::domain::{
     TriggerEvent, TriggerTiming,
 };
 
-use super::super::sql::{quote_identifier, quote_string};
+use super::super::sql::{
+    COLUMN_METADATA_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS, INDEX_RESULT_COLUMNS,
+    TABLES_RESULT_COLUMNS, TRIGGER_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, columns_query,
+    foreign_keys_query, indexes_query, show_create_query, show_create_result_columns, table_query,
+    triggers_query, unique_columns_query,
+};
 use super::super::{
     cli::{MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, MysqlResultSet},
     dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
 };
 use super::catalog::{
-    COLUMN_METADATA_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS, MysqlColumnMetadata,
-    MysqlTableMetadata, TABLES_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, column_from_metadata,
-    columns_query, execute_metadata_queries_in_session, expect_columns, find_table,
-    foreign_keys_from_metadata, foreign_keys_query, mark_single_column_unique,
-    metadata_shape_error, metadata_snapshot_from_result, optional_text, parse_boolean_flag,
-    parse_columns_for_table, parse_foreign_key_metadata, parse_positive_i32,
-    parse_unique_column_metadata, primary_key_names, required_text, selected_database, table_query,
-    unique_columns_query, validate_selected_schema_name,
+    MysqlColumnMetadata, MysqlTableMetadata, column_from_metadata,
+    execute_metadata_queries_in_session, expect_columns, find_table, foreign_keys_from_metadata,
+    mark_single_column_unique, metadata_shape_error, metadata_snapshot_from_result, optional_text,
+    parse_boolean_flag, parse_columns_for_table, parse_foreign_key_metadata, parse_positive_i32,
+    parse_unique_column_metadata, primary_key_names, required_text, selected_database,
+    validate_selected_schema_name,
 };
 
 #[derive(Debug, Clone)]
@@ -240,56 +243,6 @@ fn table_from_columns_and_foreign_keys(
             virtual_module: None,
         },
     }
-}
-
-const INDEX_RESULT_COLUMNS: &[&str] = &[
-    "INDEX_NAME",
-    "NON_UNIQUE",
-    "INDEX_TYPE",
-    "SEQ_IN_INDEX",
-    "COLUMN_NAME",
-    "EXPRESSION",
-    "IS_PRIMARY",
-];
-const TRIGGER_RESULT_COLUMNS: &[&str] = &[
-    "TRIGGER_NAME",
-    "ACTION_TIMING",
-    "EVENT_MANIPULATION",
-    "ACTION_STATEMENT",
-    "DEFINER",
-];
-const TABLE_SHOW_CREATE_RESULT_COLUMNS: &[&str] = &["Table", "Create Table"];
-const VIEW_SHOW_CREATE_RESULT_COLUMNS: &[&str] = &["View", "Create View"];
-
-fn show_create_result_columns(kind: TableKind) -> &'static [&'static str] {
-    if kind == TableKind::View {
-        VIEW_SHOW_CREATE_RESULT_COLUMNS
-    } else {
-        TABLE_SHOW_CREATE_RESULT_COLUMNS
-    }
-}
-
-fn indexes_query(table: &str) -> String {
-    format!(
-        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.EXPRESSION, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = DATABASE() AND s.TABLE_NAME = {} ORDER BY INDEX_NAME, SEQ_IN_INDEX",
-        quote_string(table),
-    )
-}
-
-fn triggers_query(table: &str) -> String {
-    format!(
-        "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {} ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION",
-        quote_string(table),
-    )
-}
-
-fn show_create_query(table: &str, kind: TableKind) -> String {
-    let object_type = if kind == TableKind::View {
-        "VIEW"
-    } else {
-        "TABLE"
-    };
-    format!("SHOW CREATE {object_type} {}", quote_identifier(table))
 }
 
 fn parse_trigger_metadata(
@@ -887,18 +840,6 @@ mod tests {
         let result = result(TRIGGER_RESULT_COLUMNS, Vec::new());
 
         assert!(parse_trigger_metadata(&result).unwrap().is_empty());
-    }
-
-    #[test]
-    fn show_create_query_uses_object_kind_and_identifier_quoting() {
-        assert_eq!(
-            show_create_query("table`name", TableKind::Table),
-            "SHOW CREATE TABLE `table``name`"
-        );
-        assert_eq!(
-            show_create_query("view_name", TableKind::View),
-            "SHOW CREATE VIEW `view_name`"
-        );
     }
 
     #[test]

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -1,3 +1,189 @@
+use super::literal::{quote_identifier, quote_string};
+use crate::domain::{Column, TableKind};
+
+pub(in crate::adapters::mysql) const TABLES_QUERY: &str = "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') ORDER BY TABLE_SCHEMA, TABLE_NAME";
+pub(in crate::adapters::mysql) const TABLES_RESULT_COLUMNS: &[&str] = &[
+    "TABLE_SCHEMA",
+    "TABLE_NAME",
+    "TABLE_TYPE",
+    "TABLE_ROWS",
+    "TABLE_COMMENT",
+];
+pub(in crate::adapters::mysql) const COLUMN_METADATA_RESULT_COLUMNS: &[&str] = &[
+    "COLUMN_NAME",
+    "COLUMN_TYPE",
+    "IS_NULLABLE",
+    "COLUMN_DEFAULT",
+    "EXTRA",
+    "COLUMN_COMMENT",
+    "ORDINAL_POSITION",
+    "PRIMARY_KEY_POSITION",
+];
+pub(in crate::adapters::mysql) const UNIQUE_COLUMN_RESULT_COLUMNS: &[&str] = &["COLUMN_NAME"];
+pub(in crate::adapters::mysql) const FOREIGN_KEY_RESULT_COLUMNS: &[&str] = &[
+    "CONSTRAINT_NAME",
+    "TABLE_SCHEMA",
+    "TABLE_NAME",
+    "COLUMN_NAME",
+    "REFERENCED_TABLE_SCHEMA",
+    "REFERENCED_TABLE_NAME",
+    "REFERENCED_COLUMN_NAME",
+    "ORDINAL_POSITION",
+    "UPDATE_RULE",
+    "DELETE_RULE",
+];
+
+pub(in crate::adapters::mysql) fn table_query(schema: &str, table: &str) -> String {
+    format!(
+        "SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_ROWS, t.TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_SCHEMA = {} AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') AND t.TABLE_NAME = {} ORDER BY TABLE_SCHEMA, TABLE_NAME",
+        quote_string(schema),
+        quote_string(table),
+    )
+}
+
+pub(in crate::adapters::mysql) fn columns_query(schema: &str, table: &str) -> String {
+    format!(
+        "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = {} AND c.TABLE_NAME = {} ORDER BY ORDINAL_POSITION",
+        quote_string(schema),
+        quote_string(table),
+    )
+}
+
+pub(in crate::adapters::mysql) fn unique_columns_query(schema: &str, table: &str) -> String {
+    format!(
+        "SELECT MIN(s.COLUMN_NAME) AS COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = {} AND s.TABLE_NAME = {} AND s.NON_UNIQUE = 0 AND s.INDEX_NAME <> 'PRIMARY' GROUP BY s.INDEX_NAME HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1 ORDER BY s.INDEX_NAME",
+        quote_string(schema),
+        quote_string(table),
+    )
+}
+
+pub(in crate::adapters::mysql) fn foreign_keys_query(schema: &str, table: &str) -> String {
+    format!(
+        "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = {} AND tc.TABLE_SCHEMA = {} AND tc.TABLE_NAME = {} AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
+        quote_string(schema),
+        quote_string(schema),
+        quote_string(table),
+    )
+}
+
+pub(in crate::adapters::mysql) const SIGNATURE_COLUMNS_QUERY: &str = "SELECT c.TABLE_SCHEMA, c.TABLE_NAME, c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = DATABASE() ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION";
+pub(in crate::adapters::mysql) const SIGNATURE_COLUMNS_RESULT_COLUMNS: &[&str] = &[
+    "TABLE_SCHEMA",
+    "TABLE_NAME",
+    "COLUMN_NAME",
+    "COLUMN_TYPE",
+    "IS_NULLABLE",
+    "COLUMN_DEFAULT",
+    "EXTRA",
+    "COLUMN_COMMENT",
+    "ORDINAL_POSITION",
+    "PRIMARY_KEY_POSITION",
+];
+pub(in crate::adapters::mysql) const SIGNATURE_UNIQUE_COLUMNS_QUERY: &str = "SELECT s.TABLE_NAME, MIN(s.COLUMN_NAME) AS COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = DATABASE() AND s.NON_UNIQUE = 0 AND s.INDEX_NAME <> 'PRIMARY' GROUP BY s.TABLE_NAME, s.INDEX_NAME HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1 ORDER BY s.TABLE_NAME, s.INDEX_NAME";
+pub(in crate::adapters::mysql) const SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS: &[&str] =
+    &["TABLE_NAME", "COLUMN_NAME"];
+pub(in crate::adapters::mysql) const SIGNATURE_FOREIGN_KEYS_QUERY: &str = "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = DATABASE() AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION";
+
+pub(in crate::adapters::mysql) const INDEX_RESULT_COLUMNS: &[&str] = &[
+    "INDEX_NAME",
+    "NON_UNIQUE",
+    "INDEX_TYPE",
+    "SEQ_IN_INDEX",
+    "COLUMN_NAME",
+    "EXPRESSION",
+    "IS_PRIMARY",
+];
+pub(in crate::adapters::mysql) const TRIGGER_RESULT_COLUMNS: &[&str] = &[
+    "TRIGGER_NAME",
+    "ACTION_TIMING",
+    "EVENT_MANIPULATION",
+    "ACTION_STATEMENT",
+    "DEFINER",
+];
+const TABLE_SHOW_CREATE_RESULT_COLUMNS: &[&str] = &["Table", "Create Table"];
+const VIEW_SHOW_CREATE_RESULT_COLUMNS: &[&str] = &["View", "Create View"];
+
+pub(in crate::adapters::mysql) fn indexes_query(table: &str) -> String {
+    format!(
+        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.EXPRESSION, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = DATABASE() AND s.TABLE_NAME = {} ORDER BY INDEX_NAME, SEQ_IN_INDEX",
+        quote_string(table),
+    )
+}
+
+pub(in crate::adapters::mysql) fn triggers_query(table: &str) -> String {
+    format!(
+        "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {} ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION",
+        quote_string(table),
+    )
+}
+
+pub(in crate::adapters::mysql) fn show_create_query(table: &str, kind: TableKind) -> String {
+    let object_type = if kind == TableKind::View {
+        "VIEW"
+    } else {
+        "TABLE"
+    };
+    format!("SHOW CREATE {object_type} {}", quote_identifier(table))
+}
+
+pub(in crate::adapters::mysql) fn show_create_result_columns(
+    kind: TableKind,
+) -> &'static [&'static str] {
+    if kind == TableKind::View {
+        VIEW_SHOW_CREATE_RESULT_COLUMNS
+    } else {
+        TABLE_SHOW_CREATE_RESULT_COLUMNS
+    }
+}
+
+const PREVIEW_IDENTITY_ALIAS_PREFIX: &str = "__sabiql_row_identity_";
+
+pub(in crate::adapters::mysql) fn build_preview_query(
+    schema: &str,
+    table: &str,
+    order_columns: &[String],
+    visible_columns: &[Column],
+    identity_columns: &[Column],
+    limit: usize,
+    offset: usize,
+) -> String {
+    let visible_select = visible_columns
+        .iter()
+        .map(|column| quote_identifier(&column.name))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let identity_select = identity_columns
+        .iter()
+        .enumerate()
+        .map(|(index, column)| {
+            format!(
+                "{} AS {}",
+                quote_identifier(&column.name),
+                quote_identifier(&preview_identity_alias(index)),
+            )
+        })
+        .collect::<Vec<_>>();
+    let columns = std::iter::once(visible_select)
+        .chain(identity_select)
+        .filter(|select| !select.is_empty())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let order_by = order_columns
+        .iter()
+        .map(|column| quote_identifier(column))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "SELECT {columns} FROM {}.{} ORDER BY {order_by} LIMIT {limit} OFFSET {offset}",
+        quote_identifier(schema),
+        quote_identifier(table),
+    )
+}
+
+pub(in crate::adapters::mysql) fn preview_identity_alias(index: usize) -> String {
+    format!("{PREVIEW_IDENTITY_ALIAS_PREFIX}{index}")
+}
+
 pub(in crate::adapters::mysql) fn build_metadata_select_query(
     query: &str,
     source_alias: &str,
@@ -11,12 +197,112 @@ pub(in crate::adapters::mysql) fn build_metadata_select_query(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::ColumnAttributes;
+
+    fn column(name: &str, data_type: &str) -> Column {
+        Column {
+            name: name.to_string(),
+            data_type: data_type.to_string(),
+            default: None,
+            attributes: ColumnAttributes::empty(),
+            comment: None,
+            ordinal_position: 1,
+        }
+    }
 
     #[test]
     fn builds_metadata_select_query_without_changing_the_fallback_sql() {
         assert_eq!(
             build_metadata_select_query("SELECT 1", "__source", "__marker"),
             "WITH __source AS (SELECT * FROM ((SELECT 1\n) LIMIT 0) AS __sabiql_metadata_inner) SELECT __source.* FROM __source RIGHT JOIN (SELECT 1 AS __marker) AS __sabiql_metadata_marker ON TRUE"
+        );
+    }
+
+    #[test]
+    fn metadata_queries_escape_literals_and_preserve_scope_conditions() {
+        let schema = "app\\\n\r\t\u{0008}\u{001a}'";
+        let table = "items\\\n\r\t\u{0008}\u{001a}'";
+
+        assert_eq!(
+            quote_string(schema),
+            format!(
+                "'app{}{}{}{}{}{}{}'",
+                r"\\", r"\n", r"\r", r"\t", r"\b", r"\Z", r"\'",
+            )
+        );
+        assert_eq!(
+            quote_string(table),
+            format!(
+                "'items{}{}{}{}{}{}{}'",
+                r"\\", r"\n", r"\r", r"\t", r"\b", r"\Z", r"\'",
+            )
+        );
+
+        assert!(!TABLES_QUERY.contains("UNION ALL SELECT NULL"));
+        for query in [
+            table_query(schema, table),
+            columns_query(schema, table),
+            unique_columns_query(schema, table),
+            foreign_keys_query(schema, table),
+            indexes_query(table),
+            triggers_query(table),
+        ] {
+            assert!(query.contains(&quote_string(table)));
+            assert!(!query.contains("UNION ALL SELECT NULL"));
+        }
+        assert!(table_query(schema, table).contains(&quote_string(schema)));
+        assert!(!table_query(schema, table).contains("KEY_COLUMN_USAGE"));
+        assert!(unique_columns_query(schema, table).contains("HAVING COUNT(*) = 1"));
+        assert!(
+            SIGNATURE_COLUMNS_QUERY.contains("ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION")
+        );
+        assert!(
+            SIGNATURE_FOREIGN_KEYS_QUERY
+                .contains("ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION")
+        );
+    }
+
+    #[test]
+    fn show_create_query_uses_object_kind_and_identifier_quoting() {
+        assert_eq!(
+            show_create_query("table`name", TableKind::Table),
+            "SHOW CREATE TABLE `table``name`"
+        );
+        assert_eq!(
+            show_create_query("view_name", TableKind::View),
+            "SHOW CREATE VIEW `view_name`"
+        );
+    }
+
+    #[test]
+    fn preview_query_lists_visible_and_hidden_identity_columns() {
+        let columns = vec![column("id", "int"), column("display", "text")];
+        assert_eq!(
+            build_preview_query(
+                "app",
+                "items",
+                &["id".to_string()],
+                &columns,
+                &[],
+                500,
+                1000,
+            ),
+            "SELECT `id`, `display` FROM `app`.`items` ORDER BY `id` LIMIT 500 OFFSET 1000"
+        );
+
+        let visible_columns = vec![column("payload", "text")];
+        let identity_columns = vec![column("id", "int")];
+        assert_eq!(
+            build_preview_query(
+                "app",
+                "items",
+                &["id".to_string()],
+                &visible_columns,
+                &identity_columns,
+                10,
+                0,
+            ),
+            "SELECT `payload`, `id` AS `__sabiql_row_identity_0` FROM `app`.`items` ORDER BY `id` LIMIT 10 OFFSET 0"
         );
     }
 }

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -210,6 +210,16 @@ mod tests {
         }
     }
 
+    fn assert_contains_in_order(query: &str, fragments: &[&str]) {
+        let mut remaining = query;
+        for fragment in fragments {
+            let Some(index) = remaining.find(fragment) else {
+                panic!("missing SQL fragment {fragment:?} in {query:?}");
+            };
+            remaining = &remaining[index + fragment.len()..];
+        }
+    }
+
     #[test]
     fn builds_metadata_select_query_without_changing_the_fallback_sql() {
         assert_eq!(
@@ -238,27 +248,217 @@ mod tests {
             )
         );
 
-        assert!(!TABLES_QUERY.contains("UNION ALL SELECT NULL"));
-        for query in [
-            table_query(schema, table),
-            columns_query(schema, table),
-            unique_columns_query(schema, table),
-            foreign_keys_query(schema, table),
-            indexes_query(table),
-            triggers_query(table),
-        ] {
-            assert!(query.contains(&quote_string(table)));
-            assert!(!query.contains("UNION ALL SELECT NULL"));
-        }
-        assert!(table_query(schema, table).contains(&quote_string(schema)));
-        assert!(!table_query(schema, table).contains("KEY_COLUMN_USAGE"));
-        assert!(unique_columns_query(schema, table).contains("HAVING COUNT(*) = 1"));
-        assert!(
-            SIGNATURE_COLUMNS_QUERY.contains("ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION")
+        let quoted_schema = quote_string(schema);
+        let quoted_table = quote_string(table);
+
+        let table_query = table_query(schema, table);
+        assert_contains_in_order(
+            &table_query,
+            &[
+                "SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_ROWS, t.TABLE_COMMENT",
+                "FROM INFORMATION_SCHEMA.TABLES AS t",
+                &format!("WHERE t.TABLE_SCHEMA = {quoted_schema}"),
+                "AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW')",
+                &format!("AND t.TABLE_NAME = {quoted_table}"),
+                "ORDER BY TABLE_SCHEMA, TABLE_NAME",
+            ],
         );
-        assert!(
-            SIGNATURE_FOREIGN_KEYS_QUERY
-                .contains("ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION")
+
+        let columns_query = columns_query(schema, table);
+        assert_contains_in_order(
+            &columns_query,
+            &[
+                "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION",
+                "FROM INFORMATION_SCHEMA.COLUMNS AS c",
+                "LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY'",
+                "LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME",
+                &format!("WHERE c.TABLE_SCHEMA = {quoted_schema}"),
+                &format!("AND c.TABLE_NAME = {quoted_table}"),
+                "ORDER BY ORDINAL_POSITION",
+            ],
+        );
+
+        let unique_columns_query = unique_columns_query(schema, table);
+        assert_contains_in_order(
+            &unique_columns_query,
+            &[
+                "SELECT MIN(s.COLUMN_NAME) AS COLUMN_NAME",
+                "FROM INFORMATION_SCHEMA.STATISTICS AS s",
+                &format!("WHERE s.TABLE_SCHEMA = {quoted_schema}"),
+                &format!("AND s.TABLE_NAME = {quoted_table}"),
+                "AND s.NON_UNIQUE = 0",
+                "AND s.INDEX_NAME <> 'PRIMARY'",
+                "GROUP BY s.INDEX_NAME",
+                "HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1",
+                "ORDER BY s.INDEX_NAME",
+            ],
+        );
+
+        let foreign_keys_query = foreign_keys_query(schema, table);
+        assert_contains_in_order(
+            &foreign_keys_query,
+            &[
+                "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE",
+                "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc",
+                "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME",
+                "INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME",
+                &format!("WHERE tc.CONSTRAINT_SCHEMA = {quoted_schema}"),
+                &format!("AND tc.TABLE_SCHEMA = {quoted_schema}"),
+                &format!("AND tc.TABLE_NAME = {quoted_table}"),
+                "AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'",
+                "ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
+            ],
+        );
+
+        let indexes_query = indexes_query(table);
+        assert_contains_in_order(
+            &indexes_query,
+            &[
+                "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.EXPRESSION, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY",
+                "FROM INFORMATION_SCHEMA.STATISTICS AS s",
+                "LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME",
+                "WHERE s.TABLE_SCHEMA = DATABASE()",
+                &format!("AND s.TABLE_NAME = {quoted_table}"),
+                "ORDER BY INDEX_NAME, SEQ_IN_INDEX",
+            ],
+        );
+
+        let triggers_query = triggers_query(table);
+        assert_contains_in_order(
+            &triggers_query,
+            &[
+                "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER",
+                "FROM INFORMATION_SCHEMA.TRIGGERS",
+                "WHERE TRIGGER_SCHEMA = DATABASE()",
+                "AND EVENT_OBJECT_SCHEMA = DATABASE()",
+                &format!("AND EVENT_OBJECT_TABLE = {quoted_table}"),
+                "ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION",
+            ],
+        );
+
+        assert_contains_in_order(
+            TABLES_QUERY,
+            &[
+                "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT",
+                "FROM INFORMATION_SCHEMA.TABLES",
+                "WHERE TABLE_SCHEMA = DATABASE()",
+                "AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')",
+                "ORDER BY TABLE_SCHEMA, TABLE_NAME",
+            ],
+        );
+        assert_contains_in_order(
+            SIGNATURE_COLUMNS_QUERY,
+            &[
+                "SELECT c.TABLE_SCHEMA, c.TABLE_NAME, c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION",
+                "FROM INFORMATION_SCHEMA.COLUMNS AS c",
+                "WHERE c.TABLE_SCHEMA = DATABASE()",
+                "ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION",
+            ],
+        );
+        assert_contains_in_order(
+            SIGNATURE_UNIQUE_COLUMNS_QUERY,
+            &[
+                "SELECT s.TABLE_NAME, MIN(s.COLUMN_NAME) AS COLUMN_NAME",
+                "FROM INFORMATION_SCHEMA.STATISTICS AS s",
+                "WHERE s.TABLE_SCHEMA = DATABASE()",
+                "AND s.NON_UNIQUE = 0",
+                "AND s.INDEX_NAME <> 'PRIMARY'",
+                "GROUP BY s.TABLE_NAME, s.INDEX_NAME",
+                "HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1",
+                "ORDER BY s.TABLE_NAME, s.INDEX_NAME",
+            ],
+        );
+        assert_contains_in_order(
+            SIGNATURE_FOREIGN_KEYS_QUERY,
+            &[
+                "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE",
+                "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc",
+                "WHERE tc.CONSTRAINT_SCHEMA = DATABASE()",
+                "AND tc.TABLE_SCHEMA = DATABASE()",
+                "AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'",
+                "ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION",
+            ],
+        );
+
+        assert_eq!(
+            TABLES_RESULT_COLUMNS,
+            &[
+                "TABLE_SCHEMA",
+                "TABLE_NAME",
+                "TABLE_TYPE",
+                "TABLE_ROWS",
+                "TABLE_COMMENT"
+            ]
+        );
+        assert_eq!(
+            COLUMN_METADATA_RESULT_COLUMNS,
+            &[
+                "COLUMN_NAME",
+                "COLUMN_TYPE",
+                "IS_NULLABLE",
+                "COLUMN_DEFAULT",
+                "EXTRA",
+                "COLUMN_COMMENT",
+                "ORDINAL_POSITION",
+                "PRIMARY_KEY_POSITION",
+            ]
+        );
+        assert_eq!(UNIQUE_COLUMN_RESULT_COLUMNS, &["COLUMN_NAME"]);
+        assert_eq!(
+            FOREIGN_KEY_RESULT_COLUMNS,
+            &[
+                "CONSTRAINT_NAME",
+                "TABLE_SCHEMA",
+                "TABLE_NAME",
+                "COLUMN_NAME",
+                "REFERENCED_TABLE_SCHEMA",
+                "REFERENCED_TABLE_NAME",
+                "REFERENCED_COLUMN_NAME",
+                "ORDINAL_POSITION",
+                "UPDATE_RULE",
+                "DELETE_RULE",
+            ]
+        );
+        assert_eq!(
+            SIGNATURE_COLUMNS_RESULT_COLUMNS,
+            &[
+                "TABLE_SCHEMA",
+                "TABLE_NAME",
+                "COLUMN_NAME",
+                "COLUMN_TYPE",
+                "IS_NULLABLE",
+                "COLUMN_DEFAULT",
+                "EXTRA",
+                "COLUMN_COMMENT",
+                "ORDINAL_POSITION",
+                "PRIMARY_KEY_POSITION",
+            ]
+        );
+        assert_eq!(
+            SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS,
+            &["TABLE_NAME", "COLUMN_NAME"]
+        );
+        assert_eq!(
+            INDEX_RESULT_COLUMNS,
+            &[
+                "INDEX_NAME",
+                "NON_UNIQUE",
+                "INDEX_TYPE",
+                "SEQ_IN_INDEX",
+                "COLUMN_NAME",
+                "EXPRESSION",
+                "IS_PRIMARY",
+            ]
+        );
+        assert_eq!(
+            TRIGGER_RESULT_COLUMNS,
+            &[
+                "TRIGGER_NAME",
+                "ACTION_TIMING",
+                "EVENT_MANIPULATION",
+                "ACTION_STATEMENT",
+                "DEFINER",
+            ]
         );
     }
 

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -210,16 +210,6 @@ mod tests {
         }
     }
 
-    fn assert_contains_in_order(query: &str, fragments: &[&str]) {
-        let mut remaining = query;
-        for fragment in fragments {
-            let Some(index) = remaining.find(fragment) else {
-                panic!("missing SQL fragment {fragment:?} in {query:?}");
-            };
-            remaining = &remaining[index + fragment.len()..];
-        }
-    }
-
     #[test]
     fn builds_metadata_select_query_without_changing_the_fallback_sql() {
         assert_eq!(
@@ -251,134 +241,79 @@ mod tests {
         let quoted_schema = quote_string(schema);
         let quoted_table = quote_string(table);
 
-        let table_query = table_query(schema, table);
-        assert_contains_in_order(
-            &table_query,
-            &[
-                "SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_ROWS, t.TABLE_COMMENT",
-                "FROM INFORMATION_SCHEMA.TABLES AS t",
-                &format!("WHERE t.TABLE_SCHEMA = {quoted_schema}"),
-                "AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW')",
-                &format!("AND t.TABLE_NAME = {quoted_table}"),
-                "ORDER BY TABLE_SCHEMA, TABLE_NAME",
-            ],
+        assert_eq!(
+            table_query(schema, table),
+            format!(
+                "SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_ROWS, t.TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_SCHEMA = {quoted_schema} AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') AND t.TABLE_NAME = {quoted_table} ORDER BY TABLE_SCHEMA, TABLE_NAME"
+            )
         );
 
-        let columns_query = columns_query(schema, table);
-        assert_contains_in_order(
-            &columns_query,
-            &[
-                "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION",
-                "FROM INFORMATION_SCHEMA.COLUMNS AS c",
-                "LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY'",
-                "LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME",
-                &format!("WHERE c.TABLE_SCHEMA = {quoted_schema}"),
-                &format!("AND c.TABLE_NAME = {quoted_table}"),
-                "ORDER BY ORDINAL_POSITION",
-            ],
+        assert_eq!(
+            columns_query(schema, table),
+            format!(
+                "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = {quoted_schema} AND c.TABLE_NAME = {quoted_table} ORDER BY ORDINAL_POSITION"
+            )
         );
 
-        let unique_columns_query = unique_columns_query(schema, table);
-        assert_contains_in_order(
-            &unique_columns_query,
-            &[
-                "SELECT MIN(s.COLUMN_NAME) AS COLUMN_NAME",
-                "FROM INFORMATION_SCHEMA.STATISTICS AS s",
-                &format!("WHERE s.TABLE_SCHEMA = {quoted_schema}"),
-                &format!("AND s.TABLE_NAME = {quoted_table}"),
-                "AND s.NON_UNIQUE = 0",
-                "AND s.INDEX_NAME <> 'PRIMARY'",
-                "GROUP BY s.INDEX_NAME",
-                "HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1",
-                "ORDER BY s.INDEX_NAME",
-            ],
+        assert_eq!(
+            unique_columns_query(schema, table),
+            format!(
+                "SELECT MIN(s.COLUMN_NAME) AS COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = {quoted_schema} AND s.TABLE_NAME = {quoted_table} AND s.NON_UNIQUE = 0 AND s.INDEX_NAME <> 'PRIMARY' GROUP BY s.INDEX_NAME HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1 ORDER BY s.INDEX_NAME"
+            )
         );
 
-        let foreign_keys_query = foreign_keys_query(schema, table);
-        assert_contains_in_order(
-            &foreign_keys_query,
-            &[
-                "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE",
-                "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc",
-                "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME",
-                "INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME",
-                &format!("WHERE tc.CONSTRAINT_SCHEMA = {quoted_schema}"),
-                &format!("AND tc.TABLE_SCHEMA = {quoted_schema}"),
-                &format!("AND tc.TABLE_NAME = {quoted_table}"),
-                "AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'",
-                "ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
-            ],
+        assert_eq!(
+            foreign_keys_query(schema, table),
+            format!(
+                "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = {quoted_schema} AND tc.TABLE_SCHEMA = {quoted_schema} AND tc.TABLE_NAME = {quoted_table} AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION"
+            )
         );
 
-        let indexes_query = indexes_query(table);
-        assert_contains_in_order(
-            &indexes_query,
-            &[
-                "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.EXPRESSION, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY",
-                "FROM INFORMATION_SCHEMA.STATISTICS AS s",
-                "LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME",
-                "WHERE s.TABLE_SCHEMA = DATABASE()",
-                &format!("AND s.TABLE_NAME = {quoted_table}"),
-                "ORDER BY INDEX_NAME, SEQ_IN_INDEX",
-            ],
+        assert_eq!(
+            indexes_query(table),
+            format!(
+                "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.EXPRESSION, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = DATABASE() AND s.TABLE_NAME = {quoted_table} ORDER BY INDEX_NAME, SEQ_IN_INDEX"
+            )
         );
 
-        let triggers_query = triggers_query(table);
-        assert_contains_in_order(
-            &triggers_query,
-            &[
-                "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER",
-                "FROM INFORMATION_SCHEMA.TRIGGERS",
-                "WHERE TRIGGER_SCHEMA = DATABASE()",
-                "AND EVENT_OBJECT_SCHEMA = DATABASE()",
-                &format!("AND EVENT_OBJECT_TABLE = {quoted_table}"),
-                "ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION",
-            ],
+        assert_eq!(
+            triggers_query(table),
+            format!(
+                "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {quoted_table} ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION"
+            )
         );
 
-        assert_contains_in_order(
+        assert_eq!(
             TABLES_QUERY,
-            &[
-                "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT",
-                "FROM INFORMATION_SCHEMA.TABLES",
-                "WHERE TABLE_SCHEMA = DATABASE()",
-                "AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')",
-                "ORDER BY TABLE_SCHEMA, TABLE_NAME",
-            ],
+            "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') ORDER BY TABLE_SCHEMA, TABLE_NAME"
         );
-        assert_contains_in_order(
+        assert_eq!(
             SIGNATURE_COLUMNS_QUERY,
-            &[
-                "SELECT c.TABLE_SCHEMA, c.TABLE_NAME, c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION",
-                "FROM INFORMATION_SCHEMA.COLUMNS AS c",
-                "WHERE c.TABLE_SCHEMA = DATABASE()",
-                "ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION",
-            ],
+            "SELECT c.TABLE_SCHEMA, c.TABLE_NAME, c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = DATABASE() ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION"
         );
-        assert_contains_in_order(
+        assert_eq!(
             SIGNATURE_UNIQUE_COLUMNS_QUERY,
-            &[
-                "SELECT s.TABLE_NAME, MIN(s.COLUMN_NAME) AS COLUMN_NAME",
-                "FROM INFORMATION_SCHEMA.STATISTICS AS s",
-                "WHERE s.TABLE_SCHEMA = DATABASE()",
-                "AND s.NON_UNIQUE = 0",
-                "AND s.INDEX_NAME <> 'PRIMARY'",
-                "GROUP BY s.TABLE_NAME, s.INDEX_NAME",
-                "HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1",
-                "ORDER BY s.TABLE_NAME, s.INDEX_NAME",
-            ],
+            "SELECT s.TABLE_NAME, MIN(s.COLUMN_NAME) AS COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = DATABASE() AND s.NON_UNIQUE = 0 AND s.INDEX_NAME <> 'PRIMARY' GROUP BY s.TABLE_NAME, s.INDEX_NAME HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1 ORDER BY s.TABLE_NAME, s.INDEX_NAME"
         );
-        assert_contains_in_order(
+        assert_eq!(
             SIGNATURE_FOREIGN_KEYS_QUERY,
-            &[
-                "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE",
-                "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc",
-                "WHERE tc.CONSTRAINT_SCHEMA = DATABASE()",
-                "AND tc.TABLE_SCHEMA = DATABASE()",
-                "AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'",
-                "ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION",
-            ],
+            "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = DATABASE() AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION"
         );
+
+        for query in [
+            TABLES_QUERY,
+            SIGNATURE_COLUMNS_QUERY,
+            SIGNATURE_UNIQUE_COLUMNS_QUERY,
+            SIGNATURE_FOREIGN_KEYS_QUERY,
+            &table_query(schema, table),
+            &columns_query(schema, table),
+            &unique_columns_query(schema, table),
+            &foreign_keys_query(schema, table),
+            &indexes_query(table),
+            &triggers_query(table),
+        ] {
+            assert!(!query.contains("UNION ALL SELECT NULL"));
+        }
 
         assert_eq!(
             TABLES_RESULT_COLUMNS,
@@ -471,6 +406,14 @@ mod tests {
         assert_eq!(
             show_create_query("view_name", TableKind::View),
             "SHOW CREATE VIEW `view_name`"
+        );
+        assert_eq!(
+            show_create_result_columns(TableKind::Table),
+            &["Table", "Create Table"]
+        );
+        assert_eq!(
+            show_create_result_columns(TableKind::View),
+            &["View", "Create View"]
         );
     }
 

--- a/src/infra/adapters/mysql/sql/mod.rs
+++ b/src/infra/adapters/mysql/sql/mod.rs
@@ -5,5 +5,12 @@ mod grid_write;
 mod literal;
 mod metadata;
 
-pub(super) use literal::{quote_identifier, quote_string};
-pub(super) use metadata::build_metadata_select_query;
+pub(super) use metadata::{
+    COLUMN_METADATA_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS, INDEX_RESULT_COLUMNS,
+    SIGNATURE_COLUMNS_QUERY, SIGNATURE_COLUMNS_RESULT_COLUMNS, SIGNATURE_FOREIGN_KEYS_QUERY,
+    SIGNATURE_UNIQUE_COLUMNS_QUERY, SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS, TABLES_QUERY,
+    TABLES_RESULT_COLUMNS, TRIGGER_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS,
+    build_metadata_select_query, build_preview_query, columns_query, foreign_keys_query,
+    indexes_query, preview_identity_alias, show_create_query, show_create_result_columns,
+    table_query, triggers_query, unique_columns_query,
+};


### PR DESCRIPTION
## Problem
MySQL catalog and metadata SQL generation was mixed into result parsing and orchestration modules, making metadata changes require searching across both responsibilities.

## Background
PostgreSQL and SQLite keep pure metadata SQL under their adapter `sql/` modules.

## Approach
Centralize MySQL catalog, signature, index, trigger, SHOW CREATE, preview, and empty-result metadata SQL builders and result-column contracts in `mysql/sql/metadata.rs`. Keep metadata modules focused on session orchestration, parsing, and domain conversion while preserving existing SQL, ordering, and behavior.