### PR TITLE
test(mysql): organize boundary coverage

### DIFF
--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -276,7 +276,6 @@ mod mysql_tests {
     #[case::unterminated_comment("SELECT 1 /* unfinished")]
     #[case::unsupported_statement("MERGE INTO items USING source ON items.id = source.id")]
     #[case::replace("REPLACE INTO items VALUES (1)")]
-    #[case::begin_work("BEGIN WORK")]
     fn invalid_mysql_scripts_are_blocked_before_execution(#[case] sql: &str) {
         assert!(
             matches!(mysql(sql), MultiStatementDecision::Block { .. }),
@@ -2702,9 +2701,8 @@ mod tests {
     }
 
     #[test]
-    fn rejects_mysql_single_statement_risk_entry() {
+    fn rejects_unsupported_mysql_single_statement_risk_entries() {
         for sql in [
-            "BEGIN WORK",
             "REPLACE INTO items VALUES (1)",
             "MERGE INTO items USING source ON items.id = source.id",
         ] {
@@ -2713,5 +2711,17 @@ mod tests {
                 "{sql}"
             );
         }
+    }
+
+    #[test]
+    fn rejects_begin_work_as_single_statement_risk_entry() {
+        assert!(
+            evaluate_sql_risk_for_database(
+                DatabaseType::MySQL,
+                &classify("BEGIN WORK"),
+                "BEGIN WORK",
+            )
+            .is_none()
+        );
     }
 }

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -293,6 +293,17 @@ mod probe_tests {
     }
 
     #[test]
+    fn rejects_no_backslash_escapes_sql_mode() {
+        assert!(matches!(
+            validate_sql_mode("STRICT_TRANS_TABLES,NO_BACKSLASH_ESCAPES"),
+            Err(DbOperationError::UnsupportedOperationWithKind {
+                kind: UnsupportedOperationKind::SessionMode,
+                ..
+            })
+        ));
+    }
+
+    #[test]
     fn uses_tcp_and_keeps_defaults_file_first() {
         let args = mysql_probe_args(std::path::Path::new("/tmp/sabiql-mysql.cnf"));
 

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -18,7 +18,7 @@ use super::sql;
 
 #[cfg(feature = "test-support")]
 pub(super) mod test_support {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     use crate::adapters::csv_export::export_to_path;
     use crate::app::ports::outbound::{AccessMode, DbOperationError};
@@ -27,6 +27,28 @@ pub(super) mod test_support {
         MySqlOptionFile, export_mysql_csv_to_file, parse_and_validate_mysql_dsn, run_mysql_adhoc,
         validate_mysql_multi_query,
     };
+
+    #[doc(hidden)]
+    pub struct MySqlOptionFileForTest {
+        option_file: MySqlOptionFile,
+    }
+
+    impl MySqlOptionFileForTest {
+        #[must_use]
+        pub fn path(&self) -> &Path {
+            &self.option_file.path
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn create_mysql_option_file_for_test(
+        dsn: &str,
+    ) -> Result<MySqlOptionFileForTest, DbOperationError> {
+        let target = parse_and_validate_mysql_dsn(dsn)?;
+        Ok(MySqlOptionFileForTest {
+            option_file: MySqlOptionFile::create(&target)?,
+        })
+    }
 
     #[doc(hidden)]
     /// Runs the normal adhoc CLI process with a read-only session without the app-side policy

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -666,6 +666,29 @@ mod tests {
     }
 
     #[test]
+    fn metadata_parser_marks_invisible_columns_hidden_and_read_only() {
+        let parsed = parse_column_metadata(&result(
+            COLUMN_METADATA_RESULT_COLUMNS,
+            vec![vec![
+                QueryValue::Text("hidden_value".to_string()),
+                QueryValue::Text("varchar(20)".to_string()),
+                QueryValue::Text("YES".to_string()),
+                QueryValue::Null,
+                QueryValue::Text("INVISIBLE".to_string()),
+                QueryValue::Null,
+                QueryValue::Text("1".to_string()),
+                QueryValue::Null,
+            ]],
+        ))
+        .expect("metadata parses");
+
+        let column = column_from_metadata(&parsed[0]);
+
+        assert!(column.is_hidden());
+        assert!(column.is_read_only());
+    }
+
+    #[test]
     fn empty_columns_result_maps_to_missing_table() {
         let result = result(COLUMN_METADATA_RESULT_COLUMNS, Vec::new());
 

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -329,22 +329,6 @@ mod tests {
     }
 
     #[test]
-    fn binary_type_recognizes_mysql_spatial_types() {
-        for data_type in [
-            "geometry",
-            "point srid 4326",
-            "linestring",
-            "polygon",
-            "multipoint",
-            "multilinestring",
-            "multipolygon",
-            "geometrycollection",
-        ] {
-            assert!(is_binary_type(data_type), "{data_type}");
-        }
-    }
-
-    #[test]
     fn preview_conversion_keeps_numeric_server_literals_without_rounding() {
         let result = result(
             &["unsigned_value", "decimal_value", "float_value"],

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -295,6 +295,19 @@ mod tests {
     }
 
     #[test]
+    fn preview_conversion_decodes_bit_hex_as_binary() {
+        let result = result(
+            &["bit_value"],
+            vec![vec![QueryValue::Text("0x05".to_string())]],
+        );
+        let columns = vec![column("bit_value", "bit(3)")];
+
+        let values = convert_preview_values(&result, &columns, &[]).expect("conversion succeeds");
+
+        assert_eq!(values.visible[0][0], QueryValue::Blob(vec![5]));
+    }
+
+    #[test]
     fn preview_conversion_decodes_spatial_hex_as_binary() {
         let result = result(
             &["location"],

--- a/src/infra/adapters/mysql/mod.rs
+++ b/src/infra/adapters/mysql/mod.rs
@@ -14,5 +14,6 @@ pub use executor::test_support::run_mysql_cli_script_for_test;
 
 #[cfg(feature = "test-support")]
 pub use executor::test_support::{
+    MySqlOptionFileForTest, create_mysql_option_file_for_test,
     execute_mysql_adhoc_with_read_only_session_for_test, export_mysql_csv_to_path_for_test,
 };

--- a/src/infra/adapters/mysql/sql/grid_write.rs
+++ b/src/infra/adapters/mysql/sql/grid_write.rs
@@ -109,6 +109,22 @@ mod tests {
     }
 
     #[test]
+    fn update_uses_null_literal_for_cell_value() {
+        let sql = build_update_sql(
+            "sabiql_test",
+            "items",
+            "payload",
+            &QueryValue::Null,
+            &[("id".to_string(), QueryValue::SqlLiteral("1".into()))],
+        );
+
+        assert_eq!(
+            sql,
+            "UPDATE `sabiql_test`.`items`\nSET `payload` = NULL\nWHERE `id` = 1;"
+        );
+    }
+
+    #[test]
     fn json_document_update_keeps_json_null_distinct_from_string_null() {
         let json_null = build_update_sql(
             "sabiql_test",
@@ -151,5 +167,16 @@ mod tests {
             sql,
             "DELETE FROM `sabiql_test`.`items`\nWHERE (`first` = 1 AND `second` = 20) OR (`first` = 2 AND `second` = 10);"
         );
+    }
+
+    #[test]
+    fn bulk_delete_uses_unwrapped_predicate_for_single_row() {
+        let sql = build_bulk_delete_sql(
+            "sabiql_test",
+            "items",
+            &[vec![("id".to_string(), QueryValue::SqlLiteral("1".into()))]],
+        );
+
+        assert_eq!(sql, "DELETE FROM `sabiql_test`.`items`\nWHERE `id` = 1;");
     }
 }

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -211,14 +211,6 @@ mod tests {
     }
 
     #[test]
-    fn builds_metadata_select_query_without_changing_the_fallback_sql() {
-        assert_eq!(
-            build_metadata_select_query("SELECT 1", "__source", "__marker"),
-            "WITH __source AS (SELECT * FROM ((SELECT 1\n) LIMIT 0) AS __sabiql_metadata_inner) SELECT __source.* FROM __source RIGHT JOIN (SELECT 1 AS __marker) AS __sabiql_metadata_marker ON TRUE"
-        );
-    }
-
-    #[test]
     fn metadata_queries_escape_literals_and_preserve_scope_conditions() {
         let schema = "app\\\n\r\t\u{0008}\u{001a}'";
         let table = "items\\\n\r\t\u{0008}\u{001a}'";

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1454,7 +1454,7 @@ mod query_execution {
 
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
-    async fn preserves_empty_result_columns_for_select_show_describe_and_table() {
+    async fn preserves_empty_select_columns_without_reexecution() {
         with_mysql_test_db(|db| {
             Box::pin(async move {
                 let select = db
@@ -1564,6 +1564,17 @@ mod query_execution {
                     ));
                 }
 
+                Ok(())
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+    async fn rejects_unsafe_empty_selects_before_execution() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
                 let duplicate_aliases = db
                     .adapter()
                     .execute_adhoc(
@@ -1597,7 +1608,17 @@ mod query_execution {
                         ));
                     }
                 }
+                Ok(())
+            })
+        })
+        .await;
+    }
 
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+    async fn preserves_empty_show_columns() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
                 let show = db
                     .adapter()
                     .execute_adhoc(
@@ -1612,7 +1633,17 @@ mod query_execution {
                 {
                     return Err(format!("unexpected empty SHOW result: {show:?}"));
                 }
+                Ok(())
+            })
+        })
+        .await;
+    }
 
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+    async fn preserves_empty_describe_columns() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
                 let describe = db
                     .adapter()
                     .execute_adhoc(
@@ -1627,7 +1658,17 @@ mod query_execution {
                 {
                     return Err(format!("unexpected empty DESCRIBE result: {describe:?}"));
                 }
+                Ok(())
+            })
+        })
+        .await;
+    }
 
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+    async fn preserves_empty_table_columns() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
                 let table = db
                     .adapter()
                     .execute_adhoc(

--- a/src/tests/harness/mysql.rs
+++ b/src/tests/harness/mysql.rs
@@ -2,10 +2,9 @@ use std::process::Stdio;
 
 use sabiql_app::ports::outbound::{ConnectionProbe, DbOperationError, DsnBuilder};
 use sabiql_domain::connection::{ConnectionProfile, MySqlConnectionConfig, MySqlSslMode};
-use sabiql_infra::adapters::mysql::MySqlAdapter;
 #[cfg(unix)]
 use sabiql_infra::adapters::mysql::run_mysql_cli_script_for_test;
-use tempfile::NamedTempFile;
+use sabiql_infra::adapters::mysql::{MySqlAdapter, create_mysql_option_file_for_test};
 use tokio::process::Command;
 
 pub const MYSQL_FIXTURE_TABLE: &str = "mysql_cli_fixture";
@@ -15,7 +14,6 @@ type MySqlFixtureTest<'db> = std::pin::Pin<Box<dyn Future<Output = Result<(), St
 pub struct MySqlTestDb {
     adapter: MySqlAdapter,
     dsn: String,
-    config: MySqlConnectionConfig,
 }
 
 impl MySqlTestDb {
@@ -34,11 +32,7 @@ impl MySqlTestDb {
         let adapter = MySqlAdapter::new();
         let dsn = adapter.build_dsn(&profile);
         adapter.probe(&dsn).await?;
-        Ok(Self {
-            adapter,
-            dsn,
-            config,
-        })
+        Ok(Self { adapter, dsn })
     }
 
     pub fn adapter(&self) -> &MySqlAdapter {
@@ -63,9 +57,8 @@ impl MySqlTestDb {
     }
 
     async fn run_cli(&self, query: &str) -> Result<String, String> {
-        let option_file = NamedTempFile::new().map_err(|error| error.to_string())?;
-        std::fs::write(option_file.path(), serialize_option_file(&self.config))
-            .map_err(|error| error.to_string())?;
+        let option_file =
+            create_mysql_option_file_for_test(&self.dsn).map_err(|error| error.to_string())?;
         let output = Command::new("mysql")
             .args([
                 format!("--defaults-file={}", option_file.path().display()),
@@ -157,29 +150,4 @@ pub fn mysql_tls_config() -> MySqlConnectionConfig {
         Some(std::env::var("SABIQL_MYSQL_TEST_SSL_CERT").expect("TLS client certificate path")),
         Some(std::env::var("SABIQL_MYSQL_TEST_SSL_KEY").expect("TLS client key path")),
     )
-}
-
-fn serialize_option_file(config: &MySqlConnectionConfig) -> String {
-    let mut contents = String::from("[client]\n");
-    push_option(&mut contents, "host", &config.host);
-    push_option(&mut contents, "port", &config.port.to_string());
-    push_option(&mut contents, "user", &config.username);
-    push_option(&mut contents, "password", &config.password);
-    if let Some(database) = config.database.as_deref() {
-        push_option(&mut contents, "database", database);
-    }
-    contents
-}
-
-fn push_option(contents: &mut String, key: &str, value: &str) {
-    contents.push_str(key);
-    contents.push_str(" = \"");
-    for character in value.chars() {
-        match character {
-            '\\' => contents.push_str("\\\\"),
-            '"' => contents.push_str("\\\""),
-            _ => contents.push(character),
-        }
-    }
-    contents.push_str("\"\n");
 }


### PR DESCRIPTION
## Problem
MySQL integration support duplicated production option-file serialization, and several boundary cases were concentrated in broad tests.

## Background
The duplicated harness path could drift from the production serializer, while the large empty-result test obscured distinct server and policy contracts.

## Approach
Route the integration harness through the production option-file serializer, split empty-result coverage by responsibility, and add focused unit coverage for MySQL metadata, preview, grid writes, SQL mode, and BEGIN WORK boundaries. Production behavior and the existing Oracle MySQL 8.4 fixture path remain unchanged.

## Checks
Focused MySQL tests, all-features and no-default-features clippy, release builds, lint, snapshots, Oracle MySQL 8.4 integration, and cargo audit passed. The workspace test suite retains one unrelated pre-existing SQLite export failure.