### PR TITLE
feat: show effective database users in header

### DIFF
--- a/src/infra/adapters/mysql/metadata/mod.rs
+++ b/src/infra/adapters/mysql/metadata/mod.rs
@@ -4,6 +4,8 @@ use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
 use crate::domain::{DatabaseMetadata, Schema, Table, TableSignature};
 
 use super::adapter::MySqlAdapter;
+use super::cli::MysqlResultSet;
+use super::sql::{EFFECTIVE_USER_QUERY, EFFECTIVE_USER_RESULT_COLUMNS};
 
 mod catalog;
 mod preview;
@@ -20,6 +22,16 @@ impl MetadataProvider for MySqlAdapter {
         metadata.schemas = vec![Schema::new(snapshot.database)];
         metadata.table_summaries = snapshot.table_summaries;
         Ok(metadata)
+    }
+
+    async fn fetch_effective_user(&self, dsn: &str) -> Result<Option<String>, DbOperationError> {
+        let result = catalog::execute_metadata_query(
+            dsn,
+            EFFECTIVE_USER_QUERY,
+            EFFECTIVE_USER_RESULT_COLUMNS,
+        )
+        .await?;
+        Ok(effective_user_from_result(&result))
     }
 
     async fn fetch_table_detail(
@@ -45,5 +57,48 @@ impl MetadataProvider for MySqlAdapter {
         dsn: &str,
     ) -> Result<Vec<TableSignature>, DbOperationError> {
         signature::fetch_table_signatures(dsn).await
+    }
+}
+
+fn effective_user_from_result(result: &MysqlResultSet) -> Option<String> {
+    let [row] = result.values.as_slice() else {
+        return None;
+    };
+    let [value] = row.as_slice() else {
+        return None;
+    };
+    let user = value.as_str()?.trim();
+    (!user.is_empty()).then(|| user.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::QueryValue;
+
+    fn result(values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
+        MysqlResultSet {
+            columns: vec!["CURRENT_USER()".to_string()],
+            values,
+        }
+    }
+
+    #[test]
+    fn parses_mysql_effective_user_and_trims_server_whitespace() {
+        let result = result(vec![vec![QueryValue::text("app_user@%  ")]]);
+
+        assert_eq!(
+            effective_user_from_result(&result),
+            Some("app_user@%".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_missing_or_empty_mysql_effective_user_values() {
+        assert_eq!(effective_user_from_result(&result(Vec::new())), None);
+        assert_eq!(
+            effective_user_from_result(&result(vec![vec![QueryValue::text("  ")]])),
+            None
+        );
     }
 }

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -1,6 +1,8 @@
 use super::literal::{quote_identifier, quote_string};
 use crate::domain::{Column, TableKind};
 
+pub(in crate::adapters::mysql) const EFFECTIVE_USER_QUERY: &str = "SELECT CURRENT_USER()";
+pub(in crate::adapters::mysql) const EFFECTIVE_USER_RESULT_COLUMNS: &[&str] = &["CURRENT_USER()"];
 pub(in crate::adapters::mysql) const TABLES_QUERY: &str = "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') ORDER BY TABLE_SCHEMA, TABLE_NAME";
 pub(in crate::adapters::mysql) const TABLES_RESULT_COLUMNS: &[&str] = &[
     "TABLE_SCHEMA",
@@ -214,6 +216,9 @@ mod tests {
     fn metadata_queries_escape_literals_and_preserve_scope_conditions() {
         let schema = "app\\\n\r\t\u{0008}\u{001a}'";
         let table = "items\\\n\r\t\u{0008}\u{001a}'";
+
+        assert_eq!(EFFECTIVE_USER_QUERY, "SELECT CURRENT_USER()");
+        assert_eq!(EFFECTIVE_USER_RESULT_COLUMNS, &["CURRENT_USER()"][..]);
 
         assert_eq!(
             quote_string(schema),

--- a/src/infra/adapters/mysql/sql/mod.rs
+++ b/src/infra/adapters/mysql/sql/mod.rs
@@ -6,11 +6,12 @@ mod literal;
 mod metadata;
 
 pub(super) use metadata::{
-    COLUMN_METADATA_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS, INDEX_RESULT_COLUMNS,
-    SIGNATURE_COLUMNS_QUERY, SIGNATURE_COLUMNS_RESULT_COLUMNS, SIGNATURE_FOREIGN_KEYS_QUERY,
-    SIGNATURE_UNIQUE_COLUMNS_QUERY, SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS, TABLES_QUERY,
-    TABLES_RESULT_COLUMNS, TRIGGER_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS,
-    build_metadata_select_query, build_preview_query, columns_query, foreign_keys_query,
-    indexes_query, preview_identity_alias, show_create_query, show_create_result_columns,
-    table_query, triggers_query, unique_columns_query,
+    COLUMN_METADATA_RESULT_COLUMNS, EFFECTIVE_USER_QUERY, EFFECTIVE_USER_RESULT_COLUMNS,
+    FOREIGN_KEY_RESULT_COLUMNS, INDEX_RESULT_COLUMNS, SIGNATURE_COLUMNS_QUERY,
+    SIGNATURE_COLUMNS_RESULT_COLUMNS, SIGNATURE_FOREIGN_KEYS_QUERY, SIGNATURE_UNIQUE_COLUMNS_QUERY,
+    SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS, TABLES_QUERY, TABLES_RESULT_COLUMNS,
+    TRIGGER_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, build_metadata_select_query,
+    build_preview_query, columns_query, foreign_keys_query, indexes_query, preview_identity_alias,
+    show_create_query, show_create_result_columns, table_query, triggers_query,
+    unique_columns_query,
 };

--- a/src/infra/adapters/registry.rs
+++ b/src/infra/adapters/registry.rs
@@ -83,6 +83,14 @@ impl MetadataProvider for DbAdapterRegistry {
         }
     }
 
+    async fn fetch_effective_user(&self, dsn: &str) -> Result<Option<String>, DbOperationError> {
+        match Self::db_type_from_dsn(dsn)? {
+            DatabaseType::PostgreSQL => self.postgres.fetch_effective_user(dsn).await,
+            DatabaseType::SQLite => self.sqlite.fetch_effective_user(dsn).await,
+            DatabaseType::MySQL => self.mysql.fetch_effective_user(dsn).await,
+        }
+    }
+
     async fn fetch_table_detail(
         &self,
         dsn: &str,
@@ -512,6 +520,31 @@ mod tests {
         let metadata = registry.fetch_metadata(&dsn).await.unwrap();
 
         assert_eq!(metadata.table_summaries[0].qualified_name(), "main.users");
+    }
+
+    #[tokio::test]
+    async fn sqlite_effective_user_dispatch_preserves_unknown_user() {
+        let (_dir, dsn) =
+            test_support::make_sqlite_db("CREATE TABLE users(id INTEGER PRIMARY KEY);");
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+
+        let effective_user = registry.fetch_effective_user(&dsn).await.unwrap();
+
+        assert_eq!(effective_user, None);
+    }
+
+    #[tokio::test]
+    async fn mysql_effective_user_dispatch_does_not_expose_password_on_validation_failure() {
+        let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+
+        let error = registry
+            .fetch_effective_user("mysql://app:header-secret%01@localhost/app")
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(error, DbOperationError::ConnectionFailed(details) if !details.contains("header-secret"))
+        );
     }
 
     #[tokio::test]

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -176,13 +176,43 @@ mod connection {
 
 mod metadata_fetch {
 
+    use std::sync::Arc;
+
     use super::shared::{MYSQL_COMPOSITE_TABLE, MYSQL_VIEW};
-    use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, with_mysql_test_db};
+    use crate::tests::harness::mysql::{
+        MYSQL_FIXTURE_TABLE, mysql_integration_config, with_mysql_test_db,
+    };
     use sabiql_app::ports::outbound::{AccessMode, DdlGenerator, MetadataProvider, QueryExecutor};
     use sabiql_domain::{FkAction, IndexType, TableKind, TriggerEvent, TriggerTiming};
+    use sabiql_infra::adapters::{DbAdapterRegistry, PostgresAdapter};
 
     const MYSQL_FK_PARENT: &str = "mysql_metadata_parent";
     const MYSQL_FK_CHILD: &str = "mysql_metadata_child";
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn registry_fetches_mysql_effective_user_for_the_connection_header() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
+                let registry = DbAdapterRegistry::new(Arc::new(PostgresAdapter::new()));
+                let effective_user = registry
+                    .fetch_effective_user(db.dsn())
+                    .await
+                    .map_err(|error| format!("{error:?}"))?
+                    .ok_or_else(|| "MySQL effective user was empty".to_string())?;
+                let config = mysql_integration_config();
+
+                if !effective_user.starts_with(&format!("{}@", config.username)) {
+                    return Err(format!("unexpected MySQL effective user: {effective_user}"));
+                }
+                if effective_user.contains(&config.password) {
+                    return Err("MySQL effective user exposed the connection password".to_string());
+                }
+                Ok(())
+            })
+        })
+        .await;
+    }
 
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and CLI"]

--- a/src/tests/render_snapshots/initial_state.rs
+++ b/src/tests/render_snapshots/initial_state.rs
@@ -45,6 +45,26 @@ fn header_shows_effective_user_at_normal_width() {
 }
 
 #[test]
+fn mysql_header_shows_effective_user_without_dsn_password() {
+    let mut state = connected_state();
+    state.session.activate_connection_with_dsn(
+        &ConnectionId::new(),
+        "test",
+        DatabaseType::MySQL,
+        "mysql://app:header-secret@localhost/app",
+    );
+    state
+        .session
+        .mark_effective_user_loaded(Some("app@%".to_string()));
+    let mut terminal = create_test_terminal();
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    assert!(output.contains("user: app@%"));
+    assert!(!output.contains("header-secret"));
+}
+
+#[test]
 fn header_truncates_connection_name_at_narrow_width() {
     let mut state = connected_state();
     state.session.activate_connection_with_dsn(


### PR DESCRIPTION
## Problem
The connection header needs to show the effective database user for every adapter that can provide one. The registry currently falls back to `None` for MySQL.

## Background
MySQL exposes the authenticated account through `CURRENT_USER()`, while SQLite has no effective-user identity to display.

## Approach
Dispatch effective-user lookup through `DbAdapterRegistry`, reuse the MySQL metadata session for `CURRENT_USER()`, and keep the result trimmed and password-free. Tests cover SQLite absence, stale-result protection, header rendering, invalid-DSN masking, and a real Oracle MySQL 8.4 fixture.

## Validation
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Targeted infra and header tests
- `scripts/mysql_integration.sh test` under the required host-global lock: 40/40 passed
- Full workspace nextest has one unrelated existing SQLite export test failure: `export_to_csv_missing_table_returns_object_missing_and_removes_file`

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-459