### PR TITLE
fix(mysql): avoid metadata refresh for temporary tables

### DIFF
--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -5,7 +5,7 @@ use crate::app::policy::sql::mysql_statement::{
 };
 use crate::app::policy::write::sql_risk::{
     MultiStatementDecision, evaluate_mysql_multi_statement, mysql_statement_is_data_modifying,
-    mysql_statement_is_persistent_schema_change, mysql_statement_is_schema_modifying,
+    mysql_statement_is_persistent_schema_change,
 };
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{CommandTag, QueryValue, RefreshScope};
@@ -263,7 +263,7 @@ pub(super) fn mysql_command_tag(
 }
 
 pub(super) fn mysql_refresh_scope(kind: &MysqlStatementKind) -> RefreshScope {
-    if mysql_statement_is_schema_modifying(kind) {
+    if mysql_statement_is_persistent_schema_change(kind) {
         RefreshScope::Metadata
     } else if mysql_statement_is_data_modifying(kind) {
         RefreshScope::Data
@@ -516,6 +516,29 @@ mod tests {
             &statements
         ));
     }
+
+    #[test]
+    fn refresh_scope_ignores_temporary_table_ddl() {
+        for kind in [
+            MysqlStatementKind::CreateTable { temporary: true },
+            MysqlStatementKind::DropTable { temporary: true },
+        ] {
+            assert_eq!(mysql_refresh_scope(&kind), RefreshScope::None);
+        }
+    }
+
+    #[test]
+    fn refresh_scope_preserves_data_and_persistent_metadata_changes() {
+        assert_eq!(
+            mysql_refresh_scope(&MysqlStatementKind::Insert),
+            RefreshScope::Data
+        );
+        assert_eq!(
+            mysql_refresh_scope(&MysqlStatementKind::CreateTable { temporary: false }),
+            RefreshScope::Metadata
+        );
+    }
+
     #[test]
     fn transaction_rollback_removes_pending_data_tag() {
         let events = vec![

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2006,9 +2006,30 @@ mod query_execution {
             if result.columns != ["id"]
                 || result.values() != [[QueryValue::Text("1".to_string())], [QueryValue::Text("2".to_string())]]
                 || result.command_tag != Some(CommandTag::Insert(2))
-                || result.refresh_scope != RefreshScope::Metadata
+                || result.refresh_scope != RefreshScope::Data
             {
                 return Err(format!("unexpected temporary-table result: {result:?}"));
+            }
+
+            let ddl_only_table = format!("sabiql_sab461_tmp_{suffix}");
+            let ddl_only_result = db
+                .adapter()
+                .execute_adhoc(
+                    db.dsn(),
+                    &format!(
+                        "CREATE TEMPORARY TABLE {ddl_only_table} (id INT); DROP TEMPORARY TABLE {ddl_only_table}"
+                    ),
+                    AccessMode::ReadWrite,
+                )
+                .await
+                .map_err(|error| format!("temporary-table DDL-only query failed: {error:?}"))?;
+            if ddl_only_result.command_tag
+                    != Some(CommandTag::Other("DROP TEMPORARY TABLE".to_string()))
+                || ddl_only_result.refresh_scope != RefreshScope::None
+            {
+                return Err(format!(
+                    "unexpected temporary-table DDL-only result: {ddl_only_result:?}"
+                ));
             }
 
             let empty_table = format!("sabiql_sab414_empty_tmp_{suffix}");


### PR DESCRIPTION
## Problem

Temporary MySQL table DDL was reported as a metadata change, so a SQL submission containing only temporary CREATE/DROP statements could trigger an invalid metadata reload from another session.

## Background

Temporary tables are scoped to the MySQL session used for the submission and are not visible to the separate metadata-loading session. Data changes in the same submission still require a data refresh, while persistent DDL still requires a metadata refresh.

## Approach

Base refresh classification on persistent schema changes, leaving temporary table DDL at `RefreshScope::None`. Preserve the existing aggregation behavior for mixed INSERT and persistent DDL submissions, and cover the boundaries with unit and Oracle MySQL integration assertions.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-461

## Validation

- `cargo fmt --all -- --check`
- Direct MySQL CLI fragment rustfmt check
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Focused refresh-scope tests passed
- Oracle MySQL 8.4 integration: 39/39 passed under the host-global lock
- Full workspace tests: 950 passed, 1 unrelated existing SQLite failure
