### PR TITLE
perf(mysql): avoid PTY idle wait for read-only sessions

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -20,7 +20,8 @@ use super::pipe::MysqlExportPipeSource;
 use super::policy::mysql_metadata_fallback_kind;
 use super::process::{
     MYSQL_QUERY_TIMEOUT, MysqlProcess, cleanup_mysql_process, configure_mysql_session,
-    finish_mysql_session, mysql_metadata_columns, read_one_mysql_resultset, write_mysql_statement,
+    finish_mysql_session_after_result, mysql_metadata_columns, read_one_mysql_resultset,
+    write_mysql_statement,
 };
 #[cfg(unix)]
 use super::pty::MysqlExportPtySource;
@@ -92,7 +93,7 @@ pub(super) async fn run_mysql_export_process(
         csv_writer.write_record(columns.iter()).await?;
     }
 
-    let result = finish_mysql_session(process).await?;
+    let result = finish_mysql_session_after_result(process).await?;
     validate_mysql_export_exit(result.status, result.forcibly_stopped, &result.error_bytes)?;
 
     csv_writer.finish().await

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -167,20 +167,15 @@ impl MysqlProcess {
 }
 
 #[cfg(unix)]
-async fn stop_mysql_process(
-    process: &mut MysqlProcess,
-) -> Result<(ExitStatus, bool), DbOperationError> {
-    if let Some(status) = process
-        .child
+async fn stop_mysql_process(child: &mut Child) -> Result<(ExitStatus, bool), DbOperationError> {
+    if let Some(status) = child
         .try_wait()
         .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?
     {
         return Ok((status, false));
     }
-    // Normal session completion drains the PTY first because mysql --binary-mode does not accept quit commands.
-    let _ = process.child.kill().await;
-    let status = process
-        .child
+    let _ = child.kill().await;
+    let status = child
         .wait()
         .await
         .map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
@@ -235,7 +230,7 @@ pub(in crate::adapters::mysql::cli) async fn finish_mysql_session(
     };
 
     #[cfg(unix)]
-    let (status, forcibly_stopped) = stop_mysql_process(process).await?;
+    let (status, forcibly_stopped) = stop_mysql_process(&mut process.child).await?;
     #[cfg(not(unix))]
     let forcibly_stopped = false;
 
@@ -246,6 +241,32 @@ pub(in crate::adapters::mysql::cli) async fn finish_mysql_session(
         stdout,
         error_bytes,
     })
+}
+
+pub(in crate::adapters::mysql::cli) async fn finish_mysql_session_after_result(
+    process: &mut MysqlProcess,
+) -> Result<MysqlSessionResult, DbOperationError> {
+    #[cfg(unix)]
+    {
+        shutdown_mysql_input(process).await?;
+        // The caller has consumed the expected final resultset, so the client can be
+        // terminated explicitly while the PTY is drained for already-produced diagnostics.
+        let (error_bytes, status) = tokio::join!(
+            read_pty_all(&mut process.pty),
+            stop_mysql_process(&mut process.child),
+        );
+        let error_bytes =
+            error_bytes.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+        let (status, forcibly_stopped) = status?;
+        Ok(MysqlSessionResult {
+            status,
+            forcibly_stopped,
+            error_bytes,
+        })
+    }
+
+    #[cfg(not(unix))]
+    finish_mysql_session(process).await
 }
 
 pub(super) async fn configure_mysql_session(
@@ -455,7 +476,7 @@ pub(in crate::adapters::mysql) async fn run_mysql_cli_script_for_test(
     if result.is_err() {
         cleanup_mysql_process(&mut process).await;
     } else {
-        let _ = stop_mysql_process(&mut process).await;
+        let _ = stop_mysql_process(&mut process.child).await;
     }
     result
 }

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -19,7 +19,8 @@ use super::super::xml::MysqlResultSet;
 use super::metadata::mysql_metadata_columns;
 use super::{
     MYSQL_QUERY_TIMEOUT, MysqlProcess, cleanup_mysql_process, configure_mysql_session,
-    finish_mysql_session, read_one_mysql_resultset, write_mysql_statement,
+    finish_mysql_session, finish_mysql_session_after_result, read_one_mysql_resultset,
+    write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) async fn run_mysql_adhoc(
@@ -254,7 +255,11 @@ async fn run_mysql_adhoc_process(
         refresh_scope = execution.refresh_scope;
     }
 
-    let result = finish_mysql_session(process).await?;
+    let result = if access_mode.is_read_only() {
+        finish_mysql_session_after_result(process).await?
+    } else {
+        finish_mysql_session(process).await?
+    };
     if has_mysql_cli_error(&result.error_bytes) {
         return Err(query_failed_after_change(
             classify_mysql_query_failure(&result.error_bytes),

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -6,8 +6,9 @@ use crate::app::ports::outbound::{AccessMode, DbOperationError};
 
 use super::super::xml::{MysqlResultSet, parse_mysql_xml};
 use super::{
-    MysqlProcess, cleanup_mysql_process, configure_mysql_session, finish_mysql_session,
-    read_one_mysql_resultset, validate_mode_probe, write_mysql_statement,
+    MysqlProcess, cleanup_mysql_process, configure_mysql_session,
+    finish_mysql_session_after_result, read_one_mysql_resultset, validate_mode_probe,
+    write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) struct MysqlMetadataSession {
@@ -63,7 +64,7 @@ impl MysqlMetadataSession {
     }
 
     pub(in crate::adapters::mysql) async fn finish(&mut self) -> Result<(), DbOperationError> {
-        let result = finish_mysql_session(&mut self.process).await?;
+        let result = finish_mysql_session_after_result(&mut self.process).await?;
         if super::has_mysql_cli_error(&result.error_bytes) {
             return Err(super::classify_mysql_query_failure(&result.error_bytes));
         }

--- a/src/infra/adapters/mysql/cli/process/single.rs
+++ b/src/infra/adapters/mysql/cli/process/single.rs
@@ -8,7 +8,8 @@ use super::super::error::{classify_mysql_query_failure, has_mysql_cli_error, val
 use super::super::xml::{MysqlResultSet, parse_mysql_xml};
 use super::{
     MYSQL_QUERY_TIMEOUT, MysqlProcess, cleanup_mysql_process, configure_mysql_session,
-    finish_mysql_session, read_one_mysql_resultset, write_mysql_statement,
+    finish_mysql_session, finish_mysql_session_after_result, read_one_mysql_resultset,
+    write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) async fn run_mysql_single_statement(
@@ -55,7 +56,11 @@ pub(super) async fn run_mysql_single_statement_process(
 
     #[cfg(unix)]
     let stdout = read_one_mysql_resultset(process).await?;
-    let result = finish_mysql_session(process).await?;
+    let result = if access_mode.is_read_only() {
+        finish_mysql_session_after_result(process).await?
+    } else {
+        finish_mysql_session(process).await?
+    };
     if has_mysql_cli_error(&result.error_bytes) {
         return Err(classify_mysql_query_failure(&result.error_bytes));
     }


### PR DESCRIPTION
## Summary

Successful read-only MySQL sessions now terminate the client explicitly after the expected result has been consumed. The PTY remains in place, and write paths retain the idle-drain behavior needed for delayed stderr and error recovery.

## Validation

- Focused MySQL process tests: 25 passed
- : passed
- Oracle MySQL 8.4.10 integration under the required host lock: 39 passed
- The broader local infra suite was not used as a gate; one pre-existing SQLite export test failed independently of this MySQL-only diff

## Measurement

The matched baseline measurement identified two 100 ms PTY idle waits per MySQL preview. This change removes those waits only after the expected read-only result, while preserving write, CSV, delayed-stderr, and error collection paths.