### PR TITLE
fix(test): isolate MySQL integration runs

### DIFF
--- a/compose.mysql-tls.yml
+++ b/compose.mysql-tls.yml
@@ -1,7 +1,7 @@
 services:
   mysql:
     volumes:
-      - ./.tmp/mysql/tls:/etc/mysql/tls:ro
+      - "${SABIQL_MYSQL_TLS_DIR:-./.tmp/mysql/tls}:/etc/mysql/tls:ro"
     command:
       - mysqld
       - --ssl-ca=/etc/mysql/tls/ca.pem

--- a/compose.yml
+++ b/compose.yml
@@ -20,13 +20,15 @@ services:
 
   mysql:
     image: mysql:8.4.10
+    labels:
+      com.sabiql.mysql.integration: "${SABIQL_MYSQL_RUN_LABEL:-manual}"
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: sabiql_test
       MYSQL_USER: sabiql
       MYSQL_PASSWORD: sabiql
     ports:
-      - "3306:3306"
+      - "${SABIQL_MYSQL_HOST_PORT:-3306}:3306"
     volumes:
       - ./scripts/init-mysql.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
       - ./scripts/seed-mysql.sql:/docker-entrypoint-initdb.d/02-seed.sql:ro

--- a/scripts/mysql_integration.sh
+++ b/scripts/mysql_integration.sh
@@ -17,6 +17,7 @@ readonly mysql_password="${SABIQL_MYSQL_TEST_PASSWORD:-p a#ss;=\"word}"
 readonly mysql_client_label_key='com.sabiql.mysql.integration'
 
 run_dir=''
+run_id=''
 temp_dir=''
 tls_dir=''
 compose_project=''
@@ -30,7 +31,7 @@ mysql_client_label=''
 cleanup_failed=0
 
 create_client_container_label() {
-    mysql_run_label="run-${repo_hash}-$(basename "$run_dir")"
+    mysql_run_label="run-${repo_hash}-${run_id}"
     mysql_client_label="${mysql_client_label_key}=${mysql_run_label}"
 }
 
@@ -43,11 +44,12 @@ prepare_run() {
 
     mkdir -p -- "$temp_root"
     run_dir="$(mktemp -d "$temp_root/run-XXXXXX")"
+    run_id="$(basename "$run_dir" | tr '[:upper:]' '[:lower:]')-$$"
     temp_dir="$run_dir"
     tls_dir="$temp_dir/tls"
     repo_hash_value="$(printf '%s' "$repo_root" | cksum | awk '{print $1}')"
     repo_hash="$repo_hash_value"
-    compose_project="sabiql-mysql-${repo_hash}-${run_dir##*/}"
+    compose_project="sabiql-mysql-${repo_hash}-${run_id}"
     compose_args=(
         --project-name "$compose_project"
         --file "$compose_file"

--- a/scripts/mysql_integration.sh
+++ b/scripts/mysql_integration.sh
@@ -7,24 +7,65 @@ repo_root="$(cd "$script_dir/.." && pwd)"
 readonly repo_root
 readonly compose_file="$repo_root/compose.yml"
 readonly tls_compose_file="$repo_root/compose.mysql-tls.yml"
-readonly temp_dir="$repo_root/.tmp/mysql"
-readonly tls_dir="$temp_dir/tls"
+readonly temp_root="$repo_root/.tmp/mysql"
 readonly mysql_image="mysql:8.4.10"
 readonly mysql_host="${SABIQL_MYSQL_TEST_HOST:-host.docker.internal}"
-readonly mysql_port="${SABIQL_MYSQL_TEST_PORT:-3306}"
+mysql_port="${SABIQL_MYSQL_TEST_PORT:-}"
 readonly mysql_database="${SABIQL_MYSQL_TEST_DATABASE:-sabiql_test}"
 readonly mysql_user="${SABIQL_MYSQL_TEST_USER:-sabiql_test_runner}"
 readonly mysql_password="${SABIQL_MYSQL_TEST_PASSWORD:-p a#ss;=\"word}"
 readonly mysql_client_label_key='com.sabiql.mysql.integration'
 
+run_dir=''
+temp_dir=''
+tls_dir=''
+compose_project=''
+compose_args=()
+repo_hash=''
+mysql_host_port=''
 mysql_option_file=''
 mysql_bin_dir=''
+mysql_run_label=''
 mysql_client_label=''
+cleanup_failed=0
 
 create_client_container_label() {
-    local label_file
-    label_file="$(mktemp "$temp_dir/mysql-client-label.XXXXXX")"
-    printf '%s=run-%s-%s-%s\n' "$mysql_client_label_key" "$repo_root" "$$" "$(basename "$label_file")"
+    mysql_run_label="run-${repo_hash}-$(basename "$run_dir")"
+    mysql_client_label="${mysql_client_label_key}=${mysql_run_label}"
+}
+
+run_compose() {
+    docker compose "${compose_args[@]}" "$@"
+}
+
+prepare_run() {
+    local repo_hash_value
+
+    mkdir -p -- "$temp_root"
+    run_dir="$(mktemp -d "$temp_root/run-XXXXXX")"
+    temp_dir="$run_dir"
+    tls_dir="$temp_dir/tls"
+    repo_hash_value="$(printf '%s' "$repo_root" | cksum | awk '{print $1}')"
+    repo_hash="$repo_hash_value"
+    compose_project="sabiql-mysql-${repo_hash}-${run_dir##*/}"
+    compose_args=(
+        --project-name "$compose_project"
+        --file "$compose_file"
+        --file "$tls_compose_file"
+    )
+    if [[ -n "${SABIQL_MYSQL_TEST_PORT:-}" ]]; then
+        mysql_host_port="$SABIQL_MYSQL_TEST_PORT"
+    else
+        mysql_host_port=0
+    fi
+    create_client_container_label
+    export SABIQL_MYSQL_CONTAINER_LABEL="$mysql_client_label"
+    export SABIQL_MYSQL_HOST_PORT="$mysql_host_port"
+    export SABIQL_MYSQL_RUN_LABEL="$mysql_run_label"
+    export SABIQL_MYSQL_TLS_DIR="$tls_dir"
+    export TMPDIR="$temp_dir"
+    export RUSTC_WRAPPER=
+    export CARGO_TARGET_DIR="$temp_dir/cargo-target"
 }
 
 cleanup_client_containers() {
@@ -40,7 +81,7 @@ cleanup_client_containers() {
     fi
     while IFS= read -r container_id; do
         if [[ -n "$container_id" ]]; then
-            docker rm --force "$container_id" >/dev/null 2>&1 || :
+            docker rm --force --volumes "$container_id" >/dev/null 2>&1 || :
         fi
     done <<<"$container_ids"
 
@@ -52,21 +93,28 @@ cleanup_client_containers() {
 
 cleanup() {
     local status="$1"
+    cleanup_failed=0
 
     if ! cleanup_client_containers; then
         printf 'failed to clean up MySQL client containers for %s\n' "$mysql_client_label" >&2
-        if [[ "$status" == 0 ]]; then
-            status=1
-        fi
+        cleanup_failed=1
     fi
-    if [[ -n "$mysql_option_file" ]]; then
-        rm -f -- "$mysql_option_file"
+    if [[ -n "$compose_project" ]] && ! run_compose down --volumes --remove-orphans >/dev/null 2>&1; then
+        printf 'failed to clean up MySQL Compose project %s\n' "$compose_project" >&2
+        cleanup_failed=1
     fi
-    if [[ -n "$mysql_bin_dir" ]]; then
-        rm -rf -- "$mysql_bin_dir"
+    if [[ -n "$mysql_option_file" ]] && ! rm -f -- "$mysql_option_file"; then
+        cleanup_failed=1
     fi
-    rm -rf -- "$temp_dir"
-    docker compose --file "$compose_file" --file "$tls_compose_file" rm --force --stop --volumes mysql >/dev/null 2>&1 || true
+    if [[ -n "$mysql_bin_dir" ]] && ! rm -rf -- "$mysql_bin_dir"; then
+        cleanup_failed=1
+    fi
+    if [[ -n "$run_dir" ]] && ! rm -rf -- "$run_dir"; then
+        cleanup_failed=1
+    fi
+    if [[ "$status" == 0 && "$cleanup_failed" != 0 ]]; then
+        status=1
+    fi
     return "$status"
 }
 
@@ -90,7 +138,10 @@ handle_signal() {
     local status="$1"
 
     trap - EXIT HUP INT TERM
-    cleanup "$status"
+    cleanup "$status" || :
+    if [[ "$cleanup_failed" != 0 ]]; then
+        exit 1
+    fi
     exit "$status"
 }
 
@@ -117,6 +168,21 @@ create_option_file() {
         printf 'password = %s\n' "$(quote_option_value "$mysql_password")"
         printf 'database = %s\n' "$(quote_option_value "$mysql_database")"
     } >"$mysql_option_file"
+}
+
+discover_mysql_port() {
+    if [[ "$mysql_host_port" != 0 ]]; then
+        return
+    fi
+
+    local published_port
+    published_port="$(run_compose port mysql 3306)"
+    if [[ "$published_port" =~ :([0-9]+)$ ]]; then
+        mysql_port="${BASH_REMATCH[1]}"
+    else
+        printf 'failed to discover the published MySQL port: %s\n' "$published_port" >&2
+        return 1
+    fi
 }
 
 create_tls_material() {
@@ -202,20 +268,17 @@ run_tests() {
 
 case "${1:-test}" in
     test)
-        mkdir -p -- "$temp_dir"
-        export TMPDIR="$temp_dir"
-        mysql_client_label="$(create_client_container_label)"
-        export SABIQL_MYSQL_CONTAINER_LABEL="$mysql_client_label"
-        docker compose --file "$compose_file" --file "$tls_compose_file" rm --force --stop --volumes mysql >/dev/null 2>&1 || true
+        prepare_run
         create_tls_material
-        docker compose --file "$compose_file" --file "$tls_compose_file" up --detach --wait mysql
+        run_compose up --detach --wait mysql
+        discover_mysql_port
         install_cli_wrapper
         create_option_file
         assert_versions
         run_tests
         ;;
     stop)
-        docker compose --file "$compose_file" --file "$tls_compose_file" rm --force --stop --volumes mysql
+        docker compose --file "$compose_file" --file "$tls_compose_file" down --volumes --remove-orphans
         ;;
     *)
         echo "usage: $0 [test|stop]" >&2

--- a/scripts/mysql_integration.sh
+++ b/scripts/mysql_integration.sh
@@ -278,7 +278,7 @@ case "${1:-test}" in
         run_tests
         ;;
     stop)
-        docker compose --file "$compose_file" --file "$tls_compose_file" down --volumes --remove-orphans
+        docker compose --file "$compose_file" --file "$tls_compose_file" rm --force --stop --volumes mysql
         ;;
     *)
         echo "usage: $0 [test|stop]" >&2

--- a/scripts/test_mysql_docker_cleanup.sh
+++ b/scripts/test_mysql_docker_cleanup.sh
@@ -11,9 +11,18 @@ state_file="$test_root/containers"
 readonly state_file
 label_log="$test_root/labels.log"
 readonly label_log
+compose_log="$test_root/compose.log"
+readonly compose_log
+cargo_log="$test_root/cargo.log"
+readonly cargo_log
+rm_log="$test_root/rm.log"
+readonly rm_log
 mkdir -p -- "$fake_bin"
 : >"$state_file"
 : >"$label_log"
+: >"$compose_log"
+: >"$cargo_log"
+: >"$rm_log"
 
 cleanup() {
     rm -rf -- "$test_root"
@@ -27,9 +36,41 @@ set -Eeuo pipefail
 
 state_file="${FAKE_DOCKER_STATE:?}"
 label_log="${FAKE_DOCKER_LABEL_LOG:?}"
+compose_log="${FAKE_DOCKER_COMPOSE_LOG:?}"
+rm_log="${FAKE_DOCKER_RM_LOG:?}"
+state_lock="${state_file}.lock"
+while ! mkdir "$state_lock" 2>/dev/null; do
+    sleep 0.01
+done
+trap 'rmdir "$state_lock"' EXIT
 
 case "${1:-}" in
     compose)
+        project='default'
+        command=''
+        while (($# > 0)); do
+            case "$1" in
+                --project-name)
+                    project="$2"
+                    shift 2
+                    ;;
+                --file)
+                    shift 2
+                    ;;
+                up|port|down)
+                    command="$1"
+                    break
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+        printf '%s|%s|%s\n' "$project" "$command" "$*" >>"$compose_log"
+        if [[ "$command" == port ]]; then
+            port="$(printf '%s' "$project" | cksum | awk '{ print 30000 + ($1 % 20000) }')"
+            printf '127.0.0.1:%s\n' "$port"
+        fi
         exit 0
         ;;
     ps)
@@ -48,6 +89,7 @@ case "${1:-}" in
         done <"$state_file"
         ;;
     rm)
+        printf '%s\n' "$*" >>"$rm_log"
         if [[ "${FAKE_DOCKER_RM_STATUS:-0}" != 0 ]]; then
             exit "$FAKE_DOCKER_RM_STATUS"
         fi
@@ -105,12 +147,18 @@ set -Eeuo pipefail
 
 case "${FAKE_CARGO_MODE:-success}" in
     success)
+        printf '%s|%s|%s\n' "${SABIQL_MYSQL_RUN_LABEL:-}" \
+            "${SABIQL_MYSQL_TEST_PORT:-}" "${CARGO_TARGET_DIR:-}" >>"${FAKE_CARGO_LOG:?}"
         exit 0
         ;;
     failure|timeout)
+        printf '%s|%s|%s\n' "${SABIQL_MYSQL_RUN_LABEL:-}" \
+            "${SABIQL_MYSQL_TEST_PORT:-}" "${CARGO_TARGET_DIR:-}" >>"${FAKE_CARGO_LOG:?}"
         exit "${FAKE_CARGO_STATUS:-17}"
         ;;
     signal)
+        printf '%s|%s|%s\n' "${SABIQL_MYSQL_RUN_LABEL:-}" \
+            "${SABIQL_MYSQL_TEST_PORT:-}" "${CARGO_TARGET_DIR:-}" >>"${FAKE_CARGO_LOG:?}"
         : >"${FAKE_CARGO_MARKER:?}"
         while [[ ! -e "${FAKE_CARGO_RELEASE:?}" ]]; do
             sleep 0.05
@@ -139,6 +187,9 @@ chmod +x "$fake_bin/docker" "$fake_bin/cargo" "$fake_bin/openssl"
 
 export FAKE_DOCKER_STATE="$state_file"
 export FAKE_DOCKER_LABEL_LOG="$label_log"
+export FAKE_DOCKER_COMPOSE_LOG="$compose_log"
+export FAKE_DOCKER_RM_LOG="$rm_log"
+export FAKE_CARGO_LOG="$cargo_log"
 
 assert_only_unrelated_container_remains() {
     local unrelated_count
@@ -213,26 +264,6 @@ if [[ "$signal_status" != 143 ]]; then
 fi
 assert_only_unrelated_container_remains
 
-cat >"$fake_bin/mktemp" <<'EOF'
-#!/usr/bin/env bash
-set -Eeuo pipefail
-
-for argument in "$@"; do
-    case "$argument" in
-        */mysql-client-label.XXXXXX)
-            label_file="$(printf '%s\n' "$argument" | sed 's/XXXXXX$/fixed/')"
-            mkdir -p -- "$(dirname "$label_file")"
-            : >"$label_file"
-            printf '%s\n' "$label_file"
-            exit 0
-            ;;
-    esac
-done
-
-exec /usr/bin/mktemp "$@"
-EOF
-chmod +x "$fake_bin/mktemp"
-
 same_suffix_root="$test_root/other-worktree"
 mkdir -p -- "$same_suffix_root/scripts"
 cp -- "$script_dir/mysql_integration.sh" "$same_suffix_root/scripts/mysql_integration.sh"
@@ -244,6 +275,68 @@ same_suffix_labels="$(awk '/^com\.sabiql\.mysql\.integration=run-/ { labels[$0] 
 if [[ "$same_suffix_labels" != 6 ]]; then
     printf 'expected distinct labels for same suffix across worktrees, got %s\n%s\n' \
         "$same_suffix_labels" "$(<"$label_log")" >&2
+    exit 1
+fi
+assert_only_unrelated_container_remains
+
+parallel_start="$(wc -l <"$cargo_log")"
+parallel_one_marker="$test_root/parallel-one.marker"
+parallel_one_release="$test_root/parallel-one.release"
+parallel_two_marker="$test_root/parallel-two.marker"
+parallel_two_release="$test_root/parallel-two.release"
+parallel_one_output="$test_root/parallel-one.out"
+parallel_two_output="$test_root/parallel-two.out"
+FAKE_CARGO_MODE=signal \
+FAKE_CARGO_MARKER="$parallel_one_marker" \
+FAKE_CARGO_RELEASE="$parallel_one_release" \
+PATH="$fake_bin:$PATH" "$script_dir/mysql_integration.sh" test \
+    >"$parallel_one_output" 2>&1 &
+parallel_one_pid=$!
+FAKE_CARGO_MODE=signal \
+FAKE_CARGO_MARKER="$parallel_two_marker" \
+FAKE_CARGO_RELEASE="$parallel_two_release" \
+PATH="$fake_bin:$PATH" "$same_suffix_root/scripts/mysql_integration.sh" test \
+    >"$parallel_two_output" 2>&1 &
+parallel_two_pid=$!
+for _ in {1..100}; do
+    if [[ -e "$parallel_one_marker" && -e "$parallel_two_marker" ]]; then
+        break
+    fi
+    sleep 0.05
+done
+if [[ ! -e "$parallel_one_marker" || ! -e "$parallel_two_marker" ]]; then
+    printf 'parallel test did not reach fake cargo\n%s\n%s\n' \
+        "$(<"$parallel_one_output")" "$(<"$parallel_two_output")" >&2
+    kill "$parallel_one_pid" "$parallel_two_pid" 2>/dev/null || true
+    exit 1
+fi
+kill -TERM "$parallel_one_pid" "$parallel_two_pid"
+: >"$parallel_one_release"
+: >"$parallel_two_release"
+parallel_one_status=0
+parallel_two_status=0
+if wait "$parallel_one_pid"; then
+    parallel_one_status=0
+else
+    parallel_one_status=$?
+fi
+if wait "$parallel_two_pid"; then
+    parallel_two_status=0
+else
+    parallel_two_status=$?
+fi
+if [[ "$parallel_one_status" != 143 || "$parallel_two_status" != 143 ]]; then
+    printf 'parallel tests exited %s and %s, expected 143\n%s\n%s\n' \
+        "$parallel_one_status" "$parallel_two_status" \
+        "$(<"$parallel_one_output")" "$(<"$parallel_two_output")" >&2
+    exit 1
+fi
+parallel_rows="$(tail -n +$((parallel_start + 1)) "$cargo_log")"
+parallel_label_count="$(printf '%s\n' "$parallel_rows" | awk -F'|' 'NF >= 3 { labels[$1] = 1 } END { print length(labels) + 0 }')"
+parallel_port_count="$(printf '%s\n' "$parallel_rows" | awk -F'|' 'NF >= 3 { ports[$2] = 1 } END { print length(ports) + 0 }')"
+parallel_target_count="$(printf '%s\n' "$parallel_rows" | awk -F'|' 'NF >= 3 { targets[$3] = 1 } END { print length(targets) + 0 }')"
+if [[ "$parallel_label_count" != 2 || "$parallel_port_count" != 2 || "$parallel_target_count" != 2 ]]; then
+    printf 'parallel runs did not isolate label, port, or target:\n%s\n' "$parallel_rows" >&2
     exit 1
 fi
 assert_only_unrelated_container_remains
@@ -267,15 +360,30 @@ if [[ "$cleanup_failure_status" != 1 ]] || \
 fi
 while IFS='|' read -r container_id label; do
     if [[ "$label" == com.sabiql.mysql.integration=run-* ]]; then
-        "$fake_bin/docker" rm --force "$container_id"
+        "$fake_bin/docker" rm --force --volumes "$container_id"
     fi
 done <"$state_file"
 assert_only_unrelated_container_remains
 
 unique_run_labels="$(awk '/^com\.sabiql\.mysql\.integration=run-/ { labels[$0] = 1 } END { print length(labels) + 0 }' "$label_log")"
-if [[ "$unique_run_labels" != 7 ]]; then
-    printf 'expected seven unique run labels, got %s\n%s\n' \
+if [[ "$unique_run_labels" != 9 ]]; then
+    printf 'expected nine unique run labels, got %s\n%s\n' \
         "$unique_run_labels" "$(<"$label_log")" >&2
+    exit 1
+fi
+
+run_project_count="$(awk -F'|' '$2 == "up" { print $1 }' "$compose_log" | sort -u | wc -l | tr -d ' ')"
+port_lookup_count="$(awk -F'|' '$2 == "port" { print $1 }' "$compose_log" | sort -u | wc -l | tr -d ' ')"
+down_project_count="$(awk -F'|' '$2 == "down" && $1 != "default" { print $1 }' "$compose_log" | sort -u | wc -l | tr -d ' ')"
+if [[ "$run_project_count" != 9 || "$port_lookup_count" != 9 || "$down_project_count" != 9 ]] || \
+    ! diff -u \
+        <(awk -F'|' '$2 == "up" { print $1 }' "$compose_log" | sort -u) \
+        <(awk -F'|' '$2 == "down" && $1 != "default" { print $1 }' "$compose_log" | sort -u); then
+    printf 'Compose project lifecycle was not isolated:\n%s\n' "$(<"$compose_log")" >&2
+    exit 1
+fi
+if ! grep -q -- '--force --volumes' "$rm_log"; then
+    printf 'client cleanup did not request anonymous volume removal:\n%s\n' "$(<"$rm_log")" >&2
     exit 1
 fi
 

--- a/scripts/test_mysql_docker_cleanup.sh
+++ b/scripts/test_mysql_docker_cleanup.sh
@@ -66,6 +66,10 @@ case "${1:-}" in
                     ;;
             esac
         done
+        if [[ ! "$project" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+            printf 'invalid fake Compose project name: %s\n' "$project" >&2
+            exit 1
+        fi
         printf '%s|%s|%s\n' "$project" "$command" "$*" >>"$compose_log"
         if [[ "$command" == port ]]; then
             port="$(printf '%s' "$project" | cksum | awk '{ print 30000 + ($1 % 20000) }')"

--- a/scripts/test_mysql_docker_cleanup.sh
+++ b/scripts/test_mysql_docker_cleanup.sh
@@ -57,7 +57,7 @@ case "${1:-}" in
                 --file)
                     shift 2
                     ;;
-                up|port|down)
+                up|port|down|rm)
                     command="$1"
                     break
                     ;;
@@ -389,3 +389,8 @@ fi
 
 PATH="$fake_bin:$PATH" "$script_dir/mysql_integration.sh" stop >/dev/null 2>&1
 assert_only_unrelated_container_remains
+if ! grep -Fq 'default|rm|rm --force --stop --volumes mysql' "$compose_log" || \
+    grep -Fq 'default|down|' "$compose_log"; then
+    printf 'stop did not remain scoped to the MySQL service:\n%s\n' "$(<"$compose_log")" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Problem
Parallel worktrees shared the Compose project, MySQL container lifecycle, TLS files, and host port, so one integration run could stop or replace another run's fixture.

## Background
The cleanup path also targeted the fixed Compose project and did not request anonymous volume removal for the run-owned client containers.

## Approach
Each invocation now gets a unique Compose project, ephemeral host port, TLS directory, Cargo target directory, and integration label. Cleanup uses only that project's resources and exact client label, including forced volume removal on normal exit, failure, and signals.

Focused fake-Docker coverage exercises isolated parallel runs, signal cleanup, failure cleanup, distinct ports and target directories, and the volume-removal request.
