### PR TITLE
test(mysql): pin empty metadata fallback contract

### DIFF
--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -445,6 +445,21 @@ mod tests {
     }
 
     #[test]
+    fn metadata_fallback_wraps_source_query_with_limit_zero() {
+        let source_query = "SELECT SLEEP(10) AS sleep_value WHERE FALSE";
+
+        let fallback_query =
+            mysql_metadata_select_query(source_query, "__source", "__marker").unwrap();
+
+        assert!(
+            fallback_query.contains(
+                "SELECT * FROM ((SELECT SLEEP(10) AS sleep_value WHERE FALSE\n) LIMIT 0)"
+            )
+        );
+        assert_eq!(fallback_query.matches("SELECT SLEEP(10)").count(), 1);
+    }
+
+    #[test]
     fn failure_before_a_change_keeps_original_error() {
         let error = query_failed_after_change(
             DbOperationError::ForeignKeyViolation("foreign key failed".to_string()),


### PR DESCRIPTION
## Problem

Empty SELECT/TABLE metadata fallback must preserve columns without re-executing the source query.

## Background

The fallback contract is a zero-row wrapper around the original query. Oracle MySQL 8.4 validation also confirms that `--column-type-info` remains required for empty SHOW/DESCRIBE headers.

## Approach

Pin the SQL-shape contract in a unit test: the source query appears once inside a `LIMIT 0` wrapper. No production behavior changes.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-462
