### PR TITLE
test(mysql): deduplicate integration coverage

### DIFF
--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -738,17 +738,6 @@ mod tests {
     }
 
     #[test]
-    fn empty_table_list_result_parses_as_no_tables() {
-        let result = result(TABLES_RESULT_COLUMNS, Vec::new());
-
-        assert!(
-            parse_table_metadata(&result)
-                .expect("empty table metadata parses")
-                .is_empty()
-        );
-    }
-
-    #[test]
     fn groups_foreign_keys_by_name_and_orders_columns_by_sequence() {
         let result = result(
             &[

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -212,6 +212,16 @@ mod tests {
         }
     }
 
+    fn assert_contains_in_order(query: &str, fragments: &[&str]) {
+        let mut remaining = query;
+        for fragment in fragments {
+            let Some(index) = remaining.find(fragment) else {
+                panic!("missing SQL fragment {fragment:?} in {query:?}");
+            };
+            remaining = &remaining[index + fragment.len()..];
+        }
+    }
+
     #[test]
     fn metadata_queries_escape_literals_and_preserve_scope_conditions() {
         let schema = "app\\\n\r\t\u{0008}\u{001a}'";
@@ -238,63 +248,134 @@ mod tests {
         let quoted_schema = quote_string(schema);
         let quoted_table = quote_string(table);
 
-        assert_eq!(
-            table_query(schema, table),
-            format!(
-                "SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_ROWS, t.TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES AS t WHERE t.TABLE_SCHEMA = {quoted_schema} AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW') AND t.TABLE_NAME = {quoted_table} ORDER BY TABLE_SCHEMA, TABLE_NAME"
-            )
+        let table_sql = table_query(schema, table);
+        assert_contains_in_order(
+            &table_sql,
+            &[
+                "SELECT t.TABLE_SCHEMA, t.TABLE_NAME, t.TABLE_TYPE, t.TABLE_ROWS, t.TABLE_COMMENT",
+                "FROM INFORMATION_SCHEMA.TABLES AS t",
+                &format!("WHERE t.TABLE_SCHEMA = {quoted_schema}"),
+                "AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW')",
+                &format!("AND t.TABLE_NAME = {quoted_table}"),
+                "ORDER BY TABLE_SCHEMA, TABLE_NAME",
+            ],
         );
 
-        assert_eq!(
-            columns_query(schema, table),
-            format!(
-                "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = {quoted_schema} AND c.TABLE_NAME = {quoted_table} ORDER BY ORDINAL_POSITION"
-            )
+        let columns_sql = columns_query(schema, table);
+        assert_contains_in_order(
+            &columns_sql,
+            &[
+                "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION",
+                "FROM INFORMATION_SCHEMA.COLUMNS AS c",
+                "tc.CONSTRAINT_SCHEMA = DATABASE()",
+                "kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA",
+                &format!("WHERE c.TABLE_SCHEMA = {quoted_schema}"),
+                &format!("AND c.TABLE_NAME = {quoted_table}"),
+                "ORDER BY ORDINAL_POSITION",
+            ],
         );
 
-        assert_eq!(
-            unique_columns_query(schema, table),
-            format!(
-                "SELECT MIN(s.COLUMN_NAME) AS COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = {quoted_schema} AND s.TABLE_NAME = {quoted_table} AND s.NON_UNIQUE = 0 AND s.INDEX_NAME <> 'PRIMARY' GROUP BY s.INDEX_NAME HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1 ORDER BY s.INDEX_NAME"
-            )
+        let unique_columns_sql = unique_columns_query(schema, table);
+        assert_contains_in_order(
+            &unique_columns_sql,
+            &[
+                "SELECT MIN(s.COLUMN_NAME) AS COLUMN_NAME",
+                "FROM INFORMATION_SCHEMA.STATISTICS AS s",
+                &format!("WHERE s.TABLE_SCHEMA = {quoted_schema}"),
+                &format!("AND s.TABLE_NAME = {quoted_table}"),
+                "AND s.NON_UNIQUE = 0",
+                "AND s.INDEX_NAME <> 'PRIMARY'",
+                "GROUP BY s.INDEX_NAME",
+                "HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1",
+                "ORDER BY s.INDEX_NAME",
+            ],
         );
 
-        assert_eq!(
-            foreign_keys_query(schema, table),
-            format!(
-                "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = {quoted_schema} AND tc.TABLE_SCHEMA = {quoted_schema} AND tc.TABLE_NAME = {quoted_table} AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION"
-            )
+        let foreign_keys_sql = foreign_keys_query(schema, table);
+        assert_contains_in_order(
+            &foreign_keys_sql,
+            &[
+                "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE",
+                "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc",
+                "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu",
+                "INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc",
+                &format!("WHERE tc.CONSTRAINT_SCHEMA = {quoted_schema}"),
+                &format!("AND tc.TABLE_SCHEMA = {quoted_schema}"),
+                &format!("AND tc.TABLE_NAME = {quoted_table}"),
+                "AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'",
+                "ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION",
+            ],
         );
 
-        assert_eq!(
-            indexes_query(table),
-            format!(
-                "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.EXPRESSION, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = DATABASE() AND s.TABLE_NAME = {quoted_table} ORDER BY INDEX_NAME, SEQ_IN_INDEX"
-            )
+        let indexes_sql = indexes_query(table);
+        assert_contains_in_order(
+            &indexes_sql,
+            &[
+                "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.EXPRESSION",
+                "CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY",
+                "FROM INFORMATION_SCHEMA.STATISTICS AS s",
+                "WHERE s.TABLE_SCHEMA = DATABASE()",
+                &format!("AND s.TABLE_NAME = {quoted_table}"),
+                "ORDER BY INDEX_NAME, SEQ_IN_INDEX",
+            ],
         );
 
-        assert_eq!(
-            triggers_query(table),
-            format!(
-                "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER FROM INFORMATION_SCHEMA.TRIGGERS WHERE TRIGGER_SCHEMA = DATABASE() AND EVENT_OBJECT_SCHEMA = DATABASE() AND EVENT_OBJECT_TABLE = {quoted_table} ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION"
-            )
+        let triggers_sql = triggers_query(table);
+        assert_contains_in_order(
+            &triggers_sql,
+            &[
+                "SELECT TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION, ACTION_STATEMENT, DEFINER",
+                "FROM INFORMATION_SCHEMA.TRIGGERS",
+                "WHERE TRIGGER_SCHEMA = DATABASE()",
+                "AND EVENT_OBJECT_SCHEMA = DATABASE()",
+                &format!("AND EVENT_OBJECT_TABLE = {quoted_table}"),
+                "ORDER BY TRIGGER_NAME, ACTION_TIMING, EVENT_MANIPULATION",
+            ],
         );
 
-        assert_eq!(
+        assert_contains_in_order(
             TABLES_QUERY,
-            "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_TYPE IN ('BASE TABLE', 'VIEW') ORDER BY TABLE_SCHEMA, TABLE_NAME"
+            &[
+                "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, TABLE_ROWS, TABLE_COMMENT",
+                "FROM INFORMATION_SCHEMA.TABLES",
+                "WHERE TABLE_SCHEMA = DATABASE()",
+                "AND TABLE_TYPE IN ('BASE TABLE', 'VIEW')",
+                "ORDER BY TABLE_SCHEMA, TABLE_NAME",
+            ],
         );
-        assert_eq!(
+        assert_contains_in_order(
             SIGNATURE_COLUMNS_QUERY,
-            "SELECT c.TABLE_SCHEMA, c.TABLE_NAME, c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = DATABASE() ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION"
+            &[
+                "SELECT c.TABLE_SCHEMA, c.TABLE_NAME, c.COLUMN_NAME, c.COLUMN_TYPE",
+                "FROM INFORMATION_SCHEMA.COLUMNS AS c",
+                "tc.CONSTRAINT_SCHEMA = DATABASE()",
+                "WHERE c.TABLE_SCHEMA = DATABASE()",
+                "ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION",
+            ],
         );
-        assert_eq!(
+        assert_contains_in_order(
             SIGNATURE_UNIQUE_COLUMNS_QUERY,
-            "SELECT s.TABLE_NAME, MIN(s.COLUMN_NAME) AS COLUMN_NAME FROM INFORMATION_SCHEMA.STATISTICS AS s WHERE s.TABLE_SCHEMA = DATABASE() AND s.NON_UNIQUE = 0 AND s.INDEX_NAME <> 'PRIMARY' GROUP BY s.TABLE_NAME, s.INDEX_NAME HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1 ORDER BY s.TABLE_NAME, s.INDEX_NAME"
+            &[
+                "SELECT s.TABLE_NAME, MIN(s.COLUMN_NAME) AS COLUMN_NAME",
+                "FROM INFORMATION_SCHEMA.STATISTICS AS s",
+                "WHERE s.TABLE_SCHEMA = DATABASE()",
+                "AND s.NON_UNIQUE = 0",
+                "AND s.INDEX_NAME <> 'PRIMARY'",
+                "GROUP BY s.TABLE_NAME, s.INDEX_NAME",
+                "HAVING COUNT(*) = 1 AND COUNT(s.COLUMN_NAME) = 1",
+                "ORDER BY s.TABLE_NAME, s.INDEX_NAME",
+            ],
         );
-        assert_eq!(
+        assert_contains_in_order(
             SIGNATURE_FOREIGN_KEYS_QUERY,
-            "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = DATABASE() AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION"
+            &[
+                "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME",
+                "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc",
+                "WHERE tc.CONSTRAINT_SCHEMA = DATABASE()",
+                "AND tc.TABLE_SCHEMA = DATABASE()",
+                "AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY'",
+                "ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION",
+            ],
         );
 
         for query in [

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -32,31 +32,6 @@ mod connection {
     }
 
     #[tokio::test]
-    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
-    async fn connects_to_oracle_mysql_84_fixture() {
-        with_mysql_test_db(|db| {
-            Box::pin(async move {
-                let result = db
-                    .adapter()
-                    .execute_adhoc(
-                        db.dsn(),
-                        &format!("SELECT id FROM {MYSQL_FIXTURE_TABLE}"),
-                        AccessMode::ReadWrite,
-                    )
-                    .await
-                    .map_err(|error| format!("{error:?}"))?;
-                if result.columns != ["id"]
-                    || result.values() != [[QueryValue::Text("1".to_string())]]
-                {
-                    return Err(format!("unexpected MySQL connection result: {result:?}"));
-                }
-                Ok(())
-            })
-        })
-        .await;
-    }
-
-    #[tokio::test]
     #[cfg(unix)]
     #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
     async fn batch_mysql_cli_does_not_execute_shell_commands() {
@@ -2426,7 +2401,7 @@ mod csv_export {
 
     use super::shared::MYSQL_EMPTY_TABLE;
     use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, with_mysql_test_db};
-    use sabiql_app::ports::outbound::{DbOperationError, QueryExecutor};
+    use sabiql_app::ports::outbound::DbOperationError;
     use sabiql_infra::adapters::mysql::export_mysql_csv_to_path_for_test;
     use tempfile::tempdir;
 
@@ -2497,45 +2472,6 @@ mod csv_export {
                     if csv.trim().is_empty() {
                         return Err(format!("{name} CSV export was empty"));
                     }
-                }
-                Ok(())
-            })
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
-    async fn count_query_rows_rejects_empty_and_non_integer_results() {
-        with_mysql_test_db(|db| {
-            Box::pin(async move {
-                let empty = db
-                    .adapter()
-                    .count_query_rows(
-                        db.dsn(),
-                        &format!("SELECT id FROM {MYSQL_EMPTY_TABLE} WHERE FALSE"),
-                    )
-                    .await;
-                if !matches!(
-                    empty,
-                    Err(DbOperationError::QueryFailed(ref details))
-                        if details.contains("invalid result")
-                ) {
-                    return Err(format!("empty count result was accepted: {empty:?}"));
-                }
-
-                let non_integer = db
-                    .adapter()
-                    .count_query_rows(db.dsn(), "SELECT 'not-a-count'")
-                    .await;
-                if !matches!(
-                    non_integer,
-                    Err(DbOperationError::QueryFailed(ref details))
-                        if details.contains("not an integer")
-                ) {
-                    return Err(format!(
-                        "non-integer count result was accepted: {non_integer:?}"
-                    ));
                 }
                 Ok(())
             })


### PR DESCRIPTION
## Problem
MySQL coverage contains checks whose regression responsibility is already owned by shared setup or focused unit tests, while metadata SQL tests are brittle full-string snapshots.

## Background
The remaining integration tests must continue to prove Oracle MySQL CLI transport, CSV contracts, and metadata behavior without changing production code.

## Approach
Remove only the invalid `TABLES_RESULT_COLUMNS` empty-list tautology, the non-TLS connection smoke covered by shared fixture setup/version checks, and the count integration duplicated by `parse_mysql_count_result` unit tests. Keep one real adhoc and one real export ERROR-in-cell path, and preserve the CSV header/value loop. Replace metadata SQL blobs with ordered assertions for escaping, database scope, table type, joins, grouping, and ordering.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-466