### PR TITLE
refactor(mysql): centralize CLI timeout cleanup

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -6,7 +6,6 @@ use quick_xml::Reader;
 use quick_xml::escape::unescape;
 use quick_xml::events::Event;
 use tokio::io::{AsyncRead, BufReader};
-use tokio::time::timeout;
 use uuid::Uuid;
 
 use crate::adapters::csv_export::CsvFileWriter;
@@ -19,8 +18,8 @@ use super::error::{classify_mysql_query_failure, has_mysql_cli_error, validate_m
 use super::pipe::MysqlExportPipeSource;
 use super::policy::mysql_metadata_fallback_kind;
 use super::process::{
-    MYSQL_QUERY_TIMEOUT, MysqlProcess, cleanup_mysql_process, configure_mysql_session,
-    finish_mysql_session_after_result, mysql_metadata_columns, read_one_mysql_resultset,
+    MYSQL_QUERY_TIMEOUT, MysqlProcess, configure_mysql_session, finish_mysql_session_after_result,
+    mysql_metadata_columns, read_one_mysql_resultset, run_mysql_process_with_timeout,
     write_mysql_statement,
 };
 #[cfg(unix)]
@@ -36,24 +35,10 @@ pub(in crate::adapters::mysql) async fn export_mysql_csv_to_file(
 ) -> Result<(), DbOperationError> {
     let option_file = MySqlOptionFile::create(&target)?;
     let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
-    let result = timeout(
-        MYSQL_EXPORT_TIMEOUT,
-        run_mysql_export_process(&mut process, &option_file.path, query, path),
-    )
-    .await;
-    match result {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(error)) => {
-            cleanup_mysql_process(&mut process).await;
-            Err(error)
-        }
-        Err(_) => {
-            cleanup_mysql_process(&mut process).await;
-            Err(DbOperationError::Timeout(
-                "mysql query exceeded the execution timeout".to_string(),
-            ))
-        }
-    }
+    run_mysql_process_with_timeout(MYSQL_EXPORT_TIMEOUT, &mut process, async |process| {
+        run_mysql_export_process(process, &option_file.path, query, path).await
+    })
+    .await
 }
 
 pub(super) async fn run_mysql_export_process(

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -421,6 +421,29 @@ pub(super) async fn cleanup_mysql_process(process: &mut MysqlProcess) {
     let _ = process.child.wait().await;
 }
 
+pub(super) async fn run_mysql_process_with_timeout<T, F>(
+    execution_timeout: Duration,
+    process: &mut MysqlProcess,
+    execute: F,
+) -> Result<T, DbOperationError>
+where
+    F: AsyncFnOnce(&mut MysqlProcess) -> Result<T, DbOperationError>,
+{
+    match tokio::time::timeout(execution_timeout, execute(process)).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) => {
+            cleanup_mysql_process(process).await;
+            Err(error)
+        }
+        Err(_) => {
+            cleanup_mysql_process(process).await;
+            Err(DbOperationError::Timeout(
+                "mysql query exceeded the execution timeout".to_string(),
+            ))
+        }
+    }
+}
+
 pub(super) async fn read_one_mysql_resultset(
     process: &mut MysqlProcess,
 ) -> Result<Vec<u8>, DbOperationError> {
@@ -488,13 +511,6 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use crate::adapters::csv_export::export_to_path;
-    use crate::app::policy::sql::mysql_statement::{
-        classify_mysql_statement, split_mysql_statements,
-    };
-    use crate::domain::{CommandTag, QueryValue, RefreshScope};
-    use tokio::time::timeout;
-
     use super::super::export::run_mysql_export_process;
     use super::super::xml::MysqlResultSet;
     use super::adhoc::run_mysql_adhoc_with_program_and_statements_and_expected_columns;
@@ -504,6 +520,11 @@ mod tests {
     };
     use super::single::run_mysql_single_statement_process;
     use super::*;
+    use crate::adapters::csv_export::export_to_path;
+    use crate::app::policy::sql::mysql_statement::{
+        classify_mysql_statement, split_mysql_statements,
+    };
+    use crate::domain::{CommandTag, QueryValue, RefreshScope};
 
     async fn export_mysql_csv_with_program(
         program: &OsStr,
@@ -513,26 +534,12 @@ mod tests {
         execution_timeout: Duration,
     ) -> Result<(), DbOperationError> {
         let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
-        let result = timeout(
-            execution_timeout,
-            run_mysql_export_process(&mut process, option_file, query, path),
-        )
-        .await;
-        match result {
-            Ok(Ok(())) => Ok(()),
-            Ok(Err(error)) => {
-                cleanup_mysql_process(&mut process).await;
-                Err(error)
-            }
-            Err(_) => {
-                cleanup_mysql_process(&mut process).await;
-                Err(DbOperationError::Timeout(
-                    "mysql query exceeded the execution timeout".to_string(),
-                ))
-            }
-        }
+        run_mysql_process_with_timeout(execution_timeout, &mut process, async |process| {
+            run_mysql_export_process(process, option_file, query, path).await
+        })
+        .await
     }
-    async fn run_mysql_adhoc_with_program(
+    async fn run_mysql_single_statement_with_program(
         program: &OsStr,
         option_file: &std::path::Path,
         query: &str,
@@ -540,24 +547,10 @@ mod tests {
         execution_timeout: Duration,
     ) -> Result<MysqlResultSet, DbOperationError> {
         let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
-        let result = timeout(
-            execution_timeout,
-            run_mysql_single_statement_process(&mut process, query, access_mode),
-        )
-        .await;
-        match result {
-            Ok(Ok(result_set)) => Ok(result_set),
-            Ok(Err(error)) => {
-                cleanup_mysql_process(&mut process).await;
-                Err(error)
-            }
-            Err(_) => {
-                cleanup_mysql_process(&mut process).await;
-                Err(DbOperationError::Timeout(
-                    "mysql query exceeded the execution timeout".to_string(),
-                ))
-            }
-        }
+        run_mysql_process_with_timeout(execution_timeout, &mut process, async |process| {
+            run_mysql_single_statement_process(process, query, access_mode).await
+        })
+        .await
     }
 
     fn fake_mysql(mode: &str) -> (TempDir, PathBuf, PathBuf) {
@@ -816,7 +809,7 @@ done
         let (_directory, program, log_file) = fake_mysql("success");
         let option_file = log_file.with_extension("cnf");
         fs::write(&option_file, "[client]\n").unwrap();
-        let result = run_mysql_adhoc_with_program(
+        let result = run_mysql_single_statement_with_program(
             OsStr::new(&program),
             &option_file,
             "SELECT 123",
@@ -959,7 +952,7 @@ done
         let (_directory, program, log_file) = fake_mysql("read_only_failure");
         let option_file = log_file.with_extension("cnf");
         fs::write(&option_file, "[client]\n").unwrap();
-        let result = run_mysql_adhoc_with_program(
+        let result = run_mysql_single_statement_with_program(
             OsStr::new(&program),
             &option_file,
             "SELECT 123",
@@ -1220,7 +1213,7 @@ done
             let (_directory, program, log_file) = fake_mysql(mode);
             let option_file = log_file.with_extension("cnf");
             fs::write(&option_file, "[client]\n").unwrap();
-            let result = run_mysql_adhoc_with_program(
+            let result = run_mysql_single_statement_with_program(
                 OsStr::new(&program),
                 &option_file,
                 "SELECT 123",
@@ -1240,7 +1233,7 @@ done
         let (_directory, program, log_file) = fake_mysql("timeout");
         let option_file = log_file.with_extension("cnf");
         fs::write(&option_file, "[client]\n").unwrap();
-        let result = run_mysql_adhoc_with_program(
+        let result = run_mysql_single_statement_with_program(
             OsStr::new(&program),
             &option_file,
             "SELECT 123",
@@ -1259,7 +1252,7 @@ done
         let (_directory, program, log_file) = fake_mysql("failure");
         let option_file = log_file.with_extension("cnf");
         fs::write(&option_file, "[client]\n").unwrap();
-        let result = run_mysql_adhoc_with_program(
+        let result = run_mysql_single_statement_with_program(
             OsStr::new(&program),
             &option_file,
             "SELECT 123",
@@ -1276,7 +1269,7 @@ done
         let (_directory, program, log_file) = fake_mysql("no_result_failure");
         let option_file = log_file.with_extension("cnf");
         fs::write(&option_file, "[client]\n").unwrap();
-        let result = run_mysql_adhoc_with_program(
+        let result = run_mysql_single_statement_with_program(
             OsStr::new(&program),
             &option_file,
             "SELECT 123",

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -18,8 +18,8 @@ use super::super::policy::{
 use super::super::xml::MysqlResultSet;
 use super::metadata::mysql_metadata_columns;
 use super::{
-    MYSQL_QUERY_TIMEOUT, MysqlProcess, cleanup_mysql_process, configure_mysql_session,
-    finish_mysql_session, finish_mysql_session_after_result, read_one_mysql_resultset,
+    MYSQL_QUERY_TIMEOUT, MysqlProcess, configure_mysql_session, finish_mysql_session,
+    finish_mysql_session_after_result, read_one_mysql_resultset, run_mysql_process_with_timeout,
     write_mysql_statement,
 };
 
@@ -54,31 +54,17 @@ pub(super) async fn run_mysql_adhoc_with_program_and_statements_and_expected_col
         ));
     }
     let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
-    let result = tokio::time::timeout(
-        execution_timeout,
+    run_mysql_process_with_timeout(execution_timeout, &mut process, async |process| {
         run_mysql_adhoc_process(
-            &mut process,
+            process,
             option_file,
             statements,
             access_mode,
             expected_columns,
-        ),
-    )
-    .await;
-
-    match result {
-        Ok(Ok(result_set)) => Ok(result_set),
-        Ok(Err(error)) => {
-            cleanup_mysql_process(&mut process).await;
-            Err(error)
-        }
-        Err(_) => {
-            cleanup_mysql_process(&mut process).await;
-            Err(DbOperationError::Timeout(
-                "mysql query exceeded the execution timeout".to_string(),
-            ))
-        }
-    }
+        )
+        .await
+    })
+    .await
 }
 
 struct MysqlStatementExecution {

--- a/src/infra/adapters/mysql/cli/process/single.rs
+++ b/src/infra/adapters/mysql/cli/process/single.rs
@@ -1,5 +1,4 @@
 use std::ffi::OsStr;
-use tokio::time::timeout;
 use uuid::Uuid;
 
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
@@ -7,8 +6,8 @@ use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use super::super::error::{classify_mysql_query_failure, has_mysql_cli_error, validate_mode_probe};
 use super::super::xml::{MysqlResultSet, parse_mysql_xml};
 use super::{
-    MYSQL_QUERY_TIMEOUT, MysqlProcess, cleanup_mysql_process, configure_mysql_session,
-    finish_mysql_session, finish_mysql_session_after_result, read_one_mysql_resultset,
+    MYSQL_QUERY_TIMEOUT, MysqlProcess, configure_mysql_session, finish_mysql_session,
+    finish_mysql_session_after_result, read_one_mysql_resultset, run_mysql_process_with_timeout,
     write_mysql_statement,
 };
 
@@ -18,24 +17,10 @@ pub(in crate::adapters::mysql) async fn run_mysql_single_statement(
     access_mode: AccessMode,
 ) -> Result<MysqlResultSet, DbOperationError> {
     let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), option_file)?;
-    let result = timeout(
-        MYSQL_QUERY_TIMEOUT,
-        run_mysql_single_statement_process(&mut process, query, access_mode),
-    )
-    .await;
-    match result {
-        Ok(Ok(result_set)) => Ok(result_set),
-        Ok(Err(error)) => {
-            cleanup_mysql_process(&mut process).await;
-            Err(error)
-        }
-        Err(_) => {
-            cleanup_mysql_process(&mut process).await;
-            Err(DbOperationError::Timeout(
-                "mysql query exceeded the execution timeout".to_string(),
-            ))
-        }
-    }
+    run_mysql_process_with_timeout(MYSQL_QUERY_TIMEOUT, &mut process, async |process| {
+        run_mysql_single_statement_process(process, query, access_mode).await
+    })
+    .await
 }
 
 pub(super) async fn run_mysql_single_statement_process(


### PR DESCRIPTION
## Problem
The adhoc, single-statement, and CSV export MysqlProcess paths duplicated timeout and cleanup handling.

## Background
Keeping these boundaries separate risks the paths drifting in when cleanup runs or which timeout error is returned.

## Approach
A private MysqlProcess-scoped helper owns timeout handling and cleanup for execution errors and timeouts while preserving successful values, timeout values, and existing process shutdown behavior. The single-statement test helper now reflects the operation it runs.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-465