### PR TITLE
fix: update directly to latest stable release

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -61,12 +61,35 @@ struct Args {
 #[derive(clap::Subcommand, Debug)]
 enum Command {
     #[cfg(feature = "self-update")]
-    /// Update sabiql to the latest compatible version
+    /// Update sabiql to the latest stable version
     Update,
     #[cfg(not(feature = "self-update"))]
     /// Self-update is disabled in this build
     #[command(hide = true)]
     Update,
+}
+
+#[cfg(feature = "self-update")]
+fn latest_stable_release<'a>(
+    current_version: &str,
+    releases: &'a [self_update::update::Release],
+) -> Option<&'a self_update::update::Release> {
+    releases
+        .iter()
+        .filter(|release| !release.version.contains('-'))
+        .filter(|release| {
+            self_update::version::bump_is_greater(current_version, &release.version)
+                .unwrap_or(false)
+        })
+        .reduce(|latest, release| {
+            if self_update::version::bump_is_greater(&latest.version, &release.version)
+                .unwrap_or(false)
+            {
+                release
+            } else {
+                latest
+            }
+        })
 }
 
 #[tokio::main]
@@ -459,6 +482,17 @@ fn run_update() -> Result<()> {
     println!("Current version: v{current}");
     println!("Checking for updates...");
 
+    let releases = self_update::backends::github::ReleaseList::configure()
+        .repo_owner("riii111")
+        .repo_name("sabiql")
+        .build()?
+        .fetch()?;
+    let Some(latest) = latest_stable_release(current, &releases) else {
+        println!("Already up to date (v{current}).");
+        return Ok(());
+    };
+    let target_version = format!("v{}", latest.version);
+
     let status = self_update::backends::github::Update::configure()
         .repo_owner("riii111")
         .repo_name("sabiql")
@@ -466,6 +500,7 @@ fn run_update() -> Result<()> {
         .show_download_progress(true)
         .no_confirm(true)
         .current_version(current)
+        .target_version_tag(&target_version)
         .build()?
         .update()?;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -21,6 +21,27 @@ fn update_subcommand_is_recognized() {
     assert!(matches!(args.command, Some(Command::Update)));
 }
 
+#[cfg(feature = "self-update")]
+mod self_update_selection {
+    use super::super::latest_stable_release;
+
+    fn release(version: &str) -> self_update::update::Release {
+        self_update::update::Release {
+            version: version.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn selects_latest_stable_release_across_major_versions() {
+        let releases = vec![release("1.15.1"), release("2.0.0-rc.1"), release("2.0.0")];
+
+        let selected = latest_stable_release("1.14.0", &releases).unwrap();
+
+        assert_eq!(selected.version, "2.0.0");
+    }
+}
+
 #[test]
 fn database_positional_is_recognized() {
     let args = Args::parse_from(["sabiql", "/tmp/app.db"]);


### PR DESCRIPTION
## Problem
`sabiql update` could stop at an intermediate same-major release before reaching a newer major.

## Background
`self_update` prioritizes compatible releases when no target tag is specified.

## Approach
Select the newest published stable release across all majors, then pass its tag to the existing target-asset download and self-replacement path.