### PR TITLE
refactor(mysql): unify Rust type naming

### DIFF
--- a/src/app/policy/sql/mysql_export.rs
+++ b/src/app/policy/sql/mysql_export.rs
@@ -1,14 +1,14 @@
 use super::mysql_statement::{
-    MysqlStatementKind, classify_mysql_statement, split_mysql_statements,
+    MySqlStatementKind, classify_mysql_statement, split_mysql_statements,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MysqlExportPlan {
+pub enum MySqlExportPlan {
     CountRows,
     UseResultRowCount,
 }
 
-pub fn mysql_export_plan(query: &str) -> Option<MysqlExportPlan> {
+pub fn mysql_export_plan(query: &str) -> Option<MySqlExportPlan> {
     let statements = split_mysql_statements(query).ok()?;
     let [statement] = statements.as_slice() else {
         return None;
@@ -16,9 +16,9 @@ pub fn mysql_export_plan(query: &str) -> Option<MysqlExportPlan> {
     let statement = classify_mysql_statement(statement).ok()?;
 
     match statement.kind {
-        MysqlStatementKind::Select => Some(MysqlExportPlan::CountRows),
-        MysqlStatementKind::Table | MysqlStatementKind::Show | MysqlStatementKind::Describe => {
-            Some(MysqlExportPlan::UseResultRowCount)
+        MySqlStatementKind::Select => Some(MySqlExportPlan::CountRows),
+        MySqlStatementKind::Table | MySqlStatementKind::Show | MySqlStatementKind::Describe => {
+            Some(MySqlExportPlan::UseResultRowCount)
         }
         _ => None,
     }
@@ -30,13 +30,13 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case::select("SELECT id FROM users", MysqlExportPlan::CountRows)]
-    #[case::table("TABLE users", MysqlExportPlan::UseResultRowCount)]
-    #[case::show("SHOW TABLES", MysqlExportPlan::UseResultRowCount)]
-    #[case::describe("DESCRIBE users", MysqlExportPlan::UseResultRowCount)]
+    #[case::select("SELECT id FROM users", MySqlExportPlan::CountRows)]
+    #[case::table("TABLE users", MySqlExportPlan::UseResultRowCount)]
+    #[case::show("SHOW TABLES", MySqlExportPlan::UseResultRowCount)]
+    #[case::describe("DESCRIBE users", MySqlExportPlan::UseResultRowCount)]
     fn plans_supported_mysql_export_queries(
         #[case] query: &str,
-        #[case] expected: MysqlExportPlan,
+        #[case] expected: MySqlExportPlan,
     ) {
         assert_eq!(mysql_export_plan(query), Some(expected));
     }

--- a/src/app/policy/sql/mysql_statement.rs
+++ b/src/app/policy/sql/mysql_statement.rs
@@ -9,7 +9,7 @@ mod transaction;
 use lexer::TokenKind;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MysqlStatementKind {
+pub enum MySqlStatementKind {
     Select,
     Table,
     Show,
@@ -38,30 +38,30 @@ pub enum MysqlStatementKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MysqlStatement {
+pub struct MySqlStatement {
     pub sql: String,
-    pub kind: MysqlStatementKind,
+    pub kind: MySqlStatementKind,
     pub target: Option<String>,
     pub target_database: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct MysqlLexError(pub String);
+pub struct MySqlLexError(pub String);
 
-impl fmt::Display for MysqlLexError {
+impl fmt::Display for MySqlLexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
     }
 }
 
-pub fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MysqlLexError> {
+pub fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MySqlLexError> {
     lexer::split_mysql_statements(sql)
 }
 
-pub fn classify_mysql_statement(sql: &str) -> Result<MysqlStatement, MysqlLexError> {
+pub fn classify_mysql_statement(sql: &str) -> Result<MySqlStatement, MySqlLexError> {
     let tokens = lexer::lex_mysql_statement(sql)?;
     if tokens.is_empty() {
-        return Err(MysqlLexError("empty MySQL statement".to_string()));
+        return Err(MySqlLexError("empty MySQL statement".to_string()));
     }
     if tokens.iter().any(|token| {
         matches!(
@@ -69,12 +69,12 @@ pub fn classify_mysql_statement(sql: &str) -> Result<MysqlStatement, MysqlLexErr
             TokenKind::Word(word) if word == "UNSUPPORTED_VERSION_COMMENT"
         )
     }) {
-        return Err(MysqlLexError(
+        return Err(MySqlLexError(
             "executable MySQL version comment contains another statement".to_string(),
         ));
     }
     let (kind, target, target_database) = classifier::kind_and_target(&tokens)?;
-    Ok(MysqlStatement {
+    Ok(MySqlStatement {
         sql: sql.to_string(),
         kind,
         target,
@@ -82,20 +82,20 @@ pub fn classify_mysql_statement(sql: &str) -> Result<MysqlStatement, MysqlLexErr
     })
 }
 
-pub fn has_top_level_into_clause(sql: &str) -> Result<bool, MysqlLexError> {
+pub fn has_top_level_into_clause(sql: &str) -> Result<bool, MySqlLexError> {
     side_effect::has_top_level_into_clause(sql)
 }
 
-pub fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MysqlLexError> {
+pub fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MySqlLexError> {
     side_effect::has_mysql_read_only_side_effect(sql)
 }
 
-pub fn has_mysql_version_comment(sql: &str) -> Result<bool, MysqlLexError> {
+pub fn has_mysql_version_comment(sql: &str) -> Result<bool, MySqlLexError> {
     side_effect::has_mysql_version_comment(sql)
 }
 
 pub fn target_is_selected_database(
-    statement: &MysqlStatement,
+    statement: &MySqlStatement,
     selected_database: Option<&str>,
 ) -> bool {
     target::target_is_selected_database(statement, selected_database)
@@ -121,11 +121,11 @@ pub fn mysql_explain_rejection_message(sql: &str) -> Option<&'static str> {
     };
     (!matches!(
         statement.kind,
-        MysqlStatementKind::Select
-            | MysqlStatementKind::Table
-            | MysqlStatementKind::Insert
-            | MysqlStatementKind::Update { .. }
-            | MysqlStatementKind::Delete { .. }
+        MySqlStatementKind::Select
+            | MySqlStatementKind::Table
+            | MySqlStatementKind::Insert
+            | MySqlStatementKind::Update { .. }
+            | MySqlStatementKind::Delete { .. }
     ))
     .then_some("MySQL EXPLAIN supports SELECT, TABLE, INSERT, UPDATE, or DELETE statements")
 }
@@ -142,7 +142,7 @@ pub fn mysql_tree_explain_query_kind(sql: &str) -> Option<bool> {
                     && classify_mysql_statement(&statements[0]).is_ok_and(|statement| {
                         matches!(
                             statement.kind,
-                            MysqlStatementKind::Select | MysqlStatementKind::Table
+                            MySqlStatementKind::Select | MySqlStatementKind::Table
                         ) && !has_mysql_read_only_side_effect(target).unwrap_or(true)
                     })
             })
@@ -233,7 +233,7 @@ mod tests {
             "WITH rows(id) AS (SELECT 1) UPDATE `app`.`items` SET value = 1",
         )
         .unwrap();
-        assert!(matches!(statement.kind, MysqlStatementKind::Update { .. }));
+        assert!(matches!(statement.kind, MySqlStatementKind::Update { .. }));
         assert_eq!(statement.target, Some("items".to_string()));
     }
 
@@ -246,8 +246,8 @@ mod tests {
     fn classifies_leading_version_comment_statement() {
         assert!(matches!(
             classify_mysql_statement("/*!80000 SELECT 1 */"),
-            Ok(MysqlStatement {
-                kind: MysqlStatementKind::Select,
+            Ok(MySqlStatement {
+                kind: MySqlStatementKind::Select,
                 ..
             })
         ));
@@ -258,67 +258,67 @@ mod tests {
         let cases = [
             (
                 "RENAME TABLE app.items TO app.archived_items",
-                MysqlStatementKind::RenameTable,
+                MySqlStatementKind::RenameTable,
                 "items",
                 Some("app"),
             ),
             (
                 "RENAME TABLE items TO app.archived_items",
-                MysqlStatementKind::RenameTable,
+                MySqlStatementKind::RenameTable,
                 "items",
                 Some("app"),
             ),
             (
                 "ALTER TABLE app.items RENAME TO app.archived_items",
-                MysqlStatementKind::AlterTable,
+                MySqlStatementKind::AlterTable,
                 "items",
                 Some("app"),
             ),
             (
                 "ALTER TABLE app.items RENAME AS app.archived_items",
-                MysqlStatementKind::AlterTable,
+                MySqlStatementKind::AlterTable,
                 "items",
                 Some("app"),
             ),
             (
                 "ALTER TABLE app.items RENAME COLUMN old_name TO new_name",
-                MysqlStatementKind::AlterTable,
+                MySqlStatementKind::AlterTable,
                 "items",
                 Some("app"),
             ),
             (
                 "ALTER TABLE app.items RENAME INDEX old_index TO new_index",
-                MysqlStatementKind::AlterTable,
+                MySqlStatementKind::AlterTable,
                 "items",
                 Some("app"),
             ),
             (
                 "CREATE OR REPLACE VIEW app.item_view AS SELECT id FROM app.items",
-                MysqlStatementKind::CreateView,
+                MySqlStatementKind::CreateView,
                 "item_view",
                 Some("app"),
             ),
             (
                 "CREATE OR REPLACE ALGORITHM=MERGE DEFINER=CURRENT_USER SQL SECURITY INVOKER VIEW app.item_view AS SELECT id FROM app.items",
-                MysqlStatementKind::CreateView,
+                MySqlStatementKind::CreateView,
                 "item_view",
                 Some("app"),
             ),
             (
                 "ALTER VIEW app.item_view AS SELECT id FROM app.items",
-                MysqlStatementKind::AlterView,
+                MySqlStatementKind::AlterView,
                 "item_view",
                 Some("app"),
             ),
             (
                 "ALTER ALGORITHM=MERGE DEFINER=CURRENT_USER SQL SECURITY INVOKER VIEW app.item_view AS SELECT id FROM app.items",
-                MysqlStatementKind::AlterView,
+                MySqlStatementKind::AlterView,
                 "item_view",
                 Some("app"),
             ),
             (
                 "CREATE FULLTEXT INDEX item_text ON app.items (body)",
-                MysqlStatementKind::CreateIndex,
+                MySqlStatementKind::CreateIndex,
                 "item_text",
                 Some("app"),
             ),
@@ -344,7 +344,7 @@ mod tests {
         .expect("trailing DDL version comment");
         assert_eq!(
             statement.kind,
-            MysqlStatementKind::CreateTable { temporary: false }
+            MySqlStatementKind::CreateTable { temporary: false }
         );
         assert!(
             classify_mysql_statement("CREATE TABLE items (id INT) /* ordinary comment */").is_ok()

--- a/src/app/policy/sql/mysql_statement/classifier.rs
+++ b/src/app/policy/sql/mysql_statement/classifier.rs
@@ -1,15 +1,15 @@
 use super::{
-    MysqlLexError, MysqlStatementKind,
+    MySqlLexError, MySqlStatementKind,
     lexer::{Token, TokenKind},
     target, transaction,
 };
 
-type MysqlClassification = (MysqlStatementKind, Option<String>, Option<String>);
+type MySqlClassification = (MySqlStatementKind, Option<String>, Option<String>);
 
-pub(super) fn kind_and_target(tokens: &[Token]) -> Result<MysqlClassification, MysqlLexError> {
+pub(super) fn kind_and_target(tokens: &[Token]) -> Result<MySqlClassification, MySqlLexError> {
     let start = target::effective_start(tokens);
     let first = target::word(tokens, start)
-        .ok_or_else(|| MysqlLexError("unknown MySQL statement".to_string()))?;
+        .ok_or_else(|| MySqlLexError("unknown MySQL statement".to_string()))?;
     match first {
         "SELECT" | "INSERT" | "REPLACE" | "UPDATE" | "DELETE" => {
             classify_mysql_crud_statement(tokens, start, first)
@@ -21,7 +21,7 @@ pub(super) fn kind_and_target(tokens: &[Token]) -> Result<MysqlClassification, M
             transaction::classify_mysql_transaction_statement(tokens, start, first)
         }
         "TABLE" | "SHOW" | "DESCRIBE" | "DESC" => Ok(classify_mysql_utility_statement(first)),
-        _ => Err(MysqlLexError(format!(
+        _ => Err(MySqlLexError(format!(
             "unsupported MySQL statement: {first}"
         ))),
     }
@@ -31,9 +31,9 @@ fn classify_mysql_crud_statement(
     tokens: &[Token],
     start: usize,
     first: &str,
-) -> Result<MysqlClassification, MysqlLexError> {
+) -> Result<MySqlClassification, MySqlLexError> {
     match first {
-        "SELECT" => Ok((MysqlStatementKind::Select, None, None)),
+        "SELECT" => Ok((MySqlStatementKind::Select, None, None)),
         "INSERT" | "REPLACE" => {
             let index = if first == "INSERT" {
                 target::skip_mysql_modifiers(
@@ -51,9 +51,9 @@ fn classify_mysql_crud_statement(
             };
             let (target, database) = target::target_after(tokens, target_index)?;
             let kind = if first == "REPLACE" {
-                MysqlStatementKind::Replace
+                MySqlStatementKind::Replace
             } else {
-                MysqlStatementKind::Insert
+                MySqlStatementKind::Insert
             };
             Ok((kind, target, database))
         }
@@ -61,15 +61,15 @@ fn classify_mysql_crud_statement(
             let target_index =
                 target::skip_mysql_modifiers(tokens, start + 1, &["LOW_PRIORITY", "IGNORE"]);
             let set_index = target::find_word(tokens, "SET", target_index)
-                .ok_or_else(|| MysqlLexError("MySQL UPDATE target is ambiguous".to_string()))?;
+                .ok_or_else(|| MySqlLexError("MySQL UPDATE target is ambiguous".to_string()))?;
             if has_multi_table_reference(tokens, target_index, set_index) {
-                return Err(MysqlLexError(
+                return Err(MySqlLexError(
                     "MySQL multiple-table UPDATE statements are not supported".to_string(),
                 ));
             }
             let has_where = target::top_level_word(&tokens[start..], "WHERE");
             let (target, database) = target::target_after(tokens, target_index)?;
-            Ok((MysqlStatementKind::Update { has_where }, target, database))
+            Ok((MySqlStatementKind::Update { has_where }, target, database))
         }
         "DELETE" => {
             let has_where = target::top_level_word(&tokens[start..], "WHERE");
@@ -79,7 +79,7 @@ fn classify_mysql_crud_statement(
                 &["LOW_PRIORITY", "QUICK", "IGNORE"],
             );
             if target::word(tokens, index) != Some("FROM") {
-                return Err(MysqlLexError(
+                return Err(MySqlLexError(
                     "MySQL multiple-table DELETE statements are not supported".to_string(),
                 ));
             }
@@ -89,12 +89,12 @@ fn classify_mysql_crud_statement(
             if has_multi_table_reference(tokens, target_index, where_index)
                 || has_top_level_word(tokens, "USING", target_index, where_index)
             {
-                return Err(MysqlLexError(
+                return Err(MySqlLexError(
                     "MySQL multiple-table DELETE statements are not supported".to_string(),
                 ));
             }
             let (target, database) = target::target_after(tokens, target_index)?;
-            Ok((MysqlStatementKind::Delete { has_where }, target, database))
+            Ok((MySqlStatementKind::Delete { has_where }, target, database))
         }
         _ => unreachable!("not a MySQL CRUD statement: {first}"),
     }
@@ -222,12 +222,12 @@ fn classify_mysql_ddl_statement(
     tokens: &[Token],
     start: usize,
     first: &str,
-) -> Result<MysqlClassification, MysqlLexError> {
+) -> Result<MySqlClassification, MySqlLexError> {
     match first {
         "CREATE" => {
             if let Some(view_index) = view_statement_start(tokens, start, true) {
                 let (target, database) = target::target_after(tokens, view_index + 1)?;
-                return Ok((MysqlStatementKind::CreateView, target, database));
+                return Ok((MySqlStatementKind::CreateView, target, database));
             }
             let mut index = start + 1;
             let temporary = target::word(tokens, index) == Some("TEMPORARY");
@@ -242,51 +242,51 @@ fn classify_mysql_ddl_statement(
                     }
                     let (target, database) = target::target_after(tokens, index)?;
                     Ok((
-                        MysqlStatementKind::CreateTable { temporary },
+                        MySqlStatementKind::CreateTable { temporary },
                         target,
                         database,
                     ))
                 }
                 Some("VIEW") => {
                     let (target, database) = target::target_after(tokens, index + 1)?;
-                    Ok((MysqlStatementKind::CreateView, target, database))
+                    Ok((MySqlStatementKind::CreateView, target, database))
                 }
                 Some("FULLTEXT") if target::word(tokens, index + 1) == Some("INDEX") => {
                     let (index_name, _, index_end) = target::identifier_at(tokens, index + 2)
                         .ok_or_else(|| {
-                            MysqlLexError("CREATE INDEX name is ambiguous".to_string())
+                            MySqlLexError("CREATE INDEX name is ambiguous".to_string())
                         })?;
                     if target::word(tokens, index_end) != Some("ON") {
-                        return Err(MysqlLexError(
+                        return Err(MySqlLexError(
                             "CREATE INDEX target is ambiguous".to_string(),
                         ));
                     }
                     let (_, database) = target::target_after(tokens, index_end + 1)?;
-                    Ok((MysqlStatementKind::CreateIndex, Some(index_name), database))
+                    Ok((MySqlStatementKind::CreateIndex, Some(index_name), database))
                 }
                 Some("UNIQUE") if target::word(tokens, index + 1) == Some("INDEX") => {
                     let on = target::find_word(tokens, "ON", index + 2).ok_or_else(|| {
-                        MysqlLexError("CREATE INDEX target is ambiguous".to_string())
+                        MySqlLexError("CREATE INDEX target is ambiguous".to_string())
                     })?;
                     let (_, database) = target::target_after(tokens, on + 1)?;
                     let (index_name, _, _) =
                         target::identifier_at(tokens, index + 2).ok_or_else(|| {
-                            MysqlLexError("CREATE INDEX name is ambiguous".to_string())
+                            MySqlLexError("CREATE INDEX name is ambiguous".to_string())
                         })?;
-                    Ok((MysqlStatementKind::CreateIndex, Some(index_name), database))
+                    Ok((MySqlStatementKind::CreateIndex, Some(index_name), database))
                 }
                 Some("INDEX" | "KEY") => {
                     let on = target::find_word(tokens, "ON", index + 1).ok_or_else(|| {
-                        MysqlLexError("CREATE INDEX target is ambiguous".to_string())
+                        MySqlLexError("CREATE INDEX target is ambiguous".to_string())
                     })?;
                     let (_, database) = target::target_after(tokens, on + 1)?;
                     let (index_name, _, _) =
                         target::identifier_at(tokens, index + 1).ok_or_else(|| {
-                            MysqlLexError("CREATE INDEX name is ambiguous".to_string())
+                            MySqlLexError("CREATE INDEX name is ambiguous".to_string())
                         })?;
-                    Ok((MysqlStatementKind::CreateIndex, Some(index_name), database))
+                    Ok((MySqlStatementKind::CreateIndex, Some(index_name), database))
                 }
-                _ => Err(MysqlLexError(
+                _ => Err(MySqlLexError(
                     "unsupported MySQL CREATE statement".to_string(),
                 )),
             }
@@ -294,38 +294,38 @@ fn classify_mysql_ddl_statement(
         "ALTER" => {
             if let Some(view_index) = view_statement_start(tokens, start, false) {
                 let (target, database) = target::target_after(tokens, view_index + 1)?;
-                return Ok((MysqlStatementKind::AlterView, target, database));
+                return Ok((MySqlStatementKind::AlterView, target, database));
             }
             match target::word(tokens, start + 1) {
                 Some("TABLE") => {
                     let (target, database) = classify_alter_table_target(tokens, start + 2)?;
-                    Ok((MysqlStatementKind::AlterTable, target, database))
+                    Ok((MySqlStatementKind::AlterTable, target, database))
                 }
-                _ => Err(MysqlLexError(
+                _ => Err(MySqlLexError(
                     "unsupported MySQL ALTER statement".to_string(),
                 )),
             }
         }
         "RENAME" => {
             if target::word(tokens, start + 1) != Some("TABLE") {
-                return Err(MysqlLexError(
+                return Err(MySqlLexError(
                     "unsupported MySQL RENAME statement".to_string(),
                 ));
             }
             let (target, database, next) = target::identifier_at(tokens, start + 2)
-                .ok_or_else(|| MysqlLexError("RENAME TABLE source is ambiguous".to_string()))?;
+                .ok_or_else(|| MySqlLexError("RENAME TABLE source is ambiguous".to_string()))?;
             if target::word(tokens, next) != Some("TO") {
-                return Err(MysqlLexError(
+                return Err(MySqlLexError(
                     "RENAME TABLE requires one source and destination".to_string(),
                 ));
             }
             let (_, destination_database, end) = target::identifier_at(tokens, next + 1)
                 .ok_or_else(|| {
-                    MysqlLexError("RENAME TABLE destination is ambiguous".to_string())
+                    MySqlLexError("RENAME TABLE destination is ambiguous".to_string())
                 })?;
             let effective_database = match (database.as_deref(), destination_database.as_deref()) {
                 (Some(source), Some(destination)) if !source.eq_ignore_ascii_case(destination) => {
-                    return Err(MysqlLexError(
+                    return Err(MySqlLexError(
                         "RENAME TABLE cannot move a table across databases".to_string(),
                     ));
                 }
@@ -337,13 +337,13 @@ fn classify_mysql_ddl_statement(
                 .iter()
                 .any(|token| !matches!(token.kind, TokenKind::Symbol(';')))
             {
-                return Err(MysqlLexError(
+                return Err(MySqlLexError(
                     "MySQL RENAME TABLE statements must have one source and destination"
                         .to_string(),
                 ));
             }
             Ok((
-                MysqlStatementKind::RenameTable,
+                MySqlStatementKind::RenameTable,
                 Some(target),
                 effective_database,
             ))
@@ -363,7 +363,7 @@ fn classify_mysql_ddl_statement(
                     };
                     let (target, database) = target::drop_target_after(tokens, target_index)?;
                     Ok((
-                        MysqlStatementKind::DropTable { temporary },
+                        MySqlStatementKind::DropTable { temporary },
                         target,
                         database,
                     ))
@@ -375,11 +375,11 @@ fn classify_mysql_ddl_statement(
                         index + 1
                     };
                     let (target, database) = target::drop_target_after(tokens, target_index)?;
-                    Ok((MysqlStatementKind::DropView, target, database))
+                    Ok((MySqlStatementKind::DropView, target, database))
                 }
                 Some("INDEX" | "KEY") => {
                     let on = target::find_word(tokens, "ON", index + 1).ok_or_else(|| {
-                        MysqlLexError("DROP INDEX target is ambiguous".to_string())
+                        MySqlLexError("DROP INDEX target is ambiguous".to_string())
                     })?;
                     let (_, database) = target::target_after(tokens, on + 1)?;
                     let index_name_index = if target::word(tokens, index + 1) == Some("IF") {
@@ -388,10 +388,10 @@ fn classify_mysql_ddl_statement(
                         index + 1
                     };
                     let (index_name, _, _) = target::identifier_at(tokens, index_name_index)
-                        .ok_or_else(|| MysqlLexError("DROP INDEX name is ambiguous".to_string()))?;
-                    Ok((MysqlStatementKind::DropIndex, Some(index_name), database))
+                        .ok_or_else(|| MySqlLexError("DROP INDEX name is ambiguous".to_string()))?;
+                    Ok((MySqlStatementKind::DropIndex, Some(index_name), database))
                 }
-                _ => Err(MysqlLexError(
+                _ => Err(MySqlLexError(
                     "unsupported MySQL DROP statement".to_string(),
                 )),
             }
@@ -403,7 +403,7 @@ fn classify_mysql_ddl_statement(
                 start + 1
             };
             let (target, database) = target::target_after(tokens, target_index)?;
-            Ok((MysqlStatementKind::TruncateTable, target, database))
+            Ok((MySqlStatementKind::TruncateTable, target, database))
         }
         _ => unreachable!("not a MySQL DDL statement: {first}"),
     }
@@ -412,13 +412,13 @@ fn classify_mysql_ddl_statement(
 fn classify_alter_table_target(
     tokens: &[Token],
     table_index: usize,
-) -> Result<(Option<String>, Option<String>), MysqlLexError> {
+) -> Result<(Option<String>, Option<String>), MySqlLexError> {
     let (target, source_database, after_target) = target::identifier_at(tokens, table_index)
-        .ok_or_else(|| MysqlLexError("MySQL statement target is ambiguous".to_string()))?;
+        .ok_or_else(|| MySqlLexError("MySQL statement target is ambiguous".to_string()))?;
     let destination_database = alter_table_rename_database(tokens, after_target)?;
     let effective_database = match (source_database.as_deref(), destination_database.as_deref()) {
         (Some(source), Some(destination)) if !source.eq_ignore_ascii_case(destination) => {
-            return Err(MysqlLexError(
+            return Err(MySqlLexError(
                 "ALTER TABLE RENAME cannot move a table across databases".to_string(),
             ));
         }
@@ -432,7 +432,7 @@ fn classify_alter_table_target(
 fn alter_table_rename_database(
     tokens: &[Token],
     start: usize,
-) -> Result<Option<String>, MysqlLexError> {
+) -> Result<Option<String>, MySqlLexError> {
     let Some(destination_start) =
         tokens
             .iter()
@@ -448,15 +448,15 @@ fn alter_table_rename_database(
         return Ok(None);
     };
     let (_, database, _) = target::identifier_at(tokens, destination_start)
-        .ok_or_else(|| MysqlLexError("ALTER TABLE RENAME destination is ambiguous".to_string()))?;
+        .ok_or_else(|| MySqlLexError("ALTER TABLE RENAME destination is ambiguous".to_string()))?;
     Ok(database)
 }
 
-fn classify_mysql_utility_statement(first: &str) -> MysqlClassification {
+fn classify_mysql_utility_statement(first: &str) -> MySqlClassification {
     match first {
-        "TABLE" => (MysqlStatementKind::Table, None, None),
-        "SHOW" => (MysqlStatementKind::Show, None, None),
-        "DESCRIBE" | "DESC" => (MysqlStatementKind::Describe, None, None),
+        "TABLE" => (MySqlStatementKind::Table, None, None),
+        "SHOW" => (MySqlStatementKind::Show, None, None),
+        "DESCRIBE" | "DESC" => (MySqlStatementKind::Describe, None, None),
         _ => unreachable!("not a MySQL utility statement: {first}"),
     }
 }

--- a/src/app/policy/sql/mysql_statement/lexer.rs
+++ b/src/app/policy/sql/mysql_statement/lexer.rs
@@ -1,4 +1,4 @@
-use super::MysqlLexError;
+use super::MySqlLexError;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum TokenKind {
@@ -16,7 +16,7 @@ pub(super) struct Token {
     pub(super) text: String,
 }
 
-pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MysqlLexError> {
+pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MySqlLexError> {
     let bytes = sql.as_bytes();
     let mut tokens = Vec::new();
     let mut index = 0;
@@ -41,7 +41,7 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MysqlLexError
                     continue;
                 };
                 if content.is_empty() {
-                    return Err(MysqlLexError(
+                    return Err(MySqlLexError(
                         "MySQL version comment has no executable statement".to_string(),
                     ));
                 }
@@ -147,7 +147,7 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MysqlLexError
             b')' => {
                 depth = depth
                     .checked_sub(1)
-                    .ok_or_else(|| MysqlLexError("unbalanced MySQL parentheses".to_string()))?;
+                    .ok_or_else(|| MySqlLexError("unbalanced MySQL parentheses".to_string()))?;
             }
             _ => {}
         }
@@ -156,7 +156,7 @@ pub(super) fn lex_mysql_statement(sql: &str) -> Result<Vec<Token>, MysqlLexError
     Ok(tokens)
 }
 
-pub(super) fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MysqlLexError> {
+pub(super) fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MySqlLexError> {
     let mut statements = Vec::new();
     let mut start = 0;
     let mut index = 0;
@@ -202,7 +202,7 @@ pub(super) fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MysqlLexE
             b')' => {
                 depth = depth
                     .checked_sub(1)
-                    .ok_or_else(|| MysqlLexError("unbalanced MySQL parentheses".to_string()))?;
+                    .ok_or_else(|| MySqlLexError("unbalanced MySQL parentheses".to_string()))?;
             }
             b';' if depth == 0 => {
                 push_mysql_statement(&mut statements, &sql[start..index]);
@@ -214,12 +214,12 @@ pub(super) fn split_mysql_statements(sql: &str) -> Result<Vec<String>, MysqlLexE
     }
 
     if quote.is_some() {
-        return Err(MysqlLexError(
+        return Err(MySqlLexError(
             "unterminated MySQL quoted literal".to_string(),
         ));
     }
     if depth != 0 {
-        return Err(MysqlLexError("unbalanced MySQL parentheses".to_string()));
+        return Err(MySqlLexError("unbalanced MySQL parentheses".to_string()));
     }
     push_mysql_statement(&mut statements, &sql[start..]);
     Ok(statements)
@@ -249,7 +249,7 @@ pub(super) fn skip_line_comment(bytes: &[u8], mut index: usize) -> usize {
     index
 }
 
-pub(super) fn skip_block_comment(bytes: &[u8], index: usize) -> Result<usize, MysqlLexError> {
+pub(super) fn skip_block_comment(bytes: &[u8], index: usize) -> Result<usize, MySqlLexError> {
     let mut cursor = index + 2;
     while cursor + 1 < bytes.len() {
         if bytes[cursor] == b'*' && bytes[cursor + 1] == b'/' {
@@ -257,7 +257,7 @@ pub(super) fn skip_block_comment(bytes: &[u8], index: usize) -> Result<usize, My
         }
         cursor += 1;
     }
-    Err(MysqlLexError(
+    Err(MySqlLexError(
         "unterminated MySQL block comment".to_string(),
     ))
 }
@@ -313,10 +313,10 @@ fn is_safe_trailing_ddl_clause(tokens: &[Token], inner: &[Token]) -> bool {
         })
 }
 
-fn mysql_version_comment_content(body: &str) -> Result<Option<&str>, MysqlLexError> {
+fn mysql_version_comment_content(body: &str) -> Result<Option<&str>, MySqlLexError> {
     let digit_len = body.bytes().take_while(u8::is_ascii_digit).count();
     if digit_len == 0 {
-        return Err(MysqlLexError(
+        return Err(MySqlLexError(
             "MySQL version comment has no verifiable version".to_string(),
         ));
     }
@@ -403,7 +403,7 @@ fn is_mysql_statement_keyword(word: &str) -> bool {
     )
 }
 
-fn skip_quoted(bytes: &[u8], index: usize, quote: u8) -> Result<usize, MysqlLexError> {
+fn skip_quoted(bytes: &[u8], index: usize, quote: u8) -> Result<usize, MySqlLexError> {
     let mut cursor = index + 1;
     while cursor < bytes.len() {
         if bytes[cursor] == b'\\' && quote != b'`' {
@@ -420,7 +420,7 @@ fn skip_quoted(bytes: &[u8], index: usize, quote: u8) -> Result<usize, MysqlLexE
             cursor += 1;
         }
     }
-    Err(MysqlLexError(
+    Err(MySqlLexError(
         "unterminated MySQL quoted literal".to_string(),
     ))
 }

--- a/src/app/policy/sql/mysql_statement/side_effect.rs
+++ b/src/app/policy/sql/mysql_statement/side_effect.rs
@@ -1,13 +1,13 @@
-use super::{MysqlLexError, lexer, lexer::TokenKind, target};
+use super::{MySqlLexError, lexer, lexer::TokenKind, target};
 
-pub(super) fn has_top_level_into_clause(sql: &str) -> Result<bool, MysqlLexError> {
+pub(super) fn has_top_level_into_clause(sql: &str) -> Result<bool, MySqlLexError> {
     let tokens = lexer::lex_mysql_statement(sql)?;
     Ok(tokens.iter().any(|token| {
         token.depth == 0 && matches!(&token.kind, TokenKind::Word(word) if word == "INTO")
     }))
 }
 
-pub(super) fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MysqlLexError> {
+pub(super) fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MySqlLexError> {
     if has_mysql_version_comment(sql)? {
         return Ok(true);
     }
@@ -47,7 +47,7 @@ pub(super) fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MysqlLe
     Ok(false)
 }
 
-pub(super) fn has_mysql_version_comment(sql: &str) -> Result<bool, MysqlLexError> {
+pub(super) fn has_mysql_version_comment(sql: &str) -> Result<bool, MySqlLexError> {
     let bytes = sql.as_bytes();
     let mut index = 0;
     let mut quote = None;
@@ -86,7 +86,7 @@ pub(super) fn has_mysql_version_comment(sql: &str) -> Result<bool, MysqlLexError
     }
 
     if quote.is_some() {
-        return Err(MysqlLexError(
+        return Err(MySqlLexError(
             "unterminated MySQL quoted literal".to_string(),
         ));
     }

--- a/src/app/policy/sql/mysql_statement/target.rs
+++ b/src/app/policy/sql/mysql_statement/target.rs
@@ -1,28 +1,28 @@
 use super::{
-    MysqlLexError, MysqlStatement,
+    MySqlLexError, MySqlStatement,
     lexer::{Token, TokenKind},
 };
 
 pub(super) fn target_after(
     tokens: &[Token],
     index: usize,
-) -> Result<(Option<String>, Option<String>), MysqlLexError> {
+) -> Result<(Option<String>, Option<String>), MySqlLexError> {
     identifier_at(tokens, index)
         .map(|(target, database, _)| (Some(target), database))
-        .ok_or_else(|| MysqlLexError("MySQL statement target is ambiguous".to_string()))
+        .ok_or_else(|| MySqlLexError("MySQL statement target is ambiguous".to_string()))
 }
 
 pub(super) fn drop_target_after(
     tokens: &[Token],
     index: usize,
-) -> Result<(Option<String>, Option<String>), MysqlLexError> {
+) -> Result<(Option<String>, Option<String>), MySqlLexError> {
     let (target, database, next) = identifier_at(tokens, index)
-        .ok_or_else(|| MysqlLexError("MySQL statement target is ambiguous".to_string()))?;
+        .ok_or_else(|| MySqlLexError("MySQL statement target is ambiguous".to_string()))?;
     if tokens[next..]
         .iter()
         .any(|token| token.depth == 0 && matches!(token.kind, TokenKind::Symbol(',')))
     {
-        return Err(MysqlLexError(
+        return Err(MySqlLexError(
             "MySQL DROP statements must have one target".to_string(),
         ));
     }
@@ -34,7 +34,7 @@ pub(super) fn effective_start(tokens: &[Token]) -> usize {
 }
 
 pub(super) fn target_is_selected_database(
-    statement: &MysqlStatement,
+    statement: &MySqlStatement,
     selected_database: Option<&str>,
 ) -> bool {
     match (statement.target_database.as_deref(), selected_database) {

--- a/src/app/policy/sql/mysql_statement/transaction.rs
+++ b/src/app/policy/sql/mysql_statement/transaction.rs
@@ -1,38 +1,38 @@
-use super::{MysqlLexError, MysqlStatementKind, lexer::Token, target};
+use super::{MySqlLexError, MySqlStatementKind, lexer::Token, target};
 
 pub(super) fn classify_mysql_transaction_statement(
     tokens: &[Token],
     start: usize,
     first: &str,
-) -> Result<(MysqlStatementKind, Option<String>, Option<String>), MysqlLexError> {
+) -> Result<(MySqlStatementKind, Option<String>, Option<String>), MySqlLexError> {
     match first {
         "BEGIN" => {
             if tokens.len() != start + 1 {
-                return Err(MysqlLexError(
+                return Err(MySqlLexError(
                     "BEGIN modifiers are not supported".to_string(),
                 ));
             }
-            Ok((MysqlStatementKind::Begin, None, None))
+            Ok((MySqlStatementKind::Begin, None, None))
         }
         "START" if target::word(tokens, start + 1) == Some("TRANSACTION") => {
             if tokens.len() != start + 2 {
-                return Err(MysqlLexError(
+                return Err(MySqlLexError(
                     "START TRANSACTION modifiers are not supported".to_string(),
                 ));
             }
-            Ok((MysqlStatementKind::StartTransaction, None, None))
+            Ok((MySqlStatementKind::StartTransaction, None, None))
         }
         "COMMIT" => {
             if tokens.len() != start + 1 {
-                return Err(MysqlLexError(
+                return Err(MySqlLexError(
                     "COMMIT modifiers are not supported".to_string(),
                 ));
             }
-            Ok((MysqlStatementKind::Commit, None, None))
+            Ok((MySqlStatementKind::Commit, None, None))
         }
         "ROLLBACK" => {
             if target::word(tokens, start + 1).is_none() && tokens.len() == start + 1 {
-                Ok((MysqlStatementKind::Rollback, None, None))
+                Ok((MySqlStatementKind::Rollback, None, None))
             } else if target::word(tokens, start + 1) == Some("TO") {
                 let name_index = if target::word(tokens, start + 2) == Some("SAVEPOINT") {
                     start + 3
@@ -40,39 +40,39 @@ pub(super) fn classify_mysql_transaction_statement(
                     start + 2
                 };
                 if tokens.len() != name_index + 1 {
-                    return Err(MysqlLexError(
+                    return Err(MySqlLexError(
                         "ROLLBACK modifiers are not supported".to_string(),
                     ));
                 }
                 let (name, database, _) =
                     target::identifier_at(tokens, name_index).ok_or_else(|| {
-                        MysqlLexError("ROLLBACK SAVEPOINT name is ambiguous".to_string())
+                        MySqlLexError("ROLLBACK SAVEPOINT name is ambiguous".to_string())
                     })?;
                 Ok((
-                    MysqlStatementKind::RollbackToSavepoint,
+                    MySqlStatementKind::RollbackToSavepoint,
                     Some(name),
                     database,
                 ))
             } else {
-                Err(MysqlLexError(
+                Err(MySqlLexError(
                     "ROLLBACK modifiers are not supported".to_string(),
                 ))
             }
         }
         "SAVEPOINT" if tokens.len() == start + 2 => {
             let (name, database, _) = target::identifier_at(tokens, start + 1)
-                .ok_or_else(|| MysqlLexError("SAVEPOINT name is ambiguous".to_string()))?;
-            Ok((MysqlStatementKind::Savepoint, Some(name), database))
+                .ok_or_else(|| MySqlLexError("SAVEPOINT name is ambiguous".to_string()))?;
+            Ok((MySqlStatementKind::Savepoint, Some(name), database))
         }
         "RELEASE"
             if target::word(tokens, start + 1) == Some("SAVEPOINT")
                 && tokens.len() == start + 3 =>
         {
             let (name, database, _) = target::identifier_at(tokens, start + 2)
-                .ok_or_else(|| MysqlLexError("RELEASE SAVEPOINT name is ambiguous".to_string()))?;
-            Ok((MysqlStatementKind::ReleaseSavepoint, Some(name), database))
+                .ok_or_else(|| MySqlLexError("RELEASE SAVEPOINT name is ambiguous".to_string()))?;
+            Ok((MySqlStatementKind::ReleaseSavepoint, Some(name), database))
         }
-        _ => Err(MysqlLexError(format!(
+        _ => Err(MySqlLexError(format!(
             "unsupported MySQL statement: {first}"
         ))),
     }

--- a/src/app/policy/write/inline_cell_edit.rs
+++ b/src/app/policy/write/inline_cell_edit.rs
@@ -28,7 +28,7 @@ enum InlineCellEditKind {
     Text,
     SqliteInteger,
     SqliteReal,
-    MysqlNumeric,
+    MySqlNumeric,
 }
 
 pub fn supports_inline_edit(database_type: DatabaseType, value: &QueryValue) -> bool {
@@ -46,7 +46,7 @@ pub fn text_for_inline_edit(
         },
         InlineCellEditKind::SqliteInteger
         | InlineCellEditKind::SqliteReal
-        | InlineCellEditKind::MysqlNumeric => Ok(value.display_value()),
+        | InlineCellEditKind::MySqlNumeric => Ok(value.display_value()),
     }
 }
 
@@ -59,7 +59,7 @@ pub fn build_inline_edited_value(
         InlineCellEditKind::Text => Ok(QueryValue::text(edited_text)),
         InlineCellEditKind::SqliteInteger => parse_sqlite_integer_text(edited_text),
         InlineCellEditKind::SqliteReal => parse_sqlite_real_text(edited_text),
-        InlineCellEditKind::MysqlNumeric => matches_mysql_numeric_lexeme(edited_text)
+        InlineCellEditKind::MySqlNumeric => matches_mysql_numeric_lexeme(edited_text)
             .then(|| QueryValue::SqlLiteral(edited_text.to_string()))
             .ok_or(InlineCellEditError::InvalidNumeric),
     }
@@ -84,7 +84,7 @@ fn classify_mysql_inline_cell_edit(
         QueryValue::Null => Err(InlineCellEditError::NullUnsupported),
         QueryValue::Blob(_) => Err(InlineCellEditError::BlobUnsupported),
         QueryValue::SqlLiteral(value) if matches_mysql_numeric_lexeme(value) => {
-            Ok(InlineCellEditKind::MysqlNumeric)
+            Ok(InlineCellEditKind::MySqlNumeric)
         }
         QueryValue::SqlLiteral(_) => Err(InlineCellEditError::UnsupportedCellType),
     }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -1,7 +1,7 @@
 use super::write_guardrails::{self, RiskLevel};
 use crate::domain::DatabaseType;
 use crate::policy::sql::mysql_statement::{
-    MysqlLexError, MysqlStatement, MysqlStatementKind, classify_mysql_statement,
+    MySqlLexError, MySqlStatement, MySqlStatementKind, classify_mysql_statement,
     has_mysql_read_only_side_effect, has_top_level_into_clause, split_mysql_statements,
     statement_contains_unsupported_mysql_control, target_is_selected_database,
 };
@@ -74,7 +74,7 @@ mod mysql_tests {
 
         assert!(matches!(
             statements[0].kind,
-            MysqlStatementKind::Update { has_where: false }
+            MySqlStatementKind::Update { has_where: false }
         ));
         assert_eq!(statements[1].sql, "SELECT 2");
     }
@@ -82,13 +82,13 @@ mod mysql_tests {
     #[test]
     fn distinguishes_persistent_mysql_schema_changes_from_temporary_tables() {
         assert!(mysql_statement_is_persistent_schema_change(
-            &MysqlStatementKind::CreateTable { temporary: false }
+            &MySqlStatementKind::CreateTable { temporary: false }
         ));
         assert!(!mysql_statement_is_persistent_schema_change(
-            &MysqlStatementKind::CreateTable { temporary: true }
+            &MySqlStatementKind::CreateTable { temporary: true }
         ));
         assert!(!mysql_statement_is_persistent_schema_change(
-            &MysqlStatementKind::DropTable { temporary: true }
+            &MySqlStatementKind::DropTable { temporary: true }
         ));
     }
 
@@ -122,25 +122,25 @@ mod mysql_tests {
         let cases = [
             (
                 "RENAME TABLE items TO archived_items",
-                MysqlStatementKind::RenameTable,
+                MySqlStatementKind::RenameTable,
                 RiskLevel::Medium,
                 "RENAME TABLE",
             ),
             (
                 "CREATE OR REPLACE VIEW item_view AS SELECT 1",
-                MysqlStatementKind::CreateView,
+                MySqlStatementKind::CreateView,
                 RiskLevel::Low,
                 "CREATE VIEW",
             ),
             (
                 "ALTER VIEW item_view AS SELECT 1",
-                MysqlStatementKind::AlterView,
+                MySqlStatementKind::AlterView,
                 RiskLevel::Medium,
                 "ALTER VIEW",
             ),
             (
                 "CREATE FULLTEXT INDEX item_text ON items (body)",
-                MysqlStatementKind::CreateIndex,
+                MySqlStatementKind::CreateIndex,
                 RiskLevel::Low,
                 "CREATE INDEX",
             ),
@@ -530,7 +530,7 @@ fn mysql_low(read_only_allowed: bool) -> SqlRiskDecision {
     }
 }
 
-fn mysql_table_name_input(statement: &MysqlStatement) -> SqlRiskDecision {
+fn mysql_table_name_input(statement: &MySqlStatement) -> SqlRiskDecision {
     match statement.target.as_deref() {
         Some(target) => SqlRiskDecision {
             risk_level: RiskLevel::High,
@@ -550,114 +550,114 @@ fn mysql_table_name_input(statement: &MysqlStatement) -> SqlRiskDecision {
     }
 }
 
-fn mysql_statement_risk(statement: &MysqlStatement) -> SqlRiskDecision {
+fn mysql_statement_risk(statement: &MySqlStatement) -> SqlRiskDecision {
     match statement.kind {
-        MysqlStatementKind::Select
-        | MysqlStatementKind::Table
-        | MysqlStatementKind::Show
-        | MysqlStatementKind::Describe => {
+        MySqlStatementKind::Select
+        | MySqlStatementKind::Table
+        | MySqlStatementKind::Show
+        | MySqlStatementKind::Describe => {
             mysql_low(!has_mysql_read_only_side_effect(&statement.sql).unwrap_or(true))
         }
-        MysqlStatementKind::Begin
-        | MysqlStatementKind::StartTransaction
-        | MysqlStatementKind::Commit
-        | MysqlStatementKind::Rollback
-        | MysqlStatementKind::Savepoint
-        | MysqlStatementKind::RollbackToSavepoint
-        | MysqlStatementKind::ReleaseSavepoint
-        | MysqlStatementKind::Insert
-        | MysqlStatementKind::CreateTable { .. }
-        | MysqlStatementKind::CreateView
-        | MysqlStatementKind::CreateIndex => mysql_low(false),
-        MysqlStatementKind::Update { has_where: true }
-        | MysqlStatementKind::Delete { has_where: true }
-        | MysqlStatementKind::AlterTable
-        | MysqlStatementKind::RenameTable
-        | MysqlStatementKind::AlterView => SqlRiskDecision {
+        MySqlStatementKind::Begin
+        | MySqlStatementKind::StartTransaction
+        | MySqlStatementKind::Commit
+        | MySqlStatementKind::Rollback
+        | MySqlStatementKind::Savepoint
+        | MySqlStatementKind::RollbackToSavepoint
+        | MySqlStatementKind::ReleaseSavepoint
+        | MySqlStatementKind::Insert
+        | MySqlStatementKind::CreateTable { .. }
+        | MySqlStatementKind::CreateView
+        | MySqlStatementKind::CreateIndex => mysql_low(false),
+        MySqlStatementKind::Update { has_where: true }
+        | MySqlStatementKind::Delete { has_where: true }
+        | MySqlStatementKind::AlterTable
+        | MySqlStatementKind::RenameTable
+        | MySqlStatementKind::AlterView => SqlRiskDecision {
             risk_level: RiskLevel::Medium,
             confirmation: ConfirmationType::Immediate,
             read_only_allowed: false,
         },
-        MysqlStatementKind::Replace
-        | MysqlStatementKind::Update { has_where: false }
-        | MysqlStatementKind::Delete { has_where: false }
-        | MysqlStatementKind::DropTable { .. }
-        | MysqlStatementKind::DropView
-        | MysqlStatementKind::DropIndex
-        | MysqlStatementKind::TruncateTable => mysql_table_name_input(statement),
+        MySqlStatementKind::Replace
+        | MySqlStatementKind::Update { has_where: false }
+        | MySqlStatementKind::Delete { has_where: false }
+        | MySqlStatementKind::DropTable { .. }
+        | MySqlStatementKind::DropView
+        | MySqlStatementKind::DropIndex
+        | MySqlStatementKind::TruncateTable => mysql_table_name_input(statement),
     }
 }
 
-pub fn mysql_statement_label(kind: &MysqlStatementKind) -> &'static str {
+pub fn mysql_statement_label(kind: &MySqlStatementKind) -> &'static str {
     match kind {
-        MysqlStatementKind::Select => "SELECT",
-        MysqlStatementKind::Table => "TABLE",
-        MysqlStatementKind::Show => "SHOW",
-        MysqlStatementKind::Describe => "DESCRIBE",
-        MysqlStatementKind::Insert => "INSERT",
-        MysqlStatementKind::Replace => "REPLACE",
-        MysqlStatementKind::Update { has_where: true } => "UPDATE",
-        MysqlStatementKind::Update { has_where: false } => "UPDATE (no WHERE)",
-        MysqlStatementKind::Delete { has_where: true } => "DELETE",
-        MysqlStatementKind::Delete { has_where: false } => "DELETE (no WHERE)",
-        MysqlStatementKind::CreateTable { temporary: true } => "CREATE TEMPORARY TABLE",
-        MysqlStatementKind::CreateTable { temporary: false } => "CREATE TABLE",
-        MysqlStatementKind::AlterTable => "ALTER TABLE",
-        MysqlStatementKind::RenameTable => "RENAME TABLE",
-        MysqlStatementKind::DropTable { temporary: true } => "DROP TEMPORARY TABLE",
-        MysqlStatementKind::DropTable { temporary: false } => "DROP TABLE",
-        MysqlStatementKind::TruncateTable => "TRUNCATE TABLE",
-        MysqlStatementKind::CreateView => "CREATE VIEW",
-        MysqlStatementKind::AlterView => "ALTER VIEW",
-        MysqlStatementKind::DropView => "DROP VIEW",
-        MysqlStatementKind::CreateIndex => "CREATE INDEX",
-        MysqlStatementKind::DropIndex => "DROP INDEX",
-        MysqlStatementKind::Begin => "BEGIN",
-        MysqlStatementKind::StartTransaction => "START TRANSACTION",
-        MysqlStatementKind::Commit => "COMMIT",
-        MysqlStatementKind::Rollback => "ROLLBACK",
-        MysqlStatementKind::Savepoint => "SAVEPOINT",
-        MysqlStatementKind::RollbackToSavepoint => "ROLLBACK TO SAVEPOINT",
-        MysqlStatementKind::ReleaseSavepoint => "RELEASE SAVEPOINT",
+        MySqlStatementKind::Select => "SELECT",
+        MySqlStatementKind::Table => "TABLE",
+        MySqlStatementKind::Show => "SHOW",
+        MySqlStatementKind::Describe => "DESCRIBE",
+        MySqlStatementKind::Insert => "INSERT",
+        MySqlStatementKind::Replace => "REPLACE",
+        MySqlStatementKind::Update { has_where: true } => "UPDATE",
+        MySqlStatementKind::Update { has_where: false } => "UPDATE (no WHERE)",
+        MySqlStatementKind::Delete { has_where: true } => "DELETE",
+        MySqlStatementKind::Delete { has_where: false } => "DELETE (no WHERE)",
+        MySqlStatementKind::CreateTable { temporary: true } => "CREATE TEMPORARY TABLE",
+        MySqlStatementKind::CreateTable { temporary: false } => "CREATE TABLE",
+        MySqlStatementKind::AlterTable => "ALTER TABLE",
+        MySqlStatementKind::RenameTable => "RENAME TABLE",
+        MySqlStatementKind::DropTable { temporary: true } => "DROP TEMPORARY TABLE",
+        MySqlStatementKind::DropTable { temporary: false } => "DROP TABLE",
+        MySqlStatementKind::TruncateTable => "TRUNCATE TABLE",
+        MySqlStatementKind::CreateView => "CREATE VIEW",
+        MySqlStatementKind::AlterView => "ALTER VIEW",
+        MySqlStatementKind::DropView => "DROP VIEW",
+        MySqlStatementKind::CreateIndex => "CREATE INDEX",
+        MySqlStatementKind::DropIndex => "DROP INDEX",
+        MySqlStatementKind::Begin => "BEGIN",
+        MySqlStatementKind::StartTransaction => "START TRANSACTION",
+        MySqlStatementKind::Commit => "COMMIT",
+        MySqlStatementKind::Rollback => "ROLLBACK",
+        MySqlStatementKind::Savepoint => "SAVEPOINT",
+        MySqlStatementKind::RollbackToSavepoint => "ROLLBACK TO SAVEPOINT",
+        MySqlStatementKind::ReleaseSavepoint => "RELEASE SAVEPOINT",
     }
 }
 
-pub fn mysql_statement_is_schema_modifying(kind: &MysqlStatementKind) -> bool {
+pub fn mysql_statement_is_schema_modifying(kind: &MySqlStatementKind) -> bool {
     matches!(
         kind,
-        MysqlStatementKind::CreateTable { .. }
-            | MysqlStatementKind::AlterTable
-            | MysqlStatementKind::RenameTable
-            | MysqlStatementKind::DropTable { .. }
-            | MysqlStatementKind::TruncateTable
-            | MysqlStatementKind::CreateView
-            | MysqlStatementKind::AlterView
-            | MysqlStatementKind::DropView
-            | MysqlStatementKind::CreateIndex
-            | MysqlStatementKind::DropIndex
+        MySqlStatementKind::CreateTable { .. }
+            | MySqlStatementKind::AlterTable
+            | MySqlStatementKind::RenameTable
+            | MySqlStatementKind::DropTable { .. }
+            | MySqlStatementKind::TruncateTable
+            | MySqlStatementKind::CreateView
+            | MySqlStatementKind::AlterView
+            | MySqlStatementKind::DropView
+            | MySqlStatementKind::CreateIndex
+            | MySqlStatementKind::DropIndex
     )
 }
 
-pub fn mysql_statement_is_data_modifying(kind: &MysqlStatementKind) -> bool {
+pub fn mysql_statement_is_data_modifying(kind: &MySqlStatementKind) -> bool {
     matches!(
         kind,
-        MysqlStatementKind::Insert
-            | MysqlStatementKind::Replace
-            | MysqlStatementKind::Update { .. }
-            | MysqlStatementKind::Delete { .. }
+        MySqlStatementKind::Insert
+            | MySqlStatementKind::Replace
+            | MySqlStatementKind::Update { .. }
+            | MySqlStatementKind::Delete { .. }
     )
 }
 
-pub fn mysql_statement_is_persistent_schema_change(kind: &MysqlStatementKind) -> bool {
+pub fn mysql_statement_is_persistent_schema_change(kind: &MySqlStatementKind) -> bool {
     mysql_statement_is_schema_modifying(kind)
         && !matches!(
             kind,
-            MysqlStatementKind::CreateTable { temporary: true }
-                | MysqlStatementKind::DropTable { temporary: true }
+            MySqlStatementKind::CreateTable { temporary: true }
+                | MySqlStatementKind::DropTable { temporary: true }
         )
 }
 
-fn mysql_target_key(statement: &MysqlStatement, selected_database: Option<&str>) -> Option<String> {
+fn mysql_target_key(statement: &MySqlStatement, selected_database: Option<&str>) -> Option<String> {
     Some(format!(
         "{}:{}",
         statement
@@ -671,7 +671,7 @@ fn mysql_target_key(statement: &MysqlStatement, selected_database: Option<&str>)
 }
 
 fn mysql_validate_submission_state(
-    planned: &[(MysqlStatement, SqlRiskDecision)],
+    planned: &[(MySqlStatement, SqlRiskDecision)],
     selected_database: Option<&str>,
 ) -> Result<(), String> {
     let mut transaction_open = false;
@@ -680,18 +680,18 @@ fn mysql_validate_submission_state(
 
     for (statement, _) in planned {
         match &statement.kind {
-            MysqlStatementKind::Begin | MysqlStatementKind::StartTransaction => {
+            MySqlStatementKind::Begin | MySqlStatementKind::StartTransaction => {
                 if transaction_open {
                     return Err("nested MySQL transactions are not supported".to_string());
                 }
                 transaction_open = true;
                 savepoints.clear();
             }
-            MysqlStatementKind::Commit | MysqlStatementKind::Rollback => {
+            MySqlStatementKind::Commit | MySqlStatementKind::Rollback => {
                 transaction_open = false;
                 savepoints.clear();
             }
-            MysqlStatementKind::Savepoint => {
+            MySqlStatementKind::Savepoint => {
                 if !transaction_open {
                     return Err("MySQL SAVEPOINT requires an explicit transaction".to_string());
                 }
@@ -702,7 +702,7 @@ fn mysql_validate_submission_state(
                 savepoints.retain(|current| !current.eq_ignore_ascii_case(name));
                 savepoints.push(name.to_string());
             }
-            MysqlStatementKind::RollbackToSavepoint => {
+            MySqlStatementKind::RollbackToSavepoint => {
                 if !transaction_open {
                     return Err(
                         "MySQL ROLLBACK TO SAVEPOINT requires an explicit transaction".to_string(),
@@ -720,7 +720,7 @@ fn mysql_validate_submission_state(
                 };
                 savepoints.truncate(index + 1);
             }
-            MysqlStatementKind::ReleaseSavepoint => {
+            MySqlStatementKind::ReleaseSavepoint => {
                 if !transaction_open {
                     return Err(
                         "MySQL RELEASE SAVEPOINT requires an explicit transaction".to_string()
@@ -738,7 +738,7 @@ fn mysql_validate_submission_state(
                 };
                 savepoints.remove(index);
             }
-            MysqlStatementKind::CreateTable { temporary: true } => {
+            MySqlStatementKind::CreateTable { temporary: true } => {
                 let key = mysql_target_key(statement, selected_database)
                     .ok_or_else(|| "MySQL temporary table target is ambiguous".to_string())?;
                 if temporary_tables.iter().any(|current| current == &key) {
@@ -746,7 +746,7 @@ fn mysql_validate_submission_state(
                 }
                 temporary_tables.push(key);
             }
-            MysqlStatementKind::DropTable { temporary: true } => {
+            MySqlStatementKind::DropTable { temporary: true } => {
                 let key = mysql_target_key(statement, selected_database)
                     .ok_or_else(|| "MySQL temporary table target is ambiguous".to_string())?;
                 let Some(index) = temporary_tables.iter().position(|current| current == &key)
@@ -777,7 +777,7 @@ fn mysql_validate_submission_state(
 pub fn evaluate_mysql_multi_statement(
     sql: &str,
     selected_database: Option<&str>,
-) -> MultiStatementDecision<MysqlStatement> {
+) -> MultiStatementDecision<MySqlStatement> {
     if statement_contains_unsupported_mysql_control(sql) {
         return MultiStatementDecision::Block {
             reason: "unsupported MySQL session or table-lock statement".to_string(),
@@ -807,14 +807,14 @@ pub fn evaluate_mysql_multi_statement(
                 };
             }
         };
-        if matches!(statement.kind, MysqlStatementKind::Replace) {
+        if matches!(statement.kind, MySqlStatementKind::Replace) {
             return MultiStatementDecision::Block {
                 reason: "MySQL REPLACE execution is not supported".to_string(),
             };
         }
         if matches!(
             statement.kind,
-            MysqlStatementKind::Select | MysqlStatementKind::Table
+            MySqlStatementKind::Select | MySqlStatementKind::Table
         ) && has_top_level_into_clause(&statement.sql).unwrap_or(true)
         {
             return MultiStatementDecision::Block {
@@ -955,7 +955,7 @@ pub fn split_statements(sql: &str) -> Vec<String> {
 pub fn split_statements_for_database(
     database_type: DatabaseType,
     sql: &str,
-) -> Result<Vec<String>, MysqlLexError> {
+) -> Result<Vec<String>, MySqlLexError> {
     if database_type == DatabaseType::MySQL {
         return split_mysql_statements(sql);
     }
@@ -1173,7 +1173,7 @@ pub fn evaluate_mysql_explain_analyze_target(sql: &str) -> Option<SqlRiskDecisio
     let statement = classify_mysql_statement(&statements[0]).ok()?;
     if !matches!(
         statement.kind,
-        MysqlStatementKind::Select | MysqlStatementKind::Table
+        MySqlStatementKind::Select | MySqlStatementKind::Table
     ) {
         return None;
     }

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -6,7 +6,7 @@ use crate::domain::{DatabaseType, QuerySource, QueryValue};
 use crate::model::app_state::AppState;
 use crate::model::shared::confirm_dialog::{ConfirmIntent, CsvExportCacheSnapshot};
 use crate::model::shared::input_mode::InputMode;
-use crate::policy::sql::mysql_export::{MysqlExportPlan, mysql_export_plan};
+use crate::policy::sql::mysql_export::{MySqlExportPlan, mysql_export_plan};
 use crate::policy::sql::sqlite_export::{SqliteExportPlan, sqlite_export_plan};
 use crate::services::AppServices;
 use crate::update::action::Action;
@@ -211,8 +211,8 @@ pub fn reduce_pagination(
                     return DispatchResult::handled();
                 };
                 let row_count = match plan {
-                    MysqlExportPlan::CountRows => RerunnableCsvRowCount::QueryDatabase,
-                    MysqlExportPlan::UseResultRowCount => RerunnableCsvRowCount::Known(row_count),
+                    MySqlExportPlan::CountRows => RerunnableCsvRowCount::QueryDatabase,
+                    MySqlExportPlan::UseResultRowCount => RerunnableCsvRowCount::Known(row_count),
                 };
                 let run_id = state.query.begin_running(now);
                 return dispatch_rerunnable_csv_export(

--- a/src/infra/adapters/mysql/cli/error.rs
+++ b/src/infra/adapters/mysql/cli/error.rs
@@ -3,7 +3,7 @@ use std::io::{self, Write};
 use crate::app::ports::outbound::DbOperationError;
 
 use super::probe::{is_mysql_connect_timeout_message, mysql_tls_failure_kind, validate_sql_mode};
-use super::xml::MysqlResultSet;
+use super::xml::MySqlResultSet;
 
 pub(super) fn has_mysql_cli_error(output: &[u8]) -> bool {
     output
@@ -40,7 +40,7 @@ pub(super) fn write_mysql_transcript_line(line: &str) {
 }
 
 pub(super) fn validate_mode_probe(
-    result: &MysqlResultSet,
+    result: &MySqlResultSet,
     marker: &str,
 ) -> Result<(), DbOperationError> {
     if result.values.len() != 1 || result.columns != ["__sabiql_probe", "__sabiql_sql_mode"] {

--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -15,16 +15,16 @@ use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use super::super::{dsn::MySqlDsn, option_file::MySqlOptionFile};
 use super::error::{classify_mysql_query_failure, has_mysql_cli_error, validate_mode_probe};
 #[cfg(not(unix))]
-use super::pipe::MysqlExportPipeSource;
+use super::pipe::MySqlExportPipeSource;
 use super::policy::mysql_metadata_fallback_kind;
 use super::process::{
-    MYSQL_QUERY_TIMEOUT, MysqlProcess, configure_mysql_session, finish_mysql_session_after_result,
+    MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session_after_result,
     mysql_metadata_columns, read_one_mysql_resultset, run_mysql_process_with_timeout,
     write_mysql_statement,
 };
 #[cfg(unix)]
-use super::pty::MysqlExportPtySource;
-use super::xml::{MysqlField, decode_mysql_xml_reference, parse_mysql_field, parse_mysql_xml};
+use super::pty::MySqlExportPtySource;
+use super::xml::{MySqlField, decode_mysql_xml_reference, parse_mysql_field, parse_mysql_xml};
 
 const MYSQL_EXPORT_TIMEOUT: Duration = Duration::from_secs(MYSQL_QUERY_TIMEOUT.as_secs() * 10);
 
@@ -34,7 +34,7 @@ pub(in crate::adapters::mysql) async fn export_mysql_csv_to_file(
     path: PathBuf,
 ) -> Result<(), DbOperationError> {
     let option_file = MySqlOptionFile::create(&target)?;
-    let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
+    let mut process = MySqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
     run_mysql_process_with_timeout(MYSQL_EXPORT_TIMEOUT, &mut process, async |process| {
         run_mysql_export_process(process, &option_file.path, query, path).await
     })
@@ -42,7 +42,7 @@ pub(in crate::adapters::mysql) async fn export_mysql_csv_to_file(
 }
 
 pub(super) async fn run_mysql_export_process(
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
     option_file: &std::path::Path,
     query: &str,
     path: PathBuf,
@@ -99,17 +99,17 @@ fn validate_mysql_export_exit(
 }
 
 async fn stream_mysql_resultset_to_csv(
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
     csv_writer: &mut CsvFileWriter,
 ) -> Result<Option<Vec<String>>, DbOperationError> {
     #[cfg(unix)]
     {
-        let source = MysqlExportPtySource {
+        let source = MySqlExportPtySource {
             pty: &mut process.pty,
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: super::xml::MysqlResultsetFrameScanner::default(),
+            frame_scanner: super::xml::MySqlResultsetFrameScanner::default(),
             started: false,
         };
         let mut reader = Reader::from_reader(BufReader::new(source));
@@ -128,7 +128,7 @@ async fn stream_mysql_resultset_to_csv(
 
     #[cfg(not(unix))]
     {
-        let source = MysqlExportPipeSource {
+        let source = MySqlExportPipeSource {
             stdout: &mut process.stdout,
             stderr: &mut process.stderr,
             pending: &mut process.pending,
@@ -162,7 +162,7 @@ where
     let mut resultset_count = 0;
     let mut in_resultset = false;
     let mut current_row: Option<Vec<(String, String)>> = None;
-    let mut current_field: Option<MysqlField> = None;
+    let mut current_field: Option<MySqlField> = None;
     let mut columns: Option<Vec<String>> = None;
 
     loop {

--- a/src/infra/adapters/mysql/cli/mod.rs
+++ b/src/infra/adapters/mysql/cli/mod.rs
@@ -14,14 +14,14 @@ pub(super) use export::export_mysql_csv_to_file;
 pub(super) use policy::{validate_mysql_export_query, validate_mysql_multi_query};
 pub(super) use probe::{check_mysql_cli_version, probe_mysql_server};
 pub(super) use process::{
-    MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, run_mysql_adhoc, run_mysql_single_statement,
+    MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, run_mysql_adhoc, run_mysql_single_statement,
 };
-pub(super) use xml::MysqlResultSet;
+pub(super) use xml::MySqlResultSet;
 
 #[cfg(all(unix, feature = "test-support"))]
 pub(super) use process::run_mysql_cli_script_for_test;
 
 #[cfg(test)]
 pub(super) mod test_support {
-    pub(in crate::adapters::mysql) use super::process::MysqlProcess;
+    pub(in crate::adapters::mysql) use super::process::MySqlProcess;
 }

--- a/src/infra/adapters/mysql/cli/pipe.rs
+++ b/src/infra/adapters/mysql/cli/pipe.rs
@@ -8,10 +8,10 @@ use crate::app::ports::outbound::DbOperationError;
 
 use super::error::{classify_mysql_query_failure, has_mysql_cli_error};
 use super::xml::{
-    MysqlResultsetFrameScanner, take_mysql_resultset_frame_after_error_check, trace_mysql_frame,
+    MySqlResultsetFrameScanner, take_mysql_resultset_frame_after_error_check, trace_mysql_frame,
 };
 
-pub(super) struct MysqlExportPipeSource<'a, O, E> {
+pub(super) struct MySqlExportPipeSource<'a, O, E> {
     pub(super) stdout: &'a mut O,
     pub(super) stderr: &'a mut E,
     pub(super) pending: &'a mut Vec<u8>,
@@ -21,7 +21,7 @@ pub(super) struct MysqlExportPipeSource<'a, O, E> {
     pub(super) stdout_closed: bool,
 }
 
-impl<O, E> MysqlExportPipeSource<'_, O, E>
+impl<O, E> MySqlExportPipeSource<'_, O, E>
 where
     O: AsyncRead + Unpin,
     E: AsyncRead + Unpin,
@@ -61,7 +61,7 @@ where
     }
 }
 
-impl<O, E> AsyncRead for MysqlExportPipeSource<'_, O, E>
+impl<O, E> AsyncRead for MySqlExportPipeSource<'_, O, E>
 where
     O: AsyncRead + Unpin,
     E: AsyncRead + Unpin,
@@ -125,7 +125,7 @@ pub(super) async fn read_one_mysql_resultset_from_pipes<R, E>(
     child: &mut tokio::process::Child,
     pending: &mut Vec<u8>,
     pending_stderr: &mut Vec<u8>,
-    frame_scanner: &mut MysqlResultsetFrameScanner,
+    frame_scanner: &mut MySqlResultsetFrameScanner,
 ) -> Result<Vec<u8>, DbOperationError>
 where
     R: AsyncRead + Unpin,
@@ -245,7 +245,7 @@ mod tests {
             .unwrap();
         drop(stdout_writer);
         drop(stderr_writer);
-        let mut frame_scanner = MysqlResultsetFrameScanner::default();
+        let mut frame_scanner = MySqlResultsetFrameScanner::default();
         let mut child = exited_child();
 
         let result = read_one_mysql_resultset_from_pipes(
@@ -279,7 +279,7 @@ mod tests {
         let mut stderr = child.stderr.take().expect("piped stderr");
         let mut pending = Vec::new();
         let mut pending_stderr = Vec::new();
-        let mut frame_scanner = MysqlResultsetFrameScanner::default();
+        let mut frame_scanner = MySqlResultsetFrameScanner::default();
 
         let result = read_one_mysql_resultset_from_pipes(
             &mut stdout,
@@ -314,7 +314,7 @@ mod tests {
             stderr_writer.write_all(&stderr).await.unwrap();
         });
 
-        let mut source = MysqlExportPipeSource {
+        let mut source = MySqlExportPipeSource {
             stdout: &mut stdout_reader,
             stderr: &mut stderr_reader,
             pending: &mut Vec::new(),

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::app::policy::sql::mysql_statement::{
-    MysqlStatement, MysqlStatementKind, has_mysql_read_only_side_effect,
+    MySqlStatement, MySqlStatementKind, has_mysql_read_only_side_effect,
 };
 use crate::app::policy::write::sql_risk::{
     MultiStatementDecision, evaluate_mysql_multi_statement, mysql_statement_is_data_modifying,
@@ -11,12 +11,12 @@ use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{CommandTag, QueryValue, RefreshScope};
 
 use super::super::sql;
-use super::xml::MysqlResultSet;
+use super::xml::MySqlResultSet;
 
 pub(super) const MYSQL_SESSION_MARKER_COLUMN: &str = "__sabiql_session_marker";
 
 #[derive(Debug, Clone, Copy)]
-pub(super) enum MysqlMetadataFallbackKind {
+pub(super) enum MySqlMetadataFallbackKind {
     Select,
     Table,
     Show,
@@ -24,14 +24,14 @@ pub(super) enum MysqlMetadataFallbackKind {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub(in crate::adapters::mysql) struct MysqlExecutionResult {
-    pub(in crate::adapters::mysql) result_set: Option<MysqlResultSet>,
+pub(in crate::adapters::mysql) struct MySqlExecutionResult {
+    pub(in crate::adapters::mysql) result_set: Option<MySqlResultSet>,
     pub(in crate::adapters::mysql) command_tag: Option<CommandTag>,
     pub(in crate::adapters::mysql) refresh_scope: RefreshScope,
 }
 
-pub(super) struct MysqlCommandEvent {
-    pub(super) kind: MysqlStatementKind,
+pub(super) struct MySqlCommandEvent {
+    pub(super) kind: MySqlStatementKind,
     pub(super) target: Option<String>,
     pub(super) tag: CommandTag,
 }
@@ -40,7 +40,7 @@ pub(in crate::adapters::mysql) fn validate_mysql_multi_query(
     query: &str,
     selected_database: Option<&str>,
     access_mode: AccessMode,
-) -> Result<Vec<MysqlStatement>, DbOperationError> {
+) -> Result<Vec<MySqlStatement>, DbOperationError> {
     let decision = evaluate_mysql_multi_statement(query, selected_database);
     let (statements, risk) = match decision {
         MultiStatementDecision::Allow { statements, risk } => (statements, risk),
@@ -64,10 +64,10 @@ pub(in crate::adapters::mysql) fn validate_mysql_export_query(
     if statements.len() != 1
         || !matches!(
             statements[0].kind,
-            MysqlStatementKind::Select
-                | MysqlStatementKind::Table
-                | MysqlStatementKind::Show
-                | MysqlStatementKind::Describe
+            MySqlStatementKind::Select
+                | MySqlStatementKind::Table
+                | MySqlStatementKind::Show
+                | MySqlStatementKind::Describe
         )
     {
         return Err(DbOperationError::UnsupportedOperation(
@@ -78,33 +78,33 @@ pub(in crate::adapters::mysql) fn validate_mysql_export_query(
 }
 
 pub(super) fn mysql_metadata_fallback_kind(
-    kind: &MysqlStatementKind,
-) -> Option<MysqlMetadataFallbackKind> {
+    kind: &MySqlStatementKind,
+) -> Option<MySqlMetadataFallbackKind> {
     match kind {
-        MysqlStatementKind::Select => Some(MysqlMetadataFallbackKind::Select),
-        MysqlStatementKind::Table => Some(MysqlMetadataFallbackKind::Table),
-        MysqlStatementKind::Show => Some(MysqlMetadataFallbackKind::Show),
-        MysqlStatementKind::Describe => Some(MysqlMetadataFallbackKind::Describe),
+        MySqlStatementKind::Select => Some(MySqlMetadataFallbackKind::Select),
+        MySqlStatementKind::Table => Some(MySqlMetadataFallbackKind::Table),
+        MySqlStatementKind::Show => Some(MySqlMetadataFallbackKind::Show),
+        MySqlStatementKind::Describe => Some(MySqlMetadataFallbackKind::Describe),
         _ => None,
     }
 }
 
 pub(super) fn mysql_metadata_fallback_has_unsupported_session_state(
-    statements: &[MysqlStatement],
+    statements: &[MySqlStatement],
 ) -> bool {
     let mut temporary_table_created = false;
     for statement in statements {
         if temporary_table_created
             && matches!(
                 statement.kind,
-                MysqlStatementKind::Show | MysqlStatementKind::Describe
+                MySqlStatementKind::Show | MySqlStatementKind::Describe
             )
         {
             return true;
         }
         if matches!(
             statement.kind,
-            MysqlStatementKind::CreateTable { temporary: true }
+            MySqlStatementKind::CreateTable { temporary: true }
         ) {
             temporary_table_created = true;
         }
@@ -139,7 +139,7 @@ pub(super) fn mysql_metadata_select_query(
 }
 
 pub(super) fn validate_mysql_session_marker(
-    result: &MysqlResultSet,
+    result: &MySqlResultSet,
     marker: &str,
 ) -> Result<(), DbOperationError> {
     if result.columns != [MYSQL_SESSION_MARKER_COLUMN]
@@ -194,14 +194,14 @@ fn is_mysql_statement_failure(error: &DbOperationError) -> bool {
     )
 }
 
-pub(super) fn is_mysql_row_count_marker(result: &MysqlResultSet, marker: &str) -> bool {
+pub(super) fn is_mysql_row_count_marker(result: &MySqlResultSet, marker: &str) -> bool {
     result.columns == ["__sabiql_marker", "affected_rows"]
         && result.values.len() == 1
         && result.values[0].first().and_then(QueryValue::as_str) == Some(marker)
 }
 
 pub(super) fn mysql_row_count_marker(
-    result: &MysqlResultSet,
+    result: &MySqlResultSet,
     marker: &str,
 ) -> Result<i64, DbOperationError> {
     if !is_mysql_row_count_marker(result, marker) || result.values[0].len() != 2 {
@@ -218,51 +218,51 @@ pub(super) fn mysql_row_count_marker(
 }
 
 pub(super) fn mysql_command_tag(
-    kind: &MysqlStatementKind,
+    kind: &MySqlStatementKind,
     affected_rows: i64,
-    user_result: Option<&MysqlResultSet>,
+    user_result: Option<&MySqlResultSet>,
 ) -> CommandTag {
     let rows = || u64::try_from(affected_rows.max(0)).unwrap_or(0);
     match kind {
-        MysqlStatementKind::Select
-        | MysqlStatementKind::Table
-        | MysqlStatementKind::Show
-        | MysqlStatementKind::Describe => {
+        MySqlStatementKind::Select
+        | MySqlStatementKind::Table
+        | MySqlStatementKind::Show
+        | MySqlStatementKind::Describe => {
             CommandTag::Select(user_result.map_or(0, |result| result.values.len() as u64))
         }
-        MysqlStatementKind::Insert | MysqlStatementKind::Replace => CommandTag::Insert(rows()),
-        MysqlStatementKind::Update { .. } => CommandTag::Update(rows()),
-        MysqlStatementKind::Delete { .. } => CommandTag::Delete(rows()),
-        MysqlStatementKind::CreateTable { temporary: true } => {
+        MySqlStatementKind::Insert | MySqlStatementKind::Replace => CommandTag::Insert(rows()),
+        MySqlStatementKind::Update { .. } => CommandTag::Update(rows()),
+        MySqlStatementKind::Delete { .. } => CommandTag::Delete(rows()),
+        MySqlStatementKind::CreateTable { temporary: true } => {
             CommandTag::Other("CREATE TEMPORARY TABLE".to_string())
         }
-        MysqlStatementKind::CreateTable { temporary: false } => {
+        MySqlStatementKind::CreateTable { temporary: false } => {
             CommandTag::Create("TABLE".to_string())
         }
-        MysqlStatementKind::AlterTable | MysqlStatementKind::RenameTable => {
+        MySqlStatementKind::AlterTable | MySqlStatementKind::RenameTable => {
             CommandTag::Alter("TABLE".to_string())
         }
-        MysqlStatementKind::DropTable { temporary: true } => {
+        MySqlStatementKind::DropTable { temporary: true } => {
             CommandTag::Other("DROP TEMPORARY TABLE".to_string())
         }
-        MysqlStatementKind::DropTable { temporary: false } => CommandTag::Drop("TABLE".to_string()),
-        MysqlStatementKind::TruncateTable => CommandTag::Truncate,
-        MysqlStatementKind::CreateView => CommandTag::Create("VIEW".to_string()),
-        MysqlStatementKind::AlterView => CommandTag::Alter("VIEW".to_string()),
-        MysqlStatementKind::DropView => CommandTag::Drop("VIEW".to_string()),
-        MysqlStatementKind::CreateIndex => CommandTag::Create("INDEX".to_string()),
-        MysqlStatementKind::DropIndex => CommandTag::Drop("INDEX".to_string()),
-        MysqlStatementKind::Begin | MysqlStatementKind::StartTransaction => CommandTag::Begin,
-        MysqlStatementKind::Commit => CommandTag::Commit,
-        MysqlStatementKind::Rollback | MysqlStatementKind::RollbackToSavepoint => {
+        MySqlStatementKind::DropTable { temporary: false } => CommandTag::Drop("TABLE".to_string()),
+        MySqlStatementKind::TruncateTable => CommandTag::Truncate,
+        MySqlStatementKind::CreateView => CommandTag::Create("VIEW".to_string()),
+        MySqlStatementKind::AlterView => CommandTag::Alter("VIEW".to_string()),
+        MySqlStatementKind::DropView => CommandTag::Drop("VIEW".to_string()),
+        MySqlStatementKind::CreateIndex => CommandTag::Create("INDEX".to_string()),
+        MySqlStatementKind::DropIndex => CommandTag::Drop("INDEX".to_string()),
+        MySqlStatementKind::Begin | MySqlStatementKind::StartTransaction => CommandTag::Begin,
+        MySqlStatementKind::Commit => CommandTag::Commit,
+        MySqlStatementKind::Rollback | MySqlStatementKind::RollbackToSavepoint => {
             CommandTag::Rollback
         }
-        MysqlStatementKind::Savepoint => CommandTag::Other("SAVEPOINT".to_string()),
-        MysqlStatementKind::ReleaseSavepoint => CommandTag::Other("RELEASE SAVEPOINT".to_string()),
+        MySqlStatementKind::Savepoint => CommandTag::Other("SAVEPOINT".to_string()),
+        MySqlStatementKind::ReleaseSavepoint => CommandTag::Other("RELEASE SAVEPOINT".to_string()),
     }
 }
 
-pub(super) fn mysql_refresh_scope(kind: &MysqlStatementKind) -> RefreshScope {
+pub(super) fn mysql_refresh_scope(kind: &MySqlStatementKind) -> RefreshScope {
     if mysql_statement_is_persistent_schema_change(kind) {
         RefreshScope::Metadata
     } else if mysql_statement_is_data_modifying(kind) {
@@ -273,13 +273,13 @@ pub(super) fn mysql_refresh_scope(kind: &MysqlStatementKind) -> RefreshScope {
 }
 
 #[derive(Default)]
-struct MysqlPendingTransactionTags {
+struct MySqlPendingTransactionTags {
     data: Vec<CommandTag>,
     savepoints: Vec<(String, usize)>,
 }
 
 fn apply_pending_mysql_data(
-    pending: MysqlPendingTransactionTags,
+    pending: MySqlPendingTransactionTags,
     committed_data: &mut Option<CommandTag>,
 ) {
     if let Some(tag) = pending.data.last() {
@@ -287,7 +287,7 @@ fn apply_pending_mysql_data(
     }
 }
 
-pub(super) fn aggregate_mysql_command_tag(events: &[MysqlCommandEvent]) -> Option<CommandTag> {
+pub(super) fn aggregate_mysql_command_tag(events: &[MySqlCommandEvent]) -> Option<CommandTag> {
     let mut committed_schema = None;
     let mut committed_data = None;
     let mut pending = None;
@@ -296,18 +296,18 @@ pub(super) fn aggregate_mysql_command_tag(events: &[MysqlCommandEvent]) -> Optio
     for event in events {
         last_tag = Some(event.tag.clone());
         match &event.kind {
-            MysqlStatementKind::Begin | MysqlStatementKind::StartTransaction => {
-                pending = Some(MysqlPendingTransactionTags::default());
+            MySqlStatementKind::Begin | MySqlStatementKind::StartTransaction => {
+                pending = Some(MySqlPendingTransactionTags::default());
             }
-            MysqlStatementKind::Commit => {
+            MySqlStatementKind::Commit => {
                 if let Some(transaction) = pending.take() {
                     apply_pending_mysql_data(transaction, &mut committed_data);
                 }
             }
-            MysqlStatementKind::Rollback => {
+            MySqlStatementKind::Rollback => {
                 pending = None;
             }
-            MysqlStatementKind::Savepoint => {
+            MySqlStatementKind::Savepoint => {
                 if let Some(transaction) = pending.as_mut()
                     && let Some(name) = event.target.as_deref()
                 {
@@ -319,7 +319,7 @@ pub(super) fn aggregate_mysql_command_tag(events: &[MysqlCommandEvent]) -> Optio
                         .push((name.to_string(), transaction.data.len()));
                 }
             }
-            MysqlStatementKind::RollbackToSavepoint => {
+            MySqlStatementKind::RollbackToSavepoint => {
                 if let Some(transaction) = pending.as_mut()
                     && let Some(name) = event.target.as_deref()
                     && let Some(index) = transaction
@@ -331,7 +331,7 @@ pub(super) fn aggregate_mysql_command_tag(events: &[MysqlCommandEvent]) -> Optio
                     transaction.savepoints.truncate(index + 1);
                 }
             }
-            MysqlStatementKind::ReleaseSavepoint => {
+            MySqlStatementKind::ReleaseSavepoint => {
                 if let Some(transaction) = pending.as_mut()
                     && let Some(name) = event.target.as_deref()
                     && let Some(index) = transaction
@@ -342,8 +342,8 @@ pub(super) fn aggregate_mysql_command_tag(events: &[MysqlCommandEvent]) -> Optio
                     transaction.savepoints.remove(index);
                 }
             }
-            MysqlStatementKind::CreateTable { temporary: true }
-            | MysqlStatementKind::DropTable { temporary: true } => {}
+            MySqlStatementKind::CreateTable { temporary: true }
+            | MySqlStatementKind::DropTable { temporary: true } => {}
             kind if mysql_statement_is_persistent_schema_change(kind) => {
                 if let Some(transaction) = pending.take() {
                     apply_pending_mysql_data(transaction, &mut committed_data);
@@ -393,7 +393,7 @@ mod tests {
 
     #[test]
     fn mode_probe_requires_marker_and_allowed_mode_before_user_sql() {
-        let probe = MysqlResultSet {
+        let probe = MySqlResultSet {
             columns: vec![
                 "__sabiql_probe".to_string(),
                 "__sabiql_sql_mode".to_string(),
@@ -535,8 +535,8 @@ mod tests {
     #[test]
     fn refresh_scope_ignores_temporary_table_ddl() {
         for kind in [
-            MysqlStatementKind::CreateTable { temporary: true },
-            MysqlStatementKind::DropTable { temporary: true },
+            MySqlStatementKind::CreateTable { temporary: true },
+            MySqlStatementKind::DropTable { temporary: true },
         ] {
             assert_eq!(mysql_refresh_scope(&kind), RefreshScope::None);
         }
@@ -545,11 +545,11 @@ mod tests {
     #[test]
     fn refresh_scope_preserves_data_and_persistent_metadata_changes() {
         assert_eq!(
-            mysql_refresh_scope(&MysqlStatementKind::Insert),
+            mysql_refresh_scope(&MySqlStatementKind::Insert),
             RefreshScope::Data
         );
         assert_eq!(
-            mysql_refresh_scope(&MysqlStatementKind::CreateTable { temporary: false }),
+            mysql_refresh_scope(&MySqlStatementKind::CreateTable { temporary: false }),
             RefreshScope::Metadata
         );
     }
@@ -557,23 +557,23 @@ mod tests {
     #[test]
     fn transaction_rollback_removes_pending_data_tag() {
         let events = vec![
-            MysqlCommandEvent {
-                kind: MysqlStatementKind::Begin,
+            MySqlCommandEvent {
+                kind: MySqlStatementKind::Begin,
                 target: None,
                 tag: CommandTag::Begin,
             },
-            MysqlCommandEvent {
-                kind: MysqlStatementKind::Update { has_where: true },
+            MySqlCommandEvent {
+                kind: MySqlStatementKind::Update { has_where: true },
                 target: Some("items".to_string()),
                 tag: CommandTag::Update(1),
             },
-            MysqlCommandEvent {
-                kind: MysqlStatementKind::Rollback,
+            MySqlCommandEvent {
+                kind: MySqlStatementKind::Rollback,
                 target: None,
                 tag: CommandTag::Rollback,
             },
-            MysqlCommandEvent {
-                kind: MysqlStatementKind::Select,
+            MySqlCommandEvent {
+                kind: MySqlStatementKind::Select,
                 target: None,
                 tag: CommandTag::Select(1),
             },
@@ -588,23 +588,23 @@ mod tests {
     #[test]
     fn ddl_implicit_commit_keeps_prior_data_change() {
         let events = vec![
-            MysqlCommandEvent {
-                kind: MysqlStatementKind::Begin,
+            MySqlCommandEvent {
+                kind: MySqlStatementKind::Begin,
                 target: None,
                 tag: CommandTag::Begin,
             },
-            MysqlCommandEvent {
-                kind: MysqlStatementKind::Insert,
+            MySqlCommandEvent {
+                kind: MySqlStatementKind::Insert,
                 target: Some("items".to_string()),
                 tag: CommandTag::Insert(1),
             },
-            MysqlCommandEvent {
-                kind: MysqlStatementKind::CreateTable { temporary: false },
+            MySqlCommandEvent {
+                kind: MySqlStatementKind::CreateTable { temporary: false },
                 target: Some("created".to_string()),
                 tag: CommandTag::Create("TABLE".to_string()),
             },
-            MysqlCommandEvent {
-                kind: MysqlStatementKind::Rollback,
+            MySqlCommandEvent {
+                kind: MySqlStatementKind::Rollback,
                 target: None,
                 tag: CommandTag::Rollback,
             },

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -22,14 +22,14 @@ use super::policy::{MYSQL_SESSION_MARKER_COLUMN, validate_mysql_session_marker};
 use super::pty::read_pty_until_first_byte_then_idle;
 #[cfg(unix)]
 use super::pty::{
-    MysqlPty, create_mysql_pty, read_one_pty_resultset, read_pty_all, read_pty_until_idle,
+    MySqlPty, create_mysql_pty, read_one_pty_resultset, read_pty_all, read_pty_until_idle,
 };
 #[cfg(all(unix, feature = "test-support"))]
 use super::xml::trace_mysql_frame;
-use super::xml::{MysqlResultsetFrameScanner, parse_mysql_xml, trace_mysql_statement};
+use super::xml::{MySqlResultsetFrameScanner, parse_mysql_xml, trace_mysql_statement};
 
 mod session;
-pub(in crate::adapters::mysql) use session::MysqlMetadataSession;
+pub(in crate::adapters::mysql) use session::MySqlMetadataSession;
 mod adhoc;
 pub(in crate::adapters::mysql) use adhoc::run_mysql_adhoc;
 mod single;
@@ -45,10 +45,10 @@ use super::super::option_file::MySqlOptionFile;
 pub(in crate::adapters::mysql) const MYSQL_QUERY_TIMEOUT: Duration = Duration::from_secs(31);
 const MYSQL_READ_ONLY_STATEMENT: &str = "SET SESSION TRANSACTION READ ONLY";
 
-pub(in crate::adapters::mysql) struct MysqlProcess {
+pub(in crate::adapters::mysql) struct MySqlProcess {
     pub(super) child: Child,
     #[cfg(unix)]
-    pub(super) pty: MysqlPty,
+    pub(super) pty: MySqlPty,
     #[cfg(not(unix))]
     pub(super) stdin: Option<ChildStdin>,
     #[cfg(not(unix))]
@@ -60,10 +60,10 @@ pub(in crate::adapters::mysql) struct MysqlProcess {
     #[cfg(not(unix))]
     pub(super) pending_stderr: Vec<u8>,
     #[cfg(not(unix))]
-    pub(super) frame_scanner: MysqlResultsetFrameScanner,
+    pub(super) frame_scanner: MySqlResultsetFrameScanner,
 }
 
-impl MysqlProcess {
+impl MySqlProcess {
     pub(in crate::adapters::mysql) fn spawn_with_program(
         program: &OsStr,
         option_file: &std::path::Path,
@@ -110,7 +110,7 @@ impl MysqlProcess {
                 stderr,
                 pending: Vec::new(),
                 pending_stderr: Vec::new(),
-                frame_scanner: MysqlResultsetFrameScanner::default(),
+                frame_scanner: MySqlResultsetFrameScanner::default(),
             })
         }
     }
@@ -154,11 +154,11 @@ impl MysqlProcess {
         let input = TokioFile::from_std(master);
         Ok(Self {
             child,
-            pty: MysqlPty {
+            pty: MySqlPty {
                 input,
                 output,
                 pending: Vec::new(),
-                frame_scanner: MysqlResultsetFrameScanner::default(),
+                frame_scanner: MySqlResultsetFrameScanner::default(),
             },
         })
     }
@@ -180,7 +180,7 @@ async fn stop_mysql_process(child: &mut Child) -> Result<(ExitStatus, bool), DbO
     Ok((status, true))
 }
 
-pub(super) struct MysqlSessionResult {
+pub(super) struct MySqlSessionResult {
     pub(super) status: ExitStatus,
     pub(super) forcibly_stopped: bool,
     #[cfg(not(unix))]
@@ -188,7 +188,7 @@ pub(super) struct MysqlSessionResult {
     pub(super) error_bytes: Vec<u8>,
 }
 
-async fn shutdown_mysql_input(process: &mut MysqlProcess) -> Result<(), DbOperationError> {
+async fn shutdown_mysql_input(process: &mut MySqlProcess) -> Result<(), DbOperationError> {
     #[cfg(unix)]
     {
         write_mysql_input(process, b"\x04").await?;
@@ -205,8 +205,8 @@ async fn shutdown_mysql_input(process: &mut MysqlProcess) -> Result<(), DbOperat
 }
 
 pub(in crate::adapters::mysql::cli) async fn finish_mysql_session(
-    process: &mut MysqlProcess,
-) -> Result<MysqlSessionResult, DbOperationError> {
+    process: &mut MySqlProcess,
+) -> Result<MySqlSessionResult, DbOperationError> {
     shutdown_mysql_input(process).await?;
 
     #[cfg(unix)]
@@ -232,7 +232,7 @@ pub(in crate::adapters::mysql::cli) async fn finish_mysql_session(
     #[cfg(not(unix))]
     let forcibly_stopped = false;
 
-    Ok(MysqlSessionResult {
+    Ok(MySqlSessionResult {
         status,
         forcibly_stopped,
         #[cfg(not(unix))]
@@ -242,8 +242,8 @@ pub(in crate::adapters::mysql::cli) async fn finish_mysql_session(
 }
 
 pub(in crate::adapters::mysql::cli) async fn finish_mysql_session_after_result(
-    process: &mut MysqlProcess,
-) -> Result<MysqlSessionResult, DbOperationError> {
+    process: &mut MySqlProcess,
+) -> Result<MySqlSessionResult, DbOperationError> {
     #[cfg(unix)]
     {
         shutdown_mysql_input(process).await?;
@@ -256,7 +256,7 @@ pub(in crate::adapters::mysql::cli) async fn finish_mysql_session_after_result(
         let error_bytes =
             error_bytes.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
         let (status, forcibly_stopped) = status?;
-        Ok(MysqlSessionResult {
+        Ok(MySqlSessionResult {
             status,
             forcibly_stopped,
             error_bytes,
@@ -268,7 +268,7 @@ pub(in crate::adapters::mysql::cli) async fn finish_mysql_session_after_result(
 }
 
 pub(super) async fn configure_mysql_session(
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
     access_mode: AccessMode,
 ) -> Result<(), DbOperationError> {
     if !access_mode.is_read_only() {
@@ -293,7 +293,7 @@ pub(super) async fn configure_mysql_session(
 }
 
 pub(super) async fn write_mysql_statement(
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
     query: &str,
 ) -> Result<(), DbOperationError> {
     trace_mysql_statement(query.trim_end());
@@ -373,7 +373,7 @@ fn mysql_skip_block_comment(bytes: &[u8], index: usize) -> usize {
 }
 
 pub(super) async fn write_mysql_input(
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
     input: &[u8],
 ) -> Result<(), DbOperationError> {
     #[cfg(unix)]
@@ -409,7 +409,7 @@ pub(super) async fn write_mysql_input(
     Ok(())
 }
 
-pub(super) async fn cleanup_mysql_process(process: &mut MysqlProcess) {
+pub(super) async fn cleanup_mysql_process(process: &mut MySqlProcess) {
     let _ = process.child.kill().await;
     #[cfg(unix)]
     let _ = read_pty_all(&mut process.pty).await;
@@ -423,11 +423,11 @@ pub(super) async fn cleanup_mysql_process(process: &mut MysqlProcess) {
 
 pub(super) async fn run_mysql_process_with_timeout<T, F>(
     execution_timeout: Duration,
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
     execute: F,
 ) -> Result<T, DbOperationError>
 where
-    F: AsyncFnOnce(&mut MysqlProcess) -> Result<T, DbOperationError>,
+    F: AsyncFnOnce(&mut MySqlProcess) -> Result<T, DbOperationError>,
 {
     match tokio::time::timeout(execution_timeout, execute(process)).await {
         Ok(Ok(value)) => Ok(value),
@@ -445,7 +445,7 @@ where
 }
 
 pub(super) async fn read_one_mysql_resultset(
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
 ) -> Result<Vec<u8>, DbOperationError> {
     #[cfg(unix)]
     {
@@ -482,7 +482,7 @@ pub(in crate::adapters::mysql) async fn run_mysql_cli_script_for_test(
 ) -> Result<Vec<u8>, DbOperationError> {
     let target = parse_and_validate_mysql_dsn(dsn)?;
     let option_file = MySqlOptionFile::create(&target)?;
-    let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
+    let mut process = MySqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
     let result = async {
         trace_mysql_statement(script);
         write_mysql_input(&mut process, script.as_bytes()).await?;
@@ -512,7 +512,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::super::export::run_mysql_export_process;
-    use super::super::xml::MysqlResultSet;
+    use super::super::xml::MySqlResultSet;
     use super::adhoc::run_mysql_adhoc_with_program_and_statements_and_expected_columns;
     use super::metadata::{
         mysql_metadata_columns_external_with_program,
@@ -533,7 +533,7 @@ mod tests {
         path: PathBuf,
         execution_timeout: Duration,
     ) -> Result<(), DbOperationError> {
-        let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+        let mut process = MySqlProcess::spawn_with_program(program, option_file)?;
         run_mysql_process_with_timeout(execution_timeout, &mut process, async |process| {
             run_mysql_export_process(process, option_file, query, path).await
         })
@@ -545,8 +545,8 @@ mod tests {
         query: &str,
         access_mode: AccessMode,
         execution_timeout: Duration,
-    ) -> Result<MysqlResultSet, DbOperationError> {
-        let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+    ) -> Result<MySqlResultSet, DbOperationError> {
+        let mut process = MySqlProcess::spawn_with_program(program, option_file)?;
         run_mysql_process_with_timeout(execution_timeout, &mut process, async |process| {
             run_mysql_single_statement_process(process, query, access_mode).await
         })
@@ -897,7 +897,7 @@ done
     async fn metadata_session_reuses_one_process_for_ordered_resultsets() {
         let (_directory, program, option_file) = fake_mysql_multi();
         let mut session =
-            MysqlMetadataSession::spawn_with_program(OsStr::new(&program), &option_file)
+            MySqlMetadataSession::spawn_with_program(OsStr::new(&program), &option_file)
                 .expect("spawn fake mysql");
 
         session.probe().await.expect("mode probe");
@@ -1308,7 +1308,7 @@ done
 
         assert_eq!(
             result.result_set,
-            Some(MysqlResultSet {
+            Some(MySqlResultSet {
                 columns: vec!["value".to_string()],
                 values: vec![vec![QueryValue::Text("two".to_string())]],
             })
@@ -1506,14 +1506,14 @@ mod windows_tests {
         let stdin = child.stdin.take().expect("piped stdin");
         let stdout = child.stdout.take().expect("piped stdout");
         let stderr = child.stderr.take().expect("piped stderr");
-        let mut process = MysqlProcess {
+        let mut process = MySqlProcess {
             child,
             stdin: Some(stdin),
             stdout,
             stderr,
             pending: Vec::new(),
             pending_stderr: Vec::new(),
-            frame_scanner: MysqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultsetFrameScanner::default(),
         };
 
         let result =

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -4,30 +4,30 @@ use std::time::Duration;
 
 use uuid::Uuid;
 
-use crate::app::policy::sql::mysql_statement::{MysqlStatement, MysqlStatementKind};
+use crate::app::policy::sql::mysql_statement::{MySqlStatement, MySqlStatementKind};
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::RefreshScope;
 
 use super::super::error::{classify_mysql_query_failure, has_mysql_cli_error, validate_mode_probe};
 use super::super::policy::{
-    MysqlCommandEvent, MysqlExecutionResult, aggregate_mysql_command_tag,
+    MySqlCommandEvent, MySqlExecutionResult, aggregate_mysql_command_tag,
     is_mysql_row_count_marker, mysql_command_tag,
     mysql_metadata_fallback_has_unsupported_session_state, mysql_refresh_scope,
     mysql_row_count_marker, query_failed_after_change, query_failed_after_mysql_statement,
 };
-use super::super::xml::MysqlResultSet;
+use super::super::xml::MySqlResultSet;
 use super::metadata::mysql_metadata_columns;
 use super::{
-    MYSQL_QUERY_TIMEOUT, MysqlProcess, configure_mysql_session, finish_mysql_session,
+    MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
     finish_mysql_session_after_result, read_one_mysql_resultset, run_mysql_process_with_timeout,
     write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) async fn run_mysql_adhoc(
     option_file: &Path,
-    statements: &[MysqlStatement],
+    statements: &[MySqlStatement],
     access_mode: AccessMode,
-) -> Result<MysqlExecutionResult, DbOperationError> {
+) -> Result<MySqlExecutionResult, DbOperationError> {
     run_mysql_adhoc_with_program_and_statements_and_expected_columns(
         OsStr::new("mysql"),
         option_file,
@@ -42,18 +42,18 @@ pub(in crate::adapters::mysql) async fn run_mysql_adhoc(
 pub(super) async fn run_mysql_adhoc_with_program_and_statements_and_expected_columns(
     program: &OsStr,
     option_file: &Path,
-    statements: &[MysqlStatement],
+    statements: &[MySqlStatement],
     access_mode: AccessMode,
     expected_columns: Option<&[&str]>,
     execution_timeout: Duration,
-) -> Result<MysqlExecutionResult, DbOperationError> {
+) -> Result<MySqlExecutionResult, DbOperationError> {
     if mysql_metadata_fallback_has_unsupported_session_state(statements) {
         return Err(DbOperationError::UnsupportedOperation(
             "MySQL empty SHOW/DESCRIBE metadata fallback cannot preserve temporary-table session state"
                 .to_string(),
         ));
     }
-    let mut process = MysqlProcess::spawn_with_program(program, option_file)?;
+    let mut process = MySqlProcess::spawn_with_program(program, option_file)?;
     run_mysql_process_with_timeout(execution_timeout, &mut process, async |process| {
         run_mysql_adhoc_process(
             process,
@@ -67,21 +67,21 @@ pub(super) async fn run_mysql_adhoc_with_program_and_statements_and_expected_col
     .await
 }
 
-struct MysqlStatementExecution {
-    result_set: Option<MysqlResultSet>,
-    command_event: MysqlCommandEvent,
+struct MySqlStatementExecution {
+    result_set: Option<MySqlResultSet>,
+    command_event: MySqlCommandEvent,
     refresh_scope: RefreshScope,
 }
 
 pub(super) async fn fill_mysql_empty_result_columns(
-    process: &mut MysqlProcess,
-    mut result: MysqlResultSet,
+    process: &mut MySqlProcess,
+    mut result: MySqlResultSet,
     option_file: &Path,
     query: &str,
-    kind: &MysqlStatementKind,
+    kind: &MySqlStatementKind,
     access_mode: AccessMode,
     expected_columns: Option<&[&str]>,
-) -> Result<MysqlResultSet, DbOperationError> {
+) -> Result<MySqlResultSet, DbOperationError> {
     if !result.columns.is_empty() || !result.values.is_empty() {
         return Ok(result);
     }
@@ -104,13 +104,13 @@ pub(super) async fn fill_mysql_empty_result_columns(
 }
 
 async fn run_mysql_statement(
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
     option_file: &Path,
-    statement: &MysqlStatement,
+    statement: &MySqlStatement,
     access_mode: AccessMode,
     expected_columns: Option<&[&str]>,
     refresh_scope: RefreshScope,
-) -> Result<MysqlStatementExecution, DbOperationError> {
+) -> Result<MySqlStatementExecution, DbOperationError> {
     let marker = Uuid::new_v4().simple().to_string();
     let statement_scope = mysql_refresh_scope(&statement.kind);
     let possible_refresh_scope = refresh_scope.merge(statement_scope);
@@ -172,9 +172,9 @@ async fn run_mysql_statement(
     };
     let tag = mysql_command_tag(&statement.kind, affected_rows, user_result.as_ref());
 
-    Ok(MysqlStatementExecution {
+    Ok(MySqlStatementExecution {
         result_set: user_result,
-        command_event: MysqlCommandEvent {
+        command_event: MySqlCommandEvent {
             kind: statement.kind.clone(),
             target: statement.target.clone(),
             tag,
@@ -184,12 +184,12 @@ async fn run_mysql_statement(
 }
 
 async fn run_mysql_adhoc_process(
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
     option_file: &Path,
-    statements: &[MysqlStatement],
+    statements: &[MySqlStatement],
     access_mode: AccessMode,
     expected_columns: Option<&[&str]>,
-) -> Result<MysqlExecutionResult, DbOperationError> {
+) -> Result<MySqlExecutionResult, DbOperationError> {
     let probe_marker = Uuid::new_v4().simple().to_string();
     let probe_query = format!(
         "SELECT '{probe_marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode"
@@ -242,7 +242,7 @@ async fn run_mysql_adhoc_process(
         ));
     }
 
-    Ok(MysqlExecutionResult {
+    Ok(MySqlExecutionResult {
         result_set: last_result_set,
         command_tag: aggregate_mysql_command_tag(&command_tags),
         refresh_scope,

--- a/src/infra/adapters/mysql/cli/process/metadata.rs
+++ b/src/infra/adapters/mysql/cli/process/metadata.rs
@@ -16,23 +16,23 @@ use super::super::error::{
     classify_mysql_query_failure, has_mysql_cli_error, is_mysql_batch_diagnostic,
 };
 use super::super::policy::{
-    MYSQL_SESSION_MARKER_COLUMN, MysqlMetadataFallbackKind, mysql_metadata_select_query,
+    MYSQL_SESSION_MARKER_COLUMN, MySqlMetadataFallbackKind, mysql_metadata_select_query,
 };
 use super::super::probe::{run_mysql_command_with_timeout, validate_sql_mode};
-use super::{MYSQL_QUERY_TIMEOUT, MysqlProcess, read_one_mysql_resultset, write_mysql_statement};
+use super::{MYSQL_QUERY_TIMEOUT, MySqlProcess, read_one_mysql_resultset, write_mysql_statement};
 
 pub(in crate::adapters::mysql) async fn mysql_metadata_columns(
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
     option_file: &std::path::Path,
     query: &str,
-    kind: MysqlMetadataFallbackKind,
+    kind: MySqlMetadataFallbackKind,
     access_mode: AccessMode,
 ) -> Result<Vec<String>, DbOperationError> {
     let query = match kind {
-        MysqlMetadataFallbackKind::Select | MysqlMetadataFallbackKind::Table => {
+        MySqlMetadataFallbackKind::Select | MySqlMetadataFallbackKind::Table => {
             return mysql_metadata_select_columns(process, query).await;
         }
-        MysqlMetadataFallbackKind::Show | MysqlMetadataFallbackKind::Describe => {
+        MySqlMetadataFallbackKind::Show | MySqlMetadataFallbackKind::Describe => {
             query.trim().trim_end_matches(';').trim_end().to_string()
         }
     };
@@ -40,7 +40,7 @@ pub(in crate::adapters::mysql) async fn mysql_metadata_columns(
 }
 
 async fn mysql_metadata_select_columns(
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
     query: &str,
 ) -> Result<Vec<String>, DbOperationError> {
     let suffix = Uuid::new_v4().simple().to_string();
@@ -119,14 +119,14 @@ pub(super) async fn mysql_metadata_columns_external_with_program(
     parse_mysql_metadata_header(&output.stdout, query)
 }
 
-struct MysqlMetadataProcess {
+struct MySqlMetadataProcess {
     child: Child,
     stdin: Option<tokio::process::ChildStdin>,
     stdout: BufReader<tokio::process::ChildStdout>,
     stderr: BufReader<tokio::process::ChildStderr>,
 }
 
-impl MysqlMetadataProcess {
+impl MySqlMetadataProcess {
     fn spawn(program: &OsStr, option_file: &std::path::Path) -> Result<Self, DbOperationError> {
         let mut command = Command::new(program);
         command
@@ -213,7 +213,7 @@ impl MysqlMetadataProcess {
 }
 
 async fn finish_mysql_metadata_process(
-    process: &mut MysqlMetadataProcess,
+    process: &mut MySqlMetadataProcess,
 ) -> Result<(ExitStatus, Vec<u8>, Vec<u8>), DbOperationError> {
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
@@ -229,7 +229,7 @@ async fn finish_mysql_metadata_process(
     Ok((status, stdout, stderr))
 }
 
-async fn cleanup_mysql_metadata_process(process: &mut MysqlMetadataProcess) {
+async fn cleanup_mysql_metadata_process(process: &mut MySqlMetadataProcess) {
     drop(process.stdin.take());
     let _ = process.child.kill().await;
     let _ = finish_mysql_metadata_process(process).await;
@@ -255,7 +255,7 @@ pub(super) async fn run_mysql_metadata_query_with_read_only_session_with_timeout
     query: &str,
     execution_timeout: Duration,
 ) -> Result<Vec<String>, DbOperationError> {
-    let mut process = MysqlMetadataProcess::spawn(program, option_file)?;
+    let mut process = MySqlMetadataProcess::spawn(program, option_file)?;
     match timeout(
         execution_timeout,
         run_mysql_metadata_query_with_read_only_session_process(&mut process, query),
@@ -277,7 +277,7 @@ pub(super) async fn run_mysql_metadata_query_with_read_only_session_with_timeout
 }
 
 async fn run_mysql_metadata_query_with_read_only_session_process(
-    process: &mut MysqlMetadataProcess,
+    process: &mut MySqlMetadataProcess,
     query: &str,
 ) -> Result<Vec<String>, DbOperationError> {
     let probe_marker = Uuid::new_v4().simple().to_string();

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -4,24 +4,24 @@ use uuid::Uuid;
 
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 
-use super::super::xml::{MysqlResultSet, parse_mysql_xml};
+use super::super::xml::{MySqlResultSet, parse_mysql_xml};
 use super::{
-    MysqlProcess, cleanup_mysql_process, configure_mysql_session,
+    MySqlProcess, cleanup_mysql_process, configure_mysql_session,
     finish_mysql_session_after_result, read_one_mysql_resultset, validate_mode_probe,
     write_mysql_statement,
 };
 
-pub(in crate::adapters::mysql) struct MysqlMetadataSession {
-    process: MysqlProcess,
+pub(in crate::adapters::mysql) struct MySqlMetadataSession {
+    process: MySqlProcess,
 }
 
-impl MysqlMetadataSession {
+impl MySqlMetadataSession {
     pub(in crate::adapters::mysql) fn spawn_with_program(
         program: &OsStr,
         option_file: &std::path::Path,
     ) -> Result<Self, DbOperationError> {
         Ok(Self {
-            process: MysqlProcess::spawn_with_program(program, option_file)?,
+            process: MySqlProcess::spawn_with_program(program, option_file)?,
         })
     }
 
@@ -42,7 +42,7 @@ impl MysqlMetadataSession {
     pub(in crate::adapters::mysql) async fn execute(
         &mut self,
         query: &str,
-    ) -> Result<MysqlResultSet, DbOperationError> {
+    ) -> Result<MySqlResultSet, DbOperationError> {
         self.execute_with_expected_columns(query, &[]).await
     }
 
@@ -50,7 +50,7 @@ impl MysqlMetadataSession {
         &mut self,
         query: &str,
         expected_columns: &[&str],
-    ) -> Result<MysqlResultSet, DbOperationError> {
+    ) -> Result<MySqlResultSet, DbOperationError> {
         write_mysql_statement(&mut self.process, query).await?;
         let xml = read_one_mysql_resultset(&mut self.process).await?;
         let mut result = parse_mysql_xml(&xml)?;

--- a/src/infra/adapters/mysql/cli/process/single.rs
+++ b/src/infra/adapters/mysql/cli/process/single.rs
@@ -4,9 +4,9 @@ use uuid::Uuid;
 use crate::app::ports::outbound::{AccessMode, DbOperationError};
 
 use super::super::error::{classify_mysql_query_failure, has_mysql_cli_error, validate_mode_probe};
-use super::super::xml::{MysqlResultSet, parse_mysql_xml};
+use super::super::xml::{MySqlResultSet, parse_mysql_xml};
 use super::{
-    MYSQL_QUERY_TIMEOUT, MysqlProcess, configure_mysql_session, finish_mysql_session,
+    MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
     finish_mysql_session_after_result, read_one_mysql_resultset, run_mysql_process_with_timeout,
     write_mysql_statement,
 };
@@ -15,8 +15,8 @@ pub(in crate::adapters::mysql) async fn run_mysql_single_statement(
     option_file: &std::path::Path,
     query: &str,
     access_mode: AccessMode,
-) -> Result<MysqlResultSet, DbOperationError> {
-    let mut process = MysqlProcess::spawn_with_program(OsStr::new("mysql"), option_file)?;
+) -> Result<MySqlResultSet, DbOperationError> {
+    let mut process = MySqlProcess::spawn_with_program(OsStr::new("mysql"), option_file)?;
     run_mysql_process_with_timeout(MYSQL_QUERY_TIMEOUT, &mut process, async |process| {
         run_mysql_single_statement_process(process, query, access_mode).await
     })
@@ -24,10 +24,10 @@ pub(in crate::adapters::mysql) async fn run_mysql_single_statement(
 }
 
 pub(super) async fn run_mysql_single_statement_process(
-    process: &mut MysqlProcess,
+    process: &mut MySqlProcess,
     query: &str,
     access_mode: AccessMode,
-) -> Result<MysqlResultSet, DbOperationError> {
+) -> Result<MySqlResultSet, DbOperationError> {
     let marker = Uuid::new_v4().simple().to_string();
     let probe_query =
         format!("SELECT '{marker}' AS __sabiql_probe, @@SESSION.sql_mode AS __sabiql_sql_mode");

--- a/src/infra/adapters/mysql/cli/pty.rs
+++ b/src/infra/adapters/mysql/cli/pty.rs
@@ -10,13 +10,13 @@ use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 use crate::app::ports::outbound::DbOperationError;
 
 use super::error::{classify_mysql_query_failure, has_mysql_cli_error, trace_mysql_error};
-use super::xml::{MysqlResultsetFrameScanner, take_mysql_pty_resultset_frame, trace_mysql_frame};
+use super::xml::{MySqlResultsetFrameScanner, take_mysql_pty_resultset_frame, trace_mysql_frame};
 
-pub(super) struct MysqlPty {
+pub(super) struct MySqlPty {
     pub(super) input: TokioFile,
     pub(super) output: TokioFile,
     pub(super) pending: Vec<u8>,
-    pub(super) frame_scanner: MysqlResultsetFrameScanner,
+    pub(super) frame_scanner: MySqlResultsetFrameScanner,
 }
 
 pub(super) fn create_mysql_pty() -> io::Result<(std::fs::File, std::fs::File)> {
@@ -57,7 +57,7 @@ fn configure_mysql_pty(fd: RawFd) -> io::Result<()> {
 }
 
 pub(super) async fn read_one_pty_resultset(
-    pty: &mut MysqlPty,
+    pty: &mut MySqlPty,
 ) -> Result<Vec<u8>, DbOperationError> {
     let mut chunk = [0; 4096];
     loop {
@@ -88,7 +88,7 @@ pub(super) async fn read_one_pty_resultset(
     }
 }
 
-pub(super) async fn read_pty_all(pty: &mut MysqlPty) -> io::Result<Vec<u8>> {
+pub(super) async fn read_pty_all(pty: &mut MySqlPty) -> io::Result<Vec<u8>> {
     let mut output = std::mem::take(&mut pty.pending);
     pty.frame_scanner.reset();
     let mut chunk = [0; 4096];
@@ -104,14 +104,14 @@ pub(super) async fn read_pty_all(pty: &mut MysqlPty) -> io::Result<Vec<u8>> {
     }
 }
 
-pub(super) async fn read_pty_until_idle(pty: &mut MysqlPty) -> io::Result<Vec<u8>> {
+pub(super) async fn read_pty_until_idle(pty: &mut MySqlPty) -> io::Result<Vec<u8>> {
     let output = std::mem::take(&mut pty.pending);
     pty.frame_scanner.reset();
     read_pty_until_idle_from(&mut pty.output, output, false).await
 }
 
 #[cfg(all(unix, feature = "test-support"))]
-pub(super) async fn read_pty_until_first_byte_then_idle(pty: &mut MysqlPty) -> io::Result<Vec<u8>> {
+pub(super) async fn read_pty_until_first_byte_then_idle(pty: &mut MySqlPty) -> io::Result<Vec<u8>> {
     let output = std::mem::take(&mut pty.pending);
     pty.frame_scanner.reset();
     read_pty_until_idle_from(&mut pty.output, output, true).await
@@ -151,16 +151,16 @@ where
     }
 }
 
-pub(super) struct MysqlExportPtySource<'a> {
-    pub(super) pty: &'a mut MysqlPty,
+pub(super) struct MySqlExportPtySource<'a> {
+    pub(super) pty: &'a mut MySqlPty,
     pub(super) error_output: Vec<u8>,
     pub(super) error_buffer: Vec<u8>,
     pub(super) pending: Vec<u8>,
-    pub(super) frame_scanner: MysqlResultsetFrameScanner,
+    pub(super) frame_scanner: MySqlResultsetFrameScanner,
     pub(super) started: bool,
 }
 
-impl MysqlExportPtySource<'_> {
+impl MySqlExportPtySource<'_> {
     fn capture_error(&mut self, bytes: &[u8]) {
         if !self.error_output.is_empty() {
             return;
@@ -202,7 +202,7 @@ impl MysqlExportPtySource<'_> {
     }
 }
 
-impl AsyncRead for MysqlExportPtySource<'_> {
+impl AsyncRead for MySqlExportPtySource<'_> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -258,16 +258,16 @@ mod tests {
 
     use super::*;
 
-    fn source_with_output(output: &[u8]) -> (tempfile::NamedTempFile, MysqlPty) {
+    fn source_with_output(output: &[u8]) -> (tempfile::NamedTempFile, MySqlPty) {
         let mut output_file = tempfile::NamedTempFile::new().unwrap();
         output_file.write_all(output).unwrap();
         output_file.as_file_mut().seek(SeekFrom::Start(0)).unwrap();
         let input_file = tempfile::NamedTempFile::new().unwrap();
-        let pty = MysqlPty {
+        let pty = MySqlPty {
             input: TokioFile::from_std(input_file.reopen().unwrap()),
             output: TokioFile::from_std(output_file.reopen().unwrap()),
             pending: Vec::new(),
-            frame_scanner: MysqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultsetFrameScanner::default(),
         };
         (output_file, pty)
     }
@@ -311,12 +311,12 @@ mod tests {
         let xml = br#"<resultset><row><field name="message">line 1
 ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
         let (_output_file, mut pty) = source_with_output(xml);
-        let mut source = MysqlExportPtySource {
+        let mut source = MySqlExportPtySource {
             pty: &mut pty,
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: MysqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultsetFrameScanner::default(),
             started: false,
         };
         let mut result = Vec::new();
@@ -331,12 +331,12 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
     async fn export_source_keeps_cli_error_before_resultset() {
         let output = b"ERROR 1054 (42S22): Unknown column\n<resultset></resultset>";
         let (_output_file, mut pty) = source_with_output(output);
-        let mut source = MysqlExportPtySource {
+        let mut source = MySqlExportPtySource {
             pty: &mut pty,
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: MysqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultsetFrameScanner::default(),
             started: false,
         };
         let mut result = Vec::new();
@@ -351,11 +351,11 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
         let (master, slave) = create_mysql_pty().expect("create test PTY");
         let output = TokioFile::from_std(master.try_clone().expect("clone PTY master"));
         let input = TokioFile::from_std(master);
-        let mut pty = MysqlPty {
+        let mut pty = MySqlPty {
             input,
             output,
             pending: Vec::new(),
-            frame_scanner: MysqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultsetFrameScanner::default(),
         };
         let mut writer = TokioFile::from_std(slave);
         let producer = tokio::spawn(async move {
@@ -366,12 +366,12 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
                 .await
                 .unwrap();
         });
-        let mut source = MysqlExportPtySource {
+        let mut source = MySqlExportPtySource {
             pty: &mut pty,
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: MysqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultsetFrameScanner::default(),
             started: false,
         };
         let mut output = vec![0; 1024];
@@ -394,11 +394,11 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
         let (master, slave) = create_mysql_pty().expect("create test PTY");
         let output = TokioFile::from_std(master.try_clone().expect("clone PTY master"));
         let input = TokioFile::from_std(master);
-        let mut pty = MysqlPty {
+        let mut pty = MySqlPty {
             input,
             output,
             pending: Vec::new(),
-            frame_scanner: MysqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultsetFrameScanner::default(),
         };
         let mut writer = TokioFile::from_std(slave);
         let producer = tokio::spawn(async move {
@@ -411,12 +411,12 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
                 .await
                 .unwrap();
         });
-        let mut source = MysqlExportPtySource {
+        let mut source = MySqlExportPtySource {
             pty: &mut pty,
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: MysqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultsetFrameScanner::default(),
             started: false,
         };
         let mut output = vec![0; 1024];
@@ -437,12 +437,12 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
     #[test]
     fn rescans_resultset_marker_after_draining_large_pty_reads() {
         let (_output_file, mut pty) = source_with_output(&[]);
-        let mut source = MysqlExportPtySource {
+        let mut source = MySqlExportPtySource {
             pty: &mut pty,
             error_output: Vec::new(),
             error_buffer: Vec::new(),
             pending: Vec::new(),
-            frame_scanner: MysqlResultsetFrameScanner::default(),
+            frame_scanner: MySqlResultsetFrameScanner::default(),
             started: false,
         };
         let mut first = vec![b'x'; 4096 - b"<resultse".len()];

--- a/src/infra/adapters/mysql/cli/xml.rs
+++ b/src/infra/adapters/mysql/cli/xml.rs
@@ -11,7 +11,7 @@ use super::error::{
 };
 
 #[derive(Debug, PartialEq, Eq)]
-pub(in crate::adapters::mysql) struct MysqlResultSet {
+pub(in crate::adapters::mysql) struct MySqlResultSet {
     pub(in crate::adapters::mysql) columns: Vec<String>,
     pub(in crate::adapters::mysql) values: Vec<Vec<QueryValue>>,
 }
@@ -20,14 +20,14 @@ const MYSQL_RESULTSET_START: &[u8] = b"<resultset";
 const MYSQL_RESULTSET_END: &[u8] = b"</resultset>";
 
 #[derive(Debug, Default)]
-pub(super) struct MysqlResultsetFrameScanner {
+pub(super) struct MySqlResultsetFrameScanner {
     resultset_start: Option<usize>,
     resultset_end: Option<usize>,
     resultset_start_cursor: usize,
     resultset_end_cursor: usize,
 }
 
-impl MysqlResultsetFrameScanner {
+impl MySqlResultsetFrameScanner {
     pub(super) fn frame_start(&mut self, buffer: &[u8]) -> Option<usize> {
         let _ = self.frame_bounds(buffer);
         self.resultset_start
@@ -102,7 +102,7 @@ impl MysqlResultsetFrameScanner {
 #[cfg(any(unix, test))]
 pub(super) fn take_mysql_pty_resultset_frame(
     buffer: &mut Vec<u8>,
-    scanner: &mut MysqlResultsetFrameScanner,
+    scanner: &mut MySqlResultsetFrameScanner,
 ) -> Result<Option<Vec<u8>>, DbOperationError> {
     let bounds = scanner.frame_bounds(buffer);
     let resultset_start = scanner.resultset_start.unwrap_or(buffer.len());
@@ -117,7 +117,7 @@ pub(super) fn take_mysql_pty_resultset_frame(
 pub(super) fn take_mysql_resultset_frame_after_error_check(
     buffer: &mut Vec<u8>,
     error_output: &[u8],
-    scanner: &mut MysqlResultsetFrameScanner,
+    scanner: &mut MySqlResultsetFrameScanner,
 ) -> Result<Option<Vec<u8>>, DbOperationError> {
     if has_mysql_cli_error(error_output) {
         trace_mysql_error(error_output);
@@ -178,14 +178,14 @@ pub(super) fn decode_mysql_xml_reference(
         .map_err(|error| DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}")))
 }
 
-pub(super) fn parse_mysql_xml(xml: &[u8]) -> Result<MysqlResultSet, DbOperationError> {
+pub(super) fn parse_mysql_xml(xml: &[u8]) -> Result<MySqlResultSet, DbOperationError> {
     let mut reader = Reader::from_reader(xml);
     reader.config_mut().trim_text(false);
     let mut buffer = Vec::new();
     let mut resultset_count = 0;
     let mut in_resultset = false;
     let mut current_row: Option<Vec<(String, QueryValue)>> = None;
-    let mut current_field: Option<MysqlField> = None;
+    let mut current_field: Option<MySqlField> = None;
     let mut rows = Vec::new();
     let mut columns = Vec::new();
 
@@ -328,19 +328,19 @@ pub(super) fn parse_mysql_xml(xml: &[u8]) -> Result<MysqlResultSet, DbOperationE
             "MySQL XML result did not contain one complete resultset".to_string(),
         ));
     }
-    Ok(MysqlResultSet {
+    Ok(MySqlResultSet {
         columns,
         values: rows,
     })
 }
 
-pub(super) struct MysqlField {
+pub(super) struct MySqlField {
     name: String,
     pub(super) value: String,
     is_null: bool,
 }
 
-impl MysqlField {
+impl MySqlField {
     fn finish(self) -> (String, QueryValue) {
         let value = if self.is_null {
             QueryValue::Null
@@ -362,7 +362,7 @@ impl MysqlField {
 
 pub(super) fn parse_mysql_field(
     element: &quick_xml::events::BytesStart<'_>,
-) -> Result<MysqlField, DbOperationError> {
+) -> Result<MySqlField, DbOperationError> {
     let mut name = None;
     let mut is_null = false;
     for attribute in element.attributes() {
@@ -380,7 +380,7 @@ pub(super) fn parse_mysql_field(
     }
     let name = name
         .ok_or_else(|| DbOperationError::QueryFailed("MySQL XML field has no name".to_string()))?;
-    Ok(MysqlField {
+    Ok(MySqlField {
         name,
         value: String::new(),
         is_null,
@@ -477,7 +477,7 @@ mod tests {
     fn frames_one_xml_resultset_and_preserves_following_output() {
         let mut buffer = b"    -> <?xml version=\"1.0\"?>\n<resultset></resultset>\r\n    -> <?xml version=\"1.0\"?>\n<resultset>"
             .to_vec();
-        let mut scanner = MysqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultsetFrameScanner::default();
 
         assert_eq!(
             scanner.take(&mut buffer),
@@ -495,7 +495,7 @@ mod tests {
     fn frames_resultset_after_mysql_cli_text() {
         let mut buffer =
             b"SELECT 1;\n<?xml version=\"1.0\"?>\nquery text\n<resultset></resultset>".to_vec();
-        let mut scanner = MysqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultsetFrameScanner::default();
 
         assert_eq!(
             scanner.take(&mut buffer),
@@ -512,7 +512,7 @@ mod tests {
         expected.extend_from_slice(MYSQL_RESULTSET_END);
 
         let mut buffer = Vec::new();
-        let mut scanner = MysqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultsetFrameScanner::default();
         let mut frames = Vec::new();
         for chunk in expected.chunks(4096) {
             buffer.extend_from_slice(chunk);
@@ -535,7 +535,7 @@ mod tests {
         expected.extend_from_slice(MYSQL_RESULTSET_END);
 
         let mut buffer = Vec::new();
-        let mut scanner = MysqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultsetFrameScanner::default();
         let mut frames = Vec::new();
         for chunk in expected.chunks(37) {
             buffer.extend_from_slice(chunk);
@@ -555,7 +555,7 @@ mod tests {
         let mut input = first.to_vec();
         input.extend_from_slice(second);
         let mut buffer = Vec::new();
-        let mut scanner = MysqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultsetFrameScanner::default();
         let mut frames = Vec::new();
 
         for chunk in input.chunks(11) {
@@ -573,7 +573,7 @@ mod tests {
     fn delimiter_prefix_in_field_text_does_not_end_the_frame() {
         let expected = b"<resultset><row><field name=\"value\">literal </resultset prefix</field></row></resultset>";
         let mut buffer = expected.to_vec();
-        let mut scanner = MysqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultsetFrameScanner::default();
 
         assert_eq!(scanner.take(&mut buffer), Some(expected.to_vec()));
         assert!(buffer.is_empty());
@@ -584,7 +584,7 @@ mod tests {
         let mut buffer = br#"<resultset><row><field name="message">line 1
 ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#
             .to_vec();
-        let mut scanner = MysqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultsetFrameScanner::default();
 
         let frame = take_mysql_pty_resultset_frame(&mut buffer, &mut scanner).unwrap();
 
@@ -596,7 +596,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#
     fn cli_error_before_resultset_frame_is_still_rejected() {
         let mut buffer =
             b"ERROR 1054 (42S22): Unknown column\n<resultset><row></row></resultset>".to_vec();
-        let mut scanner = MysqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultsetFrameScanner::default();
 
         let result = take_mysql_pty_resultset_frame(&mut buffer, &mut scanner);
 
@@ -611,7 +611,7 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#
     fn error_before_resultset_frame_is_not_accepted() {
         let mut buffer = b"<resultset><row></row></resultset>".to_vec();
         let error = b"ERROR 1054 (42S22): Unknown column missing_column\n";
-        let mut scanner = MysqlResultsetFrameScanner::default();
+        let mut scanner = MySqlResultsetFrameScanner::default();
 
         assert!(matches!(
             take_mysql_resultset_frame_after_error_check(&mut buffer, error, &mut scanner),

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -9,7 +9,7 @@ use crate::domain::{
 };
 
 use super::super::{
-    cli::{MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, MysqlResultSet},
+    cli::{MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, MySqlResultSet},
     dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
     sql::{
@@ -19,13 +19,13 @@ use super::super::{
 };
 
 #[derive(Debug, Clone)]
-enum MysqlColumnUnique {
+enum MySqlColumnUnique {
     None,
     SingleColumnIndex,
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct MysqlColumnMetadata {
+pub(super) struct MySqlColumnMetadata {
     name: String,
     data_type: String,
     nullable: bool,
@@ -33,13 +33,13 @@ pub(super) struct MysqlColumnMetadata {
     comment: Option<String>,
     pub(super) ordinal_position: i32,
     primary_key_position: Option<i32>,
-    unique: MysqlColumnUnique,
+    unique: MySqlColumnUnique,
     invisible: bool,
     generated: bool,
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct MysqlForeignKeyMetadata {
+pub(super) struct MySqlForeignKeyMetadata {
     pub(super) name: String,
     pub(super) from_schema: String,
     pub(super) from_table: String,
@@ -53,7 +53,7 @@ pub(super) struct MysqlForeignKeyMetadata {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct MysqlTableMetadata {
+pub(super) struct MySqlTableMetadata {
     pub(super) schema: String,
     pub(super) name: String,
     pub(super) kind: TableKind,
@@ -62,15 +62,15 @@ pub(super) struct MysqlTableMetadata {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct MysqlMetadataSnapshot {
+pub(super) struct MySqlMetadataSnapshot {
     pub(super) database: String,
-    pub(super) tables: Vec<MysqlTableMetadata>,
+    pub(super) tables: Vec<MySqlTableMetadata>,
     pub(super) table_summaries: Vec<TableSummary>,
 }
 
 pub(super) async fn fetch_metadata_snapshot(
     dsn: &str,
-) -> Result<MysqlMetadataSnapshot, DbOperationError> {
+) -> Result<MySqlMetadataSnapshot, DbOperationError> {
     let database = selected_database(dsn)?;
     let result = execute_metadata_query(dsn, TABLES_QUERY, TABLES_RESULT_COLUMNS).await?;
     metadata_snapshot_from_result(&database, None, &result)
@@ -79,8 +79,8 @@ pub(super) async fn fetch_metadata_snapshot(
 pub(super) fn find_table(
     schema: &str,
     table: &str,
-    tables: &[MysqlTableMetadata],
-) -> Result<MysqlTableMetadata, DbOperationError> {
+    tables: &[MySqlTableMetadata],
+) -> Result<MySqlTableMetadata, DbOperationError> {
     tables
         .iter()
         .find(|candidate| candidate.schema.eq_ignore_ascii_case(schema) && candidate.name == table)
@@ -91,10 +91,10 @@ pub(super) fn find_table(
 }
 
 pub(super) fn parse_columns_for_table(
-    result: &MysqlResultSet,
+    result: &MySqlResultSet,
     schema: &str,
     table: &str,
-) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
+) -> Result<Vec<MySqlColumnMetadata>, DbOperationError> {
     let columns = parse_column_metadata(result)?;
     if columns.is_empty() {
         return Err(DbOperationError::ObjectMissing(format!(
@@ -108,7 +108,7 @@ pub(super) async fn execute_metadata_query(
     dsn: &str,
     query: &str,
     expected_columns: &[&str],
-) -> Result<MysqlResultSet, DbOperationError> {
+) -> Result<MySqlResultSet, DbOperationError> {
     execute_metadata_queries_in_session(dsn, &[(query, expected_columns)])
         .await?
         .into_iter()
@@ -123,7 +123,7 @@ pub(super) async fn execute_metadata_query(
 pub(super) async fn execute_metadata_queries_in_session(
     dsn: &str,
     queries: &[(&str, &[&str])],
-) -> Result<Vec<MysqlResultSet>, DbOperationError> {
+) -> Result<Vec<MySqlResultSet>, DbOperationError> {
     execute_metadata_queries_in_session_with_program(
         dsn,
         queries,
@@ -138,10 +138,10 @@ async fn execute_metadata_queries_in_session_with_program(
     queries: &[(&str, &[&str])],
     program: &OsStr,
     timeout: Duration,
-) -> Result<Vec<MysqlResultSet>, DbOperationError> {
+) -> Result<Vec<MySqlResultSet>, DbOperationError> {
     let target = parse_and_validate_mysql_dsn(dsn)?;
     let option_file = MySqlOptionFile::create(&target)?;
-    let mut session = MysqlMetadataSession::spawn_with_program(program, &option_file.path)?;
+    let mut session = MySqlMetadataSession::spawn_with_program(program, &option_file.path)?;
     let result = tokio::time::timeout(timeout, async {
         session.probe().await?;
         session.prepare_read_only().await?;
@@ -197,14 +197,14 @@ pub(super) fn validate_selected_schema_name(
 pub(super) fn metadata_snapshot_from_result(
     database: &str,
     requested_schema: Option<&str>,
-    result: &MysqlResultSet,
-) -> Result<MysqlMetadataSnapshot, DbOperationError> {
+    result: &MySqlResultSet,
+) -> Result<MySqlMetadataSnapshot, DbOperationError> {
     if let Some(schema) = requested_schema {
         validate_selected_schema_name(database, schema)?;
     }
     let tables = parse_table_metadata(result)?;
     let table_summaries = tables.iter().cloned().map(table_summary).collect();
-    Ok(MysqlMetadataSnapshot {
+    Ok(MySqlMetadataSnapshot {
         database: database.to_string(),
         tables,
         table_summaries,
@@ -212,8 +212,8 @@ pub(super) fn metadata_snapshot_from_result(
 }
 
 fn parse_table_metadata(
-    result: &MysqlResultSet,
-) -> Result<Vec<MysqlTableMetadata>, DbOperationError> {
+    result: &MySqlResultSet,
+) -> Result<Vec<MySqlTableMetadata>, DbOperationError> {
     expect_columns(result, TABLES_RESULT_COLUMNS)?;
     result
         .values
@@ -245,7 +245,7 @@ fn parse_table_metadata(
             let comment = optional_text(&row[4], "TABLE_COMMENT")?
                 .filter(|value| !value.is_empty())
                 .map(str::to_string);
-            Ok(MysqlTableMetadata {
+            Ok(MySqlTableMetadata {
                 schema,
                 name,
                 kind,
@@ -257,8 +257,8 @@ fn parse_table_metadata(
 }
 
 fn parse_column_metadata(
-    result: &MysqlResultSet,
-) -> Result<Vec<MysqlColumnMetadata>, DbOperationError> {
+    result: &MySqlResultSet,
+) -> Result<Vec<MySqlColumnMetadata>, DbOperationError> {
     expect_columns(result, COLUMN_METADATA_RESULT_COLUMNS)?;
     result
         .values
@@ -275,12 +275,12 @@ fn parse_column_metadata(
 pub(super) fn parse_column_metadata_row(
     row: &[QueryValue],
     field: &str,
-) -> Result<MysqlColumnMetadata, DbOperationError> {
+) -> Result<MySqlColumnMetadata, DbOperationError> {
     if row.len() != 8 {
         return Err(metadata_shape_error(field));
     }
     let extra = required_text(&row[4], "EXTRA")?;
-    Ok(MysqlColumnMetadata {
+    Ok(MySqlColumnMetadata {
         name: required_text(&row[0], "COLUMN_NAME")?.to_string(),
         data_type: required_text(&row[1], "COLUMN_TYPE")?.to_string(),
         nullable: required_text(&row[2], "IS_NULLABLE")? == "YES",
@@ -292,7 +292,7 @@ pub(super) fn parse_column_metadata_row(
         primary_key_position: optional_text(&row[7], "PRIMARY_KEY_POSITION")?
             .map(|value| parse_positive_i32_text(value, "PRIMARY_KEY_POSITION"))
             .transpose()?,
-        unique: MysqlColumnUnique::None,
+        unique: MySqlColumnUnique::None,
         invisible: extra
             .split_ascii_whitespace()
             .any(|word| word.eq_ignore_ascii_case("INVISIBLE")),
@@ -303,8 +303,8 @@ pub(super) fn parse_column_metadata_row(
 }
 
 pub(super) fn parse_foreign_key_metadata(
-    result: &MysqlResultSet,
-) -> Result<Vec<MysqlForeignKeyMetadata>, DbOperationError> {
+    result: &MySqlResultSet,
+) -> Result<Vec<MySqlForeignKeyMetadata>, DbOperationError> {
     expect_columns(result, FOREIGN_KEY_RESULT_COLUMNS)?;
     result
         .values
@@ -313,7 +313,7 @@ pub(super) fn parse_foreign_key_metadata(
             if row.len() != 10 {
                 return Err(metadata_shape_error("foreign key row"));
             }
-            Ok(MysqlForeignKeyMetadata {
+            Ok(MySqlForeignKeyMetadata {
                 name: required_text(&row[0], "CONSTRAINT_NAME")?.to_string(),
                 from_schema: required_text(&row[1], "TABLE_SCHEMA")?.to_string(),
                 from_table: required_text(&row[2], "TABLE_NAME")?.to_string(),
@@ -330,7 +330,7 @@ pub(super) fn parse_foreign_key_metadata(
 }
 
 pub(super) fn foreign_keys_from_metadata(
-    mut raw: Vec<MysqlForeignKeyMetadata>,
+    mut raw: Vec<MySqlForeignKeyMetadata>,
     database: &str,
 ) -> Result<Vec<ForeignKey>, DbOperationError> {
     raw.sort_by(|left, right| {
@@ -375,12 +375,12 @@ pub(super) fn foreign_keys_from_metadata(
     Ok(foreign_keys)
 }
 
-pub(super) fn column_from_metadata(metadata: &MysqlColumnMetadata) -> Column {
+pub(super) fn column_from_metadata(metadata: &MySqlColumnMetadata) -> Column {
     let primary_key = metadata.primary_key_position.is_some();
     let attributes = ColumnAttributes::from_parts(
         metadata.nullable,
         primary_key,
-        matches!(metadata.unique, MysqlColumnUnique::SingleColumnIndex),
+        matches!(metadata.unique, MySqlColumnUnique::SingleColumnIndex),
     ) | if metadata.invisible {
         ColumnAttributes::HIDDEN | ColumnAttributes::READ_ONLY
     } else {
@@ -401,7 +401,7 @@ pub(super) fn column_from_metadata(metadata: &MysqlColumnMetadata) -> Column {
 }
 
 pub(super) fn parse_unique_column_metadata(
-    result: &MysqlResultSet,
+    result: &MySqlResultSet,
 ) -> Result<HashSet<String>, DbOperationError> {
     expect_columns(result, UNIQUE_COLUMN_RESULT_COLUMNS)?;
     result
@@ -417,19 +417,19 @@ pub(super) fn parse_unique_column_metadata(
 }
 
 pub(super) fn mark_single_column_unique(
-    columns: &mut [MysqlColumnMetadata],
+    columns: &mut [MySqlColumnMetadata],
     unique_columns: &HashSet<String>,
 ) {
     for column in columns {
         column.unique = if unique_columns.contains(&column.name) {
-            MysqlColumnUnique::SingleColumnIndex
+            MySqlColumnUnique::SingleColumnIndex
         } else {
-            MysqlColumnUnique::None
+            MySqlColumnUnique::None
         };
     }
 }
 
-pub(super) fn primary_key_names(columns: &[MysqlColumnMetadata]) -> Vec<String> {
+pub(super) fn primary_key_names(columns: &[MySqlColumnMetadata]) -> Vec<String> {
     let mut columns = columns
         .iter()
         .filter_map(|column| {
@@ -461,7 +461,7 @@ fn parse_fk_action(value: &QueryValue, field: &str) -> Result<FkAction, DbOperat
     })
 }
 
-fn table_summary(table: MysqlTableMetadata) -> TableSummary {
+fn table_summary(table: MySqlTableMetadata) -> TableSummary {
     TableSummary::new(table.schema, table.name, table.row_count_estimate, false).with_kind_info(
         TableKindInfo {
             kind: table.kind,
@@ -473,7 +473,7 @@ fn table_summary(table: MysqlTableMetadata) -> TableSummary {
 }
 
 pub(super) fn expect_columns(
-    result: &MysqlResultSet,
+    result: &MySqlResultSet,
     expected: &[&str],
 ) -> Result<(), DbOperationError> {
     if result.columns == expected {
@@ -530,8 +530,8 @@ pub(super) fn metadata_shape_error(field: &str) -> DbOperationError {
 mod tests {
     use super::*;
 
-    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
-        MysqlResultSet {
+    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
+        MySqlResultSet {
             columns: columns.iter().map(|value| (*value).to_string()).collect(),
             values,
         }

--- a/src/infra/adapters/mysql/metadata/mod.rs
+++ b/src/infra/adapters/mysql/metadata/mod.rs
@@ -4,7 +4,7 @@ use crate::app::ports::outbound::{DbOperationError, MetadataProvider};
 use crate::domain::{DatabaseMetadata, Schema, Table, TableSignature};
 
 use super::adapter::MySqlAdapter;
-use super::cli::MysqlResultSet;
+use super::cli::MySqlResultSet;
 use super::sql::{EFFECTIVE_USER_QUERY, EFFECTIVE_USER_RESULT_COLUMNS};
 
 mod catalog;
@@ -60,7 +60,7 @@ impl MetadataProvider for MySqlAdapter {
     }
 }
 
-fn effective_user_from_result(result: &MysqlResultSet) -> Option<String> {
+fn effective_user_from_result(result: &MySqlResultSet) -> Option<String> {
     let [row] = result.values.as_slice() else {
         return None;
     };
@@ -76,8 +76,8 @@ mod tests {
     use super::*;
     use crate::domain::QueryValue;
 
-    fn result(values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
-        MysqlResultSet {
+    fn result(values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
+        MySqlResultSet {
             columns: vec!["CURRENT_USER()".to_string()],
             values,
         }

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -5,7 +5,7 @@ use crate::app::ports::outbound::{AccessMode, DbOperationError};
 use crate::domain::{Column, QueryValue};
 
 use super::super::{
-    cli::{MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, MysqlResultSet, validate_mysql_multi_query},
+    cli::{MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, MySqlResultSet, validate_mysql_multi_query},
     dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
     sql::{
@@ -14,7 +14,7 @@ use super::super::{
     },
 };
 use super::catalog::{
-    MysqlColumnMetadata, column_from_metadata, mark_single_column_unique, parse_columns_for_table,
+    MySqlColumnMetadata, column_from_metadata, mark_single_column_unique, parse_columns_for_table,
     parse_unique_column_metadata, primary_key_names, validate_selected_schema_name,
 };
 
@@ -33,7 +33,7 @@ pub(in crate::adapters::mysql) struct ConvertedPreviewValues {
 
 pub(in crate::adapters::mysql) struct PreviewExecution {
     pub(in crate::adapters::mysql) metadata: PreviewMetadata,
-    pub(in crate::adapters::mysql) result_set: MysqlResultSet,
+    pub(in crate::adapters::mysql) result_set: MySqlResultSet,
     pub(in crate::adapters::mysql) display_query: String,
 }
 
@@ -74,7 +74,7 @@ async fn execute_preview_with_program(
     validate_selected_schema_name(database, schema)?;
 
     let option_file = MySqlOptionFile::create(&target)?;
-    let mut session = MysqlMetadataSession::spawn_with_program(program, &option_file.path)?;
+    let mut session = MySqlMetadataSession::spawn_with_program(program, &option_file.path)?;
     let result = tokio::time::timeout(
         timeout,
         execute_preview_with_session(&mut session, database, schema, table, limit, offset),
@@ -98,7 +98,7 @@ async fn execute_preview_with_program(
 }
 
 async fn execute_preview_with_session(
-    session: &mut MysqlMetadataSession,
+    session: &mut MySqlMetadataSession,
     database: &str,
     schema: &str,
     table: &str,
@@ -166,7 +166,7 @@ async fn execute_preview_with_session(
 }
 
 fn preview_metadata_from_columns(
-    column_metadata: &[MysqlColumnMetadata],
+    column_metadata: &[MySqlColumnMetadata],
     schema: &str,
     table: &str,
 ) -> Result<PreviewMetadata, DbOperationError> {
@@ -216,7 +216,7 @@ fn preview_metadata_from_columns(
 }
 
 pub(in crate::adapters::mysql) fn convert_preview_values(
-    result: &MysqlResultSet,
+    result: &MySqlResultSet,
     columns: &[Column],
     identity_columns: &[Column],
 ) -> Result<ConvertedPreviewValues, DbOperationError> {
@@ -463,8 +463,8 @@ done
         (directory, program, log_path)
     }
 
-    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
-        MysqlResultSet {
+    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
+        MySqlResultSet {
             columns: columns.iter().map(|value| (*value).to_string()).collect(),
             values,
         }

--- a/src/infra/adapters/mysql/metadata/signature.rs
+++ b/src/infra/adapters/mysql/metadata/signature.rs
@@ -3,14 +3,14 @@ use std::collections::{HashMap, HashSet};
 use crate::app::ports::outbound::DbOperationError;
 use crate::domain::{FkAction, Table, TableKind, TableKindInfo, TableSignature};
 
-use super::super::cli::MysqlResultSet;
+use super::super::cli::MySqlResultSet;
 use super::super::sql::{
     FOREIGN_KEY_RESULT_COLUMNS, SIGNATURE_COLUMNS_QUERY, SIGNATURE_COLUMNS_RESULT_COLUMNS,
     SIGNATURE_FOREIGN_KEYS_QUERY, SIGNATURE_UNIQUE_COLUMNS_QUERY,
     SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS, TABLES_QUERY, TABLES_RESULT_COLUMNS,
 };
 use super::catalog::{
-    MysqlColumnMetadata, MysqlForeignKeyMetadata, MysqlTableMetadata, column_from_metadata,
+    MySqlColumnMetadata, MySqlForeignKeyMetadata, MySqlTableMetadata, column_from_metadata,
     execute_metadata_queries_in_session, expect_columns, foreign_keys_from_metadata,
     mark_single_column_unique, metadata_shape_error, metadata_snapshot_from_result,
     parse_column_metadata_row, parse_foreign_key_metadata, primary_key_names, required_text,
@@ -18,10 +18,10 @@ use super::catalog::{
 };
 
 #[derive(Debug, Clone)]
-struct MysqlSignatureColumnMetadata {
+struct MySqlSignatureColumnMetadata {
     schema: String,
     table: String,
-    column: MysqlColumnMetadata,
+    column: MySqlColumnMetadata,
 }
 
 pub(super) async fn fetch_table_signatures(
@@ -52,8 +52,8 @@ pub(super) async fn fetch_table_signatures(
 }
 
 fn parse_signature_column_metadata(
-    result: &MysqlResultSet,
-) -> Result<Vec<MysqlSignatureColumnMetadata>, DbOperationError> {
+    result: &MySqlResultSet,
+) -> Result<Vec<MySqlSignatureColumnMetadata>, DbOperationError> {
     expect_columns(result, SIGNATURE_COLUMNS_RESULT_COLUMNS)?;
     result
         .values
@@ -62,7 +62,7 @@ fn parse_signature_column_metadata(
             if row.len() != 10 {
                 return Err(metadata_shape_error("signature COLUMNS row"));
             }
-            Ok(MysqlSignatureColumnMetadata {
+            Ok(MySqlSignatureColumnMetadata {
                 schema: required_text(&row[0], "TABLE_SCHEMA")?.to_string(),
                 table: required_text(&row[1], "TABLE_NAME")?.to_string(),
                 column: parse_column_metadata_row(&row[2..], "signature COLUMNS row")?,
@@ -72,17 +72,17 @@ fn parse_signature_column_metadata(
 }
 
 fn table_signatures_from_metadata(
-    tables: &[MysqlTableMetadata],
+    tables: &[MySqlTableMetadata],
     database: &str,
-    columns: Vec<MysqlSignatureColumnMetadata>,
-    foreign_keys: Vec<MysqlForeignKeyMetadata>,
+    columns: Vec<MySqlSignatureColumnMetadata>,
+    foreign_keys: Vec<MySqlForeignKeyMetadata>,
     mut unique_columns_by_table: HashMap<String, HashSet<String>>,
 ) -> Result<Vec<TableSignature>, DbOperationError> {
     let known_tables: HashSet<(String, String)> = tables
         .iter()
         .map(|table| (table.schema.clone(), table.name.clone()))
         .collect();
-    let mut columns_by_table: HashMap<(String, String), Vec<MysqlColumnMetadata>> = HashMap::new();
+    let mut columns_by_table: HashMap<(String, String), Vec<MySqlColumnMetadata>> = HashMap::new();
     for metadata in columns {
         let key = (metadata.schema.clone(), metadata.table.clone());
         if !known_tables.contains(&key) {
@@ -97,7 +97,7 @@ fn table_signatures_from_metadata(
             .push(metadata.column);
     }
 
-    let mut foreign_keys_by_table: HashMap<(String, String), Vec<MysqlForeignKeyMetadata>> =
+    let mut foreign_keys_by_table: HashMap<(String, String), Vec<MySqlForeignKeyMetadata>> =
         HashMap::new();
     for foreign_key in foreign_keys {
         let key = (
@@ -312,7 +312,7 @@ fn foreign_key_action_name(action: &FkAction) -> &'static str {
 }
 
 fn parse_signature_unique_column_metadata(
-    result: &MysqlResultSet,
+    result: &MySqlResultSet,
 ) -> Result<HashMap<String, HashSet<String>>, DbOperationError> {
     expect_columns(result, SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS)?;
     let mut unique_columns_by_table = HashMap::new();
@@ -333,8 +333,8 @@ mod tests {
     use super::*;
     use crate::domain::{Column, ColumnAttributes, ForeignKey, QueryValue};
 
-    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
-        MysqlResultSet {
+    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
+        MySqlResultSet {
             columns: columns.iter().map(|value| (*value).to_string()).collect(),
             values,
         }
@@ -467,14 +467,14 @@ mod tests {
     #[test]
     fn signature_metadata_batches_columns_and_foreign_keys_by_server_table() {
         let tables = vec![
-            MysqlTableMetadata {
+            MySqlTableMetadata {
                 schema: "App".to_string(),
                 name: "child".to_string(),
                 kind: TableKind::Table,
                 row_count_estimate: None,
                 comment: None,
             },
-            MysqlTableMetadata {
+            MySqlTableMetadata {
                 schema: "App".to_string(),
                 name: "parent".to_string(),
                 kind: TableKind::Table,
@@ -595,7 +595,7 @@ mod tests {
 
     #[test]
     fn signature_metadata_requires_columns_for_each_table() {
-        let tables = vec![MysqlTableMetadata {
+        let tables = vec![MySqlTableMetadata {
             schema: "app".to_string(),
             name: "users".to_string(),
             kind: TableKind::Table,

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -15,12 +15,12 @@ use super::super::sql::{
     triggers_query, unique_columns_query,
 };
 use super::super::{
-    cli::{MYSQL_QUERY_TIMEOUT, MysqlMetadataSession, MysqlResultSet},
+    cli::{MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, MySqlResultSet},
     dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
 };
 use super::catalog::{
-    MysqlColumnMetadata, MysqlTableMetadata, column_from_metadata,
+    MySqlColumnMetadata, MySqlTableMetadata, column_from_metadata,
     execute_metadata_queries_in_session, expect_columns, find_table, foreign_keys_from_metadata,
     mark_single_column_unique, metadata_shape_error, metadata_snapshot_from_result, optional_text,
     parse_boolean_flag, parse_columns_for_table, parse_foreign_key_metadata, parse_positive_i32,
@@ -29,7 +29,7 @@ use super::catalog::{
 };
 
 #[derive(Debug, Clone)]
-struct MysqlIndexMetadata {
+struct MySqlIndexMetadata {
     name: String,
     non_unique: bool,
     index_type: String,
@@ -40,7 +40,7 @@ struct MysqlIndexMetadata {
 }
 
 #[derive(Debug, Clone)]
-struct MysqlTriggerMetadata {
+struct MySqlTriggerMetadata {
     name: String,
     timing: TriggerTiming,
     event: TriggerEvent,
@@ -112,7 +112,7 @@ async fn fetch_table_detail_in_session_with_program(
     })?;
     validate_selected_schema_name(database, schema)?;
     let option_file = MySqlOptionFile::create(&target)?;
-    let mut session = MysqlMetadataSession::spawn_with_program(program, &option_file.path)?;
+    let mut session = MySqlMetadataSession::spawn_with_program(program, &option_file.path)?;
     let result = tokio::time::timeout(
         timeout,
         fetch_table_detail_with_session(&mut session, database, schema, table),
@@ -136,7 +136,7 @@ async fn fetch_table_detail_in_session_with_program(
 }
 
 async fn fetch_table_detail_with_session(
-    session: &mut MysqlMetadataSession,
+    session: &mut MySqlMetadataSession,
     database: &str,
     schema: &str,
     table: &str,
@@ -218,8 +218,8 @@ async fn fetch_table_detail_with_session(
 }
 
 fn table_from_columns_and_foreign_keys(
-    table_metadata: MysqlTableMetadata,
-    columns: Vec<MysqlColumnMetadata>,
+    table_metadata: MySqlTableMetadata,
+    columns: Vec<MySqlColumnMetadata>,
     foreign_keys: Vec<ForeignKey>,
 ) -> Table {
     let primary_key = primary_key_names(&columns);
@@ -246,8 +246,8 @@ fn table_from_columns_and_foreign_keys(
 }
 
 fn parse_trigger_metadata(
-    result: &MysqlResultSet,
-) -> Result<Vec<MysqlTriggerMetadata>, DbOperationError> {
+    result: &MySqlResultSet,
+) -> Result<Vec<MySqlTriggerMetadata>, DbOperationError> {
     expect_columns(result, TRIGGER_RESULT_COLUMNS)?;
     result
         .values
@@ -262,7 +262,7 @@ fn parse_trigger_metadata(
             let event = required_text(&row[2], "EVENT_MANIPULATION")?
                 .parse::<TriggerEvent>()
                 .map_err(|error| DbOperationError::MetadataParseFailed(error.to_string()))?;
-            Ok(MysqlTriggerMetadata {
+            Ok(MySqlTriggerMetadata {
                 name: required_text(&row[0], "TRIGGER_NAME")?.to_string(),
                 timing,
                 event,
@@ -274,7 +274,7 @@ fn parse_trigger_metadata(
 }
 
 fn triggers_from_metadata(
-    raw: Vec<MysqlTriggerMetadata>,
+    raw: Vec<MySqlTriggerMetadata>,
 ) -> Result<Vec<Trigger>, DbOperationError> {
     let mut triggers = Vec::new();
     for metadata in raw {
@@ -302,7 +302,7 @@ fn triggers_from_metadata(
     Ok(triggers)
 }
 
-fn parse_source_ddl(result: &MysqlResultSet, kind: TableKind) -> Result<String, DbOperationError> {
+fn parse_source_ddl(result: &MySqlResultSet, kind: TableKind) -> Result<String, DbOperationError> {
     let expected_columns = if kind == TableKind::View {
         ["View", "Create View"]
     } else {
@@ -329,8 +329,8 @@ fn parse_source_ddl(result: &MysqlResultSet, kind: TableKind) -> Result<String, 
 }
 
 fn parse_index_metadata(
-    result: &MysqlResultSet,
-) -> Result<Vec<MysqlIndexMetadata>, DbOperationError> {
+    result: &MySqlResultSet,
+) -> Result<Vec<MySqlIndexMetadata>, DbOperationError> {
     expect_columns(result, INDEX_RESULT_COLUMNS)?;
     result
         .values
@@ -359,7 +359,7 @@ fn parse_index_metadata(
                     ));
                 }
             };
-            Ok(MysqlIndexMetadata {
+            Ok(MySqlIndexMetadata {
                 name: required_text(&row[0], "INDEX_NAME")?.to_string(),
                 non_unique: parse_boolean_flag(&row[1], "NON_UNIQUE")?,
                 index_type: required_text(&row[2], "INDEX_TYPE")?.to_string(),
@@ -372,7 +372,7 @@ fn parse_index_metadata(
         .collect()
 }
 
-fn indexes_from_metadata(mut raw: Vec<MysqlIndexMetadata>) -> Vec<Index> {
+fn indexes_from_metadata(mut raw: Vec<MySqlIndexMetadata>) -> Vec<Index> {
     raw.sort_by(|left, right| {
         left.name
             .cmp(&right.name)
@@ -413,8 +413,8 @@ fn indexes_from_metadata(mut raw: Vec<MysqlIndexMetadata>) -> Vec<Index> {
     indexes
 }
 
-fn unique_single_columns_from_metadata(raw: &[MysqlIndexMetadata]) -> HashSet<String> {
-    let mut indexes_by_name: HashMap<&str, Vec<&MysqlIndexMetadata>> = HashMap::new();
+fn unique_single_columns_from_metadata(raw: &[MySqlIndexMetadata]) -> HashSet<String> {
+    let mut indexes_by_name: HashMap<&str, Vec<&MySqlIndexMetadata>> = HashMap::new();
     for index in raw
         .iter()
         .filter(|index| !index.non_unique && !index.primary)
@@ -789,8 +789,8 @@ mod tests {
     use super::*;
     use crate::domain::QueryValue;
 
-    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MysqlResultSet {
-        MysqlResultSet {
+    fn result(columns: &[&str], values: Vec<Vec<QueryValue>>) -> MySqlResultSet {
+        MySqlResultSet {
             columns: columns.iter().map(|value| (*value).to_string()).collect(),
             values,
         }

--- a/src/infra/adapters/mysql/option_file.rs
+++ b/src/infra/adapters/mysql/option_file.rs
@@ -225,7 +225,7 @@ mod tests {
     use std::collections::HashSet;
     use std::sync::{Arc, Barrier};
 
-    use super::super::cli::test_support::MysqlProcess;
+    use super::super::cli::test_support::MySqlProcess;
     use crate::domain::connection::MySqlSslMode;
 
     use super::*;
@@ -472,7 +472,7 @@ mod tests {
         let (result, path) = {
             let option_file = MySqlOptionFile::create(&target()).unwrap();
             let path = option_file.path.clone();
-            let result = MysqlProcess::spawn_with_program(
+            let result = MySqlProcess::spawn_with_program(
                 std::ffi::OsStr::new("__sabiql_missing_mysql_binary__"),
                 &path,
             );


### PR DESCRIPTION
## Problem
Rust code uses both `MySql*` and `Mysql*` names for the same MySQL responsibilities, making naming and search inconsistent.

## Background
MRF3-03 applies the established `MySql*` spelling after the completed MySQL follow-up work.

## Approach
Rename Rust internal types, functions, test helpers, and module-local identifiers with a `Mysql*` prefix to `MySql*`. Leave SQL, UI text, serialized and external formats, configuration names, filenames, and database enum values unchanged.

## Screenshots
Not applicable.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-455