### PR TITLE
fix: resize completion cache for scoped ER prefetch

### DIFF
--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -776,6 +776,22 @@ mod tests {
         }
 
         #[test]
+        fn very_large_db_uses_ceiling_capacity() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            state.session.set_metadata(Some(make_metadata(10_001)));
+
+            let effects = dispatch_metadata(&mut state, &Action::StartPrefetchAll, Instant::now())
+                .into_effects()
+                .expect("reducer should handle action");
+
+            assert!(
+                effects
+                    .iter()
+                    .any(|e| matches!(e, Effect::ResizeCompletionCache { capacity: 10_000 }))
+            );
+        }
+
+        #[test]
         fn sets_fk_expanded_true() {
             let mut state = state_with_dsn("postgres://localhost/test");
             state.session.set_metadata(Some(make_metadata(10)));
@@ -788,6 +804,18 @@ mod tests {
 
     mod start_prefetch_scoped {
         use super::*;
+        use crate::domain::{DatabaseMetadata, TableSummary};
+
+        fn make_metadata(table_count: usize) -> Arc<DatabaseMetadata> {
+            let tables: Vec<TableSummary> = (0..table_count)
+                .map(|i| TableSummary::new(format!("t{i}"), "public".to_string(), None, false))
+                .collect();
+            Arc::new({
+                let mut metadata = DatabaseMetadata::new("test".to_string());
+                metadata.table_summaries = tables;
+                metadata
+            })
+        }
 
         #[test]
         fn second_call_while_running_is_ignored() {
@@ -857,6 +885,29 @@ mod tests {
                     .iter()
                     .any(|e| matches!(e, Effect::ProcessPrefetchQueue { .. }))
             );
+        }
+
+        #[test]
+        fn resizes_to_total_table_count_before_processing_scoped_queue() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            state.session.set_metadata(Some(make_metadata(560)));
+            let tables: Vec<String> = (0..60).map(|i| format!("public.t{i}")).collect();
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::StartPrefetchScoped { tables },
+                Instant::now(),
+            )
+            .into_effects()
+            .expect("reducer should handle action");
+
+            assert!(matches!(
+                effects.as_slice(),
+                [
+                    Effect::ResizeCompletionCache { capacity: 560 },
+                    Effect::ProcessPrefetchQueue { .. }
+                ]
+            ));
         }
     }
 

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -11,10 +11,16 @@ use super::check_er_completion;
 
 const BASE_BACKOFF_SECS: u64 = 1;
 const MAX_BACKOFF_SECS: u64 = 4;
+const MIN_COMPLETION_CACHE_CAPACITY: usize = 500;
+const MAX_COMPLETION_CACHE_CAPACITY: usize = 10_000;
 pub(super) const MAX_PREFETCH_RETRIES: u32 = 3;
 
 pub(super) fn backoff_secs_for(retry_count: u32) -> u64 {
     (BASE_BACKOFF_SECS * 2u64.pow(retry_count)).min(MAX_BACKOFF_SECS)
+}
+
+fn completion_cache_capacity(table_count: usize) -> usize {
+    table_count.clamp(MIN_COMPLETION_CACHE_CAPACITY, MAX_COMPLETION_CACHE_CAPACITY)
 }
 
 pub(super) fn reduce_prefetch(
@@ -37,8 +43,7 @@ pub(super) fn reduce_prefetch(
                     .er_preparation
                     .begin_all_prefetch(qualified_names.iter().cloned());
 
-                let table_count = qualified_names.len();
-                let resize_capacity = table_count.clamp(500, 10_000);
+                let resize_capacity = completion_cache_capacity(metadata.table_summaries.len());
 
                 for qualified_name in qualified_names {
                     state.sql_modal.queue_table_prefetch(qualified_name);
@@ -64,7 +69,14 @@ pub(super) fn reduce_prefetch(
                 for qualified_name in tables {
                     state.sql_modal.queue_table_prefetch(qualified_name.clone());
                 }
-                DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue { run_id }])
+                let mut effects = Vec::with_capacity(2);
+                if let Some(metadata) = state.session.metadata() {
+                    effects.push(Effect::ResizeCompletionCache {
+                        capacity: completion_cache_capacity(metadata.table_summaries.len()),
+                    });
+                }
+                effects.push(Effect::ProcessPrefetchQueue { run_id });
+                DispatchResult::handled_with(effects)
             }
         }
 


### PR DESCRIPTION
## Problem
Scoped ER prefetch can evict selected tables from the 500-entry completion cache in databases with more than 500 tables, causing diagram generation to fail.

## Background
Scoped prefetch previously did not apply the database-wide completion-cache capacity policy.

## Approach
Apply the existing 500-to-10,000 capacity policy using the current session metadata table count before processing the scoped prefetch queue.