### PR TITLE
ci: reuse Cargo target in integration job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,8 @@ jobs:
   integration:
     name: Integration Test
     runs-on: ubuntu-latest
+    env:
+      CARGO_TARGET_DIR: ${{ runner.temp }}/sabiql-integration-cargo-target
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,6 @@ jobs:
   integration:
     name: Integration Test
     runs-on: ubuntu-latest
-    env:
-      CARGO_TARGET_DIR: ${{ runner.temp }}/sabiql-integration-cargo-target
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
@@ -150,8 +148,12 @@ jobs:
       - name: Start PostgreSQL
         run: docker compose up -d --wait postgres
       - name: Run psql integration tests (Tier 2)
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/sabiql-integration-cargo-target
         run: cargo nextest run -p sabiql --run-ignored ignored-only -E 'test(tests::adapter_postgres)' --show-progress=none
       - name: Run Oracle MySQL 8.4 integration tests (Tier 2)
+        env:
+          CARGO_TARGET_DIR: ${{ runner.temp }}/sabiql-integration-cargo-target
         run: bash scripts/mysql_integration.sh test
 
   sqlite-safe-mode:

--- a/scripts/mysql_integration.sh
+++ b/scripts/mysql_integration.sh
@@ -67,7 +67,9 @@ prepare_run() {
     export SABIQL_MYSQL_TLS_DIR="$tls_dir"
     export TMPDIR="$temp_dir"
     export RUSTC_WRAPPER=
-    export CARGO_TARGET_DIR="$temp_dir/cargo-target"
+    if [[ -z "${CARGO_TARGET_DIR:-}" ]]; then
+        export CARGO_TARGET_DIR="$temp_dir/cargo-target"
+    fi
 }
 
 cleanup_client_containers() {

--- a/scripts/test_mysql_docker_cleanup.sh
+++ b/scripts/test_mysql_docker_cleanup.sh
@@ -283,6 +283,17 @@ if [[ "$same_suffix_labels" != 6 ]]; then
 fi
 assert_only_unrelated_container_remains
 
+shared_target="$test_root/shared-cargo-target"
+shared_target_start="$(wc -l <"$cargo_log")"
+CARGO_TARGET_DIR="$shared_target" PATH="$fake_bin:$PATH" \
+    "$script_dir/mysql_integration.sh" test >/dev/null 2>&1
+shared_target_row="$(tail -n +$((shared_target_start + 1)) "$cargo_log")"
+if [[ "$(printf '%s\n' "$shared_target_row" | awk -F'|' 'NF >= 3 { print $3; exit }')" != "$shared_target" ]]; then
+    printf 'configured cargo target was not preserved:\n%s\n' "$shared_target_row" >&2
+    exit 1
+fi
+assert_only_unrelated_container_remains
+
 parallel_start="$(wc -l <"$cargo_log")"
 parallel_one_marker="$test_root/parallel-one.marker"
 parallel_one_release="$test_root/parallel-one.release"
@@ -370,8 +381,8 @@ done <"$state_file"
 assert_only_unrelated_container_remains
 
 unique_run_labels="$(awk '/^com\.sabiql\.mysql\.integration=run-/ { labels[$0] = 1 } END { print length(labels) + 0 }' "$label_log")"
-if [[ "$unique_run_labels" != 9 ]]; then
-    printf 'expected nine unique run labels, got %s\n%s\n' \
+if [[ "$unique_run_labels" != 10 ]]; then
+    printf 'expected ten unique run labels, got %s\n%s\n' \
         "$unique_run_labels" "$(<"$label_log")" >&2
     exit 1
 fi
@@ -379,7 +390,7 @@ fi
 run_project_count="$(awk -F'|' '$2 == "up" { print $1 }' "$compose_log" | sort -u | wc -l | tr -d ' ')"
 port_lookup_count="$(awk -F'|' '$2 == "port" { print $1 }' "$compose_log" | sort -u | wc -l | tr -d ' ')"
 down_project_count="$(awk -F'|' '$2 == "down" && $1 != "default" { print $1 }' "$compose_log" | sort -u | wc -l | tr -d ' ')"
-if [[ "$run_project_count" != 9 || "$port_lookup_count" != 9 || "$down_project_count" != 9 ]] || \
+if [[ "$run_project_count" != 10 || "$port_lookup_count" != 10 || "$down_project_count" != 10 ]] || \
     ! diff -u \
         <(awk -F'|' '$2 == "up" { print $1 }' "$compose_log" | sort -u) \
         <(awk -F'|' '$2 == "down" && $1 != "default" { print $1 }' "$compose_log" | sort -u); then


### PR DESCRIPTION
## Problem
The PostgreSQL and MySQL integration steps rebuilt the same workspace in separate task-local Cargo targets.

## Background
The representative integration run spent about 47 seconds on the duplicate build.

## Approach
The Integration Test job provides one runner-local target directory to both database steps. The MySQL script preserves an explicitly configured target for CI while retaining its task-local target default for standalone runs.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-481