### PR TITLE
fix(mysql): reject LAST_INSERT_ID side effects in read-only mode

### DIFF
--- a/src/app/policy/sql/mysql_statement/side_effect.rs
+++ b/src/app/policy/sql/mysql_statement/side_effect.rs
@@ -17,10 +17,7 @@ pub(super) fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MySqlLe
         if matches!(&token.kind, TokenKind::Word(word) if word == "INTO") {
             return Ok(true);
         }
-        if matches!(&token.kind, TokenKind::Word(word) if matches!(
-            word.as_str(),
-            "GET_LOCK" | "RELEASE_LOCK" | "RELEASE_ALL_LOCKS"
-        )) {
+        if has_mysql_read_only_side_effect_function(&tokens, index) {
             return Ok(true);
         }
         if matches!(&token.kind, TokenKind::Symbol(':'))
@@ -45,6 +42,27 @@ pub(super) fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MySqlLe
         }
     }
     Ok(false)
+}
+
+fn has_mysql_read_only_side_effect_function(tokens: &[lexer::Token], index: usize) -> bool {
+    let Some(TokenKind::Word(word)) = tokens.get(index).map(|token| &token.kind) else {
+        return false;
+    };
+    if !matches!(
+        tokens.get(index + 1).map(|token| &token.kind),
+        Some(TokenKind::Symbol('('))
+    ) {
+        return false;
+    }
+
+    match word.as_str() {
+        "GET_LOCK" | "RELEASE_LOCK" | "RELEASE_ALL_LOCKS" => true,
+        "LAST_INSERT_ID" => !matches!(
+            tokens.get(index + 2).map(|token| &token.kind),
+            Some(TokenKind::Symbol(')'))
+        ),
+        _ => false,
+    }
 }
 
 pub(super) fn has_mysql_version_comment(sql: &str) -> Result<bool, MySqlLexError> {

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -192,6 +192,7 @@ mod mysql_tests {
             "DESCRIBE items",
             "WITH rows AS (SELECT 1) SELECT * FROM rows",
             "WITH RECURSIVE rows AS (SELECT 1) SELECT * FROM rows",
+            "SELECT LAST_INSERT_ID()",
         ] {
             let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
                 panic!("{sql}");
@@ -207,6 +208,7 @@ mod mysql_tests {
             "SELECT GET_LOCK('sabiql', 0)",
             "SELECT RELEASE_LOCK('sabiql')",
             "SELECT RELEASE_ALL_LOCKS()",
+            "SELECT LAST_INSERT_ID(42)",
             "/*!80000 SELECT 1 */",
         ] {
             let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {


### PR DESCRIPTION
## Problem

`LAST_INSERT_ID(expr)` changes per-session state while appearing as a read query, so the MySQL Read-Only policy currently permits a side effect.

## Background

The existing MySQL side-effect classifier already rejects locking functions and user-variable assignment, but it treated the no-argument and value-setting forms of `LAST_INSERT_ID()` identically.

## Approach

Recognize the documented value-setting form as a side effect while retaining the read-only value lookup form. The same classifier protects normal Read-Only execution, metadata fallback, and `EXPLAIN ANALYZE` eligibility.

## Linear Issue Link (optional)

- Implements https://linear.app/sabiql/issue/SAB-469