### PR TITLE
fix(mysql): treat initial metadata failure as connection failure

### DIFF
--- a/src/app/update/connection/helpers.rs
+++ b/src/app/update/connection/helpers.rs
@@ -76,7 +76,7 @@ pub(super) fn connection_save_fetch_effects(
 }
 
 pub(super) fn mysql_connection_completion_effects(state: &mut AppState, dsn: &str) -> Vec<Effect> {
-    state.session.mark_probe_connected();
+    state.session.mark_connecting();
     let run_id = state.session.begin_metadata_refresh();
     let effects = vec![
         Effect::ClearCompletionEngineCache,

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -859,7 +859,7 @@ mod tests {
             let effects = reduce(
                 &mut state,
                 &Action::ConnectionProbeCompleted {
-                    target,
+                    target: target.clone(),
                     run_id: probe_run_id,
                 },
             )
@@ -869,8 +869,37 @@ mod tests {
                 effect,
                 Effect::FetchMetadata { dsn, .. } if dsn == "mysql://user@localhost:3306/app"
             )));
-            assert_eq!(state.session.connection_state(), ConnectionState::Connected);
+            assert_eq!(
+                state.session.connection_state(),
+                ConnectionState::Connecting
+            );
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
+
+            let metadata_run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::FetchMetadata { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .expect("probe completion should start metadata loading");
+            let error_effects = reduce_app(
+                &mut state,
+                Action::MetadataFailed {
+                    dsn: target.dsn,
+                    run_id: metadata_run_id,
+                    error: DbOperationError::ConnectionFailed("connection refused".to_string()),
+                },
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(state.session.connection_state().is_failed());
+            assert_eq!(state.modal.active_mode(), InputMode::ConnectionError);
+            assert!(state.connection_error.error_info().is_some());
+            assert!(matches!(
+                error_effects.as_slice(),
+                [Effect::CancelActiveTasks]
+            ));
         }
 
         #[test]
@@ -930,7 +959,7 @@ mod tests {
                 state.session.active_database_type(),
                 Some(DatabaseType::MySQL)
             );
-            assert!(state.session.connection_state().is_connected());
+            assert!(state.session.connection_state().is_connecting());
             assert_eq!(state.modal.active_mode(), InputMode::Normal);
             assert!(state.connection_error.error_info().is_none());
         }

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -1049,7 +1049,10 @@ mod tests {
                 effect,
                 Effect::FetchMetadata { dsn, .. } if dsn == "mysql://user@localhost:3306/app"
             )));
-            assert_eq!(state.session.connection_state(), ConnectionState::Connected);
+            assert_eq!(
+                state.session.connection_state(),
+                ConnectionState::Connecting
+            );
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
             assert_eq!(state.input_mode(), InputMode::Normal);
         }


### PR DESCRIPTION
## Problem
MySQL probe success currently marks the session connected before the first metadata load. A first metadata failure is therefore shown as a metadata error instead of a connection failure.

## Approach
Keep the session in the connecting state until initial MySQL metadata succeeds, while preserving the connected state for metadata reloads. Cover the probe-to-metadata failure path and retain the mysql base lifecycle assertions.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-470