### PR TITLE
fix(mysql): classify connection errors by server code

### DIFF
--- a/src/app/model/connection/error.rs
+++ b/src/app/model/connection/error.rs
@@ -20,6 +20,7 @@ pub enum ConnectionErrorKind {
     SqliteCliNotFound,
     HostUnreachable,
     AuthFailed,
+    PermissionDenied,
     DatabaseNotFound,
     ConnectionLost,
     Timeout,
@@ -55,6 +56,17 @@ impl ConnectionErrorKind {
             || stderr_lower.contains("unknown mysql server host")
         {
             return Self::HostUnreachable;
+        }
+
+        if let Some(error_code) = mysql_server_error_code(&stderr_lower) {
+            match error_code {
+                1044 => return Self::PermissionDenied,
+                1045 => return Self::AuthFailed,
+                1049 => return Self::DatabaseNotFound,
+                2003 => {}
+                2006 | 2013 => return Self::ConnectionLost,
+                _ => return Self::Unknown,
+            }
         }
 
         if stderr_lower.contains("password authentication failed")
@@ -106,6 +118,7 @@ impl ConnectionErrorKind {
             Self::SqliteCliNotFound => DatabaseCli::Sqlite3.not_found_summary(),
             Self::HostUnreachable => "Could not resolve host",
             Self::AuthFailed => "Authentication failed",
+            Self::PermissionDenied => "Permission denied",
             Self::DatabaseNotFound => "Database does not exist",
             Self::ConnectionLost => "Connection lost during operation",
             Self::Timeout => "Connection timed out",
@@ -146,6 +159,7 @@ impl ConnectionErrorKind {
             Self::SqliteCliNotFound => DatabaseCli::Sqlite3.not_found_hint(),
             Self::HostUnreachable => "Check the hostname",
             Self::AuthFailed => "Check username and password",
+            Self::PermissionDenied => "Check the connected user's privileges",
             Self::DatabaseNotFound => "Check database name",
             Self::ConnectionLost => "Reconnect and retry the operation",
             Self::Timeout => "Check network connectivity",
@@ -181,6 +195,15 @@ fn is_mysql_connect_timeout_message(value: &str) -> bool {
         && MYSQL_CONNECT_TIMEOUT_ERRNOS
             .iter()
             .any(|errno| value.contains(errno))
+}
+
+fn mysql_server_error_code(lowercase_details: &str) -> Option<u32> {
+    let start = lowercase_details.find("error ")? + "error ".len();
+    let digits = &lowercase_details[start..];
+    let end = digits
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(digits.len());
+    digits[..end].parse().ok()
 }
 
 fn mysql_ssl_mode_from_dsn(dsn: &str) -> Option<MySqlSslMode> {
@@ -245,6 +268,7 @@ impl ConnectionErrorInfo {
             DbOperationError::CommandNotFound { .. } => ConnectionErrorKind::CliNotFound,
             DbOperationError::ConnectionLost(_) => ConnectionErrorKind::ConnectionLost,
             DbOperationError::Timeout(_) => ConnectionErrorKind::Timeout,
+            DbOperationError::PermissionDenied(_) => ConnectionErrorKind::PermissionDenied,
             DbOperationError::UnsupportedOperationWithKind { kind, .. } => match kind {
                 UnsupportedOperationKind::ClientVersion => {
                     ConnectionErrorKind::MySqlCliVersionUnsupported
@@ -392,6 +416,34 @@ mod tests {
             );
         }
 
+        #[rstest]
+        #[case(
+            "ERROR 1044 (42000): Access denied for user 'user' to database 'mysql'",
+            ConnectionErrorKind::PermissionDenied
+        )]
+        #[case(
+            "ERROR 1045 (28000): Access denied for user 'user'",
+            ConnectionErrorKind::AuthFailed
+        )]
+        #[case(
+            "ERROR 1049 (42000): Unknown database 'missing'",
+            ConnectionErrorKind::DatabaseNotFound
+        )]
+        fn mysql_server_error_codes_use_specific_connection_guidance(
+            #[case] stderr: &str,
+            #[case] expected: ConnectionErrorKind,
+        ) {
+            assert_eq!(ConnectionErrorKind::classify(stderr), expected);
+        }
+
+        #[test]
+        fn unknown_mysql_server_error_code_fails_closed() {
+            assert_eq!(
+                ConnectionErrorKind::classify("ERROR 9999 (HY000): Access denied for user 'user'"),
+                ConnectionErrorKind::Unknown
+            );
+        }
+
         #[test]
         fn stderr_as_database_not_found() {
             assert_eq!(
@@ -458,6 +510,7 @@ mod tests {
         #[case(ConnectionErrorKind::SqliteCliNotFound)]
         #[case(ConnectionErrorKind::HostUnreachable)]
         #[case(ConnectionErrorKind::AuthFailed)]
+        #[case(ConnectionErrorKind::PermissionDenied)]
         #[case(ConnectionErrorKind::DatabaseNotFound)]
         #[case(ConnectionErrorKind::ConnectionLost)]
         #[case(ConnectionErrorKind::Timeout)]
@@ -543,6 +596,17 @@ mod tests {
             );
 
             assert_eq!(info.kind, ConnectionErrorKind::ConnectionLost);
+        }
+
+        #[test]
+        fn from_db_operation_error_preserves_permission_denied_kind() {
+            let info =
+                ConnectionErrorInfo::from_db_operation_error(&DbOperationError::PermissionDenied(
+                    "ERROR 1044 (42000): Access denied to database".to_string(),
+                ));
+
+            assert_eq!(info.kind, ConnectionErrorKind::PermissionDenied);
+            assert_eq!(info.hint(), "Check the connected user's privileges");
         }
 
         #[test]

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -683,6 +683,45 @@ mod tests {
         }
 
         #[test]
+        fn mysql_probe_failure_uses_server_error_codes_for_connection_guidance() {
+            for (stderr, expected) in [
+                (
+                    "ERROR 1044 (42000): Access denied for user 'user' to database 'mysql'",
+                    ConnectionErrorKind::PermissionDenied,
+                ),
+                (
+                    "ERROR 1045 (28000): Access denied for user 'user'",
+                    ConnectionErrorKind::AuthFailed,
+                ),
+                (
+                    "ERROR 1049 (42000): Unknown database 'missing'",
+                    ConnectionErrorKind::DatabaseNotFound,
+                ),
+            ] {
+                let mut state = AppState::new("test".to_string());
+                state
+                    .connection_setup
+                    .set_database_type(DatabaseType::MySQL);
+
+                reduce(
+                    &mut state,
+                    &Action::ConnectionSaveFailed(ConnectionSaveError::Probe {
+                        error: DbOperationError::ConnectionFailed(stderr.to_string()),
+                        dsn: "mysql://user:password@localhost:3306/app?ssl-mode=PREFERRED"
+                            .to_string(),
+                    }),
+                    Instant::now(),
+                );
+
+                let error_info = state.connection_error.error_info().unwrap();
+                assert_eq!(error_info.kind, expected);
+                if expected == ConnectionErrorKind::PermissionDenied {
+                    assert!(!error_info.hint().contains("password"));
+                }
+            }
+        }
+
+        #[test]
         fn save_invalidates_in_flight_mysql_probe() {
             let mut state = AppState::new("test".to_string());
             let current_id = ConnectionId::from_string("postgres-a");

--- a/src/infra/adapters/mysql/cli/probe.rs
+++ b/src/infra/adapters/mysql/cli/probe.rs
@@ -189,8 +189,13 @@ fn classify_mysql_probe_failure(stderr: String) -> DbOperationError {
             kind,
             details: stderr,
         }
-    } else {
+    } else if stderr
+        .to_ascii_lowercase()
+        .contains("can't connect to mysql server")
+    {
         DbOperationError::ConnectionFailed(stderr)
+    } else {
+        super::error::classify_mysql_query_failure(stderr.as_bytes())
     }
 }
 
@@ -369,6 +374,28 @@ mod probe_tests {
                 kind: ConnectionFailureKind::TlsCertificateVerification,
                 ..
             }
+        ));
+    }
+
+    #[test]
+    fn classifies_mysql_server_probe_failures_with_query_error_vocabulary() {
+        assert!(matches!(
+            classify_mysql_probe_failure(
+                "ERROR 1044 (42000): Access denied for user 'user' to database 'mysql'".to_string()
+            ),
+            DbOperationError::PermissionDenied(_)
+        ));
+        assert!(matches!(
+            classify_mysql_probe_failure(
+                "ERROR 1045 (28000): Access denied for user 'user'".to_string()
+            ),
+            DbOperationError::ConnectionFailed(_)
+        ));
+        assert!(matches!(
+            classify_mysql_probe_failure(
+                "ERROR 1049 (42000): Unknown database 'missing'".to_string()
+            ),
+            DbOperationError::ConnectionFailed(_)
         ));
     }
 

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -11,7 +11,9 @@ mod shared {
 
 mod connection {
 
-    use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, mysql_tls_config, with_mysql_test_db};
+    use crate::tests::harness::mysql::{
+        MYSQL_FIXTURE_TABLE, mysql_integration_config, mysql_tls_config, with_mysql_test_db,
+    };
     use sabiql_app::model::connection::error::{ConnectionErrorInfo, ConnectionErrorKind};
     use sabiql_app::ports::outbound::{AccessMode, ConnectionProbe, DsnBuilder, QueryExecutor};
     use sabiql_domain::QueryValue;
@@ -22,7 +24,7 @@ mod connection {
     #[cfg(unix)]
     use tempfile::NamedTempFile;
 
-    fn mysql_tls_profile(name: &str, config: MySqlConnectionConfig) -> ConnectionProfile {
+    fn mysql_profile(name: &str, config: MySqlConnectionConfig) -> ConnectionProfile {
         ConnectionProfile::with_id_and_config(
             ConnectionId::new(),
             name,
@@ -98,7 +100,7 @@ mod connection {
     #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
     async fn connects_to_oracle_mysql_84_fixture_with_ca_and_client_certificate() {
         let config = mysql_tls_config();
-        let profile = mysql_tls_profile("mysql-tls-integration", config);
+        let profile = mysql_profile("mysql-tls-integration", config);
         let adapter = MySqlAdapter::new();
         let dsn = adapter.build_dsn(&profile);
 
@@ -119,7 +121,7 @@ mod connection {
     async fn rejects_oracle_mysql_84_fixture_with_wrong_ca() {
         let mut config = mysql_tls_config();
         config.ssl_ca = config.ssl_cert.clone();
-        let profile = mysql_tls_profile("mysql-tls-wrong-ca", config);
+        let profile = mysql_profile("mysql-tls-wrong-ca", config);
         let adapter = MySqlAdapter::new();
         let dsn = adapter.build_dsn(&profile);
         let error = adapter.probe(&dsn).await.unwrap_err();
@@ -135,7 +137,7 @@ mod connection {
         let mut config = mysql_tls_config();
         config.host = "host.docker.internal".to_string();
         config.ssl_mode = MySqlSslMode::VerifyIdentity;
-        let profile = mysql_tls_profile("mysql-tls-wrong-host", config);
+        let profile = mysql_profile("mysql-tls-wrong-host", config);
         let adapter = MySqlAdapter::new();
         let dsn = adapter.build_dsn(&profile);
         let error = adapter.probe(&dsn).await.unwrap_err();
@@ -145,6 +147,54 @@ mod connection {
             ConnectionErrorKind::MySqlHostnameVerificationFailed,
             "masked connection error details: {}",
             error_info.masked_details()
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn classifies_real_mysql_connection_errors_by_server_code() {
+        let adapter = MySqlAdapter::new();
+        let base_config = mysql_integration_config();
+
+        let mut permission_config = base_config.clone();
+        permission_config.database = Some("mysql".to_string());
+        let permission_profile = mysql_profile("mysql-permission", permission_config);
+        let permission_dsn = adapter.build_dsn(&permission_profile);
+        let permission_error = adapter.probe(&permission_dsn).await.unwrap_err();
+        assert_eq!(
+            ConnectionErrorInfo::from_db_operation_error_with_dsn(
+                &permission_error,
+                &permission_dsn
+            )
+            .kind,
+            ConnectionErrorKind::PermissionDenied
+        );
+
+        let mut missing_config = base_config.clone();
+        missing_config.database = Some("sabiql_missing_connection_database".to_string());
+        missing_config.username = "root".to_string();
+        missing_config.password = "root".to_string();
+        let missing_profile = mysql_profile("mysql-missing-database", missing_config);
+        let missing_dsn = adapter.build_dsn(&missing_profile);
+        let missing_error = adapter.probe(&missing_dsn).await.unwrap_err();
+        assert_eq!(
+            ConnectionErrorInfo::from_db_operation_error_with_dsn(&missing_error, &missing_dsn)
+                .kind,
+            ConnectionErrorKind::DatabaseNotFound
+        );
+
+        let mut auth_config = mysql_tls_config();
+        auth_config.password = "wrong-password".to_string();
+        let auth_profile = mysql_profile("mysql-authentication", auth_config);
+        let auth_dsn = adapter.build_dsn(&auth_profile);
+        let auth_error = adapter.probe(&auth_dsn).await.unwrap_err();
+        let auth_info =
+            ConnectionErrorInfo::from_db_operation_error_with_dsn(&auth_error, &auth_dsn);
+        assert_eq!(
+            auth_info.kind,
+            ConnectionErrorKind::AuthFailed,
+            "MySQL authentication error: {auth_error:?}; masked details: {}",
+            auth_info.masked_details()
         );
     }
 }


### PR DESCRIPTION
## Problem
MySQL connection failures with server errors 1044 and 1049 were shown as authentication or generic failures, so the guidance did not match the selected database or its privileges.

## Background
The probe and query paths already recognize MySQL server codes, but the connection UI fell back to wording-based classification.

## Approach
Classify 1044, 1045, and 1049 at the connection error boundary, map permission failures to privilege guidance, reuse the query error vocabulary in probes, and keep unknown codes fail closed. Add focused and Oracle MySQL 8.4 integration coverage.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-471