### PR TITLE
fix(mysql): consolidate pipe tests

### DIFF
--- a/src/infra/adapters/mysql/cli/pipe.rs
+++ b/src/infra/adapters/mysql/cli/pipe.rs
@@ -216,12 +216,17 @@ fn mysql_pipe_empty_response_or_error(pending_stderr: &[u8]) -> DbOperationError
 }
 
 #[cfg(test)]
-mod source_tests {
+#[cfg(not(unix))]
+mod tests {
+    use std::process::Stdio;
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     };
     use std::task::{Wake, Waker};
+
+    use tokio::io::AsyncWriteExt;
+    use tokio::process::{Child, Command};
 
     use super::*;
 
@@ -277,17 +282,6 @@ mod source_tests {
         assert!(matches!(result, Poll::Pending));
         assert_eq!(wake_counter.0.load(Ordering::Relaxed), 0);
     }
-}
-
-#[cfg(test)]
-#[cfg(not(unix))]
-mod tests {
-    use std::process::Stdio;
-
-    use tokio::io::AsyncWriteExt;
-    use tokio::process::{Child, Command};
-
-    use super::*;
 
     fn exited_child() -> Child {
         Command::new("cmd.exe")


### PR DESCRIPTION
## Problem
The Windows pipe regression test was introduced as a separate module even though the parent pipe module is already non-Unix-only.

## Approach
Merge the regression test and its helpers into the existing non-Unix pipe test module. Audit the adjacent PTY and process modules; no matching placement issue was found there.

## Linear Issue
- Implements https://linear.app/sabiql/issue/SAB-475