### PR TITLE
perf(mysql): finish preview after final result frame

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -18,7 +18,7 @@ use super::error::{classify_mysql_query_failure, has_mysql_cli_error, validate_m
 use super::pipe::MySqlExportPipeSource;
 use super::policy::mysql_metadata_fallback_kind;
 use super::process::{
-    MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session_after_result,
+    MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
     mysql_metadata_columns, read_one_mysql_resultset, run_mysql_process_with_timeout,
     write_mysql_statement,
 };
@@ -78,7 +78,7 @@ pub(super) async fn run_mysql_export_process(
         csv_writer.write_record(columns.iter()).await?;
     }
 
-    let result = finish_mysql_session_after_result(process).await?;
+    let result = finish_mysql_session(process).await?;
     validate_mysql_export_exit(result.status, result.forcibly_stopped, &result.error_bytes)?;
 
     csv_writer.finish().await

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -243,7 +243,7 @@ pub(in crate::adapters::mysql::cli) async fn finish_mysql_session(
     })
 }
 
-pub(in crate::adapters::mysql::cli) async fn finish_mysql_session_after_result(
+pub(in crate::adapters::mysql::cli) async fn finish_mysql_session_after_preview_frame(
     process: &mut MySqlProcess,
 ) -> Result<MySqlSessionResult, DbOperationError> {
     #[cfg(unix)]

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -19,8 +19,7 @@ use super::super::xml::MySqlResultSet;
 use super::metadata::mysql_metadata_columns;
 use super::{
     MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
-    finish_mysql_session_after_result, read_one_mysql_resultset, run_mysql_process_with_timeout,
-    write_mysql_statement,
+    read_one_mysql_resultset, run_mysql_process_with_timeout, write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) async fn run_mysql_adhoc(
@@ -224,11 +223,7 @@ async fn run_mysql_adhoc_process(
         refresh_scope = execution.refresh_scope;
     }
 
-    let result = if access_mode.is_read_only() {
-        finish_mysql_session_after_result(process).await?
-    } else {
-        finish_mysql_session(process).await?
-    };
+    let result = finish_mysql_session(process).await?;
     if has_mysql_cli_error(&result.error_bytes) {
         return Err(query_failed_after_change(
             classify_mysql_query_failure(&result.error_bytes),

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -15,6 +15,8 @@ pub(in crate::adapters::mysql) struct MySqlMetadataSession {
     process: MySqlProcess,
 }
 
+const MYSQL_PREVIEW_COMPLETION_MARKER_COLUMN: &str = "__sabiql_preview_completion";
+
 impl MySqlMetadataSession {
     pub(in crate::adapters::mysql) fn spawn_with_program(
         program: &OsStr,
@@ -77,6 +79,21 @@ impl MySqlMetadataSession {
     pub(in crate::adapters::mysql) async fn finish_preview(
         &mut self,
     ) -> Result<(), DbOperationError> {
+        let marker = Uuid::new_v4().simple().to_string();
+        let marker_result = self
+            .execute(&format!(
+                "SELECT '{marker}' AS {MYSQL_PREVIEW_COMPLETION_MARKER_COLUMN}"
+            ))
+            .await?;
+        if marker_result.columns != [MYSQL_PREVIEW_COMPLETION_MARKER_COLUMN]
+            || marker_result.values.len() != 1
+            || marker_result.values[0].len() != 1
+            || marker_result.values[0][0].as_str() != Some(marker.as_str())
+        {
+            return Err(DbOperationError::QueryFailed(
+                "mysql preview completion marker did not match".to_string(),
+            ));
+        }
         let result = finish_mysql_session_after_preview_frame(&mut self.process).await?;
         if super::has_mysql_cli_error(&result.error_bytes) {
             return Err(super::classify_mysql_query_failure(&result.error_bytes));

--- a/src/infra/adapters/mysql/cli/process/session.rs
+++ b/src/infra/adapters/mysql/cli/process/session.rs
@@ -6,8 +6,8 @@ use crate::app::ports::outbound::{AccessMode, DbOperationError};
 
 use super::super::xml::{MySqlResultSet, parse_mysql_xml};
 use super::{
-    MySqlProcess, cleanup_mysql_process, configure_mysql_session,
-    finish_mysql_session_after_result, read_one_mysql_resultset, validate_mode_probe,
+    MySqlProcess, cleanup_mysql_process, configure_mysql_session, finish_mysql_session,
+    finish_mysql_session_after_preview_frame, read_one_mysql_resultset, validate_mode_probe,
     write_mysql_statement,
 };
 
@@ -64,7 +64,20 @@ impl MySqlMetadataSession {
     }
 
     pub(in crate::adapters::mysql) async fn finish(&mut self) -> Result<(), DbOperationError> {
-        let result = finish_mysql_session_after_result(&mut self.process).await?;
+        let result = finish_mysql_session(&mut self.process).await?;
+        if super::has_mysql_cli_error(&result.error_bytes) {
+            return Err(super::classify_mysql_query_failure(&result.error_bytes));
+        }
+        if !result.status.success() && !result.forcibly_stopped {
+            return Err(super::classify_mysql_query_failure(&result.error_bytes));
+        }
+        Ok(())
+    }
+
+    pub(in crate::adapters::mysql) async fn finish_preview(
+        &mut self,
+    ) -> Result<(), DbOperationError> {
+        let result = finish_mysql_session_after_preview_frame(&mut self.process).await?;
         if super::has_mysql_cli_error(&result.error_bytes) {
             return Err(super::classify_mysql_query_failure(&result.error_bytes));
         }

--- a/src/infra/adapters/mysql/cli/process/single.rs
+++ b/src/infra/adapters/mysql/cli/process/single.rs
@@ -7,8 +7,7 @@ use super::super::error::{classify_mysql_query_failure, has_mysql_cli_error, val
 use super::super::xml::{MySqlResultSet, parse_mysql_xml};
 use super::{
     MYSQL_QUERY_TIMEOUT, MySqlProcess, configure_mysql_session, finish_mysql_session,
-    finish_mysql_session_after_result, read_one_mysql_resultset, run_mysql_process_with_timeout,
-    write_mysql_statement,
+    read_one_mysql_resultset, run_mysql_process_with_timeout, write_mysql_statement,
 };
 
 pub(in crate::adapters::mysql) async fn run_mysql_single_statement(
@@ -41,11 +40,7 @@ pub(super) async fn run_mysql_single_statement_process(
 
     #[cfg(unix)]
     let stdout = read_one_mysql_resultset(process).await?;
-    let result = if access_mode.is_read_only() {
-        finish_mysql_session_after_result(process).await?
-    } else {
-        finish_mysql_session(process).await?
-    };
+    let result = finish_mysql_session(process).await?;
     if has_mysql_cli_error(&result.error_bytes) {
         return Err(classify_mysql_query_failure(&result.error_bytes));
     }

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -156,7 +156,7 @@ async fn execute_preview_with_session(
         limit,
         offset,
     );
-    session.finish().await?;
+    session.finish_preview().await?;
 
     Ok(PreviewExecution {
         metadata,

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -410,7 +410,10 @@ mod tests {
     use crate::domain::ColumnAttributes;
 
     #[cfg(unix)]
-    fn fake_preview_mysql(metadata_failure: bool) -> (tempfile::TempDir, PathBuf, PathBuf) {
+    fn fake_preview_mysql(
+        metadata_failure: bool,
+        delayed_preview_error: bool,
+    ) -> (tempfile::TempDir, PathBuf, PathBuf) {
         let directory = tempfile::tempdir().expect("temporary directory");
         let program = directory.path().join("mysql");
         let log_path = directory.path().join("mysql.log");
@@ -447,12 +450,22 @@ while IFS= read -r line; do
       ;;
     *"LIMIT 2 OFFSET 1"*)
       printf '%s\n' '<resultset><row><field name="payload">0x00FF</field><field name="__sabiql_row_identity_0">1</field></row></resultset>'
+      {delayed_preview_error}
+      ;;
+    *__sabiql_preview_completion*)
+      marker=$(printf '%s\n' "$line" | sed "s/.*SELECT '\([^']*\)' AS __sabiql_preview_completion.*/\1/")
+      printf '%s\n' '<resultset><row><field name="__sabiql_preview_completion">'"$marker"'</field></row></resultset>'
       ;;
   esac
 done
 "#,
             log = log_path.display(),
             columns_result = columns_result,
+            delayed_preview_error = if delayed_preview_error {
+                "sleep 0.05\nprintf '%s\\n' 'ERROR 1054 (42S22): delayed preview error' >&2"
+            } else {
+                ""
+            },
         );
         fs::write(&program, script).expect("fake MySQL program");
         let mut permissions = fs::metadata(&program)
@@ -484,7 +497,7 @@ done
     #[cfg(unix)]
     #[tokio::test]
     async fn preview_metadata_and_rows_share_one_mysql_session() {
-        let (_directory, program, log_path) = fake_preview_mysql(false);
+        let (_directory, program, log_path) = fake_preview_mysql(false, false);
         let execution = execute_preview_with_program(
             "mysql://preview:secret@localhost:3306/sabiql_test",
             "sabiql_test",
@@ -543,6 +556,7 @@ done
             "INFORMATION_SCHEMA.COLUMNS",
             "INFORMATION_SCHEMA.STATISTICS",
             "LIMIT 2 OFFSET 1",
+            "__sabiql_preview_completion",
         ]
         .into_iter()
         .map(|query| log.find(query).expect("query in transcript"))
@@ -553,7 +567,7 @@ done
     #[cfg(unix)]
     #[tokio::test]
     async fn preview_metadata_failure_never_sends_user_select() {
-        let (_directory, program, log_path) = fake_preview_mysql(true);
+        let (_directory, program, log_path) = fake_preview_mysql(true, false);
         let result = execute_preview_with_program(
             "mysql://preview:secret@localhost:3306/sabiql_test",
             "sabiql_test",
@@ -572,6 +586,28 @@ done
         let log = fs::read_to_string(log_path).expect("fake MySQL transcript");
         assert!(log.contains("INFORMATION_SCHEMA.COLUMNS"));
         assert!(!log.contains("LIMIT 2 OFFSET 1"), "{log}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn delayed_error_between_preview_and_completion_frames_is_classified() {
+        let (_directory, program, _log_path) = fake_preview_mysql(false, true);
+        let result = execute_preview_with_program(
+            "mysql://preview:secret@localhost:3306/sabiql_test",
+            "sabiql_test",
+            "items",
+            2,
+            1,
+            OsStr::new(&program),
+            Duration::from_secs(5),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(DbOperationError::ObjectMissing(details))
+                if details.contains("delayed preview error")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep the PTY final-frame fast path scoped to successful MySQL result previews
- retain the normal PTY drain for write, CSV, metadata detail, error classification, and timeout cleanup paths

## Validation

- focused MySQL CLI/process tests: 26 passed
- focused preview tests: 9 passed
- focused table-detail tests: 13 passed
- targeted cargo clippy -p sabiql-infra --features test-support --lib --tests -- -D warnings
- cargo fmt --all -- --check
- direct MySQL CLI rustfmt check
- scripts/lint_all.sh