### PR TITLE
test(mysql): shorten timeout integration test

### DIFF
--- a/src/infra/adapters/mysql/cli/mod.rs
+++ b/src/infra/adapters/mysql/cli/mod.rs
@@ -16,6 +16,9 @@ pub(super) use probe::{check_mysql_cli_version, probe_mysql_server};
 pub(super) use process::{
     MYSQL_QUERY_TIMEOUT, MySqlMetadataSession, run_mysql_adhoc, run_mysql_single_statement,
 };
+
+#[cfg(feature = "test-support")]
+pub(super) use process::run_mysql_adhoc_with_timeout_for_test;
 pub(super) use xml::MySqlResultSet;
 
 #[cfg(all(unix, feature = "test-support"))]

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -32,6 +32,8 @@ mod session;
 pub(in crate::adapters::mysql) use session::MySqlMetadataSession;
 mod adhoc;
 pub(in crate::adapters::mysql) use adhoc::run_mysql_adhoc;
+#[cfg(feature = "test-support")]
+pub(in crate::adapters::mysql) use adhoc::run_mysql_adhoc_with_timeout_for_test;
 mod single;
 pub(in crate::adapters::mysql) use single::run_mysql_single_statement;
 mod metadata;
@@ -448,6 +450,18 @@ where
                 "mysql query exceeded the execution timeout".to_string(),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod timeout_tests {
+    use std::time::Duration;
+
+    use super::MYSQL_QUERY_TIMEOUT;
+
+    #[test]
+    fn keeps_production_query_timeout_at_31_seconds() {
+        assert_eq!(MYSQL_QUERY_TIMEOUT, Duration::from_secs(31));
     }
 }
 

--- a/src/infra/adapters/mysql/cli/process/adhoc.rs
+++ b/src/infra/adapters/mysql/cli/process/adhoc.rs
@@ -39,6 +39,24 @@ pub(in crate::adapters::mysql) async fn run_mysql_adhoc(
     .await
 }
 
+#[cfg(feature = "test-support")]
+pub(in crate::adapters::mysql) async fn run_mysql_adhoc_with_timeout_for_test(
+    option_file: &Path,
+    statements: &[MySqlStatement],
+    access_mode: AccessMode,
+    execution_timeout: Duration,
+) -> Result<MySqlExecutionResult, DbOperationError> {
+    run_mysql_adhoc_with_program_and_statements_and_expected_columns(
+        OsStr::new("mysql"),
+        option_file,
+        statements,
+        access_mode,
+        None,
+        execution_timeout,
+    )
+    .await
+}
+
 pub(super) async fn run_mysql_adhoc_with_program_and_statements_and_expected_columns(
     program: &OsStr,
     option_file: &Path,

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -18,10 +18,12 @@ use super::option_file::MySqlOptionFile;
 #[cfg(feature = "test-support")]
 pub(super) mod test_support {
     use std::path::{Path, PathBuf};
+    use std::time::Duration;
 
     use crate::adapters::csv_export::export_to_path;
     use crate::app::ports::outbound::{AccessMode, DbOperationError};
 
+    use super::super::cli::run_mysql_adhoc_with_timeout_for_test;
     use super::{
         MySqlOptionFile, export_mysql_csv_to_file, parse_and_validate_mysql_dsn, run_mysql_adhoc,
         validate_mysql_multi_query,
@@ -61,6 +63,27 @@ pub(super) mod test_support {
             validate_mysql_multi_query(query, target.database.as_deref(), AccessMode::ReadWrite)?;
         let option_file = MySqlOptionFile::create(&target)?;
         let result = run_mysql_adhoc(&option_file.path, &statements, AccessMode::ReadOnly).await;
+        drop(option_file);
+        result.map(|_| ())
+    }
+
+    #[doc(hidden)]
+    pub async fn execute_mysql_adhoc_with_timeout_for_test(
+        dsn: &str,
+        query: &str,
+        execution_timeout: Duration,
+    ) -> Result<(), DbOperationError> {
+        let target = parse_and_validate_mysql_dsn(dsn)?;
+        let statements =
+            validate_mysql_multi_query(query, target.database.as_deref(), AccessMode::ReadWrite)?;
+        let option_file = MySqlOptionFile::create(&target)?;
+        let result = run_mysql_adhoc_with_timeout_for_test(
+            &option_file.path,
+            &statements,
+            AccessMode::ReadWrite,
+            execution_timeout,
+        )
+        .await;
         drop(option_file);
         result.map(|_| ())
     }

--- a/src/infra/adapters/mysql/mod.rs
+++ b/src/infra/adapters/mysql/mod.rs
@@ -15,5 +15,6 @@ pub use executor::test_support::run_mysql_cli_script_for_test;
 #[cfg(feature = "test-support")]
 pub use executor::test_support::{
     MySqlOptionFileForTest, create_mysql_option_file_for_test,
-    execute_mysql_adhoc_with_read_only_session_for_test, export_mysql_csv_to_path_for_test,
+    execute_mysql_adhoc_with_read_only_session_for_test, execute_mysql_adhoc_with_timeout_for_test,
+    export_mysql_csv_to_path_for_test,
 };

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -1475,7 +1475,10 @@ mod query_execution {
         AccessMode, DbOperationError, QueryExecutor, UnsupportedOperationKind,
     };
     use sabiql_domain::{CommandTag, QueryValue, RefreshScope};
-    use sabiql_infra::adapters::mysql::execute_mysql_adhoc_with_read_only_session_for_test;
+    use sabiql_infra::adapters::mysql::{
+        execute_mysql_adhoc_with_read_only_session_for_test,
+        execute_mysql_adhoc_with_timeout_for_test,
+    };
     use std::time::Duration;
 
     #[tokio::test]
@@ -2290,10 +2293,16 @@ mod query_execution {
     async fn times_out_real_cli_query_and_discards_output() {
         with_mysql_test_db(|db| {
             Box::pin(async move {
-                let result = db
-                    .adapter()
-                    .execute_adhoc(db.dsn(), "SELECT SLEEP(32)", AccessMode::ReadWrite)
-                    .await;
+                let result = tokio::time::timeout(
+                    Duration::from_secs(5),
+                    execute_mysql_adhoc_with_timeout_for_test(
+                        db.dsn(),
+                        "SELECT SLEEP(10), 'discarded'",
+                        Duration::from_secs(1),
+                    ),
+                )
+                .await
+                .map_err(|_| "timeout cleanup did not finish within 5 seconds".to_string())?;
                 if !matches!(result, Err(DbOperationError::Timeout(_))) {
                     return Err(format!("expected a query timeout: {result:?}"));
                 }


### PR DESCRIPTION
## Problem
The MySQL timeout integration test waited for the production 31-second timeout, making the Oracle MySQL integration suite unnecessarily slow.

## Background
The production timeout and cleanup behavior must remain unchanged while the integration test exercises the same orchestration with a short test-only timeout.

## Approach
Expose a test-support entry point that injects the timeout into the existing MySQL process orchestration, pin the production default with a unit test, and verify Oracle MySQL SLEEP timeout cleanup with a one-second test timeout.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-482
