### PR TITLE
feat(mysql): preserve binary charset bytes in preview

### DIFF
--- a/scripts/init-mysql.sql
+++ b/scripts/init-mysql.sql
@@ -38,6 +38,34 @@ INSERT INTO mysql_cli_fixture (
     1.23e100
 );
 
+CREATE TABLE mysql_preview_binary_charset (
+    id INT PRIMARY KEY,
+    binary_char CHAR(4) CHARACTER SET binary NOT NULL,
+    binary_varchar VARCHAR(4) CHARACTER SET binary NOT NULL,
+    regular_varchar VARCHAR(6) CHARACTER SET utf8mb4 NOT NULL,
+    binary_varbinary VARBINARY(4) NOT NULL,
+    binary_blob BLOB NOT NULL,
+    binary_bit BIT(8) NOT NULL
+) CHARACTER SET utf8mb4;
+
+INSERT INTO mysql_preview_binary_charset (
+    id,
+    binary_char,
+    binary_varchar,
+    regular_varchar,
+    binary_varbinary,
+    binary_blob,
+    binary_bit
+) VALUES (
+    1,
+    X'00FFA10D',
+    X'00FFA10D',
+    '0x00FF',
+    X'00FFA10D',
+    X'00FFA10D',
+    b'10100101'
+);
+
 CREATE DEFINER='sabiql'@'%' TRIGGER mysql_cli_fixture_audit
 BEFORE UPDATE ON mysql_cli_fixture
 FOR EACH ROW

--- a/src/infra/adapters/mysql/executor.rs
+++ b/src/infra/adapters/mysql/executor.rs
@@ -108,10 +108,12 @@ impl QueryExecutor for MySqlAdapter {
         let start = Instant::now();
         let execution = metadata::execute_preview(dsn, schema, table, limit, offset).await?;
         let preview = execution.metadata;
-        let values = metadata::convert_preview_values(
+        let values = metadata::convert_preview_values_with_binary_charset(
             &execution.result_set,
             &preview.visible_columns,
             &preview.identity_columns,
+            &preview.binary_charset_columns,
+            &preview.binary_charset_identity_columns,
         )?;
         let elapsed = start.elapsed().as_millis() as u64;
 

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -13,8 +13,9 @@ use super::super::{
     dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
     sql::{
-        COLUMN_METADATA_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS, TABLES_QUERY,
-        TABLES_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS,
+        COLUMN_METADATA_RESULT_COLUMNS, FOREIGN_KEY_RESULT_COLUMNS,
+        PREVIEW_COLUMN_METADATA_RESULT_COLUMNS, TABLES_QUERY, TABLES_RESULT_COLUMNS,
+        UNIQUE_COLUMN_RESULT_COLUMNS,
     },
 };
 
@@ -28,6 +29,7 @@ enum MySqlColumnUnique {
 pub(super) struct MySqlColumnMetadata {
     name: String,
     data_type: String,
+    character_set_name: Option<String>,
     nullable: bool,
     default: Option<String>,
     comment: Option<String>,
@@ -36,6 +38,18 @@ pub(super) struct MySqlColumnMetadata {
     unique: MySqlColumnUnique,
     invisible: bool,
     generated: bool,
+}
+
+impl MySqlColumnMetadata {
+    pub(super) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(super) fn has_binary_character_set(&self) -> bool {
+        self.character_set_name
+            .as_deref()
+            .is_some_and(|name| name.eq_ignore_ascii_case("binary"))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -96,6 +110,39 @@ pub(super) fn parse_columns_for_table(
     table: &str,
 ) -> Result<Vec<MySqlColumnMetadata>, DbOperationError> {
     let columns = parse_column_metadata(result)?;
+    if columns.is_empty() {
+        return Err(DbOperationError::ObjectMissing(format!(
+            "MySQL table not found: {schema}.{table}"
+        )));
+    }
+    Ok(columns)
+}
+
+pub(super) fn parse_preview_columns_for_table(
+    result: &MySqlResultSet,
+    schema: &str,
+    table: &str,
+) -> Result<Vec<MySqlColumnMetadata>, DbOperationError> {
+    expect_columns(result, PREVIEW_COLUMN_METADATA_RESULT_COLUMNS)?;
+    let columns = result
+        .values
+        .iter()
+        .map(|row| {
+            if row.len() != PREVIEW_COLUMN_METADATA_RESULT_COLUMNS.len() {
+                return Err(metadata_shape_error("preview COLUMNS row"));
+            }
+            let mut column = parse_column_metadata_row(
+                &row[..COLUMN_METADATA_RESULT_COLUMNS.len()],
+                "preview COLUMNS row",
+            )?;
+            column.character_set_name = optional_text(
+                &row[COLUMN_METADATA_RESULT_COLUMNS.len()],
+                "CHARACTER_SET_NAME",
+            )?
+            .map(str::to_string);
+            Ok(column)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
     if columns.is_empty() {
         return Err(DbOperationError::ObjectMissing(format!(
             "MySQL table not found: {schema}.{table}"
@@ -283,6 +330,7 @@ pub(super) fn parse_column_metadata_row(
     Ok(MySqlColumnMetadata {
         name: required_text(&row[0], "COLUMN_NAME")?.to_string(),
         data_type: required_text(&row[1], "COLUMN_TYPE")?.to_string(),
+        character_set_name: None,
         nullable: required_text(&row[2], "IS_NULLABLE")? == "YES",
         default: optional_text(&row[3], "COLUMN_DEFAULT")?.map(str::to_string),
         comment: optional_text(&row[5], "COLUMN_COMMENT")?
@@ -677,6 +725,45 @@ mod tests {
 
         assert!(column.is_hidden());
         assert!(column.is_read_only());
+    }
+
+    #[test]
+    fn preview_metadata_preserves_binary_character_set() {
+        let parsed = parse_preview_columns_for_table(
+            &result(
+                PREVIEW_COLUMN_METADATA_RESULT_COLUMNS,
+                vec![
+                    vec![
+                        QueryValue::Text("binary_char".to_string()),
+                        QueryValue::Text("char(4)".to_string()),
+                        QueryValue::Text("NO".to_string()),
+                        QueryValue::Null,
+                        QueryValue::Text(String::new()),
+                        QueryValue::Null,
+                        QueryValue::Text("1".to_string()),
+                        QueryValue::Text("1".to_string()),
+                        QueryValue::Text("binary".to_string()),
+                    ],
+                    vec![
+                        QueryValue::Text("normal_text".to_string()),
+                        QueryValue::Text("varchar(4)".to_string()),
+                        QueryValue::Text("NO".to_string()),
+                        QueryValue::Null,
+                        QueryValue::Text(String::new()),
+                        QueryValue::Null,
+                        QueryValue::Text("2".to_string()),
+                        QueryValue::Null,
+                        QueryValue::Text("utf8mb4".to_string()),
+                    ],
+                ],
+            ),
+            "app",
+            "items",
+        )
+        .expect("preview metadata parses");
+
+        assert!(parsed[0].has_binary_character_set());
+        assert!(!parsed[1].has_binary_character_set());
     }
 
     #[test]

--- a/src/infra/adapters/mysql/metadata/mod.rs
+++ b/src/infra/adapters/mysql/metadata/mod.rs
@@ -12,7 +12,7 @@ mod preview;
 mod signature;
 mod table_detail;
 
-pub(super) use preview::{convert_preview_values, execute_preview};
+pub(super) use preview::{convert_preview_values_with_binary_charset, execute_preview};
 
 #[async_trait]
 impl MetadataProvider for MySqlAdapter {

--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -9,13 +9,14 @@ use super::super::{
     dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
     sql::{
-        COLUMN_METADATA_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, build_preview_query,
-        columns_query, preview_identity_alias, unique_columns_query,
+        PREVIEW_COLUMN_METADATA_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, build_preview_query,
+        preview_columns_query, preview_identity_alias, unique_columns_query,
     },
 };
 use super::catalog::{
-    MySqlColumnMetadata, column_from_metadata, mark_single_column_unique, parse_columns_for_table,
-    parse_unique_column_metadata, primary_key_names, validate_selected_schema_name,
+    MySqlColumnMetadata, column_from_metadata, mark_single_column_unique,
+    parse_preview_columns_for_table, parse_unique_column_metadata, primary_key_names,
+    validate_selected_schema_name,
 };
 
 #[derive(Debug, Clone)]
@@ -23,6 +24,8 @@ pub(in crate::adapters::mysql) struct PreviewMetadata {
     pub(in crate::adapters::mysql) visible_columns: Vec<Column>,
     pub(in crate::adapters::mysql) order_columns: Vec<String>,
     pub(in crate::adapters::mysql) identity_columns: Vec<Column>,
+    pub(in crate::adapters::mysql) binary_charset_columns: Vec<bool>,
+    pub(in crate::adapters::mysql) binary_charset_identity_columns: Vec<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -110,8 +113,8 @@ async fn execute_preview_with_session(
 
     let column_result = session
         .execute_with_expected_columns(
-            &columns_query(schema, table),
-            COLUMN_METADATA_RESULT_COLUMNS,
+            &preview_columns_query(schema, table),
+            PREVIEW_COLUMN_METADATA_RESULT_COLUMNS,
         )
         .await?;
     let unique_result = session
@@ -120,7 +123,7 @@ async fn execute_preview_with_session(
             UNIQUE_COLUMN_RESULT_COLUMNS,
         )
         .await?;
-    let mut column_metadata = parse_columns_for_table(&column_result, schema, table)?;
+    let mut column_metadata = parse_preview_columns_for_table(&column_result, schema, table)?;
     mark_single_column_unique(
         &mut column_metadata,
         &parse_unique_column_metadata(&unique_result)?,
@@ -174,10 +177,18 @@ fn preview_metadata_from_columns(
         .iter()
         .map(column_from_metadata)
         .collect::<Vec<_>>();
-    let visible_columns = columns
+    let visible_metadata = column_metadata
         .iter()
-        .filter(|column| !column.is_hidden())
-        .cloned()
+        .zip(&columns)
+        .filter(|(_, column)| !column.is_hidden())
+        .collect::<Vec<_>>();
+    let visible_columns = visible_metadata
+        .iter()
+        .map(|(_, column)| (*column).clone())
+        .collect::<Vec<_>>();
+    let binary_charset_columns = visible_metadata
+        .iter()
+        .map(|(metadata, _)| metadata.has_binary_character_set())
         .collect::<Vec<_>>();
     if visible_columns.is_empty() {
         return Err(DbOperationError::MetadataParseFailed(format!(
@@ -199,6 +210,15 @@ fn preview_metadata_from_columns(
     } else {
         Vec::new()
     };
+    let binary_charset_identity_columns = identity_columns
+        .iter()
+        .map(|column| {
+            column_metadata
+                .iter()
+                .find(|metadata| metadata.name() == column.name)
+                .is_some_and(MySqlColumnMetadata::has_binary_character_set)
+        })
+        .collect();
     let order_columns = primary_key_names;
     let order_columns = if order_columns.is_empty() {
         visible_columns
@@ -212,13 +232,17 @@ fn preview_metadata_from_columns(
         visible_columns,
         order_columns,
         identity_columns,
+        binary_charset_columns,
+        binary_charset_identity_columns,
     })
 }
 
-pub(in crate::adapters::mysql) fn convert_preview_values(
+pub(in crate::adapters::mysql) fn convert_preview_values_with_binary_charset(
     result: &MySqlResultSet,
     columns: &[Column],
     identity_columns: &[Column],
+    binary_charset_columns: &[bool],
+    binary_charset_identity_columns: &[bool],
 ) -> Result<ConvertedPreviewValues, DbOperationError> {
     let expected_columns = preview_result_columns(columns, identity_columns);
     if result.values.is_empty() {
@@ -248,7 +272,22 @@ pub(in crate::adapters::mysql) fn convert_preview_values(
             }
             row.iter()
                 .zip(columns.iter().chain(identity_columns))
-                .map(|(value, column)| Ok(convert_preview_value(value, &column.data_type)))
+                .enumerate()
+                .map(|(index, (value, column))| {
+                    let has_binary_charset = if index < columns.len() {
+                        binary_charset_columns.get(index).copied().unwrap_or(false)
+                    } else {
+                        binary_charset_identity_columns
+                            .get(index - columns.len())
+                            .copied()
+                            .unwrap_or(false)
+                    };
+                    Ok(convert_preview_value(
+                        value,
+                        &column.data_type,
+                        has_binary_charset,
+                    ))
+                })
                 .collect::<Result<Vec<_>, _>>()
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -282,11 +321,15 @@ pub(in crate::adapters::mysql) fn preview_result_columns(
         .collect()
 }
 
-fn convert_preview_value(value: &QueryValue, data_type: &str) -> QueryValue {
+fn convert_preview_value(
+    value: &QueryValue,
+    data_type: &str,
+    has_binary_charset: bool,
+) -> QueryValue {
     let QueryValue::Text(value) = value else {
         return value.clone();
     };
-    if is_binary_type(data_type)
+    if (has_binary_charset || is_binary_type(data_type))
         && let Some(bytes) = decode_hex(value)
     {
         return QueryValue::Blob(bytes);
@@ -409,6 +452,14 @@ mod tests {
     use super::*;
     use crate::domain::ColumnAttributes;
 
+    fn convert_preview_values(
+        result: &MySqlResultSet,
+        columns: &[Column],
+        identity_columns: &[Column],
+    ) -> Result<ConvertedPreviewValues, DbOperationError> {
+        convert_preview_values_with_binary_charset(result, columns, identity_columns, &[], &[])
+    }
+
     #[cfg(unix)]
     fn fake_preview_mysql(metadata_failure: bool) -> (tempfile::TempDir, PathBuf, PathBuf) {
         let directory = tempfile::tempdir().expect("temporary directory");
@@ -417,7 +468,7 @@ mod tests {
         let columns_result = if metadata_failure {
             r#"printf '%s\n' '<resultset><row><field name="wrong">x</field></row></resultset>'"#
         } else {
-            r#"printf '%s\n' '<resultset><row><field name="COLUMN_NAME">id</field><field name="COLUMN_TYPE">int</field><field name="IS_NULLABLE">NO</field><field name="COLUMN_DEFAULT" xsi:nil="true"/><field name="EXTRA">INVISIBLE</field><field name="COLUMN_COMMENT" xsi:nil="true"/><field name="ORDINAL_POSITION">1</field><field name="PRIMARY_KEY_POSITION">1</field></row><row><field name="COLUMN_NAME">payload</field><field name="COLUMN_TYPE">varbinary(16)</field><field name="IS_NULLABLE">YES</field><field name="COLUMN_DEFAULT" xsi:nil="true"/><field name="EXTRA"></field><field name="COLUMN_COMMENT"></field><field name="ORDINAL_POSITION">2</field><field name="PRIMARY_KEY_POSITION" xsi:nil="true"/></row></resultset>'"#
+            r#"printf '%s\n' '<resultset><row><field name="COLUMN_NAME">id</field><field name="COLUMN_TYPE">int</field><field name="IS_NULLABLE">NO</field><field name="COLUMN_DEFAULT" xsi:nil="true"/><field name="EXTRA">INVISIBLE</field><field name="COLUMN_COMMENT" xsi:nil="true"/><field name="ORDINAL_POSITION">1</field><field name="PRIMARY_KEY_POSITION">1</field><field name="CHARACTER_SET_NAME" xsi:nil="true"/></row><row><field name="COLUMN_NAME">payload</field><field name="COLUMN_TYPE">varbinary(16)</field><field name="IS_NULLABLE">YES</field><field name="COLUMN_DEFAULT" xsi:nil="true"/><field name="EXTRA"></field><field name="COLUMN_COMMENT"></field><field name="ORDINAL_POSITION">2</field><field name="PRIMARY_KEY_POSITION" xsi:nil="true"/><field name="CHARACTER_SET_NAME" xsi:nil="true"/></row></resultset>'"#
         };
         let script = format!(
             r#"#!/bin/sh
@@ -592,6 +643,36 @@ done
 
         assert_eq!(values.visible[0][0], QueryValue::Text("0x41".to_string()));
         assert_eq!(values.visible[0][1], QueryValue::Blob(vec![0, 255]));
+    }
+
+    #[test]
+    fn preview_conversion_decodes_binary_character_set_hex() {
+        let result = result(
+            &["char_value", "varchar_value", "text_value"],
+            vec![vec![
+                QueryValue::Text("0x00FFA1".to_string()),
+                QueryValue::Text("0x10FE".to_string()),
+                QueryValue::Text("0x41".to_string()),
+            ]],
+        );
+        let columns = vec![
+            column("char_value", "char(3)"),
+            column("varchar_value", "varchar(3)"),
+            column("text_value", "varchar(3)"),
+        ];
+
+        let values = convert_preview_values_with_binary_charset(
+            &result,
+            &columns,
+            &[],
+            &[true, true, false],
+            &[],
+        )
+        .expect("conversion succeeds");
+
+        assert_eq!(values.visible[0][0], QueryValue::Blob(vec![0, 255, 161]));
+        assert_eq!(values.visible[0][1], QueryValue::Blob(vec![16, 254]));
+        assert_eq!(values.visible[0][2], QueryValue::Text("0x41".to_string()));
     }
 
     #[test]

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -21,6 +21,17 @@ pub(in crate::adapters::mysql) const COLUMN_METADATA_RESULT_COLUMNS: &[&str] = &
     "ORDINAL_POSITION",
     "PRIMARY_KEY_POSITION",
 ];
+pub(in crate::adapters::mysql) const PREVIEW_COLUMN_METADATA_RESULT_COLUMNS: &[&str] = &[
+    "COLUMN_NAME",
+    "COLUMN_TYPE",
+    "IS_NULLABLE",
+    "COLUMN_DEFAULT",
+    "EXTRA",
+    "COLUMN_COMMENT",
+    "ORDINAL_POSITION",
+    "PRIMARY_KEY_POSITION",
+    "CHARACTER_SET_NAME",
+];
 pub(in crate::adapters::mysql) const UNIQUE_COLUMN_RESULT_COLUMNS: &[&str] = &["COLUMN_NAME"];
 pub(in crate::adapters::mysql) const FOREIGN_KEY_RESULT_COLUMNS: &[&str] = &[
     "CONSTRAINT_NAME",
@@ -46,6 +57,14 @@ pub(in crate::adapters::mysql) fn table_query(schema: &str, table: &str) -> Stri
 pub(in crate::adapters::mysql) fn columns_query(schema: &str, table: &str) -> String {
     format!(
         "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = {} AND c.TABLE_NAME = {} ORDER BY ORDINAL_POSITION",
+        quote_string(schema),
+        quote_string(table),
+    )
+}
+
+pub(in crate::adapters::mysql) fn preview_columns_query(schema: &str, table: &str) -> String {
+    format!(
+        "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION, c.CHARACTER_SET_NAME FROM INFORMATION_SCHEMA.COLUMNS AS c LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = c.TABLE_SCHEMA AND tc.TABLE_NAME = c.TABLE_NAME AND tc.CONSTRAINT_NAME = 'PRIMARY' AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY' LEFT JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND kcu.COLUMN_NAME = c.COLUMN_NAME WHERE c.TABLE_SCHEMA = {} AND c.TABLE_NAME = {} ORDER BY ORDINAL_POSITION",
         quote_string(schema),
         quote_string(table),
     )
@@ -279,6 +298,18 @@ mod tests {
             ],
         );
 
+        let preview_columns_sql = preview_columns_query(schema, table);
+        assert_contains_in_order(
+            &preview_columns_sql,
+            &[
+                "SELECT c.COLUMN_NAME, c.COLUMN_TYPE, c.IS_NULLABLE, c.COLUMN_DEFAULT, c.EXTRA, c.COLUMN_COMMENT, c.ORDINAL_POSITION, kcu.ORDINAL_POSITION AS PRIMARY_KEY_POSITION, c.CHARACTER_SET_NAME",
+                "FROM INFORMATION_SCHEMA.COLUMNS AS c",
+                &format!("WHERE c.TABLE_SCHEMA = {quoted_schema}"),
+                &format!("AND c.TABLE_NAME = {quoted_table}"),
+                "ORDER BY ORDINAL_POSITION",
+            ],
+        );
+
         let unique_columns_sql = unique_columns_query(schema, table);
         assert_contains_in_order(
             &unique_columns_sql,
@@ -390,6 +421,7 @@ mod tests {
             SIGNATURE_FOREIGN_KEYS_QUERY,
             &table_query(schema, table),
             &columns_query(schema, table),
+            &preview_columns_query(schema, table),
             &unique_columns_query(schema, table),
             &foreign_keys_query(schema, table),
             &indexes_query(schema, table),
@@ -419,6 +451,20 @@ mod tests {
                 "COLUMN_COMMENT",
                 "ORDINAL_POSITION",
                 "PRIMARY_KEY_POSITION",
+            ]
+        );
+        assert_eq!(
+            PREVIEW_COLUMN_METADATA_RESULT_COLUMNS,
+            &[
+                "COLUMN_NAME",
+                "COLUMN_TYPE",
+                "IS_NULLABLE",
+                "COLUMN_DEFAULT",
+                "EXTRA",
+                "COLUMN_COMMENT",
+                "ORDINAL_POSITION",
+                "PRIMARY_KEY_POSITION",
+                "CHARACTER_SET_NAME",
             ]
         );
         assert_eq!(UNIQUE_COLUMN_RESULT_COLUMNS, &["COLUMN_NAME"]);

--- a/src/infra/adapters/mysql/sql/mod.rs
+++ b/src/infra/adapters/mysql/sql/mod.rs
@@ -7,11 +7,11 @@ mod metadata;
 
 pub(super) use metadata::{
     COLUMN_METADATA_RESULT_COLUMNS, EFFECTIVE_USER_QUERY, EFFECTIVE_USER_RESULT_COLUMNS,
-    FOREIGN_KEY_RESULT_COLUMNS, INDEX_RESULT_COLUMNS, SIGNATURE_COLUMNS_QUERY,
-    SIGNATURE_COLUMNS_RESULT_COLUMNS, SIGNATURE_FOREIGN_KEYS_QUERY, SIGNATURE_UNIQUE_COLUMNS_QUERY,
-    SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS, TABLES_QUERY, TABLES_RESULT_COLUMNS,
-    TRIGGER_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, build_metadata_select_query,
-    build_preview_query, columns_query, foreign_keys_query, indexes_query, preview_identity_alias,
-    show_create_query, show_create_result_columns, table_query, triggers_query,
-    unique_columns_query,
+    FOREIGN_KEY_RESULT_COLUMNS, INDEX_RESULT_COLUMNS, PREVIEW_COLUMN_METADATA_RESULT_COLUMNS,
+    SIGNATURE_COLUMNS_QUERY, SIGNATURE_COLUMNS_RESULT_COLUMNS, SIGNATURE_FOREIGN_KEYS_QUERY,
+    SIGNATURE_UNIQUE_COLUMNS_QUERY, SIGNATURE_UNIQUE_COLUMNS_RESULT_COLUMNS, TABLES_QUERY,
+    TABLES_RESULT_COLUMNS, TRIGGER_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS,
+    build_metadata_select_query, build_preview_query, columns_query, foreign_keys_query,
+    indexes_query, preview_columns_query, preview_identity_alias, show_create_query,
+    show_create_result_columns, table_query, triggers_query, unique_columns_query,
 };

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -638,11 +638,12 @@ mod query_preview {
 
     use super::shared::{MYSQL_COMPOSITE_TABLE, MYSQL_EMPTY_TABLE, MYSQL_VIEW};
     use crate::tests::harness::mysql::{MYSQL_FIXTURE_TABLE, with_mysql_test_db};
-    use sabiql_app::ports::outbound::{AccessMode, QueryExecutor};
-    use sabiql_domain::QueryValue;
+    use sabiql_app::ports::outbound::{AccessMode, QueryExecutor, SqlDialect};
+    use sabiql_domain::{DatabaseType, QueryValue};
 
     const MYSQL_NO_PK_TABLE: &str = "mysql_preview_no_pk";
     const MYSQL_SPATIAL_TABLE: &str = "demo_warehouses";
+    const MYSQL_BINARY_CHARSET_TABLE: &str = "mysql_preview_binary_charset";
 
     fn decode_hex(value: &str) -> Result<Vec<u8>, String> {
         if value.is_empty() || !value.len().is_multiple_of(2) {
@@ -750,6 +751,99 @@ mod query_preview {
                     ));
                 }
                 Ok(())
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and mysql CLI"]
+    async fn previews_and_writes_binary_charset_strings_without_byte_changes() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
+                let preview = db
+                    .adapter()
+                    .execute_preview(
+                        db.dsn(),
+                        "sabiql_test",
+                        MYSQL_BINARY_CHARSET_TABLE,
+                        1,
+                        0,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to preview binary charset table: {error:?}"))?;
+                let expected = vec![
+                    QueryValue::Blob(vec![0x00, 0xFF, 0xA1, 0x0D]),
+                    QueryValue::Blob(vec![0x00, 0xFF, 0xA1, 0x0D]),
+                    QueryValue::Text("0x00FF".to_string()),
+                    QueryValue::Blob(vec![0x00, 0xFF, 0xA1, 0x0D]),
+                    QueryValue::Blob(vec![0x00, 0xFF, 0xA1, 0x0D]),
+                    QueryValue::Blob(vec![0xA5]),
+                ];
+                if preview.columns
+                    != [
+                        "id",
+                        "binary_char",
+                        "binary_varchar",
+                        "regular_varchar",
+                        "binary_varbinary",
+                        "binary_blob",
+                        "binary_bit",
+                    ]
+                    || preview.values() != [
+                        vec![QueryValue::SqlLiteral("1".to_string())]
+                            .into_iter()
+                            .chain(expected.clone())
+                            .collect::<Vec<_>>(),
+                    ]
+                {
+                    return Err(format!("unexpected binary charset preview: {preview:?}"));
+                }
+
+                for (column, value) in [
+                    ("binary_char", expected[0].clone()),
+                    ("binary_varchar", expected[1].clone()),
+                    ("binary_varbinary", expected[3].clone()),
+                    ("binary_blob", expected[4].clone()),
+                    ("binary_bit", expected[5].clone()),
+                ] {
+                    let update_sql = db.adapter().build_update_sql(
+                        DatabaseType::MySQL,
+                        "sabiql_test",
+                        MYSQL_BINARY_CHARSET_TABLE,
+                        column,
+                        &value,
+                        &[("id".to_string(), QueryValue::SqlLiteral("1".to_string()))],
+                    );
+                    db.adapter()
+                        .execute_write(db.dsn(), &update_sql, AccessMode::ReadWrite)
+                        .await
+                        .map_err(|error| {
+                            format!("failed to write binary charset column {column}: {error:?}")
+                        })?;
+                }
+
+                let hex = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        "SELECT HEX(binary_char), HEX(binary_varchar), HEX(binary_varbinary), HEX(binary_blob), HEX(binary_bit) FROM mysql_preview_binary_charset WHERE id = 1",
+                        AccessMode::ReadOnly,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to read binary charset HEX values: {error:?}"))?;
+                if hex.values()
+                    != [[
+                        QueryValue::Text("00FFA10D".to_string()),
+                        QueryValue::Text("00FFA10D".to_string()),
+                        QueryValue::Text("00FFA10D".to_string()),
+                        QueryValue::Text("00FFA10D".to_string()),
+                        QueryValue::Text("A5".to_string()),
+                    ]]
+                {
+                    return Err(format!("binary charset bytes changed: {hex:?}"));
+                }
+                Ok::<(), String>(())
             })
         })
         .await;


### PR DESCRIPTION
## Problem
MySQL `CHAR` and `VARCHAR` columns using `CHARACTER SET binary` are returned through the preview path as text, so NUL and high-byte values cannot safely round-trip through grid writes.

## Background
The preview metadata previously included the MySQL type but not the column character set, while the existing Blob conversion already handles BINARY/VARBINARY/BLOB, BIT, and spatial values.

## Approach
Preview-only column metadata now carries `CHARACTER_SET_NAME` and marks only the `binary` character set for the existing Blob conversion path. A real MySQL fixture covers `CHAR`/`VARCHAR CHARACTER SET binary`, ordinary text, and existing binary types, asserting preview-to-write-to-HEX byte preservation.

## Screenshots

## Linear Issue Link (optional)

- Implements https://linear.app/sabiql/issue/SAB-473