### PR TITLE
fix(test): remove unscoped MySQL stop command

### DIFF
--- a/scripts/mysql_integration.sh
+++ b/scripts/mysql_integration.sh
@@ -281,11 +281,8 @@ case "${1:-test}" in
         assert_versions
         run_tests
         ;;
-    stop)
-        docker compose --file "$compose_file" --file "$tls_compose_file" rm --force --stop --volumes mysql
-        ;;
     *)
-        echo "usage: $0 [test|stop]" >&2
+        echo "usage: $0 [test]" >&2
         exit 2
         ;;
 esac

--- a/scripts/test_mysql_docker_cleanup.sh
+++ b/scripts/test_mysql_docker_cleanup.sh
@@ -402,10 +402,7 @@ if ! grep -q -- '--force --volumes' "$rm_log"; then
     exit 1
 fi
 
-PATH="$fake_bin:$PATH" "$script_dir/mysql_integration.sh" stop >/dev/null 2>&1
-assert_only_unrelated_container_remains
-if ! grep -Fq 'default|rm|rm --force --stop --volumes mysql' "$compose_log" || \
-    grep -Fq 'default|down|' "$compose_log"; then
-    printf 'stop did not remain scoped to the MySQL service:\n%s\n' "$(<"$compose_log")" >&2
+if grep -Fq 'default|' "$compose_log"; then
+    printf 'unowned default Compose project was accessed:\n%s\n' "$(<"$compose_log")" >&2
     exit 1
 fi


### PR DESCRIPTION
## Problem
The `stop` helper can remove a default Compose MySQL service and volume without identifying the owning integration run.

## Background
Parallel worktrees and manually started MySQL environments can share the default Compose project name.

## Approach
Remove the unscoped stop entry point and its deletion-specific test. Keep the run-scoped cleanup coverage and assert that the default Compose project is never accessed.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-485