### PR TITLE
fix(mysql): preserve Windows pipe stderr

### DIFF
--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -128,15 +128,18 @@ async fn stream_mysql_resultset_to_csv(
 
     #[cfg(not(unix))]
     {
-        let source = MySqlExportPipeSource {
+        let mut source = MySqlExportPipeSource {
             stdout: &mut process.stdout,
             stderr: &mut process.stderr,
             pending: &mut process.pending,
             error_output: Vec::new(),
+            error_buffer: Vec::new(),
             stderr_buffer: [0; 4096],
             stderr_closed: false,
             stdout_closed: false,
         };
+        let pending_stderr = std::mem::take(&mut process.pending_stderr);
+        source.capture_error(&pending_stderr);
         let mut reader = Reader::from_reader(BufReader::new(source));
         reader.config_mut().trim_text(false);
         let result = stream_mysql_xml_to_csv(&mut reader, csv_writer).await;

--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -98,7 +98,7 @@ fn validate_mysql_export_exit(
     Ok(())
 }
 
-async fn stream_mysql_resultset_to_csv(
+pub(super) async fn stream_mysql_resultset_to_csv(
     process: &mut MySqlProcess,
     csv_writer: &mut CsvFileWriter,
 ) -> Result<Option<Vec<String>>, DbOperationError> {
@@ -147,6 +147,11 @@ async fn stream_mysql_resultset_to_csv(
         let unread = buffered.buffer().to_vec();
         let source = buffered.into_inner();
         source.pending.extend(unread);
+        if source.error_output.is_empty() {
+            process
+                .pending_stderr
+                .extend_from_slice(&source.error_buffer);
+        }
         if has_mysql_cli_error(&source.error_output) {
             return Err(classify_mysql_query_failure(&source.error_output));
         }

--- a/src/infra/adapters/mysql/cli/pipe.rs
+++ b/src/infra/adapters/mysql/cli/pipe.rs
@@ -36,7 +36,13 @@ where
             let discard = self.error_buffer.len() - 32 * 1024;
             self.error_buffer.drain(..discard);
         }
-        if has_mysql_cli_error(&self.error_buffer) {
+        if has_complete_mysql_cli_error(&self.error_buffer) {
+            self.error_output.extend_from_slice(&self.error_buffer);
+        }
+    }
+
+    fn finish_error_capture(&mut self) {
+        if self.error_output.is_empty() && has_mysql_cli_error(&self.error_buffer) {
             self.error_output.extend_from_slice(&self.error_buffer);
         }
     }
@@ -57,6 +63,7 @@ where
             Poll::Ready(Ok(bytes)) => {
                 if bytes.is_empty() {
                     self.stderr_closed = true;
+                    self.finish_error_capture();
                 } else {
                     self.capture_error(&bytes);
                 }
@@ -66,6 +73,16 @@ where
             Poll::Pending => Poll::Pending,
         }
     }
+}
+
+fn has_complete_mysql_cli_error(output: &[u8]) -> bool {
+    output
+        .split_inclusive(|byte| *byte == b'\n' || *byte == b'\r')
+        .any(|line| {
+            line.last()
+                .is_some_and(|byte| *byte == b'\n' || *byte == b'\r')
+                && has_mysql_cli_error(line)
+        })
 }
 
 impl<O, E> AsyncRead for MySqlExportPipeSource<'_, O, E>
@@ -425,7 +442,12 @@ mod tests {
             stderr_writer.write_all(b"ERROR 1").await.unwrap();
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             stderr_writer
-                .write_all(b"054 (42S22): Unknown column missing_column\n")
+                .write_all(b"054 (42S22): Unknown column missing_column \xe6")
+                .await
+                .unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            stderr_writer
+                .write_all(b"\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e\n")
                 .await
                 .unwrap();
         });
@@ -449,7 +471,7 @@ mod tests {
         assert!(matches!(
             classify_mysql_query_failure(&source.error_output),
             DbOperationError::ObjectMissing(details)
-                if details.contains("missing_column")
+                if details.contains("missing_column 日本語")
         ));
     }
 }

--- a/src/infra/adapters/mysql/cli/pipe.rs
+++ b/src/infra/adapters/mysql/cli/pipe.rs
@@ -16,6 +16,7 @@ pub(super) struct MySqlExportPipeSource<'a, O, E> {
     pub(super) stderr: &'a mut E,
     pub(super) pending: &'a mut Vec<u8>,
     pub(super) error_output: Vec<u8>,
+    pub(super) error_buffer: Vec<u8>,
     pub(super) stderr_buffer: [u8; 4096],
     pub(super) stderr_closed: bool,
     pub(super) stdout_closed: bool,
@@ -26,11 +27,17 @@ where
     O: AsyncRead + Unpin,
     E: AsyncRead + Unpin,
 {
-    fn capture_error(&mut self, bytes: &[u8]) {
-        let remaining = (32usize * 1024).saturating_sub(self.error_output.len());
-        if remaining > 0 {
-            self.error_output
-                .extend_from_slice(&bytes[..bytes.len().min(remaining)]);
+    pub(super) fn capture_error(&mut self, bytes: &[u8]) {
+        if !self.error_output.is_empty() {
+            return;
+        }
+        self.error_buffer.extend_from_slice(bytes);
+        if self.error_buffer.len() > 32 * 1024 {
+            let discard = self.error_buffer.len() - 32 * 1024;
+            self.error_buffer.drain(..discard);
+        }
+        if has_mysql_cli_error(&self.error_buffer) {
+            self.error_output.extend_from_slice(&self.error_buffer);
         }
     }
 
@@ -267,6 +274,7 @@ mod tests {
             stderr: &mut stderr,
             pending: &mut pending,
             error_output: Vec::new(),
+            error_buffer: Vec::new(),
             stderr_buffer: [0; 4096],
             stderr_closed: false,
             stdout_closed: false,
@@ -381,6 +389,7 @@ mod tests {
             stderr: &mut stderr_reader,
             pending: &mut Vec::new(),
             error_output: Vec::new(),
+            error_buffer: Vec::new(),
             stderr_buffer: [0; 4096],
             stderr_closed: false,
             stdout_closed: false,
@@ -395,6 +404,52 @@ mod tests {
         assert!(matches!(
             classify_mysql_query_failure(&source.error_output),
             DbOperationError::ObjectMissing(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn captures_error_after_large_stderr_prefix_and_read_split() {
+        let (mut stdout_writer, mut stdout_reader) = tokio::io::duplex(1024);
+        let (mut stderr_writer, mut stderr_reader) = tokio::io::duplex(64);
+        let stdout_task = tokio::spawn(async move {
+            stdout_writer
+                .write_all(b"<resultset><row></row></resultset>")
+                .await
+                .unwrap();
+        });
+        let stderr_task = tokio::spawn(async move {
+            stderr_writer
+                .write_all(&b"warning\n".repeat(8 * 1024))
+                .await
+                .unwrap();
+            stderr_writer.write_all(b"ERROR 1").await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            stderr_writer
+                .write_all(b"054 (42S22): Unknown column missing_column\n")
+                .await
+                .unwrap();
+        });
+
+        let mut source = MySqlExportPipeSource {
+            stdout: &mut stdout_reader,
+            stderr: &mut stderr_reader,
+            pending: &mut Vec::new(),
+            error_output: Vec::new(),
+            error_buffer: Vec::new(),
+            stderr_buffer: [0; 4096],
+            stderr_closed: false,
+            stdout_closed: false,
+        };
+        let mut output = Vec::new();
+        source.read_to_end(&mut output).await.unwrap();
+        stdout_task.await.unwrap();
+        stderr_task.await.unwrap();
+
+        assert_eq!(output, b"<resultset><row></row></resultset>");
+        assert!(matches!(
+            classify_mysql_query_failure(&source.error_output),
+            DbOperationError::ObjectMissing(details)
+                if details.contains("missing_column")
         ));
     }
 }

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -228,7 +228,9 @@ pub(in crate::adapters::mysql::cli) async fn finish_mysql_session(
         let stdout = stdout.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
         let stderr = stderr.map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
         let status = status.map_err(|error| DbOperationError::ConnectionLost(error.to_string()))?;
-        (stdout, stderr, status)
+        let mut error_bytes = std::mem::take(&mut process.pending_stderr);
+        error_bytes.extend_from_slice(&stderr);
+        (stdout, error_bytes, status)
     };
 
     #[cfg(unix)]
@@ -1573,6 +1575,43 @@ done
 #[cfg(all(test, not(unix)))]
 mod windows_tests {
     use super::*;
+
+    #[tokio::test]
+    async fn pipe_finish_combines_pending_stderr_with_final_read() {
+        let mut child = Command::new("cmd.exe")
+            .args([
+                "/C",
+                "findstr /R \"^\" >nul & echo 054 (42S22): missing_column 1>&2 & exit /B 0",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn cmd.exe");
+        let stdin = child.stdin.take().expect("piped stdin");
+        let stdout = child.stdout.take().expect("piped stdout");
+        let stderr = child.stderr.take().expect("piped stderr");
+        let mut process = MySqlProcess {
+            child,
+            stdin: Some(stdin),
+            stdout,
+            stderr,
+            pending: Vec::new(),
+            pending_stderr: b"ERROR 1".to_vec(),
+            frame_scanner: MySqlResultsetFrameScanner::default(),
+        };
+
+        let result =
+            tokio::time::timeout(Duration::from_secs(2), finish_mysql_session(&mut process))
+                .await
+                .expect("finish pipe process timed out waiting for stdin EOF")
+                .expect("finish pipe process");
+
+        assert!(matches!(
+            classify_mysql_query_failure(&result.error_bytes),
+            DbOperationError::ObjectMissing(details) if details.contains("missing_column")
+        ));
+    }
 
     #[tokio::test]
     async fn pipe_finish_shuts_down_stdin_before_draining_cli_error() {

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -1574,7 +1574,59 @@ done
 
 #[cfg(all(test, not(unix)))]
 mod windows_tests {
+    use crate::adapters::csv_export::CsvFileWriter;
+
+    use super::super::export::stream_mysql_resultset_to_csv;
     use super::*;
+
+    #[tokio::test]
+    async fn csv_stream_returns_incomplete_stderr_for_final_classification() {
+        let mut child = Command::new("cmd.exe")
+            .args([
+                "/C",
+                "echo ^<resultset^>^</resultset^> & ping -n 2 127.0.0.1 >nul & echo 054 (42S22): missing_column 1>&2",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn cmd.exe");
+        let stdin = child.stdin.take().expect("piped stdin");
+        let stdout = child.stdout.take().expect("piped stdout");
+        let stderr = child.stderr.take().expect("piped stderr");
+        let mut process = MySqlProcess {
+            child,
+            stdin: Some(stdin),
+            stdout,
+            stderr,
+            pending: Vec::new(),
+            pending_stderr: b"ERROR 1".to_vec(),
+            frame_scanner: MySqlResultsetFrameScanner::default(),
+        };
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("export.csv");
+        let mut csv_writer = CsvFileWriter::create(path).await.unwrap();
+
+        assert!(
+            stream_mysql_resultset_to_csv(&mut process, &mut csv_writer)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(process.pending_stderr, b"ERROR 1");
+        csv_writer.finish().await.unwrap();
+
+        let result =
+            tokio::time::timeout(Duration::from_secs(3), finish_mysql_session(&mut process))
+                .await
+                .expect("finish pipe process timed out")
+                .expect("finish pipe process");
+
+        assert!(matches!(
+            classify_mysql_query_failure(&result.error_bytes),
+            DbOperationError::ObjectMissing(details) if details.contains("missing_column")
+        ));
+    }
 
     #[tokio::test]
     async fn pipe_finish_combines_pending_stderr_with_final_read() {


### PR DESCRIPTION
## Problem
Windows pipe reads can leave a partial MySQL CLI error in `pending_stderr`, but session finalization discarded that carry before classifying stderr.

## Background
CSV pipe capture was also limited to the first 32 KiB, so a CLI error after a large warning prefix could be omitted from typed error classification.

## Approach
Combine pending stderr with the final pipe drain and retain a bounded rolling stderr window until a complete CLI error is found. Add focused Windows-path coverage for a split error and a large-prefix CSV stream while preserving resultset field boundaries.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-494