### PR TITLE
fix(mysql): enforce exact database scope

### DIFF
--- a/scripts/init-mysql.sql
+++ b/scripts/init-mysql.sql
@@ -162,6 +162,27 @@ CREATE TABLE mysql_preview_empty (
 CREATE VIEW mysql_preview_view AS
 SELECT id, unicode_text FROM mysql_cli_fixture;
 
+CREATE DATABASE SABIQL_TEST CHARACTER SET utf8mb4;
+
+CREATE TABLE SABIQL_TEST.mysql_case_scope_parent (
+    id INT PRIMARY KEY
+) CHARACTER SET utf8mb4;
+
+INSERT INTO SABIQL_TEST.mysql_case_scope_parent (id)
+VALUES (1);
+
+CREATE TABLE sabiql_test.mysql_case_scope_child (
+    parent_id INT NOT NULL,
+    payload TEXT NOT NULL,
+    CONSTRAINT fk_mysql_case_scope_parent
+        FOREIGN KEY (parent_id)
+        REFERENCES SABIQL_TEST.mysql_case_scope_parent (id)
+) CHARACTER SET utf8mb4;
+
+INSERT INTO sabiql_test.mysql_case_scope_child (parent_id, payload)
+VALUES (1, 'case-sensitive foreign key');
+
 CREATE USER 'sabiql_test_runner'@'%' IDENTIFIED BY 'p a#ss;="word';
 GRANT ALL PRIVILEGES ON sabiql_test.* TO 'sabiql_test_runner'@'%';
+GRANT ALL PRIVILEGES ON SABIQL_TEST.* TO 'sabiql_test_runner'@'%';
 GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO 'sabiql'@'%', 'sabiql_test_runner'@'%';

--- a/src/app/policy/sql/mysql_statement/classifier.rs
+++ b/src/app/policy/sql/mysql_statement/classifier.rs
@@ -324,7 +324,7 @@ fn classify_mysql_ddl_statement(
                     MySqlLexError("RENAME TABLE destination is ambiguous".to_string())
                 })?;
             let effective_database = match (database.as_deref(), destination_database.as_deref()) {
-                (Some(source), Some(destination)) if !source.eq_ignore_ascii_case(destination) => {
+                (Some(source), Some(destination)) if source != destination => {
                     return Err(MySqlLexError(
                         "RENAME TABLE cannot move a table across databases".to_string(),
                     ));
@@ -417,7 +417,7 @@ fn classify_alter_table_target(
         .ok_or_else(|| MySqlLexError("MySQL statement target is ambiguous".to_string()))?;
     let destination_database = alter_table_rename_database(tokens, after_target)?;
     let effective_database = match (source_database.as_deref(), destination_database.as_deref()) {
-        (Some(source), Some(destination)) if !source.eq_ignore_ascii_case(destination) => {
+        (Some(source), Some(destination)) if source != destination => {
             return Err(MySqlLexError(
                 "ALTER TABLE RENAME cannot move a table across databases".to_string(),
             ));

--- a/src/app/policy/sql/mysql_statement/target.rs
+++ b/src/app/policy/sql/mysql_statement/target.rs
@@ -38,7 +38,7 @@ pub(super) fn target_is_selected_database(
     selected_database: Option<&str>,
 ) -> bool {
     match (statement.target_database.as_deref(), selected_database) {
-        (Some(target_database), Some(selected)) => target_database.eq_ignore_ascii_case(selected),
+        (Some(target_database), Some(selected)) => target_database == selected,
         (None, Some(_)) => true,
         (Some(_) | None, None) => false,
     }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -440,6 +440,51 @@ mod mysql_tests {
     }
 
     #[test]
+    fn qualified_mysql_mutations_require_exact_selected_database() {
+        for sql in [
+            "INSERT INTO other.items VALUES (1)",
+            "UPDATE other.items SET value = 1",
+            "DELETE FROM other.items WHERE id = 1",
+            "INSERT INTO APP.items VALUES (1)",
+            "UPDATE APP.items SET value = 1",
+            "DELETE FROM APP.items WHERE id = 1",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Block { .. }),
+                "{sql}"
+            );
+        }
+
+        for sql in [
+            "INSERT INTO items VALUES (1)",
+            "UPDATE items SET value = 1",
+            "DELETE FROM items WHERE id = 1",
+            "INSERT INTO app.items VALUES (1)",
+            "UPDATE app.items SET value = 1",
+            "DELETE FROM app.items WHERE id = 1",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Allow { .. }),
+                "{sql}"
+            );
+        }
+    }
+
+    #[test]
+    fn rename_rejects_database_names_that_differ_only_by_case() {
+        for sql in [
+            "ALTER TABLE APP.items ADD COLUMN value INT",
+            "ALTER TABLE app.items RENAME TO APP.archived_items",
+            "RENAME TABLE app.items TO APP.archived_items",
+        ] {
+            assert!(
+                matches!(mysql(sql), MultiStatementDecision::Block { .. }),
+                "{sql}"
+            );
+        }
+    }
+
+    #[test]
     fn transaction_modifiers_are_rejected() {
         for sql in [
             "START TRANSACTION READ ONLY",
@@ -666,8 +711,7 @@ fn mysql_target_key(statement: &MySqlStatement, selected_database: Option<&str>)
             .target_database
             .as_deref()
             .or(selected_database)
-            .unwrap_or_default()
-            .to_ascii_uppercase(),
+            .unwrap_or_default(),
         statement.target.as_deref()?.to_ascii_uppercase()
     ))
 }
@@ -823,11 +867,12 @@ pub fn evaluate_mysql_multi_statement(
                 reason: "MySQL SELECT INTO clauses are not supported".to_string(),
             };
         }
-        if mysql_statement_is_schema_modifying(&statement.kind)
+        if (mysql_statement_is_schema_modifying(&statement.kind)
+            || mysql_statement_is_data_modifying(&statement.kind))
             && !target_is_selected_database(&statement, selected_database)
         {
             return MultiStatementDecision::Block {
-                reason: "MySQL DDL target must be in the selected database".to_string(),
+                reason: "MySQL target must be in the selected database".to_string(),
             };
         }
         let decision = mysql_statement_risk(&statement);

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -97,7 +97,7 @@ pub(super) fn find_table(
 ) -> Result<MySqlTableMetadata, DbOperationError> {
     tables
         .iter()
-        .find(|candidate| candidate.schema.eq_ignore_ascii_case(schema) && candidate.name == table)
+        .find(|candidate| candidate.schema == schema && candidate.name == table)
         .cloned()
         .ok_or_else(|| {
             DbOperationError::ObjectMissing(format!("MySQL table not found: {schema}.{table}"))
@@ -233,7 +233,7 @@ pub(super) fn validate_selected_schema_name(
     database: &str,
     schema: &str,
 ) -> Result<(), DbOperationError> {
-    if !schema.eq_ignore_ascii_case(database) {
+    if schema != database {
         return Err(DbOperationError::UnsupportedOperation(
             "MySQL metadata is limited to the selected database".to_string(),
         ));
@@ -388,7 +388,7 @@ pub(super) fn foreign_keys_from_metadata(
     });
     let mut foreign_keys = Vec::new();
     for column in raw {
-        let reference_resolved = column.to_schema.eq_ignore_ascii_case(database);
+        let reference_resolved = column.to_schema == database;
         if let Some(foreign_key) = foreign_keys
             .iter_mut()
             .find(|foreign_key: &&mut ForeignKey| foreign_key.name == column.name)
@@ -608,7 +608,7 @@ mod tests {
     #[test]
     fn metadata_snapshot_uses_server_schema() {
         let snapshot = metadata_snapshot_from_result(
-            "APP",
+            "app",
             Some("app"),
             &result(
                 &[
@@ -634,6 +634,18 @@ mod tests {
     }
 
     #[test]
+    fn metadata_rejects_database_with_different_case() {
+        let error =
+            metadata_snapshot_from_result("app", Some("APP"), &result(&[], vec![])).unwrap_err();
+
+        assert!(matches!(
+            error,
+            DbOperationError::UnsupportedOperation(message)
+                if message == "MySQL metadata is limited to the selected database"
+        ));
+    }
+
+    #[test]
     fn metadata_schema_mismatch_rejects_before_parsing() {
         let error =
             metadata_snapshot_from_result("app", Some("other"), &result(&[], vec![])).unwrap_err();
@@ -643,6 +655,24 @@ mod tests {
             DbOperationError::UnsupportedOperation(message)
                 if message == "MySQL metadata is limited to the selected database"
         ));
+    }
+
+    #[test]
+    fn find_table_rejects_schema_with_different_case() {
+        let error = find_table(
+            "APP",
+            "users",
+            &[MySqlTableMetadata {
+                schema: "app".to_string(),
+                name: "users".to_string(),
+                kind: TableKind::Table,
+                row_count_estimate: None,
+                comment: None,
+            }],
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, DbOperationError::ObjectMissing(_)));
     }
 
     #[test]
@@ -873,7 +903,7 @@ mod tests {
         assert!(foreign_keys[0].is_reference_resolved());
 
         let unresolved =
-            foreign_keys_from_metadata(parse_foreign_key_metadata(&result).unwrap(), "other")
+            foreign_keys_from_metadata(parse_foreign_key_metadata(&result).unwrap(), "SABIQL_TEST")
                 .unwrap();
         assert!(!unresolved[0].is_reference_resolved());
     }

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -918,12 +918,128 @@ mod query_preview {
 mod write_operations {
 
     use crate::tests::harness::mysql::with_mysql_test_db;
-    use sabiql_app::ports::outbound::{AccessMode, MetadataProvider, QueryExecutor, SqlDialect};
+    use sabiql_app::ports::outbound::{
+        AccessMode, DbOperationError, MetadataProvider, QueryExecutor, SqlDialect,
+    };
     use sabiql_domain::{CommandTag, DatabaseType, QueryValue};
 
+    const MYSQL_CASE_SCOPE_CHILD: &str = "mysql_case_scope_child";
+    const MYSQL_CASE_SCOPE_PARENT: &str = "mysql_case_scope_parent";
     const MYSQL_INVISIBLE_PK_TABLE: &str = "mysql_edit_invisible_pk";
     const MYSQL_INVISIBLE_COMPOSITE_TABLE: &str = "mysql_edit_invisible_composite";
     const MYSQL_FUNCTIONAL_INDEX: &str = "mysql_metadata_functional";
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn enforces_case_sensitive_database_scope_on_oracle_mysql_84() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
+                let lower_case_table_names = db
+                    .run_cli_script("SELECT @@lower_case_table_names")
+                    .await
+                    .map_err(|error| format!("failed to inspect MySQL name case mode: {error}"))?;
+                if lower_case_table_names.trim() != "0" {
+                    return Err(format!(
+                        "case-sensitive MySQL server is required, got lower_case_table_names={lower_case_table_names:?}"
+                    ));
+                }
+
+                let external_database = db
+                    .run_cli_script(&format!(
+                        "SELECT COUNT(*) FROM SABIQL_TEST.{MYSQL_CASE_SCOPE_PARENT}"
+                    ))
+                    .await
+                    .map_err(|error| format!("case-sensitive database fixture is missing: {error}"))?;
+                if external_database.trim() != "1" {
+                    return Err(format!(
+                        "unexpected case-sensitive database fixture result: {external_database:?}"
+                    ));
+                }
+
+                for query in [
+                    format!(
+                        "INSERT INTO SABIQL_TEST.{MYSQL_CASE_SCOPE_PARENT} (id) VALUES (2)"
+                    ),
+                    format!(
+                        "UPDATE SABIQL_TEST.{MYSQL_CASE_SCOPE_PARENT} SET id = 2 WHERE id = 1"
+                    ),
+                    format!(
+                        "DELETE FROM SABIQL_TEST.{MYSQL_CASE_SCOPE_PARENT} WHERE id = 1"
+                    ),
+                    format!(
+                        "ALTER TABLE SABIQL_TEST.{MYSQL_CASE_SCOPE_PARENT} ADD COLUMN blocked INT"
+                    ),
+                ] {
+                    let result = db
+                        .adapter()
+                        .execute_adhoc(db.dsn(), &query, AccessMode::ReadWrite)
+                        .await;
+                    if !matches!(
+                        &result,
+                        Err(DbOperationError::UnsupportedOperation(details))
+                            if details.contains("selected database")
+                    ) {
+                        return Err(format!(
+                            "cross-database mutation was not rejected before execution: query={query:?}, result={result:?}"
+                        ));
+                    }
+                }
+
+                let qualified_same_database = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!(
+                            "INSERT INTO sabiql_test.{MYSQL_CASE_SCOPE_CHILD} (parent_id, payload) VALUES (1, 'temporary'); UPDATE sabiql_test.{MYSQL_CASE_SCOPE_CHILD} SET payload = 'temporary updated' WHERE parent_id = 1 AND payload = 'temporary'; DELETE FROM sabiql_test.{MYSQL_CASE_SCOPE_CHILD} WHERE parent_id = 1 AND payload = 'temporary updated'"
+                        ),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| {
+                        format!(
+                            "same-database qualified DML was rejected on Oracle MySQL: {error:?}"
+                        )
+                    })?;
+                if qualified_same_database.refresh_scope != sabiql_domain::RefreshScope::Data {
+                    return Err(format!(
+                        "same-database qualified DML had unexpected refresh scope: {qualified_same_database:?}"
+                    ));
+                }
+
+                let child = db
+                    .adapter()
+                    .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_CASE_SCOPE_CHILD)
+                    .await
+                    .map_err(|error| format!("failed to fetch case-sensitive FK metadata: {error:?}"))?;
+                if child.foreign_keys.len() != 1
+                    || child.foreign_keys[0].is_reference_resolved()
+                    || child.foreign_keys[0].to_schema != "SABIQL_TEST"
+                {
+                    return Err(format!(
+                        "case-sensitive external FK was resolved incorrectly: {:?}",
+                        child.foreign_keys
+                    ));
+                }
+
+                let wrong_schema = db
+                    .adapter()
+                    .fetch_table_detail(db.dsn(), "SABIQL_TEST", MYSQL_CASE_SCOPE_PARENT)
+                    .await;
+                if !matches!(
+                    &wrong_schema,
+                    Err(DbOperationError::UnsupportedOperation(details))
+                        if details.contains("limited to the selected database")
+                ) {
+                    return Err(format!(
+                        "case-only metadata schema was not rejected: {wrong_schema:?}"
+                    ));
+                }
+
+                Ok(())
+            })
+        })
+        .await;
+    }
 
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and CLI"]


### PR DESCRIPTION
## Problem

MySQL write and metadata paths treated database names case-insensitively and did not scope qualified INSERT, UPDATE, or DELETE statements to the selected database.

## Background

On the case-sensitive Unix default, databases whose names differ only by case are distinct. The previous behavior could permit writes outside the Explorer-selected database and mark cross-database foreign-key metadata as resolved.

## Approach

Require exact database identity for MySQL target, rename, catalog, and foreign-key resolution. Apply the existing selected-database check to qualified data mutations and add unit plus Oracle MySQL 8.4 integration coverage for DDL, DML, metadata, and foreign-key boundaries.

## Linear Issue Link

- Implements SAB-486
- https://linear.app/sabiql/issue/SAB-486