### PR TITLE
fix(mysql): align CSV export policy and count query

### DIFF
--- a/src/app/policy/sql/mysql_export.rs
+++ b/src/app/policy/sql/mysql_export.rs
@@ -1,24 +1,33 @@
-use super::mysql_statement::{
-    MySqlStatementKind, classify_mysql_statement, split_mysql_statements,
-};
+use super::mysql_statement::MySqlStatementKind;
+use crate::policy::write::sql_risk::{MultiStatementDecision, evaluate_mysql_multi_statement};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MySqlExportPlan {
-    CountRows,
-    UseResultRowCount,
+    CountRows { statement: String },
+    UseResultRowCount { statement: String },
 }
 
 pub fn mysql_export_plan(query: &str) -> Option<MySqlExportPlan> {
-    let statements = split_mysql_statements(query).ok()?;
+    let MultiStatementDecision::Allow { statements, risk } =
+        evaluate_mysql_multi_statement(query, None)
+    else {
+        return None;
+    };
+    if !risk.read_only_allowed {
+        return None;
+    }
     let [statement] = statements.as_slice() else {
         return None;
     };
-    let statement = classify_mysql_statement(statement).ok()?;
 
     match statement.kind {
-        MySqlStatementKind::Select => Some(MySqlExportPlan::CountRows),
+        MySqlStatementKind::Select => Some(MySqlExportPlan::CountRows {
+            statement: statement.sql.clone(),
+        }),
         MySqlStatementKind::Table | MySqlStatementKind::Show | MySqlStatementKind::Describe => {
-            Some(MySqlExportPlan::UseResultRowCount)
+            Some(MySqlExportPlan::UseResultRowCount {
+                statement: statement.sql.clone(),
+            })
         }
         _ => None,
     }
@@ -30,10 +39,10 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case::select("SELECT id FROM users", MySqlExportPlan::CountRows)]
-    #[case::table("TABLE users", MySqlExportPlan::UseResultRowCount)]
-    #[case::show("SHOW TABLES", MySqlExportPlan::UseResultRowCount)]
-    #[case::describe("DESCRIBE users", MySqlExportPlan::UseResultRowCount)]
+    #[case::select("SELECT id FROM users", MySqlExportPlan::CountRows { statement: "SELECT id FROM users".to_string() })]
+    #[case::table("TABLE users", MySqlExportPlan::UseResultRowCount { statement: "TABLE users".to_string() })]
+    #[case::show("SHOW TABLES", MySqlExportPlan::UseResultRowCount { statement: "SHOW TABLES".to_string() })]
+    #[case::describe("DESCRIBE users", MySqlExportPlan::UseResultRowCount { statement: "DESCRIBE users".to_string() })]
     fn plans_supported_mysql_export_queries(
         #[case] query: &str,
         #[case] expected: MySqlExportPlan,
@@ -45,7 +54,19 @@ mod tests {
     #[case::insert("INSERT INTO users VALUES (1)")]
     #[case::multiple_statements("SELECT 1; SELECT 2")]
     #[case::unknown("GRANT SELECT ON users TO 'user'")]
+    #[case::side_effect("SELECT GET_LOCK('sabiql', 0)")]
+    #[case::client_control("SET sql_mode = 'STRICT_TRANS_TABLES'")]
     fn rejects_queries_without_a_safe_mysql_export_plan(#[case] query: &str) {
         assert_eq!(mysql_export_plan(query), None);
+    }
+
+    #[test]
+    fn plan_uses_the_single_normalized_statement_after_a_trailing_comment() {
+        assert_eq!(
+            mysql_export_plan("SELECT id FROM users; -- trailing comment"),
+            Some(MySqlExportPlan::CountRows {
+                statement: "SELECT id FROM users".to_string(),
+            })
+        );
     }
 }

--- a/src/app/update/browse/query/pagination.rs
+++ b/src/app/update/browse/query/pagination.rs
@@ -127,6 +127,7 @@ fn dispatch_rerunnable_csv_export(
     export_query: String,
     file_name: String,
     row_count: RerunnableCsvRowCount,
+    count_query_statement: Option<String>,
 ) -> DispatchResult {
     if let RerunnableCsvRowCount::Known(row_count) = row_count {
         return dispatch_counted_rerunnable_csv_export(
@@ -139,8 +140,12 @@ fn dispatch_rerunnable_csv_export(
         );
     }
 
-    let stripped = export_query.trim_end().trim_end_matches(';').to_string();
-    let count_query = format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count");
+    let count_query = if let Some(statement) = count_query_statement {
+        format!("SELECT COUNT(*) FROM (\n{statement}\n) AS _export_count")
+    } else {
+        let stripped = export_query.trim_end().trim_end_matches(';').to_string();
+        format!("SELECT COUNT(*) FROM ({stripped}) AS _export_count")
+    };
     DispatchResult::handled_with(vec![Effect::CountRowsForExport {
         dsn,
         run_id,
@@ -187,6 +192,7 @@ pub fn reduce_pagination(
                             query,
                             file_name,
                             RerunnableCsvRowCount::QueryDatabase,
+                            None,
                         );
                     }
                     SqliteExportPlan::CachedResult { row_count } => {
@@ -210,9 +216,13 @@ pub fn reduce_pagination(
                 let Some(plan) = mysql_export_plan(&export_query) else {
                     return DispatchResult::handled();
                 };
-                let row_count = match plan {
-                    MySqlExportPlan::CountRows => RerunnableCsvRowCount::QueryDatabase,
-                    MySqlExportPlan::UseResultRowCount => RerunnableCsvRowCount::Known(row_count),
+                let (row_count, count_query_statement) = match plan {
+                    MySqlExportPlan::CountRows { statement } => {
+                        (RerunnableCsvRowCount::QueryDatabase, Some(statement))
+                    }
+                    MySqlExportPlan::UseResultRowCount { .. } => {
+                        (RerunnableCsvRowCount::Known(row_count), None)
+                    }
                 };
                 let run_id = state.query.begin_running(now);
                 return dispatch_rerunnable_csv_export(
@@ -222,6 +232,7 @@ pub fn reduce_pagination(
                     export_query,
                     file_name,
                     row_count,
+                    count_query_statement,
                 );
             }
 
@@ -233,6 +244,7 @@ pub fn reduce_pagination(
                 export_query,
                 file_name,
                 RerunnableCsvRowCount::QueryDatabase,
+                None,
             )
         }
 
@@ -1051,6 +1063,42 @@ mod tests {
                         }
                     ),
                     !expects_count
+                );
+            }
+
+            #[rstest]
+            #[case::semicolon_comment(
+                "SELECT id FROM users; -- trailing comment",
+                "SELECT id FROM users"
+            )]
+            #[case::dash_comment(
+                "SELECT id FROM users -- trailing comment",
+                "SELECT id FROM users -- trailing comment"
+            )]
+            #[case::hash_comment(
+                "SELECT id FROM users # trailing comment",
+                "SELECT id FROM users # trailing comment"
+            )]
+            fn count_query_wraps_mysql_statement_with_newlines(
+                #[case] query: &str,
+                #[case] normalized_statement: &str,
+            ) {
+                let mut state = mysql_state(query);
+
+                let effects = dispatch_query(
+                    &mut state,
+                    &Action::RequestCsvExport,
+                    Instant::now(),
+                    &AppServices::stub(),
+                )
+                .unwrap();
+
+                let Effect::CountRowsForExport { count_query, .. } = &effects[0] else {
+                    panic!("expected CountRowsForExport effect");
+                };
+                assert_eq!(
+                    count_query,
+                    &format!("SELECT COUNT(*) FROM (\n{normalized_statement}\n) AS _export_count")
                 );
             }
         }

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::app::policy::sql::mysql_export::mysql_export_plan;
 use crate::app::policy::sql::mysql_statement::{
     MySqlStatement, MySqlStatementKind, has_mysql_read_only_side_effect,
 };
@@ -60,16 +61,8 @@ pub(in crate::adapters::mysql) fn validate_mysql_export_query(
     query: &str,
     selected_database: Option<&str>,
 ) -> Result<(), DbOperationError> {
-    let statements = validate_mysql_multi_query(query, selected_database, AccessMode::ReadOnly)?;
-    if statements.len() != 1
-        || !matches!(
-            statements[0].kind,
-            MySqlStatementKind::Select
-                | MySqlStatementKind::Table
-                | MySqlStatementKind::Show
-                | MySqlStatementKind::Describe
-        )
-    {
+    validate_mysql_multi_query(query, selected_database, AccessMode::ReadOnly)?;
+    if mysql_export_plan(query).is_none() {
         return Err(DbOperationError::UnsupportedOperation(
             "MySQL CSV export supports a single read-only result query".to_string(),
         ));
@@ -388,6 +381,10 @@ mod tests {
             validate_mysql_export_query("SELECT 1; SELECT 2", Some("app")),
             Err(DbOperationError::UnsupportedOperation(details))
                 if details.contains("single read-only result")
+        ));
+        assert!(matches!(
+            validate_mysql_export_query("SELECT GET_LOCK('sabiql', 0)", Some("app")),
+            Err(DbOperationError::PermissionDenied(_))
         ));
     }
 


### PR DESCRIPTION
## Problem
MySQL CSV export availability and CLI validation used different safety decisions, and count queries broke when the source ended with a semicolon or line comment.

## Background
The UI could offer an export that the MySQL adapter rejected before execution. Failed count queries were treated as unknown row counts, causing an unnecessary confirmation path.

## Approach
Build the export decision from the shared MySQL statement/risk analysis and reuse it for app gating and adapter validation. Generate MySQL count queries from the splitter’s single normalized statement with newline boundaries around the derived table, while preserving existing safety rejection and non-MySQL behavior.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-495