### PR TITLE
fix(mysql): show index key part metadata

### DIFF
--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -448,6 +448,9 @@ fn index_detail(index: &Index) -> String {
     if index.has_non_binary_collation() {
         details.push("collation");
     }
+    if index.is_invisible() {
+        details.push("invisible");
+    }
     details.join("; ")
 }
 
@@ -815,6 +818,37 @@ mod tests {
                 assert!(*show_details);
                 assert!(rows[0].detail.is_some());
                 assert_eq!(rows[1].detail, None);
+            }
+            section => panic!("expected index section, got {section:?}"),
+        }
+    }
+
+    #[test]
+    fn mysql_index_rows_show_prefix_direction_and_visibility() {
+        let mut table = table();
+        table.indexes = vec![Index {
+            name: "users_email_idx".to_string(),
+            columns: vec!["email(8) DESC".to_string()],
+            attributes: IndexAttributes::DESCENDING | IndexAttributes::INVISIBLE,
+            index_type: IndexType::BTree,
+            definition: None,
+        }];
+
+        let model = InspectorViewModel::build(
+            &EngineFeatureProfile::mysql_like(),
+            InspectorTab::Indexes,
+            Some(&table),
+            DatabaseType::MySQL,
+            &TestDdlGenerator,
+        );
+
+        match model.section() {
+            Some(InspectorSection::Indexes {
+                rows, show_details, ..
+            }) => {
+                assert!(*show_details);
+                assert_eq!(rows[0].columns, "email(8) DESC");
+                assert_eq!(rows[0].detail.as_deref(), Some("descending; invisible"));
             }
             section => panic!("expected index section, got {section:?}"),
         }

--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -432,7 +432,11 @@ fn index_detail(index: &Index) -> String {
     if index.needs_source_definition_detail()
         && let Some(definition) = &index.definition
     {
-        return definition.clone();
+        let mut detail = definition.clone();
+        if index.is_invisible() {
+            detail.push_str("; invisible");
+        }
+        return detail;
     }
 
     let mut details = Vec::new();
@@ -826,13 +830,22 @@ mod tests {
     #[test]
     fn mysql_index_rows_show_prefix_direction_and_visibility() {
         let mut table = table();
-        table.indexes = vec![Index {
-            name: "users_email_idx".to_string(),
-            columns: vec!["email(8) DESC".to_string()],
-            attributes: IndexAttributes::DESCENDING | IndexAttributes::INVISIBLE,
-            index_type: IndexType::BTree,
-            definition: None,
-        }];
+        table.indexes = vec![
+            Index {
+                name: "users_email_idx".to_string(),
+                columns: vec!["email(8) DESC".to_string()],
+                attributes: IndexAttributes::DESCENDING | IndexAttributes::INVISIBLE,
+                index_type: IndexType::BTree,
+                definition: None,
+            },
+            Index {
+                name: "users_email_functional_idx".to_string(),
+                columns: vec!["lower(email)".to_string()],
+                attributes: IndexAttributes::EXPRESSION | IndexAttributes::INVISIBLE,
+                index_type: IndexType::BTree,
+                definition: Some("lower(email)".to_string()),
+            },
+        ];
 
         let model = InspectorViewModel::build(
             &EngineFeatureProfile::mysql_like(),
@@ -849,6 +862,7 @@ mod tests {
                 assert!(*show_details);
                 assert_eq!(rows[0].columns, "email(8) DESC");
                 assert_eq!(rows[0].detail.as_deref(), Some("descending; invisible"));
+                assert_eq!(rows[1].detail.as_deref(), Some("lower(email); invisible"));
             }
             section => panic!("expected index section, got {section:?}"),
         }

--- a/src/domain/index.rs
+++ b/src/domain/index.rs
@@ -20,6 +20,7 @@ impl IndexAttributes {
     pub const HAS_AUXILIARY_COLUMNS: Self = Self(0b1_0000);
     pub const DESCENDING: Self = Self(0b10_0000);
     pub const NON_BINARY_COLLATION: Self = Self(0b100_0000);
+    pub const INVISIBLE: Self = Self(0b1000_0000);
 
     pub const fn empty() -> Self {
         Self(0)
@@ -81,12 +82,17 @@ impl Index {
             .contains(IndexAttributes::NON_BINARY_COLLATION)
     }
 
+    pub const fn is_invisible(&self) -> bool {
+        self.attributes.contains(IndexAttributes::INVISIBLE)
+    }
+
     pub const fn has_index_detail(&self) -> bool {
         self.is_partial()
             || self.has_expression()
             || self.has_auxiliary_columns()
             || self.has_descending_key()
             || self.has_non_binary_collation()
+            || self.is_invisible()
     }
 
     pub const fn needs_source_definition_detail(&self) -> bool {

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -37,7 +37,21 @@ struct MySqlIndexMetadata {
     column_name: String,
     sub_part: Option<i32>,
     expression: Option<String>,
+    descending: bool,
+    visibility: MySqlIndexVisibility,
     primary: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MySqlIndexVisibility {
+    Visible,
+    Invisible,
+}
+
+impl MySqlIndexVisibility {
+    const fn is_invisible(self) -> bool {
+        matches!(self, Self::Invisible)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -337,12 +351,27 @@ fn parse_index_metadata(
         .values
         .iter()
         .map(|row| {
-            if row.len() != 8 {
+            if row.len() != 10 {
                 return Err(metadata_shape_error("STATISTICS row"));
             }
             let column_name = optional_text(&row[4], "COLUMN_NAME")?;
             let sub_part = parse_optional_positive_i32(&row[5], "SUB_PART")?;
             let expression = optional_text(&row[6], "EXPRESSION")?;
+            let descending = match optional_text(&row[7], "COLLATION")? {
+                None => false,
+                Some(value) if value.eq_ignore_ascii_case("A") => false,
+                Some(value) if value.eq_ignore_ascii_case("D") => true,
+                Some(_) => {
+                    return Err(DbOperationError::MetadataParseFailed(
+                        "invalid MySQL metadata collation".to_string(),
+                    ));
+                }
+            };
+            let visibility = if parse_boolean_flag(&row[8], "IS_VISIBLE")? {
+                MySqlIndexVisibility::Visible
+            } else {
+                MySqlIndexVisibility::Invisible
+            };
             let (column_name, expression) = match (column_name, expression) {
                 (Some(column_name), None) => (column_name.to_string(), None),
                 (None, Some(expression)) => {
@@ -369,7 +398,9 @@ fn parse_index_metadata(
                 column_name,
                 sub_part,
                 expression,
-                primary: parse_boolean_flag(&row[7], "IS_PRIMARY")?,
+                descending,
+                visibility,
+                primary: parse_boolean_flag(&row[9], "IS_PRIMARY")?,
             })
         })
         .collect()
@@ -383,11 +414,12 @@ fn indexes_from_metadata(mut raw: Vec<MySqlIndexMetadata>) -> Vec<Index> {
     });
     let mut indexes = Vec::new();
     for column in raw {
+        let column_name = index_column_name(&column);
         if let Some(index) = indexes
             .iter_mut()
             .find(|index: &&mut Index| index.name == column.name)
         {
-            index.columns.push(column.column_name);
+            index.columns.push(column_name);
             if let Some(expression) = column.expression {
                 index.attributes = index.attributes | IndexAttributes::EXPRESSION;
                 index.definition = Some(match index.definition.take() {
@@ -395,15 +427,27 @@ fn indexes_from_metadata(mut raw: Vec<MySqlIndexMetadata>) -> Vec<Index> {
                     None => expression,
                 });
             }
+            if column.descending {
+                index.attributes = index.attributes | IndexAttributes::DESCENDING;
+            }
+            if column.visibility.is_invisible() {
+                index.attributes = index.attributes | IndexAttributes::INVISIBLE;
+            }
             continue;
         }
         let mut attributes = IndexAttributes::from_parts(!column.non_unique, column.primary);
         if column.expression.is_some() {
             attributes = attributes | IndexAttributes::EXPRESSION;
         }
+        if column.descending {
+            attributes = attributes | IndexAttributes::DESCENDING;
+        }
+        if column.visibility.is_invisible() {
+            attributes = attributes | IndexAttributes::INVISIBLE;
+        }
         indexes.push(Index {
             name: column.name,
-            columns: vec![column.column_name],
+            columns: vec![column_name],
             attributes,
             index_type: column
                 .index_type
@@ -414,6 +458,19 @@ fn indexes_from_metadata(mut raw: Vec<MySqlIndexMetadata>) -> Vec<Index> {
         });
     }
     indexes
+}
+
+fn index_column_name(column: &MySqlIndexMetadata) -> String {
+    let mut name = column.column_name.clone();
+    if column.expression.is_none()
+        && let Some(sub_part) = column.sub_part
+    {
+        name = format!("{name}({sub_part})");
+    }
+    if column.descending {
+        name.push_str(" DESC");
+    }
+    name
 }
 
 fn unique_single_columns_from_metadata(raw: &[MySqlIndexMetadata]) -> HashSet<String> {
@@ -507,7 +564,7 @@ while IFS= read -r line; do
       printf '%s\n' '<resultset></resultset>'
       ;;
     *STATISTICS*)
-      printf '%s\n' '<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><field name="INDEX_NAME">PRIMARY</field><field name="NON_UNIQUE">0</field><field name="INDEX_TYPE">BTREE</field><field name="SEQ_IN_INDEX">1</field><field name="COLUMN_NAME" xsi:nil="true"/><field name="SUB_PART" xsi:nil="true"/><field name="EXPRESSION">expr</field><field name="IS_PRIMARY">YES</field></row></resultset>'
+      printf '%s\n' '<resultset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><row><field name="INDEX_NAME">PRIMARY</field><field name="NON_UNIQUE">0</field><field name="INDEX_TYPE">BTREE</field><field name="SEQ_IN_INDEX">1</field><field name="COLUMN_NAME" xsi:nil="true"/><field name="SUB_PART" xsi:nil="true"/><field name="EXPRESSION">expr</field><field name="COLLATION" xsi:nil="true"/><field name="IS_VISIBLE">YES</field><field name="IS_PRIMARY">YES</field></row></resultset>'
       ;;
     *FOREIGN*)
       printf '%s\n' '<resultset><row><field name="CONSTRAINT_NAME">fk_items_self</field><field name="TABLE_SCHEMA">app</field><field name="TABLE_NAME">items</field><field name="COLUMN_NAME">id</field><field name="REFERENCED_TABLE_SCHEMA">app</field><field name="REFERENCED_TABLE_NAME">items</field><field name="REFERENCED_COLUMN_NAME">id</field><field name="ORDINAL_POSITION">1</field><field name="UPDATE_RULE">CASCADE</field><field name="DELETE_RULE">CASCADE</field></row></resultset>'
@@ -878,6 +935,8 @@ mod tests {
                 "COLUMN_NAME",
                 "SUB_PART",
                 "EXPRESSION",
+                "COLLATION",
+                "IS_VISIBLE",
                 "IS_PRIMARY",
             ],
             vec![
@@ -889,6 +948,8 @@ mod tests {
                     QueryValue::Text("second_key".to_string()),
                     QueryValue::Null,
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("YES".to_string()),
                 ],
                 vec![
@@ -899,6 +960,8 @@ mod tests {
                     QueryValue::Text("first_key".to_string()),
                     QueryValue::Null,
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("YES".to_string()),
                 ],
                 vec![
@@ -909,6 +972,8 @@ mod tests {
                     QueryValue::Text("body".to_string()),
                     QueryValue::Null,
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
             ],
@@ -927,6 +992,48 @@ mod tests {
     }
 
     #[test]
+    fn maps_prefix_descending_and_invisible_key_parts() {
+        let result = result(
+            INDEX_RESULT_COLUMNS,
+            vec![
+                vec![
+                    QueryValue::Text("idx_email_created".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("email".to_string()),
+                    QueryValue::Text("8".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("D".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                ],
+                vec![
+                    QueryValue::Text("idx_email_created".to_string()),
+                    QueryValue::Text("1".to_string()),
+                    QueryValue::Text("BTREE".to_string()),
+                    QueryValue::Text("2".to_string()),
+                    QueryValue::Text("created_at".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("A".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                    QueryValue::Text("NO".to_string()),
+                ],
+            ],
+        );
+
+        let index = indexes_from_metadata(parse_index_metadata(&result).unwrap())
+            .into_iter()
+            .next()
+            .unwrap();
+
+        assert_eq!(index.columns, ["email(8) DESC", "created_at"]);
+        assert!(index.has_descending_key());
+        assert!(index.is_invisible());
+    }
+
+    #[test]
     fn single_column_unique_indexes_exclude_prefix_and_non_single_indexes() {
         let result = result(
             INDEX_RESULT_COLUMNS,
@@ -939,6 +1046,8 @@ mod tests {
                     QueryValue::Text("email".to_string()),
                     QueryValue::Null,
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
                 vec![
@@ -949,6 +1058,8 @@ mod tests {
                     QueryValue::Text("email".to_string()),
                     QueryValue::Text("8".to_string()),
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
                 vec![
@@ -959,6 +1070,8 @@ mod tests {
                     QueryValue::Text("email".to_string()),
                     QueryValue::Text("8".to_string()),
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
                 vec![
@@ -969,6 +1082,8 @@ mod tests {
                     QueryValue::Text("id".to_string()),
                     QueryValue::Null,
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
                 vec![
@@ -979,6 +1094,8 @@ mod tests {
                     QueryValue::Text("first_key".to_string()),
                     QueryValue::Null,
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
                 vec![
@@ -989,6 +1106,8 @@ mod tests {
                     QueryValue::Text("second_key".to_string()),
                     QueryValue::Null,
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
                 vec![
@@ -999,6 +1118,8 @@ mod tests {
                     QueryValue::Text("id".to_string()),
                     QueryValue::Null,
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("YES".to_string()),
                 ],
                 vec![
@@ -1009,6 +1130,8 @@ mod tests {
                     QueryValue::Text("email".to_string()),
                     QueryValue::Null,
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
                 vec![
@@ -1019,6 +1142,8 @@ mod tests {
                     QueryValue::Null,
                     QueryValue::Null,
                     QueryValue::Text("lower(`email`)".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
             ],
@@ -1050,6 +1175,8 @@ mod tests {
                 "COLUMN_NAME",
                 "SUB_PART",
                 "EXPRESSION",
+                "COLLATION",
+                "IS_VISIBLE",
                 "IS_PRIMARY",
             ],
             vec![
@@ -1061,6 +1188,8 @@ mod tests {
                     QueryValue::Text("sort_key".to_string()),
                     QueryValue::Null,
                     QueryValue::Null,
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
                 vec![
@@ -1071,6 +1200,8 @@ mod tests {
                     QueryValue::Null,
                     QueryValue::Null,
                     QueryValue::Text("lower(`payload`->>'$.code')".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
                 vec![
@@ -1081,6 +1212,8 @@ mod tests {
                     QueryValue::Null,
                     QueryValue::Null,
                     QueryValue::Text("lower(`payload`->>'$.code')".to_string()),
+                    QueryValue::Null,
+                    QueryValue::Text("YES".to_string()),
                     QueryValue::Text("NO".to_string()),
                 ],
             ],
@@ -1126,6 +1259,8 @@ mod tests {
                 "COLUMN_NAME",
                 "SUB_PART",
                 "EXPRESSION",
+                "COLLATION",
+                "IS_VISIBLE",
                 "IS_PRIMARY",
             ],
             vec![vec![
@@ -1136,6 +1271,8 @@ mod tests {
                 QueryValue::Null,
                 QueryValue::Null,
                 QueryValue::Null,
+                QueryValue::Null,
+                QueryValue::Text("YES".to_string()),
                 QueryValue::Text("NO".to_string()),
             ]],
         );

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -113,6 +113,8 @@ pub(in crate::adapters::mysql) const INDEX_RESULT_COLUMNS: &[&str] = &[
     "COLUMN_NAME",
     "SUB_PART",
     "EXPRESSION",
+    "COLLATION",
+    "IS_VISIBLE",
     "IS_PRIMARY",
 ];
 pub(in crate::adapters::mysql) const TRIGGER_RESULT_COLUMNS: &[&str] = &[
@@ -127,7 +129,7 @@ const VIEW_SHOW_CREATE_RESULT_COLUMNS: &[&str] = &["View", "Create View"];
 
 pub(in crate::adapters::mysql) fn indexes_query(schema: &str, table: &str) -> String {
     format!(
-        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.SUB_PART, s.EXPRESSION, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = {} AND s.TABLE_NAME = {} ORDER BY INDEX_NAME, SEQ_IN_INDEX",
+        "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.SUB_PART, s.EXPRESSION, s.COLLATION, s.IS_VISIBLE, CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY FROM INFORMATION_SCHEMA.STATISTICS AS s LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc ON tc.CONSTRAINT_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_SCHEMA = s.TABLE_SCHEMA AND tc.TABLE_NAME = s.TABLE_NAME AND tc.CONSTRAINT_NAME = s.INDEX_NAME WHERE s.TABLE_SCHEMA = {} AND s.TABLE_NAME = {} ORDER BY INDEX_NAME, SEQ_IN_INDEX",
         quote_string(schema),
         quote_string(table),
     )
@@ -346,7 +348,7 @@ mod tests {
         assert_contains_in_order(
             &indexes_sql,
             &[
-                "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.SUB_PART, s.EXPRESSION",
+                "SELECT s.INDEX_NAME, s.NON_UNIQUE, s.INDEX_TYPE, s.SEQ_IN_INDEX, s.COLUMN_NAME, s.SUB_PART, s.EXPRESSION, s.COLLATION, s.IS_VISIBLE",
                 "CASE WHEN tc.CONSTRAINT_TYPE = 'PRIMARY KEY' THEN 'YES' ELSE 'NO' END AS IS_PRIMARY",
                 "FROM INFORMATION_SCHEMA.STATISTICS AS s",
                 &format!("WHERE s.TABLE_SCHEMA = {quoted_schema}"),
@@ -512,6 +514,8 @@ mod tests {
                 "COLUMN_NAME",
                 "SUB_PART",
                 "EXPRESSION",
+                "COLLATION",
+                "IS_VISIBLE",
                 "IS_PRIMARY",
             ]
         );

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -215,6 +215,7 @@ mod metadata_fetch {
 
     const MYSQL_FK_PARENT: &str = "mysql_metadata_parent";
     const MYSQL_FK_CHILD: &str = "mysql_metadata_child";
+    const MYSQL_INDEX_METADATA: &str = "mysql_metadata_index_parts";
 
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
@@ -629,6 +630,82 @@ mod metadata_fetch {
                 if before != after_drop {
                     return Err("dropping the single unique index did not restore the signature".to_string());
                 }
+                Ok(())
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn reflects_mysql_index_prefix_direction_visibility_and_functional_parts() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
+                db.adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!(
+                            "CREATE TABLE {MYSQL_INDEX_METADATA} (email VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL, status VARCHAR(32) NOT NULL, KEY idx_normal_status (status), KEY idx_email_prefix_desc (email(8) DESC, created_at), KEY idx_invisible_created_at (created_at) INVISIBLE, KEY idx_functional_email ((LOWER(email)))) ENGINE=InnoDB"
+                        ),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to create index metadata fixture: {error:?}"))?;
+
+                let detail = db
+                    .adapter()
+                    .fetch_table_detail(db.dsn(), "sabiql_test", MYSQL_INDEX_METADATA)
+                    .await
+                    .map_err(|error| format!("failed to fetch index metadata fixture: {error:?}"))?;
+
+                let normal = detail
+                    .indexes
+                    .iter()
+                    .find(|index| index.name == "idx_normal_status")
+                    .ok_or_else(|| "normal MySQL index was not returned".to_string())?;
+                if normal.columns != ["status"] || normal.is_unique() {
+                    return Err(format!("unexpected normal index: {normal:?}"));
+                }
+
+                let prefix_desc = detail
+                    .indexes
+                    .iter()
+                    .find(|index| index.name == "idx_email_prefix_desc")
+                    .ok_or_else(|| "prefix descending MySQL index was not returned".to_string())?;
+                if prefix_desc.columns != ["email(8) DESC", "created_at"]
+                    || !prefix_desc.has_descending_key()
+                {
+                    return Err(format!(
+                        "unexpected prefix descending index: {prefix_desc:?}"
+                    ));
+                }
+
+                let invisible = detail
+                    .indexes
+                    .iter()
+                    .find(|index| index.name == "idx_invisible_created_at")
+                    .ok_or_else(|| "invisible MySQL index was not returned".to_string())?;
+                if invisible.columns != ["created_at"] || !invisible.is_invisible() {
+                    return Err(format!("unexpected invisible index: {invisible:?}"));
+                }
+
+                let functional = detail
+                    .indexes
+                    .iter()
+                    .find(|index| index.name == "idx_functional_email")
+                    .ok_or_else(|| "functional MySQL index was not returned".to_string())?;
+                if !functional.has_expression() {
+                    return Err(format!("functional index lost its expression: {functional:?}"));
+                }
+
+                db.adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        &format!("DROP TABLE {MYSQL_INDEX_METADATA}"),
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("failed to drop index metadata fixture: {error:?}"))?;
                 Ok(())
             })
         })

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -645,7 +645,7 @@ mod metadata_fetch {
                     .execute_adhoc(
                         db.dsn(),
                         &format!(
-                            "CREATE TABLE {MYSQL_INDEX_METADATA} (email VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL, status VARCHAR(32) NOT NULL, KEY idx_normal_status (status), KEY idx_email_prefix_desc (email(8) DESC, created_at), KEY idx_invisible_created_at (created_at) INVISIBLE, KEY idx_functional_email ((LOWER(email)))) ENGINE=InnoDB"
+                            "CREATE TABLE {MYSQL_INDEX_METADATA} (email VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL, status VARCHAR(32) NOT NULL, KEY idx_normal_status (status), KEY idx_email_prefix_desc (email(8) DESC, created_at), KEY idx_invisible_created_at (created_at) INVISIBLE, KEY idx_functional_email ((LOWER(email))) INVISIBLE) ENGINE=InnoDB"
                         ),
                         AccessMode::ReadWrite,
                     )
@@ -694,8 +694,10 @@ mod metadata_fetch {
                     .iter()
                     .find(|index| index.name == "idx_functional_email")
                     .ok_or_else(|| "functional MySQL index was not returned".to_string())?;
-                if !functional.has_expression() {
-                    return Err(format!("functional index lost its expression: {functional:?}"));
+                if !functional.has_expression() || !functional.is_invisible() {
+                    return Err(format!(
+                        "functional invisible index lost metadata: {functional:?}"
+                    ));
                 }
 
                 db.adapter()


### PR DESCRIPTION
## Problem

MySQL index metadata discarded prefix lengths, key-part sort direction, and index visibility, so the Inspector could show a different definition from the server.

## Background

The metadata query already selected \`SUB_PART\`, but the mapping omitted it and did not select \`COLLATION\` or \`IS_VISIBLE\`.

## Approach

Map prefix lengths and descending key parts into the existing index column display, retain invisible indexes as an existing-domain index attribute, and show visibility in the existing Inspector detail column. The real Oracle MySQL 8.4 path covers normal, prefix/descending, invisible, and functional indexes.

## Screenshots

Not applicable.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-491
