### PR TITLE
fix(mysql): guard SaveAndConnect runs (SAB-487)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Safety follows a plan-before-apply flow familiar from Terraform: inline edits an
 
 ![hero_1000_20fps](https://github.com/user-attachments/assets/06e1900d-b044-4f29-a2a8-7d7bab5bd3a1)
 
-- **Browse and inspect** — Find tables with fuzzy search, inspect columns, constraints, indexes, foreign keys, triggers, and DDL, or switch MySQL databases without reconnecting
+- **Browse and inspect** — Find tables with fuzzy search, inspect columns, constraints, indexes, foreign keys, triggers, and DDL
 - **Run SQL** — Write ad-hoc queries with completion for tables, columns, and keywords, then recall them from query history
 - **Edit with previews** — Update cells or delete rows only after reviewing the SQL and its risk level
 - **Browse in read-only mode** (`Ctrl+R`) — Block writes while investigating data

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
@@ -23,6 +24,12 @@ use crate::update::action::{
     Action, ConnectionSaveError, ConnectionTarget, ConnectionsLoadedPayload,
 };
 
+fn claim_save_run(run_guard: &AtomicU64, run_id: u64) -> bool {
+    run_guard
+        .compare_exchange(run_id, 0, Ordering::AcqRel, Ordering::Acquire)
+        .is_ok()
+}
+
 pub(crate) async fn run(
     effect: Effect,
     action_tx: &mpsc::Sender<Action>,
@@ -32,14 +39,25 @@ pub(crate) async fn run(
     state: &AppState,
 ) -> Result<()> {
     match effect {
-        Effect::SaveAndConnect { id, name, config } => {
+        Effect::SaveAndConnect {
+            id,
+            name,
+            config,
+            run_id,
+            run_guard,
+        } => {
+            let database_type = config.database_type();
             let id = id.unwrap_or_else(ConnectionId::new);
             let profile = ConnectionProfile::with_id_and_config(id, name, config);
             let profile = match profile {
                 Ok(p) => p,
                 Err(e) => {
                     action_tx
-                        .send(Action::ConnectionSaveFailed(e.into()))
+                        .send(Action::ConnectionSaveFailed {
+                            error: e.into(),
+                            database_type,
+                            run_id,
+                        })
                         .await
                         .ok();
                     return Ok(());
@@ -58,7 +76,11 @@ pub(crate) async fn run(
                     Ok(profile) => profile,
                     Err(error) => {
                         action_tx
-                            .send(Action::ConnectionSaveFailed(error.into()))
+                            .send(Action::ConnectionSaveFailed {
+                                error: error.into(),
+                                database_type,
+                                run_id,
+                            })
                             .await
                             .ok();
                         return Ok(());
@@ -69,20 +91,32 @@ pub(crate) async fn run(
                 let name = profile.name.as_str().to_string();
                 let database_type = profile.database_type();
 
-                tokio::task::spawn_blocking(move || match store.save(&profile) {
-                    Ok(()) => {
-                        tx.blocking_send(Action::ConnectionSaveCompleted(ConnectionTarget {
-                            id,
-                            dsn,
-                            name,
-                            database_type,
-                            database: None,
-                        }))
-                        .ok();
+                tokio::task::spawn_blocking(move || {
+                    if !claim_save_run(&run_guard, run_id) {
+                        return;
                     }
-                    Err(e) => {
-                        tx.blocking_send(Action::ConnectionSaveFailed(e.into()))
+                    match store.save(&profile) {
+                        Ok(()) => {
+                            tx.blocking_send(Action::ConnectionSaveCompleted {
+                                target: ConnectionTarget {
+                                    id,
+                                    dsn,
+                                    name,
+                                    database_type,
+                                    database: None,
+                                },
+                                run_id,
+                            })
                             .ok();
+                        }
+                        Err(e) => {
+                            tx.blocking_send(Action::ConnectionSaveFailed {
+                                error: e.into(),
+                                database_type,
+                                run_id,
+                            })
+                            .ok();
+                        }
                     }
                 });
                 return Ok(());
@@ -107,22 +141,39 @@ pub(crate) async fn run(
                 let probe = Arc::clone(&connection.mysql_connection_probe);
                 tokio::spawn(async move {
                     match probe.probe(&target.dsn).await {
-                        Ok(()) => match tokio::task::spawn_blocking(move || store.save(&profile))
+                        Ok(()) => {
+                            let save_result = tokio::task::spawn_blocking(move || {
+                                claim_save_run(&run_guard, run_id).then(|| store.save(&profile))
+                            })
                             .await
-                            .expect("connection store save task panicked")
-                        {
-                            Ok(()) => {
-                                tx.send(Action::ConnectionSaveCompleted(target)).await.ok();
+                            .expect("connection store save task panicked");
+                            match save_result {
+                                Some(Ok(())) => {
+                                    tx.send(Action::ConnectionSaveCompleted { target, run_id })
+                                        .await
+                                        .ok();
+                                }
+                                Some(Err(e)) => {
+                                    tx.send(Action::ConnectionSaveFailed {
+                                        error: e.into(),
+                                        database_type,
+                                        run_id,
+                                    })
+                                    .await
+                                    .ok();
+                                }
+                                None => {}
                             }
-                            Err(e) => {
-                                tx.send(Action::ConnectionSaveFailed(e.into())).await.ok();
-                            }
-                        },
+                        }
                         Err(e) => {
-                            tx.send(Action::ConnectionSaveFailed(ConnectionSaveError::Probe {
-                                error: e,
-                                dsn: target.dsn.clone(),
-                            }))
+                            tx.send(Action::ConnectionSaveFailed {
+                                error: ConnectionSaveError::Probe {
+                                    error: e,
+                                    dsn: target.dsn.clone(),
+                                },
+                                database_type,
+                                run_id,
+                            })
                             .await
                             .ok();
                         }
@@ -137,29 +188,47 @@ pub(crate) async fn run(
                 match provider.fetch_metadata(&dsn).await {
                     Ok(metadata) => {
                         cache.set(dsn.clone(), Arc::new(metadata)).await;
-                        match tokio::task::spawn_blocking(move || store.save(&profile))
-                            .await
-                            .expect("connection store save task panicked")
-                        {
-                            Ok(()) => {
-                                tx.send(Action::ConnectionSaveCompleted(ConnectionTarget {
-                                    id,
-                                    dsn: dsn.clone(),
-                                    name,
-                                    database_type,
-                                    database: None,
-                                }))
+                        let save_result = tokio::task::spawn_blocking(move || {
+                            claim_save_run(&run_guard, run_id).then(|| store.save(&profile))
+                        })
+                        .await
+                        .expect("connection store save task panicked");
+                        match save_result {
+                            Some(Ok(())) => {
+                                tx.send(Action::ConnectionSaveCompleted {
+                                    target: ConnectionTarget {
+                                        id,
+                                        dsn: dsn.clone(),
+                                        name,
+                                        database_type,
+                                        database: None,
+                                    },
+                                    run_id,
+                                })
                                 .await
                                 .ok();
                             }
-                            Err(e) => {
+                            Some(Err(e)) => {
                                 cache.invalidate(&dsn).await;
-                                tx.send(Action::ConnectionSaveFailed(e.into())).await.ok();
+                                tx.send(Action::ConnectionSaveFailed {
+                                    error: e.into(),
+                                    database_type,
+                                    run_id,
+                                })
+                                .await
+                                .ok();
                             }
+                            None => {}
                         }
                     }
                     Err(e) => {
-                        tx.send(Action::ConnectionSaveFailed(e.into())).await.ok();
+                        tx.send(Action::ConnectionSaveFailed {
+                            error: e.into(),
+                            database_type,
+                            run_id,
+                        })
+                        .await
+                        .ok();
                     }
                 }
             });
@@ -373,6 +442,7 @@ mod tests {
         use super::*;
         use mockall::predicate::eq;
         use std::fs;
+        use std::sync::atomic::AtomicU64;
         use tempfile::tempdir;
 
         struct SqliteDsnBuilder;
@@ -448,6 +518,8 @@ mod tests {
                         id: None,
                         name: "MySQL".to_string(),
                         config: mysql_config(Some("app")),
+                        run_id: 1,
+                        run_guard: Arc::new(AtomicU64::new(1)),
                     }],
                     &mut renderer,
                     &mut state,
@@ -463,11 +535,14 @@ mod tests {
                 .unwrap();
             assert!(matches!(
                 action,
-                Action::ConnectionSaveCompleted(ConnectionTarget {
-                    database: Some(database),
-                    database_type: DatabaseType::MySQL,
-                    ..
-                }) if database == "app"
+                Action::ConnectionSaveCompleted {
+                    target: ConnectionTarget {
+                        database: Some(database),
+                        database_type: DatabaseType::MySQL,
+                        ..
+                    },
+                    run_id: 1,
+                } if database == "app"
             ));
         }
 
@@ -507,6 +582,8 @@ mod tests {
                         id: None,
                         name: "MySQL".to_string(),
                         config: mysql_config(None),
+                        run_id: 1,
+                        run_guard: Arc::new(AtomicU64::new(1)),
                     }],
                     &mut renderer,
                     &mut state,
@@ -522,8 +599,11 @@ mod tests {
                 .unwrap();
             assert!(matches!(
                 action,
-                Action::ConnectionSaveFailed(ConnectionSaveError::Probe { dsn, .. })
-                    if dsn == "mysql://user:secret@localhost:3306?ssl-mode=REQUIRED"
+                Action::ConnectionSaveFailed {
+                    error: ConnectionSaveError::Probe { dsn, .. },
+                    database_type: DatabaseType::MySQL,
+                    run_id: 1,
+                } if dsn == "mysql://user:secret@localhost:3306?ssl-mode=REQUIRED"
             ));
         }
 
@@ -571,6 +651,8 @@ mod tests {
                         config: ConnectionConfig::SQLite(
                             SqliteConnectionConfig::new(input_path).unwrap(),
                         ),
+                        run_id: 1,
+                        run_guard: Arc::new(AtomicU64::new(1)),
                     }],
                     &mut renderer,
                     state,
@@ -585,7 +667,13 @@ mod tests {
                 .expect("action timeout")
                 .expect("channel closed");
             assert!(
-                matches!(action, Action::ConnectionSaveCompleted(ConnectionTarget { ref dsn, .. }) if dsn == &expected_dsn),
+                matches!(
+                    action,
+                    Action::ConnectionSaveCompleted {
+                        target: ConnectionTarget { ref dsn, .. },
+                        run_id: 1,
+                    } if dsn == &expected_dsn
+                ),
                 "expected sqlite ConnectionSaveCompleted, got {action:?}"
             );
         }
@@ -622,6 +710,8 @@ mod tests {
                         config: ConnectionConfig::SQLite(
                             SqliteConnectionConfig::new(path_str).unwrap(),
                         ),
+                        run_id: 1,
+                        run_guard: Arc::new(AtomicU64::new(1)),
                     }],
                     &mut renderer,
                     state,
@@ -638,9 +728,13 @@ mod tests {
             assert!(
                 matches!(
                     action,
-                    Action::ConnectionSaveFailed(ConnectionSaveError::Validation(
-                        ConnectionProfileError::SqlitePath(SqlitePathError::FileNotFound(_))
-                    ))
+                    Action::ConnectionSaveFailed {
+                        error: ConnectionSaveError::Validation(ConnectionProfileError::SqlitePath(
+                            SqlitePathError::FileNotFound(_)
+                        ),),
+                        database_type: DatabaseType::SQLite,
+                        run_id: 1,
+                    }
                 ),
                 "expected sqlite path validation failure, got {action:?}"
             );

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -442,7 +442,7 @@ mod tests {
         use super::*;
         use mockall::predicate::eq;
         use std::fs;
-        use std::sync::atomic::AtomicU64;
+        use std::sync::atomic::{AtomicU64, Ordering};
         use tempfile::tempdir;
 
         struct SqliteDsnBuilder;
@@ -605,6 +605,61 @@ mod tests {
                     run_id: 1,
                 } if dsn == "mysql://user:secret@localhost:3306?ssl-mode=REQUIRED"
             ));
+        }
+
+        #[tokio::test]
+        async fn mysql_profile_is_not_saved_when_run_is_cancelled_after_probe() {
+            let dsn = "mysql://user:secret@localhost:3306/app?ssl-mode=REQUIRED";
+            let run_guard = Arc::new(AtomicU64::new(1));
+            let guard_for_probe = Arc::clone(&run_guard);
+            let mut probe = MockMySqlConnectionProbe::new();
+            probe
+                .expect_probe()
+                .with(eq(dsn.to_string()))
+                .once()
+                .returning(move |_| {
+                    guard_for_probe.store(0, Ordering::Release);
+                    Ok(())
+                });
+
+            let mut store = MockConnectionStore::new();
+            store.expect_save().never();
+            let (tx, mut rx) = mpsc::channel(8);
+            let runner = test_fixtures::make_runner_with_dsn_and_probe(
+                Arc::new(MockMetadataProvider::new()),
+                Arc::new(MockQueryExecutor::new()),
+                Arc::new(store),
+                TtlCache::new(300),
+                tx,
+                Arc::new(MySqlDsnBuilder),
+                Arc::new(probe),
+            );
+            let mut renderer = NoopRenderer;
+            let mut state = AppState::new("test".to_string());
+            let ce = RefCell::new(CompletionEngine::new());
+
+            runner
+                .run(
+                    vec![Effect::SaveAndConnect {
+                        id: None,
+                        name: "MySQL".to_string(),
+                        config: mysql_config(Some("app")),
+                        run_id: 1,
+                        run_guard,
+                    }],
+                    &mut renderer,
+                    &mut state,
+                    &ce,
+                    &AppServices::stub(),
+                )
+                .await
+                .unwrap();
+
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(500), rx.recv())
+                    .await
+                    .is_err()
+            );
         }
 
         #[tokio::test]

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+
 use crate::domain::connection::{ConnectionConfig, ConnectionId, DatabaseType};
 use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{QueryValue, Table};
@@ -12,6 +15,8 @@ pub enum Effect {
         id: Option<ConnectionId>,
         name: String,
         config: ConnectionConfig,
+        run_id: u64,
+        run_guard: Arc<AtomicU64>,
     },
     ProbeMySqlConnection {
         target: ConnectionTarget,

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{
@@ -98,6 +99,8 @@ pub struct BrowseSession {
     effective_user: Option<String>,
     effective_user_run: AsyncRun,
     table_detail_run: AsyncRun,
+    connection_save_run: AsyncRun,
+    connection_save_guard: Arc<AtomicU64>,
 
     // -- co-dependent: connection identity / lifecycle --
     dsn: Option<String>,
@@ -125,6 +128,8 @@ impl Default for BrowseSession {
             effective_user: None,
             effective_user_run: AsyncRun::default(),
             table_detail_run: AsyncRun::default(),
+            connection_save_run: AsyncRun::default(),
+            connection_save_guard: Arc::new(AtomicU64::new(0)),
             dsn: None,
             active_connection: None,
             mysql_connection_probe_run: AsyncRun::default(),
@@ -251,6 +256,26 @@ impl BrowseSession {
         self.metadata_state = MetadataState::Loading;
         self.effective_user = None;
         self.effective_user_run.clear_active();
+    }
+
+    #[must_use]
+    pub fn begin_connection_save(&mut self) -> u64 {
+        let run_id = self.connection_save_run.begin();
+        self.connection_save_guard.store(run_id, Ordering::Release);
+        run_id
+    }
+
+    pub fn is_current_connection_save(&self, run_id: u64) -> bool {
+        self.connection_save_run.is_current(run_id)
+    }
+
+    pub fn cancel_connection_save(&mut self) {
+        self.connection_save_run.clear_active();
+        self.connection_save_guard.store(0, Ordering::Release);
+    }
+
+    pub fn connection_save_guard(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.connection_save_guard)
     }
 
     #[must_use]
@@ -431,6 +456,7 @@ impl BrowseSession {
     pub fn clear_connection(&mut self) {
         self.dsn = None;
         self.active_connection = None;
+        self.cancel_connection_save();
         self.clear_mysql_connection_probe();
         self.active_engine_feature_profile = EngineFeatureProfile::disconnected();
     }

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -274,6 +274,13 @@ impl BrowseSession {
         self.connection_save_guard.store(0, Ordering::Release);
     }
 
+    pub fn cancel_connection_save_and_disconnect(&mut self) {
+        if self.connection_save_run.active_id().is_some() {
+            self.cancel_connection_save();
+            self.mark_disconnected();
+        }
+    }
+
     pub fn connection_save_guard(&self) -> Arc<AtomicU64> {
         Arc::clone(&self.connection_save_guard)
     }
@@ -456,7 +463,7 @@ impl BrowseSession {
     pub fn clear_connection(&mut self) {
         self.dsn = None;
         self.active_connection = None;
-        self.cancel_connection_save();
+        self.cancel_connection_save_and_disconnect();
         self.clear_mysql_connection_probe();
         self.active_engine_feature_profile = EngineFeatureProfile::disconnected();
     }

--- a/src/app/model/connection/error_state.rs
+++ b/src/app/model/connection/error_state.rs
@@ -1,6 +1,19 @@
 use std::time::{Duration, Instant};
 
 use super::error::ConnectionErrorInfo;
+use crate::domain::DatabaseType;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum ConnectionErrorSource {
+    #[default]
+    ActiveConnection,
+    SaveAndConnect {
+        database_type: DatabaseType,
+    },
+    ConnectionSwitch {
+        database_type: DatabaseType,
+    },
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct ConnectionErrorState {
@@ -8,16 +21,44 @@ pub struct ConnectionErrorState {
     pub(crate) details_expanded: bool,
     pub(crate) scroll_offset: usize,
     pub(crate) copied_feedback_expires: Option<Instant>,
+    source: ConnectionErrorSource,
 }
 
 impl ConnectionErrorState {
     const FEEDBACK_TIMEOUT_SECS: u64 = 3;
 
     pub fn set_error(&mut self, info: ConnectionErrorInfo) {
+        self.set_error_with_source(info, ConnectionErrorSource::ActiveConnection);
+    }
+
+    pub fn set_save_and_connect_error(
+        &mut self,
+        info: ConnectionErrorInfo,
+        database_type: DatabaseType,
+    ) {
+        self.set_error_with_source(
+            info,
+            ConnectionErrorSource::SaveAndConnect { database_type },
+        );
+    }
+
+    pub fn set_connection_switch_error(
+        &mut self,
+        info: ConnectionErrorInfo,
+        database_type: DatabaseType,
+    ) {
+        self.set_error_with_source(
+            info,
+            ConnectionErrorSource::ConnectionSwitch { database_type },
+        );
+    }
+
+    fn set_error_with_source(&mut self, info: ConnectionErrorInfo, source: ConnectionErrorSource) {
         self.error_info = Some(info);
         self.details_expanded = false;
         self.scroll_offset = 0;
         self.copied_feedback_expires = None;
+        self.source = source;
     }
 
     pub fn error_info(&self) -> Option<&ConnectionErrorInfo> {
@@ -26,6 +67,18 @@ impl ConnectionErrorState {
 
     pub fn has_error(&self) -> bool {
         self.error_info.is_some()
+    }
+
+    pub fn is_save_and_connect_failure(&self) -> bool {
+        matches!(self.source, ConnectionErrorSource::SaveAndConnect { .. })
+    }
+
+    pub fn target_database_type(&self) -> Option<DatabaseType> {
+        match self.source {
+            ConnectionErrorSource::ActiveConnection => None,
+            ConnectionErrorSource::SaveAndConnect { database_type }
+            | ConnectionErrorSource::ConnectionSwitch { database_type } => Some(database_type),
+        }
     }
 
     pub fn can_retry(&self) -> bool {
@@ -56,6 +109,7 @@ impl ConnectionErrorState {
         self.details_expanded = false;
         self.scroll_offset = 0;
         self.copied_feedback_expires = None;
+        self.source = ConnectionErrorSource::ActiveConnection;
     }
 
     pub fn toggle_details(&mut self) {

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -386,8 +386,15 @@ pub enum Action {
     ConnectionSetupDropdownCancel,
     ConnectionSetupSave,
     ConnectionSetupCancel,
-    ConnectionSaveCompleted(ConnectionTarget),
-    ConnectionSaveFailed(ConnectionSaveError),
+    ConnectionSaveCompleted {
+        target: ConnectionTarget,
+        run_id: u64,
+    },
+    ConnectionSaveFailed {
+        error: ConnectionSaveError,
+        database_type: DatabaseType,
+        run_id: u64,
+    },
     MySqlConnectionProbeCompleted {
         target: ConnectionTarget,
         run_id: u64,

--- a/src/app/update/connection/error.rs
+++ b/src/app/update/connection/error.rs
@@ -71,17 +71,22 @@ pub(super) fn reduce_connection_error(
             DispatchResult::handled()
         }
         Action::ReenterConnectionSetup => {
-            if state.session.has_pending_connection_switch()
-                || !state.session.can_reenter_connection_setup()
+            if !state.connection_error.is_save_and_connect_failure()
+                && (state.session.has_pending_connection_switch()
+                    || !state.session.can_reenter_connection_setup())
             {
                 return DispatchResult::handled();
             }
             state.connection_error.clear();
+            state.session.cancel_connection_save();
             state.session.mark_disconnected();
             state.modal.replace_mode(InputMode::ConnectionSetup);
             DispatchResult::handled()
         }
         Action::RetryConnection => {
+            if state.connection_error.is_save_and_connect_failure() {
+                return DispatchResult::handled();
+            }
             if let Some(pending) = state.session.pending_mysql_connection_probe().cloned() {
                 let target = ConnectionTarget {
                     id: pending.id,

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -22,7 +22,7 @@ pub fn reduce_connection_lifecycle(
 ) -> DispatchResult {
     match action {
         Action::TryConnect => {
-            state.session.cancel_connection_save();
+            state.session.cancel_connection_save_and_disconnect();
             if state.session.connection_state().is_not_connected()
                 && state.modal.active_mode() == InputMode::Normal
             {
@@ -74,7 +74,7 @@ pub fn reduce_connection_lifecycle(
         }
 
         Action::SwitchConnection(target) => {
-            state.session.cancel_connection_save();
+            state.session.cancel_connection_save_and_disconnect();
             state.connection_error.clear();
             let ConnectionTarget {
                 id,

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -22,6 +22,7 @@ pub fn reduce_connection_lifecycle(
 ) -> DispatchResult {
     match action {
         Action::TryConnect => {
+            state.session.cancel_connection_save();
             if state.session.connection_state().is_not_connected()
                 && state.modal.active_mode() == InputMode::Normal
             {
@@ -73,6 +74,7 @@ pub fn reduce_connection_lifecycle(
         }
 
         Action::SwitchConnection(target) => {
+            state.session.cancel_connection_save();
             state.connection_error.clear();
             let ConnectionTarget {
                 id,
@@ -213,8 +215,9 @@ pub fn reduce_connection_lifecycle(
                     .mark_table_detail_probe_failed(&target.dsn, message.clone());
                 state.session.mark_connection_failed(message);
             }
-            state.connection_error.set_error(
+            state.connection_error.set_connection_switch_error(
                 ConnectionErrorInfo::from_db_operation_error_with_dsn(error, &target.dsn),
+                target.database_type,
             );
             state.modal.replace_mode(InputMode::ConnectionError);
             DispatchResult::handled_with(table_detail_retry.into_iter().collect())

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -30,6 +30,7 @@ pub fn reduce_connection_setup(
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::ConnectionSetup) => {
+            state.session.cancel_connection_save();
             state.connection_setup.reset();
             if !state.connections().is_empty() || state.session.dsn().is_some() {
                 state.connection_setup.set_first_run(false);
@@ -41,6 +42,7 @@ pub fn reduce_connection_setup(
             DispatchResult::handled_with(vec![Effect::LoadConnectionForEdit { id: id.clone() }])
         }
         Action::ConnectionEditLoaded(profile) => {
+            state.session.cancel_connection_save();
             state.connection_setup = ConnectionSetupState::from(&**profile);
             state.modal.set_mode(InputMode::ConnectionSetup);
             DispatchResult::handled()
@@ -50,6 +52,7 @@ pub fn reduce_connection_setup(
             DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::ConnectionSetup) => {
+            state.session.cancel_connection_save();
             state.modal.set_mode(InputMode::Normal);
             DispatchResult::handled()
         }
@@ -198,6 +201,8 @@ pub fn reduce_connection_setup(
             if state.session.connection_state() == ConnectionState::Connected {
                 save_current_connection_cache(state);
             }
+            let run_id = state.session.begin_connection_save();
+            let run_guard = state.session.connection_save_guard();
             state.query.reset_for_context_change();
             state.session.clear_mysql_connection_probe();
             state.session.invalidate_connection_generation();
@@ -214,10 +219,13 @@ pub fn reduce_connection_setup(
                         .trim()
                         .to_string(),
                     config,
+                    run_id,
+                    run_guard,
                 }],
             ))
         }
         Action::ConnectionSetupCancel => {
+            state.session.cancel_connection_save();
             if state.connection_setup.is_first_run() {
                 state.confirm_dialog.open(
                     "Confirm",
@@ -233,13 +241,18 @@ pub fn reduce_connection_setup(
                 ])])
             }
         }
-        Action::ConnectionSaveCompleted(ConnectionTarget {
-            id,
-            dsn,
-            name,
-            database_type,
-            database,
-        }) => {
+        Action::ConnectionSaveCompleted { target, run_id } => {
+            if !state.session.is_current_connection_save(*run_id) {
+                return DispatchResult::handled();
+            }
+            state.session.cancel_connection_save();
+            let ConnectionTarget {
+                id,
+                dsn,
+                name,
+                database_type,
+                database,
+            } = target;
             state.connection_setup.set_first_run(false);
             state.modal.set_mode(InputMode::Normal);
             state.connection_caches.remove(id);
@@ -258,8 +271,16 @@ pub fn reduce_connection_setup(
                 *database_type,
             ))
         }
-        Action::ConnectionSaveFailed(e) => {
-            if let ConnectionSaveError::Validation(ConnectionProfileError::SqlitePath(error)) = &e {
+        Action::ConnectionSaveFailed {
+            error: e,
+            database_type,
+            run_id,
+        } => {
+            if !state.session.is_current_connection_save(*run_id) {
+                return DispatchResult::handled();
+            }
+            state.session.cancel_connection_save();
+            if let ConnectionSaveError::Validation(ConnectionProfileError::SqlitePath(error)) = e {
                 state
                     .connection_setup
                     .record_sqlite_path_error(error.clone());
@@ -269,21 +290,21 @@ pub fn reduce_connection_setup(
             }
             let mysql_error = match e {
                 ConnectionSaveError::Probe { error, dsn }
-                    if state.connection_setup.database_type() == DatabaseType::MySQL =>
+                    if *database_type == DatabaseType::MySQL =>
                 {
                     Some(ConnectionErrorInfo::from_db_operation_error_with_dsn(
                         error, dsn,
                     ))
                 }
-                ConnectionSaveError::Metadata(error)
-                    if state.connection_setup.database_type() == DatabaseType::MySQL =>
-                {
+                ConnectionSaveError::Metadata(error) if *database_type == DatabaseType::MySQL => {
                     Some(ConnectionErrorInfo::from_db_operation_error(error))
                 }
                 _ => None,
             };
             if let Some(error_info) = mysql_error {
-                state.connection_error.set_error(error_info);
+                state
+                    .connection_error
+                    .set_save_and_connect_error(error_info, *database_type);
                 state.modal.replace_mode(InputMode::ConnectionError);
                 return DispatchResult::handled();
             }
@@ -344,6 +365,7 @@ mod tests {
     use crate::model::er_state::ErStatus;
     use crate::services::AppServices;
     use crate::update::action::TextKillDirection;
+    use crate::update::connection::error::reduce_connection_error;
     use crate::update::connection::lifecycle::reduce_connection_lifecycle;
     use crate::update::test_fixtures;
     fn reduce(state: &mut AppState, action: &Action, now: Instant) -> Option<Vec<Effect>> {
@@ -668,10 +690,15 @@ mod tests {
             };
             let dsn =
                 "mysql://user:password@localhost:3306/app?ssl-mode=VERIFY_IDENTITY".to_string();
+            let run_id = state.session.begin_connection_save();
 
             reduce(
                 &mut state,
-                &Action::ConnectionSaveFailed(ConnectionSaveError::Probe { error, dsn }),
+                &Action::ConnectionSaveFailed {
+                    error: ConnectionSaveError::Probe { error, dsn },
+                    database_type: DatabaseType::MySQL,
+                    run_id,
+                },
                 Instant::now(),
             );
 
@@ -702,14 +729,19 @@ mod tests {
                 state
                     .connection_setup
                     .set_database_type(DatabaseType::MySQL);
+                let run_id = state.session.begin_connection_save();
 
                 reduce(
                     &mut state,
-                    &Action::ConnectionSaveFailed(ConnectionSaveError::Probe {
-                        error: DbOperationError::ConnectionFailed(stderr.to_string()),
-                        dsn: "mysql://user:password@localhost:3306/app?ssl-mode=PREFERRED"
-                            .to_string(),
-                    }),
+                    &Action::ConnectionSaveFailed {
+                        error: ConnectionSaveError::Probe {
+                            error: DbOperationError::ConnectionFailed(stderr.to_string()),
+                            dsn: "mysql://user:password@localhost:3306/app?ssl-mode=PREFERRED"
+                                .to_string(),
+                        },
+                        database_type: DatabaseType::MySQL,
+                        run_id,
+                    },
                     Instant::now(),
                 );
 
@@ -763,6 +795,128 @@ mod tests {
 
             assert_eq!(state.session.active_connection_id(), Some(&current_id));
             assert!(state.session.pending_mysql_connection_probe().is_none());
+        }
+
+        #[test]
+        fn cancelled_save_completion_is_ignored() {
+            let mut state = AppState::new("test".to_string());
+            fill_valid_form(&mut state);
+            let effects = reduce(&mut state, &Action::ConnectionSetupSave, Instant::now())
+                .expect("save handled");
+            let run_id = effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::SaveAndConnect { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .expect("save run id");
+
+            reduce(&mut state, &Action::ConnectionSetupCancel, Instant::now());
+            assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
+
+            reduce(
+                &mut state,
+                &Action::ConnectionSaveCompleted {
+                    target: ConnectionTarget {
+                        id: ConnectionId::new(),
+                        dsn: "postgres://localhost/stale".to_string(),
+                        name: "stale".to_string(),
+                        database_type: DatabaseType::PostgreSQL,
+                        database: None,
+                    },
+                    run_id,
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(state.input_mode(), InputMode::ConfirmDialog);
+            assert!(state.session.active_connection_id().is_none());
+        }
+
+        #[test]
+        fn starting_switch_invalidates_previous_save_completion() {
+            let mut state = AppState::new("test".to_string());
+            let save_run_id = state.session.begin_connection_save();
+            let target = ConnectionTarget {
+                id: ConnectionId::from_string("mysql-b"),
+                dsn: "mysql://user@localhost:3306/b?ssl-mode=PREFERRED".to_string(),
+                name: "mysql-b".to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some("b".to_string()),
+            };
+
+            reduce_connection_lifecycle(
+                &mut state,
+                &Action::SwitchConnection(target.clone()),
+                Instant::now(),
+                &AppServices::stub(),
+            );
+            reduce(
+                &mut state,
+                &Action::ConnectionSaveCompleted {
+                    target: ConnectionTarget {
+                        id: ConnectionId::new(),
+                        dsn: "postgres://localhost/stale".to_string(),
+                        name: "stale".to_string(),
+                        database_type: DatabaseType::PostgreSQL,
+                        database: None,
+                    },
+                    run_id: save_run_id,
+                },
+                Instant::now(),
+            );
+
+            assert_eq!(
+                state
+                    .session
+                    .pending_mysql_connection_probe()
+                    .map(|pending| &pending.id),
+                Some(&target.id)
+            );
+            assert!(state.session.active_connection_id().is_none());
+        }
+
+        #[test]
+        fn mysql_save_failure_keeps_retry_from_using_previous_service() {
+            let mut state = AppState::new("test".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::from_string("service:mydb"),
+                "mydb",
+                DatabaseType::PostgreSQL,
+                "service=mydb",
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            let run_id = state.session.begin_connection_save();
+
+            reduce(
+                &mut state,
+                &Action::ConnectionSaveFailed {
+                    error: ConnectionSaveError::Probe {
+                        error: DbOperationError::ConnectionFailed("connection refused".to_string()),
+                        dsn: "mysql://user@localhost:3306/app?ssl-mode=PREFERRED".to_string(),
+                    },
+                    database_type: DatabaseType::MySQL,
+                    run_id,
+                },
+                Instant::now(),
+            );
+
+            assert!(state.connection_error.is_save_and_connect_failure());
+            assert_eq!(
+                state.connection_error.target_database_type(),
+                Some(DatabaseType::MySQL)
+            );
+            let effects =
+                reduce_connection_error(&mut state, &Action::RetryConnection, Instant::now())
+                    .into_effects()
+                    .expect("retry action handled");
+            assert!(effects.is_empty());
+            assert_eq!(state.input_mode(), InputMode::ConnectionError);
+
+            reduce_connection_error(&mut state, &Action::ReenterConnectionSetup, Instant::now());
+            assert_eq!(state.input_mode(), InputMode::ConnectionSetup);
         }
 
         #[test]
@@ -900,14 +1054,18 @@ mod tests {
         fn save_completed_resets_read_only() {
             let mut state = AppState::new("test".to_string());
             state.session.enable_read_only();
+            let run_id = state.session.begin_connection_save();
 
-            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
-                id: ConnectionId::new(),
-                dsn: "postgres://localhost/new_db".to_string(),
-                name: "new_db".to_string(),
-                database_type: DatabaseType::PostgreSQL,
-                database: None,
-            });
+            let action = Action::ConnectionSaveCompleted {
+                target: ConnectionTarget {
+                    id: ConnectionId::new(),
+                    dsn: "postgres://localhost/new_db".to_string(),
+                    name: "new_db".to_string(),
+                    database_type: DatabaseType::PostgreSQL,
+                    database: None,
+                },
+                run_id,
+            };
             reduce(&mut state, &action, Instant::now());
 
             assert!(!state.session.is_read_only());
@@ -941,13 +1099,17 @@ mod tests {
                     QuerySource::Preview,
                 )));
 
-            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
-                id: ConnectionId::new(),
-                dsn: "sqlite:///tmp/new.db".to_string(),
-                name: "new.db".to_string(),
-                database_type: DatabaseType::SQLite,
-                database: None,
-            });
+            let run_id = state.session.begin_connection_save();
+            let action = Action::ConnectionSaveCompleted {
+                target: ConnectionTarget {
+                    id: ConnectionId::new(),
+                    dsn: "sqlite:///tmp/new.db".to_string(),
+                    name: "new.db".to_string(),
+                    database_type: DatabaseType::SQLite,
+                    database: None,
+                },
+                run_id,
+            };
             let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
             assert!(state.session.metadata().is_none());
@@ -1010,13 +1172,17 @@ mod tests {
                 },
             );
 
-            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
-                id: saved_id.clone(),
-                dsn: "sqlite:///tmp/new.db".to_string(),
-                name: "new.db".to_string(),
-                database_type: DatabaseType::SQLite,
-                database: None,
-            });
+            let run_id = state.session.begin_connection_save();
+            let action = Action::ConnectionSaveCompleted {
+                target: ConnectionTarget {
+                    id: saved_id.clone(),
+                    dsn: "sqlite:///tmp/new.db".to_string(),
+                    name: "new.db".to_string(),
+                    database_type: DatabaseType::SQLite,
+                    database: None,
+                },
+                run_id,
+            };
             reduce(&mut state, &action, Instant::now());
 
             assert!(state.connection_caches.get(&saved_id).is_none());
@@ -1026,13 +1192,17 @@ mod tests {
         fn sqlite_save_completed_fetches_metadata() {
             let mut state = AppState::new("test".to_string());
 
-            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
-                id: ConnectionId::new(),
-                dsn: "sqlite:///tmp/app.db".to_string(),
-                name: "app.db".to_string(),
-                database_type: DatabaseType::SQLite,
-                database: None,
-            });
+            let run_id = state.session.begin_connection_save();
+            let action = Action::ConnectionSaveCompleted {
+                target: ConnectionTarget {
+                    id: ConnectionId::new(),
+                    dsn: "sqlite:///tmp/app.db".to_string(),
+                    name: "app.db".to_string(),
+                    database_type: DatabaseType::SQLite,
+                    database: None,
+                },
+                run_id,
+            };
             let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 
             assert_eq!(effects.len(), 1);
@@ -1056,14 +1226,18 @@ mod tests {
             state
                 .er_preparation
                 .queue_pending_table("public.users".to_string());
+            let run_id = state.session.begin_connection_save();
 
-            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
-                id: ConnectionId::new(),
-                dsn: "sqlite:///tmp/app.db".to_string(),
-                name: "app.db".to_string(),
-                database_type: DatabaseType::SQLite,
-                database: None,
-            });
+            let action = Action::ConnectionSaveCompleted {
+                target: ConnectionTarget {
+                    id: ConnectionId::new(),
+                    dsn: "sqlite:///tmp/app.db".to_string(),
+                    name: "app.db".to_string(),
+                    database_type: DatabaseType::SQLite,
+                    database: None,
+                },
+                run_id,
+            };
             reduce(&mut state, &action, Instant::now());
 
             assert!(!state.ui.pending_er_picker());
@@ -1074,13 +1248,17 @@ mod tests {
         #[test]
         fn mysql_save_completed_fetches_metadata_for_selected_database() {
             let mut state = AppState::new("test".to_string());
-            let action = Action::ConnectionSaveCompleted(ConnectionTarget {
-                id: ConnectionId::new(),
-                dsn: "mysql://user@localhost:3306/app".to_string(),
-                name: "mysql".to_string(),
-                database_type: DatabaseType::MySQL,
-                database: Some("app".to_string()),
-            });
+            let run_id = state.session.begin_connection_save();
+            let action = Action::ConnectionSaveCompleted {
+                target: ConnectionTarget {
+                    id: ConnectionId::new(),
+                    dsn: "mysql://user@localhost:3306/app".to_string(),
+                    name: "mysql".to_string(),
+                    database_type: DatabaseType::MySQL,
+                    database: Some("app".to_string()),
+                },
+                run_id,
+            };
 
             let effects = reduce(&mut state, &action, Instant::now()).unwrap();
 

--- a/src/app/update/connection/setup.rs
+++ b/src/app/update/connection/setup.rs
@@ -30,7 +30,7 @@ pub fn reduce_connection_setup(
 ) -> DispatchResult {
     match action {
         Action::OpenModal(ModalKind::ConnectionSetup) => {
-            state.session.cancel_connection_save();
+            state.session.cancel_connection_save_and_disconnect();
             state.connection_setup.reset();
             if !state.connections().is_empty() || state.session.dsn().is_some() {
                 state.connection_setup.set_first_run(false);
@@ -42,7 +42,7 @@ pub fn reduce_connection_setup(
             DispatchResult::handled_with(vec![Effect::LoadConnectionForEdit { id: id.clone() }])
         }
         Action::ConnectionEditLoaded(profile) => {
-            state.session.cancel_connection_save();
+            state.session.cancel_connection_save_and_disconnect();
             state.connection_setup = ConnectionSetupState::from(&**profile);
             state.modal.set_mode(InputMode::ConnectionSetup);
             DispatchResult::handled()
@@ -52,7 +52,7 @@ pub fn reduce_connection_setup(
             DispatchResult::handled()
         }
         Action::CloseModal(ModalKind::ConnectionSetup) => {
-            state.session.cancel_connection_save();
+            state.session.cancel_connection_save_and_disconnect();
             state.modal.set_mode(InputMode::Normal);
             DispatchResult::handled()
         }
@@ -225,7 +225,7 @@ pub fn reduce_connection_setup(
             ))
         }
         Action::ConnectionSetupCancel => {
-            state.session.cancel_connection_save();
+            state.session.cancel_connection_save_and_disconnect();
             if state.connection_setup.is_first_run() {
                 state.confirm_dialog.open(
                     "Confirm",
@@ -674,6 +674,67 @@ mod tests {
                 ConnectionState::Connecting
             );
             assert_eq!(state.session.metadata_state(), &MetadataState::Loading);
+        }
+
+        #[test]
+        fn cancelled_save_can_be_submitted_again() {
+            let mut state = AppState::new("test".to_string());
+            fill_valid_form(&mut state);
+
+            reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
+            assert!(state.session.connection_state().is_connecting());
+
+            reduce(&mut state, &Action::ConnectionSetupCancel, Instant::now());
+            assert!(state.session.connection_state().is_not_connected());
+
+            state.modal.set_mode(InputMode::ConnectionSetup);
+            let effects = reduce(&mut state, &Action::ConnectionSetupSave, Instant::now())
+                .expect("second save handled");
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::SaveAndConnect { .. }))
+            );
+        }
+
+        #[test]
+        fn cancelled_save_can_retry_previous_connection() {
+            let mut state = AppState::new("test".to_string());
+            let previous_id = ConnectionId::from_string("previous");
+            state.session.activate_connection_with_dsn(
+                &previous_id,
+                "previous",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/previous",
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            state.modal.set_mode(InputMode::ConnectionSetup);
+            state.connection_setup.set_first_run(false);
+            fill_valid_form(&mut state);
+
+            reduce(&mut state, &Action::ConnectionSetupSave, Instant::now());
+            reduce(&mut state, &Action::ConnectionSetupCancel, Instant::now());
+
+            assert!(state.session.connection_state().is_not_connected());
+            assert_eq!(state.session.active_connection_id(), Some(&previous_id));
+            assert_eq!(state.session.dsn(), Some("postgres://localhost/previous"));
+
+            let effects = reduce_connection_lifecycle(
+                &mut state,
+                &Action::TryConnect,
+                Instant::now(),
+                &AppServices::stub(),
+            )
+            .into_effects()
+            .expect("retry handled");
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::FetchMetadata { .. }))
+            );
+            assert!(state.session.connection_state().is_connecting());
         }
 
         #[test]

--- a/src/app/update/helpers.rs
+++ b/src/app/update/helpers.rs
@@ -618,6 +618,23 @@ mod tests {
 
             assert!(!state.has_validation_error(ConnectionField::Name));
         }
+
+        #[test]
+        fn zero_port_sets_error() {
+            let mut state = ConnectionSetupState::default();
+            state.set_database_type(DatabaseType::MySQL);
+            state
+                .input_mut(ConnectionField::Port)
+                .unwrap()
+                .set_content("0".to_string());
+
+            validate_field(&mut state, ConnectionField::Port);
+
+            assert_eq!(
+                state.validation_error(ConnectionField::Port),
+                Some("Port must be > 0")
+            );
+        }
     }
 
     mod validate_sqlite_path {

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -2042,17 +2042,21 @@ mod tests {
                 .connection_setup
                 .database
                 .set_content("mydb".to_string());
+            let run_id = state.session.begin_connection_save();
             let now = Instant::now();
 
             let effects = reduce(
                 &mut state,
-                Action::ConnectionSaveCompleted(ConnectionTarget {
-                    id: ConnectionId::new(),
-                    dsn: "postgres://db.example.com/mydb".to_string(),
-                    name: "Test Connection".to_string(),
-                    database_type: DatabaseType::PostgreSQL,
-                    database: None,
-                }),
+                Action::ConnectionSaveCompleted {
+                    target: ConnectionTarget {
+                        id: ConnectionId::new(),
+                        dsn: "postgres://db.example.com/mydb".to_string(),
+                        name: "Test Connection".to_string(),
+                        database_type: DatabaseType::PostgreSQL,
+                        database: None,
+                    },
+                    run_id,
+                },
                 now,
                 &AppServices::stub(),
             );
@@ -2071,13 +2075,18 @@ mod tests {
         fn save_failed_sets_error_message() {
             let mut state = create_test_state();
             state.modal.set_mode(InputMode::ConnectionSetup);
+            let run_id = state.session.begin_connection_save();
             let now = Instant::now();
 
             let effects = reduce(
                 &mut state,
-                Action::ConnectionSaveFailed(ConnectionSaveError::Store(ConnectionStoreError::Io(
-                    Arc::new(std::io::Error::other("Write error")),
-                ))),
+                Action::ConnectionSaveFailed {
+                    error: ConnectionSaveError::Store(ConnectionStoreError::Io(Arc::new(
+                        std::io::Error::other("Write error"),
+                    ))),
+                    database_type: DatabaseType::PostgreSQL,
+                    run_id,
+                },
                 now,
                 &AppServices::stub(),
             );
@@ -2560,17 +2569,21 @@ mod tests {
                 .session
                 .set_connection_state(ConnectionState::NotConnected);
             state.session.set_metadata_state(MetadataState::NotLoaded);
+            let run_id = state.session.begin_connection_save();
             let now = Instant::now();
 
             let effects = reduce(
                 &mut state,
-                Action::ConnectionSaveCompleted(ConnectionTarget {
-                    id: ConnectionId::new(),
-                    dsn: "postgres://localhost/test".to_string(),
-                    name: "Test".to_string(),
-                    database_type: DatabaseType::PostgreSQL,
-                    database: None,
-                }),
+                Action::ConnectionSaveCompleted {
+                    target: ConnectionTarget {
+                        id: ConnectionId::new(),
+                        dsn: "postgres://localhost/test".to_string(),
+                        name: "Test".to_string(),
+                        database_type: DatabaseType::PostgreSQL,
+                        database: None,
+                    },
+                    run_id,
+                },
                 now,
                 &AppServices::stub(),
             );

--- a/src/domain/connection/profile.rs
+++ b/src/domain/connection/profile.rs
@@ -30,6 +30,8 @@ pub enum ConnectionProfileError {
     MissingMySqlField(&'static str),
     #[error("MySQL connection host is invalid")]
     InvalidMySqlHost,
+    #[error("MySQL connection port must be > 0")]
+    InvalidMySqlPort,
     #[error("{0}")]
     SqlitePath(#[from] SqlitePathError),
 }
@@ -140,8 +142,13 @@ impl ConnectionProfile {
         name: impl Into<String>,
         config: ConnectionConfig,
     ) -> Result<Self, ConnectionProfileError> {
-        if matches!(&config, ConnectionConfig::MySQL(config) if !config.is_valid()) {
-            return Err(ConnectionProfileError::InvalidMySqlHost);
+        if let ConnectionConfig::MySQL(mysql) = &config {
+            if mysql.port == 0 {
+                return Err(ConnectionProfileError::InvalidMySqlPort);
+            }
+            if !mysql.is_valid() {
+                return Err(ConnectionProfileError::InvalidMySqlHost);
+            }
         }
         Ok(Self {
             id,
@@ -227,6 +234,24 @@ mod tests {
             assert!(matches!(
                 result,
                 Err(ConnectionProfileError::InvalidMySqlHost)
+            ));
+        }
+
+        #[test]
+        fn zero_mysql_port_returns_error() {
+            let result = ConnectionProfile::new_mysql(
+                "MySQL",
+                "localhost",
+                0,
+                None,
+                "user",
+                "password",
+                MySqlSslMode::Preferred,
+            );
+
+            assert!(matches!(
+                result,
+                Err(ConnectionProfileError::InvalidMySqlPort)
             ));
         }
     }

--- a/src/infra/config/connection_config.rs
+++ b/src/infra/config/connection_config.rs
@@ -161,6 +161,9 @@ impl TryFrom<&ConnectionConfigEntry> for ConnectionProfile {
                 )?)?),
             ),
             DatabaseType::MySQL => {
+                if entry.port == Some(0) {
+                    return Err(ConnectionProfileError::InvalidMySqlPort);
+                }
                 let database = entry.database.clone().filter(|value| !value.is_empty());
                 Self::with_id_and_config(
                     id,
@@ -463,6 +466,17 @@ mod tests {
         assert!(matches!(
             ConnectionProfile::try_from(&entry),
             Err(ConnectionProfileError::InvalidMySqlHost)
+        ));
+    }
+
+    #[test]
+    fn mysql_entry_rejects_zero_port() {
+        let mut entry = mysql_entry(None);
+        entry.port = Some(0);
+
+        assert!(matches!(
+            ConnectionProfile::try_from(&entry),
+            Err(ConnectionProfileError::InvalidMySqlPort)
         ));
     }
 }

--- a/src/tests/render_snapshots/connection_flow.rs
+++ b/src/tests/render_snapshots/connection_flow.rs
@@ -392,6 +392,48 @@ fn connection_error_collapsed() {
     insta::assert_snapshot!(output);
 }
 
+fn render_service_error_without_service_file_hint(save_and_connect: bool) -> String {
+    let mut state = create_test_state();
+    let mut terminal = create_test_terminal();
+    state.session.activate_connection_with_dsn(
+        &sabiql_domain::ConnectionId::from_string("service"),
+        "service",
+        DatabaseType::PostgreSQL,
+        "service=mydb",
+    );
+    state
+        .runtime
+        .set_service_file_path(Some(std::path::PathBuf::from("/etc/pg_service.conf")));
+    if save_and_connect {
+        state.connection_error.set_save_and_connect_error(
+            ConnectionErrorInfo::new("mysql save failed"),
+            DatabaseType::MySQL,
+        );
+    } else {
+        state.connection_error.set_connection_switch_error(
+            ConnectionErrorInfo::new("mysql switch failed"),
+            DatabaseType::MySQL,
+        );
+    }
+    state.modal.set_mode(InputMode::ConnectionError);
+
+    render_to_string(&mut terminal, &mut state)
+}
+
+#[test]
+fn connection_error_omits_service_file_hint_for_mysql_save() {
+    let output = render_service_error_without_service_file_hint(true);
+
+    assert!(!output.contains("pg_service.conf"));
+}
+
+#[test]
+fn connection_error_omits_service_file_hint_for_mysql_switch() {
+    let output = render_service_error_without_service_file_hint(false);
+
+    assert!(!output.contains("pg_service.conf"));
+}
+
 #[test]
 fn connection_error_expanded() {
     let mut state = create_test_state();

--- a/src/ui/features/connections/error.rs
+++ b/src/ui/features/connections/error.rs
@@ -100,6 +100,7 @@ impl ConnectionError {
             Span::styled(hint, Style::default().fg(theme.semantic.text.secondary)),
         ];
         if state.session.is_service_connection()
+            && state.connection_error.target_database_type().is_none()
             && let Some(path) = state.runtime.service_file_path()
         {
             spans.push(Span::styled(
@@ -178,9 +179,10 @@ impl ConnectionError {
             Style::default().fg(theme.semantic.text.muted),
         )];
 
-        if state.session.has_pending_connection_switch()
-            || !state.session.can_reenter_connection_setup()
-            || can_retry
+        if !error_state.is_save_and_connect_failure()
+            && (state.session.has_pending_connection_switch()
+                || !state.session.can_reenter_connection_setup()
+                || can_retry)
         {
             spans.push(key_chip("r", theme));
             spans.push(Span::raw(" Retry  "));


### PR DESCRIPTION
Summary: bind SaveAndConnect completion and persistence to the active run identity; prevent stale retry and service-file guidance; reject MySQL port 0; remove the obsolete README claim. Linear: SAB-487.