### PR TITLE
feat(ui): highlight SQL with active database dialect (SAB-496)

### DIFF
--- a/src/ui/features/overlays/confirm_dialog.rs
+++ b/src/ui/features/overlays/confirm_dialog.rs
@@ -7,7 +7,7 @@ use crate::app::model::shared::render_output::ConfirmPreviewLayout;
 use crate::app::policy::json::json_diff::JsonDiffLine;
 use crate::app::policy::write::write_guardrails::{RiskLevel, WriteOperation};
 use crate::app::policy::write::write_update::escape_preview_value;
-use crate::domain::QueryValue;
+use crate::domain::{DatabaseType, QueryValue};
 use crate::primitives::atoms::highlight_sql;
 use crate::primitives::molecules::{FooterHintBar, render_modal, render_modal_with_border_color};
 use crate::primitives::utils::text_utils::wrapped_line_count;
@@ -181,9 +181,10 @@ impl ConfirmDialog {
             "SQL Preview",
             Style::default().fg(theme.semantic.text.secondary),
         )]));
+        let database_type = state.session.active_database_type_or_default();
         for sql_line in preview.sql.lines() {
             let indented = format!("  {sql_line}");
-            content_lines.push(Self::highlight_sql_line(&indented, theme));
+            content_lines.push(Self::highlight_sql_line(&indented, database_type, theme));
         }
 
         content_lines.push(Line::from(""));
@@ -315,8 +316,12 @@ impl ConfirmDialog {
         }
     }
 
-    fn highlight_sql_line(line: &str, theme: &ThemePalette) -> Line<'static> {
-        highlight_sql(line, theme)
+    fn highlight_sql_line(
+        line: &str,
+        database_type: DatabaseType,
+        theme: &ThemePalette,
+    ) -> Line<'static> {
+        highlight_sql(line, database_type, theme)
             .into_iter()
             .next()
             .unwrap_or_else(|| Line::from(""))

--- a/src/ui/features/sql_modal/editor.rs
+++ b/src/ui/features/sql_modal/editor.rs
@@ -74,7 +74,11 @@ pub(super) fn render_editor(
         base_style: Style::default(),
         current_line_style: Style::default().bg(theme.component.editor.current_line_bg),
     };
-    let line_spans = highlight_sql_spans(content, theme);
+    let line_spans = highlight_sql_spans(
+        content,
+        state.session.active_database_type_or_default(),
+        theme,
+    );
     let mut lines = build_modal_text_surface_lines(surface, line_spans, theme);
 
     let flash_active = state.flash_timers.is_active(FlashId::SqlModal, now);

--- a/src/ui/primitives/atoms/sql_highlight.rs
+++ b/src/ui/primitives/atoms/sql_highlight.rs
@@ -344,12 +344,24 @@ mod tests {
         assert_eq!(
             spans
                 .iter()
-                .find(|span| span.content.as_ref().starts_with("#"))
+                .find(|span| span.content.as_ref().starts_with('#'))
                 .expect("MySQL hash comment should be highlighted")
                 .style
                 .fg,
             Some(DEFAULT_THEME.component.syntax.sql_comment)
         );
+
+        let backtick_lines = highlight_sql("SELECT `select`", DatabaseType::MySQL, &DEFAULT_THEME);
+        let backtick_span = backtick_lines[0]
+            .spans
+            .iter()
+            .find(|span| span.content.as_ref() == "`select`")
+            .expect("MySQL backtick identifier should remain one span");
+        assert_eq!(
+            backtick_span.style.fg,
+            Some(DEFAULT_THEME.component.syntax.sql_text)
+        );
+        assert!(!backtick_span.style.add_modifier.contains(Modifier::BOLD));
     }
 
     #[test]

--- a/src/ui/primitives/atoms/sql_highlight.rs
+++ b/src/ui/primitives/atoms/sql_highlight.rs
@@ -2,21 +2,30 @@ use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
 use crate::app::policy::sql::lexer::{SqlLexer, TokenKind};
+use crate::domain::DatabaseType;
 use crate::theme::ThemePalette;
 
-pub fn highlight_sql(text: &str, theme: &ThemePalette) -> Vec<Line<'static>> {
-    highlight_sql_spans(text, theme)
+pub fn highlight_sql(
+    text: &str,
+    database_type: DatabaseType,
+    theme: &ThemePalette,
+) -> Vec<Line<'static>> {
+    highlight_sql_spans(text, database_type, theme)
         .into_iter()
         .map(Line::from)
         .collect()
 }
 
-pub fn highlight_sql_spans(text: &str, theme: &ThemePalette) -> Vec<Vec<Span<'static>>> {
+pub fn highlight_sql_spans(
+    text: &str,
+    database_type: DatabaseType,
+    theme: &ThemePalette,
+) -> Vec<Vec<Span<'static>>> {
     if text.is_empty() {
         return vec![];
     }
 
-    let lexer = SqlLexer::default();
+    let lexer = SqlLexer::new(database_type);
     let tokens = lexer.tokenize(text, text.chars().count());
     let mut lines: Vec<Vec<Span<'static>>> = vec![Vec::new()];
 
@@ -93,7 +102,7 @@ mod tests {
         cursor_col: usize,
         kind: CursorKind,
     ) -> Vec<Span<'static>> {
-        let mut lines = highlight_sql_spans(text, &DEFAULT_THEME);
+        let mut lines = highlight_sql_spans(text, DatabaseType::PostgreSQL, &DEFAULT_THEME);
         let line = lines
             .get_mut(cursor_row)
             .expect("cursor test should target an existing line");
@@ -103,7 +112,11 @@ mod tests {
 
     #[test]
     fn highlight_sql_splits_multiline_comment_across_lines() {
-        let lines = highlight_sql("SELECT 1 /* hello\nworld */", &DEFAULT_THEME);
+        let lines = highlight_sql(
+            "SELECT 1 /* hello\nworld */",
+            DatabaseType::PostgreSQL,
+            &DEFAULT_THEME,
+        );
 
         assert_eq!(lines.len(), 2);
         assert_eq!(line_text(&lines[0]), "SELECT 1 /* hello");
@@ -124,7 +137,11 @@ mod tests {
 
     #[test]
     fn highlight_sql_marks_token_types_with_expected_colors() {
-        let lines = highlight_sql("SELECT 'x', 42 -- note", &DEFAULT_THEME);
+        let lines = highlight_sql(
+            "SELECT 'x', 42 -- note",
+            DatabaseType::PostgreSQL,
+            &DEFAULT_THEME,
+        );
         let spans = &lines[0].spans;
 
         assert_eq!(
@@ -189,7 +206,11 @@ mod tests {
 
     #[test]
     fn highlight_sql_with_cursor_on_empty_middle_line_adds_cursor_cell() {
-        let lines = highlight_sql("SELECT 1\n\nFROM users", &DEFAULT_THEME);
+        let lines = highlight_sql(
+            "SELECT 1\n\nFROM users",
+            DatabaseType::PostgreSQL,
+            &DEFAULT_THEME,
+        );
         let spans = line_spans_with_cursor("SELECT 1\n\nFROM users", 1, 0, CursorKind::Block);
 
         assert_eq!(lines.len(), 3);
@@ -271,7 +292,7 @@ mod tests {
             ..DEFAULT_THEME
         };
 
-        let highlighted = highlight_sql("SELECT", &custom_theme);
+        let highlighted = highlight_sql("SELECT", DatabaseType::PostgreSQL, &custom_theme);
 
         assert_eq!(
             highlighted[0].spans[0].style.fg,
@@ -292,7 +313,7 @@ mod tests {
             ..DEFAULT_THEME
         };
 
-        let mut lines = highlight_sql_spans("SELECT", &custom_theme);
+        let mut lines = highlight_sql_spans("SELECT", DatabaseType::PostgreSQL, &custom_theme);
         let spans = std::mem::take(
             lines
                 .get_mut(0)
@@ -304,6 +325,69 @@ mod tests {
         assert_eq!(
             highlighted_with_cursor[0].style.fg,
             Some(custom_theme.component.syntax.sql_keyword)
+        );
+    }
+
+    #[test]
+    fn highlight_sql_uses_mysql_comments_and_keywords() {
+        let lines = highlight_sql(
+            "DESCRIBE users # MySQL comment",
+            DatabaseType::MySQL,
+            &DEFAULT_THEME,
+        );
+        let spans = &lines[0].spans;
+
+        assert_eq!(
+            spans[0].style.fg,
+            Some(DEFAULT_THEME.component.syntax.sql_keyword)
+        );
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.content.as_ref().starts_with("#"))
+                .expect("MySQL hash comment should be highlighted")
+                .style
+                .fg,
+            Some(DEFAULT_THEME.component.syntax.sql_comment)
+        );
+    }
+
+    #[test]
+    fn highlight_sql_preserves_postgresql_quotes() {
+        let lines = highlight_sql(
+            r#"SELECT "user" AS name, $$body$$"#,
+            DatabaseType::PostgreSQL,
+            &DEFAULT_THEME,
+        );
+        let spans = &lines[0].spans;
+
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.content.as_ref() == "$$body$$")
+                .expect("dollar quote should be highlighted")
+                .style
+                .fg,
+            Some(DEFAULT_THEME.component.syntax.sql_string)
+        );
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.content.as_ref() == "\"user\"")
+                .expect("double-quoted identifier should remain present")
+                .style
+                .fg,
+            Some(DEFAULT_THEME.component.syntax.sql_text)
+        );
+    }
+
+    #[test]
+    fn highlight_sql_keeps_sqlite_display_compatible_with_postgresql() {
+        let text = r#"SELECT "user" FROM users -- comment"#;
+
+        assert_eq!(
+            highlight_sql_spans(text, DatabaseType::SQLite, &DEFAULT_THEME),
+            highlight_sql_spans(text, DatabaseType::PostgreSQL, &DEFAULT_THEME)
         );
     }
 }


### PR DESCRIPTION
## Problem
SQL editor highlighting always used the PostgreSQL lexer, so MySQL-specific quoting, comments, and keywords were rendered incorrectly.

## Background
The selected database type already reaches the application session and the existing SQL lexer already supports MySQL syntax.

## Approach
Pass the active database type through the existing highlight entry points, defaulting to PostgreSQL when no database is selected. Cover MySQL, PostgreSQL, and SQLite render-model behavior without changing SQL execution policy or lexer rules.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-496