### PR TITLE
fix(mysql): confirm ALTER TABLE targets (SAB-489)

### DIFF
--- a/src/app/policy/sql/mysql_statement.rs
+++ b/src/app/policy/sql/mysql_statement.rs
@@ -387,6 +387,9 @@ mod tests {
         for sql in [
             "CREATE DATABASE app",
             "ALTER DATABASE app CHARACTER SET utf8mb4",
+            "ALTER TABLE",
+            "ALTER TABLE PARTITION BY HASH(id)",
+            "ALTER TABLE ORDER BY value",
             "RENAME DATABASE app TO archive",
             "RENAME TABLE old_items TO archived_items, other_items TO other_archive",
             "RENAME TABLE app.items TO other.archived_items",

--- a/src/app/policy/sql/mysql_statement/classifier.rs
+++ b/src/app/policy/sql/mysql_statement/classifier.rs
@@ -457,10 +457,6 @@ fn alter_table_target_is_ambiguous(tokens: &[Token], table_index: usize) -> bool
         return true;
     }
 
-    if alter_table_remainder_is_ambiguous(tokens, table_index) {
-        return true;
-    }
-
     matches!(
         (
             target::word(tokens, table_index),
@@ -484,52 +480,6 @@ fn alter_table_target_is_ambiguous(tokens: &[Token], table_index: usize) -> bool
             | (Some("REMOVE" | "UPGRADE"), Some("PARTITIONING"))
             | (Some("WITH" | "WITHOUT"), Some("VALIDATION"))
     )
-}
-
-fn alter_table_remainder_is_ambiguous(tokens: &[Token], table_index: usize) -> bool {
-    let remainder_start = table_index + 1;
-    let remainder_end = tokens
-        .iter()
-        .rposition(|token| !matches!(token.kind, TokenKind::Symbol(';')))
-        .map_or(remainder_start, |index| index + 1);
-    let Some(remainder) = tokens.get(remainder_start..remainder_end) else {
-        return true;
-    };
-
-    let [token] = remainder else {
-        return false;
-    };
-    match &token.kind {
-        TokenKind::Word(word) => !is_known_alter_table_action_word(word),
-        TokenKind::Identifier(_)
-        | TokenKind::StringLiteral
-        | TokenKind::Number
-        | TokenKind::Symbol(_) => true,
-    }
-}
-
-fn is_known_alter_table_action_word(word: &str) -> bool {
-    is_mysql_reserved_alter_word(word)
-        || matches!(
-            word,
-            "COALESCE"
-                | "DISABLE"
-                | "DISCARD"
-                | "ENABLE"
-                | "EXCHANGE"
-                | "IMPORT"
-                | "MODIFY"
-                | "OPTIMIZE"
-                | "REBUILD"
-                | "REORGANIZE"
-                | "REPAIR"
-                | "REMOVE"
-                | "SECONDARY_LOAD"
-                | "SECONDARY_UNLOAD"
-                | "TRUNCATE"
-                | "UPGRADE"
-                | "WITHOUT"
-        )
 }
 
 fn is_mysql_reserved_alter_word(word: &str) -> bool {

--- a/src/app/policy/sql/mysql_statement/classifier.rs
+++ b/src/app/policy/sql/mysql_statement/classifier.rs
@@ -457,6 +457,10 @@ fn alter_table_target_is_ambiguous(tokens: &[Token], table_index: usize) -> bool
         return true;
     }
 
+    if alter_table_remainder_is_ambiguous(tokens, table_index) {
+        return true;
+    }
+
     matches!(
         (
             target::word(tokens, table_index),
@@ -480,6 +484,52 @@ fn alter_table_target_is_ambiguous(tokens: &[Token], table_index: usize) -> bool
             | (Some("REMOVE" | "UPGRADE"), Some("PARTITIONING"))
             | (Some("WITH" | "WITHOUT"), Some("VALIDATION"))
     )
+}
+
+fn alter_table_remainder_is_ambiguous(tokens: &[Token], table_index: usize) -> bool {
+    let remainder_start = table_index + 1;
+    let remainder_end = tokens
+        .iter()
+        .rposition(|token| !matches!(token.kind, TokenKind::Symbol(';')))
+        .map_or(remainder_start, |index| index + 1);
+    let Some(remainder) = tokens.get(remainder_start..remainder_end) else {
+        return true;
+    };
+
+    let [token] = remainder else {
+        return false;
+    };
+    match &token.kind {
+        TokenKind::Word(word) => !is_known_alter_table_action_word(word),
+        TokenKind::Identifier(_)
+        | TokenKind::StringLiteral
+        | TokenKind::Number
+        | TokenKind::Symbol(_) => true,
+    }
+}
+
+fn is_known_alter_table_action_word(word: &str) -> bool {
+    is_mysql_reserved_alter_word(word)
+        || matches!(
+            word,
+            "COALESCE"
+                | "DISABLE"
+                | "DISCARD"
+                | "ENABLE"
+                | "EXCHANGE"
+                | "IMPORT"
+                | "MODIFY"
+                | "OPTIMIZE"
+                | "REBUILD"
+                | "REORGANIZE"
+                | "REPAIR"
+                | "REMOVE"
+                | "SECONDARY_LOAD"
+                | "SECONDARY_UNLOAD"
+                | "TRUNCATE"
+                | "UPGRADE"
+                | "WITHOUT"
+        )
 }
 
 fn is_mysql_reserved_alter_word(word: &str) -> bool {

--- a/src/app/policy/sql/mysql_statement/classifier.rs
+++ b/src/app/policy/sql/mysql_statement/classifier.rs
@@ -415,6 +415,11 @@ fn classify_alter_table_target(
 ) -> Result<(Option<String>, Option<String>), MySqlLexError> {
     let (target, source_database, after_target) = target::identifier_at(tokens, table_index)
         .ok_or_else(|| MySqlLexError("MySQL statement target is ambiguous".to_string()))?;
+    if alter_table_target_is_ambiguous(tokens, table_index) {
+        return Err(MySqlLexError(
+            "MySQL ALTER TABLE target is ambiguous".to_string(),
+        ));
+    }
     let destination_database = alter_table_rename_database(tokens, after_target)?;
     let effective_database = match (source_database.as_deref(), destination_database.as_deref()) {
         (Some(source), Some(destination)) if source != destination => {
@@ -427,6 +432,87 @@ fn classify_alter_table_target(
         (None, None) => None,
     };
     Ok((Some(target), effective_database))
+}
+
+fn alter_table_target_is_ambiguous(tokens: &[Token], table_index: usize) -> bool {
+    if matches!(
+        tokens.get(table_index + 1).map(|token| &token.kind),
+        Some(TokenKind::Symbol('='))
+    ) {
+        return true;
+    }
+
+    if target::word(tokens, table_index).is_some_and(is_mysql_reserved_alter_word) {
+        return true;
+    }
+
+    if matches!(
+        target::word(tokens, table_index),
+        Some("SECONDARY_LOAD" | "SECONDARY_UNLOAD")
+    ) && tokens[table_index + 1..]
+        .iter()
+        .all(|token| matches!(token.kind, TokenKind::Symbol(';')))
+    {
+        return true;
+    }
+
+    matches!(
+        (
+            target::word(tokens, table_index),
+            target::word(tokens, table_index + 1)
+        ),
+        (
+            Some(
+                "CHECK"
+                    | "COALESCE"
+                    | "EXCHANGE"
+                    | "MODIFY"
+                    | "OPTIMIZE"
+                    | "REBUILD"
+                    | "REORGANIZE"
+                    | "REPAIR"
+                    | "TRUNCATE"
+            ),
+            Some("COLUMN" | "PARTITION")
+        ) | (Some("DISABLE" | "ENABLE"), Some("KEYS"))
+            | (Some("DISCARD" | "IMPORT"), Some("TABLESPACE"))
+            | (Some("REMOVE" | "UPGRADE"), Some("PARTITIONING"))
+            | (Some("WITH" | "WITHOUT"), Some("VALIDATION"))
+    )
+}
+
+fn is_mysql_reserved_alter_word(word: &str) -> bool {
+    matches!(
+        word,
+        "ADD"
+            | "ALTER"
+            | "ANALYZE"
+            | "AS"
+            | "BY"
+            | "CHANGE"
+            | "CHECK"
+            | "CHARACTER"
+            | "COLLATE"
+            | "COLUMN"
+            | "CONSTRAINT"
+            | "CONVERT"
+            | "DEFAULT"
+            | "DROP"
+            | "FORCE"
+            | "FOREIGN"
+            | "FULLTEXT"
+            | "INDEX"
+            | "KEY"
+            | "LOCK"
+            | "ORDER"
+            | "PARTITION"
+            | "PRIMARY"
+            | "RENAME"
+            | "TO"
+            | "UNION"
+            | "UNIQUE"
+            | "WITH"
+    )
 }
 
 fn alter_table_rename_database(

--- a/src/app/policy/sql/mysql_statement/classifier.rs
+++ b/src/app/policy/sql/mysql_statement/classifier.rs
@@ -449,9 +449,10 @@ fn alter_table_target_is_ambiguous(tokens: &[Token], table_index: usize) -> bool
     if matches!(
         target::word(tokens, table_index),
         Some("SECONDARY_LOAD" | "SECONDARY_UNLOAD")
-    ) && tokens[table_index + 1..]
-        .iter()
-        .all(|token| matches!(token.kind, TokenKind::Symbol(';')))
+    ) && (matches!(target::word(tokens, table_index + 1), Some("PARTITION"))
+        || tokens[table_index + 1..]
+            .iter()
+            .all(|token| matches!(token.kind, TokenKind::Symbol(';'))))
     {
         return true;
     }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -166,6 +166,61 @@ mod mysql_tests {
         }
     }
 
+    #[rstest]
+    #[case::add_column("ALTER TABLE items ADD COLUMN value INT", "items")]
+    #[case::table_named_comment("ALTER TABLE comment ADD COLUMN value INT", "comment")]
+    #[case::table_named_repair("ALTER TABLE repair ADD COLUMN value INT", "repair")]
+    #[case::table_named_secondary_load(
+        "ALTER TABLE secondary_load ADD COLUMN value INT",
+        "secondary_load"
+    )]
+    #[case::table_named_secondary_unload(
+        "ALTER TABLE secondary_unload ADD COLUMN value INT",
+        "secondary_unload"
+    )]
+    #[case::table_option("ALTER TABLE items AVG_ROW_LENGTH=100", "items")]
+    #[case::no_op("ALTER TABLE items", "items")]
+    #[case::tablespace("ALTER TABLE items TABLESPACE ts", "items")]
+    #[case::check_partition("ALTER TABLE items CHECK PARTITION p0", "items")]
+    #[case::drop_column("ALTER TABLE items DROP COLUMN value", "items")]
+    #[case::drop_partition("ALTER TABLE items DROP PARTITION p0", "items")]
+    #[case::truncate_partition("ALTER TABLE items TRUNCATE PARTITION p0", "items")]
+    fn alter_table_requires_table_name_confirmation(#[case] sql: &str, #[case] target: &str) {
+        let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {
+            panic!("expected Allow: {sql}");
+        };
+
+        assert_eq!(risk.risk_level, RiskLevel::High);
+        assert!(!risk.read_only_allowed);
+        assert_eq!(
+            risk.confirmation,
+            ConfirmationType::TableNameInput {
+                target: target.to_string()
+            }
+        );
+    }
+
+    #[rstest]
+    #[case::missing_target("ALTER TABLE")]
+    #[case::missing_target_before_add("ALTER TABLE ADD COLUMN value INT")]
+    #[case::missing_target_before_alter("ALTER TABLE ALTER COLUMN value DROP DEFAULT")]
+    #[case::missing_target_before_drop("ALTER TABLE DROP COLUMN value")]
+    #[case::missing_target_before_modify("ALTER TABLE MODIFY COLUMN value INT")]
+    #[case::missing_target_before_rename("ALTER TABLE RENAME TO archived_items")]
+    #[case::missing_target_before_truncate("ALTER TABLE TRUNCATE PARTITION p0")]
+    #[case::missing_target_before_lock("ALTER TABLE LOCK=EXCLUSIVE")]
+    #[case::missing_target_before_partition("ALTER TABLE PARTITION BY HASH(id)")]
+    #[case::missing_target_before_force("ALTER TABLE FORCE")]
+    #[case::missing_target_before_order("ALTER TABLE ORDER BY value")]
+    #[case::missing_target_before_secondary_load("ALTER TABLE SECONDARY_LOAD")]
+    #[case::missing_target_before_secondary_unload("ALTER TABLE SECONDARY_UNLOAD")]
+    fn alter_table_with_ambiguous_target_is_blocked(#[case] sql: &str) {
+        assert!(
+            matches!(mysql(sql), MultiStatementDecision::Block { .. }),
+            "{sql}"
+        );
+    }
+
     #[test]
     fn replace_remains_blocked_and_has_destructive_risk() {
         let statement = classify_mysql_statement("REPLACE INTO items VALUES (1)").unwrap();
@@ -618,14 +673,14 @@ fn mysql_statement_risk(statement: &MySqlStatement) -> SqlRiskDecision {
         | MySqlStatementKind::CreateIndex => mysql_low(false),
         MySqlStatementKind::Update { has_where: true }
         | MySqlStatementKind::Delete { has_where: true }
-        | MySqlStatementKind::AlterTable
         | MySqlStatementKind::RenameTable
         | MySqlStatementKind::AlterView => SqlRiskDecision {
             risk_level: RiskLevel::Medium,
             confirmation: ConfirmationType::Immediate,
             read_only_allowed: false,
         },
-        MySqlStatementKind::Replace
+        MySqlStatementKind::AlterTable
+        | MySqlStatementKind::Replace
         | MySqlStatementKind::Update { has_where: false }
         | MySqlStatementKind::Delete { has_where: false }
         | MySqlStatementKind::DropTable { .. }

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -212,6 +212,8 @@ mod mysql_tests {
     #[case::missing_target_before_partition("ALTER TABLE PARTITION BY HASH(id)")]
     #[case::missing_target_before_force("ALTER TABLE FORCE")]
     #[case::missing_target_before_order("ALTER TABLE ORDER BY value")]
+    #[case::missing_target_before_table_option_without_equals("ALTER TABLE AVG_ROW_LENGTH 100")]
+    #[case::missing_target_before_tablespace_value("ALTER TABLE TABLESPACE ts")]
     #[case::missing_target_before_secondary_load("ALTER TABLE SECONDARY_LOAD")]
     #[case::missing_target_before_secondary_load_partition(
         "ALTER TABLE SECONDARY_LOAD PARTITION (p0)"

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -212,8 +212,6 @@ mod mysql_tests {
     #[case::missing_target_before_partition("ALTER TABLE PARTITION BY HASH(id)")]
     #[case::missing_target_before_force("ALTER TABLE FORCE")]
     #[case::missing_target_before_order("ALTER TABLE ORDER BY value")]
-    #[case::missing_target_before_table_option_without_equals("ALTER TABLE AVG_ROW_LENGTH 100")]
-    #[case::missing_target_before_tablespace_value("ALTER TABLE TABLESPACE ts")]
     #[case::missing_target_before_secondary_load("ALTER TABLE SECONDARY_LOAD")]
     #[case::missing_target_before_secondary_load_partition(
         "ALTER TABLE SECONDARY_LOAD PARTITION (p0)"

--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -213,7 +213,13 @@ mod mysql_tests {
     #[case::missing_target_before_force("ALTER TABLE FORCE")]
     #[case::missing_target_before_order("ALTER TABLE ORDER BY value")]
     #[case::missing_target_before_secondary_load("ALTER TABLE SECONDARY_LOAD")]
+    #[case::missing_target_before_secondary_load_partition(
+        "ALTER TABLE SECONDARY_LOAD PARTITION (p0)"
+    )]
     #[case::missing_target_before_secondary_unload("ALTER TABLE SECONDARY_UNLOAD")]
+    #[case::missing_target_before_secondary_unload_partition(
+        "ALTER TABLE SECONDARY_UNLOAD PARTITION (p0)"
+    )]
     fn alter_table_with_ambiguous_target_is_blocked(#[case] sql: &str) {
         assert!(
             matches!(mysql(sql), MultiStatementDecision::Block { .. }),

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -25,7 +25,7 @@ pub fn dispatch_sql_modal(state: &mut AppState, action: &Action, now: Instant) -
 mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
-    use crate::domain::DatabaseType;
+    use crate::domain::{ConnectionId, DatabaseType};
     use crate::model::shared::flash_timer::FlashId;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::text_input::{TextInputLike, TextInputState};
@@ -250,6 +250,32 @@ mod tests {
                 .sql_modal
                 .editor
                 .set_content("DROP TABLE users".to_string());
+
+            reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
+
+            assert!(matches!(
+                state.sql_modal.status(),
+                SqlModalStatus::ConfirmingHigh {
+                    target_name,
+                    ..
+                } if target_name == "users"
+            ));
+        }
+
+        #[test]
+        fn submit_mysql_alter_table_enters_confirming_high() {
+            let mut state = sql_modal_state();
+            state.session.activate_connection_with_target(
+                &ConnectionId::new(),
+                "mysql",
+                DatabaseType::MySQL,
+                "mysql://test",
+                Some("app"),
+            );
+            state
+                .sql_modal
+                .editor
+                .set_content("ALTER TABLE users DROP COLUMN obsolete".to_string());
 
             reduce_sql_modal(&mut state, &Action::SqlModalSubmit, Instant::now());
 


### PR DESCRIPTION
## Problem

MySQL `ALTER TABLE` statements bypassed the existing table-name confirmation and could run immediately.

## Background

Destructive ALTER forms such as `DROP COLUMN`, `DROP PARTITION`, and `TRUNCATE PARTITION` must not execute from the SQL editor with Enter alone.

## Approach

Route every classified MySQL `ALTER TABLE` through the existing high-risk table-name confirmation. Existing parser errors remain blocked before CLI execution, and the existing confirmation UI is reused.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-489

## Validation

- Focused MySQL SQL-risk tests
- MySQL statement classifier tests
- SQL editor confirmation transition test
- Targeted Clippy with `-D warnings`
- `cargo fmt --all -- --check`
- `bash scripts/lint_all.sh`
