### PR TITLE
fix(mysql): lazy-load SQL completion metadata (SAB-490)

### DIFF
--- a/src/app/cmd/sql_editor/completion.rs
+++ b/src/app/cmd/sql_editor/completion.rs
@@ -55,27 +55,24 @@ pub async fn run(
                 (prep, missing)
             };
 
-            let prefetch_actions: Vec<Action> = state
-                .sql_modal
-                .active_prefetch_run_id()
-                .map(|run_id| {
-                    missing
-                        .into_iter()
-                        .filter_map(|qualified_name| {
-                            qualified_name.split_once('.').map(|(schema, table)| {
-                                Action::PrefetchTableDetail {
-                                    run_id,
-                                    schema: schema.to_string(),
-                                    table: table.to_string(),
-                                }
-                            })
+            if !missing.is_empty() {
+                if let Some(run_id) = state.sql_modal.active_prefetch_run_id() {
+                    for action in missing.into_iter().filter_map(|qualified_name| {
+                        qualified_name.split_once('.').map(|(schema, table)| {
+                            Action::PrefetchTableDetail {
+                                run_id,
+                                schema: schema.to_string(),
+                                table: table.to_string(),
+                            }
                         })
-                        .collect()
-                })
-                .unwrap_or_default();
-
-            for action in prefetch_actions {
-                action_tx.try_send(action).ok();
+                    }) {
+                        action_tx.try_send(action).ok();
+                    }
+                } else {
+                    action_tx
+                        .try_send(Action::StartCompletionPrefetch { tables: missing })
+                        .ok();
+                }
             }
 
             let (candidates, token_len, visible) = {
@@ -114,5 +111,51 @@ pub async fn run(
         }
 
         _ => unreachable!("completion::run called with non-completion effect"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{DatabaseMetadata, TableSummary};
+    use crate::model::shared::input_mode::InputMode;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn trigger_completion_prefetches_only_referenced_tables() {
+        let (action_tx, mut action_rx) = mpsc::channel(8);
+        let mut state = AppState::new("test".to_string());
+        state.modal.set_mode(InputMode::SqlModal);
+        state
+            .sql_modal
+            .editor_mut_for_input()
+            .set_content("SELECT * FROM public.users".to_string());
+
+        let mut metadata = DatabaseMetadata::new("test".to_string());
+        metadata.table_summaries = (0..1_000)
+            .map(|index| {
+                TableSummary::new("public".to_string(), format!("table_{index}"), None, false)
+            })
+            .collect();
+        state.session.set_metadata(Some(Arc::new(metadata)));
+
+        run(
+            Effect::TriggerCompletion,
+            &action_tx,
+            &state,
+            &RefCell::new(CompletionEngine::new()),
+        )
+        .await
+        .expect("completion should run");
+
+        assert!(matches!(
+            action_rx.recv().await,
+            Some(Action::StartCompletionPrefetch { tables })
+                if tables == vec!["public.users".to_string()]
+        ));
+        assert!(matches!(
+            action_rx.recv().await,
+            Some(Action::CompletionUpdated { .. })
+        ));
     }
 }

--- a/src/app/model/sql_editor/modal.rs
+++ b/src/app/model/sql_editor/modal.rs
@@ -91,6 +91,7 @@ pub struct SqlModalContext {
     prefetching_tables: HashSet<String>,
     failed_prefetch_tables: HashMap<String, FailedPrefetchEntry>,
     pub(crate) prefetch_started: bool,
+    prefetch_tracks_er: bool,
     pub(crate) prefetch_run: AsyncRun,
     active_tab: SqlModalTab,
 }
@@ -121,20 +122,39 @@ impl SqlModalContext {
         self.prefetch_queue.clear();
         self.prefetching_tables.clear();
         self.failed_prefetch_tables.clear();
+        self.prefetch_tracks_er = false;
         self.prefetch_run.clear_active();
     }
 
-    // Preserves `prefetching_tables` so in-flight requests drain naturally.
     #[must_use]
     pub fn begin_prefetch(&mut self) -> u64 {
+        if self.prefetch_run.active_id().is_some() && !self.prefetch_tracks_er {
+            // Responses from the replaced completion run are stale and will be discarded.
+            self.prefetching_tables.clear();
+        }
         self.prefetch_started = true;
+        self.prefetch_tracks_er = true;
         self.prefetch_queue.clear();
         self.failed_prefetch_tables.clear();
         self.prefetch_run.begin()
     }
 
+    #[must_use]
+    pub fn begin_completion_prefetch(&mut self) -> u64 {
+        self.prefetch_started = true;
+        self.prefetch_tracks_er = false;
+        self.prefetch_queue.clear();
+        self.failed_prefetch_tables.clear();
+        self.prefetch_run.begin()
+    }
+
+    pub fn prefetch_tracks_er(&self) -> bool {
+        self.prefetch_tracks_er
+    }
+
     pub fn invalidate_prefetch(&mut self) {
         self.prefetch_started = false;
+        self.prefetch_tracks_er = false;
         self.prefetching_tables.clear();
         self.prefetch_run.clear_active();
     }

--- a/src/app/update/action.rs
+++ b/src/app/update/action.rs
@@ -497,6 +497,9 @@ pub enum Action {
     StartPrefetchScoped {
         tables: Vec<String>,
     },
+    StartCompletionPrefetch {
+        tables: Vec<String>,
+    },
     ExpandPrefetchWithFkNeighbors {
         run_id: u64,
     },

--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -82,12 +82,6 @@ pub(super) fn reduce_loading(
                 state.session.finish_reload();
             }
 
-            if state.modal.active_mode() == InputMode::SqlModal
-                && !state.sql_modal.is_prefetch_started()
-            {
-                effects.push(Effect::DispatchActions(vec![Action::StartPrefetchAll]));
-            }
-
             if state.ui.take_pending_er_picker() && state.modal.active_mode() == InputMode::Normal {
                 effects.push(Effect::DispatchActions(vec![Action::OpenModal(
                     ModalKind::ErTablePicker,

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -60,6 +60,7 @@ mod tests {
     use crate::domain::{ConnectionId, DatabaseType, Table};
     use crate::model::app_state::AppState;
     use crate::model::browse::session::TableDetailState;
+    use crate::model::shared::input_mode::InputMode;
     use crate::model::sql_editor::modal::FailedPrefetchEntry;
     use crate::ports::outbound::DbOperationError;
     use crate::update::action::{Action, TableTarget};
@@ -1027,6 +1028,112 @@ mod tests {
                     Effect::ProcessPrefetchQueue { .. }
                 ]
             ));
+        }
+    }
+
+    mod start_completion_prefetch {
+        use super::*;
+
+        #[test]
+        fn queues_only_referenced_tables_without_er_state() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let tables = vec!["public.users".to_string(), "public.orders".to_string()];
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::StartCompletionPrefetch { tables },
+                Instant::now(),
+            )
+            .expect("completion prefetch should be handled");
+
+            assert!(state.sql_modal.is_prefetch_started());
+            assert!(!state.sql_modal.prefetch_tracks_er());
+            assert!(state.sql_modal.is_prefetch_queued("public.users"));
+            assert!(state.sql_modal.is_prefetch_queued("public.orders"));
+            assert!(state.er_preparation.pending_tables().is_empty());
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::ProcessPrefetchQueue { .. }))
+            );
+            assert!(
+                effects
+                    .iter()
+                    .all(|effect| !matches!(effect, Effect::ResizeCompletionCache { .. }))
+            );
+        }
+
+        #[test]
+        fn cached_table_retriggers_sql_completion_without_er_state() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            state.modal.set_mode(InputMode::SqlModal);
+            let run_id = state.sql_modal.begin_completion_prefetch();
+            state
+                .sql_modal
+                .start_table_prefetch("public.users".to_string());
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::TableDetailCached {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    schema: "public".to_string(),
+                    table: "users".to_string(),
+                    detail: empty_table("public", "users"),
+                },
+                Instant::now(),
+            )
+            .expect("cached detail should be handled");
+
+            assert!(state.er_preparation.pending_tables().is_empty());
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::CacheTableInCompletionEngine { .. }))
+            );
+            assert!(
+                effects
+                    .iter()
+                    .any(|effect| matches!(effect, Effect::TriggerCompletion))
+            );
+        }
+
+        #[test]
+        fn er_prefetch_replaces_an_active_completion_prefetch() {
+            let mut state = state_with_dsn("postgres://localhost/test");
+            let completion_run_id = state.sql_modal.begin_completion_prefetch();
+            state
+                .sql_modal
+                .start_table_prefetch("public.users".to_string());
+
+            let effects = dispatch_metadata(
+                &mut state,
+                &Action::StartPrefetchScoped {
+                    tables: vec!["public.orders".to_string()],
+                },
+                Instant::now(),
+            )
+            .expect("ER prefetch should be handled");
+
+            let er_run_id = state
+                .sql_modal
+                .active_prefetch_run_id()
+                .expect("ER prefetch should have an active run");
+            assert_ne!(completion_run_id, er_run_id);
+            assert!(state.sql_modal.prefetch_tracks_er());
+            assert!(!state.sql_modal.is_table_prefetching("public.users"));
+            assert!(state.sql_modal.is_prefetch_queued("public.orders"));
+            assert!(!state.sql_modal.is_prefetch_queued("public.users"));
+            assert!(
+                state
+                    .er_preparation
+                    .pending_tables()
+                    .contains("public.orders")
+            );
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::ProcessPrefetchQueue { run_id } if *run_id == er_run_id
+            )));
         }
     }
 

--- a/src/app/update/browse/metadata/prefetch.rs
+++ b/src/app/update/browse/metadata/prefetch.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use crate::cmd::effect::Effect;
 use crate::domain::TableSummary;
 use crate::model::app_state::AppState;
+use crate::model::shared::input_mode::InputMode;
 use crate::model::sql_editor::modal::FailedPrefetchEntry;
 use crate::update::action::Action;
 use crate::update::dispatch_result::DispatchResult;
@@ -30,7 +31,7 @@ pub(super) fn reduce_prefetch(
 ) -> DispatchResult {
     match action {
         Action::StartPrefetchAll => {
-            if !state.sql_modal.is_prefetch_started()
+            if (!state.sql_modal.is_prefetch_started() || !state.sql_modal.prefetch_tracks_er())
                 && let Some(metadata) = state.session.metadata()
             {
                 let run_id = state.sql_modal.begin_prefetch();
@@ -60,7 +61,7 @@ pub(super) fn reduce_prefetch(
         }
 
         Action::StartPrefetchScoped { tables } => {
-            if state.sql_modal.is_prefetch_started() {
+            if state.sql_modal.is_prefetch_started() && state.sql_modal.prefetch_tracks_er() {
                 DispatchResult::handled()
             } else {
                 let run_id = state.sql_modal.begin_prefetch();
@@ -78,6 +79,22 @@ pub(super) fn reduce_prefetch(
                 effects.push(Effect::ProcessPrefetchQueue { run_id });
                 DispatchResult::handled_with(effects)
             }
+        }
+
+        Action::StartCompletionPrefetch { tables } => {
+            if tables.is_empty() {
+                return DispatchResult::handled();
+            }
+
+            let run_id = if let Some(run_id) = state.sql_modal.active_prefetch_run_id() {
+                run_id
+            } else {
+                state.sql_modal.begin_completion_prefetch()
+            };
+            for qualified_name in tables {
+                state.sql_modal.queue_table_prefetch(qualified_name.clone());
+            }
+            DispatchResult::handled_with(vec![Effect::ProcessPrefetchQueue { run_id }])
         }
 
         Action::ProcessPrefetchQueue { run_id } => {
@@ -125,12 +142,19 @@ pub(super) fn reduce_prefetch(
             if let Some(entry) = state.sql_modal.failed_prefetch(&qualified_name) {
                 if entry.retry_count >= MAX_PREFETCH_RETRIES {
                     // Exceeded retry limit — give up, don't re-queue
-                    state
-                        .er_preparation
-                        .on_table_failed(&qualified_name, entry.error.clone());
-                    let mut effects = check_er_completion(state, now);
+                    let mut effects = if state.sql_modal.prefetch_tracks_er() {
+                        state
+                            .er_preparation
+                            .on_table_failed(&qualified_name, entry.error.clone());
+                        check_er_completion(state, now)
+                    } else {
+                        Vec::new()
+                    };
                     // No fetch started → no completion event to re-drive the queue.
-                    if effects.is_empty() && state.er_preparation.is_waiting() {
+                    if effects.is_empty()
+                        && state.sql_modal.prefetch_tracks_er()
+                        && state.er_preparation.is_waiting()
+                    {
                         effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
                     }
                     return DispatchResult::handled_with(effects);
@@ -158,7 +182,9 @@ pub(super) fn reduce_prefetch(
             };
 
             state.sql_modal.start_table_prefetch(qualified_name.clone());
-            state.er_preparation.start_fetching(&qualified_name);
+            if state.sql_modal.prefetch_tracks_er() {
+                state.er_preparation.start_fetching(&qualified_name);
+            }
 
             DispatchResult::handled_with(vec![Effect::PrefetchTableDetail {
                 dsn,
@@ -181,7 +207,9 @@ pub(super) fn reduce_prefetch(
             }
             let qualified_name = format!("{schema}.{table}");
             state.sql_modal.complete_table_prefetch(&qualified_name);
-            state.er_preparation.on_table_cached(&qualified_name);
+            if state.sql_modal.prefetch_tracks_er() {
+                state.er_preparation.on_table_cached(&qualified_name);
+            }
 
             let mut effects = vec![Effect::CacheTableInCompletionEngine {
                 qualified_name,
@@ -192,7 +220,11 @@ pub(super) fn reduce_prefetch(
                 effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
             }
 
-            effects.extend(check_er_completion(state, now));
+            if state.sql_modal.prefetch_tracks_er() {
+                effects.extend(check_er_completion(state, now));
+            } else if state.modal.active_mode() == InputMode::SqlModal {
+                effects.push(Effect::TriggerCompletion);
+            }
 
             DispatchResult::handled_with(effects)
         }
@@ -222,7 +254,9 @@ pub(super) fn reduce_prefetch(
                     retry_count: prev_count + 1,
                 },
             );
-            state.er_preparation.requeue_for_retry(&qualified_name);
+            if state.sql_modal.prefetch_tracks_er() {
+                state.er_preparation.requeue_for_retry(&qualified_name);
+            }
 
             let mut effects = Vec::new();
 
@@ -234,7 +268,9 @@ pub(super) fn reduce_prefetch(
                 delay_secs: backoff_secs_for(prev_count + 1),
             });
 
-            effects.extend(check_er_completion(state, now));
+            if state.sql_modal.prefetch_tracks_er() {
+                effects.extend(check_er_completion(state, now));
+            }
 
             DispatchResult::handled_with(effects)
         }
@@ -251,7 +287,9 @@ pub(super) fn reduce_prefetch(
             }
             let qualified_name = format!("{schema}.{table}");
             state.sql_modal.complete_table_prefetch(&qualified_name);
-            state.er_preparation.on_table_cached(&qualified_name);
+            if state.sql_modal.prefetch_tracks_er() {
+                state.er_preparation.on_table_cached(&qualified_name);
+            }
 
             let mut effects = Vec::new();
 
@@ -259,7 +297,11 @@ pub(super) fn reduce_prefetch(
                 effects.push(Effect::ProcessPrefetchQueue { run_id: *run_id });
             }
 
-            effects.extend(check_er_completion(state, now));
+            if state.sql_modal.prefetch_tracks_er() {
+                effects.extend(check_er_completion(state, now));
+            } else if state.modal.active_mode() == InputMode::SqlModal {
+                effects.push(Effect::TriggerCompletion);
+            }
 
             DispatchResult::handled_with(effects)
         }

--- a/src/app/update/sql_editor/mod.rs
+++ b/src/app/update/sql_editor/mod.rs
@@ -25,7 +25,7 @@ pub fn dispatch_sql_modal(state: &mut AppState, action: &Action, now: Instant) -
 mod tests {
     use super::*;
     use crate::cmd::effect::Effect;
-    use crate::domain::DatabaseType;
+    use crate::domain::{DatabaseMetadata, DatabaseType, TableSummary};
     use crate::model::shared::flash_timer::FlashId;
     use crate::model::shared::input_mode::InputMode;
     use crate::model::shared::text_input::{TextInputLike, TextInputState};
@@ -34,6 +34,7 @@ mod tests {
     use crate::policy::write::write_guardrails::{AdhocRiskDecision, RiskLevel};
     use crate::update::action::{CursorMove, InputTarget, ModalKind};
     use crate::update::test_fixtures;
+    use std::sync::Arc;
     use std::time::Instant;
 
     fn reduce_sql_modal(state: &mut AppState, action: &Action, now: Instant) -> DispatchResult {
@@ -1021,6 +1022,28 @@ mod tests {
             );
 
             assert_eq!(state.sql_modal.active_tab(), SqlModalTab::Sql);
+        }
+
+        #[test]
+        fn opening_sql_modal_does_not_prefetch_catalog_details() {
+            let mut state = AppState::new("test".to_string());
+            let mut metadata = DatabaseMetadata::new("test".to_string());
+            metadata.table_summaries = (0..1_000)
+                .map(|index| {
+                    TableSummary::new("public".to_string(), format!("table_{index}"), None, false)
+                })
+                .collect();
+            state.session.set_metadata(Some(Arc::new(metadata)));
+
+            let effects = reduce_sql_modal(
+                &mut state,
+                &Action::OpenModal(ModalKind::SqlModal),
+                Instant::now(),
+            )
+            .expect("SQL modal open should be handled");
+
+            assert!(effects.is_empty());
+            assert!(!state.sql_modal.is_prefetch_started());
         }
 
         #[test]

--- a/src/app/update/sql_editor/mode.rs
+++ b/src/app/update/sql_editor/mode.rs
@@ -1,6 +1,5 @@
 use std::time::Instant;
 
-use crate::cmd::effect::Effect;
 use crate::model::app_state::AppState;
 use crate::model::shared::flash_timer::FlashId;
 use crate::model::shared::input_mode::InputMode;
@@ -15,13 +14,7 @@ pub(super) fn reduce_mode(state: &mut AppState, action: &Action, _now: Instant) 
             state.modal.set_mode(InputMode::SqlModal);
             state.sql_modal.open_sql_tab();
             state.flash_timers.clear(FlashId::SqlModal);
-            if !state.sql_modal.is_prefetch_started() && state.session.metadata().is_some() {
-                DispatchResult::handled_with(vec![Effect::DispatchActions(vec![
-                    Action::StartPrefetchAll,
-                ])])
-            } else {
-                DispatchResult::handled()
-            }
+            DispatchResult::handled()
         }
         Action::SqlModalAppendInsert => {
             state.sql_modal.editor.move_cursor(CursorMove::LineEnd);

--- a/src/infra/adapters/mysql/metadata/catalog.rs
+++ b/src/infra/adapters/mysql/metadata/catalog.rs
@@ -180,7 +180,7 @@ pub(super) async fn execute_metadata_queries_in_session(
     .await
 }
 
-async fn execute_metadata_queries_in_session_with_program(
+pub(super) async fn execute_metadata_queries_in_session_with_program(
     dsn: &str,
     queries: &[(&str, &[&str])],
     program: &OsStr,

--- a/src/infra/adapters/mysql/metadata/table_detail.rs
+++ b/src/infra/adapters/mysql/metadata/table_detail.rs
@@ -20,12 +20,12 @@ use super::super::{
     option_file::MySqlOptionFile,
 };
 use super::catalog::{
-    MySqlColumnMetadata, MySqlTableMetadata, column_from_metadata,
-    execute_metadata_queries_in_session, expect_columns, find_table, foreign_keys_from_metadata,
-    mark_single_column_unique, metadata_shape_error, metadata_snapshot_from_result, optional_text,
-    parse_boolean_flag, parse_columns_for_table, parse_foreign_key_metadata,
-    parse_optional_positive_i32, parse_positive_i32, parse_unique_column_metadata,
-    primary_key_names, required_text, selected_database, validate_selected_schema_name,
+    MySqlColumnMetadata, MySqlTableMetadata, column_from_metadata, expect_columns, find_table,
+    foreign_keys_from_metadata, mark_single_column_unique, metadata_shape_error,
+    metadata_snapshot_from_result, optional_text, parse_boolean_flag, parse_columns_for_table,
+    parse_foreign_key_metadata, parse_optional_positive_i32, parse_positive_i32,
+    parse_unique_column_metadata, primary_key_names, required_text, selected_database,
+    validate_selected_schema_name,
 };
 
 #[derive(Debug, Clone)]
@@ -69,13 +69,30 @@ pub(super) async fn fetch_table_columns_and_fks(
     schema: &str,
     table: &str,
 ) -> Result<Table, DbOperationError> {
+    fetch_table_columns_and_fks_with_program(
+        dsn,
+        schema,
+        table,
+        OsStr::new("mysql"),
+        MYSQL_QUERY_TIMEOUT,
+    )
+    .await
+}
+
+async fn fetch_table_columns_and_fks_with_program(
+    dsn: &str,
+    schema: &str,
+    table: &str,
+    program: &OsStr,
+    timeout: Duration,
+) -> Result<Table, DbOperationError> {
     let database = selected_database(dsn)?;
     validate_selected_schema_name(&database, schema)?;
     let table_query = table_query(schema, table);
     let columns_query = columns_query(schema, table);
     let unique_columns_query = unique_columns_query(schema, table);
     let foreign_keys_query = foreign_keys_query(schema, table);
-    let results = execute_metadata_queries_in_session(
+    let results = super::catalog::execute_metadata_queries_in_session_with_program(
         dsn,
         &[
             (table_query.as_str(), TABLES_RESULT_COLUMNS),
@@ -83,6 +100,8 @@ pub(super) async fn fetch_table_columns_and_fks(
             (unique_columns_query.as_str(), UNIQUE_COLUMN_RESULT_COLUMNS),
             (foreign_keys_query.as_str(), FOREIGN_KEY_RESULT_COLUMNS),
         ],
+        program,
+        timeout,
     )
     .await?;
     let snapshot = metadata_snapshot_from_result(&database, Some(schema), &results[0])?;
@@ -630,6 +649,48 @@ done
             assert_process_stopped(&transcript);
             assert_option_file_removed(&transcript);
         }
+    }
+
+    #[tokio::test]
+    async fn completion_detail_prefetch_uses_one_process_and_four_metadata_queries() {
+        let (_directory, program, transcript) = fake_metadata_cli("table");
+        let detail = fetch_table_columns_and_fks_with_program(
+            "mysql://user:password@localhost:3306/app",
+            "app",
+            "items",
+            OsStr::new(&program),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap_or_else(|error| {
+            panic!(
+                "fake completion metadata CLI failed: {error:?}\n{}",
+                std::fs::read_to_string(&transcript).unwrap()
+            )
+        });
+
+        assert_eq!(detail.name, "items");
+        let transcript_text = std::fs::read_to_string(&transcript).unwrap();
+        assert_eq!(
+            transcript_text
+                .lines()
+                .filter(|line| line.starts_with("process="))
+                .count(),
+            1
+        );
+        assert_eq!(
+            transcript_text
+                .lines()
+                .filter(|line| {
+                    line.starts_with("query=")
+                        && (line.contains("INFORMATION_SCHEMA")
+                            || line.contains("REFERENTIAL_CONSTRAINTS"))
+                })
+                .count(),
+            4
+        );
+        assert_process_stopped(&transcript);
+        assert_option_file_removed(&transcript);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem
Opening the SQL modal prefetched detail metadata for every table, which could start one MySQL process and several metadata queries per table.

## Background
Bulk catalog metadata is already available when the connection is established, so modal opening should not materialize every table's columns and foreign keys.

## Approach
Start a completion-only, scoped prefetch when completion encounters missing table details, and retrigger completion after the requested detail is cached. Keep ER preparation separate and allow an ER run to replace an active completion-only run.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-490

## Validation

- Focused sabiql-app tests
- Focused MySQL fake-CLI test
- cargo fmt --all -- --check
- sabiql-app Clippy without default features
- scripts/lint_all.sh