### PR TITLE
fix(mysql): bound CSV export buffering [SAB-509]

### DIFF
--- a/src/infra/adapters/cached_result_exporter.rs
+++ b/src/infra/adapters/cached_result_exporter.rs
@@ -162,6 +162,26 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn preserves_cached_rows_larger_than_mysql_field_limit() {
+            let dir = tempdir().unwrap();
+            let path = dir.path().join("large_cached_export.csv");
+            let big_value = "x".repeat(16 * 1024 * 1024 + 1);
+
+            write_cached_result_csv(
+                path.clone(),
+                vec!["data".to_string()],
+                vec![vec![QueryValue::Text(big_value.clone())]],
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(
+                std::fs::metadata(path).unwrap().len(),
+                ("data\n".len() + big_value.len() + 1) as u64
+            );
+        }
+
+        #[tokio::test]
         async fn returns_error_when_file_cannot_be_created() {
             let dir = tempdir().unwrap();
             let path = dir.path().join("missing").join("export.csv");

--- a/src/infra/adapters/csv_export.rs
+++ b/src/infra/adapters/csv_export.rs
@@ -7,6 +7,10 @@ use tokio::io::{AsyncWriteExt, BufWriter};
 
 pub const CSV_FLUSH_THRESHOLD: usize = 64 * 1024;
 
+fn new_csv_writer() -> csv::Writer<Vec<u8>> {
+    csv::WriterBuilder::new().from_writer(Vec::with_capacity(CSV_FLUSH_THRESHOLD))
+}
+
 fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
     let z = days + 719_468;
     let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
@@ -119,8 +123,7 @@ impl CsvFileWriter {
             .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
         Ok(Self {
             file: BufWriter::new(file),
-            csv_writer: csv::WriterBuilder::new()
-                .from_writer(Vec::with_capacity(CSV_FLUSH_THRESHOLD)),
+            csv_writer: new_csv_writer(),
             bytes_since_flush: 0,
         })
     }
@@ -157,7 +160,10 @@ impl CsvFileWriter {
     }
 
     async fn flush_buffer(&mut self) -> Result<(), DbOperationError> {
-        let encoded = self.csv_writer.get_ref().as_slice().to_vec();
+        let csv_writer = std::mem::replace(&mut self.csv_writer, new_csv_writer());
+        let encoded = csv_writer
+            .into_inner()
+            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
         self.file
             .write_all(&encoded)
             .await
@@ -166,8 +172,6 @@ impl CsvFileWriter {
             .flush()
             .await
             .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
-        self.csv_writer =
-            csv::WriterBuilder::new().from_writer(Vec::with_capacity(CSV_FLUSH_THRESHOLD));
         self.bytes_since_flush = 0;
         Ok(())
     }
@@ -209,6 +213,24 @@ mod tests {
     use tokio::sync::oneshot;
 
     use super::*;
+
+    const MEMORY_MEASUREMENT_FIELD_BYTES: usize = 8 * 1024 * 1024;
+
+    #[tokio::test]
+    async fn writes_large_record_without_changing_csv_bytes() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("large-record.csv");
+        let value = "x".repeat(MEMORY_MEASUREMENT_FIELD_BYTES);
+        let mut writer = CsvFileWriter::create(path.clone()).await.unwrap();
+
+        writer.write_record([value.as_str()]).await.unwrap();
+        writer.finish().await.unwrap();
+
+        assert_eq!(
+            tokio::fs::metadata(path).await.unwrap().len(),
+            (MEMORY_MEASUREMENT_FIELD_BYTES + 1) as u64
+        );
+    }
 
     #[tokio::test]
     async fn cancellation_removes_partial_temporary_file() {

--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -36,17 +36,28 @@ const MYSQL_CSV_FIELD_LIMIT_ERROR: &str = "MySQL CSV field exceeds the 16777216-
 #[derive(Clone, Copy)]
 enum MySqlXmlFieldState {
     Outside,
+    FieldStartCandidate,
     FieldStartPending,
     FieldStartTag,
     FieldContent,
     Cdata,
 }
 
+#[derive(Clone, Copy)]
+enum MySqlXmlPendingKind {
+    Markup,
+    Entity,
+}
+
 struct MySqlXmlFieldLimitReader<R> {
     inner: R,
     state: MySqlXmlFieldState,
     field_bytes: usize,
-    window: Vec<u8>,
+    field_start_match: usize,
+    field_start_quote: Option<u8>,
+    field_start_self_closing: bool,
+    pending: Vec<u8>,
+    pending_kind: Option<MySqlXmlPendingKind>,
     limit_error_pending: bool,
 }
 
@@ -56,7 +67,11 @@ impl<R> MySqlXmlFieldLimitReader<R> {
             inner,
             state: MySqlXmlFieldState::Outside,
             field_bytes: 0,
-            window: Vec::with_capacity(9),
+            field_start_match: 0,
+            field_start_quote: None,
+            field_start_self_closing: false,
+            pending: Vec::new(),
+            pending_kind: None,
             limit_error_pending: false,
         }
     }
@@ -65,64 +80,176 @@ impl<R> MySqlXmlFieldLimitReader<R> {
         self.inner
     }
 
-    fn process(&mut self, bytes: &[u8]) -> usize {
-        for (index, &byte) in bytes.iter().enumerate() {
-            match self.state {
-                MySqlXmlFieldState::FieldStartTag => {
-                    if byte == b'>' {
-                        self.state = if self.window.ends_with(b"/>") {
-                            self.field_bytes = 0;
-                            MySqlXmlFieldState::Outside
+    fn count_field_bytes(&mut self, bytes: usize) -> bool {
+        if self.field_bytes > MYSQL_CSV_MAX_FIELD_BYTES.saturating_sub(bytes) {
+            false
+        } else {
+            self.field_bytes += bytes;
+            true
+        }
+    }
+
+    fn process_pending_byte(&mut self, byte: u8) -> bool {
+        self.pending.push(byte);
+        match self.pending_kind {
+            Some(MySqlXmlPendingKind::Markup) => {
+                let target = match self.state {
+                    MySqlXmlFieldState::FieldContent => {
+                        if self.pending.first() == Some(&b'<') && self.pending.get(1) == Some(&b'!')
+                        {
+                            b"<![CDATA[".as_slice()
                         } else {
-                            MySqlXmlFieldState::FieldContent
+                            b"</field>".as_slice()
+                        }
+                    }
+                    MySqlXmlFieldState::Cdata => b"]]>".as_slice(),
+                    _ => unreachable!(),
+                };
+                if target.starts_with(&self.pending) {
+                    if self.pending == target {
+                        let state = self.state;
+                        self.pending.clear();
+                        self.pending_kind = None;
+                        self.state = match state {
+                            MySqlXmlFieldState::FieldContent => {
+                                if target == b"<![CDATA[" {
+                                    MySqlXmlFieldState::Cdata
+                                } else {
+                                    self.field_bytes = 0;
+                                    MySqlXmlFieldState::Outside
+                                }
+                            }
+                            MySqlXmlFieldState::Cdata => MySqlXmlFieldState::FieldContent,
+                            _ => unreachable!(),
                         };
                     }
+                    true
+                } else {
+                    let pending_len = self.pending.len();
+                    self.pending.clear();
+                    self.pending_kind = None;
+                    self.count_field_bytes(pending_len)
                 }
-                MySqlXmlFieldState::FieldContent | MySqlXmlFieldState::Cdata => {
-                    if self.field_bytes >= MYSQL_CSV_MAX_FIELD_BYTES {
-                        return index;
-                    }
-                    self.field_bytes += 1;
-                }
-                MySqlXmlFieldState::FieldStartPending => {
-                    if byte.is_ascii_whitespace() || matches!(byte, b'>' | b'/') {
-                        self.state = if byte == b'>' {
-                            MySqlXmlFieldState::FieldContent
-                        } else {
-                            MySqlXmlFieldState::FieldStartTag
-                        };
-                    } else {
-                        self.state = MySqlXmlFieldState::Outside;
-                    }
-                }
-                MySqlXmlFieldState::Outside => {}
             }
-
-            self.window.push(byte);
-            if self.window.len() > 9 {
-                self.window.remove(0);
+            Some(MySqlXmlPendingKind::Entity) => {
+                if byte == b';' {
+                    let decoded_len = std::str::from_utf8(&self.pending)
+                        .ok()
+                        .and_then(|entity| unescape(entity).ok())
+                        .map_or(self.pending.len(), |decoded| decoded.len());
+                    self.pending.clear();
+                    self.pending_kind = None;
+                    self.count_field_bytes(decoded_len)
+                } else if self.pending.len() >= 64 {
+                    let pending_len = self.pending.len();
+                    self.pending.clear();
+                    self.pending_kind = None;
+                    self.count_field_bytes(pending_len)
+                } else {
+                    true
+                }
             }
+            None => unreachable!(),
+        }
+    }
 
-            match self.state {
-                MySqlXmlFieldState::FieldStartTag => {}
-                MySqlXmlFieldState::FieldContent => {
-                    if self.window.ends_with(b"<![CDATA[") {
-                        self.state = MySqlXmlFieldState::Cdata;
-                    } else if self.window.ends_with(b"</field>") {
-                        self.state = MySqlXmlFieldState::Outside;
-                        self.field_bytes = 0;
-                    }
+    fn process_byte(&mut self, byte: u8) -> bool {
+        if self.pending_kind.is_some() {
+            return self.process_pending_byte(byte);
+        }
+
+        match self.state {
+            MySqlXmlFieldState::Outside => {
+                if byte == b'<' {
+                    self.state = MySqlXmlFieldState::FieldStartCandidate;
+                    self.field_start_match = 0;
                 }
-                MySqlXmlFieldState::Cdata => {
-                    if self.window.ends_with(b"]]>") {
-                        self.state = MySqlXmlFieldState::FieldContent;
-                    }
-                }
-                MySqlXmlFieldState::FieldStartPending | MySqlXmlFieldState::Outside => {
-                    if self.window.ends_with(b"<field") {
+                true
+            }
+            MySqlXmlFieldState::FieldStartCandidate => {
+                let field_name = b"field";
+                if byte == field_name[self.field_start_match] {
+                    self.field_start_match += 1;
+                    if self.field_start_match == field_name.len() {
                         self.state = MySqlXmlFieldState::FieldStartPending;
                     }
+                } else {
+                    self.state = if byte == b'<' {
+                        self.field_start_match = 0;
+                        MySqlXmlFieldState::FieldStartCandidate
+                    } else {
+                        MySqlXmlFieldState::Outside
+                    };
                 }
+                true
+            }
+            MySqlXmlFieldState::FieldStartPending => {
+                if byte.is_ascii_whitespace() {
+                    self.state = MySqlXmlFieldState::FieldStartTag;
+                    self.field_start_quote = None;
+                    self.field_start_self_closing = false;
+                } else if byte == b'>' {
+                    self.field_bytes = 0;
+                    self.state = MySqlXmlFieldState::FieldContent;
+                } else if byte == b'/' {
+                    self.state = MySqlXmlFieldState::FieldStartTag;
+                    self.field_start_quote = None;
+                    self.field_start_self_closing = true;
+                } else {
+                    self.state = MySqlXmlFieldState::Outside;
+                }
+                true
+            }
+            MySqlXmlFieldState::FieldStartTag => {
+                if let Some(quote) = self.field_start_quote {
+                    if byte == quote {
+                        self.field_start_quote = None;
+                    }
+                } else if matches!(byte, b'\'' | b'"') {
+                    self.field_start_quote = Some(byte);
+                } else if byte == b'/' {
+                    self.field_start_self_closing = true;
+                } else if byte == b'>' {
+                    self.field_bytes = 0;
+                    self.state = if self.field_start_self_closing {
+                        MySqlXmlFieldState::Outside
+                    } else {
+                        MySqlXmlFieldState::FieldContent
+                    };
+                } else if !byte.is_ascii_whitespace() {
+                    self.field_start_self_closing = false;
+                }
+                true
+            }
+            MySqlXmlFieldState::FieldContent => {
+                if byte == b'<' {
+                    self.pending.push(byte);
+                    self.pending_kind = Some(MySqlXmlPendingKind::Markup);
+                    true
+                } else if byte == b'&' {
+                    self.pending.push(byte);
+                    self.pending_kind = Some(MySqlXmlPendingKind::Entity);
+                    true
+                } else {
+                    self.count_field_bytes(1)
+                }
+            }
+            MySqlXmlFieldState::Cdata => {
+                if byte == b']' {
+                    self.pending.push(byte);
+                    self.pending_kind = Some(MySqlXmlPendingKind::Markup);
+                    true
+                } else {
+                    self.count_field_bytes(1)
+                }
+            }
+        }
+    }
+
+    fn process(&mut self, bytes: &[u8]) -> usize {
+        for (index, &byte) in bytes.iter().enumerate() {
+            if !self.process_byte(byte) {
+                return index;
             }
         }
         bytes.len()
@@ -565,6 +692,50 @@ line2]]></field>
 
         assert_eq!(error.to_string(), MYSQL_CSV_FIELD_LIMIT_ERROR);
         assert!(output.len() < xml.len());
+    }
+
+    #[tokio::test]
+    async fn accepts_null_fields_without_accumulating_their_xml_bytes() {
+        let null_field = r#"<field name="null" xsi:nil="true"/>"#;
+        let xml = format!(
+            "<resultset><row>{}</row></resultset>",
+            null_field.repeat(MYSQL_CSV_MAX_FIELD_BYTES / null_field.len() + 1)
+        );
+        let mut source = MySqlXmlFieldLimitReader::new(std::io::Cursor::new(xml.as_bytes()));
+        let mut output = Vec::new();
+
+        tokio::io::AsyncReadExt::read_to_end(&mut source, &mut output)
+            .await
+            .unwrap();
+
+        assert_eq!(output, xml.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn does_not_count_xml_syntax_against_mysql_csv_field_limit() {
+        let escaped_value = format!("{}&amp;", "x".repeat(MYSQL_CSV_MAX_FIELD_BYTES - 1));
+        let cases = [
+            format!(
+                "<resultset><row><field name=\"payload\">{}</field></row></resultset>",
+                "x".repeat(MYSQL_CSV_MAX_FIELD_BYTES)
+            ),
+            format!(
+                "<resultset><row><field name=\"payload\">{escaped_value}</field></row></resultset>"
+            ),
+            format!(
+                "<resultset><row><field name=\"payload\"><![CDATA[{}]]></field></row></resultset>",
+                "x".repeat(MYSQL_CSV_MAX_FIELD_BYTES)
+            ),
+        ];
+
+        for xml in cases {
+            let mut source = MySqlXmlFieldLimitReader::new(std::io::Cursor::new(xml.as_bytes()));
+            let mut output = Vec::new();
+            tokio::io::AsyncReadExt::read_to_end(&mut source, &mut output)
+                .await
+                .unwrap();
+            assert_eq!(output, xml.as_bytes());
+        }
     }
 
     #[cfg(unix)]

--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -1,11 +1,14 @@
 use std::ffi::OsStr;
+use std::io;
 use std::path::PathBuf;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use quick_xml::Reader;
 use quick_xml::escape::unescape;
 use quick_xml::events::Event;
-use tokio::io::{AsyncRead, BufReader};
+use tokio::io::{AsyncRead, BufReader, ReadBuf};
 use uuid::Uuid;
 
 use crate::adapters::csv_export::CsvFileWriter;
@@ -27,6 +30,162 @@ use super::pty::MySqlExportPtySource;
 use super::xml::{MySqlField, decode_mysql_xml_reference, parse_mysql_field, parse_mysql_xml};
 
 const MYSQL_EXPORT_TIMEOUT: Duration = Duration::from_secs(MYSQL_QUERY_TIMEOUT.as_secs() * 10);
+const MYSQL_CSV_MAX_FIELD_BYTES: usize = 16 * 1024 * 1024;
+const MYSQL_CSV_FIELD_LIMIT_ERROR: &str = "MySQL CSV field exceeds the 16777216-byte limit";
+
+#[derive(Clone, Copy)]
+enum MySqlXmlFieldState {
+    Outside,
+    FieldStartPending,
+    FieldStartTag,
+    FieldContent,
+    Cdata,
+}
+
+struct MySqlXmlFieldLimitReader<R> {
+    inner: R,
+    state: MySqlXmlFieldState,
+    field_bytes: usize,
+    window: Vec<u8>,
+    limit_error_pending: bool,
+}
+
+impl<R> MySqlXmlFieldLimitReader<R> {
+    fn new(inner: R) -> Self {
+        Self {
+            inner,
+            state: MySqlXmlFieldState::Outside,
+            field_bytes: 0,
+            window: Vec::with_capacity(9),
+            limit_error_pending: false,
+        }
+    }
+
+    fn into_inner(self) -> R {
+        self.inner
+    }
+
+    fn process(&mut self, bytes: &[u8]) -> usize {
+        for (index, &byte) in bytes.iter().enumerate() {
+            match self.state {
+                MySqlXmlFieldState::FieldStartTag => {
+                    if byte == b'>' {
+                        self.state = if self.window.ends_with(b"/>") {
+                            self.field_bytes = 0;
+                            MySqlXmlFieldState::Outside
+                        } else {
+                            MySqlXmlFieldState::FieldContent
+                        };
+                    }
+                }
+                MySqlXmlFieldState::FieldContent | MySqlXmlFieldState::Cdata => {
+                    if self.field_bytes >= MYSQL_CSV_MAX_FIELD_BYTES {
+                        return index;
+                    }
+                    self.field_bytes += 1;
+                }
+                MySqlXmlFieldState::FieldStartPending => {
+                    if byte.is_ascii_whitespace() || matches!(byte, b'>' | b'/') {
+                        self.state = if byte == b'>' {
+                            MySqlXmlFieldState::FieldContent
+                        } else {
+                            MySqlXmlFieldState::FieldStartTag
+                        };
+                    } else {
+                        self.state = MySqlXmlFieldState::Outside;
+                    }
+                }
+                MySqlXmlFieldState::Outside => {}
+            }
+
+            self.window.push(byte);
+            if self.window.len() > 9 {
+                self.window.remove(0);
+            }
+
+            match self.state {
+                MySqlXmlFieldState::FieldStartTag => {}
+                MySqlXmlFieldState::FieldContent => {
+                    if self.window.ends_with(b"<![CDATA[") {
+                        self.state = MySqlXmlFieldState::Cdata;
+                    } else if self.window.ends_with(b"</field>") {
+                        self.state = MySqlXmlFieldState::Outside;
+                        self.field_bytes = 0;
+                    }
+                }
+                MySqlXmlFieldState::Cdata => {
+                    if self.window.ends_with(b"]]>") {
+                        self.state = MySqlXmlFieldState::FieldContent;
+                    }
+                }
+                MySqlXmlFieldState::FieldStartPending | MySqlXmlFieldState::Outside => {
+                    if self.window.ends_with(b"<field") {
+                        self.state = MySqlXmlFieldState::FieldStartPending;
+                    }
+                }
+            }
+        }
+        bytes.len()
+    }
+}
+
+impl<R> AsyncRead for MySqlXmlFieldLimitReader<R>
+where
+    R: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if self.limit_error_pending {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                MYSQL_CSV_FIELD_LIMIT_ERROR,
+            )));
+        }
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        let mut chunk = [0; 8192];
+        let chunk_len = buf.remaining().min(chunk.len());
+        let mut chunk_buf = ReadBuf::new(&mut chunk[..chunk_len]);
+        match Pin::new(&mut self.inner).poll_read(cx, &mut chunk_buf) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+            Poll::Ready(Ok(())) => {
+                let bytes_read = chunk_buf.filled().len();
+                if bytes_read == 0 {
+                    return Poll::Ready(Ok(()));
+                }
+                let bytes_allowed = self.process(&chunk[..bytes_read]);
+                if bytes_allowed < bytes_read {
+                    self.limit_error_pending = true;
+                }
+                if bytes_allowed > 0 {
+                    buf.put_slice(&chunk[..bytes_allowed]);
+                    Poll::Ready(Ok(()))
+                } else {
+                    Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        MYSQL_CSV_FIELD_LIMIT_ERROR,
+                    )))
+                }
+            }
+        }
+    }
+}
+
+fn append_csv_field_value(field: &mut MySqlField, value: &str) -> Result<(), DbOperationError> {
+    if field.value.len().saturating_add(value.len()) > MYSQL_CSV_MAX_FIELD_BYTES {
+        return Err(DbOperationError::QueryFailed(
+            MYSQL_CSV_FIELD_LIMIT_ERROR.to_string(),
+        ));
+    }
+    field.value.push_str(value);
+    Ok(())
+}
 
 pub(in crate::adapters::mysql) async fn export_mysql_csv_to_file(
     target: MySqlDsn,
@@ -112,12 +271,13 @@ pub(super) async fn stream_mysql_resultset_to_csv(
             frame_scanner: super::xml::MySqlResultsetFrameScanner::default(),
             started: false,
         };
+        let source = MySqlXmlFieldLimitReader::new(source);
         let mut reader = Reader::from_reader(BufReader::new(source));
         reader.config_mut().trim_text(false);
         let result = stream_mysql_xml_to_csv(&mut reader, csv_writer).await;
         let buffered = reader.into_inner();
         let unread = buffered.buffer().to_vec();
-        let source = buffered.into_inner();
+        let source = buffered.into_inner().into_inner();
         source.pty.pending.extend(unread);
         source.pty.pending.extend(source.pending);
         if has_mysql_cli_error(&source.error_output) {
@@ -140,12 +300,13 @@ pub(super) async fn stream_mysql_resultset_to_csv(
         };
         let pending_stderr = std::mem::take(&mut process.pending_stderr);
         source.capture_error(&pending_stderr);
+        let source = MySqlXmlFieldLimitReader::new(source);
         let mut reader = Reader::from_reader(BufReader::new(source));
         reader.config_mut().trim_text(false);
         let result = stream_mysql_xml_to_csv(&mut reader, csv_writer).await;
         let buffered = reader.into_inner();
         let unread = buffered.buffer().to_vec();
-        let source = buffered.into_inner();
+        let source = buffered.into_inner().into_inner();
         source.pending.extend(unread);
         if source.error_output.is_empty() {
             process
@@ -222,7 +383,7 @@ where
                     DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
                 })?;
                 if let Some(field) = current_field.as_mut() {
-                    field.value.push_str(&text);
+                    append_csv_field_value(field, &text)?;
                 } else if !text.chars().all(char::is_whitespace) {
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
@@ -232,7 +393,7 @@ where
             Event::GeneralRef(reference) => {
                 let text = decode_mysql_xml_reference(&reference)?;
                 if let Some(field) = current_field.as_mut() {
-                    field.value.push_str(&text);
+                    append_csv_field_value(field, &text)?;
                 } else if !text.chars().all(char::is_whitespace) {
                     return Err(DbOperationError::QueryFailed(
                         "unexpected text in MySQL XML result".to_string(),
@@ -241,13 +402,10 @@ where
             }
             Event::CData(data) => {
                 if let Some(field) = current_field.as_mut() {
-                    field
-                        .value
-                        .push_str(std::str::from_utf8(data.as_ref()).map_err(|error| {
-                            DbOperationError::QueryFailed(format!(
-                                "invalid MySQL XML text: {error}"
-                            ))
-                        })?);
+                    let text = std::str::from_utf8(data.as_ref()).map_err(|error| {
+                        DbOperationError::QueryFailed(format!("invalid MySQL XML text: {error}"))
+                    })?;
+                    append_csv_field_value(field, text)?;
                 } else {
                     return Err(DbOperationError::QueryFailed(
                         "unexpected CDATA in MySQL XML result".to_string(),
@@ -351,7 +509,7 @@ line2]]></field>
         let directory = tempdir().unwrap();
         let path = directory.path().join("stream.csv");
         let mut csv_writer = CsvFileWriter::create(path.clone()).await.unwrap();
-        let mut reader = Reader::from_reader(BufReader::new(output));
+        let mut reader = Reader::from_reader(BufReader::new(MySqlXmlFieldLimitReader::new(output)));
         reader.config_mut().trim_text(false);
 
         stream_mysql_xml_to_csv(&mut reader, &mut csv_writer)
@@ -367,6 +525,46 @@ line2]]></field>
              line2\",a\tb,日本語,,,0x00FF\n"
                 .replace("             ", "")
         );
+    }
+
+    #[tokio::test]
+    async fn rejects_mysql_csv_field_over_byte_limit() {
+        let value = "x".repeat(MYSQL_CSV_MAX_FIELD_BYTES + 1);
+        let xml =
+            format!("<resultset><row><field name=\"payload\">{value}</field></row></resultset>");
+        let (mut input, output) = tokio::io::duplex(32);
+        let producer = tokio::spawn(async move {
+            input.write_all(xml.as_bytes()).await.unwrap();
+        });
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("oversized-field.csv");
+        let mut csv_writer = CsvFileWriter::create(path).await.unwrap();
+        let mut reader = Reader::from_reader(BufReader::new(output));
+        reader.config_mut().trim_text(false);
+
+        let error = stream_mysql_xml_to_csv(&mut reader, &mut csv_writer)
+            .await
+            .unwrap_err();
+        producer.await.unwrap();
+
+        assert!(matches!(&error, DbOperationError::QueryFailed(_)));
+        assert!(error.masked_details().contains(MYSQL_CSV_FIELD_LIMIT_ERROR));
+    }
+
+    #[tokio::test]
+    async fn stops_reading_mysql_csv_field_at_byte_limit() {
+        let value = "x".repeat(MYSQL_CSV_MAX_FIELD_BYTES + 1);
+        let xml =
+            format!("<resultset><row><field name=\"payload\">{value}</field></row></resultset>");
+        let mut source = MySqlXmlFieldLimitReader::new(std::io::Cursor::new(xml.as_bytes()));
+        let mut output = Vec::new();
+
+        let error = tokio::io::AsyncReadExt::read_to_end(&mut source, &mut output)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.to_string(), MYSQL_CSV_FIELD_LIMIT_ERROR);
+        assert!(output.len() < xml.len());
     }
 
     #[cfg(unix)]

--- a/src/infra/adapters/mysql/cli/export.rs
+++ b/src/infra/adapters/mysql/cli/export.rs
@@ -125,10 +125,23 @@ impl<R> MySqlXmlFieldLimitReader<R> {
                     }
                     true
                 } else {
-                    let pending_len = self.pending.len();
-                    self.pending.clear();
-                    self.pending_kind = None;
-                    self.count_field_bytes(pending_len)
+                    let keep = (1..target.len().min(self.pending.len()))
+                        .rev()
+                        .find(|&length| self.pending.ends_with(&target[..length]))
+                        .unwrap_or(0);
+                    let count = self.pending.len() - keep;
+                    if !self.count_field_bytes(count) {
+                        return false;
+                    }
+                    if keep == 0 {
+                        self.pending.clear();
+                        self.pending_kind = None;
+                    } else {
+                        let start = self.pending.len() - keep;
+                        self.pending.copy_within(start.., 0);
+                        self.pending.truncate(keep);
+                    }
+                    true
                 }
             }
             Some(MySqlXmlPendingKind::Entity) => {
@@ -729,6 +742,26 @@ line2]]></field>
         ];
 
         for xml in cases {
+            let mut source = MySqlXmlFieldLimitReader::new(std::io::Cursor::new(xml.as_bytes()));
+            let mut output = Vec::new();
+            tokio::io::AsyncReadExt::read_to_end(&mut source, &mut output)
+                .await
+                .unwrap();
+            assert_eq!(output, xml.as_bytes());
+        }
+    }
+
+    #[tokio::test]
+    async fn handles_cdata_values_ending_in_brackets_before_the_next_field() {
+        let cases = [
+            format!("{}]", "x".repeat(MYSQL_CSV_MAX_FIELD_BYTES - 1)),
+            format!("{}]]", "x".repeat(MYSQL_CSV_MAX_FIELD_BYTES - 2)),
+        ];
+
+        for value in cases {
+            let xml = format!(
+                "<resultset><row><field name=\"payload\"><![CDATA[{value}]]></field><field name=\"next\">ok</field></row></resultset>"
+            );
             let mut source = MySqlXmlFieldLimitReader::new(std::io::Cursor::new(xml.as_bytes()));
             let mut output = Vec::new();
             tokio::io::AsyncReadExt::read_to_end(&mut source, &mut output)


### PR DESCRIPTION
SAB-509: move flushed CSV buffer ownership into file writes without to_vec duplication. Enforce a 16 MiB field limit only on MySQL XML input before quick_xml accumulates a giant Text event; oversized fields fail as QueryFailed and temporary-file cleanup remains intact. Cached-result exports remain unrestricted by the MySQL limit, with a regression test for rows larger than 16 MiB. Validation: focused infra tests, PostgreSQL/SQLite/cached export tests, clippy, fmt, scripts/lint_all.sh, and Oracle MySQL 8.4 integration (40 passed).