### PR TITLE
fix(inspector): preserve table detail state across databases

### DIFF
--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -250,24 +250,14 @@ impl AppState {
     }
 
     pub fn inspector_view_model(&self, ddl_generator: &dyn DdlGenerator) -> InspectorViewModel {
-        if self.session.active_database_type() == Some(DatabaseType::MySQL) {
-            InspectorViewModel::build_with_detail_state(
-                self.session.active_engine_feature_profile(),
-                self.ui.inspector_tab(),
-                self.session.table_detail(),
-                self.session.table_detail_state(),
-                DatabaseType::MySQL,
-                ddl_generator,
-            )
-        } else {
-            InspectorViewModel::build(
-                self.session.active_engine_feature_profile(),
-                self.ui.inspector_tab(),
-                self.session.table_detail(),
-                self.session.active_database_type_or_default(),
-                ddl_generator,
-            )
-        }
+        InspectorViewModel::build_with_detail_state(
+            self.session.active_engine_feature_profile(),
+            self.ui.inspector_tab(),
+            self.session.table_detail(),
+            self.session.table_detail_state(),
+            self.session.active_database_type_or_default(),
+            ddl_generator,
+        )
     }
 
     pub fn json_detail_editor_visible_rows(&self) -> usize {
@@ -532,13 +522,13 @@ mod tests {
         }
     }
 
-    #[test]
-    fn non_mysql_inspector_keeps_legacy_no_table_state() {
+    #[rstest]
+    fn inspector_view_model_exposes_not_selected_for_each_database_type(
+        #[values(DatabaseType::MySQL, DatabaseType::PostgreSQL, DatabaseType::SQLite)]
+        database_type: DatabaseType,
+    ) {
         let mut state = make_state();
-        activate_postgres_connection(&mut state, "postgres://localhost/test");
-        let _ = state
-            .session
-            .select_table("public", "users", &mut state.query);
+        activate_database_connection(&mut state, database_type);
 
         let services = AppServices::stub();
         let view_model = state.inspector_view_model(services.ddl_generator.as_ref());
@@ -551,6 +541,83 @@ mod tests {
             view_model.empty_state(),
             Some(InspectorEmptyState::NoTableSelected)
         );
+    }
+
+    #[rstest]
+    fn inspector_view_model_exposes_loading_for_each_database_type(
+        #[values(DatabaseType::MySQL, DatabaseType::PostgreSQL, DatabaseType::SQLite)]
+        database_type: DatabaseType,
+    ) {
+        let mut state = make_state();
+        activate_database_connection(&mut state, database_type);
+        let _ = state
+            .session
+            .select_table("public", "users", &mut state.query);
+
+        let services = AppServices::stub();
+        let view_model = state.inspector_view_model(services.ddl_generator.as_ref());
+
+        assert_eq!(view_model.load_state(), &InspectorLoadState::Loading);
+        assert_eq!(view_model.empty_state(), None);
+    }
+
+    #[rstest]
+    fn inspector_view_model_exposes_error_for_each_database_type(
+        #[values(DatabaseType::MySQL, DatabaseType::PostgreSQL, DatabaseType::SQLite)]
+        database_type: DatabaseType,
+    ) {
+        let mut state = make_state();
+        activate_database_connection(&mut state, database_type);
+        let _ = state
+            .session
+            .select_table("public", "users", &mut state.query);
+        assert!(state.session.mark_table_detail_failed(
+            state.session.selection_generation(),
+            "permission denied".to_string()
+        ));
+
+        let services = AppServices::stub();
+        let view_model = state.inspector_view_model(services.ddl_generator.as_ref());
+
+        assert_eq!(
+            view_model.load_state(),
+            &InspectorLoadState::Error("permission denied".to_string())
+        );
+        assert_eq!(view_model.empty_state(), None);
+    }
+
+    #[rstest]
+    fn inspector_view_model_exposes_loaded_for_each_database_type(
+        #[values(DatabaseType::MySQL, DatabaseType::PostgreSQL, DatabaseType::SQLite)]
+        database_type: DatabaseType,
+    ) {
+        let mut state = make_state();
+        activate_database_connection(&mut state, database_type);
+        let generation = state
+            .session
+            .select_table("public", "users", &mut state.query);
+        assert!(
+            state
+                .session
+                .set_table_detail(make_table_detail(), generation)
+        );
+
+        let services = AppServices::stub();
+        let view_model = state.inspector_view_model(services.ddl_generator.as_ref());
+
+        assert_eq!(view_model.load_state(), &InspectorLoadState::Success);
+        assert!(view_model.section().is_some());
+    }
+
+    fn activate_database_connection(state: &mut AppState, database_type: DatabaseType) {
+        let (name, dsn) = match database_type {
+            DatabaseType::MySQL => ("mysql", "mysql://localhost/test"),
+            DatabaseType::PostgreSQL => ("postgres", "postgres://localhost/test"),
+            DatabaseType::SQLite => ("sqlite", "sqlite:///tmp/app.db"),
+        };
+        state
+            .session
+            .activate_connection_with_dsn(&ConnectionId::new(), name, database_type, dsn);
     }
 
     #[test]

--- a/src/app/model/browse/inspector_view_model.rs
+++ b/src/app/model/browse/inspector_view_model.rs
@@ -127,28 +127,6 @@ pub enum InspectorUnavailableReason {
 }
 
 impl InspectorViewModel {
-    pub fn build(
-        profile: &EngineFeatureProfile,
-        selected_tab: InspectorTab,
-        table: Option<&Table>,
-        database_type: DatabaseType,
-        ddl_generator: &dyn DdlGenerator,
-    ) -> Self {
-        let table_detail_state = if table.is_some() {
-            TableDetailState::Loaded
-        } else {
-            TableDetailState::NotSelected
-        };
-        Self::build_with_detail_state(
-            profile,
-            selected_tab,
-            table,
-            &table_detail_state,
-            database_type,
-            ddl_generator,
-        )
-    }
-
     pub fn build_with_detail_state(
         profile: &EngineFeatureProfile,
         selected_tab: InspectorTab,
@@ -580,12 +558,30 @@ mod tests {
         }
     }
 
+    fn build_loaded(
+        profile: &EngineFeatureProfile,
+        selected_tab: InspectorTab,
+        table: &Table,
+        database_type: DatabaseType,
+        ddl_generator: &dyn DdlGenerator,
+    ) -> InspectorViewModel {
+        InspectorViewModel::build_with_detail_state(
+            profile,
+            selected_tab,
+            Some(table),
+            &TableDetailState::Loaded,
+            database_type,
+            ddl_generator,
+        )
+    }
+
     #[test]
     fn no_table_exposes_empty_state_without_display_rows() {
-        let model = InspectorViewModel::build(
+        let model = InspectorViewModel::build_with_detail_state(
             &EngineFeatureProfile::postgres_like(),
             InspectorTab::Info,
             None,
+            &TableDetailState::NotSelected,
             DatabaseType::PostgreSQL,
             &TestDdlGenerator,
         );
@@ -647,17 +643,17 @@ mod tests {
             ),
         }];
 
-        let info = InspectorViewModel::build(
+        let info = build_loaded(
             &EngineFeatureProfile::mysql_like(),
             InspectorTab::Info,
-            Some(&table),
+            &table,
             DatabaseType::MySQL,
             &TestDdlGenerator,
         );
-        let indexes = InspectorViewModel::build(
+        let indexes = build_loaded(
             &EngineFeatureProfile::mysql_like(),
             InspectorTab::Indexes,
-            Some(&table),
+            &table,
             DatabaseType::MySQL,
             &TestDdlGenerator,
         );
@@ -694,10 +690,10 @@ mod tests {
         ];
 
         for (tab, expected_rows) in cases {
-            let model = InspectorViewModel::build(
+            let model = build_loaded(
                 &EngineFeatureProfile::postgres_like(),
                 tab,
-                Some(&table),
+                &table,
                 DatabaseType::PostgreSQL,
                 &TestDdlGenerator,
             );
@@ -717,20 +713,20 @@ mod tests {
         table.columns.clear();
         table.rls = None;
 
-        let empty = InspectorViewModel::build(
+        let empty = build_loaded(
             &EngineFeatureProfile::postgres_like(),
             InspectorTab::Columns,
-            Some(&table),
+            &table,
             DatabaseType::PostgreSQL,
             &TestDdlGenerator,
         );
         assert_eq!(empty.row_count(), 0);
         assert_eq!(empty.empty_state(), Some(InspectorEmptyState::NoColumns));
 
-        let unavailable = InspectorViewModel::build(
+        let unavailable = build_loaded(
             &EngineFeatureProfile::postgres_like(),
             InspectorTab::Rls,
-            Some(&table),
+            &table,
             DatabaseType::PostgreSQL,
             &TestDdlGenerator,
         );
@@ -751,10 +747,10 @@ mod tests {
         ];
 
         for (tab, expected_rows) in cases {
-            let model = InspectorViewModel::build(
+            let model = build_loaded(
                 &EngineFeatureProfile::postgres_like(),
                 tab,
-                Some(&table),
+                &table,
                 DatabaseType::PostgreSQL,
                 &TestDdlGenerator,
             );
@@ -773,10 +769,10 @@ mod tests {
         let mut table = table();
         let column = table.columns[0].clone();
         table.columns.resize(6, column);
-        let model = InspectorViewModel::build(
+        let model = build_loaded(
             &EngineFeatureProfile::postgres_like(),
             InspectorTab::Columns,
-            Some(&table),
+            &table,
             DatabaseType::PostgreSQL,
             &TestDdlGenerator,
         );
@@ -807,10 +803,10 @@ mod tests {
             },
         ];
 
-        let model = InspectorViewModel::build(
+        let model = build_loaded(
             &EngineFeatureProfile::postgres_like(),
             InspectorTab::Indexes,
-            Some(&table),
+            &table,
             DatabaseType::PostgreSQL,
             &TestDdlGenerator,
         );
@@ -847,10 +843,10 @@ mod tests {
             },
         ];
 
-        let model = InspectorViewModel::build(
+        let model = build_loaded(
             &EngineFeatureProfile::mysql_like(),
             InspectorTab::Indexes,
-            Some(&table),
+            &table,
             DatabaseType::MySQL,
             &TestDdlGenerator,
         );


### PR DESCRIPTION
## Problem
PostgreSQL and SQLite Inspector views reconstructed table detail state from table presence, hiding Loading and Error states.

## Background
The session already tracks the real TableDetailState for all database types.

## Approach
Pass the session table detail state through the shared Inspector view-model builder for every database type and remove the state-reconstructing builder. Add coverage for NotSelected, Loading, Error, and Loaded across MySQL, PostgreSQL, and SQLite.

## Linear Issue Link
- Implements https://linear.app/sabiql/issue/SAB-493