### PR TITLE
fix(mysql): preserve pending probe during metadata reload

### DIFF
--- a/src/app/update/browse/metadata/loading.rs
+++ b/src/app/update/browse/metadata/loading.rs
@@ -11,6 +11,8 @@ use crate::update::browse::query::preview_effect_for_current_table;
 use crate::update::dispatch_result::DispatchResult;
 use crate::update::query_context::termination_effects;
 
+const CONNECTION_SWITCH_IN_PROGRESS: &str = "Connection switch in progress";
+
 pub(super) fn reduce_loading(
     state: &mut AppState,
     action: &Action,
@@ -139,6 +141,12 @@ pub(super) fn reduce_loading(
             })
         }
         Action::LoadMetadata => {
+            if state.session.has_pending_connection_switch() {
+                state
+                    .messages
+                    .set_error_at(CONNECTION_SWITCH_IN_PROGRESS.to_string(), now);
+                return DispatchResult::handled();
+            }
             if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.session.begin_metadata_refresh();
                 DispatchResult::handled_with(vec![Effect::FetchMetadata { dsn, run_id }])
@@ -147,6 +155,12 @@ pub(super) fn reduce_loading(
             }
         }
         Action::ReloadMetadata => {
+            if state.session.has_pending_connection_switch() {
+                state
+                    .messages
+                    .set_error_at(CONNECTION_SWITCH_IN_PROGRESS.to_string(), now);
+                return DispatchResult::handled();
+            }
             if let Some(dsn) = state.session.dsn().map(String::from) {
                 let run_id = state.session.begin_reload();
                 state.sql_modal.reset_prefetch();

--- a/src/app/update/browse/metadata/mod.rs
+++ b/src/app/update/browse/metadata/mod.rs
@@ -268,6 +268,49 @@ mod tests {
             assert!(state.messages.last_error().is_none());
         }
 
+        #[test]
+        fn mysql_metadata_actions_during_pending_switch_preserve_probe() {
+            let mut state = AppState::new("test".to_string());
+            let current_id = ConnectionId::from_string("mysql-a");
+            let target_id = ConnectionId::from_string("mysql-b");
+            state.session.activate_connection_with_target(
+                &current_id,
+                "mysql-a",
+                DatabaseType::MySQL,
+                "mysql://user@localhost:3306/a",
+                Some("a"),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            let probe_run_id = state.session.begin_mysql_connection_probe(
+                &target_id,
+                "mysql-b",
+                DatabaseType::MySQL,
+                "mysql://user@localhost:3306/b",
+                Some("b"),
+            );
+
+            for action in [Action::LoadMetadata, Action::ReloadMetadata] {
+                let effects = dispatch_metadata(&mut state, &action, Instant::now())
+                    .into_effects()
+                    .unwrap();
+
+                assert!(effects.is_empty());
+                assert_eq!(
+                    state
+                        .session
+                        .pending_mysql_connection_probe()
+                        .map(|pending| pending.run_id),
+                    Some(probe_run_id)
+                );
+                assert_eq!(
+                    state.messages.last_error(),
+                    Some("Connection switch in progress")
+                );
+            }
+        }
+
         fn contains_fetch_metadata(effect: &Effect) -> bool {
             match effect {
                 Effect::FetchMetadata { .. } => true,

--- a/src/app/update/connection/lifecycle.rs
+++ b/src/app/update/connection/lifecycle.rs
@@ -272,6 +272,152 @@ mod tests {
         })
     }
 
+    mod metadata_reload_race {
+        use super::*;
+
+        fn mysql_target(id: &str, database: &str) -> ConnectionTarget {
+            ConnectionTarget {
+                id: ConnectionId::from_string(id),
+                dsn: format!("mysql://user@localhost:3306/{database}"),
+                name: id.to_string(),
+                database_type: DatabaseType::MySQL,
+                database: Some(database.to_string()),
+            }
+        }
+
+        fn active_mysql_state() -> AppState {
+            let mut state = AppState::new("test".to_string());
+            let current = mysql_target("mysql-a", "a");
+            state.session.activate_connection_with_target(
+                &current.id,
+                &current.name,
+                current.database_type,
+                &current.dsn,
+                current.database.as_deref(),
+            );
+            state
+                .session
+                .set_connection_state(ConnectionState::Connected);
+            state
+        }
+
+        #[test]
+        fn reload_during_switch_preserves_probe_until_success() {
+            let mut state = active_mysql_state();
+            let target = mysql_target("mysql-b", "b");
+            let probe_effects = reduce(&mut state, &Action::SwitchConnection(target.clone()))
+                .expect("switch should start a probe");
+            let probe_run_id = probe_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeMySqlConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .expect("switch should include the probe run");
+
+            let reload_effects = reduce_app(
+                &mut state,
+                Action::ReloadMetadata,
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(reload_effects.is_empty());
+            assert_eq!(
+                state
+                    .session
+                    .pending_mysql_connection_probe()
+                    .map(|pending| pending.run_id),
+                Some(probe_run_id)
+            );
+            assert_eq!(
+                state.messages.last_error(),
+                Some("Connection switch in progress")
+            );
+
+            let completion_effects = reduce_app(
+                &mut state,
+                Action::MySqlConnectionProbeCompleted {
+                    target: target.clone(),
+                    run_id: probe_run_id,
+                },
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert_eq!(state.session.active_connection_id(), Some(&target.id));
+            assert!(state.session.pending_mysql_connection_probe().is_none());
+            assert!(completion_effects.iter().any(|effect| matches!(
+                effect,
+                Effect::FetchMetadata { dsn, .. } if dsn == &target.dsn
+            )));
+        }
+
+        #[test]
+        fn reload_during_switch_preserves_probe_until_failure() {
+            let mut state = active_mysql_state();
+            let target = mysql_target("mysql-b", "b");
+            let probe_effects = reduce(&mut state, &Action::SwitchConnection(target.clone()))
+                .expect("switch should start a probe");
+            let probe_run_id = probe_effects
+                .iter()
+                .find_map(|effect| match effect {
+                    Effect::ProbeMySqlConnection { run_id, .. } => Some(*run_id),
+                    _ => None,
+                })
+                .expect("switch should include the probe run");
+
+            let reload_effects = reduce_app(
+                &mut state,
+                Action::ReloadMetadata,
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(reload_effects.is_empty());
+            let failure_effects = reduce_app(
+                &mut state,
+                Action::MySqlConnectionProbeFailed {
+                    target: target.clone(),
+                    run_id: probe_run_id,
+                    error: DbOperationError::Timeout("timed out".to_string()),
+                },
+                std::time::Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(failure_effects.is_empty());
+            assert_eq!(
+                state.session.active_connection_id(),
+                Some(&ConnectionId::from_string("mysql-a"))
+            );
+            assert_eq!(
+                state
+                    .session
+                    .pending_mysql_connection_probe()
+                    .map(|pending| pending.run_id),
+                Some(probe_run_id)
+            );
+            assert_eq!(state.modal.active_mode(), InputMode::ConnectionError);
+            assert!(state.connection_error.can_retry());
+
+            let retry_effects = reduce_connection_error(
+                &mut state,
+                &Action::RetryConnection,
+                std::time::Instant::now(),
+            )
+            .into_effects()
+            .unwrap();
+            assert!(retry_effects.iter().any(|effect| matches!(
+                effect,
+                Effect::ProbeMySqlConnection { target: retry_target, .. }
+                    if retry_target.id == target.id
+                        && retry_target.dsn == target.dsn
+                        && retry_target.database == target.database
+            )));
+        }
+    }
+
     mod cache_tests {
         use super::*;
 


### PR DESCRIPTION
## Problem
Metadata reload can invalidate a pending MySQL connection switch probe, causing the successful target connection to be discarded as stale.

## Background
`LoadMetadata` and `ReloadMetadata` previously started a new metadata run while an A-to-B switch probe was pending. The metadata lifecycle cleared the pending probe and its run identity before the probe completed.

## Approach
Block metadata load and reload actions while a connection switch is pending, preserve the probe run identity, and surface the existing footer message path. Reducer and lifecycle tests cover reload races with successful and failed probes, including Retry behavior.

## Linear Issue Link (optional)

- Implements https://linear.app/sabiql/issue/SAB-502