### PR TITLE
fix(mysql): bound test PTY initial output wait (SAB-508)

### DIFF
--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -505,14 +505,36 @@ pub(in crate::adapters::mysql) async fn run_mysql_cli_script_for_test(
 ) -> Result<Vec<u8>, DbOperationError> {
     let target = parse_and_validate_mysql_dsn(dsn)?;
     let option_file = MySqlOptionFile::create(&target)?;
-    let mut process = MySqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
+    run_mysql_cli_script_with_program(
+        OsStr::new("mysql"),
+        &option_file.path,
+        script,
+        MYSQL_QUERY_TIMEOUT,
+    )
+    .await
+}
+
+#[cfg(all(unix, feature = "test-support"))]
+async fn run_mysql_cli_script_with_program(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    script: &str,
+    first_byte_timeout: Duration,
+) -> Result<Vec<u8>, DbOperationError> {
+    let mut process = MySqlProcess::spawn_with_program(program, option_file)?;
     let result = async {
         trace_mysql_statement(script);
         write_mysql_input(&mut process, script.as_bytes()).await?;
         write_mysql_input(&mut process, b"\x04").await?;
-        let output = read_pty_until_first_byte_then_idle(&mut process.pty)
+        let output = read_pty_until_first_byte_then_idle(&mut process.pty, first_byte_timeout)
             .await
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+            .map_err(|error| {
+                if error.kind() == io::ErrorKind::TimedOut {
+                    DbOperationError::Timeout(error.to_string())
+                } else {
+                    DbOperationError::QueryFailed(error.to_string())
+                }
+            })?;
         trace_mysql_frame("receive script output", output.len());
         Ok(output)
     }
@@ -659,6 +681,26 @@ while IFS= read -r line; do
 done
 "#,
         );
+        fs::write(&program, script).unwrap();
+        let mut permissions = fs::metadata(&program).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).unwrap();
+        (directory, program, log_file)
+    }
+
+    #[cfg(feature = "test-support")]
+    fn fake_mysql_without_output() -> (TempDir, PathBuf, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let option_file = directory.path().join("option.cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let program = directory.path().join("mysql");
+        let log_file = PathBuf::from(format!("{}.log", option_file.display()));
+        let script = r#"#!/bin/sh
+option=$(printf '%s\n' "$1" | sed 's/^--defaults-file=//')
+log="$option.log"
+printf 'process=%s\n' "$$" >> "$log"
+while :; do :; done
+"#;
         fs::write(&program, script).unwrap();
         let mut permissions = fs::metadata(&program).unwrap().permissions();
         permissions.set_mode(0o755);
@@ -1330,6 +1372,40 @@ done
         assert!(matches!(result, Err(DbOperationError::Timeout(_))));
         let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
         assert!(!log.contains("SELECT 123"));
+    }
+
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn initial_pty_output_timeout_kills_and_reaps_the_process() {
+        let (_directory, program, option_file) = fake_mysql_without_output();
+        let result = run_mysql_cli_script_with_program(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123;\n",
+            Duration::from_secs(3),
+        )
+        .await;
+
+        match result {
+            Err(DbOperationError::Timeout(details)) => {
+                assert!(
+                    details.contains("initial MySQL PTY output wait"),
+                    "{details}"
+                );
+            }
+            result => panic!("expected initial PTY output timeout, got {result:?}"),
+        }
+        let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap();
+        let pid = log
+            .lines()
+            .find_map(|line| line.strip_prefix("process=")?.parse::<i32>().ok())
+            .expect("script process pid");
+        let status = std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("check script process");
+        assert!(!status.success(), "script process {pid} is still running");
     }
 
     #[tokio::test]

--- a/src/infra/adapters/mysql/cli/process.rs
+++ b/src/infra/adapters/mysql/cli/process.rs
@@ -505,20 +505,66 @@ pub(in crate::adapters::mysql) async fn run_mysql_cli_script_for_test(
 ) -> Result<Vec<u8>, DbOperationError> {
     let target = parse_and_validate_mysql_dsn(dsn)?;
     let option_file = MySqlOptionFile::create(&target)?;
-    let mut process = MySqlProcess::spawn_with_program(OsStr::new("mysql"), &option_file.path)?;
+    run_mysql_cli_script_with_program(
+        OsStr::new("mysql"),
+        &option_file.path,
+        script,
+        MYSQL_QUERY_TIMEOUT,
+    )
+    .await
+}
+
+#[cfg(all(unix, feature = "test-support"))]
+async fn run_mysql_cli_script_with_program(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    script: &str,
+    first_byte_timeout: Duration,
+) -> Result<Vec<u8>, DbOperationError> {
+    let mut process = MySqlProcess::spawn_with_program(program, option_file)?;
+    run_mysql_cli_script_process(&mut process, script, first_byte_timeout).await
+}
+
+#[cfg(all(test, unix, feature = "test-support"))]
+async fn run_mysql_cli_script_with_program_and_pid(
+    program: &OsStr,
+    option_file: &std::path::Path,
+    script: &str,
+    first_byte_timeout: Duration,
+) -> Result<(u32, Result<Vec<u8>, DbOperationError>), DbOperationError> {
+    let mut process = MySqlProcess::spawn_with_program(program, option_file)?;
+    let pid = process.child.id().ok_or_else(|| {
+        DbOperationError::ConnectionLost("mysql child exited before cleanup tracking".to_string())
+    })?;
+    let result = run_mysql_cli_script_process(&mut process, script, first_byte_timeout).await;
+    Ok((pid, result))
+}
+
+#[cfg(all(unix, feature = "test-support"))]
+async fn run_mysql_cli_script_process(
+    process: &mut MySqlProcess,
+    script: &str,
+    first_byte_timeout: Duration,
+) -> Result<Vec<u8>, DbOperationError> {
     let result = async {
         trace_mysql_statement(script);
-        write_mysql_input(&mut process, script.as_bytes()).await?;
-        write_mysql_input(&mut process, b"\x04").await?;
-        let output = read_pty_until_first_byte_then_idle(&mut process.pty)
+        write_mysql_input(process, script.as_bytes()).await?;
+        write_mysql_input(process, b"\x04").await?;
+        let output = read_pty_until_first_byte_then_idle(&mut process.pty, first_byte_timeout)
             .await
-            .map_err(|error| DbOperationError::QueryFailed(error.to_string()))?;
+            .map_err(|error| {
+                if error.kind() == io::ErrorKind::TimedOut {
+                    DbOperationError::Timeout(error.to_string())
+                } else {
+                    DbOperationError::QueryFailed(error.to_string())
+                }
+            })?;
         trace_mysql_frame("receive script output", output.len());
         Ok(output)
     }
     .await;
     if result.is_err() {
-        cleanup_mysql_process(&mut process).await;
+        cleanup_mysql_process(process).await;
     } else {
         let _ = stop_mysql_process(&mut process.child).await;
     }
@@ -664,6 +710,22 @@ done
         permissions.set_mode(0o755);
         fs::set_permissions(&program, permissions).unwrap();
         (directory, program, log_file)
+    }
+
+    #[cfg(feature = "test-support")]
+    fn fake_mysql_without_output() -> (TempDir, PathBuf, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let option_file = directory.path().join("option.cnf");
+        fs::write(&option_file, "[client]\n").unwrap();
+        let program = directory.path().join("mysql");
+        let script = r"#!/bin/sh
+while :; do :; done
+";
+        fs::write(&program, script).unwrap();
+        let mut permissions = fs::metadata(&program).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&program, permissions).unwrap();
+        (directory, program, option_file)
     }
 
     fn fake_mysql_multi() -> (TempDir, PathBuf, PathBuf) {
@@ -1330,6 +1392,36 @@ done
         assert!(matches!(result, Err(DbOperationError::Timeout(_))));
         let log = fs::read_to_string(format!("{}.log", option_file.display())).unwrap_or_default();
         assert!(!log.contains("SELECT 123"));
+    }
+
+    #[cfg(feature = "test-support")]
+    #[tokio::test]
+    async fn initial_pty_output_timeout_kills_and_reaps_the_process() {
+        let (_directory, program, option_file) = fake_mysql_without_output();
+        let (pid, result) = run_mysql_cli_script_with_program_and_pid(
+            OsStr::new(&program),
+            &option_file,
+            "SELECT 123;\n",
+            Duration::from_millis(50),
+        )
+        .await
+        .expect("spawn script process");
+
+        match result {
+            Err(DbOperationError::Timeout(details)) => {
+                assert!(
+                    details.contains("initial MySQL PTY output wait"),
+                    "{details}"
+                );
+            }
+            result => panic!("expected initial PTY output timeout, got {result:?}"),
+        }
+        let status = std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stderr(std::process::Stdio::null())
+            .status()
+            .expect("check script process");
+        assert!(!status.success(), "script process {pid} is still running");
     }
 
     #[tokio::test]

--- a/src/infra/adapters/mysql/cli/pty.rs
+++ b/src/infra/adapters/mysql/cli/pty.rs
@@ -107,20 +107,24 @@ pub(super) async fn read_pty_all(pty: &mut MySqlPty) -> io::Result<Vec<u8>> {
 pub(super) async fn read_pty_until_idle(pty: &mut MySqlPty) -> io::Result<Vec<u8>> {
     let output = std::mem::take(&mut pty.pending);
     pty.frame_scanner.reset();
-    read_pty_until_idle_from(&mut pty.output, output, false).await
+    read_pty_until_idle_from(&mut pty.output, output, false, None).await
 }
 
 #[cfg(all(unix, feature = "test-support"))]
-pub(super) async fn read_pty_until_first_byte_then_idle(pty: &mut MySqlPty) -> io::Result<Vec<u8>> {
+pub(super) async fn read_pty_until_first_byte_then_idle(
+    pty: &mut MySqlPty,
+    first_byte_timeout: Duration,
+) -> io::Result<Vec<u8>> {
     let output = std::mem::take(&mut pty.pending);
     pty.frame_scanner.reset();
-    read_pty_until_idle_from(&mut pty.output, output, true).await
+    read_pty_until_idle_from(&mut pty.output, output, true, Some(first_byte_timeout)).await
 }
 
 async fn read_pty_until_idle_from<R>(
     reader: &mut R,
     mut output: Vec<u8>,
     wait_for_first_byte: bool,
+    first_byte_timeout: Option<Duration>,
 ) -> io::Result<Vec<u8>>
 where
     R: AsyncRead + Unpin,
@@ -128,7 +132,19 @@ where
     let mut chunk = [0; 4096];
     loop {
         if wait_for_first_byte && output.is_empty() {
-            match reader.read(&mut chunk).await {
+            let read = if let Some(timeout) = first_byte_timeout {
+                tokio::time::timeout(timeout, reader.read(&mut chunk))
+                    .await
+                    .map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "initial MySQL PTY output wait timed out",
+                        )
+                    })?
+            } else {
+                reader.read(&mut chunk).await
+            };
+            match read {
                 Ok(0) => return Ok(output),
                 Ok(count) => output.extend_from_slice(&chunk[..count]),
                 Err(error) if matches!(error.raw_os_error(), Some(libc::EIO | libc::EPERM)) => {
@@ -460,10 +476,9 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
     #[tokio::test(start_paused = true)]
     async fn keeps_zero_byte_idle_timeout_for_production_pty_reads() {
         let (_writer, mut reader) = tokio::io::duplex(1);
-        let read_task =
-            tokio::spawn(
-                async move { read_pty_until_idle_from(&mut reader, Vec::new(), false).await },
-            );
+        let read_task = tokio::spawn(async move {
+            read_pty_until_idle_from(&mut reader, Vec::new(), false, None).await
+        });
 
         tokio::task::yield_now().await;
         tokio::time::advance(Duration::from_millis(101)).await;
@@ -474,10 +489,10 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
     #[tokio::test(start_paused = true)]
     async fn waits_for_the_first_pty_byte_before_using_idle_timeout() {
         let (mut writer, mut reader) = tokio::io::duplex(1);
-        let read_task =
-            tokio::spawn(
-                async move { read_pty_until_idle_from(&mut reader, Vec::new(), true).await },
-            );
+        let read_task = tokio::spawn(async move {
+            read_pty_until_idle_from(&mut reader, Vec::new(), true, Some(Duration::from_secs(1)))
+                .await
+        });
 
         tokio::task::yield_now().await;
         tokio::time::advance(Duration::from_millis(101)).await;
@@ -485,5 +500,24 @@ ERROR 1146 (42S02): this is a cell value</field></row></resultset>"#;
         writer.shutdown().await.unwrap();
 
         assert_eq!(read_task.await.unwrap().unwrap(), b"frame");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn times_out_when_test_support_pty_has_no_initial_output() {
+        let (_writer, mut reader) = tokio::io::duplex(1);
+        let read_task = tokio::spawn(async move {
+            read_pty_until_idle_from(&mut reader, Vec::new(), true, Some(Duration::from_secs(1)))
+                .await
+        });
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        let error = read_task
+            .await
+            .unwrap()
+            .expect_err("initial output must time out");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+        assert_eq!(error.to_string(), "initial MySQL PTY output wait timed out");
     }
 }


### PR DESCRIPTION
## Summary

- Bound the test-support PTY initial-byte wait by `MYSQL_QUERY_TIMEOUT`.
- Preserve the existing 100 ms idle behavior and production zero-byte reader contract.
- Convert the initial-output timeout to a distinguishable `DbOperationError::Timeout` and reuse process cleanup.

## Validation

- `cargo test -p sabiql-infra --all-features adapters::mysql::cli:: -- --nocapture --test-threads 1` (81 passed)
- `cargo clippy -p sabiql-infra --all-targets --all-features -- -D warnings`
- `bash scripts/lint_all.sh`
- Oracle MySQL 8.4.10 PTY/CLI integration (41 passed)

Linear: https://linear.app/sabiql/issue/SAB-508