### PR TITLE
[SAB-492] perf(mysql): streamline preview metadata and ordering

### DIFF
--- a/src/infra/adapters/mysql/metadata/preview.rs
+++ b/src/infra/adapters/mysql/metadata/preview.rs
@@ -9,13 +9,12 @@ use super::super::{
     dsn::parse_and_validate_mysql_dsn,
     option_file::MySqlOptionFile,
     sql::{
-        PREVIEW_COLUMN_METADATA_RESULT_COLUMNS, UNIQUE_COLUMN_RESULT_COLUMNS, build_preview_query,
-        preview_columns_query, preview_identity_alias, unique_columns_query,
+        PREVIEW_COLUMN_METADATA_RESULT_COLUMNS, build_preview_query, preview_columns_query,
+        preview_identity_alias,
     },
 };
 use super::catalog::{
-    MySqlColumnMetadata, column_from_metadata, mark_single_column_unique,
-    parse_preview_columns_for_table, parse_unique_column_metadata, primary_key_names,
+    MySqlColumnMetadata, column_from_metadata, parse_preview_columns_for_table, primary_key_names,
     validate_selected_schema_name,
 };
 
@@ -117,17 +116,7 @@ async fn execute_preview_with_session(
             PREVIEW_COLUMN_METADATA_RESULT_COLUMNS,
         )
         .await?;
-    let unique_result = session
-        .execute_with_expected_columns(
-            &unique_columns_query(schema, table),
-            UNIQUE_COLUMN_RESULT_COLUMNS,
-        )
-        .await?;
-    let mut column_metadata = parse_preview_columns_for_table(&column_result, schema, table)?;
-    mark_single_column_unique(
-        &mut column_metadata,
-        &parse_unique_column_metadata(&unique_result)?,
-    );
+    let column_metadata = parse_preview_columns_for_table(&column_result, schema, table)?;
     let metadata = preview_metadata_from_columns(&column_metadata, schema, table)?;
     let query = build_preview_query(
         schema,
@@ -220,14 +209,6 @@ fn preview_metadata_from_columns(
         })
         .collect();
     let order_columns = primary_key_names;
-    let order_columns = if order_columns.is_empty() {
-        visible_columns
-            .iter()
-            .map(|column| column.name.clone())
-            .collect()
-    } else {
-        order_columns
-    };
     Ok(PreviewMetadata {
         visible_columns,
         order_columns,
@@ -496,9 +477,6 @@ while IFS= read -r line; do
     *INFORMATION_SCHEMA.COLUMNS*)
       {columns_result}
       ;;
-    *INFORMATION_SCHEMA.STATISTICS*)
-      printf '%s\n' '<resultset></resultset>'
-      ;;
     *"LIMIT 2 OFFSET 1"*)
       printf '%s\n' '<resultset><row><field name="payload">0x00FF</field><field name="__sabiql_row_identity_0">1</field></row></resultset>'
       {delayed_preview_error}
@@ -605,7 +583,6 @@ done
             "__sabiql_probe",
             "SET SESSION TRANSACTION READ ONLY",
             "INFORMATION_SCHEMA.COLUMNS",
-            "INFORMATION_SCHEMA.STATISTICS",
             "LIMIT 2 OFFSET 1",
             "__sabiql_preview_completion",
         ]
@@ -613,6 +590,7 @@ done
         .map(|query| log.find(query).expect("query in transcript"))
         .collect::<Vec<_>>();
         assert!(positions.windows(2).all(|pair| pair[0] < pair[1]), "{log}");
+        assert!(!log.contains("INFORMATION_SCHEMA.STATISTICS"), "{log}");
     }
 
     #[cfg(unix)]

--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -200,8 +200,13 @@ pub(in crate::adapters::mysql) fn build_preview_query(
         .map(|column| quote_identifier(column))
         .collect::<Vec<_>>()
         .join(", ");
+    let order_clause = if order_by.is_empty() {
+        String::new()
+    } else {
+        format!(" ORDER BY {order_by}")
+    };
     format!(
-        "SELECT {columns} FROM {}.{} ORDER BY {order_by} LIMIT {limit} OFFSET {offset}",
+        "SELECT {columns} FROM {}.{}{order_clause} LIMIT {limit} OFFSET {offset}",
         quote_identifier(schema),
         quote_identifier(table),
     )
@@ -580,6 +585,11 @@ mod tests {
                 0,
             ),
             "SELECT `payload`, `id` AS `__sabiql_row_identity_0` FROM `app`.`items` ORDER BY `id` LIMIT 10 OFFSET 0"
+        );
+
+        assert_eq!(
+            build_preview_query("app", "items", &[], &visible_columns, &[], 10, 0,),
+            "SELECT `payload` FROM `app`.`items` LIMIT 10 OFFSET 0"
         );
     }
 }

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -830,11 +830,17 @@ mod query_preview {
                     .execute_preview(db.dsn(), "sabiql_test", MYSQL_NO_PK_TABLE, 1, 1)
                     .await
                     .map_err(|error| format!("{error:?}"))?;
-                if !page
-                    .query
-                    .contains("ORDER BY `duplicate_value`, `payload` LIMIT 1 OFFSET 1")
+                if page.query
+                    != "SELECT `duplicate_value`, `payload` FROM `sabiql_test`.`mysql_preview_no_pk` LIMIT 1 OFFSET 1"
                 {
                     return Err(format!("unexpected no-PK preview SQL: {}", page.query));
+                }
+                let plan = db
+                    .run_cli_script(&format!("EXPLAIN {}", page.query))
+                    .await
+                    .map_err(|error| format!("failed to explain no-PK preview: {error}"))?;
+                if plan.contains("Using filesort") {
+                    return Err(format!("no-PK preview unexpectedly used filesort: {plan:?}"));
                 }
 
                 let composite = db


### PR DESCRIPTION
## Problem
MySQL previews fetched unused single-column UNIQUE metadata and sorted every visible column for tables without primary keys, causing unnecessary metadata work and filesort.

## Background
Preview execution only needs column metadata, primary-key identity, and binary charset handling. Keyless tables do not have a deterministic key order to preserve.

## Approach
Use only preview COLUMNS metadata, retain primary-key ordering and identity behavior, and omit ORDER BY when no primary key exists so MySQL returns rows in server order. Add transcript/SQL assertions and an Oracle MySQL EXPLAIN check.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-492