### PR TITLE
feat(mysql): add TRUNCATE keyword completion (SAB-505)

### DIFF
--- a/src/app/cmd/completion_engine.rs
+++ b/src/app/cmd/completion_engine.rs
@@ -56,6 +56,7 @@ const MYSQL_COMPLETION_KEYWORDS: &[&str] = &[
     "UPDATE",
     "SET",
     "DELETE",
+    "TRUNCATE",
     "CREATE",
     "DROP",
     "ALTER",
@@ -2034,6 +2035,28 @@ mod tests {
                     .iter()
                     .any(|candidate| candidate.text == "DESCRIBE")
             );
+        }
+
+        #[test]
+        fn mysql_keyword_candidates_include_truncate_case_insensitively() {
+            let e = engine();
+            for prefix in ["TRU", "tru"] {
+                let candidates = e.get_candidates_for_database(
+                    prefix,
+                    prefix.chars().count(),
+                    None,
+                    None,
+                    &[],
+                    CompletionDatabaseScope {
+                        database_type: DatabaseType::MySQL,
+                        active_database: Some("app"),
+                    },
+                );
+
+                assert!(candidates.iter().any(|candidate| {
+                    candidate.text == "TRUNCATE" && candidate.kind == CompletionKind::Keyword
+                }));
+            }
         }
 
         #[test]


### PR DESCRIPTION
## Problem

MySQL SQL completion does not suggest the supported TRUNCATE keyword.

## Approach

Add TRUNCATE to the MySQL completion keyword candidates and cover uppercase and lowercase prefixes with a focused regression test.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-505/mysqlのtruncateをsql補完候補へ追加する