### PR TITLE
fix: preserve delete errors in result view

### DIFF
--- a/src/app/catalog.rs
+++ b/src/app/catalog.rs
@@ -249,6 +249,7 @@ fn current_section(origin: HelpOrigin, feature_policy: &FeaturePolicy) -> HelpSe
         } => rows_from_binding_refs(&[
             &result_active::ENTER_DEEPEN,
             &result_active::UNSTAGE_DELETE,
+            &result_active::CLEAR_STAGED_DELETE,
             &cell_edit::WRITE,
             &footer_nav::PAGE_NAV,
             csv_export(keymap_preset),

--- a/src/app/cmd/render_schedule.rs
+++ b/src/app/cmd/render_schedule.rs
@@ -113,11 +113,11 @@ mod tests {
         }
 
         #[test]
-        fn message_timeout_returns_expiration() {
+        fn success_message_timeout_returns_expiration() {
             let mut state = create_test_state();
             let now = Instant::now();
             let expires_at = now + Duration::from_secs(2);
-            state.messages.set_error_at(
+            state.messages.set_success_at(
                 "message".to_string(),
                 expires_at.checked_sub(MESSAGE_TIMEOUT).unwrap(),
             );
@@ -193,13 +193,13 @@ mod tests {
         }
 
         #[test]
-        fn earlier_message_timeout_takes_priority() {
+        fn earlier_success_message_timeout_takes_priority() {
             let mut state = create_test_state();
             let now = Instant::now();
             let _ = state.query.begin_running(now);
             // Message expires before spinner would update
             let expires_at = now + Duration::from_millis(50);
-            state.messages.set_error_at(
+            state.messages.set_success_at(
                 "message".to_string(),
                 expires_at.checked_sub(MESSAGE_TIMEOUT).unwrap(),
             );
@@ -216,7 +216,7 @@ mod tests {
 
             let _ = state.query.begin_running(now);
             let message_expires_at = now + Duration::from_secs(2);
-            state.messages.set_error_at(
+            state.messages.set_success_at(
                 "message".to_string(),
                 message_expires_at.checked_sub(MESSAGE_TIMEOUT).unwrap(),
             );

--- a/src/app/model/app_state.rs
+++ b/src/app/model/app_state.rs
@@ -954,7 +954,7 @@ mod tests {
                 .set_error_at("Old error".to_string(), Instant::now());
 
             assert!(state.messages.last_error().is_some());
-            assert!(state.messages.expires_at().is_some());
+            assert!(state.messages.expires_at().is_none());
 
             dispatch_metadata(&mut state, &Action::ReloadMetadata, Instant::now());
 

--- a/src/app/model/browse/result_interaction.rs
+++ b/src/app/model/browse/result_interaction.rs
@@ -5,7 +5,7 @@ use super::cell_edit::CellEditState;
 use crate::model::shared::cursor::CursorMove;
 use crate::model::shared::text_input::TextKillDirection;
 use crate::model::shared::ui_state::{ResultSelection, YankFlash};
-use crate::policy::write::write_guardrails::WritePreview;
+use crate::policy::write::write_guardrails::{WriteOperation, WritePreview};
 
 // Invariants:
 // - `reset_view` / `reset_interaction` clear staged deletes too.
@@ -177,6 +177,18 @@ impl ResultInteraction {
         self.pending_write_preview = None;
     }
 
+    pub fn complete_write_failure(&mut self) -> WriteOperation {
+        let operation = self
+            .pending_write_preview
+            .as_ref()
+            .map_or(WriteOperation::Update, |preview| preview.operation);
+        self.clear_write_preview();
+        if operation == WriteOperation::Delete {
+            self.clear_staged_deletes();
+        }
+        operation
+    }
+
     pub fn discard_cell_edit(&mut self) {
         self.cell_edit.clear();
         self.pending_write_preview = None;
@@ -328,6 +340,40 @@ mod tests {
         assert!(ri.pending_write_preview().is_none());
         assert_eq!(ri.selection().mode(), ResultNavMode::CellActive);
         assert!(ri.staged_delete_rows().contains(&0));
+    }
+
+    #[test]
+    fn complete_write_failure_for_update_preserves_selection_and_staging() {
+        let mut ri = ResultInteraction::default();
+        ri.activate_cell(2, 4);
+        ri.stage_row(0);
+        ri.set_write_preview(test_preview());
+
+        let operation = ri.complete_write_failure();
+
+        assert_eq!(operation, WriteOperation::Update);
+        assert!(ri.pending_write_preview().is_none());
+        assert_eq!(ri.selection().row(), Some(2));
+        assert_eq!(ri.selection().cell(), Some(4));
+        assert!(ri.staged_delete_rows().contains(&0));
+    }
+
+    #[test]
+    fn complete_write_failure_for_delete_clears_staging_and_preserves_selection() {
+        let mut ri = ResultInteraction::default();
+        ri.activate_cell(2, 4);
+        ri.stage_row(0);
+        let mut preview = test_preview();
+        preview.operation = WriteOperation::Delete;
+        ri.set_write_preview(preview);
+
+        let operation = ri.complete_write_failure();
+
+        assert_eq!(operation, WriteOperation::Delete);
+        assert!(ri.pending_write_preview().is_none());
+        assert_eq!(ri.selection().row(), Some(2));
+        assert_eq!(ri.selection().cell(), Some(4));
+        assert!(ri.staged_delete_rows().is_empty());
     }
 
     #[test]

--- a/src/app/model/shared/message.rs
+++ b/src/app/model/shared/message.rs
@@ -8,7 +8,6 @@ pub struct MessageState {
 }
 
 impl MessageState {
-    const ERROR_TIMEOUT_SECS: u64 = 3;
     const SUCCESS_TIMEOUT_SECS: u64 = 3;
 
     pub fn last_error(&self) -> Option<&str> {
@@ -23,10 +22,10 @@ impl MessageState {
         self.expires_at
     }
 
-    pub fn set_error_at(&mut self, msg: String, now: Instant) {
+    pub fn set_error_at(&mut self, msg: String, _now: Instant) {
         self.last_error = Some(msg);
         self.last_success = None;
-        self.expires_at = Some(now + Duration::from_secs(Self::ERROR_TIMEOUT_SECS));
+        self.expires_at = None;
     }
 
     pub fn set_success_at(&mut self, msg: String, now: Instant) {
@@ -35,11 +34,14 @@ impl MessageState {
         self.expires_at = Some(now + Duration::from_secs(Self::SUCCESS_TIMEOUT_SECS));
     }
 
+    pub fn clear_error(&mut self) {
+        self.last_error = None;
+    }
+
     pub fn clear_expired_at(&mut self, now: Instant) {
         if let Some(expires) = self.expires_at
             && expires <= now
         {
-            self.last_error = None;
             self.last_success = None;
             self.expires_at = None;
         }
@@ -87,46 +89,53 @@ mod tests {
     }
 
     #[test]
-    fn set_error_sets_expiration_time() {
+    fn set_error_does_not_set_expiration_time() {
         let now = fixed_instant();
         let mut state = MessageState::default();
         assert!(state.expires_at().is_none());
 
         state.set_error_at("Error!".to_string(), now);
 
-        assert!(state.expires_at().is_some());
-        assert_eq!(
-            state.expires_at(),
-            Some(now + Duration::from_secs(MessageState::ERROR_TIMEOUT_SECS))
-        );
+        assert!(state.expires_at().is_none());
     }
 
     #[test]
-    fn clear_expired_at_removes_expired_messages() {
+    fn clear_expired_at_keeps_error_message() {
         let now = fixed_instant();
         let mut state = MessageState::default();
-        state.set_error_at(
-            "Error".to_string(),
-            now.checked_sub(Duration::from_secs(MessageState::ERROR_TIMEOUT_SECS + 1))
+        state.set_error_at("Error".to_string(), now);
+
+        state.clear_expired_at(now + Duration::from_mins(1));
+
+        assert_eq!(state.last_error(), Some("Error"));
+        assert!(state.expires_at().is_none());
+    }
+
+    #[test]
+    fn clear_expired_at_removes_expired_success() {
+        let now = fixed_instant();
+        let mut state = MessageState::default();
+        state.set_success_at(
+            "Success".to_string(),
+            now.checked_sub(Duration::from_secs(MessageState::SUCCESS_TIMEOUT_SECS + 1))
                 .unwrap(),
         );
 
         state.clear_expired_at(now);
 
-        assert!(state.last_error().is_none());
+        assert!(state.last_success().is_none());
         assert!(state.expires_at().is_none());
     }
 
     #[test]
-    fn clear_expired_at_keeps_unexpired_messages() {
+    fn clear_error_removes_error_message() {
         let now = fixed_instant();
         let mut state = MessageState::default();
         state.set_error_at("Error".to_string(), now);
 
-        state.clear_expired_at(now);
+        state.clear_error();
 
-        assert!(state.last_error().is_some());
-        assert!(state.expires_at().is_some());
+        assert!(state.last_error().is_none());
     }
 
     #[test]

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -380,6 +380,9 @@ pub fn reduce_write(
                 .map_or(WriteOperation::Update, |p| p.operation);
             state.result_interaction.clear_write_preview();
             state.query.clear_delete_refresh_target();
+            if operation == WriteOperation::Delete {
+                state.result_interaction.clear_staged_deletes();
+            }
             state.messages.set_error_at(error.user_message(), now);
             state.modal.set_mode(match operation {
                 WriteOperation::Update => InputMode::CellEdit,
@@ -1337,6 +1340,7 @@ mod tests {
             let mut state = create_test_state();
             state.query.pagination.reset_for_table("public", "users");
             state.query.set_delete_refresh_target(1, Some(499), 1);
+            state.result_interaction.stage_row(2);
             state.result_interaction.set_write_preview(delete_preview());
             let action = write_succeeded_action(&mut state, 1);
 
@@ -1352,6 +1356,7 @@ mod tests {
                 state.messages.last_success.as_deref(),
                 Some("Deleted 1 row")
             );
+            assert!(state.result_interaction.staged_delete_rows().is_empty());
             assert_eq!(effects.len(), 1);
             match &effects[0] {
                 Effect::ExecutePreview {
@@ -1387,6 +1392,8 @@ mod tests {
         #[test]
         fn execute_write_failed_for_delete_returns_to_normal_mode() {
             let mut state = create_test_state();
+            state.result_interaction.activate_cell(4, 2);
+            state.result_interaction.stage_row(4);
             state.result_interaction.set_write_preview(delete_preview());
             let action = write_failed_action(
                 &mut state,
@@ -1402,6 +1409,9 @@ mod tests {
                 state.messages.last_error.as_deref(),
                 Some("Query failed: boom. Review the database error details and SQL.")
             );
+            assert!(state.result_interaction.staged_delete_rows().is_empty());
+            assert_eq!(state.result_interaction.selection().row(), Some(4));
+            assert_eq!(state.result_interaction.selection().cell(), Some(2));
         }
 
         #[test]

--- a/src/app/update/browse/query/write.rs
+++ b/src/app/update/browse/query/write.rs
@@ -374,15 +374,8 @@ pub fn reduce_write(
             }
 
             state.query.mark_idle();
-            let operation = state
-                .result_interaction
-                .pending_write_preview()
-                .map_or(WriteOperation::Update, |p| p.operation);
-            state.result_interaction.clear_write_preview();
+            let operation = state.result_interaction.complete_write_failure();
             state.query.clear_delete_refresh_target();
-            if operation == WriteOperation::Delete {
-                state.result_interaction.clear_staged_deletes();
-            }
             state.messages.set_error_at(error.user_message(), now);
             state.modal.set_mode(match operation {
                 WriteOperation::Update => InputMode::CellEdit,

--- a/src/app/update/browse/result/selection.rs
+++ b/src/app/update/browse/result/selection.rs
@@ -222,6 +222,21 @@ mod tests {
             assert_eq!(state.result_interaction.selection().row(), None);
             assert!(state.result_interaction.staged_delete_rows().contains(&0));
         }
+
+        #[test]
+        fn escape_from_result_scroll_clears_all_staged_rows() {
+            let mut state = base_state(
+                Some(vec!["id"]),
+                vec![vec!["1", "alice"], vec!["2", "bob"]],
+                0,
+            );
+            state.result_interaction.stage_row(0);
+            state.result_interaction.stage_row(1);
+
+            reduce_selection(&mut state, &Action::ClearStagedDeletes, Instant::now());
+
+            assert!(state.result_interaction.staged_delete_rows().is_empty());
+        }
     }
 
     mod read_only_guard {

--- a/src/app/update/input/keybindings/normal.rs
+++ b/src/app/update/input/keybindings/normal.rs
@@ -575,6 +575,15 @@ pub mod result_active {
         combos: &[KeyCombo::plain(Key::Char('u'))],
     };
 
+    pub const CLEAR_STAGED_DELETE: KeyBinding = KeyBinding {
+        key_short: "Esc",
+        key: "Esc",
+        desc_short: "Clear Del",
+        description: "Clear all staged row deletions",
+        action: Action::ClearStagedDeletes,
+        combos: &[], // Esc is resolved by the Vim result-scroll transition
+    };
+
     pub const CELL_NAV: KeyBinding = KeyBinding {
         key_short: "h/l",
         key: "h / l",
@@ -654,6 +663,7 @@ pub const RESULT_ACTIVE_KEYS: &[KeyBinding] = &[
     result_active::ROW_DETAIL,
     result_active::STAGE_DELETE,
     result_active::UNSTAGE_DELETE,
+    result_active::CLEAR_STAGED_DELETE,
     result_active::CELL_NAV,
     result_active::ROW_NAV,
     result_active::TOP_BOTTOM,

--- a/src/app/update/input/vim/actions/browse.rs
+++ b/src/app/update/input/vim/actions/browse.rs
@@ -6,8 +6,8 @@ use crate::update::action::{
 
 use super::{scroll, scroll_to_cursor};
 use crate::update::input::vim::types::{
-    BrowseVimContext, InspectorVimContext, ResultVimContext, VimModeTransition, VimNavigation,
-    VimOperator,
+    BrowseVimContext, InspectorVimContext, ResultVimContext, StagedDeleteState, VimModeTransition,
+    VimNavigation, VimOperator,
 };
 
 pub(in crate::update::input::vim) fn navigation(
@@ -32,7 +32,13 @@ pub(in crate::update::input::vim) fn mode_transition(
         ) => Action::Escape,
         (VimModeTransition::Escape, BrowseVimContext::Result(result_ctx)) => {
             match result_ctx.mode {
-                ResultNavMode::Scroll => Action::Escape,
+                ResultNavMode::Scroll => {
+                    if result_ctx.staged_delete == StagedDeleteState::InProgress {
+                        Action::ClearStagedDeletes
+                    } else {
+                        Action::Escape
+                    }
+                }
                 ResultNavMode::CellActive => {
                     if result_ctx.has_pending_draft {
                         Action::ResultDiscardCellEdit
@@ -301,6 +307,7 @@ mod tests {
         ResultVimContext {
             mode,
             has_pending_draft: false,
+            staged_delete: StagedDeleteState::None,
             yank_pending: false,
             delete_pending: false,
         }
@@ -321,6 +328,19 @@ mod tests {
         );
 
         assert!(matches!(action, Some(Action::ResultDiscardCellEdit)));
+    }
+
+    #[test]
+    fn result_scroll_escape_clears_staged_deletes() {
+        let action = action_for_command(
+            VimCommand::ModeTransition(VimModeTransition::Escape),
+            browse_result(ResultVimContext {
+                staged_delete: StagedDeleteState::InProgress,
+                ..result_ctx(ResultNavMode::Scroll)
+            }),
+        );
+
+        assert!(matches!(action, Some(Action::ClearStagedDeletes)));
     }
 
     #[test]

--- a/src/app/update/input/vim/mod.rs
+++ b/src/app/update/input/vim/mod.rs
@@ -10,8 +10,8 @@ use crate::update::input::keybindings::KeyCombo;
 pub use classify::{classify_command, classify_sequence};
 pub use types::{
     BrowseVimContext, InspectorVimContext, JsonbDetailVimContext, ResultVimContext,
-    SearchContinuation, SqlModalVimContext, VimCommand, VimModeTransition, VimNavigation,
-    VimOperator, VimSurfaceContext,
+    SearchContinuation, SqlModalVimContext, StagedDeleteState, VimCommand, VimModeTransition,
+    VimNavigation, VimOperator, VimSurfaceContext,
 };
 
 pub fn action_for_input(

--- a/src/app/update/input/vim/types.rs
+++ b/src/app/update/input/vim/types.rs
@@ -56,6 +56,12 @@ pub enum VimOperator {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StagedDeleteState {
+    None,
+    InProgress,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VimSurfaceContext {
     Browse(BrowseVimContext),
     SqlModal(SqlModalVimContext),
@@ -79,6 +85,7 @@ pub enum InspectorVimContext {
 pub struct ResultVimContext {
     pub mode: ResultNavMode,
     pub has_pending_draft: bool,
+    pub staged_delete: StagedDeleteState,
     pub yank_pending: bool,
     pub delete_pending: bool,
 }
@@ -101,6 +108,11 @@ impl From<&AppState> for BrowseVimContext {
             return Self::Result(ResultVimContext {
                 mode: state.result_interaction.selection().mode(),
                 has_pending_draft: state.result_interaction.cell_edit().has_pending_draft(),
+                staged_delete: if state.result_interaction.staged_delete_rows().is_empty() {
+                    StagedDeleteState::None
+                } else {
+                    StagedDeleteState::InProgress
+                },
                 yank_pending: state.result_interaction.is_yank_operator_pending(),
                 delete_pending: state.result_interaction.is_delete_operator_pending(),
             });

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -1285,7 +1285,7 @@ mod tests {
             }
 
             #[test]
-            fn load_failed_sets_error_with_expiry() {
+            fn load_failed_sets_persistent_error() {
                 let mut state = connected_state();
                 state.modal.set_mode(InputMode::QueryHistoryPicker);
                 let now = Instant::now();

--- a/src/app/update/modal/mod.rs
+++ b/src/app/update/modal/mod.rs
@@ -966,6 +966,9 @@ mod tests {
 
         mod cancel {
             use super::*;
+            use crate::policy::write::write_guardrails::{
+                GuardrailDecision, RiskLevel, TargetSummary, WriteOperation, WritePreview,
+            };
 
             #[test]
             fn quit_no_connection_restores_connection_setup_synchronously() {
@@ -1005,6 +1008,45 @@ mod tests {
                 assert_eq!(state.input_mode(), InputMode::CellEdit);
                 assert!(effects.is_empty());
                 assert!(state.result_interaction.pending_write_preview().is_none());
+            }
+
+            #[test]
+            fn delete_preview_preserves_staged_rows() {
+                let mut state = create_test_state();
+                enter_confirm_dialog(&mut state, InputMode::Normal);
+                state.result_interaction.activate_cell(4, 2);
+                state.result_interaction.stage_row(4);
+                state.result_interaction.set_write_preview(WritePreview {
+                    operation: WriteOperation::Delete,
+                    sql: "DELETE FROM users WHERE id = 4".to_string(),
+                    target_summary: TargetSummary {
+                        schema: "public".to_string(),
+                        table: "users".to_string(),
+                        key_values: vec![],
+                    },
+                    diff: vec![],
+                    guardrail: GuardrailDecision {
+                        risk_level: RiskLevel::Low,
+                        blocked: false,
+                        reason: None,
+                        target_summary: None,
+                    },
+                });
+                state.confirm_dialog.open(
+                    "Confirm DELETE".to_string(),
+                    "DELETE FROM users WHERE id = 4".to_string(),
+                    ConfirmIntent::ExecuteWrite {
+                        sql: "DELETE FROM users WHERE id = 4".to_string(),
+                        blocked: false,
+                    },
+                );
+
+                let effects = cancel_effects(&mut state);
+
+                assert!(effects.is_empty());
+                assert!(state.result_interaction.staged_delete_rows().contains(&4));
+                assert_eq!(state.result_interaction.selection().row(), Some(4));
+                assert_eq!(state.result_interaction.selection().cell(), Some(2));
             }
 
             #[test]
@@ -1262,7 +1304,7 @@ mod tests {
                     state.messages.last_error.as_deref(),
                     Some("IO error: disk error")
                 );
-                assert!(state.messages.expires_at.is_some());
+                assert!(state.messages.expires_at.is_none());
             }
 
             #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,8 +367,8 @@ impl Runtime {
                 pending,
                 Instant::now(),
             );
-            // Render immediately: the main loop's next wakeup is the message expiry
-            // itself, so without this draw the message would never become visible.
+            // Render immediately so the overflow error is visible before the next
+            // event-loop pass; errors do not have an expiry wake-up anymore.
             self.run_effects(vec![Effect::Render]).await?;
         }
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,9 +376,11 @@ impl Runtime {
 
     async fn process_terminal_event_burst(&mut self, first_action: Action) -> Result<()> {
         if !first_action.is_scroll() {
+            self.state.messages.clear_error();
             return self.process_action(first_action).await;
         }
 
+        self.state.messages.clear_error();
         let now = Instant::now();
         let mut effects = reduce(&mut self.state, first_action, now, &self.services);
         if !effects.is_empty() {
@@ -403,6 +405,7 @@ impl Runtime {
             }
 
             if action.is_scroll() {
+                self.state.messages.clear_error();
                 let now = Instant::now();
                 let mut effects = reduce(&mut self.state, action, now, &self.services);
                 if !effects.is_empty() {
@@ -418,6 +421,7 @@ impl Runtime {
                     self.state.clear_dirty();
                     self.process_action(Action::Render).await?;
                 }
+                self.state.messages.clear_error();
                 self.process_action(action).await?;
                 if self.state.should_quit {
                     return Ok(());

--- a/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__long_error_message_wraps_into_footer_and_command_line.snap
+++ b/src/tests/render_snapshots/snapshots/sabiql__render_snapshots__table_explorer__long_error_message_wraps_into_footer_and_command_line.snap
@@ -1,0 +1,55 @@
+---
+source: src/tests/render_snapshots/table_explorer.rs
+expression: output
+---
+test_project ▸ test_db ▸ -                                                                                                               no dsn | localhost:5432/test
+┌ [1] Explorer ─────────────────────────┐[Info] [Cols] [Idx] [FK] [RLS] [Trig] [DDL]                                                                                 
+│> public.users                         │┌ [2] Inspector ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  public.posts                         ││(select a table)                                                                                                          │
+│  public.comments                      ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       │└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+│                                       │┌ [3] Result ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                       ││(select a table to preview)                                                                                               │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+│                                       ││                                                                                                                          │
+└───────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+Connection failed: the database server returned a detailed explanation that should remain visible until the next user operation instead of disappearing from the     
+footer after a short timeout

--- a/src/tests/render_snapshots/table_explorer.rs
+++ b/src/tests/render_snapshots/table_explorer.rs
@@ -65,6 +65,22 @@ fn error_message_in_footer() {
 }
 
 #[test]
+fn long_error_message_wraps_into_footer_and_command_line() {
+    let mut state = explorer_selected_state();
+    let now = test_instant();
+    let mut terminal = create_test_terminal();
+
+    state.messages.set_error_at(
+        "Connection failed: the database server returned a detailed explanation that should remain visible until the next user operation instead of disappearing from the footer after a short timeout".to_string(),
+        now,
+    );
+
+    let output = render_to_string(&mut terminal, &mut state);
+
+    insta::assert_snapshot!(output);
+}
+
+#[test]
 fn empty_query_result() {
     let mut state = table_detail_loaded_state();
     let mut terminal = create_test_terminal();

--- a/src/ui/primitives/atoms/status_message.rs
+++ b/src/ui/primitives/atoms/status_message.rs
@@ -1,4 +1,5 @@
 use ratatui::text::{Line, Span};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::theme::{StatusTone, ThemePalette};
 
@@ -22,4 +23,72 @@ impl StatusMessage {
 
         Line::from(vec![Span::styled(format!("{prefix}{message}"), style)])
     }
+
+    pub fn render_lines(
+        message: &str,
+        msg_type: MessageType,
+        width: u16,
+        theme: &ThemePalette,
+    ) -> Vec<Line<'static>> {
+        if width == 0 {
+            return Vec::new();
+        }
+
+        let style = match msg_type {
+            MessageType::Error => theme.status_style(StatusTone::Error),
+            MessageType::Success => theme.status_style(StatusTone::Success),
+        };
+        let width = width as usize;
+        let mut lines = Vec::new();
+
+        for source_line in message.split('\n') {
+            for line in wrap_line(source_line, width) {
+                lines.push(Line::from(Span::styled(line, style)));
+            }
+        }
+
+        lines
+    }
+}
+
+fn wrap_line(source: &str, width: usize) -> Vec<String> {
+    if UnicodeWidthStr::width(source) <= width {
+        return vec![source.to_string()];
+    }
+
+    let mut lines = Vec::new();
+    let mut remaining = source;
+    while UnicodeWidthStr::width(remaining) > width {
+        let mut cut = 0;
+        let mut used = 0;
+        for (index, ch) in remaining.char_indices() {
+            let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if used + char_width > width {
+                break;
+            }
+            used += char_width;
+            cut = index + ch.len_utf8();
+        }
+
+        if cut == 0 {
+            cut = remaining
+                .char_indices()
+                .nth(1)
+                .map_or(remaining.len(), |(index, _)| index);
+        }
+
+        let candidate = &remaining[..cut];
+        let split_at = candidate
+            .char_indices()
+            .rev()
+            .find_map(|(index, ch)| ch.is_whitespace().then_some(index));
+        let (line, next) = split_at.filter(|index| *index > 0).map_or_else(
+            || (candidate, &remaining[cut..]),
+            |index| (&candidate[..index], &remaining[index..]),
+        );
+        lines.push(line.trim_end().to_string());
+        remaining = next.trim_start();
+    }
+    lines.push(remaining.to_string());
+    lines
 }

--- a/src/ui/shell/command_line.rs
+++ b/src/ui/shell/command_line.rs
@@ -5,7 +5,9 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
 use crate::app::model::app_state::AppState;
+use crate::app::model::er_state::ErStatus;
 use crate::app::model::shared::input_mode::InputMode;
+use crate::primitives::atoms::status_message::{MessageType, StatusMessage};
 use crate::primitives::atoms::text_cursor_spans;
 use crate::theme::ThemePalette;
 
@@ -35,6 +37,14 @@ impl CommandLine {
             )];
             spans.extend(cursor_spans);
             Line::from(spans)
+        } else if state.input_mode() == InputMode::Normal
+            && state.er_preparation.status() != ErStatus::Waiting
+            && let Some(error) = state.messages.last_error()
+        {
+            StatusMessage::render_lines(error, MessageType::Error, area.width, theme)
+                .into_iter()
+                .nth(1)
+                .unwrap_or_else(|| Line::raw(""))
         } else {
             Line::raw("")
         };

--- a/src/ui/shell/footer.rs
+++ b/src/ui/shell/footer.rs
@@ -44,7 +44,10 @@ impl Footer {
             let line = Self::build_er_waiting_line(state, time_ms, theme);
             frame.render_widget(Paragraph::new(line).style(base_style), area);
         } else if let Some(error) = state.messages.last_error() {
-            let line = StatusMessage::render_line(error, MessageType::Error, theme);
+            let line = StatusMessage::render_lines(error, MessageType::Error, area.width, theme)
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| StatusMessage::render_line("", MessageType::Error, theme));
             frame.render_widget(Paragraph::new(line).style(base_style), area);
         } else {
             // Show hints with optional inline success message
@@ -135,6 +138,7 @@ impl Footer {
                     let mut list = vec![result_active::ENTER_DEEPEN.as_hint()];
                     if !state.result_interaction.staged_delete_rows().is_empty() {
                         list.push(result_active::UNSTAGE_DELETE.as_hint());
+                        list.push(result_active::CLEAR_STAGED_DELETE.as_hint());
                         list.push(cell_edit::WRITE.as_hint());
                     }
                     if state.can_request_csv_export() {
@@ -189,6 +193,7 @@ impl Footer {
                         list.push(result_active::ENTER_DEEPEN.as_hint());
                         if !state.result_interaction.staged_delete_rows().is_empty() {
                             list.push(result_active::UNSTAGE_DELETE.as_hint());
+                            list.push(result_active::CLEAR_STAGED_DELETE.as_hint());
                             list.push(cell_edit::WRITE.as_hint());
                         }
                         if state.query.can_paginate_visible_result() {


### PR DESCRIPTION
## Problem
DELETE failures left staged row deletions visible, and error messages disappeared after a short timeout.

## Background
The staged-delete flow needs to distinguish preview cancellation, successful writes, and failed writes while preserving the selected cell on failure.

## Approach
Clear staged deletions after DELETE completion or failure, keep preview cancellation behavior unchanged, and make result-scroll Esc clear the staged batch. Error messages now persist until the next user operation or another message; long Normal-mode errors use the existing footer and command-line rows.

## Linear Issue Link (optional)
- Implements https://linear.app/sabiql/issue/SAB-510

## Validation
- Focused reducer, keybinding, message-lifetime, and snapshot tests pass.
- Workspace clippy and custom lints pass.
- Workspace tests: 808 passed, 13 ignored; one pre-existing SQLite CSV missing-table test fails reproducibly.