### PR TITLE
chore: add Clippy restriction lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,9 @@ naive_bytecount = "allow"  # bytecount crate would be an unnecessary dependency
 # Restriction lints (opt-in)
 absolute_paths = "warn"
 dbg_macro = "deny"
+exit = "deny"
+get_unwrap = "deny"
+mem_forget = "deny"
 todo = "deny"
 print_stdout = "deny"
 print_stderr = "deny"


### PR DESCRIPTION
## Problem

New code could bypass normal cleanup, intentionally suppress resource destruction, or express panicking collection access in a needlessly indirect form without workspace-wide lint enforcement.

## Approach

Deny the `exit`, `mem_forget`, and `get_unwrap` Clippy restriction lints through the shared workspace policy inherited by every package.

## Linear Issue Link (optional)

- Implements https://linear.app/sabiql/issue/SAB-511
