### PR TITLE
fix(mysql): reject quoted side effects in read-only mode

### DIFF
--- a/src/app/policy/write/sql_risk.rs
+++ b/src/app/policy/write/sql_risk.rs
@@ -201,7 +201,11 @@ mod mysql_tests {
             "SELECT GET_LOCK('sabiql', 0)",
             "SELECT RELEASE_LOCK('sabiql')",
             "SELECT RELEASE_ALL_LOCKS()",
+            "SELECT `GET_LOCK`('sabiql', 0)",
+            "SELECT `RELEASE_LOCK`('sabiql')",
+            "SELECT `RELEASE_ALL_LOCKS`()",
             "SELECT LAST_INSERT_ID(42)",
+            "SELECT `LAST_INSERT_ID`(42)",
             "/*!80000 SELECT 1 */",
         ] {
             let MultiStatementDecision::Allow { risk, .. } = mysql(sql) else {

--- a/src/domain/mysql_sql/side_effect.rs
+++ b/src/domain/mysql_sql/side_effect.rs
@@ -71,37 +71,6 @@ fn has_mysql_read_only_side_effect_function(tokens: &[lexer::Token], index: usiz
         )
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn rejects_word_and_quoted_mysql_side_effect_functions() {
-        for function in ["GET_LOCK", "RELEASE_LOCK", "RELEASE_ALL_LOCKS"] {
-            for quoted in [false, true] {
-                let name = if quoted {
-                    format!("`{function}`")
-                } else {
-                    function.to_string()
-                };
-                let sql = match function {
-                    "GET_LOCK" => format!("SELECT {name}('sabiql', 0)"),
-                    "RELEASE_LOCK" => format!("SELECT {name}('sabiql')"),
-                    "RELEASE_ALL_LOCKS" => format!("SELECT {name}()"),
-                    _ => unreachable!(),
-                };
-                assert!(has_mysql_read_only_side_effect(&sql).unwrap(), "{sql}");
-            }
-        }
-    }
-
-    #[test]
-    fn rejects_mixed_case_quoted_last_insert_id_with_an_argument() {
-        assert!(has_mysql_read_only_side_effect("SELECT `Last_Insert_Id`(42)").unwrap());
-        assert!(!has_mysql_read_only_side_effect("SELECT `Last_Insert_Id`()").unwrap());
-    }
-}
-
 pub(super) fn has_mysql_version_comment(sql: &str) -> Result<bool, MySqlLexError> {
     let bytes = sql.as_bytes();
     let mut index = 0;
@@ -260,4 +229,35 @@ fn contains_mysql_client_command(sql: &str) -> bool {
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_word_and_quoted_mysql_side_effect_functions() {
+        for function in ["GET_LOCK", "RELEASE_LOCK", "RELEASE_ALL_LOCKS"] {
+            for quoted in [false, true] {
+                let name = if quoted {
+                    format!("`{function}`")
+                } else {
+                    function.to_string()
+                };
+                let sql = match function {
+                    "GET_LOCK" => format!("SELECT {name}('sabiql', 0)"),
+                    "RELEASE_LOCK" => format!("SELECT {name}('sabiql')"),
+                    "RELEASE_ALL_LOCKS" => format!("SELECT {name}()"),
+                    _ => unreachable!(),
+                };
+                assert!(has_mysql_read_only_side_effect(&sql).unwrap(), "{sql}");
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_mixed_case_quoted_last_insert_id_with_an_argument() {
+        assert!(has_mysql_read_only_side_effect("SELECT `Last_Insert_Id`(42)").unwrap());
+        assert!(!has_mysql_read_only_side_effect("SELECT `Last_Insert_Id`()").unwrap());
+    }
 }

--- a/src/domain/mysql_sql/side_effect.rs
+++ b/src/domain/mysql_sql/side_effect.rs
@@ -45,7 +45,10 @@ pub(super) fn has_mysql_read_only_side_effect(sql: &str) -> Result<bool, MySqlLe
 }
 
 fn has_mysql_read_only_side_effect_function(tokens: &[lexer::Token], index: usize) -> bool {
-    let Some(TokenKind::Word(word)) = tokens.get(index).map(|token| &token.kind) else {
+    let Some(word) = tokens.get(index).and_then(|token| match &token.kind {
+        TokenKind::Word(word) | TokenKind::Identifier(word) => Some(word.as_str()),
+        _ => None,
+    }) else {
         return false;
     };
     if !matches!(
@@ -55,13 +58,47 @@ fn has_mysql_read_only_side_effect_function(tokens: &[lexer::Token], index: usiz
         return false;
     }
 
-    match word.as_str() {
-        "GET_LOCK" | "RELEASE_LOCK" | "RELEASE_ALL_LOCKS" => true,
-        "LAST_INSERT_ID" => !matches!(
+    if ["GET_LOCK", "RELEASE_LOCK", "RELEASE_ALL_LOCKS"]
+        .iter()
+        .any(|name| word.eq_ignore_ascii_case(name))
+    {
+        return true;
+    }
+    word.eq_ignore_ascii_case("LAST_INSERT_ID")
+        && !matches!(
             tokens.get(index + 2).map(|token| &token.kind),
             Some(TokenKind::Symbol(')'))
-        ),
-        _ => false,
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_word_and_quoted_mysql_side_effect_functions() {
+        for function in ["GET_LOCK", "RELEASE_LOCK", "RELEASE_ALL_LOCKS"] {
+            for quoted in [false, true] {
+                let name = if quoted {
+                    format!("`{function}`")
+                } else {
+                    function.to_string()
+                };
+                let sql = match function {
+                    "GET_LOCK" => format!("SELECT {name}('sabiql', 0)"),
+                    "RELEASE_LOCK" => format!("SELECT {name}('sabiql')"),
+                    "RELEASE_ALL_LOCKS" => format!("SELECT {name}()"),
+                    _ => unreachable!(),
+                };
+                assert!(has_mysql_read_only_side_effect(&sql).unwrap(), "{sql}");
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_mixed_case_quoted_last_insert_id_with_an_argument() {
+        assert!(has_mysql_read_only_side_effect("SELECT `Last_Insert_Id`(42)").unwrap());
+        assert!(!has_mysql_read_only_side_effect("SELECT `Last_Insert_Id`()").unwrap());
     }
 }
 

--- a/src/infra/adapters/mysql/cli/policy.rs
+++ b/src/infra/adapters/mysql/cli/policy.rs
@@ -424,6 +424,9 @@ mod tests {
             "SELECT @value := 1",
             "SELECT value FROM items WHERE FALSE FOR UPDATE",
             "SELECT GET_LOCK('sabiql', 0) WHERE FALSE",
+            "SELECT `GET_LOCK`('sabiql', 0) WHERE FALSE",
+            "SELECT `RELEASE_LOCK`('sabiql') WHERE FALSE",
+            "SELECT `RELEASE_ALL_LOCKS`() WHERE FALSE",
             "SELECT @value := 1 WHERE FALSE",
         ] {
             assert!(
@@ -508,6 +511,26 @@ mod tests {
                 Err(DbOperationError::UnsupportedOperation(_))
             ));
             assert!(!log_file.exists(), "{query}");
+        }
+    }
+
+    #[test]
+    fn read_only_rejects_quoted_side_effect_functions_before_starting_mysql() {
+        for query in [
+            "SELECT `GET_LOCK`('sabiql', 0)",
+            "SELECT `RELEASE_LOCK`('sabiql')",
+            "SELECT `RELEASE_ALL_LOCKS`()",
+        ] {
+            let result = validate_mysql_multi_query(query, Some("app"), AccessMode::ReadOnly);
+
+            assert!(
+                matches!(
+                    result,
+                    Err(DbOperationError::PermissionDenied(details))
+                        if details.contains("read-only mode blocks MySQL write statements")
+                ),
+                "{query}"
+            );
         }
     }
 

--- a/src/infra/adapters/mysql/sql/explain.rs
+++ b/src/infra/adapters/mysql/sql/explain.rs
@@ -64,6 +64,9 @@ mod tests {
             "INSERT INTO users VALUES (1)",
             "REPLACE INTO users VALUES (1)",
             "SELECT * FROM users FOR UPDATE",
+            "SELECT `GET_LOCK`('sabiql', 0)",
+            "SELECT `RELEASE_LOCK`('sabiql')",
+            "SELECT `RELEASE_ALL_LOCKS`()",
             "SELECT 1; SELECT 2",
         ] {
             assert_eq!(build_explain_analyze_sql(query), None, "{query}");

--- a/src/tests/adapter_mysql.rs
+++ b/src/tests/adapter_mysql.rs
@@ -2627,6 +2627,45 @@ mod query_execution {
 
     #[tokio::test]
     #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
+    async fn rejects_quoted_mysql_side_effects_in_read_only_adhoc() {
+        with_mysql_test_db(|db| {
+            Box::pin(async move {
+                let acquired = db
+                    .adapter()
+                    .execute_adhoc(
+                        db.dsn(),
+                        "SELECT `GET_LOCK`('sabiql_sab_469', 0) AS acquired",
+                        AccessMode::ReadWrite,
+                    )
+                    .await
+                    .map_err(|error| format!("quoted GET_LOCK failed on Oracle MySQL: {error:?}"))?;
+                if acquired.values() != [[QueryValue::Text("1".to_string())]] {
+                    return Err(format!("unexpected quoted GET_LOCK result: {acquired:?}"));
+                }
+
+                for query in [
+                    "SELECT `GET_LOCK`('sabiql_sab_469', 0)",
+                    "SELECT `RELEASE_LOCK`('sabiql_sab_469')",
+                    "SELECT `RELEASE_ALL_LOCKS`()",
+                ] {
+                    let result = db
+                        .adapter()
+                        .execute_adhoc(db.dsn(), query, AccessMode::ReadOnly)
+                        .await;
+                    if !matches!(result, Err(DbOperationError::PermissionDenied(_))) {
+                        return Err(format!(
+                            "quoted side effect was not rejected in read-only mode: {query}: {result:?}"
+                        ));
+                    }
+                }
+                Ok(())
+            })
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Oracle MySQL 8.4 server and CLI"]
     async fn rejects_next_process_when_global_sql_mode_is_unsupported() {
         with_mysql_test_db(|db| {
             Box::pin(async move {


### PR DESCRIPTION
## Problem
Backtick-quoted MySQL side-effect functions bypassed the read-only policy because the shared detector inspected only word tokens.

## Background
MySQL accepts quoted function names such as `GET_LOCK`, so the bypass affected every entry point that relies on the shared side-effect check.

## Approach
Classify word and quoted-identifier tokens through the same case-insensitive function check, with focused coverage for adhoc policy, metadata fallback, EXPLAIN ANALYZE, and Oracle MySQL 8.4 CLI execution.

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-469/引用されたmysql副作用関数をread-only判定で拒否する