### PR TITLE
fix(postgres): preserve expression and partial index metadata (SAB-525)

### DIFF
--- a/src/infra/adapters/postgres/psql/parser/metadata.rs
+++ b/src/infra/adapters/postgres/psql/parser/metadata.rs
@@ -186,12 +186,18 @@ impl PostgresAdapter {
             return Ok(Vec::new());
         };
 
+        #[expect(
+            clippy::struct_excessive_bools,
+            reason = "PostgreSQL index flags are independent catalog fields"
+        )]
         #[derive(serde::Deserialize)]
         struct RawIndex {
             name: String,
             columns: Vec<String>,
             is_unique: bool,
             is_primary: bool,
+            is_partial: bool,
+            has_expression: bool,
             index_type: String,
             definition: Option<String>,
         }
@@ -200,15 +206,25 @@ impl PostgresAdapter {
 
         Ok(raw
             .into_iter()
-            .map(|i| Index {
-                name: i.name,
-                columns: i.columns,
-                attributes: IndexAttributes::from_parts(i.is_unique, i.is_primary),
-                index_type: match i.index_type.parse::<IndexType>() {
-                    Ok(index_type) => index_type,
-                    Err(never) => match never {},
-                },
-                definition: i.definition,
+            .map(|i| {
+                let mut attributes = IndexAttributes::from_parts(i.is_unique, i.is_primary);
+                if i.is_partial {
+                    attributes = attributes | IndexAttributes::PARTIAL;
+                }
+                if i.has_expression {
+                    attributes = attributes | IndexAttributes::EXPRESSION;
+                }
+
+                Index {
+                    name: i.name,
+                    columns: i.columns,
+                    attributes,
+                    index_type: match i.index_type.parse::<IndexType>() {
+                        Ok(index_type) => index_type,
+                        Err(never) => match never {},
+                    },
+                    definition: i.definition,
+                }
             })
             .collect())
     }
@@ -654,6 +670,8 @@ mod tests {
                 "columns": ["id"],
                 "is_unique": false,
                 "is_primary": false,
+                "is_partial": false,
+                "has_expression": false,
                 "index_type": "ivfflat",
                 "definition": null
             }]"#;
@@ -664,6 +682,97 @@ mod tests {
                 result[0].index_type,
                 IndexType::Other("ivfflat".to_string())
             );
+        }
+
+        #[test]
+        fn parse_indexes_preserves_key_order_and_metadata_attributes() {
+            let json = r#"[
+                {
+                    "name": "users_pkey",
+                    "columns": ["id"],
+                    "is_unique": true,
+                    "is_primary": true,
+                    "is_partial": false,
+                    "has_expression": false,
+                    "index_type": "btree",
+                    "definition": "CREATE UNIQUE INDEX users_pkey ON users USING btree (id)"
+                },
+                {
+                    "name": "users_tenant_email_idx",
+                    "columns": ["tenant_id", "email"],
+                    "is_unique": false,
+                    "is_primary": false,
+                    "is_partial": false,
+                    "has_expression": false,
+                    "index_type": "btree",
+                    "definition": "CREATE INDEX users_tenant_email_idx ON users USING btree (tenant_id, email)"
+                },
+                {
+                    "name": "users_lower_email_idx",
+                    "columns": ["lower(email)"],
+                    "is_unique": false,
+                    "is_primary": false,
+                    "is_partial": false,
+                    "has_expression": true,
+                    "index_type": "btree",
+                    "definition": "CREATE INDEX users_lower_email_idx ON users USING btree (lower(email))"
+                },
+                {
+                    "name": "users_active_email_idx",
+                    "columns": ["email"],
+                    "is_unique": false,
+                    "is_primary": false,
+                    "is_partial": true,
+                    "has_expression": false,
+                    "index_type": "btree",
+                    "definition": "CREATE INDEX users_active_email_idx ON users USING btree (email) WHERE active"
+                },
+                {
+                    "name": "users_active_email_key",
+                    "columns": ["email"],
+                    "is_unique": true,
+                    "is_primary": false,
+                    "is_partial": true,
+                    "has_expression": false,
+                    "index_type": "btree",
+                    "definition": "CREATE UNIQUE INDEX users_active_email_key ON users USING btree (email) WHERE active"
+                },
+                {
+                    "name": "users_tenant_lower_email_idx",
+                    "columns": ["tenant_id", "lower(email)"],
+                    "is_unique": false,
+                    "is_primary": false,
+                    "is_partial": false,
+                    "has_expression": true,
+                    "index_type": "btree",
+                    "definition": "CREATE INDEX users_tenant_lower_email_idx ON users USING btree (tenant_id, lower(email))"
+                }
+            ]"#;
+
+            let indexes = PostgresAdapter::parse_indexes(json).unwrap();
+
+            assert_eq!(indexes[0].columns, ["id"]);
+            assert!(indexes[0].is_unique());
+            assert!(indexes[0].is_primary());
+
+            assert_eq!(indexes[1].columns, ["tenant_id", "email"]);
+            assert!(!indexes[1].has_expression());
+
+            assert_eq!(indexes[2].columns, ["lower(email)"]);
+            assert!(indexes[2].has_expression());
+            assert_eq!(
+                indexes[2].definition.as_deref(),
+                Some("CREATE INDEX users_lower_email_idx ON users USING btree (lower(email))")
+            );
+
+            assert!(indexes[3].is_partial());
+            assert!(!indexes[3].is_unique());
+
+            assert!(indexes[4].is_partial());
+            assert!(indexes[4].is_unique());
+
+            assert_eq!(indexes[5].columns, ["tenant_id", "lower(email)"]);
+            assert!(indexes[5].has_expression());
         }
 
         #[test]

--- a/src/infra/adapters/postgres/sql/query.rs
+++ b/src/infra/adapters/postgres/sql/query.rs
@@ -118,6 +118,8 @@ impl PostgresAdapter {
                         WHERE i.indrelid = cl.oid
                           AND i.indisunique
                           AND NOT i.indisprimary
+                          AND i.indpred IS NULL
+                          AND i.indexprs IS NULL
                           AND array_length(i.indkey, 1) = 1
                           AND a.attnum = ANY(i.indkey)
                     ) as is_unique,
@@ -193,9 +195,11 @@ impl PostgresAdapter {
             FROM (
                 SELECT
                     idx.relname as name,
-                    array_agg(a.attname ORDER BY array_position(ix.indkey, a.attnum)) as columns,
+                    array_agg(key_part.column_name ORDER BY key_part.key_position) as columns,
                     ix.indisunique as is_unique,
                     ix.indisprimary as is_primary,
+                    bool_or(ix.indpred IS NOT NULL) as is_partial,
+                    bool_or(ix.indexprs IS NOT NULL) as has_expression,
                     am.amname as index_type,
                     pg_get_indexdef(idx.oid) as definition
                 FROM pg_index ix
@@ -203,7 +207,17 @@ impl PostgresAdapter {
                 JOIN pg_class tbl ON tbl.oid = ix.indrelid
                 JOIN pg_namespace n ON n.oid = tbl.relnamespace
                 JOIN pg_am am ON am.oid = idx.relam
-                JOIN pg_attribute a ON a.attrelid = tbl.oid AND a.attnum = ANY(ix.indkey)
+                JOIN LATERAL (
+                    SELECT
+                        key_part.key_position,
+                        CASE
+                            WHEN key_part.attnum > 0 THEN a.attname
+                            ELSE pg_get_indexdef(idx.oid, key_part.key_position::integer, true)
+                        END as column_name
+                    FROM unnest(ix.indkey) WITH ORDINALITY AS key_part(attnum, key_position)
+                    LEFT JOIN pg_attribute a
+                        ON a.attrelid = tbl.oid AND a.attnum = key_part.attnum
+                ) key_part ON TRUE
                 WHERE n.nspname = {}
                   AND tbl.relname = {}
                 GROUP BY idx.relname, ix.indisunique, ix.indisprimary, am.amname, idx.oid
@@ -509,6 +523,29 @@ mod tests {
                 sql,
                 "SELECT * FROM \"public\".\"users\" ORDER BY \"my\"\"col\" LIMIT 100 OFFSET 0"
             );
+        }
+    }
+
+    mod index_metadata_queries {
+        use super::*;
+
+        #[test]
+        fn indexes_query_expands_key_parts_in_server_order() {
+            let sql = PostgresAdapter::indexes_query("public", "users");
+
+            assert!(sql.contains("unnest(ix.indkey) WITH ORDINALITY"));
+            assert!(sql.contains("pg_get_indexdef(idx.oid, key_part.key_position::integer, true)"));
+            assert!(sql.contains("array_agg(key_part.column_name ORDER BY key_part.key_position)"));
+            assert!(sql.contains("bool_or(ix.indpred IS NOT NULL) as is_partial"));
+            assert!(sql.contains("bool_or(ix.indexprs IS NOT NULL) as has_expression"));
+        }
+
+        #[test]
+        fn columns_query_excludes_partial_and_expression_indexes_from_unique_columns() {
+            let sql = PostgresAdapter::columns_query("public", "users");
+
+            assert!(sql.contains("AND i.indpred IS NULL"));
+            assert!(sql.contains("AND i.indexprs IS NULL"));
         }
     }
 


### PR DESCRIPTION
## Summary

- Preserve PostgreSQL expression and partial index metadata in Inspector.
- Expand index key parts with server ordering and PostgreSQL definitions.
- Exclude partial and expression indexes from column-wide UNIQUE detection.

Root cause: the metadata query inner-joined `pg_attribute`, so expression keys with attribute number 0 were dropped before aggregation. Partial and expression catalog fields were also not passed to the parser.

Linear: https://linear.app/sabiql/issue/SAB-525

## Validation

- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-sab-525-target cargo test -p sabiql-infra adapters::postgres::sql::query`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-sab-525-target cargo test -p sabiql-infra adapters::postgres::psql::parser::metadata`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-sab-525-target cargo clippy -p sabiql-infra --lib --tests -- -D warnings`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR=/private/tmp/sabiql-sab-525-target cargo fmt --all -- --check`
- `RUSTC_WRAPPER= CARGO_TARGET_DIR= bash scripts/lint_all.sh`
