### PR TITLE
fix: prefetch all tables after ER refresh failure (SAB-512)

### DIFF
--- a/src/app/model/er_state.rs
+++ b/src/app/model/er_state.rs
@@ -246,14 +246,6 @@ impl ErPreparationState {
         self.total_tables = total_tables;
     }
 
-    pub fn scoped_fallback_tables(&self, total_table_count: usize) -> Option<Vec<String>> {
-        if !self.target_tables.is_empty() && self.target_tables.len() < total_table_count {
-            Some(self.target_tables.clone())
-        } else {
-            None
-        }
-    }
-
     fn clear_table_tracking(&mut self) {
         self.pending_tables.clear();
         self.fetching_tables.clear();

--- a/src/app/update/er/mod.rs
+++ b/src/app/update/er/mod.rs
@@ -551,48 +551,6 @@ mod tests {
         }
 
         #[test]
-        fn falls_back_to_scoped_prefetch_when_targets_set() {
-            let mut state = state_with_dsn("postgres://localhost/test");
-            set_active_run_id(&mut state, 1);
-            state.er_preparation.mark_waiting_for_test();
-            state.session.set_metadata(Some(make_metadata(10)));
-            state
-                .er_preparation
-                .set_targets(vec!["public.t0".to_string()]);
-
-            let effects = reduce_er(
-                &mut state,
-                &Action::SmartErRefreshFailed(SmartErRefreshError {
-                    dsn: "postgres://localhost/test".to_string(),
-                    run_id: 1,
-                    error: DbOperationError::Timeout("timed out".to_string()),
-                    new_metadata: None,
-                }),
-                Instant::now(),
-            )
-            .unwrap();
-
-            assert!(
-                effects
-                    .iter()
-                    .any(|e| matches!(e, Effect::ClearCompletionEngineCache))
-            );
-            assert!(effects.iter().any(|e| matches!(
-                e,
-                Effect::DispatchActions(actions)
-                    if actions.iter().any(|a| matches!(a, Action::StartPrefetchScoped { .. }))
-            )));
-            assert!(state.er_preparation.last_signatures().is_empty());
-            assert!(
-                state
-                    .messages
-                    .last_error
-                    .as_deref()
-                    .is_some_and(|message| message.contains("falling back to scoped prefetch"))
-            );
-        }
-
-        #[test]
         fn mismatched_run_id_returns_empty_for_failed() {
             let mut state = state_with_dsn("postgres://localhost/test");
             set_active_run_id(&mut state, 5);

--- a/src/app/update/er/smart_refresh_failed.rs
+++ b/src/app/update/er/smart_refresh_failed.rs
@@ -33,34 +33,18 @@ pub(super) fn reduce_smart_refresh_failed(
                     .set_error_at("Metadata not loaded yet".to_string(), now);
                 return DispatchResult::handled();
             };
-            let scoped_tables = state
-                .er_preparation
-                .scoped_fallback_tables(metadata.table_summaries.len());
             state
                 .er_preparation
                 .invalidate_refresh_signatures(metadata.table_summaries.len());
 
-            if let Some(scoped_tables) = scoped_tables {
-                state.messages.set_error_at(
-                    format!("Smart refresh failed ({error}), falling back to scoped prefetch"),
-                    now,
-                );
-                DispatchResult::handled_with(vec![
-                    Effect::ClearCompletionEngineCache,
-                    Effect::DispatchActions(vec![Action::StartPrefetchScoped {
-                        tables: scoped_tables,
-                    }]),
-                ])
-            } else {
-                state.messages.set_error_at(
-                    format!("Smart refresh failed ({error}), falling back to full refresh"),
-                    now,
-                );
-                DispatchResult::handled_with(vec![
-                    Effect::ClearCompletionEngineCache,
-                    Effect::DispatchActions(vec![Action::StartPrefetchAll]),
-                ])
-            }
+            state.messages.set_error_at(
+                format!("Smart refresh failed ({error}), falling back to full refresh"),
+                now,
+            );
+            DispatchResult::handled_with(vec![
+                Effect::ClearCompletionEngineCache,
+                Effect::DispatchActions(vec![Action::StartPrefetchAll]),
+            ])
         }
         _ => DispatchResult::pass(),
     }

--- a/src/app/update/reducer.rs
+++ b/src/app/update/reducer.rs
@@ -205,7 +205,7 @@ mod tests {
     use crate::ports::outbound::DbOperationError;
     use crate::ports::outbound::connection_store::ConnectionStoreError;
     use crate::update::action::ModalKind;
-    use crate::update::action::{ConnectionSaveError, ConnectionTarget};
+    use crate::update::action::{ConnectionSaveError, ConnectionTarget, SmartErRefreshError};
     use crate::update::action::{InputTarget, SelectMotion};
     use crate::update::test_fixtures;
     fn create_test_state() -> AppState {
@@ -2997,6 +2997,44 @@ mod tests {
                 state.er_preparation.target_tables(),
                 vec!["public.users".to_string()]
             );
+        }
+
+        #[test]
+        fn failed_refresh_prefetches_source_and_selected_tables() {
+            let mut state = state_with_metadata();
+            state
+                .er_preparation
+                .set_targets(vec!["public.users".to_string()]);
+            let run_id = state.er_preparation.start_waiting_run();
+
+            let effects = reduce(
+                &mut state,
+                Action::SmartErRefreshFailed(SmartErRefreshError {
+                    dsn: "postgres://localhost/test".to_string(),
+                    run_id,
+                    error: DbOperationError::Timeout("timed out".to_string()),
+                    new_metadata: None,
+                }),
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(effects.iter().any(|effect| matches!(
+                effect,
+                Effect::DispatchActions(actions)
+                    if actions.iter().any(|action| matches!(action, Action::StartPrefetchAll))
+            )));
+
+            reduce(
+                &mut state,
+                Action::StartPrefetchAll,
+                Instant::now(),
+                &AppServices::stub(),
+            );
+
+            assert!(state.sql_modal.is_prefetch_queued("public.users"));
+            assert!(state.sql_modal.is_prefetch_queued("public.posts"));
+            assert!(state.er_preparation.fk_expanded());
         }
 
         #[test]


### PR DESCRIPTION
## Summary

- Fall back to full table prefetch after ER smart refresh failures so partial diagrams retain both incoming and outgoing FK neighbors.
- Remove the fallback-only scoped table selection.
- Add a reducer regression covering a selected public.users table and its public.posts source table.

## Validation

- Focused sabiql-app reducer and ER refresh tests
- Focused sabiql-domain ER reachability tests
- cargo fmt --all -- --check
- cargo clippy -p sabiql-app --lib --all-targets -- -D warnings
- bash scripts/lint_all.sh

Linear: https://linear.app/sabiql/issue/SAB-512