### PR TITLE
fix(mysql): prevent cancelled connection saves (SAB-487)

### DIFF
--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -24,27 +24,17 @@ use crate::update::action::{
     Action, ConnectionSaveError, ConnectionTarget, ConnectionsLoadedPayload,
 };
 
-fn claim_save_run(run_guard: &ConnectionSaveGuard, run_id: u64) -> bool {
-    run_guard.claim(run_id)
-}
-
-fn save_if_claimed<T>(
-    run_guard: &ConnectionSaveGuard,
-    run_id: u64,
-    save: impl FnOnce() -> T,
-) -> Option<T> {
-    run_guard.save_if_claimed(run_id, save)
-}
-
 fn claim_and_save<T>(
     run_guard: &ConnectionSaveGuard,
     run_id: u64,
     save: impl FnOnce() -> T,
 ) -> Option<T> {
-    if !claim_save_run(run_guard, run_id) {
+    if !run_guard.claim(run_id) || !run_guard.start_save(run_id) {
         return None;
     }
-    save_if_claimed(run_guard, run_id, save)
+    let result = save();
+    run_guard.finish_save(run_id);
+    Some(result)
 }
 
 pub(crate) async fn run(
@@ -456,7 +446,6 @@ mod tests {
 
     mod save_connection {
         use super::*;
-        use crate::cmd::connection::{claim_save_run, save_if_claimed};
         use mockall::predicate::eq;
         use std::fs;
         use tempfile::tempdir;
@@ -687,13 +676,25 @@ mod tests {
         #[test]
         fn cancel_after_claim_prevents_save_from_starting() {
             let run_guard = active_run_guard(1);
-            let mut save_started = false;
 
-            assert!(claim_save_run(&run_guard, 1));
+            assert!(run_guard.claim(1));
 
             run_guard.cancel();
-            assert!(save_if_claimed(&run_guard, 1, || save_started = true).is_none());
-            assert!(!save_started);
+            assert!(!run_guard.start_save(1));
+        }
+
+        #[test]
+        fn finishing_cancelled_save_does_not_clear_new_run() {
+            let run_guard = active_run_guard(1);
+
+            assert!(run_guard.claim(1));
+            assert!(run_guard.start_save(1));
+
+            run_guard.cancel();
+            run_guard.start(2);
+            run_guard.finish_save(1);
+
+            assert!(run_guard.claim(2));
         }
 
         #[tokio::test]

--- a/src/app/cmd/connection.rs
+++ b/src/app/cmd/connection.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use color_eyre::eyre::Result;
 use tokio::sync::mpsc;
@@ -17,6 +16,7 @@ use crate::domain::connection::{
     SqliteConnectionConfig,
 };
 use crate::model::app_state::AppState;
+use crate::model::browse::session::ConnectionSaveGuard;
 use crate::ports::outbound::{
     ConnectionStoreError, MetadataProvider, ServiceFileError, SqlitePathValidator,
 };
@@ -24,10 +24,27 @@ use crate::update::action::{
     Action, ConnectionSaveError, ConnectionTarget, ConnectionsLoadedPayload,
 };
 
-fn claim_save_run(run_guard: &AtomicU64, run_id: u64) -> bool {
-    run_guard
-        .compare_exchange(run_id, 0, Ordering::AcqRel, Ordering::Acquire)
-        .is_ok()
+fn claim_save_run(run_guard: &ConnectionSaveGuard, run_id: u64) -> bool {
+    run_guard.claim(run_id)
+}
+
+fn save_if_claimed<T>(
+    run_guard: &ConnectionSaveGuard,
+    run_id: u64,
+    save: impl FnOnce() -> T,
+) -> Option<T> {
+    run_guard.save_if_claimed(run_id, save)
+}
+
+fn claim_and_save<T>(
+    run_guard: &ConnectionSaveGuard,
+    run_id: u64,
+    save: impl FnOnce() -> T,
+) -> Option<T> {
+    if !claim_save_run(run_guard, run_id) {
+        return None;
+    }
+    save_if_claimed(run_guard, run_id, save)
 }
 
 pub(crate) async fn run(
@@ -92,11 +109,8 @@ pub(crate) async fn run(
                 let database_type = profile.database_type();
 
                 tokio::task::spawn_blocking(move || {
-                    if !claim_save_run(&run_guard, run_id) {
-                        return;
-                    }
-                    match store.save(&profile) {
-                        Ok(()) => {
+                    match claim_and_save(&run_guard, run_id, || store.save(&profile)) {
+                        Some(Ok(())) => {
                             tx.blocking_send(Action::ConnectionSaveCompleted {
                                 target: ConnectionTarget {
                                     id,
@@ -109,7 +123,7 @@ pub(crate) async fn run(
                             })
                             .ok();
                         }
-                        Err(e) => {
+                        Some(Err(e)) => {
                             tx.blocking_send(Action::ConnectionSaveFailed {
                                 error: e.into(),
                                 database_type,
@@ -117,6 +131,7 @@ pub(crate) async fn run(
                             })
                             .ok();
                         }
+                        None => {}
                     }
                 });
                 return Ok(());
@@ -143,7 +158,7 @@ pub(crate) async fn run(
                     match probe.probe(&target.dsn).await {
                         Ok(()) => {
                             let save_result = tokio::task::spawn_blocking(move || {
-                                claim_save_run(&run_guard, run_id).then(|| store.save(&profile))
+                                claim_and_save(&run_guard, run_id, || store.save(&profile))
                             })
                             .await
                             .expect("connection store save task panicked");
@@ -189,7 +204,7 @@ pub(crate) async fn run(
                     Ok(metadata) => {
                         cache.set(dsn.clone(), Arc::new(metadata)).await;
                         let save_result = tokio::task::spawn_blocking(move || {
-                            claim_save_run(&run_guard, run_id).then(|| store.save(&profile))
+                            claim_and_save(&run_guard, run_id, || store.save(&profile))
                         })
                         .await
                         .expect("connection store save task panicked");
@@ -414,6 +429,7 @@ mod tests {
         MySqlConnectionConfig, MySqlSslMode, SqliteConnectionConfig, SqlitePathError, SslMode,
     };
     use crate::model::app_state::AppState;
+    use crate::model::browse::session::ConnectionSaveGuard;
     use crate::ports::outbound::connection_store::MockConnectionStore;
     use crate::ports::outbound::metadata::MockMetadataProvider;
     use crate::ports::outbound::mysql_connection_probe::MockMySqlConnectionProbe;
@@ -440,9 +456,9 @@ mod tests {
 
     mod save_connection {
         use super::*;
+        use crate::cmd::connection::{claim_save_run, save_if_claimed};
         use mockall::predicate::eq;
         use std::fs;
-        use std::sync::atomic::{AtomicU64, Ordering};
         use tempfile::tempdir;
 
         struct SqliteDsnBuilder;
@@ -476,6 +492,12 @@ mod tests {
                 "secret",
                 MySqlSslMode::Required,
             ))
+        }
+
+        fn active_run_guard(run_id: u64) -> Arc<ConnectionSaveGuard> {
+            let guard = Arc::new(ConnectionSaveGuard::default());
+            guard.start(run_id);
+            guard
         }
 
         #[tokio::test]
@@ -519,7 +541,7 @@ mod tests {
                         name: "MySQL".to_string(),
                         config: mysql_config(Some("app")),
                         run_id: 1,
-                        run_guard: Arc::new(AtomicU64::new(1)),
+                        run_guard: active_run_guard(1),
                     }],
                     &mut renderer,
                     &mut state,
@@ -583,7 +605,7 @@ mod tests {
                         name: "MySQL".to_string(),
                         config: mysql_config(None),
                         run_id: 1,
-                        run_guard: Arc::new(AtomicU64::new(1)),
+                        run_guard: active_run_guard(1),
                     }],
                     &mut renderer,
                     &mut state,
@@ -610,7 +632,7 @@ mod tests {
         #[tokio::test]
         async fn mysql_profile_is_not_saved_when_run_is_cancelled_after_probe() {
             let dsn = "mysql://user:secret@localhost:3306/app?ssl-mode=REQUIRED";
-            let run_guard = Arc::new(AtomicU64::new(1));
+            let run_guard = active_run_guard(1);
             let guard_for_probe = Arc::clone(&run_guard);
             let mut probe = MockMySqlConnectionProbe::new();
             probe
@@ -618,7 +640,7 @@ mod tests {
                 .with(eq(dsn.to_string()))
                 .once()
                 .returning(move |_| {
-                    guard_for_probe.store(0, Ordering::Release);
+                    guard_for_probe.cancel();
                     Ok(())
                 });
 
@@ -660,6 +682,18 @@ mod tests {
                     .await
                     .is_err()
             );
+        }
+
+        #[test]
+        fn cancel_after_claim_prevents_save_from_starting() {
+            let run_guard = active_run_guard(1);
+            let mut save_started = false;
+
+            assert!(claim_save_run(&run_guard, 1));
+
+            run_guard.cancel();
+            assert!(save_if_claimed(&run_guard, 1, || save_started = true).is_none());
+            assert!(!save_started);
         }
 
         #[tokio::test]
@@ -707,7 +741,7 @@ mod tests {
                             SqliteConnectionConfig::new(input_path).unwrap(),
                         ),
                         run_id: 1,
-                        run_guard: Arc::new(AtomicU64::new(1)),
+                        run_guard: active_run_guard(1),
                     }],
                     &mut renderer,
                     state,
@@ -766,7 +800,7 @@ mod tests {
                             SqliteConnectionConfig::new(path_str).unwrap(),
                         ),
                         run_id: 1,
-                        run_guard: Arc::new(AtomicU64::new(1)),
+                        run_guard: active_run_guard(1),
                     }],
                     &mut renderer,
                     state,

--- a/src/app/cmd/effect.rs
+++ b/src/app/cmd/effect.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
-use std::sync::atomic::AtomicU64;
 
 use crate::domain::connection::{ConnectionConfig, ConnectionId, DatabaseType};
 use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{QueryValue, Table};
+use crate::model::browse::session::ConnectionSaveGuard;
 use crate::ports::outbound::{AccessMode, AppSettings};
 use crate::update::action::{Action, ConnectionTarget};
 
@@ -16,7 +16,7 @@ pub enum Effect {
         name: String,
         config: ConnectionConfig,
         run_id: u64,
-        run_guard: Arc<AtomicU64>,
+        run_guard: Arc<ConnectionSaveGuard>,
     },
     ProbeMySqlConnection {
         target: ConnectionTarget,

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
 
 use crate::domain::query_history::QueryHistoryScope;
 use crate::domain::{
@@ -15,6 +15,49 @@ use crate::model::shared::async_run::AsyncRun;
 use crate::model::shared::engine_feature_profile::EngineFeatureProfile;
 use crate::model::shared::inspector_tab::InspectorTab;
 use crate::policy::mask_password;
+
+#[derive(Debug, Default)]
+pub struct ConnectionSaveGuard {
+    state: Mutex<ConnectionSaveState>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+enum ConnectionSaveState {
+    #[default]
+    Idle,
+    Active(u64),
+    Claimed(u64),
+}
+
+impl ConnectionSaveGuard {
+    pub(crate) fn start(&self, run_id: u64) {
+        *self.state.lock().expect("connection save guard poisoned") =
+            ConnectionSaveState::Active(run_id);
+    }
+
+    pub(crate) fn cancel(&self) {
+        *self.state.lock().expect("connection save guard poisoned") = ConnectionSaveState::Idle;
+    }
+
+    pub(crate) fn claim(&self, run_id: u64) -> bool {
+        let mut state = self.state.lock().expect("connection save guard poisoned");
+        if *state != ConnectionSaveState::Active(run_id) {
+            return false;
+        }
+        *state = ConnectionSaveState::Claimed(run_id);
+        true
+    }
+
+    pub(crate) fn save_if_claimed<T>(&self, run_id: u64, save: impl FnOnce() -> T) -> Option<T> {
+        let mut state = self.state.lock().expect("connection save guard poisoned");
+        if *state != ConnectionSaveState::Claimed(run_id) {
+            return None;
+        }
+        let result = save();
+        *state = ConnectionSaveState::Idle;
+        Some(result)
+    }
+}
 
 #[derive(Debug, Clone)]
 struct ActiveConnection {
@@ -100,7 +143,7 @@ pub struct BrowseSession {
     effective_user_run: AsyncRun,
     table_detail_run: AsyncRun,
     connection_save_run: AsyncRun,
-    connection_save_guard: Arc<AtomicU64>,
+    connection_save_guard: Arc<ConnectionSaveGuard>,
 
     // -- co-dependent: connection identity / lifecycle --
     dsn: Option<String>,
@@ -129,7 +172,7 @@ impl Default for BrowseSession {
             effective_user_run: AsyncRun::default(),
             table_detail_run: AsyncRun::default(),
             connection_save_run: AsyncRun::default(),
-            connection_save_guard: Arc::new(AtomicU64::new(0)),
+            connection_save_guard: Arc::new(ConnectionSaveGuard::default()),
             dsn: None,
             active_connection: None,
             mysql_connection_probe_run: AsyncRun::default(),
@@ -261,7 +304,7 @@ impl BrowseSession {
     #[must_use]
     pub fn begin_connection_save(&mut self) -> u64 {
         let run_id = self.connection_save_run.begin();
-        self.connection_save_guard.store(run_id, Ordering::Release);
+        self.connection_save_guard.start(run_id);
         run_id
     }
 
@@ -270,8 +313,8 @@ impl BrowseSession {
     }
 
     pub fn cancel_connection_save(&mut self) {
+        self.connection_save_guard.cancel();
         self.connection_save_run.clear_active();
-        self.connection_save_guard.store(0, Ordering::Release);
     }
 
     pub fn cancel_connection_save_and_disconnect(&mut self) {
@@ -281,7 +324,7 @@ impl BrowseSession {
         }
     }
 
-    pub fn connection_save_guard(&self) -> Arc<AtomicU64> {
+    pub fn connection_save_guard(&self) -> Arc<ConnectionSaveGuard> {
         Arc::clone(&self.connection_save_guard)
     }
 

--- a/src/app/model/browse/session.rs
+++ b/src/app/model/browse/session.rs
@@ -27,6 +27,7 @@ enum ConnectionSaveState {
     Idle,
     Active(u64),
     Claimed(u64),
+    Saving(u64),
 }
 
 impl ConnectionSaveGuard {
@@ -48,14 +49,20 @@ impl ConnectionSaveGuard {
         true
     }
 
-    pub(crate) fn save_if_claimed<T>(&self, run_id: u64, save: impl FnOnce() -> T) -> Option<T> {
+    pub(crate) fn start_save(&self, run_id: u64) -> bool {
         let mut state = self.state.lock().expect("connection save guard poisoned");
         if *state != ConnectionSaveState::Claimed(run_id) {
-            return None;
+            return false;
         }
-        let result = save();
-        *state = ConnectionSaveState::Idle;
-        Some(result)
+        *state = ConnectionSaveState::Saving(run_id);
+        true
+    }
+
+    pub(crate) fn finish_save(&self, run_id: u64) {
+        let mut state = self.state.lock().expect("connection save guard poisoned");
+        if *state == ConnectionSaveState::Saving(run_id) {
+            *state = ConnectionSaveState::Idle;
+        }
     }
 }
 


### PR DESCRIPTION
## Problem
A connection save could persist a profile after cancellation when cancellation arrived after the run claim but before `store.save` began.

## Background
The existing guard only covered cancellation before the claim; the 2026-08-17 SAB-487 re-audit identified the claim-to-save race.

## Approach
Serialize the save guard through active, claimed, and saving states. Cancellation invalidates a claimed run before persistence, while an already-started save keeps the guard held until it finishes. Add a deterministic regression test for claim, cancellation, and save ordering.

## Linear Issue Link (optional)

- Implements https://linear.app/sabiql/issue/SAB-487