### PR TITLE
test(mysql): remove redundant metadata absence assertion

### DIFF
--- a/src/infra/adapters/mysql/sql/metadata.rs
+++ b/src/infra/adapters/mysql/sql/metadata.rs
@@ -341,22 +341,6 @@ mod tests {
             "SELECT kcu.CONSTRAINT_NAME, kcu.TABLE_SCHEMA, kcu.TABLE_NAME, kcu.COLUMN_NAME, kcu.REFERENCED_TABLE_SCHEMA, kcu.REFERENCED_TABLE_NAME, kcu.REFERENCED_COLUMN_NAME, kcu.ORDINAL_POSITION, rc.UPDATE_RULE, rc.DELETE_RULE FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS kcu ON kcu.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND kcu.TABLE_SCHEMA = tc.TABLE_SCHEMA AND kcu.TABLE_NAME = tc.TABLE_NAME AND kcu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME INNER JOIN INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS rc ON rc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA AND rc.TABLE_NAME = tc.TABLE_NAME AND rc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME WHERE tc.CONSTRAINT_SCHEMA = DATABASE() AND tc.TABLE_SCHEMA = DATABASE() AND tc.CONSTRAINT_TYPE = 'FOREIGN KEY' ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION"
         );
 
-        for query in [
-            TABLES_QUERY,
-            SIGNATURE_COLUMNS_QUERY,
-            SIGNATURE_UNIQUE_COLUMNS_QUERY,
-            SIGNATURE_FOREIGN_KEYS_QUERY,
-            table_sql.as_str(),
-            columns_sql.as_str(),
-            preview_columns_sql.as_str(),
-            unique_columns_sql.as_str(),
-            foreign_keys_sql.as_str(),
-            indexes_sql.as_str(),
-            triggers_sql.as_str(),
-        ] {
-            assert!(!query.contains("UNION ALL SELECT NULL"));
-        }
-
         assert_eq!(
             TABLES_RESULT_COLUMNS,
             &[


### PR DESCRIPTION
## Problem

The MySQL metadata SQL test still contains an absence-only assertion for the removed `UNION ALL SELECT NULL` sentinel.

## Background

The same test already protects each metadata query with full-string equality, so the loop duplicates coverage without adding a distinct guarantee.

## Approach

Delete only the redundant absence-only loop. Production SQL, positive full-SQL equality, expected-columns behavior, metadata send order, and empty-columns fail-closed coverage remain unchanged.

## Checks

- `CARGO_TARGET_DIR=target-sab-501 RUSTC_WRAPPER= cargo test -p sabiql-infra metadata_queries_escape_literals_and_preserve_scope_conditions`
- `CARGO_TARGET_DIR=target-sab-501 RUSTC_WRAPPER= cargo clippy -p sabiql-infra --lib --tests --all-features -- -D warnings`
- `CARGO_TARGET_DIR=target-sab-501 RUSTC_WRAPPER= cargo fmt --all -- --check`
- `env -u CARGO_TARGET_DIR RUSTC_WRAPPER= bash scripts/lint_all.sh`

## Linear Issue Link

- Implements https://linear.app/sabiql/issue/SAB-501/mysqlsqliteの削除済み実装を固定する重複testを整理する
