### PR TITLE
fix(SAB-155): bind EXPLAIN ANALYZE to Ctrl+Shift+E

### DIFF
--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -6,8 +6,8 @@ use crate::update::action::{
     Action, InputTarget, ModalKind, ScrollAmount, ScrollDirection, ScrollTarget,
 };
 use crate::update::input::keybindings::{
-    Key, KeyCombo, Modifiers, sql_modal_compare_explain, sql_modal_normal_query_history,
-    sql_modal_plan, sql_modal_plan_explain,
+    Key, KeyCombo, Modifiers, sql_modal_compare, sql_modal_compare_explain,
+    sql_modal_normal_query_history, sql_modal_plan, sql_modal_plan_explain,
 };
 use crate::update::input::vim::{
     SqlModalVimContext, VimSurfaceContext, action_for_input, action_for_key,
@@ -82,7 +82,11 @@ fn handle_sql_modal_keys_internal(
             SqlModalTab::Compare => sql_modal_compare_explain(keymap_preset),
             SqlModalTab::Sql | SqlModalTab::Plan => sql_modal_plan_explain(keymap_preset),
         };
-        let analyze_binding_matches = sql_modal_plan::ANALYZE.combos.contains(&combo);
+        let analyze_binding = match active_tab {
+            SqlModalTab::Compare => &sql_modal_compare::ANALYZE,
+            SqlModalTab::Sql | SqlModalTab::Plan => &sql_modal_plan::ANALYZE,
+        };
+        let analyze_binding_matches = analyze_binding.combos.contains(&combo);
         if explain_binding.combos.contains(&combo)
             && feature_policy.is_enabled(explain_binding.feature_requirement())
         {

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -59,6 +59,7 @@ fn handle_sql_modal_keys_internal(
         let ctrl = combo.modifiers.contains(Modifiers::CTRL);
         let alt = combo.modifiers.contains(Modifiers::ALT);
         let shift = combo.modifiers.contains(Modifiers::SHIFT);
+        let ctrl_shift = combo.modifiers == Modifiers::CTRL_SHIFT;
         let plain = !ctrl && !alt && !shift;
 
         if let Some(prefix) = pending_prefix {
@@ -108,7 +109,9 @@ fn handle_sql_modal_keys_internal(
             }
 
             return match combo.key {
-                Key::Char('e') if alt && supports_explain_analyze => Action::ExplainAnalyzeRequest,
+                Key::Char('e') if ctrl_shift && supports_explain_analyze => {
+                    Action::ExplainAnalyzeRequest
+                }
                 _ => Action::None,
             };
         }
@@ -123,7 +126,9 @@ fn handle_sql_modal_keys_internal(
             }
 
             return match combo.key {
-                Key::Char('e') if alt && supports_explain_analyze => Action::ExplainAnalyzeRequest,
+                Key::Char('e') if ctrl_shift && supports_explain_analyze => {
+                    Action::ExplainAnalyzeRequest
+                }
                 Key::Char('e')
                     if plain && feature_policy.is_enabled(FeatureRequirement::PlanComparison) =>
                 {
@@ -133,7 +138,7 @@ fn handle_sql_modal_keys_internal(
             };
         }
 
-        if alt && combo.key == Key::Char('e') && supports_explain_analyze {
+        if ctrl_shift && combo.key == Key::Char('e') && supports_explain_analyze {
             return Action::ExplainAnalyzeRequest;
         }
         if sql_modal_normal_query_history(keymap_preset)
@@ -296,6 +301,7 @@ fn handle_sql_modal_keys_internal(
     let ctrl = combo.modifiers.contains(Modifiers::CTRL);
     let alt = combo.modifiers.contains(Modifiers::ALT);
     let shift = combo.modifiers.contains(Modifiers::SHIFT);
+    let ctrl_shift = combo.modifiers == Modifiers::CTRL_SHIFT;
     let ctrl_only = ctrl && !alt && !shift;
 
     let plain = !ctrl && !alt && !shift;
@@ -320,7 +326,7 @@ fn handle_sql_modal_keys_internal(
         return Action::SqlModalClear;
     }
 
-    if alt && combo.key == Key::Char('e') {
+    if ctrl_shift && combo.key == Key::Char('e') {
         return if supports_explain_analyze {
             Action::ExplainAnalyzeRequest
         } else {
@@ -407,6 +413,10 @@ mod tests {
 
     fn combo_alt(k: Key) -> KeyCombo {
         KeyCombo::alt(k)
+    }
+
+    fn combo_ctrl_shift(k: Key) -> KeyCombo {
+        KeyCombo::ctrl_shift(k)
     }
 
     fn handle_sql_modal_keys(
@@ -1211,9 +1221,9 @@ mod tests {
         }
 
         #[test]
-        fn alt_e_requests_explain_analyze() {
+        fn ctrl_shift_e_requests_explain_analyze() {
             let result = handle_sql_modal_keys(
-                combo_alt(Key::Char('e')),
+                combo_ctrl_shift(Key::Char('e')),
                 false,
                 &SqlModalStatus::Normal,
                 SqlModalTab::Sql,
@@ -1384,9 +1394,9 @@ mod tests {
         #[rstest]
         #[case(SqlModalTab::Plan)]
         #[case(SqlModalTab::Compare)]
-        fn alt_e_requests_analyze(#[case] tab: SqlModalTab) {
+        fn ctrl_shift_e_requests_analyze(#[case] tab: SqlModalTab) {
             let result = handle_sql_modal_keys(
-                combo_alt(Key::Char('e')),
+                combo_ctrl_shift(Key::Char('e')),
                 false,
                 &SqlModalStatus::Normal,
                 tab,
@@ -1407,11 +1417,13 @@ mod tests {
             assert_action(result, Expected::CompareEditQuery);
         }
 
-        #[test]
-        fn editing_alt_e_requests_analyze() {
+        #[rstest]
+        #[case(false)]
+        #[case(true)]
+        fn editing_ctrl_shift_e_requests_analyze(#[case] completion_visible: bool) {
             let result = handle_sql_modal_keys(
-                combo_alt(Key::Char('e')),
-                false,
+                combo_ctrl_shift(Key::Char('e')),
+                completion_visible,
                 &SqlModalStatus::Editing,
                 SqlModalTab::Sql,
             );
@@ -1420,9 +1432,9 @@ mod tests {
         }
 
         #[test]
-        fn editing_alt_e_is_noop_when_analyze_is_unsupported() {
+        fn editing_ctrl_shift_e_is_noop_when_analyze_is_unsupported() {
             let result = handle_sql_modal_keys_with_prefix(
-                combo_alt(Key::Char('e')),
+                combo_ctrl_shift(Key::Char('e')),
                 false,
                 &SqlModalStatus::Editing,
                 SqlModalTab::Sql,
@@ -1437,9 +1449,9 @@ mod tests {
         #[rstest]
         #[case(SqlModalTab::Plan)]
         #[case(SqlModalTab::Compare)]
-        fn alt_e_is_noop_when_analyze_is_unsupported(#[case] tab: SqlModalTab) {
+        fn ctrl_shift_e_is_noop_when_analyze_is_unsupported(#[case] tab: SqlModalTab) {
             let result = handle_sql_modal_keys_with_prefix(
-                combo_alt(Key::Char('e')),
+                combo_ctrl_shift(Key::Char('e')),
                 false,
                 &SqlModalStatus::Normal,
                 tab,
@@ -1449,6 +1461,17 @@ mod tests {
             );
 
             assert!(matches!(result, Action::None));
+        }
+
+        #[rstest]
+        #[case(SqlModalStatus::Normal, SqlModalTab::Sql)]
+        #[case(SqlModalStatus::Normal, SqlModalTab::Plan)]
+        #[case(SqlModalStatus::Normal, SqlModalTab::Compare)]
+        #[case(SqlModalStatus::Editing, SqlModalTab::Sql)]
+        fn alt_e_is_no_longer_bound(#[case] status: SqlModalStatus, #[case] tab: SqlModalTab) {
+            let result = handle_sql_modal_keys(combo_alt(Key::Char('e')), false, &status, tab);
+
+            assert!(!matches!(result, Action::ExplainAnalyzeRequest));
         }
 
         #[rstest]

--- a/src/app/update/input/handlers/sql_modal.rs
+++ b/src/app/update/input/handlers/sql_modal.rs
@@ -7,7 +7,7 @@ use crate::update::action::{
 };
 use crate::update::input::keybindings::{
     Key, KeyCombo, Modifiers, sql_modal_compare_explain, sql_modal_normal_query_history,
-    sql_modal_plan_explain,
+    sql_modal_plan, sql_modal_plan_explain,
 };
 use crate::update::input::vim::{
     SqlModalVimContext, VimSurfaceContext, action_for_input, action_for_key,
@@ -59,7 +59,6 @@ fn handle_sql_modal_keys_internal(
         let ctrl = combo.modifiers.contains(Modifiers::CTRL);
         let alt = combo.modifiers.contains(Modifiers::ALT);
         let shift = combo.modifiers.contains(Modifiers::SHIFT);
-        let ctrl_shift = combo.modifiers == Modifiers::CTRL_SHIFT;
         let plain = !ctrl && !alt && !shift;
 
         if let Some(prefix) = pending_prefix {
@@ -83,6 +82,7 @@ fn handle_sql_modal_keys_internal(
             SqlModalTab::Compare => sql_modal_compare_explain(keymap_preset),
             SqlModalTab::Sql | SqlModalTab::Plan => sql_modal_plan_explain(keymap_preset),
         };
+        let analyze_binding_matches = sql_modal_plan::ANALYZE.combos.contains(&combo);
         if explain_binding.combos.contains(&combo)
             && feature_policy.is_enabled(explain_binding.feature_requirement())
         {
@@ -108,11 +108,10 @@ fn handle_sql_modal_keys_internal(
                 return action;
             }
 
-            return match combo.key {
-                Key::Char('e') if ctrl_shift && supports_explain_analyze => {
-                    Action::ExplainAnalyzeRequest
-                }
-                _ => Action::None,
+            return if analyze_binding_matches && supports_explain_analyze {
+                Action::ExplainAnalyzeRequest
+            } else {
+                Action::None
             };
         }
 
@@ -125,10 +124,10 @@ fn handle_sql_modal_keys_internal(
                 return action;
             }
 
+            if analyze_binding_matches && supports_explain_analyze {
+                return Action::ExplainAnalyzeRequest;
+            }
             return match combo.key {
-                Key::Char('e') if ctrl_shift && supports_explain_analyze => {
-                    Action::ExplainAnalyzeRequest
-                }
                 Key::Char('e')
                     if plain && feature_policy.is_enabled(FeatureRequirement::PlanComparison) =>
                 {
@@ -138,7 +137,7 @@ fn handle_sql_modal_keys_internal(
             };
         }
 
-        if ctrl_shift && combo.key == Key::Char('e') && supports_explain_analyze {
+        if analyze_binding_matches && supports_explain_analyze {
             return Action::ExplainAnalyzeRequest;
         }
         if sql_modal_normal_query_history(keymap_preset)
@@ -301,7 +300,6 @@ fn handle_sql_modal_keys_internal(
     let ctrl = combo.modifiers.contains(Modifiers::CTRL);
     let alt = combo.modifiers.contains(Modifiers::ALT);
     let shift = combo.modifiers.contains(Modifiers::SHIFT);
-    let ctrl_shift = combo.modifiers == Modifiers::CTRL_SHIFT;
     let ctrl_only = ctrl && !alt && !shift;
 
     let plain = !ctrl && !alt && !shift;
@@ -326,7 +324,7 @@ fn handle_sql_modal_keys_internal(
         return Action::SqlModalClear;
     }
 
-    if ctrl_shift && combo.key == Key::Char('e') {
+    if sql_modal_plan::ANALYZE.combos.contains(&combo) {
         return if supports_explain_analyze {
             Action::ExplainAnalyzeRequest
         } else {

--- a/src/app/update/input/keybindings/editors.rs
+++ b/src/app/update/input/keybindings/editors.rs
@@ -151,12 +151,12 @@ pub mod sql_modal_plan {
     };
 
     pub const ANALYZE: KeyBinding = KeyBinding {
-        key_short: "\u{2325}E",
-        key: "Alt+E",
+        key_short: "^⇧E",
+        key: "Ctrl+Shift+E",
         desc_short: "Analyze",
         description: "Run EXPLAIN ANALYZE on current query",
         action: Action::ExplainAnalyzeRequest,
-        combos: &[KeyCombo::alt(Key::Char('e'))],
+        combos: &[KeyCombo::ctrl_shift(Key::Char('e'))],
     };
 
     pub const YANK: KeyBinding = KeyBinding {
@@ -242,12 +242,12 @@ pub mod sql_modal_compare {
     };
 
     pub const ANALYZE: KeyBinding = KeyBinding {
-        key_short: "\u{2325}E",
-        key: "Alt+E",
+        key_short: "^⇧E",
+        key: "Ctrl+Shift+E",
         desc_short: "Analyze",
         description: "Run EXPLAIN ANALYZE on current query",
         action: Action::ExplainAnalyzeRequest,
-        combos: &[KeyCombo::alt(Key::Char('e'))],
+        combos: &[KeyCombo::ctrl_shift(Key::Char('e'))],
     };
 
     pub const EDIT_QUERY: KeyBinding = KeyBinding {

--- a/src/app/update/input/keybindings/editors.rs
+++ b/src/app/update/input/keybindings/editors.rs
@@ -156,7 +156,10 @@ pub mod sql_modal_plan {
         desc_short: "Analyze",
         description: "Run EXPLAIN ANALYZE on current query",
         action: Action::ExplainAnalyzeRequest,
-        combos: &[KeyCombo::ctrl_shift(Key::Char('e'))],
+        combos: &[
+            KeyCombo::ctrl_shift(Key::Char('e')),
+            KeyCombo::ctrl(Key::Char('E')),
+        ],
     };
 
     pub const YANK: KeyBinding = KeyBinding {
@@ -247,7 +250,10 @@ pub mod sql_modal_compare {
         desc_short: "Analyze",
         description: "Run EXPLAIN ANALYZE on current query",
         action: Action::ExplainAnalyzeRequest,
-        combos: &[KeyCombo::ctrl_shift(Key::Char('e'))],
+        combos: &[
+            KeyCombo::ctrl_shift(Key::Char('e')),
+            KeyCombo::ctrl(Key::Char('E')),
+        ],
     };
 
     pub const EDIT_QUERY: KeyBinding = KeyBinding {

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -640,4 +640,13 @@ mod tests {
             FeatureRequirement::JsonDocumentDetail
         );
     }
+
+    #[test]
+    fn explain_analyze_bindings_use_ctrl_shift_e() {
+        for binding in [&sql_modal_plan::ANALYZE, &sql_modal_compare::ANALYZE] {
+            assert_eq!(binding.key_short, "^⇧E");
+            assert_eq!(binding.key, "Ctrl+Shift+E");
+            assert_eq!(binding.combos, &[KeyCombo::ctrl_shift(Key::Char('e'))]);
+        }
+    }
 }

--- a/src/app/update/input/keybindings/mod.rs
+++ b/src/app/update/input/keybindings/mod.rs
@@ -646,7 +646,13 @@ mod tests {
         for binding in [&sql_modal_plan::ANALYZE, &sql_modal_compare::ANALYZE] {
             assert_eq!(binding.key_short, "^⇧E");
             assert_eq!(binding.key, "Ctrl+Shift+E");
-            assert_eq!(binding.combos, &[KeyCombo::ctrl_shift(Key::Char('e'))]);
+            assert_eq!(
+                binding.combos,
+                &[
+                    KeyCombo::ctrl_shift(Key::Char('e')),
+                    KeyCombo::ctrl(Key::Char('E')),
+                ]
+            );
         }
     }
 }

--- a/src/ui/event/key_translator.rs
+++ b/src/ui/event/key_translator.rs
@@ -240,4 +240,45 @@ mod tests {
             ));
         }
     }
+
+    mod sql_modal_explain_analyze_binding {
+        use super::*;
+        use crate::app::model::app_state::AppState;
+        use crate::app::model::shared::input_mode::InputMode;
+        use crate::app::model::sql_editor::modal::{SqlModalStatus, SqlModalTab};
+        use crate::app::ports::inbound::InputEvent;
+        use crate::app::update::action::Action;
+        use crate::app::update::input::handle_event;
+        use crate::domain::{ConnectionId, DatabaseType};
+        use rstest::rstest;
+
+        fn postgres_sql_modal_state() -> AppState {
+            let mut state = AppState::new("test".to_string());
+            state.session.activate_connection_with_dsn(
+                &ConnectionId::new(),
+                "postgres",
+                DatabaseType::PostgreSQL,
+                "postgres://localhost/test",
+            );
+            state.modal.set_mode(InputMode::SqlModal);
+            state.sql_modal.set_active_tab(SqlModalTab::Plan);
+            state.sql_modal.set_status_for_test(SqlModalStatus::Normal);
+            state
+        }
+
+        #[rstest]
+        #[case::lowercase('e')]
+        #[case::uppercase('E')]
+        fn translated_ctrl_shift_e_requests_explain_analyze(#[case] key: char) {
+            let state = postgres_sql_modal_state();
+            let combo = translate(KeyEvent::new(
+                KeyCode::Char(key),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            ));
+
+            let result = handle_event(InputEvent::Key(combo), &state);
+
+            assert!(matches!(result, Action::ExplainAnalyzeRequest));
+        }
+    }
 }


### PR DESCRIPTION
## Problem
SAB-155 requires Ctrl+Shift+E for EXPLAIN ANALYZE, while the current mysql implementation uses Alt+E.

## Background
The original Phase 1 flow is already implemented; this change closes the explicit keybinding acceptance gap.

## Approach
Route the required key through the existing EXPLAIN ANALYZE request and confirmation flow, update the derived user-facing binding hints, and keep ordinary Ctrl+E EXPLAIN and all existing plan/SQL behavior unchanged. Alt+E is not retained.

## Linear Issue Link (optional)
- Implements https://linear.app/sabiql/issue/SAB-155/phase-1-explain%E5%AE%9F%E8%A1%8C-%E3%83%86%E3%82%AD%E3%82%B9%E3%83%88%E8%A1%A8%E7%A4%BA-dml%E5%AE%89%E5%85%A8%E5%AF%BE%E7%AD%96